### PR TITLE
8344800: Add W3C DTDs and XSDs to the JDK built-in Catalog

### DIFF
--- a/make/modules/java.xml/Java.gmk
+++ b/make/modules/java.xml/Java.gmk
@@ -27,5 +27,5 @@ DISABLED_WARNINGS_java += dangling-doc-comments lossy-conversions this-escape
 DOCLINT += -Xdoclint:all/protected \
     '-Xdoclint/package:$(call CommaList, javax.xml.catalog javax.xml.datatype \
     javax.xml.transform javax.xml.validation javax.xml.xpath)'
-COPY += .dtd .xsd .xml
+COPY += .dtd .xsd .xml .ent .mod
 CLEAN += .properties

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java
@@ -1209,11 +1209,12 @@ public class XMLEntityManager implements XMLComponent, XMLEntityResolver {
 
         // Step 1: custom Entity resolver
         XMLInputSource xmlInputSource = null;
-
+        boolean resolveByResolver = false;
         if (fEntityResolver != null) {
             resourceIdentifier.setBaseSystemId(baseSystemId);
             resourceIdentifier.setExpandedSystemId(expandedSystemId);
             xmlInputSource = fEntityResolver.resolveEntity(resourceIdentifier);
+            resolveByResolver = (xmlInputSource != null) ? true : false;
         }
 
         // Step 2: custom catalog if specified
@@ -1229,7 +1230,8 @@ public class XMLEntityManager implements XMLComponent, XMLEntityResolver {
         }
 
         // Step 3: use the default JDK Catalog Resolver if Step 2's resolve is continue
-        if (xmlInputSource == null
+        if ((xmlInputSource == null || (!resolveByResolver && xmlInputSource.getSystemId() != null
+                && xmlInputSource.getSystemId().equals(literalSystemId)))
                 && (publicId != null || literalSystemId != null)
                 && JdkXmlUtils.isResolveContinue(fCatalogFeatures)) {
             initJdkCatalogResolver();

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java
@@ -1214,7 +1214,7 @@ public class XMLEntityManager implements XMLComponent, XMLEntityResolver {
             resourceIdentifier.setBaseSystemId(baseSystemId);
             resourceIdentifier.setExpandedSystemId(expandedSystemId);
             xmlInputSource = fEntityResolver.resolveEntity(resourceIdentifier);
-            resolveByResolver = (xmlInputSource != null) ? true : false;
+            resolveByResolver = xmlInputSource != null;
         }
 
         // Step 2: custom catalog if specified

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/JDKCatalog.xml
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/JDKCatalog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  */
 -->
 <!--
-   Catalog of DTDs for the Java platform
+   Catalog of DTDs and XSDs for the Java platform and W3C specifications
 
    @implNote: DTDs in the built-in catalog are resolved against its URI and the
               xml:base attribute. The preferences.dtd for example is resolved as:
@@ -37,5 +37,120 @@
     <group id="javadtds" prefer = "system" xml:base = "java/dtd/">
         <system systemId="http://java.sun.com/dtd/preferences.dtd" uri="preferences.dtd"/>
         <system systemId="http://java.sun.com/dtd/properties.dtd" uri="properties.dtd"/>
+    </group>
+    
+    <!-- W3C DTDs -->
+    <group id="xhtml11" prefer = "system" xml:base = "w3c/dtd/xhtml11/">
+        <system systemId="http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd" uri="xhtml11.dtd"/>
+        <systemSuffix systemIdSuffix="xhtml-attribs-1.mod" uri="xhtml-attribs-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-base-1.mod" uri="xhtml-base-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-bdo-1.mod" uri="xhtml-bdo-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-blkphras-1.mod" uri="xhtml-blkphras-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-blkpres-1.mod" uri="xhtml-blkpres-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-blkstruct-1.mod" uri="xhtml-blkstruct-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-charent-1.mod" uri="xhtml-charent-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-cicmap-1.mod" uri="xhtml-cicmap-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-csismap-1.mod" uri="xhtml-csismap-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-datatypes-1.mod" uri="xhtml-datatypes-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-edit-1.mod" uri="xhtml-edit-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-events-1.mod" uri="xhtml-events-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-form-1.mod" uri="xhtml-form-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-framework-1.mod" uri="xhtml-framework-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-hypertext-1.mod" uri="xhtml-hypertext-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-image-1.mod" uri="xhtml-image-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-inlphras-1.mod" uri="xhtml-inlphras-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-inlpres-1.mod" uri="xhtml-inlpres-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-inlstruct-1.mod" uri="xhtml-inlstruct-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-inlstyle-1.mod" uri="xhtml-inlstyle-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-lat1-1.mod" uri="xhtml-lat1-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-link-1.mod" uri="xhtml-link-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-list-1.mod" uri="xhtml-list-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-meta-1.mod" uri="xhtml-meta-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-object-1.mod" uri="xhtml-object-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-param-1.mod" uri="xhtml-param-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-pres-1.mod" uri="xhtml-pres-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-qname-1.mod" uri="xhtml-qname-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-ruby-1.mod" uri="xhtml-ruby-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-script-1.mod" uri="xhtml-script-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-special-1.mod" uri="xhtml-special-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-ssismap-1.mod" uri="xhtml-ssismap-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-struct-1.mod" uri="xhtml-struct-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-style-1.mod" uri="xhtml-style-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-symbol-1.mod" uri="xhtml-symbol-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-table-1.mod" uri="xhtml-table-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml-text-1.mod" uri="xhtml-text-1.mod"/>
+        <systemSuffix systemIdSuffix="xhtml11-model-1.mod" uri="xhtml11-model-1.mod"/>
+    </group>
+    
+    <group id="xhtml1" prefer = "system" xml:base = "w3c/dtd/xhtml10/">
+        <systemSuffix systemIdSuffix="xhtml1-strict.dtd" uri="xhtml1-strict.dtd"/>
+        <systemSuffix systemIdSuffix="xhtml1-transitional.dtd" uri="xhtml1-transitional.dtd"/>
+        <systemSuffix systemIdSuffix="xhtml1-frameset.dtd" uri="xhtml1-frameset.dtd"/>
+        <systemSuffix systemIdSuffix="xhtml-lat1.ent" uri="xhtml-lat1.ent"/>
+        <systemSuffix systemIdSuffix="xhtml-special.ent" uri="xhtml-special.ent"/>
+        <systemSuffix systemIdSuffix="xhtml-symbol.ent" uri="xhtml-symbol.ent"/>
+    </group>
+
+    <group id="XMLSchema10" prefer = "system" xml:base = "w3c/dtd/schema10/">
+        <systemSuffix systemIdSuffix="XMLSchema.dtd" uri="XMLSchema.dtd"/>
+        <systemSuffix systemIdSuffix="datatypes.dtd" uri="datatypes.dtd"/>
+        <public publicId="datatypes" uri="datatypes.dtd"/>
+        <public publicId="-//W3C//DTD XMLSCHEMA 200102//EN" uri="XMLSchema.dtd"/>
+    </group>
+    
+    <group id="xmlspec" prefer = "system" xml:base = "w3c/dtd/">
+        <system systemId="http://www.w3.org/2002/xmlspec/dtd/2.10/xmlspec.dtd" uri="xmlspec2_10/xmlspec.dtd"/>
+    </group>
+    
+    <!-- W3C XSDs -->
+    <group id="w3cxsd" prefer = "system" xml:base = "w3c/xsd/">
+        <systemSuffix systemIdSuffix="XMLSchema.xsd" uri="schema10/XMLSchema.xsd"/>
+        <systemSuffix systemIdSuffix="XMLSchema-datatypes.xsd" uri="schema10/XMLSchema-datatypes.xsd"/>
+        <system systemId="http://www.w3.org/2001/xml.xsd" uri="xmlNS2001/xml.xsd"/>
+        <systemSuffix systemIdSuffix="2001/xml.xsd" uri="xmlNS2001/xml.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml1-frameset.xsd" uri="xhtml10/xhtml1-frameset.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml1-strict.xsd" uri="xhtml10/xhtml1-strict.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml1-transitional.xsd" uri="xhtml10/xhtml1-transitional.xsd"/>
+    </group>
+    <group id="xhtml11xsd" prefer = "system" xml:base = "w3c/xsd/xhtml11/">
+        <systemSuffix systemIdSuffix="xhtml11.xsd" uri="xhtml11.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-attribs-1.xsd" uri="xhtml-attribs-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-base-1.xsd" uri="xhtml-base-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-bdo-1.xsd" uri="xhtml-bdo-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-blkphras-1.xsd" uri="xhtml-blkphras-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-blkpres-1.xsd" uri="xhtml-blkpres-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-blkstruct-1.xsd" uri="xhtml-blkstruct-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-copyright-1.xsd" uri="xhtml-copyright-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-csismap-1.xsd" uri="xhtml-csismap-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-datatypes-1.xsd" uri="xhtml-datatypes-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-edit-1.xsd" uri="xhtml-edit-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-events-1.xsd" uri="xhtml-events-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-form-1.xsd" uri="xhtml-form-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-framework-1.xsd" uri="xhtml-framework-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-hypertext-1.xsd" uri="xhtml-hypertext-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-image-1.xsd" uri="xhtml-image-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-inlphras-1.xsd" uri="xhtml-inlphras-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-inlpres-1.xsd" uri="xhtml-inlpres-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-inlstruct-1.xsd" uri="xhtml-inlstruct-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-inlstyle-1.xsd" uri="xhtml-inlstyle-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-link-1.xsd" uri="xhtml-link-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-list-1.xsd" uri="xhtml-list-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-meta-1.xsd" uri="xhtml-meta-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-notations-1.xsd" uri="xhtml-notations-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-object-1.xsd" uri="xhtml-object-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-param-1.xsd" uri="xhtml-param-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-pres-1.xsd" uri="xhtml-pres-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-ruby-1.xsd" uri="xhtml-ruby-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-script-1.xsd" uri="xhtml-script-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-ssismap-1.xsd" uri="xhtml-ssismap-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-struct-1.xsd" uri="xhtml-struct-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-style-1.xsd" uri="xhtml-style-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-table-1.xsd" uri="xhtml-table-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-target-1.xsd" uri="xhtml-target-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml-text-1.xsd" uri="xhtml-text-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml11-model-1.xsd" uri="xhtml11-model-1.xsd"/>
+        <systemSuffix systemIdSuffix="xhtml11-modules-1.xsd" uri="xhtml11-modules-1.xsd"/>
+        <systemSuffix systemIdSuffix="xml-events-1.xsd" uri="xml-events-1.xsd"/>
+        <systemSuffix systemIdSuffix="xml-events-copyright-1.xsd" uri="xml-events-copyright-1.xsd"/>
     </group>
 </catalog>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/schema10/XMLSchema.dtd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/schema10/XMLSchema.dtd
@@ -1,0 +1,513 @@
+<!-- DTD for XML Schema Definition Language Part 1: Structures
+     Public Identifier: "-//W3C//DTD XSD 1.1//EN"
+     Official Location: http://www.w3.org/2009/XMLSchema/XMLSchema.dtd -->
+<!-- Id: structures.dtd,v 1.1 2003/08/28 13:30:52 ht Exp  -->
+<!-- With the exception of cases with multiple namespace
+     prefixes for the XSD namespace, any XML document which is
+     not valid per this DTD given redefinitions in its internal subset of the
+     'p' and 's' parameter entities below appropriate to its namespace
+     declaration of the XSD namespace is almost certainly not
+     a valid schema document. -->
+
+<!-- See below (at the bottom of this document) for information about
+      the revision and namespace-versioning policy governing this DTD. -->
+<!-- The simpleType element and its constituent parts
+     are defined in XML Schema Definition Language Part 2: Datatypes -->
+<!ENTITY % xs-datatypes PUBLIC '-//W3C//DTD XSD 1.1 Datatypes//EN' 'datatypes.dtd' >
+
+<!ENTITY % p 'xs:'> <!-- can be overridden in the internal subset of a
+                         schema document to establish a different
+                         namespace prefix -->
+<!ENTITY % s ':xs'> <!-- if %p is defined (e.g. as foo:) then you must
+                         also define %s as the suffix for the appropriate
+                         namespace declaration (e.g. :foo) -->
+<!ENTITY % nds 'xmlns%s;'>
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % schema "%p;schema">
+<!ENTITY % defaultOpenContent "%p;defaultOpenContent">
+<!ENTITY % complexType "%p;complexType">
+<!ENTITY % complexContent "%p;complexContent">
+<!ENTITY % openContent "%p;openContent">
+<!ENTITY % simpleContent "%p;simpleContent">
+<!ENTITY % extension "%p;extension">
+<!ENTITY % element "%p;element">
+<!ENTITY % alternative "%p;alternative">
+<!ENTITY % unique "%p;unique">
+<!ENTITY % key "%p;key">
+<!ENTITY % keyref "%p;keyref">
+<!ENTITY % selector "%p;selector">
+<!ENTITY % field "%p;field">
+<!ENTITY % group "%p;group">
+<!ENTITY % all "%p;all">
+<!ENTITY % choice "%p;choice">
+<!ENTITY % sequence "%p;sequence">
+<!ENTITY % any "%p;any">
+<!ENTITY % anyAttribute "%p;anyAttribute">
+<!ENTITY % attribute "%p;attribute">
+<!ENTITY % attributeGroup "%p;attributeGroup">
+<!ENTITY % include "%p;include">
+<!ENTITY % import "%p;import">
+<!ENTITY % redefine "%p;redefine">
+<!ENTITY % override "%p;override">
+<!ENTITY % notation "%p;notation">
+<!ENTITY % assert   "%p;assert">
+
+
+<!-- annotation elements -->
+<!ENTITY % annotation "%p;annotation">
+<!ENTITY % appinfo "%p;appinfo">
+<!ENTITY % documentation "%p;documentation">
+
+<!-- Customisation entities for the ATTLIST of each element type.
+     Define one of these if your schema takes advantage of the
+     anyAttribute='##other' in the
+     schema for schema documents -->
+
+<!ENTITY % schemaAttrs ''>
+<!ENTITY % defaultOpenContentAttrs ''>
+<!ENTITY % complexTypeAttrs ''>
+<!ENTITY % complexContentAttrs ''>
+<!ENTITY % openContentAttrs ''>
+<!ENTITY % simpleContentAttrs ''>
+<!ENTITY % extensionAttrs ''>
+<!ENTITY % elementAttrs ''>
+<!ENTITY % groupAttrs ''>
+<!ENTITY % allAttrs ''>
+<!ENTITY % choiceAttrs ''>
+<!ENTITY % sequenceAttrs ''>
+<!ENTITY % anyAttrs ''>
+<!ENTITY % anyAttributeAttrs ''>
+<!ENTITY % attributeAttrs ''>
+<!ENTITY % attributeGroupAttrs ''>
+<!ENTITY % uniqueAttrs ''>
+<!ENTITY % keyAttrs ''>
+<!ENTITY % keyrefAttrs ''>
+<!ENTITY % selectorAttrs ''>
+<!ENTITY % fieldAttrs ''>
+<!ENTITY % assertAttrs ''>
+
+<!ENTITY % includeAttrs ''>
+<!ENTITY % importAttrs ''>
+<!ENTITY % redefineAttrs ''>
+<!ENTITY % overrideAttrs ''>
+<!ENTITY % notationAttrs ''>
+<!ENTITY % annotationAttrs ''>
+<!ENTITY % appinfoAttrs ''>
+<!ENTITY % documentationAttrs ''>
+
+<!ENTITY % complexDerivationSet "CDATA">
+      <!-- #all or space-separated list drawn from derivationChoice -->
+<!ENTITY % blockSet "CDATA">
+      <!-- #all or space-separated list drawn from
+                      derivationChoice + 'substitution' -->
+
+<!ENTITY % composition '%include; | %import; | %override; | %redefine;'>
+<!ENTITY % mgs '%all; | %choice; | %sequence;'>
+<!ENTITY % cs '%choice; | %sequence;'>
+<!ENTITY % formValues '(qualified|unqualified)'>
+
+
+<!ENTITY % attrDecls    '((%attribute;| %attributeGroup;)*,(%anyAttribute;)?)'>
+
+<!ENTITY % assertions   '(%assert;)*'>
+
+<!ENTITY % particleAndAttrs '(%openContent;?, (%mgs; | %group;)?,
+                              %attrDecls;, %assertions;)'>
+
+<!-- This is used in part2 -->
+<!ENTITY % restriction1 '(%openContent;?, (%mgs; | %group;)?)'>
+
+%xs-datatypes;
+
+<!-- the duplication below is to produce an unambiguous content model
+     which allows annotation everywhere -->
+<!ELEMENT %schema; ((%composition; | %annotation;)*,
+                    (%defaultOpenContent;, (%annotation;)*)?,
+                    ((%simpleType; | %complexType;
+                      | %element; | %attribute;
+                      | %attributeGroup; | %group;
+                      | %notation; ),
+                     (%annotation;)*)* )>
+<!ATTLIST %schema;
+   targetNamespace      %URIref;               #IMPLIED
+   version              CDATA                  #IMPLIED
+   %nds;                %URIref;               #FIXED 'http://www.w3.org/2001/XMLSchema'
+   xmlns                CDATA                  #IMPLIED
+   finalDefault         %complexDerivationSet; ''
+   blockDefault         %blockSet;             ''
+   id                   ID                     #IMPLIED
+   elementFormDefault   %formValues;           'unqualified'
+   attributeFormDefault %formValues;           'unqualified'
+   defaultAttributes    CDATA                  #IMPLIED
+   xpathDefaultNamespace    CDATA       '##local'
+   xml:lang             CDATA                  #IMPLIED
+   %schemaAttrs;>
+<!-- Note the xmlns declaration is NOT in the
+     schema for schema documents,
+     because at the Infoset level where schemas operate,
+     xmlns(:prefix) is NOT an attribute! -->
+<!-- The declaration of xmlns is a convenience for schema authors -->
+ 
+<!-- The id attribute here and below is for use in external references
+     from non-schemas using simple fragment identifiers.
+     It is NOT used for schema-to-schema reference, internal or
+     external. -->
+
+<!ELEMENT %defaultOpenContent; ((%annotation;)?, %any;)>
+<!ATTLIST %defaultOpenContent;
+          appliesToEmpty  (true|false)           'false'
+          mode            (interleave|suffix)    'interleave'
+          id              ID                     #IMPLIED
+          %defaultOpenContentAttrs;>
+
+<!-- a type is a named content type specification which allows attribute
+     declarations-->
+<!-- -->
+
+<!ELEMENT %complexType; ((%annotation;)?,
+                         (%simpleContent;|%complexContent;|
+                          %particleAndAttrs;))>
+
+<!ATTLIST %complexType;
+          name                    %NCName;                 #IMPLIED
+          id                      ID                       #IMPLIED
+          abstract                %boolean;                #IMPLIED
+          final                   %complexDerivationSet;   #IMPLIED
+          block                   %complexDerivationSet;   #IMPLIED
+          mixed                   (true|false)             'false'
+          defaultAttributesApply  %boolean;                'true'
+          %complexTypeAttrs;>
+
+<!-- particleAndAttrs is shorthand for a root type -->
+<!-- mixed is disallowed if simpleContent, overridden if complexContent has one too. -->
+
+<!-- If anyAttribute appears in one or more referenced attributeGroups
+     and/or explicitly, the intersection of the permissions is used -->
+
+<!ELEMENT %complexContent; ((%annotation;)?, (%restriction;|%extension;))>
+<!ATTLIST %complexContent;
+          mixed (true|false) #IMPLIED
+          id    ID           #IMPLIED
+          %complexContentAttrs;>
+
+<!ELEMENT %openContent; ((%annotation;)?, (%any;)?)>
+<!ATTLIST %openContent;
+          mode            (none|interleave|suffix)  'interleave'
+          id              ID                        #IMPLIED
+          %openContentAttrs;>
+
+<!-- restriction should use the branch defined above, not the simple
+     one from part2; extension should use the full model  -->
+
+<!ELEMENT %simpleContent; ((%annotation;)?, (%restriction;|%extension;))>
+<!ATTLIST %simpleContent;
+          id    ID           #IMPLIED
+          %simpleContentAttrs;>
+
+<!-- restriction should use the simple branch from part2, not the 
+     one defined above; extension should have no particle  -->
+
+<!ELEMENT %extension; ((%annotation;)?, (%particleAndAttrs;))>
+<!ATTLIST %extension;
+          base  %QName;               #REQUIRED
+          id    ID                    #IMPLIED
+          
+          %extensionAttrs;>
+
+<!-- an element is declared by either:
+ a name and a type (either nested or referenced via the type attribute)
+ or a ref to an existing element declaration -->
+
+<!ELEMENT %element; ((%annotation;)?, (%complexType;| %simpleType;)?,
+                     (%alternative;)*,
+                     (%unique; | %key; | %keyref;)*)>
+<!-- simpleType or complexType only if no type|ref attribute -->
+<!-- ref not allowed at top level -->
+<!ATTLIST %element;
+            name               %NCName;               #IMPLIED
+            id                 ID                     #IMPLIED
+            ref                %QName;                #IMPLIED
+            type               %QName;                #IMPLIED
+            minOccurs          %nonNegativeInteger;   #IMPLIED
+            maxOccurs          CDATA                  #IMPLIED
+            nillable           %boolean;              #IMPLIED
+            substitutionGroup  %QName;                #IMPLIED
+            abstract           %boolean;              #IMPLIED
+            final              %complexDerivationSet; #IMPLIED
+            block              %blockSet;             #IMPLIED
+            default            CDATA                  #IMPLIED
+            fixed              CDATA                  #IMPLIED
+            form               %formValues;           #IMPLIED
+            targetNamespace    %URIref;               #IMPLIED
+            %elementAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- In the absence of type AND ref, type defaults to type of
+     substitutionGroup, if any, else xs:anyType, i.e. unconstrained -->
+<!-- default and fixed are mutually exclusive -->
+
+<!ELEMENT %alternative; ((%annotation;)?, 
+            (%simpleType; | %complexType;)?) >
+<!ATTLIST %alternative; 
+            test                     CDATA     #IMPLIED
+            type                     %QName;   #IMPLIED
+            xpathDefaultNamespace    CDATA     #IMPLIED
+            id                       ID        #IMPLIED >
+
+
+<!ELEMENT %group; ((%annotation;)?,(%mgs;)?)>
+<!ATTLIST %group; 
+          name        %NCName;               #IMPLIED
+          ref         %QName;                #IMPLIED
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %groupAttrs;>
+
+<!ELEMENT %all; ((%annotation;)?, (%element;| %group;| %any;)*)>
+<!ATTLIST %all;
+          minOccurs   (0 | 1)                #IMPLIED
+          maxOccurs   (0 | 1)                #IMPLIED
+          id          ID                     #IMPLIED
+          %allAttrs;>
+
+<!ELEMENT %choice; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %choice;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %choiceAttrs;>
+
+<!ELEMENT %sequence; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %sequence;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %sequenceAttrs;>
+
+<!-- an anonymous grouping in a model, or
+     a top-level named group definition, or a reference to same -->
+
+
+<!ELEMENT %any; (%annotation;)?>
+<!ATTLIST %any;
+            namespace       CDATA                  #IMPLIED
+            notNamespace    CDATA                  #IMPLIED
+            notQName        CDATA                  ''
+            processContents (skip|lax|strict)      'strict'
+            minOccurs       %nonNegativeInteger;   '1'
+            maxOccurs       CDATA                  '1'
+            id              ID                     #IMPLIED
+            %anyAttrs;>
+
+<!-- namespace is interpreted as follows:
+                  ##any      - - any non-conflicting WFXML at all
+
+                  ##other    - - any non-conflicting WFXML from namespace other
+                                  than targetNamespace
+
+                  ##local    - - any unqualified non-conflicting WFXML/attribute
+                  one or     - - any non-conflicting WFXML from
+                  more URI        the listed namespaces
+                  references
+
+                  ##targetNamespace ##local may appear in the above list,
+                    with the obvious meaning -->
+
+<!-- notNamespace is interpreted as follows:
+                  ##local    - - any unqualified non-conflicting WFXML/attribute
+                  one or     - - any non-conflicting WFXML from
+                  more URI        the listed namespaces
+                  references
+
+                  ##targetNamespace ##local may appear in the above list,
+                    with the obvious meaning -->
+
+<!ELEMENT %anyAttribute; (%annotation;)?>
+<!ATTLIST %anyAttribute;
+            namespace       CDATA              #IMPLIED
+            notNamespace    CDATA              #IMPLIED
+            notQName        CDATA              ''
+            processContents (skip|lax|strict)  'strict'
+            id              ID                 #IMPLIED
+            %anyAttributeAttrs;>
+<!-- namespace and notNamespace are interpreted as for 'any' above -->
+
+<!-- simpleType only if no type|ref attribute -->
+<!-- ref not allowed at top level, name iff at top level -->
+<!ELEMENT %attribute; ((%annotation;)?, (%simpleType;)?)>
+<!ATTLIST %attribute;
+          name              %NCName;      #IMPLIED
+          id                ID            #IMPLIED
+          ref               %QName;       #IMPLIED
+          type              %QName;       #IMPLIED
+          use               (prohibited|optional|required) #IMPLIED
+          default           CDATA         #IMPLIED
+          fixed             CDATA         #IMPLIED
+          form              %formValues;  #IMPLIED
+          targetNamespace   %URIref;      #IMPLIED
+          inheritable       %boolean;      #IMPLIED
+          %attributeAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- default for use is optional when nested, none otherwise -->
+<!-- default and fixed are mutually exclusive -->
+<!-- type attr and simpleType content are mutually exclusive -->
+
+<!-- an attributeGroup is a named collection of attribute decls, or a
+     reference thereto -->
+<!ELEMENT %attributeGroup; ((%annotation;)?,
+                       (%attribute; | %attributeGroup;)*,
+                       (%anyAttribute;)?) >
+<!ATTLIST %attributeGroup;
+                 name       %NCName;       #IMPLIED
+                 id         ID             #IMPLIED
+                 ref        %QName;        #IMPLIED
+                 %attributeGroupAttrs;>
+
+<!-- ref iff no content, no name.  ref iff not top level -->
+
+<!-- better reference mechanisms -->
+<!ELEMENT %unique; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %unique;
+          name                     %NCName;       #IMPLIED
+          ref                      %QName;        #IMPLIED
+          id                       ID             #IMPLIED
+          %uniqueAttrs;>
+
+<!ELEMENT %key;    ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %key;
+          name                     %NCName;       #IMPLIED
+          ref                      %QName;        #IMPLIED
+          id                       ID             #IMPLIED
+          %keyAttrs;>
+
+<!ELEMENT %keyref; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %keyref;
+          name                     %NCName;       #IMPLIED
+          ref                      %QName;        #IMPLIED
+          refer                    %QName;        #IMPLIED
+          id                       ID             #IMPLIED
+          %keyrefAttrs;>
+
+<!ELEMENT %selector; ((%annotation;)?)>
+<!ATTLIST %selector;
+          xpath                    %XPathExpr; #REQUIRED
+          xpathDefaultNamespace    CDATA       #IMPLIED
+          id                       ID          #IMPLIED
+          %selectorAttrs;>
+<!ELEMENT %field; ((%annotation;)?)>
+<!ATTLIST %field;
+          xpath                    %XPathExpr; #REQUIRED
+          xpathDefaultNamespace    CDATA       #IMPLIED
+          id                       ID          #IMPLIED
+          %fieldAttrs;>
+
+<!-- co-constraint assertions -->
+<!ELEMENT %assert; ((%annotation;)?)>
+<!ATTLIST %assert;
+          test                     %XPathExpr; #REQUIRED
+          id                       ID          #IMPLIED
+          xpathDefaultNamespace    CDATA       #IMPLIED
+          %assertAttrs;>
+
+
+<!-- Schema combination mechanisms -->
+<!ELEMENT %include; (%annotation;)?>
+<!ATTLIST %include;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %includeAttrs;>
+
+<!ELEMENT %import; (%annotation;)?>
+<!ATTLIST %import;
+          namespace      %URIref; #IMPLIED
+          schemaLocation %URIref; #IMPLIED
+          id             ID       #IMPLIED
+          %importAttrs;>
+
+<!ELEMENT %redefine; (%annotation; | %simpleType; | %complexType; |
+                      %attributeGroup; | %group;)*>
+<!ATTLIST %redefine;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %redefineAttrs;>
+
+<!ELEMENT %override; ((%annotation;)?,
+                      ((%simpleType; | %complexType; | %group; | %attributeGroup;) |
+                       %element; | %attribute; | %notation;)*)>
+<!ATTLIST %override;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %overrideAttrs;>
+
+<!ELEMENT %notation; (%annotation;)?>
+<!ATTLIST %notation;
+	  name        %NCName;    #REQUIRED
+	  id          ID          #IMPLIED
+	  public      CDATA       #REQUIRED
+	  system      %URIref;    #IMPLIED
+	  %notationAttrs;>
+
+<!-- Annotation is either application information or documentation -->
+<!-- By having these here they are available for datatypes as well
+     as all the structures elements -->
+
+<!ELEMENT %annotation; (%appinfo; | %documentation;)*>
+<!ATTLIST %annotation; %annotationAttrs;>
+
+<!-- User must define annotation elements in internal subset for this
+     to work -->
+<!ELEMENT %appinfo; ANY>   <!-- too restrictive -->
+<!ATTLIST %appinfo;
+          source     %URIref;      #IMPLIED
+          id         ID         #IMPLIED
+          %appinfoAttrs;>
+<!ELEMENT %documentation; ANY>   <!-- too restrictive -->
+<!ATTLIST %documentation;
+          source     %URIref;   #IMPLIED
+          id         ID         #IMPLIED
+          xml:lang   CDATA      #IMPLIED
+          %documentationAttrs;>
+
+<!NOTATION XMLSchemaStructures PUBLIC
+           'structures' 'http://www.w3.org/2001/XMLSchema.xsd' >
+<!NOTATION XML PUBLIC
+           'REC-xml-1998-0210' 'http://www.w3.org/TR/1998/REC-xml-19980210' >
+
+<!-- 
+      In keeping with the XML Schema WG's standard versioning policy, 
+      this DTD will persist at the URI
+      http://www.w3.org/2012/04/XMLSchema.dtd.
+
+      At the date of issue it can also be found at the URI
+      http://www.w3.org/2009/XMLSchema/XMLSchema.dtd.
+
+      The schema document at that URI may however change in the future, 
+      in order to remain compatible with the latest version of XSD 
+      and its namespace.  In other words, if XSD or the XML Schema 
+      namespace change, the version of this document at 
+      http://www.w3.org/2009/XMLSchema/XMLSchema.dtd will change accordingly; 
+      the version at http://www.w3.org/2012/04/XMLSchema.dtd 
+      will not change.
+
+      Previous dated (and unchanging) versions of this DTD include:
+
+       http://www.w3.org/2012/01/XMLSchema.dtd
+          (XSD 1.1 Proposed Recommendation)
+
+
+        http://www.w3.org/2011/07/XMLSchema.dtd
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2009/04/XMLSchema.dtd 
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2004/10/XMLSchema.dtd
+          (XSD 1.0 Recommendation, Second Edition)
+
+        http://www.w3.org/2001/05/XMLSchema.dtd
+          (XSD 1.0 Recommendation, First Edition)
+
+-->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/schema10/datatypes.dtd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/schema10/datatypes.dtd
@@ -1,0 +1,222 @@
+<!--
+        DTD for XML Schemas: Part 2: Datatypes
+        
+        Id: datatypes.dtd,v 1.1.2.4 2005/01/31 18:40:42 cmsmcq Exp 
+        Note this DTD is NOT normative, or even definitive.
+  -->
+
+<!--
+        This DTD cannot be used on its own, it is intended
+        only for incorporation in XMLSchema.dtd, q.v.
+  -->
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % simpleType "%p;simpleType">
+<!ENTITY % restriction "%p;restriction">
+<!ENTITY % list "%p;list">
+<!ENTITY % union "%p;union">
+<!ENTITY % maxExclusive "%p;maxExclusive">
+<!ENTITY % minExclusive "%p;minExclusive">
+<!ENTITY % maxInclusive "%p;maxInclusive">
+<!ENTITY % minInclusive "%p;minInclusive">
+<!ENTITY % totalDigits "%p;totalDigits">
+<!ENTITY % fractionDigits "%p;fractionDigits">
+
+<!ENTITY % length "%p;length">
+<!ENTITY % minLength "%p;minLength">
+<!ENTITY % maxLength "%p;maxLength">
+<!ENTITY % enumeration "%p;enumeration">
+<!ENTITY % whiteSpace "%p;whiteSpace">
+<!ENTITY % pattern "%p;pattern">
+
+<!ENTITY % assertion "%p;assertion">
+
+<!ENTITY % explicitTimezone "%p;explicitTimezone">
+
+
+<!--
+        Customization entities for the ATTLIST of each element
+        type. Define one of these if your schema takes advantage
+        of the anyAttribute='##other' in the schema for schemas
+  -->
+
+<!ENTITY % simpleTypeAttrs "">
+<!ENTITY % restrictionAttrs "">
+<!ENTITY % listAttrs "">
+<!ENTITY % unionAttrs "">
+<!ENTITY % maxExclusiveAttrs "">
+<!ENTITY % minExclusiveAttrs "">
+<!ENTITY % maxInclusiveAttrs "">
+<!ENTITY % minInclusiveAttrs "">
+<!ENTITY % totalDigitsAttrs "">
+<!ENTITY % fractionDigitsAttrs "">
+<!ENTITY % lengthAttrs "">
+<!ENTITY % minLengthAttrs "">
+<!ENTITY % maxLengthAttrs "">
+
+<!ENTITY % enumerationAttrs "">
+<!ENTITY % whiteSpaceAttrs "">
+<!ENTITY % patternAttrs "">
+<!ENTITY % assertionAttrs "">
+<!ENTITY % explicitTimezoneAttrs "">
+
+<!-- Define some entities for informative use as attribute
+        types -->
+<!ENTITY % URIref "CDATA">
+<!ENTITY % XPathExpr "CDATA">
+<!ENTITY % QName "NMTOKEN">
+<!ENTITY % QNames "NMTOKENS">
+<!ENTITY % NCName "NMTOKEN">
+<!ENTITY % nonNegativeInteger "NMTOKEN">
+<!ENTITY % boolean "(true|false)">
+<!ENTITY % simpleDerivationSet "CDATA">
+<!--
+        #all or space-separated list drawn from derivationChoice
+  -->
+
+<!--
+        Note that the use of 'facet' below is less restrictive
+        than is really intended:  There should in fact be no
+        more than one of each of minInclusive, minExclusive,
+        maxInclusive, maxExclusive, totalDigits, fractionDigits,
+        length, maxLength, minLength within datatype,
+        and the min- and max- variants of Inclusive and Exclusive
+        are mutually exclusive. On the other hand,  pattern and
+        enumeration and assertion may repeat.
+  -->
+<!ENTITY % minBound "(%minInclusive; | %minExclusive;)">
+<!ENTITY % maxBound "(%maxInclusive; | %maxExclusive;)">
+<!ENTITY % bounds "%minBound; | %maxBound;">
+<!ENTITY % numeric "%totalDigits; | %fractionDigits;"> 
+<!ENTITY % ordered "%bounds; | %numeric;">
+<!ENTITY % unordered
+   "%pattern; | %enumeration; | %whiteSpace; | %length; |
+   %maxLength; | %minLength; | %assertion;
+   | %explicitTimezone;">
+<!ENTITY % implementation-defined-facets "">
+<!ENTITY % facet "%ordered; | %unordered; %implementation-defined-facets;">
+<!ENTITY % facetAttr 
+        "value CDATA #REQUIRED
+        id ID #IMPLIED">
+<!ENTITY % fixedAttr "fixed %boolean; #IMPLIED">
+<!ENTITY % facetModel "(%annotation;)?">
+<!ELEMENT %simpleType;
+        ((%annotation;)?, (%restriction; | %list; | %union;))>
+<!ATTLIST %simpleType;
+    name      %NCName; #IMPLIED
+    final     %simpleDerivationSet; #IMPLIED
+    id        ID       #IMPLIED
+    %simpleTypeAttrs;>
+<!-- name is required at top level -->
+<!ELEMENT %restriction; ((%annotation;)?,
+                         (%restriction1; |
+                          ((%simpleType;)?,(%facet;)*)),
+                         (%attrDecls;))>
+<!ATTLIST %restriction;
+    base      %QName;                  #IMPLIED
+    id        ID       #IMPLIED
+    %restrictionAttrs;>
+<!--
+        base and simpleType child are mutually exclusive,
+        one is required.
+
+        restriction is shared between simpleType and
+        simpleContent and complexContent (in XMLSchema.xsd).
+        restriction1 is for the latter cases, when this
+        is restricting a complex type, as is attrDecls.
+  -->
+<!ELEMENT %list; ((%annotation;)?,(%simpleType;)?)>
+<!ATTLIST %list;
+    itemType      %QName;             #IMPLIED
+    id        ID       #IMPLIED
+    %listAttrs;>
+<!--
+        itemType and simpleType child are mutually exclusive,
+        one is required
+  -->
+<!ELEMENT %union; ((%annotation;)?,(%simpleType;)*)>
+<!ATTLIST %union;
+    id            ID       #IMPLIED
+    memberTypes   %QNames;            #IMPLIED
+    %unionAttrs;>
+<!--
+        At least one item in memberTypes or one simpleType
+        child is required
+  -->
+
+<!ELEMENT %maxExclusive; %facetModel;>
+<!ATTLIST %maxExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxExclusiveAttrs;>
+<!ELEMENT %minExclusive; %facetModel;>
+<!ATTLIST %minExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minExclusiveAttrs;>
+
+<!ELEMENT %maxInclusive; %facetModel;>
+<!ATTLIST %maxInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxInclusiveAttrs;>
+<!ELEMENT %minInclusive; %facetModel;>
+<!ATTLIST %minInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minInclusiveAttrs;>
+
+<!ELEMENT %totalDigits; %facetModel;>
+<!ATTLIST %totalDigits;
+        %facetAttr;
+        %fixedAttr;
+        %totalDigitsAttrs;>
+<!ELEMENT %fractionDigits; %facetModel;>
+<!ATTLIST %fractionDigits;
+        %facetAttr;
+        %fixedAttr;
+        %fractionDigitsAttrs;>
+
+<!ELEMENT %length; %facetModel;>
+<!ATTLIST %length;
+        %facetAttr;
+        %fixedAttr;
+        %lengthAttrs;>
+<!ELEMENT %minLength; %facetModel;>
+<!ATTLIST %minLength;
+        %facetAttr;
+        %fixedAttr;
+        %minLengthAttrs;>
+<!ELEMENT %maxLength; %facetModel;>
+<!ATTLIST %maxLength;
+        %facetAttr;
+        %fixedAttr;
+        %maxLengthAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %enumeration; %facetModel;>
+<!ATTLIST %enumeration;
+        %facetAttr;
+        %enumerationAttrs;>
+
+<!ELEMENT %whiteSpace; %facetModel;>
+<!ATTLIST %whiteSpace;
+        %facetAttr;
+        %fixedAttr;
+        %whiteSpaceAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %pattern; %facetModel;>
+<!ATTLIST %pattern;
+        %facetAttr;
+        %patternAttrs;>
+
+<!ELEMENT %assertion; %facetModel;>
+<!ATTLIST %assertion;
+        %facetAttr;
+        %assertionAttrs;>
+
+<!ELEMENT %explicitTimezone; %facetModel;>
+<!ATTLIST %explicitTimezone;
+        %facetAttr;
+        %explicitTimezoneAttrs;>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml-lat1.ent
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml-lat1.ent
@@ -1,0 +1,196 @@
+<!-- Portions (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+-->
+<!-- Character entity set. Typical invocation:
+    <!ENTITY % HTMLlat1 PUBLIC
+       "-//W3C//ENTITIES Latin 1 for XHTML//EN"
+       "http://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent">
+    %HTMLlat1;
+-->
+
+<!ENTITY nbsp   "&#160;"> <!-- no-break space = non-breaking space,
+                                  U+00A0 ISOnum -->
+<!ENTITY iexcl  "&#161;"> <!-- inverted exclamation mark, U+00A1 ISOnum -->
+<!ENTITY cent   "&#162;"> <!-- cent sign, U+00A2 ISOnum -->
+<!ENTITY pound  "&#163;"> <!-- pound sign, U+00A3 ISOnum -->
+<!ENTITY curren "&#164;"> <!-- currency sign, U+00A4 ISOnum -->
+<!ENTITY yen    "&#165;"> <!-- yen sign = yuan sign, U+00A5 ISOnum -->
+<!ENTITY brvbar "&#166;"> <!-- broken bar = broken vertical bar,
+                                  U+00A6 ISOnum -->
+<!ENTITY sect   "&#167;"> <!-- section sign, U+00A7 ISOnum -->
+<!ENTITY uml    "&#168;"> <!-- diaeresis = spacing diaeresis,
+                                  U+00A8 ISOdia -->
+<!ENTITY copy   "&#169;"> <!-- copyright sign, U+00A9 ISOnum -->
+<!ENTITY ordf   "&#170;"> <!-- feminine ordinal indicator, U+00AA ISOnum -->
+<!ENTITY laquo  "&#171;"> <!-- left-pointing double angle quotation mark
+                                  = left pointing guillemet, U+00AB ISOnum -->
+<!ENTITY not    "&#172;"> <!-- not sign = angled dash,
+                                  U+00AC ISOnum -->
+<!ENTITY shy    "&#173;"> <!-- soft hyphen = discretionary hyphen,
+                                  U+00AD ISOnum -->
+<!ENTITY reg    "&#174;"> <!-- registered sign = registered trade mark sign,
+                                  U+00AE ISOnum -->
+<!ENTITY macr   "&#175;"> <!-- macron = spacing macron = overline
+                                  = APL overbar, U+00AF ISOdia -->
+<!ENTITY deg    "&#176;"> <!-- degree sign, U+00B0 ISOnum -->
+<!ENTITY plusmn "&#177;"> <!-- plus-minus sign = plus-or-minus sign,
+                                  U+00B1 ISOnum -->
+<!ENTITY sup2   "&#178;"> <!-- superscript two = superscript digit two
+                                  = squared, U+00B2 ISOnum -->
+<!ENTITY sup3   "&#179;"> <!-- superscript three = superscript digit three
+                                  = cubed, U+00B3 ISOnum -->
+<!ENTITY acute  "&#180;"> <!-- acute accent = spacing acute,
+                                  U+00B4 ISOdia -->
+<!ENTITY micro  "&#181;"> <!-- micro sign, U+00B5 ISOnum -->
+<!ENTITY para   "&#182;"> <!-- pilcrow sign = paragraph sign,
+                                  U+00B6 ISOnum -->
+<!ENTITY middot "&#183;"> <!-- middle dot = Georgian comma
+                                  = Greek middle dot, U+00B7 ISOnum -->
+<!ENTITY cedil  "&#184;"> <!-- cedilla = spacing cedilla, U+00B8 ISOdia -->
+<!ENTITY sup1   "&#185;"> <!-- superscript one = superscript digit one,
+                                  U+00B9 ISOnum -->
+<!ENTITY ordm   "&#186;"> <!-- masculine ordinal indicator,
+                                  U+00BA ISOnum -->
+<!ENTITY raquo  "&#187;"> <!-- right-pointing double angle quotation mark
+                                  = right pointing guillemet, U+00BB ISOnum -->
+<!ENTITY frac14 "&#188;"> <!-- vulgar fraction one quarter
+                                  = fraction one quarter, U+00BC ISOnum -->
+<!ENTITY frac12 "&#189;"> <!-- vulgar fraction one half
+                                  = fraction one half, U+00BD ISOnum -->
+<!ENTITY frac34 "&#190;"> <!-- vulgar fraction three quarters
+                                  = fraction three quarters, U+00BE ISOnum -->
+<!ENTITY iquest "&#191;"> <!-- inverted question mark
+                                  = turned question mark, U+00BF ISOnum -->
+<!ENTITY Agrave "&#192;"> <!-- latin capital letter A with grave
+                                  = latin capital letter A grave,
+                                  U+00C0 ISOlat1 -->
+<!ENTITY Aacute "&#193;"> <!-- latin capital letter A with acute,
+                                  U+00C1 ISOlat1 -->
+<!ENTITY Acirc  "&#194;"> <!-- latin capital letter A with circumflex,
+                                  U+00C2 ISOlat1 -->
+<!ENTITY Atilde "&#195;"> <!-- latin capital letter A with tilde,
+                                  U+00C3 ISOlat1 -->
+<!ENTITY Auml   "&#196;"> <!-- latin capital letter A with diaeresis,
+                                  U+00C4 ISOlat1 -->
+<!ENTITY Aring  "&#197;"> <!-- latin capital letter A with ring above
+                                  = latin capital letter A ring,
+                                  U+00C5 ISOlat1 -->
+<!ENTITY AElig  "&#198;"> <!-- latin capital letter AE
+                                  = latin capital ligature AE,
+                                  U+00C6 ISOlat1 -->
+<!ENTITY Ccedil "&#199;"> <!-- latin capital letter C with cedilla,
+                                  U+00C7 ISOlat1 -->
+<!ENTITY Egrave "&#200;"> <!-- latin capital letter E with grave,
+                                  U+00C8 ISOlat1 -->
+<!ENTITY Eacute "&#201;"> <!-- latin capital letter E with acute,
+                                  U+00C9 ISOlat1 -->
+<!ENTITY Ecirc  "&#202;"> <!-- latin capital letter E with circumflex,
+                                  U+00CA ISOlat1 -->
+<!ENTITY Euml   "&#203;"> <!-- latin capital letter E with diaeresis,
+                                  U+00CB ISOlat1 -->
+<!ENTITY Igrave "&#204;"> <!-- latin capital letter I with grave,
+                                  U+00CC ISOlat1 -->
+<!ENTITY Iacute "&#205;"> <!-- latin capital letter I with acute,
+                                  U+00CD ISOlat1 -->
+<!ENTITY Icirc  "&#206;"> <!-- latin capital letter I with circumflex,
+                                  U+00CE ISOlat1 -->
+<!ENTITY Iuml   "&#207;"> <!-- latin capital letter I with diaeresis,
+                                  U+00CF ISOlat1 -->
+<!ENTITY ETH    "&#208;"> <!-- latin capital letter ETH, U+00D0 ISOlat1 -->
+<!ENTITY Ntilde "&#209;"> <!-- latin capital letter N with tilde,
+                                  U+00D1 ISOlat1 -->
+<!ENTITY Ograve "&#210;"> <!-- latin capital letter O with grave,
+                                  U+00D2 ISOlat1 -->
+<!ENTITY Oacute "&#211;"> <!-- latin capital letter O with acute,
+                                  U+00D3 ISOlat1 -->
+<!ENTITY Ocirc  "&#212;"> <!-- latin capital letter O with circumflex,
+                                  U+00D4 ISOlat1 -->
+<!ENTITY Otilde "&#213;"> <!-- latin capital letter O with tilde,
+                                  U+00D5 ISOlat1 -->
+<!ENTITY Ouml   "&#214;"> <!-- latin capital letter O with diaeresis,
+                                  U+00D6 ISOlat1 -->
+<!ENTITY times  "&#215;"> <!-- multiplication sign, U+00D7 ISOnum -->
+<!ENTITY Oslash "&#216;"> <!-- latin capital letter O with stroke
+                                  = latin capital letter O slash,
+                                  U+00D8 ISOlat1 -->
+<!ENTITY Ugrave "&#217;"> <!-- latin capital letter U with grave,
+                                  U+00D9 ISOlat1 -->
+<!ENTITY Uacute "&#218;"> <!-- latin capital letter U with acute,
+                                  U+00DA ISOlat1 -->
+<!ENTITY Ucirc  "&#219;"> <!-- latin capital letter U with circumflex,
+                                  U+00DB ISOlat1 -->
+<!ENTITY Uuml   "&#220;"> <!-- latin capital letter U with diaeresis,
+                                  U+00DC ISOlat1 -->
+<!ENTITY Yacute "&#221;"> <!-- latin capital letter Y with acute,
+                                  U+00DD ISOlat1 -->
+<!ENTITY THORN  "&#222;"> <!-- latin capital letter THORN,
+                                  U+00DE ISOlat1 -->
+<!ENTITY szlig  "&#223;"> <!-- latin small letter sharp s = ess-zed,
+                                  U+00DF ISOlat1 -->
+<!ENTITY agrave "&#224;"> <!-- latin small letter a with grave
+                                  = latin small letter a grave,
+                                  U+00E0 ISOlat1 -->
+<!ENTITY aacute "&#225;"> <!-- latin small letter a with acute,
+                                  U+00E1 ISOlat1 -->
+<!ENTITY acirc  "&#226;"> <!-- latin small letter a with circumflex,
+                                  U+00E2 ISOlat1 -->
+<!ENTITY atilde "&#227;"> <!-- latin small letter a with tilde,
+                                  U+00E3 ISOlat1 -->
+<!ENTITY auml   "&#228;"> <!-- latin small letter a with diaeresis,
+                                  U+00E4 ISOlat1 -->
+<!ENTITY aring  "&#229;"> <!-- latin small letter a with ring above
+                                  = latin small letter a ring,
+                                  U+00E5 ISOlat1 -->
+<!ENTITY aelig  "&#230;"> <!-- latin small letter ae
+                                  = latin small ligature ae, U+00E6 ISOlat1 -->
+<!ENTITY ccedil "&#231;"> <!-- latin small letter c with cedilla,
+                                  U+00E7 ISOlat1 -->
+<!ENTITY egrave "&#232;"> <!-- latin small letter e with grave,
+                                  U+00E8 ISOlat1 -->
+<!ENTITY eacute "&#233;"> <!-- latin small letter e with acute,
+                                  U+00E9 ISOlat1 -->
+<!ENTITY ecirc  "&#234;"> <!-- latin small letter e with circumflex,
+                                  U+00EA ISOlat1 -->
+<!ENTITY euml   "&#235;"> <!-- latin small letter e with diaeresis,
+                                  U+00EB ISOlat1 -->
+<!ENTITY igrave "&#236;"> <!-- latin small letter i with grave,
+                                  U+00EC ISOlat1 -->
+<!ENTITY iacute "&#237;"> <!-- latin small letter i with acute,
+                                  U+00ED ISOlat1 -->
+<!ENTITY icirc  "&#238;"> <!-- latin small letter i with circumflex,
+                                  U+00EE ISOlat1 -->
+<!ENTITY iuml   "&#239;"> <!-- latin small letter i with diaeresis,
+                                  U+00EF ISOlat1 -->
+<!ENTITY eth    "&#240;"> <!-- latin small letter eth, U+00F0 ISOlat1 -->
+<!ENTITY ntilde "&#241;"> <!-- latin small letter n with tilde,
+                                  U+00F1 ISOlat1 -->
+<!ENTITY ograve "&#242;"> <!-- latin small letter o with grave,
+                                  U+00F2 ISOlat1 -->
+<!ENTITY oacute "&#243;"> <!-- latin small letter o with acute,
+                                  U+00F3 ISOlat1 -->
+<!ENTITY ocirc  "&#244;"> <!-- latin small letter o with circumflex,
+                                  U+00F4 ISOlat1 -->
+<!ENTITY otilde "&#245;"> <!-- latin small letter o with tilde,
+                                  U+00F5 ISOlat1 -->
+<!ENTITY ouml   "&#246;"> <!-- latin small letter o with diaeresis,
+                                  U+00F6 ISOlat1 -->
+<!ENTITY divide "&#247;"> <!-- division sign, U+00F7 ISOnum -->
+<!ENTITY oslash "&#248;"> <!-- latin small letter o with stroke,
+                                  = latin small letter o slash,
+                                  U+00F8 ISOlat1 -->
+<!ENTITY ugrave "&#249;"> <!-- latin small letter u with grave,
+                                  U+00F9 ISOlat1 -->
+<!ENTITY uacute "&#250;"> <!-- latin small letter u with acute,
+                                  U+00FA ISOlat1 -->
+<!ENTITY ucirc  "&#251;"> <!-- latin small letter u with circumflex,
+                                  U+00FB ISOlat1 -->
+<!ENTITY uuml   "&#252;"> <!-- latin small letter u with diaeresis,
+                                  U+00FC ISOlat1 -->
+<!ENTITY yacute "&#253;"> <!-- latin small letter y with acute,
+                                  U+00FD ISOlat1 -->
+<!ENTITY thorn  "&#254;"> <!-- latin small letter thorn,
+                                  U+00FE ISOlat1 -->
+<!ENTITY yuml   "&#255;"> <!-- latin small letter y with diaeresis,
+                                  U+00FF ISOlat1 -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml-special.ent
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml-special.ent
@@ -1,0 +1,80 @@
+<!-- Special characters for XHTML -->
+
+<!-- Character entity set. Typical invocation:
+     <!ENTITY % HTMLspecial PUBLIC
+        "-//W3C//ENTITIES Special for XHTML//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent">
+     %HTMLspecial;
+-->
+
+<!-- Portions (C) International Organization for Standardization 1986:
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+-->
+
+<!-- Relevant ISO entity set is given unless names are newly introduced.
+     New names (i.e., not in ISO 8879 list) do not clash with any
+     existing ISO 8879 entity names. ISO 10646 character numbers
+     are given for each character, in hex. values are decimal
+     conversions of the ISO 10646 values and refer to the document
+     character set. Names are Unicode names. 
+-->
+
+<!-- C0 Controls and Basic Latin -->
+<!ENTITY quot    "&#34;"> <!--  quotation mark, U+0022 ISOnum -->
+<!ENTITY amp     "&#38;#38;"> <!--  ampersand, U+0026 ISOnum -->
+<!ENTITY lt      "&#38;#60;"> <!--  less-than sign, U+003C ISOnum -->
+<!ENTITY gt      "&#62;"> <!--  greater-than sign, U+003E ISOnum -->
+<!ENTITY apos	 "&#39;"> <!--  apostrophe = APL quote, U+0027 ISOnum -->
+
+<!-- Latin Extended-A -->
+<!ENTITY OElig   "&#338;"> <!--  latin capital ligature OE,
+                                    U+0152 ISOlat2 -->
+<!ENTITY oelig   "&#339;"> <!--  latin small ligature oe, U+0153 ISOlat2 -->
+<!-- ligature is a misnomer, this is a separate character in some languages -->
+<!ENTITY Scaron  "&#352;"> <!--  latin capital letter S with caron,
+                                    U+0160 ISOlat2 -->
+<!ENTITY scaron  "&#353;"> <!--  latin small letter s with caron,
+                                    U+0161 ISOlat2 -->
+<!ENTITY Yuml    "&#376;"> <!--  latin capital letter Y with diaeresis,
+                                    U+0178 ISOlat2 -->
+
+<!-- Spacing Modifier Letters -->
+<!ENTITY circ    "&#710;"> <!--  modifier letter circumflex accent,
+                                    U+02C6 ISOpub -->
+<!ENTITY tilde   "&#732;"> <!--  small tilde, U+02DC ISOdia -->
+
+<!-- General Punctuation -->
+<!ENTITY ensp    "&#8194;"> <!-- en space, U+2002 ISOpub -->
+<!ENTITY emsp    "&#8195;"> <!-- em space, U+2003 ISOpub -->
+<!ENTITY thinsp  "&#8201;"> <!-- thin space, U+2009 ISOpub -->
+<!ENTITY zwnj    "&#8204;"> <!-- zero width non-joiner,
+                                    U+200C NEW RFC 2070 -->
+<!ENTITY zwj     "&#8205;"> <!-- zero width joiner, U+200D NEW RFC 2070 -->
+<!ENTITY lrm     "&#8206;"> <!-- left-to-right mark, U+200E NEW RFC 2070 -->
+<!ENTITY rlm     "&#8207;"> <!-- right-to-left mark, U+200F NEW RFC 2070 -->
+<!ENTITY ndash   "&#8211;"> <!-- en dash, U+2013 ISOpub -->
+<!ENTITY mdash   "&#8212;"> <!-- em dash, U+2014 ISOpub -->
+<!ENTITY lsquo   "&#8216;"> <!-- left single quotation mark,
+                                    U+2018 ISOnum -->
+<!ENTITY rsquo   "&#8217;"> <!-- right single quotation mark,
+                                    U+2019 ISOnum -->
+<!ENTITY sbquo   "&#8218;"> <!-- single low-9 quotation mark, U+201A NEW -->
+<!ENTITY ldquo   "&#8220;"> <!-- left double quotation mark,
+                                    U+201C ISOnum -->
+<!ENTITY rdquo   "&#8221;"> <!-- right double quotation mark,
+                                    U+201D ISOnum -->
+<!ENTITY bdquo   "&#8222;"> <!-- double low-9 quotation mark, U+201E NEW -->
+<!ENTITY dagger  "&#8224;"> <!-- dagger, U+2020 ISOpub -->
+<!ENTITY Dagger  "&#8225;"> <!-- double dagger, U+2021 ISOpub -->
+<!ENTITY permil  "&#8240;"> <!-- per mille sign, U+2030 ISOtech -->
+<!ENTITY lsaquo  "&#8249;"> <!-- single left-pointing angle quotation mark,
+                                    U+2039 ISO proposed -->
+<!-- lsaquo is proposed but not yet ISO standardized -->
+<!ENTITY rsaquo  "&#8250;"> <!-- single right-pointing angle quotation mark,
+                                    U+203A ISO proposed -->
+<!-- rsaquo is proposed but not yet ISO standardized -->
+
+<!-- Currency Symbols -->
+<!ENTITY euro   "&#8364;"> <!--  euro sign, U+20AC NEW -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml-symbol.ent
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml-symbol.ent
@@ -1,0 +1,237 @@
+<!-- Mathematical, Greek and Symbolic characters for XHTML -->
+
+<!-- Character entity set. Typical invocation:
+     <!ENTITY % HTMLsymbol PUBLIC
+        "-//W3C//ENTITIES Symbols for XHTML//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent">
+     %HTMLsymbol;
+-->
+
+<!-- Portions (C) International Organization for Standardization 1986:
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+-->
+
+<!-- Relevant ISO entity set is given unless names are newly introduced.
+     New names (i.e., not in ISO 8879 list) do not clash with any
+     existing ISO 8879 entity names. ISO 10646 character numbers
+     are given for each character, in hex. values are decimal
+     conversions of the ISO 10646 values and refer to the document
+     character set. Names are Unicode names. 
+-->
+
+<!-- Latin Extended-B -->
+<!ENTITY fnof     "&#402;"> <!-- latin small letter f with hook = function
+                                    = florin, U+0192 ISOtech -->
+
+<!-- Greek -->
+<!ENTITY Alpha    "&#913;"> <!-- greek capital letter alpha, U+0391 -->
+<!ENTITY Beta     "&#914;"> <!-- greek capital letter beta, U+0392 -->
+<!ENTITY Gamma    "&#915;"> <!-- greek capital letter gamma,
+                                    U+0393 ISOgrk3 -->
+<!ENTITY Delta    "&#916;"> <!-- greek capital letter delta,
+                                    U+0394 ISOgrk3 -->
+<!ENTITY Epsilon  "&#917;"> <!-- greek capital letter epsilon, U+0395 -->
+<!ENTITY Zeta     "&#918;"> <!-- greek capital letter zeta, U+0396 -->
+<!ENTITY Eta      "&#919;"> <!-- greek capital letter eta, U+0397 -->
+<!ENTITY Theta    "&#920;"> <!-- greek capital letter theta,
+                                    U+0398 ISOgrk3 -->
+<!ENTITY Iota     "&#921;"> <!-- greek capital letter iota, U+0399 -->
+<!ENTITY Kappa    "&#922;"> <!-- greek capital letter kappa, U+039A -->
+<!ENTITY Lambda   "&#923;"> <!-- greek capital letter lamda,
+                                    U+039B ISOgrk3 -->
+<!ENTITY Mu       "&#924;"> <!-- greek capital letter mu, U+039C -->
+<!ENTITY Nu       "&#925;"> <!-- greek capital letter nu, U+039D -->
+<!ENTITY Xi       "&#926;"> <!-- greek capital letter xi, U+039E ISOgrk3 -->
+<!ENTITY Omicron  "&#927;"> <!-- greek capital letter omicron, U+039F -->
+<!ENTITY Pi       "&#928;"> <!-- greek capital letter pi, U+03A0 ISOgrk3 -->
+<!ENTITY Rho      "&#929;"> <!-- greek capital letter rho, U+03A1 -->
+<!-- there is no Sigmaf, and no U+03A2 character either -->
+<!ENTITY Sigma    "&#931;"> <!-- greek capital letter sigma,
+                                    U+03A3 ISOgrk3 -->
+<!ENTITY Tau      "&#932;"> <!-- greek capital letter tau, U+03A4 -->
+<!ENTITY Upsilon  "&#933;"> <!-- greek capital letter upsilon,
+                                    U+03A5 ISOgrk3 -->
+<!ENTITY Phi      "&#934;"> <!-- greek capital letter phi,
+                                    U+03A6 ISOgrk3 -->
+<!ENTITY Chi      "&#935;"> <!-- greek capital letter chi, U+03A7 -->
+<!ENTITY Psi      "&#936;"> <!-- greek capital letter psi,
+                                    U+03A8 ISOgrk3 -->
+<!ENTITY Omega    "&#937;"> <!-- greek capital letter omega,
+                                    U+03A9 ISOgrk3 -->
+
+<!ENTITY alpha    "&#945;"> <!-- greek small letter alpha,
+                                    U+03B1 ISOgrk3 -->
+<!ENTITY beta     "&#946;"> <!-- greek small letter beta, U+03B2 ISOgrk3 -->
+<!ENTITY gamma    "&#947;"> <!-- greek small letter gamma,
+                                    U+03B3 ISOgrk3 -->
+<!ENTITY delta    "&#948;"> <!-- greek small letter delta,
+                                    U+03B4 ISOgrk3 -->
+<!ENTITY epsilon  "&#949;"> <!-- greek small letter epsilon,
+                                    U+03B5 ISOgrk3 -->
+<!ENTITY zeta     "&#950;"> <!-- greek small letter zeta, U+03B6 ISOgrk3 -->
+<!ENTITY eta      "&#951;"> <!-- greek small letter eta, U+03B7 ISOgrk3 -->
+<!ENTITY theta    "&#952;"> <!-- greek small letter theta,
+                                    U+03B8 ISOgrk3 -->
+<!ENTITY iota     "&#953;"> <!-- greek small letter iota, U+03B9 ISOgrk3 -->
+<!ENTITY kappa    "&#954;"> <!-- greek small letter kappa,
+                                    U+03BA ISOgrk3 -->
+<!ENTITY lambda   "&#955;"> <!-- greek small letter lamda,
+                                    U+03BB ISOgrk3 -->
+<!ENTITY mu       "&#956;"> <!-- greek small letter mu, U+03BC ISOgrk3 -->
+<!ENTITY nu       "&#957;"> <!-- greek small letter nu, U+03BD ISOgrk3 -->
+<!ENTITY xi       "&#958;"> <!-- greek small letter xi, U+03BE ISOgrk3 -->
+<!ENTITY omicron  "&#959;"> <!-- greek small letter omicron, U+03BF NEW -->
+<!ENTITY pi       "&#960;"> <!-- greek small letter pi, U+03C0 ISOgrk3 -->
+<!ENTITY rho      "&#961;"> <!-- greek small letter rho, U+03C1 ISOgrk3 -->
+<!ENTITY sigmaf   "&#962;"> <!-- greek small letter final sigma,
+                                    U+03C2 ISOgrk3 -->
+<!ENTITY sigma    "&#963;"> <!-- greek small letter sigma,
+                                    U+03C3 ISOgrk3 -->
+<!ENTITY tau      "&#964;"> <!-- greek small letter tau, U+03C4 ISOgrk3 -->
+<!ENTITY upsilon  "&#965;"> <!-- greek small letter upsilon,
+                                    U+03C5 ISOgrk3 -->
+<!ENTITY phi      "&#966;"> <!-- greek small letter phi, U+03C6 ISOgrk3 -->
+<!ENTITY chi      "&#967;"> <!-- greek small letter chi, U+03C7 ISOgrk3 -->
+<!ENTITY psi      "&#968;"> <!-- greek small letter psi, U+03C8 ISOgrk3 -->
+<!ENTITY omega    "&#969;"> <!-- greek small letter omega,
+                                    U+03C9 ISOgrk3 -->
+<!ENTITY thetasym "&#977;"> <!-- greek theta symbol,
+                                    U+03D1 NEW -->
+<!ENTITY upsih    "&#978;"> <!-- greek upsilon with hook symbol,
+                                    U+03D2 NEW -->
+<!ENTITY piv      "&#982;"> <!-- greek pi symbol, U+03D6 ISOgrk3 -->
+
+<!-- General Punctuation -->
+<!ENTITY bull     "&#8226;"> <!-- bullet = black small circle,
+                                     U+2022 ISOpub  -->
+<!-- bullet is NOT the same as bullet operator, U+2219 -->
+<!ENTITY hellip   "&#8230;"> <!-- horizontal ellipsis = three dot leader,
+                                     U+2026 ISOpub  -->
+<!ENTITY prime    "&#8242;"> <!-- prime = minutes = feet, U+2032 ISOtech -->
+<!ENTITY Prime    "&#8243;"> <!-- double prime = seconds = inches,
+                                     U+2033 ISOtech -->
+<!ENTITY oline    "&#8254;"> <!-- overline = spacing overscore,
+                                     U+203E NEW -->
+<!ENTITY frasl    "&#8260;"> <!-- fraction slash, U+2044 NEW -->
+
+<!-- Letterlike Symbols -->
+<!ENTITY weierp   "&#8472;"> <!-- script capital P = power set
+                                     = Weierstrass p, U+2118 ISOamso -->
+<!ENTITY image    "&#8465;"> <!-- black-letter capital I = imaginary part,
+                                     U+2111 ISOamso -->
+<!ENTITY real     "&#8476;"> <!-- black-letter capital R = real part symbol,
+                                     U+211C ISOamso -->
+<!ENTITY trade    "&#8482;"> <!-- trade mark sign, U+2122 ISOnum -->
+<!ENTITY alefsym  "&#8501;"> <!-- alef symbol = first transfinite cardinal,
+                                     U+2135 NEW -->
+<!-- alef symbol is NOT the same as hebrew letter alef,
+     U+05D0 although the same glyph could be used to depict both characters -->
+
+<!-- Arrows -->
+<!ENTITY larr     "&#8592;"> <!-- leftwards arrow, U+2190 ISOnum -->
+<!ENTITY uarr     "&#8593;"> <!-- upwards arrow, U+2191 ISOnum-->
+<!ENTITY rarr     "&#8594;"> <!-- rightwards arrow, U+2192 ISOnum -->
+<!ENTITY darr     "&#8595;"> <!-- downwards arrow, U+2193 ISOnum -->
+<!ENTITY harr     "&#8596;"> <!-- left right arrow, U+2194 ISOamsa -->
+<!ENTITY crarr    "&#8629;"> <!-- downwards arrow with corner leftwards
+                                     = carriage return, U+21B5 NEW -->
+<!ENTITY lArr     "&#8656;"> <!-- leftwards double arrow, U+21D0 ISOtech -->
+<!-- Unicode does not say that lArr is the same as the 'is implied by' arrow
+    but also does not have any other character for that function. So lArr can
+    be used for 'is implied by' as ISOtech suggests -->
+<!ENTITY uArr     "&#8657;"> <!-- upwards double arrow, U+21D1 ISOamsa -->
+<!ENTITY rArr     "&#8658;"> <!-- rightwards double arrow,
+                                     U+21D2 ISOtech -->
+<!-- Unicode does not say this is the 'implies' character but does not have 
+     another character with this function so rArr can be used for 'implies'
+     as ISOtech suggests -->
+<!ENTITY dArr     "&#8659;"> <!-- downwards double arrow, U+21D3 ISOamsa -->
+<!ENTITY hArr     "&#8660;"> <!-- left right double arrow,
+                                     U+21D4 ISOamsa -->
+
+<!-- Mathematical Operators -->
+<!ENTITY forall   "&#8704;"> <!-- for all, U+2200 ISOtech -->
+<!ENTITY part     "&#8706;"> <!-- partial differential, U+2202 ISOtech  -->
+<!ENTITY exist    "&#8707;"> <!-- there exists, U+2203 ISOtech -->
+<!ENTITY empty    "&#8709;"> <!-- empty set = null set, U+2205 ISOamso -->
+<!ENTITY nabla    "&#8711;"> <!-- nabla = backward difference,
+                                     U+2207 ISOtech -->
+<!ENTITY isin     "&#8712;"> <!-- element of, U+2208 ISOtech -->
+<!ENTITY notin    "&#8713;"> <!-- not an element of, U+2209 ISOtech -->
+<!ENTITY ni       "&#8715;"> <!-- contains as member, U+220B ISOtech -->
+<!ENTITY prod     "&#8719;"> <!-- n-ary product = product sign,
+                                     U+220F ISOamsb -->
+<!-- prod is NOT the same character as U+03A0 'greek capital letter pi' though
+     the same glyph might be used for both -->
+<!ENTITY sum      "&#8721;"> <!-- n-ary summation, U+2211 ISOamsb -->
+<!-- sum is NOT the same character as U+03A3 'greek capital letter sigma'
+     though the same glyph might be used for both -->
+<!ENTITY minus    "&#8722;"> <!-- minus sign, U+2212 ISOtech -->
+<!ENTITY lowast   "&#8727;"> <!-- asterisk operator, U+2217 ISOtech -->
+<!ENTITY radic    "&#8730;"> <!-- square root = radical sign,
+                                     U+221A ISOtech -->
+<!ENTITY prop     "&#8733;"> <!-- proportional to, U+221D ISOtech -->
+<!ENTITY infin    "&#8734;"> <!-- infinity, U+221E ISOtech -->
+<!ENTITY ang      "&#8736;"> <!-- angle, U+2220 ISOamso -->
+<!ENTITY and      "&#8743;"> <!-- logical and = wedge, U+2227 ISOtech -->
+<!ENTITY or       "&#8744;"> <!-- logical or = vee, U+2228 ISOtech -->
+<!ENTITY cap      "&#8745;"> <!-- intersection = cap, U+2229 ISOtech -->
+<!ENTITY cup      "&#8746;"> <!-- union = cup, U+222A ISOtech -->
+<!ENTITY int      "&#8747;"> <!-- integral, U+222B ISOtech -->
+<!ENTITY there4   "&#8756;"> <!-- therefore, U+2234 ISOtech -->
+<!ENTITY sim      "&#8764;"> <!-- tilde operator = varies with = similar to,
+                                     U+223C ISOtech -->
+<!-- tilde operator is NOT the same character as the tilde, U+007E,
+     although the same glyph might be used to represent both  -->
+<!ENTITY cong     "&#8773;"> <!-- approximately equal to, U+2245 ISOtech -->
+<!ENTITY asymp    "&#8776;"> <!-- almost equal to = asymptotic to,
+                                     U+2248 ISOamsr -->
+<!ENTITY ne       "&#8800;"> <!-- not equal to, U+2260 ISOtech -->
+<!ENTITY equiv    "&#8801;"> <!-- identical to, U+2261 ISOtech -->
+<!ENTITY le       "&#8804;"> <!-- less-than or equal to, U+2264 ISOtech -->
+<!ENTITY ge       "&#8805;"> <!-- greater-than or equal to,
+                                     U+2265 ISOtech -->
+<!ENTITY sub      "&#8834;"> <!-- subset of, U+2282 ISOtech -->
+<!ENTITY sup      "&#8835;"> <!-- superset of, U+2283 ISOtech -->
+<!ENTITY nsub     "&#8836;"> <!-- not a subset of, U+2284 ISOamsn -->
+<!ENTITY sube     "&#8838;"> <!-- subset of or equal to, U+2286 ISOtech -->
+<!ENTITY supe     "&#8839;"> <!-- superset of or equal to,
+                                     U+2287 ISOtech -->
+<!ENTITY oplus    "&#8853;"> <!-- circled plus = direct sum,
+                                     U+2295 ISOamsb -->
+<!ENTITY otimes   "&#8855;"> <!-- circled times = vector product,
+                                     U+2297 ISOamsb -->
+<!ENTITY perp     "&#8869;"> <!-- up tack = orthogonal to = perpendicular,
+                                     U+22A5 ISOtech -->
+<!ENTITY sdot     "&#8901;"> <!-- dot operator, U+22C5 ISOamsb -->
+<!-- dot operator is NOT the same character as U+00B7 middle dot -->
+
+<!-- Miscellaneous Technical -->
+<!ENTITY lceil    "&#8968;"> <!-- left ceiling = APL upstile,
+                                     U+2308 ISOamsc  -->
+<!ENTITY rceil    "&#8969;"> <!-- right ceiling, U+2309 ISOamsc  -->
+<!ENTITY lfloor   "&#8970;"> <!-- left floor = APL downstile,
+                                     U+230A ISOamsc  -->
+<!ENTITY rfloor   "&#8971;"> <!-- right floor, U+230B ISOamsc  -->
+<!ENTITY lang     "&#9001;"> <!-- left-pointing angle bracket = bra,
+                                     U+2329 ISOtech -->
+<!-- lang is NOT the same character as U+003C 'less than sign' 
+     or U+2039 'single left-pointing angle quotation mark' -->
+<!ENTITY rang     "&#9002;"> <!-- right-pointing angle bracket = ket,
+                                     U+232A ISOtech -->
+<!-- rang is NOT the same character as U+003E 'greater than sign' 
+     or U+203A 'single right-pointing angle quotation mark' -->
+
+<!-- Geometric Shapes -->
+<!ENTITY loz      "&#9674;"> <!-- lozenge, U+25CA ISOpub -->
+
+<!-- Miscellaneous Symbols -->
+<!ENTITY spades   "&#9824;"> <!-- black spade suit, U+2660 ISOpub -->
+<!-- black here seems to mean filled as opposed to hollow -->
+<!ENTITY clubs    "&#9827;"> <!-- black club suit = shamrock,
+                                     U+2663 ISOpub -->
+<!ENTITY hearts   "&#9829;"> <!-- black heart suit = valentine,
+                                     U+2665 ISOpub -->
+<!ENTITY diams    "&#9830;"> <!-- black diamond suit, U+2666 ISOpub -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml1-frameset.dtd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml1-frameset.dtd
@@ -1,0 +1,1235 @@
+<!--
+   Extensible HTML version 1.0 Frameset DTD
+
+   This is the same as HTML 4 Frameset except for
+   changes due to the differences between XML and SGML.
+
+   Namespace = http://www.w3.org/1999/xhtml
+
+   For further information, see: http://www.w3.org/TR/xhtml1
+
+   Copyright (c) 1998-2002 W3C (MIT, INRIA, Keio),
+   All Rights Reserved. 
+
+   This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+   PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN"
+   SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd"
+
+   $Revision: 1.26 $
+   $Date: 2002/08/01 18:16:48 $
+
+-->
+
+<!--================ Character mnemonic entities =========================-->
+
+<!ENTITY % HTMLlat1 PUBLIC
+   "-//W3C//ENTITIES Latin 1 for XHTML//EN"
+   "xhtml-lat1.ent">
+%HTMLlat1;
+
+<!ENTITY % HTMLsymbol PUBLIC
+   "-//W3C//ENTITIES Symbols for XHTML//EN"
+   "xhtml-symbol.ent">
+%HTMLsymbol;
+
+<!ENTITY % HTMLspecial PUBLIC
+   "-//W3C//ENTITIES Special for XHTML//EN"
+   "xhtml-special.ent">
+%HTMLspecial;
+
+<!--================== Imported Names ====================================-->
+
+<!ENTITY % ContentType "CDATA">
+    <!-- media type, as per [RFC2045] -->
+
+<!ENTITY % ContentTypes "CDATA">
+    <!-- comma-separated list of media types, as per [RFC2045] -->
+
+<!ENTITY % Charset "CDATA">
+    <!-- a character encoding, as per [RFC2045] -->
+
+<!ENTITY % Charsets "CDATA">
+    <!-- a space separated list of character encodings, as per [RFC2045] -->
+
+<!ENTITY % LanguageCode "NMTOKEN">
+    <!-- a language code, as per [RFC3066] -->
+
+<!ENTITY % Character "CDATA">
+    <!-- a single character, as per section 2.2 of [XML] -->
+
+<!ENTITY % Number "CDATA">
+    <!-- one or more digits -->
+
+<!ENTITY % LinkTypes "CDATA">
+    <!-- space-separated list of link types -->
+
+<!ENTITY % MediaDesc "CDATA">
+    <!-- single or comma-separated list of media descriptors -->
+
+<!ENTITY % URI "CDATA">
+    <!-- a Uniform Resource Identifier, see [RFC2396] -->
+
+<!ENTITY % UriList "CDATA">
+    <!-- a space separated list of Uniform Resource Identifiers -->
+
+<!ENTITY % Datetime "CDATA">
+    <!-- date and time information. ISO date format -->
+
+<!ENTITY % Script "CDATA">
+    <!-- script expression -->
+
+<!ENTITY % StyleSheet "CDATA">
+    <!-- style sheet data -->
+
+<!ENTITY % Text "CDATA">
+    <!-- used for titles etc. -->
+
+<!ENTITY % FrameTarget "NMTOKEN">
+    <!-- render in this frame -->
+
+<!ENTITY % Length "CDATA">
+    <!-- nn for pixels or nn% for percentage length -->
+
+<!ENTITY % MultiLength "CDATA">
+    <!-- pixel, percentage, or relative -->
+
+<!ENTITY % MultiLengths "CDATA">
+    <!-- comma-separated list of MultiLength -->
+
+<!ENTITY % Pixels "CDATA">
+    <!-- integer representing length in pixels -->
+
+<!-- these are used for image maps -->
+
+<!ENTITY % Shape "(rect|circle|poly|default)">
+
+<!ENTITY % Coords "CDATA">
+    <!-- comma separated list of lengths -->
+
+<!-- used for object, applet, img, input and iframe -->
+<!ENTITY % ImgAlign "(top|middle|bottom|left|right)">
+
+<!-- a color using sRGB: #RRGGBB as Hex values -->
+<!ENTITY % Color "CDATA">
+
+<!-- There are also 16 widely known color names with their sRGB values:
+
+    Black  = #000000    Green  = #008000
+    Silver = #C0C0C0    Lime   = #00FF00
+    Gray   = #808080    Olive  = #808000
+    White  = #FFFFFF    Yellow = #FFFF00
+    Maroon = #800000    Navy   = #000080
+    Red    = #FF0000    Blue   = #0000FF
+    Purple = #800080    Teal   = #008080
+    Fuchsia= #FF00FF    Aqua   = #00FFFF
+-->
+
+<!--=================== Generic Attributes ===============================-->
+
+<!-- core attributes common to most elements
+  id       document-wide unique id
+  class    space separated list of classes
+  style    associated style info
+  title    advisory title/amplification
+-->
+<!ENTITY % coreattrs
+ "id          ID             #IMPLIED
+  class       CDATA          #IMPLIED
+  style       %StyleSheet;   #IMPLIED
+  title       %Text;         #IMPLIED"
+  >
+
+<!-- internationalization attributes
+  lang        language code (backwards compatible)
+  xml:lang    language code (as per XML 1.0 spec)
+  dir         direction for weak/neutral text
+-->
+<!ENTITY % i18n
+ "lang        %LanguageCode; #IMPLIED
+  xml:lang    %LanguageCode; #IMPLIED
+  dir         (ltr|rtl)      #IMPLIED"
+  >
+
+<!-- attributes for common UI events
+  onclick     a pointer button was clicked
+  ondblclick  a pointer button was double clicked
+  onmousedown a pointer button was pressed down
+  onmouseup   a pointer button was released
+  onmousemove a pointer was moved onto the element
+  onmouseout  a pointer was moved away from the element
+  onkeypress  a key was pressed and released
+  onkeydown   a key was pressed down
+  onkeyup     a key was released
+-->
+<!ENTITY % events
+ "onclick     %Script;       #IMPLIED
+  ondblclick  %Script;       #IMPLIED
+  onmousedown %Script;       #IMPLIED
+  onmouseup   %Script;       #IMPLIED
+  onmouseover %Script;       #IMPLIED
+  onmousemove %Script;       #IMPLIED
+  onmouseout  %Script;       #IMPLIED
+  onkeypress  %Script;       #IMPLIED
+  onkeydown   %Script;       #IMPLIED
+  onkeyup     %Script;       #IMPLIED"
+  >
+
+<!-- attributes for elements that can get the focus
+  accesskey   accessibility key character
+  tabindex    position in tabbing order
+  onfocus     the element got the focus
+  onblur      the element lost the focus
+-->
+<!ENTITY % focus
+ "accesskey   %Character;    #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED"
+  >
+
+<!ENTITY % attrs "%coreattrs; %i18n; %events;">
+
+<!-- text alignment for p, div, h1-h6. The default is
+     align="left" for ltr headings, "right" for rtl -->
+
+<!ENTITY % TextAlign "align (left|center|right|justify) #IMPLIED">
+
+<!--=================== Text Elements ====================================-->
+
+<!ENTITY % special.extra
+   "object | applet | img | map | iframe">
+	
+<!ENTITY % special.basic
+	"br | span | bdo">
+
+<!ENTITY % special
+   "%special.basic; | %special.extra;">
+
+<!ENTITY % fontstyle.extra "big | small | font | basefont">
+
+<!ENTITY % fontstyle.basic "tt | i | b | u
+                      | s | strike ">
+
+<!ENTITY % fontstyle "%fontstyle.basic; | %fontstyle.extra;">
+
+<!ENTITY % phrase.extra "sub | sup">
+<!ENTITY % phrase.basic "em | strong | dfn | code | q |
+                   samp | kbd | var | cite | abbr | acronym">
+
+<!ENTITY % phrase "%phrase.basic; | %phrase.extra;">
+
+<!ENTITY % inline.forms "input | select | textarea | label | button">
+
+<!-- these can occur at block or inline level -->
+<!ENTITY % misc.inline "ins | del | script">
+
+<!-- these can only occur at block level -->
+<!ENTITY % misc "noscript | %misc.inline;">
+
+
+<!ENTITY % inline "a | %special; | %fontstyle; | %phrase; | %inline.forms;">
+
+<!-- %Inline; covers inline or "text-level" elements -->
+<!ENTITY % Inline "(#PCDATA | %inline; | %misc.inline;)*">
+
+<!--================== Block level elements ==============================-->
+
+<!ENTITY % heading "h1|h2|h3|h4|h5|h6">
+<!ENTITY % lists "ul | ol | dl | menu | dir">
+<!ENTITY % blocktext "pre | hr | blockquote | address | center">
+
+<!ENTITY % block
+    "p | %heading; | div | %lists; | %blocktext; | isindex | fieldset | table">
+
+<!-- %Flow; mixes block and inline and is used for list items etc. -->
+<!ENTITY % Flow "(#PCDATA | %block; | form | %inline; | %misc;)*">
+
+<!--================== Content models for exclusions =====================-->
+
+<!-- a elements use %Inline; excluding a -->
+
+<!ENTITY % a.content
+   "(#PCDATA | %special; | %fontstyle; | %phrase; | %inline.forms; | %misc.inline;)*">
+
+<!-- pre uses %Inline excluding img, object, applet, big, small,
+     sub, sup, font, or basefont -->
+
+<!ENTITY % pre.content
+   "(#PCDATA | a | %special.basic; | %fontstyle.basic; | %phrase.basic; |
+	   %inline.forms; | %misc.inline;)*">
+
+
+<!-- form uses %Flow; excluding form -->
+
+<!ENTITY % form.content "(#PCDATA | %block; | %inline; | %misc;)*">
+
+<!-- button uses %Flow; but excludes a, form, form controls, iframe -->
+
+<!ENTITY % button.content
+   "(#PCDATA | p | %heading; | div | %lists; | %blocktext; |
+      table | br | span | bdo | object | applet | img | map |
+      %fontstyle; | %phrase; | %misc;)*">
+
+<!--================ Document Structure ==================================-->
+
+<!-- the namespace URI designates the document profile -->
+
+<!ELEMENT html (head, frameset)>
+<!ATTLIST html
+  %i18n;
+  id          ID             #IMPLIED
+  xmlns       %URI;          #FIXED 'http://www.w3.org/1999/xhtml'
+  >
+
+<!--================ Document Head =======================================-->
+
+<!ENTITY % head.misc "(script|style|meta|link|object|isindex)*">
+
+<!-- content model is %head.misc; combined with a single
+     title and an optional base element in any order -->
+
+<!ELEMENT head (%head.misc;,
+     ((title, %head.misc;, (base, %head.misc;)?) |
+      (base, %head.misc;, (title, %head.misc;))))>
+
+<!ATTLIST head
+  %i18n;
+  id          ID             #IMPLIED
+  profile     %URI;          #IMPLIED
+  >
+
+<!-- The title element is not considered part of the flow of text.
+       It should be displayed, for example as the page header or
+       window title. Exactly one title is required per document.
+    -->
+<!ELEMENT title (#PCDATA)>
+<!ATTLIST title 
+  %i18n;
+  id          ID             #IMPLIED
+  >
+
+<!-- document base URI -->
+
+<!ELEMENT base EMPTY>
+<!ATTLIST base
+  id          ID             #IMPLIED
+  href        %URI;          #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!-- generic metainformation -->
+<!ELEMENT meta EMPTY>
+<!ATTLIST meta
+  %i18n;
+  id          ID             #IMPLIED
+  http-equiv  CDATA          #IMPLIED
+  name        CDATA          #IMPLIED
+  content     CDATA          #REQUIRED
+  scheme      CDATA          #IMPLIED
+  >
+
+<!--
+  Relationship values can be used in principle:
+
+   a) for document specific toolbars/menus when used
+      with the link element in document head e.g.
+        start, contents, previous, next, index, end, help
+   b) to link to a separate style sheet (rel="stylesheet")
+   c) to make a link to a script (rel="script")
+   d) by stylesheets to control how collections of
+      html nodes are rendered into printed documents
+   e) to make a link to a printable version of this document
+      e.g. a PostScript or PDF version (rel="alternate" media="print")
+-->
+
+<!ELEMENT link EMPTY>
+<!ATTLIST link
+  %attrs;
+  charset     %Charset;      #IMPLIED
+  href        %URI;          #IMPLIED
+  hreflang    %LanguageCode; #IMPLIED
+  type        %ContentType;  #IMPLIED
+  rel         %LinkTypes;    #IMPLIED
+  rev         %LinkTypes;    #IMPLIED
+  media       %MediaDesc;    #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!-- style info, which may include CDATA sections -->
+<!ELEMENT style (#PCDATA)>
+<!ATTLIST style
+  %i18n;
+  id          ID             #IMPLIED
+  type        %ContentType;  #REQUIRED
+  media       %MediaDesc;    #IMPLIED
+  title       %Text;         #IMPLIED
+  xml:space   (preserve)     #FIXED 'preserve'
+  >
+
+<!-- script statements, which may include CDATA sections -->
+<!ELEMENT script (#PCDATA)>
+<!ATTLIST script
+  id          ID             #IMPLIED
+  charset     %Charset;      #IMPLIED
+  type        %ContentType;  #REQUIRED
+  language    CDATA          #IMPLIED
+  src         %URI;          #IMPLIED
+  defer       (defer)        #IMPLIED
+  xml:space   (preserve)     #FIXED 'preserve'
+  >
+
+<!-- alternate content container for non script-based rendering -->
+
+<!ELEMENT noscript %Flow;>
+<!ATTLIST noscript
+  %attrs;
+  >
+
+<!--======================= Frames =======================================-->
+
+<!-- only one noframes element permitted per document -->
+
+<!ELEMENT frameset (frameset|frame|noframes)*>
+<!ATTLIST frameset
+  %coreattrs;
+  rows        %MultiLengths; #IMPLIED
+  cols        %MultiLengths; #IMPLIED
+  onload      %Script;       #IMPLIED
+  onunload    %Script;       #IMPLIED
+  >
+
+<!-- reserved frame names start with "_" otherwise starts with letter -->
+
+<!-- tiled window within frameset -->
+
+<!ELEMENT frame EMPTY>
+<!ATTLIST frame
+  %coreattrs;
+  longdesc    %URI;          #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  src         %URI;          #IMPLIED
+  frameborder (1|0)          "1"
+  marginwidth %Pixels;       #IMPLIED
+  marginheight %Pixels;      #IMPLIED
+  noresize    (noresize)     #IMPLIED
+  scrolling   (yes|no|auto)  "auto"
+  >
+
+<!-- inline subwindow -->
+
+<!ELEMENT iframe %Flow;>
+<!ATTLIST iframe
+  %coreattrs;
+  longdesc    %URI;          #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  src         %URI;          #IMPLIED
+  frameborder (1|0)          "1"
+  marginwidth %Pixels;       #IMPLIED
+  marginheight %Pixels;      #IMPLIED
+  scrolling   (yes|no|auto)  "auto"
+  align       %ImgAlign;     #IMPLIED
+  height      %Length;       #IMPLIED
+  width       %Length;       #IMPLIED
+  >
+
+<!-- alternate content container for non frame-based rendering -->
+
+<!ELEMENT noframes (body)>
+<!ATTLIST noframes
+  %attrs;
+  >
+
+<!--=================== Document Body ====================================-->
+
+<!ELEMENT body %Flow;>
+<!ATTLIST body
+  %attrs;
+  onload      %Script;       #IMPLIED
+  onunload    %Script;       #IMPLIED
+  background  %URI;          #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  text        %Color;        #IMPLIED
+  link        %Color;        #IMPLIED
+  vlink       %Color;        #IMPLIED
+  alink       %Color;        #IMPLIED
+  >
+
+<!ELEMENT div %Flow;>  <!-- generic language/style container -->
+<!ATTLIST div
+  %attrs;
+  %TextAlign;
+  >
+
+<!--=================== Paragraphs =======================================-->
+
+<!ELEMENT p %Inline;>
+<!ATTLIST p
+  %attrs;
+  %TextAlign;
+  >
+
+<!--=================== Headings =========================================-->
+
+<!--
+  There are six levels of headings from h1 (the most important)
+  to h6 (the least important).
+-->
+
+<!ELEMENT h1  %Inline;>
+<!ATTLIST h1
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h2 %Inline;>
+<!ATTLIST h2
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h3 %Inline;>
+<!ATTLIST h3
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h4 %Inline;>
+<!ATTLIST h4
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h5 %Inline;>
+<!ATTLIST h5
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h6 %Inline;>
+<!ATTLIST h6
+  %attrs;
+  %TextAlign;
+  >
+
+<!--=================== Lists ============================================-->
+
+<!-- Unordered list bullet styles -->
+
+<!ENTITY % ULStyle "(disc|square|circle)">
+
+<!-- Unordered list -->
+
+<!ELEMENT ul (li)+>
+<!ATTLIST ul
+  %attrs;
+  type        %ULStyle;     #IMPLIED
+  compact     (compact)     #IMPLIED
+  >
+
+<!-- Ordered list numbering style
+
+    1   arabic numbers      1, 2, 3, ...
+    a   lower alpha         a, b, c, ...
+    A   upper alpha         A, B, C, ...
+    i   lower roman         i, ii, iii, ...
+    I   upper roman         I, II, III, ...
+
+    The style is applied to the sequence number which by default
+    is reset to 1 for the first list item in an ordered list.
+-->
+<!ENTITY % OLStyle "CDATA">
+
+<!-- Ordered (numbered) list -->
+
+<!ELEMENT ol (li)+>
+<!ATTLIST ol
+  %attrs;
+  type        %OLStyle;      #IMPLIED
+  compact     (compact)      #IMPLIED
+  start       %Number;       #IMPLIED
+  >
+
+<!-- single column list (DEPRECATED) --> 
+<!ELEMENT menu (li)+>
+<!ATTLIST menu
+  %attrs;
+  compact     (compact)     #IMPLIED
+  >
+
+<!-- multiple column list (DEPRECATED) --> 
+<!ELEMENT dir (li)+>
+<!ATTLIST dir
+  %attrs;
+  compact     (compact)     #IMPLIED
+  >
+
+<!-- LIStyle is constrained to: "(%ULStyle;|%OLStyle;)" -->
+<!ENTITY % LIStyle "CDATA">
+
+<!-- list item -->
+
+<!ELEMENT li %Flow;>
+<!ATTLIST li
+  %attrs;
+  type        %LIStyle;      #IMPLIED
+  value       %Number;       #IMPLIED
+  >
+
+<!-- definition lists - dt for term, dd for its definition -->
+
+<!ELEMENT dl (dt|dd)+>
+<!ATTLIST dl
+  %attrs;
+  compact     (compact)      #IMPLIED
+  >
+
+<!ELEMENT dt %Inline;>
+<!ATTLIST dt
+  %attrs;
+  >
+
+<!ELEMENT dd %Flow;>
+<!ATTLIST dd
+  %attrs;
+  >
+
+<!--=================== Address ==========================================-->
+
+<!-- information on author -->
+
+<!ELEMENT address (#PCDATA | %inline; | %misc.inline; | p)*>
+<!ATTLIST address
+  %attrs;
+  >
+
+<!--=================== Horizontal Rule ==================================-->
+
+<!ELEMENT hr EMPTY>
+<!ATTLIST hr
+  %attrs;
+  align       (left|center|right) #IMPLIED
+  noshade     (noshade)      #IMPLIED
+  size        %Pixels;       #IMPLIED
+  width       %Length;       #IMPLIED
+  >
+
+<!--=================== Preformatted Text ================================-->
+
+<!-- content is %Inline; excluding 
+        "img|object|applet|big|small|sub|sup|font|basefont" -->
+
+<!ELEMENT pre %pre.content;>
+<!ATTLIST pre
+  %attrs;
+  width       %Number;      #IMPLIED
+  xml:space   (preserve)    #FIXED 'preserve'
+  >
+
+<!--=================== Block-like Quotes ================================-->
+
+<!ELEMENT blockquote %Flow;>
+<!ATTLIST blockquote
+  %attrs;
+  cite        %URI;          #IMPLIED
+  >
+
+<!--=================== Text alignment ===================================-->
+
+<!-- center content -->
+<!ELEMENT center %Flow;>
+<!ATTLIST center
+  %attrs;
+  >
+
+<!--=================== Inserted/Deleted Text ============================-->
+
+
+<!--
+  ins/del are allowed in block and inline content, but its
+  inappropriate to include block content within an ins element
+  occurring in inline content.
+-->
+<!ELEMENT ins %Flow;>
+<!ATTLIST ins
+  %attrs;
+  cite        %URI;          #IMPLIED
+  datetime    %Datetime;     #IMPLIED
+  >
+
+<!ELEMENT del %Flow;>
+<!ATTLIST del
+  %attrs;
+  cite        %URI;          #IMPLIED
+  datetime    %Datetime;     #IMPLIED
+  >
+
+<!--================== The Anchor Element ================================-->
+
+<!-- content is %Inline; except that anchors shouldn't be nested -->
+
+<!ELEMENT a %a.content;>
+<!ATTLIST a
+  %attrs;
+  %focus;
+  charset     %Charset;      #IMPLIED
+  type        %ContentType;  #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  href        %URI;          #IMPLIED
+  hreflang    %LanguageCode; #IMPLIED
+  rel         %LinkTypes;    #IMPLIED
+  rev         %LinkTypes;    #IMPLIED
+  shape       %Shape;        "rect"
+  coords      %Coords;       #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!--===================== Inline Elements ================================-->
+
+<!ELEMENT span %Inline;> <!-- generic language/style container -->
+<!ATTLIST span
+  %attrs;
+  >
+
+<!ELEMENT bdo %Inline;>  <!-- I18N BiDi over-ride -->
+<!ATTLIST bdo
+  %coreattrs;
+  %events;
+  lang        %LanguageCode; #IMPLIED
+  xml:lang    %LanguageCode; #IMPLIED
+  dir         (ltr|rtl)      #REQUIRED
+  >
+
+<!ELEMENT br EMPTY>   <!-- forced line break -->
+<!ATTLIST br
+  %coreattrs;
+  clear       (left|all|right|none) "none"
+  >
+
+<!ELEMENT em %Inline;>   <!-- emphasis -->
+<!ATTLIST em %attrs;>
+
+<!ELEMENT strong %Inline;>   <!-- strong emphasis -->
+<!ATTLIST strong %attrs;>
+
+<!ELEMENT dfn %Inline;>   <!-- definitional -->
+<!ATTLIST dfn %attrs;>
+
+<!ELEMENT code %Inline;>   <!-- program code -->
+<!ATTLIST code %attrs;>
+
+<!ELEMENT samp %Inline;>   <!-- sample -->
+<!ATTLIST samp %attrs;>
+
+<!ELEMENT kbd %Inline;>  <!-- something user would type -->
+<!ATTLIST kbd %attrs;>
+
+<!ELEMENT var %Inline;>   <!-- variable -->
+<!ATTLIST var %attrs;>
+
+<!ELEMENT cite %Inline;>   <!-- citation -->
+<!ATTLIST cite %attrs;>
+
+<!ELEMENT abbr %Inline;>   <!-- abbreviation -->
+<!ATTLIST abbr %attrs;>
+
+<!ELEMENT acronym %Inline;>   <!-- acronym -->
+<!ATTLIST acronym %attrs;>
+
+<!ELEMENT q %Inline;>   <!-- inlined quote -->
+<!ATTLIST q
+  %attrs;
+  cite        %URI;          #IMPLIED
+  >
+
+<!ELEMENT sub %Inline;> <!-- subscript -->
+<!ATTLIST sub %attrs;>
+
+<!ELEMENT sup %Inline;> <!-- superscript -->
+<!ATTLIST sup %attrs;>
+
+<!ELEMENT tt %Inline;>   <!-- fixed pitch font -->
+<!ATTLIST tt %attrs;>
+
+<!ELEMENT i %Inline;>   <!-- italic font -->
+<!ATTLIST i %attrs;>
+
+<!ELEMENT b %Inline;>   <!-- bold font -->
+<!ATTLIST b %attrs;>
+
+<!ELEMENT big %Inline;>   <!-- bigger font -->
+<!ATTLIST big %attrs;>
+
+<!ELEMENT small %Inline;>   <!-- smaller font -->
+<!ATTLIST small %attrs;>
+
+<!ELEMENT u %Inline;>   <!-- underline -->
+<!ATTLIST u %attrs;>
+
+<!ELEMENT s %Inline;>   <!-- strike-through -->
+<!ATTLIST s %attrs;>
+
+<!ELEMENT strike %Inline;>   <!-- strike-through -->
+<!ATTLIST strike %attrs;>
+
+<!ELEMENT basefont EMPTY>  <!-- base font size -->
+<!ATTLIST basefont
+  id          ID             #IMPLIED
+  size        CDATA          #REQUIRED
+  color       %Color;        #IMPLIED
+  face        CDATA          #IMPLIED
+  >
+
+<!ELEMENT font %Inline;> <!-- local change to font -->
+<!ATTLIST font
+  %coreattrs;
+  %i18n;
+  size        CDATA          #IMPLIED
+  color       %Color;        #IMPLIED
+  face        CDATA          #IMPLIED
+  >
+
+<!--==================== Object ======================================-->
+<!--
+  object is used to embed objects as part of HTML pages.
+  param elements should precede other content. Parameters
+  can also be expressed as attribute/value pairs on the
+  object element itself when brevity is desired.
+-->
+
+<!ELEMENT object (#PCDATA | param | %block; | form |%inline; | %misc;)*>
+<!ATTLIST object
+  %attrs;
+  declare     (declare)      #IMPLIED
+  classid     %URI;          #IMPLIED
+  codebase    %URI;          #IMPLIED
+  data        %URI;          #IMPLIED
+  type        %ContentType;  #IMPLIED
+  codetype    %ContentType;  #IMPLIED
+  archive     %UriList;      #IMPLIED
+  standby     %Text;         #IMPLIED
+  height      %Length;       #IMPLIED
+  width       %Length;       #IMPLIED
+  usemap      %URI;          #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  align       %ImgAlign;     #IMPLIED
+  border      %Pixels;       #IMPLIED
+  hspace      %Pixels;       #IMPLIED
+  vspace      %Pixels;       #IMPLIED
+  >
+
+<!--
+  param is used to supply a named property value.
+  In XML it would seem natural to follow RDF and support an
+  abbreviated syntax where the param elements are replaced
+  by attribute value pairs on the object start tag.
+-->
+<!ELEMENT param EMPTY>
+<!ATTLIST param
+  id          ID             #IMPLIED
+  name        CDATA          #REQUIRED
+  value       CDATA          #IMPLIED
+  valuetype   (data|ref|object) "data"
+  type        %ContentType;  #IMPLIED
+  >
+
+<!--=================== Java applet ==================================-->
+<!--
+  One of code or object attributes must be present.
+  Place param elements before other content.
+-->
+<!ELEMENT applet (#PCDATA | param | %block; | form | %inline; | %misc;)*>
+<!ATTLIST applet
+  %coreattrs;
+  codebase    %URI;          #IMPLIED
+  archive     CDATA          #IMPLIED
+  code        CDATA          #IMPLIED
+  object      CDATA          #IMPLIED
+  alt         %Text;         #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  width       %Length;       #REQUIRED
+  height      %Length;       #REQUIRED
+  align       %ImgAlign;     #IMPLIED
+  hspace      %Pixels;       #IMPLIED
+  vspace      %Pixels;       #IMPLIED
+  >
+
+<!--=================== Images ===========================================-->
+
+<!--
+   To avoid accessibility problems for people who aren't
+   able to see the image, you should provide a text
+   description using the alt and longdesc attributes.
+   In addition, avoid the use of server-side image maps.
+-->
+
+<!ELEMENT img EMPTY>
+<!ATTLIST img
+  %attrs;
+  src         %URI;          #REQUIRED
+  alt         %Text;         #REQUIRED
+  name        NMTOKEN        #IMPLIED
+  longdesc    %URI;          #IMPLIED
+  height      %Length;       #IMPLIED
+  width       %Length;       #IMPLIED
+  usemap      %URI;          #IMPLIED
+  ismap       (ismap)        #IMPLIED
+  align       %ImgAlign;     #IMPLIED
+  border      %Pixels;       #IMPLIED
+  hspace      %Pixels;       #IMPLIED
+  vspace      %Pixels;       #IMPLIED
+  >
+
+<!-- usemap points to a map element which may be in this document
+  or an external document, although the latter is not widely supported -->
+
+<!--================== Client-side image maps ============================-->
+
+<!-- These can be placed in the same document or grouped in a
+     separate document although this isn't yet widely supported -->
+
+<!ELEMENT map ((%block; | form | %misc;)+ | area+)>
+<!ATTLIST map
+  %i18n;
+  %events;
+  id          ID             #REQUIRED
+  class       CDATA          #IMPLIED
+  style       %StyleSheet;   #IMPLIED
+  title       %Text;         #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  >
+
+<!ELEMENT area EMPTY>
+<!ATTLIST area
+  %attrs;
+  %focus;
+  shape       %Shape;        "rect"
+  coords      %Coords;       #IMPLIED
+  href        %URI;          #IMPLIED
+  nohref      (nohref)       #IMPLIED
+  alt         %Text;         #REQUIRED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!--================ Forms ===============================================-->
+
+<!ELEMENT form %form.content;>   <!-- forms shouldn't be nested -->
+
+<!ATTLIST form
+  %attrs;
+  action      %URI;          #REQUIRED
+  method      (get|post)     "get"
+  name        NMTOKEN        #IMPLIED
+  enctype     %ContentType;  "application/x-www-form-urlencoded"
+  onsubmit    %Script;       #IMPLIED
+  onreset     %Script;       #IMPLIED
+  accept      %ContentTypes; #IMPLIED
+  accept-charset %Charsets;  #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!--
+  Each label must not contain more than ONE field
+  Label elements shouldn't be nested.
+-->
+<!ELEMENT label %Inline;>
+<!ATTLIST label
+  %attrs;
+  for         IDREF          #IMPLIED
+  accesskey   %Character;    #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED
+  >
+
+<!ENTITY % InputType
+  "(text | password | checkbox |
+    radio | submit | reset |
+    file | hidden | image | button)"
+   >
+
+<!-- the name attribute is required for all but submit & reset -->
+
+<!ELEMENT input EMPTY>     <!-- form control -->
+<!ATTLIST input
+  %attrs;
+  %focus;
+  type        %InputType;    "text"
+  name        CDATA          #IMPLIED
+  value       CDATA          #IMPLIED
+  checked     (checked)      #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  readonly    (readonly)     #IMPLIED
+  size        CDATA          #IMPLIED
+  maxlength   %Number;       #IMPLIED
+  src         %URI;          #IMPLIED
+  alt         CDATA          #IMPLIED
+  usemap      %URI;          #IMPLIED
+  onselect    %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  accept      %ContentTypes; #IMPLIED
+  align       %ImgAlign;     #IMPLIED
+  >
+
+<!ELEMENT select (optgroup|option)+>  <!-- option selector -->
+<!ATTLIST select
+  %attrs;
+  name        CDATA          #IMPLIED
+  size        %Number;       #IMPLIED
+  multiple    (multiple)     #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  >
+
+<!ELEMENT optgroup (option)+>   <!-- option group -->
+<!ATTLIST optgroup
+  %attrs;
+  disabled    (disabled)     #IMPLIED
+  label       %Text;         #REQUIRED
+  >
+
+<!ELEMENT option (#PCDATA)>     <!-- selectable choice -->
+<!ATTLIST option
+  %attrs;
+  selected    (selected)     #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  label       %Text;         #IMPLIED
+  value       CDATA          #IMPLIED
+  >
+
+<!ELEMENT textarea (#PCDATA)>     <!-- multi-line text field -->
+<!ATTLIST textarea
+  %attrs;
+  %focus;
+  name        CDATA          #IMPLIED
+  rows        %Number;       #REQUIRED
+  cols        %Number;       #REQUIRED
+  disabled    (disabled)     #IMPLIED
+  readonly    (readonly)     #IMPLIED
+  onselect    %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  >
+
+<!--
+  The fieldset element is used to group form fields.
+  Only one legend element should occur in the content
+  and if present should only be preceded by whitespace.
+-->
+<!ELEMENT fieldset (#PCDATA | legend | %block; | form | %inline; | %misc;)*>
+<!ATTLIST fieldset
+  %attrs;
+  >
+
+<!ENTITY % LAlign "(top|bottom|left|right)">
+
+<!ELEMENT legend %Inline;>     <!-- fieldset label -->
+<!ATTLIST legend
+  %attrs;
+  accesskey   %Character;    #IMPLIED
+  align       %LAlign;       #IMPLIED
+  >
+
+<!--
+ Content is %Flow; excluding a, form, form controls, iframe
+--> 
+<!ELEMENT button %button.content;>  <!-- push button -->
+<!ATTLIST button
+  %attrs;
+  %focus;
+  name        CDATA          #IMPLIED
+  value       CDATA          #IMPLIED
+  type        (button|submit|reset) "submit"
+  disabled    (disabled)     #IMPLIED
+  >
+
+<!-- single-line text input control (DEPRECATED) -->
+<!ELEMENT isindex EMPTY>
+<!ATTLIST isindex
+  %coreattrs;
+  %i18n;
+  prompt      %Text;         #IMPLIED
+  >
+
+<!--======================= Tables =======================================-->
+
+<!-- Derived from IETF HTML table standard, see [RFC1942] -->
+
+<!--
+ The border attribute sets the thickness of the frame around the
+ table. The default units are screen pixels.
+
+ The frame attribute specifies which parts of the frame around
+ the table should be rendered. The values are not the same as
+ CALS to avoid a name clash with the valign attribute.
+-->
+<!ENTITY % TFrame "(void|above|below|hsides|lhs|rhs|vsides|box|border)">
+
+<!--
+ The rules attribute defines which rules to draw between cells:
+
+ If rules is absent then assume:
+     "none" if border is absent or border="0" otherwise "all"
+-->
+
+<!ENTITY % TRules "(none | groups | rows | cols | all)">
+  
+<!-- horizontal placement of table relative to document -->
+<!ENTITY % TAlign "(left|center|right)">
+
+<!-- horizontal alignment attributes for cell contents
+
+  char        alignment char, e.g. char=":"
+  charoff     offset for alignment char
+-->
+<!ENTITY % cellhalign
+  "align      (left|center|right|justify|char) #IMPLIED
+   char       %Character;    #IMPLIED
+   charoff    %Length;       #IMPLIED"
+  >
+
+<!-- vertical alignment attributes for cell contents -->
+<!ENTITY % cellvalign
+  "valign     (top|middle|bottom|baseline) #IMPLIED"
+  >
+
+<!ELEMENT table
+     (caption?, (col*|colgroup*), thead?, tfoot?, (tbody+|tr+))>
+<!ELEMENT caption  %Inline;>
+<!ELEMENT thead    (tr)+>
+<!ELEMENT tfoot    (tr)+>
+<!ELEMENT tbody    (tr)+>
+<!ELEMENT colgroup (col)*>
+<!ELEMENT col      EMPTY>
+<!ELEMENT tr       (th|td)+>
+<!ELEMENT th       %Flow;>
+<!ELEMENT td       %Flow;>
+
+<!ATTLIST table
+  %attrs;
+  summary     %Text;         #IMPLIED
+  width       %Length;       #IMPLIED
+  border      %Pixels;       #IMPLIED
+  frame       %TFrame;       #IMPLIED
+  rules       %TRules;       #IMPLIED
+  cellspacing %Length;       #IMPLIED
+  cellpadding %Length;       #IMPLIED
+  align       %TAlign;       #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  >
+
+<!ENTITY % CAlign "(top|bottom|left|right)">
+
+<!ATTLIST caption
+  %attrs;
+  align       %CAlign;       #IMPLIED
+  >
+
+<!--
+colgroup groups a set of col elements. It allows you to group
+several semantically related columns together.
+-->
+<!ATTLIST colgroup
+  %attrs;
+  span        %Number;       "1"
+  width       %MultiLength;  #IMPLIED
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!--
+ col elements define the alignment properties for cells in
+ one or more columns.
+
+ The width attribute specifies the width of the columns, e.g.
+
+     width=64        width in screen pixels
+     width=0.5*      relative width of 0.5
+
+ The span attribute causes the attributes of one
+ col element to apply to more than one column.
+-->
+<!ATTLIST col
+  %attrs;
+  span        %Number;       "1"
+  width       %MultiLength;  #IMPLIED
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!--
+    Use thead to duplicate headers when breaking table
+    across page boundaries, or for static headers when
+    tbody sections are rendered in scrolling panel.
+
+    Use tfoot to duplicate footers when breaking table
+    across page boundaries, or for static footers when
+    tbody sections are rendered in scrolling panel.
+
+    Use multiple tbody sections when rules are needed
+    between groups of table rows.
+-->
+<!ATTLIST thead
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tfoot
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tbody
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tr
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  bgcolor     %Color;        #IMPLIED
+  >
+
+<!-- Scope is simpler than headers attribute for common tables -->
+<!ENTITY % Scope "(row|col|rowgroup|colgroup)">
+
+<!-- th is for headers, td for data and for cells acting as both -->
+
+<!ATTLIST th
+  %attrs;
+  abbr        %Text;         #IMPLIED
+  axis        CDATA          #IMPLIED
+  headers     IDREFS         #IMPLIED
+  scope       %Scope;        #IMPLIED
+  rowspan     %Number;       "1"
+  colspan     %Number;       "1"
+  %cellhalign;
+  %cellvalign;
+  nowrap      (nowrap)       #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  width       %Pixels;       #IMPLIED
+  height      %Pixels;       #IMPLIED
+  >
+
+<!ATTLIST td
+  %attrs;
+  abbr        %Text;         #IMPLIED
+  axis        CDATA          #IMPLIED
+  headers     IDREFS         #IMPLIED
+  scope       %Scope;        #IMPLIED
+  rowspan     %Number;       "1"
+  colspan     %Number;       "1"
+  %cellhalign;
+  %cellvalign;
+  nowrap      (nowrap)       #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  width       %Pixels;       #IMPLIED
+  height      %Pixels;       #IMPLIED
+  >
+

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml1-strict.dtd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml1-strict.dtd
@@ -1,0 +1,978 @@
+<!--
+   Extensible HTML version 1.0 Strict DTD
+
+   This is the same as HTML 4 Strict except for
+   changes due to the differences between XML and SGML.
+
+   Namespace = http://www.w3.org/1999/xhtml
+
+   For further information, see: http://www.w3.org/TR/xhtml1
+
+   Copyright (c) 1998-2002 W3C (MIT, INRIA, Keio),
+   All Rights Reserved. 
+
+   This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+   PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+   SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
+
+   $Revision: 1.24 $
+   $Date: 2002/07/31 19:34:51 $
+
+-->
+
+<!--================ Character mnemonic entities =========================-->
+
+<!ENTITY % HTMLlat1 PUBLIC
+   "-//W3C//ENTITIES Latin 1 for XHTML//EN"
+   "xhtml-lat1.ent">
+%HTMLlat1;
+
+<!ENTITY % HTMLsymbol PUBLIC
+   "-//W3C//ENTITIES Symbols for XHTML//EN"
+   "xhtml-symbol.ent">
+%HTMLsymbol;
+
+<!ENTITY % HTMLspecial PUBLIC
+   "-//W3C//ENTITIES Special for XHTML//EN"
+   "xhtml-special.ent">
+%HTMLspecial;
+
+<!--================== Imported Names ====================================-->
+
+<!ENTITY % ContentType "CDATA">
+    <!-- media type, as per [RFC2045] -->
+
+<!ENTITY % ContentTypes "CDATA">
+    <!-- comma-separated list of media types, as per [RFC2045] -->
+
+<!ENTITY % Charset "CDATA">
+    <!-- a character encoding, as per [RFC2045] -->
+
+<!ENTITY % Charsets "CDATA">
+    <!-- a space separated list of character encodings, as per [RFC2045] -->
+
+<!ENTITY % LanguageCode "NMTOKEN">
+    <!-- a language code, as per [RFC3066] -->
+
+<!ENTITY % Character "CDATA">
+    <!-- a single character, as per section 2.2 of [XML] -->
+
+<!ENTITY % Number "CDATA">
+    <!-- one or more digits -->
+
+<!ENTITY % LinkTypes "CDATA">
+    <!-- space-separated list of link types -->
+
+<!ENTITY % MediaDesc "CDATA">
+    <!-- single or comma-separated list of media descriptors -->
+
+<!ENTITY % URI "CDATA">
+    <!-- a Uniform Resource Identifier, see [RFC2396] -->
+
+<!ENTITY % UriList "CDATA">
+    <!-- a space separated list of Uniform Resource Identifiers -->
+
+<!ENTITY % Datetime "CDATA">
+    <!-- date and time information. ISO date format -->
+
+<!ENTITY % Script "CDATA">
+    <!-- script expression -->
+
+<!ENTITY % StyleSheet "CDATA">
+    <!-- style sheet data -->
+
+<!ENTITY % Text "CDATA">
+    <!-- used for titles etc. -->
+
+<!ENTITY % Length "CDATA">
+    <!-- nn for pixels or nn% for percentage length -->
+
+<!ENTITY % MultiLength "CDATA">
+    <!-- pixel, percentage, or relative -->
+
+<!ENTITY % Pixels "CDATA">
+    <!-- integer representing length in pixels -->
+
+<!-- these are used for image maps -->
+
+<!ENTITY % Shape "(rect|circle|poly|default)">
+
+<!ENTITY % Coords "CDATA">
+    <!-- comma separated list of lengths -->
+
+<!--=================== Generic Attributes ===============================-->
+
+<!-- core attributes common to most elements
+  id       document-wide unique id
+  class    space separated list of classes
+  style    associated style info
+  title    advisory title/amplification
+-->
+<!ENTITY % coreattrs
+ "id          ID             #IMPLIED
+  class       CDATA          #IMPLIED
+  style       %StyleSheet;   #IMPLIED
+  title       %Text;         #IMPLIED"
+  >
+
+<!-- internationalization attributes
+  lang        language code (backwards compatible)
+  xml:lang    language code (as per XML 1.0 spec)
+  dir         direction for weak/neutral text
+-->
+<!ENTITY % i18n
+ "lang        %LanguageCode; #IMPLIED
+  xml:lang    %LanguageCode; #IMPLIED
+  dir         (ltr|rtl)      #IMPLIED"
+  >
+
+<!-- attributes for common UI events
+  onclick     a pointer button was clicked
+  ondblclick  a pointer button was double clicked
+  onmousedown a pointer button was pressed down
+  onmouseup   a pointer button was released
+  onmousemove a pointer was moved onto the element
+  onmouseout  a pointer was moved away from the element
+  onkeypress  a key was pressed and released
+  onkeydown   a key was pressed down
+  onkeyup     a key was released
+-->
+<!ENTITY % events
+ "onclick     %Script;       #IMPLIED
+  ondblclick  %Script;       #IMPLIED
+  onmousedown %Script;       #IMPLIED
+  onmouseup   %Script;       #IMPLIED
+  onmouseover %Script;       #IMPLIED
+  onmousemove %Script;       #IMPLIED
+  onmouseout  %Script;       #IMPLIED
+  onkeypress  %Script;       #IMPLIED
+  onkeydown   %Script;       #IMPLIED
+  onkeyup     %Script;       #IMPLIED"
+  >
+
+<!-- attributes for elements that can get the focus
+  accesskey   accessibility key character
+  tabindex    position in tabbing order
+  onfocus     the element got the focus
+  onblur      the element lost the focus
+-->
+<!ENTITY % focus
+ "accesskey   %Character;    #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED"
+  >
+
+<!ENTITY % attrs "%coreattrs; %i18n; %events;">
+
+<!--=================== Text Elements ====================================-->
+
+<!ENTITY % special.pre
+   "br | span | bdo | map">
+
+
+<!ENTITY % special
+   "%special.pre; | object | img ">
+
+<!ENTITY % fontstyle "tt | i | b | big | small ">
+
+<!ENTITY % phrase "em | strong | dfn | code | q |
+                   samp | kbd | var | cite | abbr | acronym | sub | sup ">
+
+<!ENTITY % inline.forms "input | select | textarea | label | button">
+
+<!-- these can occur at block or inline level -->
+<!ENTITY % misc.inline "ins | del | script">
+
+<!-- these can only occur at block level -->
+<!ENTITY % misc "noscript | %misc.inline;">
+
+<!ENTITY % inline "a | %special; | %fontstyle; | %phrase; | %inline.forms;">
+
+<!-- %Inline; covers inline or "text-level" elements -->
+<!ENTITY % Inline "(#PCDATA | %inline; | %misc.inline;)*">
+
+<!--================== Block level elements ==============================-->
+
+<!ENTITY % heading "h1|h2|h3|h4|h5|h6">
+<!ENTITY % lists "ul | ol | dl">
+<!ENTITY % blocktext "pre | hr | blockquote | address">
+
+<!ENTITY % block
+     "p | %heading; | div | %lists; | %blocktext; | fieldset | table">
+
+<!ENTITY % Block "(%block; | form | %misc;)*">
+
+<!-- %Flow; mixes block and inline and is used for list items etc. -->
+<!ENTITY % Flow "(#PCDATA | %block; | form | %inline; | %misc;)*">
+
+<!--================== Content models for exclusions =====================-->
+
+<!-- a elements use %Inline; excluding a -->
+
+<!ENTITY % a.content
+   "(#PCDATA | %special; | %fontstyle; | %phrase; | %inline.forms; | %misc.inline;)*">
+
+<!-- pre uses %Inline excluding big, small, sup or sup -->
+
+<!ENTITY % pre.content
+   "(#PCDATA | a | %fontstyle; | %phrase; | %special.pre; | %misc.inline;
+      | %inline.forms;)*">
+
+<!-- form uses %Block; excluding form -->
+
+<!ENTITY % form.content "(%block; | %misc;)*">
+
+<!-- button uses %Flow; but excludes a, form and form controls -->
+
+<!ENTITY % button.content
+   "(#PCDATA | p | %heading; | div | %lists; | %blocktext; |
+    table | %special; | %fontstyle; | %phrase; | %misc;)*">
+
+<!--================ Document Structure ==================================-->
+
+<!-- the namespace URI designates the document profile -->
+
+<!ELEMENT html (head, body)>
+<!ATTLIST html
+  %i18n;
+  id          ID             #IMPLIED
+  xmlns       %URI;          #FIXED 'http://www.w3.org/1999/xhtml'
+  >
+
+<!--================ Document Head =======================================-->
+
+<!ENTITY % head.misc "(script|style|meta|link|object)*">
+
+<!-- content model is %head.misc; combined with a single
+     title and an optional base element in any order -->
+
+<!ELEMENT head (%head.misc;,
+     ((title, %head.misc;, (base, %head.misc;)?) |
+      (base, %head.misc;, (title, %head.misc;))))>
+
+<!ATTLIST head
+  %i18n;
+  id          ID             #IMPLIED
+  profile     %URI;          #IMPLIED
+  >
+
+<!-- The title element is not considered part of the flow of text.
+       It should be displayed, for example as the page header or
+       window title. Exactly one title is required per document.
+    -->
+<!ELEMENT title (#PCDATA)>
+<!ATTLIST title 
+  %i18n;
+  id          ID             #IMPLIED
+  >
+
+<!-- document base URI -->
+
+<!ELEMENT base EMPTY>
+<!ATTLIST base
+  href        %URI;          #REQUIRED
+  id          ID             #IMPLIED
+  >
+
+<!-- generic metainformation -->
+<!ELEMENT meta EMPTY>
+<!ATTLIST meta
+  %i18n;
+  id          ID             #IMPLIED
+  http-equiv  CDATA          #IMPLIED
+  name        CDATA          #IMPLIED
+  content     CDATA          #REQUIRED
+  scheme      CDATA          #IMPLIED
+  >
+
+<!--
+  Relationship values can be used in principle:
+
+   a) for document specific toolbars/menus when used
+      with the link element in document head e.g.
+        start, contents, previous, next, index, end, help
+   b) to link to a separate style sheet (rel="stylesheet")
+   c) to make a link to a script (rel="script")
+   d) by stylesheets to control how collections of
+      html nodes are rendered into printed documents
+   e) to make a link to a printable version of this document
+      e.g. a PostScript or PDF version (rel="alternate" media="print")
+-->
+
+<!ELEMENT link EMPTY>
+<!ATTLIST link
+  %attrs;
+  charset     %Charset;      #IMPLIED
+  href        %URI;          #IMPLIED
+  hreflang    %LanguageCode; #IMPLIED
+  type        %ContentType;  #IMPLIED
+  rel         %LinkTypes;    #IMPLIED
+  rev         %LinkTypes;    #IMPLIED
+  media       %MediaDesc;    #IMPLIED
+  >
+
+<!-- style info, which may include CDATA sections -->
+<!ELEMENT style (#PCDATA)>
+<!ATTLIST style
+  %i18n;
+  id          ID             #IMPLIED
+  type        %ContentType;  #REQUIRED
+  media       %MediaDesc;    #IMPLIED
+  title       %Text;         #IMPLIED
+  xml:space   (preserve)     #FIXED 'preserve'
+  >
+
+<!-- script statements, which may include CDATA sections -->
+<!ELEMENT script (#PCDATA)>
+<!ATTLIST script
+  id          ID             #IMPLIED
+  charset     %Charset;      #IMPLIED
+  type        %ContentType;  #REQUIRED
+  src         %URI;          #IMPLIED
+  defer       (defer)        #IMPLIED
+  xml:space   (preserve)     #FIXED 'preserve'
+  >
+
+<!-- alternate content container for non script-based rendering -->
+
+<!ELEMENT noscript %Block;>
+<!ATTLIST noscript
+  %attrs;
+  >
+
+<!--=================== Document Body ====================================-->
+
+<!ELEMENT body %Block;>
+<!ATTLIST body
+  %attrs;
+  onload          %Script;   #IMPLIED
+  onunload        %Script;   #IMPLIED
+  >
+
+<!ELEMENT div %Flow;>  <!-- generic language/style container -->
+<!ATTLIST div
+  %attrs;
+  >
+
+<!--=================== Paragraphs =======================================-->
+
+<!ELEMENT p %Inline;>
+<!ATTLIST p
+  %attrs;
+  >
+
+<!--=================== Headings =========================================-->
+
+<!--
+  There are six levels of headings from h1 (the most important)
+  to h6 (the least important).
+-->
+
+<!ELEMENT h1  %Inline;>
+<!ATTLIST h1
+   %attrs;
+   >
+
+<!ELEMENT h2 %Inline;>
+<!ATTLIST h2
+   %attrs;
+   >
+
+<!ELEMENT h3 %Inline;>
+<!ATTLIST h3
+   %attrs;
+   >
+
+<!ELEMENT h4 %Inline;>
+<!ATTLIST h4
+   %attrs;
+   >
+
+<!ELEMENT h5 %Inline;>
+<!ATTLIST h5
+   %attrs;
+   >
+
+<!ELEMENT h6 %Inline;>
+<!ATTLIST h6
+   %attrs;
+   >
+
+<!--=================== Lists ============================================-->
+
+<!-- Unordered list -->
+
+<!ELEMENT ul (li)+>
+<!ATTLIST ul
+  %attrs;
+  >
+
+<!-- Ordered (numbered) list -->
+
+<!ELEMENT ol (li)+>
+<!ATTLIST ol
+  %attrs;
+  >
+
+<!-- list item -->
+
+<!ELEMENT li %Flow;>
+<!ATTLIST li
+  %attrs;
+  >
+
+<!-- definition lists - dt for term, dd for its definition -->
+
+<!ELEMENT dl (dt|dd)+>
+<!ATTLIST dl
+  %attrs;
+  >
+
+<!ELEMENT dt %Inline;>
+<!ATTLIST dt
+  %attrs;
+  >
+
+<!ELEMENT dd %Flow;>
+<!ATTLIST dd
+  %attrs;
+  >
+
+<!--=================== Address ==========================================-->
+
+<!-- information on author -->
+
+<!ELEMENT address %Inline;>
+<!ATTLIST address
+  %attrs;
+  >
+
+<!--=================== Horizontal Rule ==================================-->
+
+<!ELEMENT hr EMPTY>
+<!ATTLIST hr
+  %attrs;
+  >
+
+<!--=================== Preformatted Text ================================-->
+
+<!-- content is %Inline; excluding "img|object|big|small|sub|sup" -->
+
+<!ELEMENT pre %pre.content;>
+<!ATTLIST pre
+  %attrs;
+  xml:space (preserve) #FIXED 'preserve'
+  >
+
+<!--=================== Block-like Quotes ================================-->
+
+<!ELEMENT blockquote %Block;>
+<!ATTLIST blockquote
+  %attrs;
+  cite        %URI;          #IMPLIED
+  >
+
+<!--=================== Inserted/Deleted Text ============================-->
+
+<!--
+  ins/del are allowed in block and inline content, but its
+  inappropriate to include block content within an ins element
+  occurring in inline content.
+-->
+<!ELEMENT ins %Flow;>
+<!ATTLIST ins
+  %attrs;
+  cite        %URI;          #IMPLIED
+  datetime    %Datetime;     #IMPLIED
+  >
+
+<!ELEMENT del %Flow;>
+<!ATTLIST del
+  %attrs;
+  cite        %URI;          #IMPLIED
+  datetime    %Datetime;     #IMPLIED
+  >
+
+<!--================== The Anchor Element ================================-->
+
+<!-- content is %Inline; except that anchors shouldn't be nested -->
+
+<!ELEMENT a %a.content;>
+<!ATTLIST a
+  %attrs;
+  %focus;
+  charset     %Charset;      #IMPLIED
+  type        %ContentType;  #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  href        %URI;          #IMPLIED
+  hreflang    %LanguageCode; #IMPLIED
+  rel         %LinkTypes;    #IMPLIED
+  rev         %LinkTypes;    #IMPLIED
+  shape       %Shape;        "rect"
+  coords      %Coords;       #IMPLIED
+  >
+
+<!--===================== Inline Elements ================================-->
+
+<!ELEMENT span %Inline;> <!-- generic language/style container -->
+<!ATTLIST span
+  %attrs;
+  >
+
+<!ELEMENT bdo %Inline;>  <!-- I18N BiDi over-ride -->
+<!ATTLIST bdo
+  %coreattrs;
+  %events;
+  lang        %LanguageCode; #IMPLIED
+  xml:lang    %LanguageCode; #IMPLIED
+  dir         (ltr|rtl)      #REQUIRED
+  >
+
+<!ELEMENT br EMPTY>   <!-- forced line break -->
+<!ATTLIST br
+  %coreattrs;
+  >
+
+<!ELEMENT em %Inline;>   <!-- emphasis -->
+<!ATTLIST em %attrs;>
+
+<!ELEMENT strong %Inline;>   <!-- strong emphasis -->
+<!ATTLIST strong %attrs;>
+
+<!ELEMENT dfn %Inline;>   <!-- definitional -->
+<!ATTLIST dfn %attrs;>
+
+<!ELEMENT code %Inline;>   <!-- program code -->
+<!ATTLIST code %attrs;>
+
+<!ELEMENT samp %Inline;>   <!-- sample -->
+<!ATTLIST samp %attrs;>
+
+<!ELEMENT kbd %Inline;>  <!-- something user would type -->
+<!ATTLIST kbd %attrs;>
+
+<!ELEMENT var %Inline;>   <!-- variable -->
+<!ATTLIST var %attrs;>
+
+<!ELEMENT cite %Inline;>   <!-- citation -->
+<!ATTLIST cite %attrs;>
+
+<!ELEMENT abbr %Inline;>   <!-- abbreviation -->
+<!ATTLIST abbr %attrs;>
+
+<!ELEMENT acronym %Inline;>   <!-- acronym -->
+<!ATTLIST acronym %attrs;>
+
+<!ELEMENT q %Inline;>   <!-- inlined quote -->
+<!ATTLIST q
+  %attrs;
+  cite        %URI;          #IMPLIED
+  >
+
+<!ELEMENT sub %Inline;> <!-- subscript -->
+<!ATTLIST sub %attrs;>
+
+<!ELEMENT sup %Inline;> <!-- superscript -->
+<!ATTLIST sup %attrs;>
+
+<!ELEMENT tt %Inline;>   <!-- fixed pitch font -->
+<!ATTLIST tt %attrs;>
+
+<!ELEMENT i %Inline;>   <!-- italic font -->
+<!ATTLIST i %attrs;>
+
+<!ELEMENT b %Inline;>   <!-- bold font -->
+<!ATTLIST b %attrs;>
+
+<!ELEMENT big %Inline;>   <!-- bigger font -->
+<!ATTLIST big %attrs;>
+
+<!ELEMENT small %Inline;>   <!-- smaller font -->
+<!ATTLIST small %attrs;>
+
+<!--==================== Object ======================================-->
+<!--
+  object is used to embed objects as part of HTML pages.
+  param elements should precede other content. Parameters
+  can also be expressed as attribute/value pairs on the
+  object element itself when brevity is desired.
+-->
+
+<!ELEMENT object (#PCDATA | param | %block; | form | %inline; | %misc;)*>
+<!ATTLIST object
+  %attrs;
+  declare     (declare)      #IMPLIED
+  classid     %URI;          #IMPLIED
+  codebase    %URI;          #IMPLIED
+  data        %URI;          #IMPLIED
+  type        %ContentType;  #IMPLIED
+  codetype    %ContentType;  #IMPLIED
+  archive     %UriList;      #IMPLIED
+  standby     %Text;         #IMPLIED
+  height      %Length;       #IMPLIED
+  width       %Length;       #IMPLIED
+  usemap      %URI;          #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  >
+
+<!--
+  param is used to supply a named property value.
+  In XML it would seem natural to follow RDF and support an
+  abbreviated syntax where the param elements are replaced
+  by attribute value pairs on the object start tag.
+-->
+<!ELEMENT param EMPTY>
+<!ATTLIST param
+  id          ID             #IMPLIED
+  name        CDATA          #IMPLIED
+  value       CDATA          #IMPLIED
+  valuetype   (data|ref|object) "data"
+  type        %ContentType;  #IMPLIED
+  >
+
+<!--=================== Images ===========================================-->
+
+<!--
+   To avoid accessibility problems for people who aren't
+   able to see the image, you should provide a text
+   description using the alt and longdesc attributes.
+   In addition, avoid the use of server-side image maps.
+   Note that in this DTD there is no name attribute. That
+   is only available in the transitional and frameset DTD.
+-->
+
+<!ELEMENT img EMPTY>
+<!ATTLIST img
+  %attrs;
+  src         %URI;          #REQUIRED
+  alt         %Text;         #REQUIRED
+  longdesc    %URI;          #IMPLIED
+  height      %Length;       #IMPLIED
+  width       %Length;       #IMPLIED
+  usemap      %URI;          #IMPLIED
+  ismap       (ismap)        #IMPLIED
+  >
+
+<!-- usemap points to a map element which may be in this document
+  or an external document, although the latter is not widely supported -->
+
+<!--================== Client-side image maps ============================-->
+
+<!-- These can be placed in the same document or grouped in a
+     separate document although this isn't yet widely supported -->
+
+<!ELEMENT map ((%block; | form | %misc;)+ | area+)>
+<!ATTLIST map
+  %i18n;
+  %events;
+  id          ID             #REQUIRED
+  class       CDATA          #IMPLIED
+  style       %StyleSheet;   #IMPLIED
+  title       %Text;         #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  >
+
+<!ELEMENT area EMPTY>
+<!ATTLIST area
+  %attrs;
+  %focus;
+  shape       %Shape;        "rect"
+  coords      %Coords;       #IMPLIED
+  href        %URI;          #IMPLIED
+  nohref      (nohref)       #IMPLIED
+  alt         %Text;         #REQUIRED
+  >
+
+<!--================ Forms ===============================================-->
+<!ELEMENT form %form.content;>   <!-- forms shouldn't be nested -->
+
+<!ATTLIST form
+  %attrs;
+  action      %URI;          #REQUIRED
+  method      (get|post)     "get"
+  enctype     %ContentType;  "application/x-www-form-urlencoded"
+  onsubmit    %Script;       #IMPLIED
+  onreset     %Script;       #IMPLIED
+  accept      %ContentTypes; #IMPLIED
+  accept-charset %Charsets;  #IMPLIED
+  >
+
+<!--
+  Each label must not contain more than ONE field
+  Label elements shouldn't be nested.
+-->
+<!ELEMENT label %Inline;>
+<!ATTLIST label
+  %attrs;
+  for         IDREF          #IMPLIED
+  accesskey   %Character;    #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED
+  >
+
+<!ENTITY % InputType
+  "(text | password | checkbox |
+    radio | submit | reset |
+    file | hidden | image | button)"
+   >
+
+<!-- the name attribute is required for all but submit & reset -->
+
+<!ELEMENT input EMPTY>     <!-- form control -->
+<!ATTLIST input
+  %attrs;
+  %focus;
+  type        %InputType;    "text"
+  name        CDATA          #IMPLIED
+  value       CDATA          #IMPLIED
+  checked     (checked)      #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  readonly    (readonly)     #IMPLIED
+  size        CDATA          #IMPLIED
+  maxlength   %Number;       #IMPLIED
+  src         %URI;          #IMPLIED
+  alt         CDATA          #IMPLIED
+  usemap      %URI;          #IMPLIED
+  onselect    %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  accept      %ContentTypes; #IMPLIED
+  >
+
+<!ELEMENT select (optgroup|option)+>  <!-- option selector -->
+<!ATTLIST select
+  %attrs;
+  name        CDATA          #IMPLIED
+  size        %Number;       #IMPLIED
+  multiple    (multiple)     #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  >
+
+<!ELEMENT optgroup (option)+>   <!-- option group -->
+<!ATTLIST optgroup
+  %attrs;
+  disabled    (disabled)     #IMPLIED
+  label       %Text;         #REQUIRED
+  >
+
+<!ELEMENT option (#PCDATA)>     <!-- selectable choice -->
+<!ATTLIST option
+  %attrs;
+  selected    (selected)     #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  label       %Text;         #IMPLIED
+  value       CDATA          #IMPLIED
+  >
+
+<!ELEMENT textarea (#PCDATA)>     <!-- multi-line text field -->
+<!ATTLIST textarea
+  %attrs;
+  %focus;
+  name        CDATA          #IMPLIED
+  rows        %Number;       #REQUIRED
+  cols        %Number;       #REQUIRED
+  disabled    (disabled)     #IMPLIED
+  readonly    (readonly)     #IMPLIED
+  onselect    %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  >
+
+<!--
+  The fieldset element is used to group form fields.
+  Only one legend element should occur in the content
+  and if present should only be preceded by whitespace.
+-->
+<!ELEMENT fieldset (#PCDATA | legend | %block; | form | %inline; | %misc;)*>
+<!ATTLIST fieldset
+  %attrs;
+  >
+
+<!ELEMENT legend %Inline;>     <!-- fieldset label -->
+<!ATTLIST legend
+  %attrs;
+  accesskey   %Character;    #IMPLIED
+  >
+
+<!--
+ Content is %Flow; excluding a, form and form controls
+--> 
+<!ELEMENT button %button.content;>  <!-- push button -->
+<!ATTLIST button
+  %attrs;
+  %focus;
+  name        CDATA          #IMPLIED
+  value       CDATA          #IMPLIED
+  type        (button|submit|reset) "submit"
+  disabled    (disabled)     #IMPLIED
+  >
+
+<!--======================= Tables =======================================-->
+
+<!-- Derived from IETF HTML table standard, see [RFC1942] -->
+
+<!--
+ The border attribute sets the thickness of the frame around the
+ table. The default units are screen pixels.
+
+ The frame attribute specifies which parts of the frame around
+ the table should be rendered. The values are not the same as
+ CALS to avoid a name clash with the valign attribute.
+-->
+<!ENTITY % TFrame "(void|above|below|hsides|lhs|rhs|vsides|box|border)">
+
+<!--
+ The rules attribute defines which rules to draw between cells:
+
+ If rules is absent then assume:
+     "none" if border is absent or border="0" otherwise "all"
+-->
+
+<!ENTITY % TRules "(none | groups | rows | cols | all)">
+  
+<!-- horizontal alignment attributes for cell contents
+
+  char        alignment char, e.g. char=':'
+  charoff     offset for alignment char
+-->
+<!ENTITY % cellhalign
+  "align      (left|center|right|justify|char) #IMPLIED
+   char       %Character;    #IMPLIED
+   charoff    %Length;       #IMPLIED"
+  >
+
+<!-- vertical alignment attributes for cell contents -->
+<!ENTITY % cellvalign
+  "valign     (top|middle|bottom|baseline) #IMPLIED"
+  >
+
+<!ELEMENT table
+     (caption?, (col*|colgroup*), thead?, tfoot?, (tbody+|tr+))>
+<!ELEMENT caption  %Inline;>
+<!ELEMENT thead    (tr)+>
+<!ELEMENT tfoot    (tr)+>
+<!ELEMENT tbody    (tr)+>
+<!ELEMENT colgroup (col)*>
+<!ELEMENT col      EMPTY>
+<!ELEMENT tr       (th|td)+>
+<!ELEMENT th       %Flow;>
+<!ELEMENT td       %Flow;>
+
+<!ATTLIST table
+  %attrs;
+  summary     %Text;         #IMPLIED
+  width       %Length;       #IMPLIED
+  border      %Pixels;       #IMPLIED
+  frame       %TFrame;       #IMPLIED
+  rules       %TRules;       #IMPLIED
+  cellspacing %Length;       #IMPLIED
+  cellpadding %Length;       #IMPLIED
+  >
+
+<!ATTLIST caption
+  %attrs;
+  >
+
+<!--
+colgroup groups a set of col elements. It allows you to group
+several semantically related columns together.
+-->
+<!ATTLIST colgroup
+  %attrs;
+  span        %Number;       "1"
+  width       %MultiLength;  #IMPLIED
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!--
+ col elements define the alignment properties for cells in
+ one or more columns.
+
+ The width attribute specifies the width of the columns, e.g.
+
+     width=64        width in screen pixels
+     width=0.5*      relative width of 0.5
+
+ The span attribute causes the attributes of one
+ col element to apply to more than one column.
+-->
+<!ATTLIST col
+  %attrs;
+  span        %Number;       "1"
+  width       %MultiLength;  #IMPLIED
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!--
+    Use thead to duplicate headers when breaking table
+    across page boundaries, or for static headers when
+    tbody sections are rendered in scrolling panel.
+
+    Use tfoot to duplicate footers when breaking table
+    across page boundaries, or for static footers when
+    tbody sections are rendered in scrolling panel.
+
+    Use multiple tbody sections when rules are needed
+    between groups of table rows.
+-->
+<!ATTLIST thead
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tfoot
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tbody
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tr
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+
+<!-- Scope is simpler than headers attribute for common tables -->
+<!ENTITY % Scope "(row|col|rowgroup|colgroup)">
+
+<!-- th is for headers, td for data and for cells acting as both -->
+
+<!ATTLIST th
+  %attrs;
+  abbr        %Text;         #IMPLIED
+  axis        CDATA          #IMPLIED
+  headers     IDREFS         #IMPLIED
+  scope       %Scope;        #IMPLIED
+  rowspan     %Number;       "1"
+  colspan     %Number;       "1"
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST td
+  %attrs;
+  abbr        %Text;         #IMPLIED
+  axis        CDATA          #IMPLIED
+  headers     IDREFS         #IMPLIED
+  scope       %Scope;        #IMPLIED
+  rowspan     %Number;       "1"
+  colspan     %Number;       "1"
+  %cellhalign;
+  %cellvalign;
+  >
+

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml1-transitional.dtd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml10/xhtml1-transitional.dtd
@@ -1,0 +1,1201 @@
+<!--
+   Extensible HTML version 1.0 Transitional DTD
+
+   This is the same as HTML 4 Transitional except for
+   changes due to the differences between XML and SGML.
+
+   Namespace = http://www.w3.org/1999/xhtml
+
+   For further information, see: http://www.w3.org/TR/xhtml1
+
+   Copyright (c) 1998-2002 W3C (MIT, INRIA, Keio),
+   All Rights Reserved. 
+
+   This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+   PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+   SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+
+   $Revision: 1.27 $
+   $Date: 2002/08/01 18:16:48 $
+
+-->
+
+<!--================ Character mnemonic entities =========================-->
+
+<!ENTITY % HTMLlat1 PUBLIC
+   "-//W3C//ENTITIES Latin 1 for XHTML//EN"
+   "xhtml-lat1.ent">
+%HTMLlat1;
+
+<!ENTITY % HTMLsymbol PUBLIC
+   "-//W3C//ENTITIES Symbols for XHTML//EN"
+   "xhtml-symbol.ent">
+%HTMLsymbol;
+
+<!ENTITY % HTMLspecial PUBLIC
+   "-//W3C//ENTITIES Special for XHTML//EN"
+   "xhtml-special.ent">
+%HTMLspecial;
+
+<!--================== Imported Names ====================================-->
+
+<!ENTITY % ContentType "CDATA">
+    <!-- media type, as per [RFC2045] -->
+
+<!ENTITY % ContentTypes "CDATA">
+    <!-- comma-separated list of media types, as per [RFC2045] -->
+
+<!ENTITY % Charset "CDATA">
+    <!-- a character encoding, as per [RFC2045] -->
+
+<!ENTITY % Charsets "CDATA">
+    <!-- a space separated list of character encodings, as per [RFC2045] -->
+
+<!ENTITY % LanguageCode "NMTOKEN">
+    <!-- a language code, as per [RFC3066] -->
+
+<!ENTITY % Character "CDATA">
+    <!-- a single character, as per section 2.2 of [XML] -->
+
+<!ENTITY % Number "CDATA">
+    <!-- one or more digits -->
+
+<!ENTITY % LinkTypes "CDATA">
+    <!-- space-separated list of link types -->
+
+<!ENTITY % MediaDesc "CDATA">
+    <!-- single or comma-separated list of media descriptors -->
+
+<!ENTITY % URI "CDATA">
+    <!-- a Uniform Resource Identifier, see [RFC2396] -->
+
+<!ENTITY % UriList "CDATA">
+    <!-- a space separated list of Uniform Resource Identifiers -->
+
+<!ENTITY % Datetime "CDATA">
+    <!-- date and time information. ISO date format -->
+
+<!ENTITY % Script "CDATA">
+    <!-- script expression -->
+
+<!ENTITY % StyleSheet "CDATA">
+    <!-- style sheet data -->
+
+<!ENTITY % Text "CDATA">
+    <!-- used for titles etc. -->
+
+<!ENTITY % FrameTarget "NMTOKEN">
+    <!-- render in this frame -->
+
+<!ENTITY % Length "CDATA">
+    <!-- nn for pixels or nn% for percentage length -->
+
+<!ENTITY % MultiLength "CDATA">
+    <!-- pixel, percentage, or relative -->
+
+<!ENTITY % Pixels "CDATA">
+    <!-- integer representing length in pixels -->
+
+<!-- these are used for image maps -->
+
+<!ENTITY % Shape "(rect|circle|poly|default)">
+
+<!ENTITY % Coords "CDATA">
+    <!-- comma separated list of lengths -->
+
+<!-- used for object, applet, img, input and iframe -->
+<!ENTITY % ImgAlign "(top|middle|bottom|left|right)">
+
+<!-- a color using sRGB: #RRGGBB as Hex values -->
+<!ENTITY % Color "CDATA">
+
+<!-- There are also 16 widely known color names with their sRGB values:
+
+    Black  = #000000    Green  = #008000
+    Silver = #C0C0C0    Lime   = #00FF00
+    Gray   = #808080    Olive  = #808000
+    White  = #FFFFFF    Yellow = #FFFF00
+    Maroon = #800000    Navy   = #000080
+    Red    = #FF0000    Blue   = #0000FF
+    Purple = #800080    Teal   = #008080
+    Fuchsia= #FF00FF    Aqua   = #00FFFF
+-->
+
+<!--=================== Generic Attributes ===============================-->
+
+<!-- core attributes common to most elements
+  id       document-wide unique id
+  class    space separated list of classes
+  style    associated style info
+  title    advisory title/amplification
+-->
+<!ENTITY % coreattrs
+ "id          ID             #IMPLIED
+  class       CDATA          #IMPLIED
+  style       %StyleSheet;   #IMPLIED
+  title       %Text;         #IMPLIED"
+  >
+
+<!-- internationalization attributes
+  lang        language code (backwards compatible)
+  xml:lang    language code (as per XML 1.0 spec)
+  dir         direction for weak/neutral text
+-->
+<!ENTITY % i18n
+ "lang        %LanguageCode; #IMPLIED
+  xml:lang    %LanguageCode; #IMPLIED
+  dir         (ltr|rtl)      #IMPLIED"
+  >
+
+<!-- attributes for common UI events
+  onclick     a pointer button was clicked
+  ondblclick  a pointer button was double clicked
+  onmousedown a pointer button was pressed down
+  onmouseup   a pointer button was released
+  onmousemove a pointer was moved onto the element
+  onmouseout  a pointer was moved away from the element
+  onkeypress  a key was pressed and released
+  onkeydown   a key was pressed down
+  onkeyup     a key was released
+-->
+<!ENTITY % events
+ "onclick     %Script;       #IMPLIED
+  ondblclick  %Script;       #IMPLIED
+  onmousedown %Script;       #IMPLIED
+  onmouseup   %Script;       #IMPLIED
+  onmouseover %Script;       #IMPLIED
+  onmousemove %Script;       #IMPLIED
+  onmouseout  %Script;       #IMPLIED
+  onkeypress  %Script;       #IMPLIED
+  onkeydown   %Script;       #IMPLIED
+  onkeyup     %Script;       #IMPLIED"
+  >
+
+<!-- attributes for elements that can get the focus
+  accesskey   accessibility key character
+  tabindex    position in tabbing order
+  onfocus     the element got the focus
+  onblur      the element lost the focus
+-->
+<!ENTITY % focus
+ "accesskey   %Character;    #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED"
+  >
+
+<!ENTITY % attrs "%coreattrs; %i18n; %events;">
+
+<!-- text alignment for p, div, h1-h6. The default is
+     align="left" for ltr headings, "right" for rtl -->
+
+<!ENTITY % TextAlign "align (left|center|right|justify) #IMPLIED">
+
+<!--=================== Text Elements ====================================-->
+
+<!ENTITY % special.extra
+   "object | applet | img | map | iframe">
+	
+<!ENTITY % special.basic
+	"br | span | bdo">
+
+<!ENTITY % special
+   "%special.basic; | %special.extra;">
+
+<!ENTITY % fontstyle.extra "big | small | font | basefont">
+
+<!ENTITY % fontstyle.basic "tt | i | b | u
+                      | s | strike ">
+
+<!ENTITY % fontstyle "%fontstyle.basic; | %fontstyle.extra;">
+
+<!ENTITY % phrase.extra "sub | sup">
+<!ENTITY % phrase.basic "em | strong | dfn | code | q |
+                   samp | kbd | var | cite | abbr | acronym">
+
+<!ENTITY % phrase "%phrase.basic; | %phrase.extra;">
+
+<!ENTITY % inline.forms "input | select | textarea | label | button">
+
+<!-- these can occur at block or inline level -->
+<!ENTITY % misc.inline "ins | del | script">
+
+<!-- these can only occur at block level -->
+<!ENTITY % misc "noscript | %misc.inline;">
+
+<!ENTITY % inline "a | %special; | %fontstyle; | %phrase; | %inline.forms;">
+
+<!-- %Inline; covers inline or "text-level" elements -->
+<!ENTITY % Inline "(#PCDATA | %inline; | %misc.inline;)*">
+
+<!--================== Block level elements ==============================-->
+
+<!ENTITY % heading "h1|h2|h3|h4|h5|h6">
+<!ENTITY % lists "ul | ol | dl | menu | dir">
+<!ENTITY % blocktext "pre | hr | blockquote | address | center | noframes">
+
+<!ENTITY % block
+    "p | %heading; | div | %lists; | %blocktext; | isindex |fieldset | table">
+
+<!-- %Flow; mixes block and inline and is used for list items etc. -->
+<!ENTITY % Flow "(#PCDATA | %block; | form | %inline; | %misc;)*">
+
+<!--================== Content models for exclusions =====================-->
+
+<!-- a elements use %Inline; excluding a -->
+
+<!ENTITY % a.content
+   "(#PCDATA | %special; | %fontstyle; | %phrase; | %inline.forms; | %misc.inline;)*">
+
+<!-- pre uses %Inline excluding img, object, applet, big, small,
+     font, or basefont -->
+
+<!ENTITY % pre.content
+   "(#PCDATA | a | %special.basic; | %fontstyle.basic; | %phrase.basic; |
+	   %inline.forms; | %misc.inline;)*">
+
+<!-- form uses %Flow; excluding form -->
+
+<!ENTITY % form.content "(#PCDATA | %block; | %inline; | %misc;)*">
+
+<!-- button uses %Flow; but excludes a, form, form controls, iframe -->
+
+<!ENTITY % button.content
+   "(#PCDATA | p | %heading; | div | %lists; | %blocktext; |
+      table | br | span | bdo | object | applet | img | map |
+      %fontstyle; | %phrase; | %misc;)*">
+
+<!--================ Document Structure ==================================-->
+
+<!-- the namespace URI designates the document profile -->
+
+<!ELEMENT html (head, body)>
+<!ATTLIST html
+  %i18n;
+  id          ID             #IMPLIED
+  xmlns       %URI;          #FIXED 'http://www.w3.org/1999/xhtml'
+  >
+
+<!--================ Document Head =======================================-->
+
+<!ENTITY % head.misc "(script|style|meta|link|object|isindex)*">
+
+<!-- content model is %head.misc; combined with a single
+     title and an optional base element in any order -->
+
+<!ELEMENT head (%head.misc;,
+     ((title, %head.misc;, (base, %head.misc;)?) |
+      (base, %head.misc;, (title, %head.misc;))))>
+
+<!ATTLIST head
+  %i18n;
+  id          ID             #IMPLIED
+  profile     %URI;          #IMPLIED
+  >
+
+<!-- The title element is not considered part of the flow of text.
+       It should be displayed, for example as the page header or
+       window title. Exactly one title is required per document.
+    -->
+<!ELEMENT title (#PCDATA)>
+<!ATTLIST title 
+  %i18n;
+  id          ID             #IMPLIED
+  >
+
+<!-- document base URI -->
+
+<!ELEMENT base EMPTY>
+<!ATTLIST base
+  id          ID             #IMPLIED
+  href        %URI;          #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!-- generic metainformation -->
+<!ELEMENT meta EMPTY>
+<!ATTLIST meta
+  %i18n;
+  id          ID             #IMPLIED
+  http-equiv  CDATA          #IMPLIED
+  name        CDATA          #IMPLIED
+  content     CDATA          #REQUIRED
+  scheme      CDATA          #IMPLIED
+  >
+
+<!--
+  Relationship values can be used in principle:
+
+   a) for document specific toolbars/menus when used
+      with the link element in document head e.g.
+        start, contents, previous, next, index, end, help
+   b) to link to a separate style sheet (rel="stylesheet")
+   c) to make a link to a script (rel="script")
+   d) by stylesheets to control how collections of
+      html nodes are rendered into printed documents
+   e) to make a link to a printable version of this document
+      e.g. a PostScript or PDF version (rel="alternate" media="print")
+-->
+
+<!ELEMENT link EMPTY>
+<!ATTLIST link
+  %attrs;
+  charset     %Charset;      #IMPLIED
+  href        %URI;          #IMPLIED
+  hreflang    %LanguageCode; #IMPLIED
+  type        %ContentType;  #IMPLIED
+  rel         %LinkTypes;    #IMPLIED
+  rev         %LinkTypes;    #IMPLIED
+  media       %MediaDesc;    #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!-- style info, which may include CDATA sections -->
+<!ELEMENT style (#PCDATA)>
+<!ATTLIST style
+  %i18n;
+  id          ID             #IMPLIED
+  type        %ContentType;  #REQUIRED
+  media       %MediaDesc;    #IMPLIED
+  title       %Text;         #IMPLIED
+  xml:space   (preserve)     #FIXED 'preserve'
+  >
+
+<!-- script statements, which may include CDATA sections -->
+<!ELEMENT script (#PCDATA)>
+<!ATTLIST script
+  id          ID             #IMPLIED
+  charset     %Charset;      #IMPLIED
+  type        %ContentType;  #REQUIRED
+  language    CDATA          #IMPLIED
+  src         %URI;          #IMPLIED
+  defer       (defer)        #IMPLIED
+  xml:space   (preserve)     #FIXED 'preserve'
+  >
+
+<!-- alternate content container for non script-based rendering -->
+
+<!ELEMENT noscript %Flow;>
+<!ATTLIST noscript
+  %attrs;
+  >
+
+<!--======================= Frames =======================================-->
+
+<!-- inline subwindow -->
+
+<!ELEMENT iframe %Flow;>
+<!ATTLIST iframe
+  %coreattrs;
+  longdesc    %URI;          #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  src         %URI;          #IMPLIED
+  frameborder (1|0)          "1"
+  marginwidth %Pixels;       #IMPLIED
+  marginheight %Pixels;      #IMPLIED
+  scrolling   (yes|no|auto)  "auto"
+  align       %ImgAlign;     #IMPLIED
+  height      %Length;       #IMPLIED
+  width       %Length;       #IMPLIED
+  >
+
+<!-- alternate content container for non frame-based rendering -->
+
+<!ELEMENT noframes %Flow;>
+<!ATTLIST noframes
+  %attrs;
+  >
+
+<!--=================== Document Body ====================================-->
+
+<!ELEMENT body %Flow;>
+<!ATTLIST body
+  %attrs;
+  onload      %Script;       #IMPLIED
+  onunload    %Script;       #IMPLIED
+  background  %URI;          #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  text        %Color;        #IMPLIED
+  link        %Color;        #IMPLIED
+  vlink       %Color;        #IMPLIED
+  alink       %Color;        #IMPLIED
+  >
+
+<!ELEMENT div %Flow;>  <!-- generic language/style container -->
+<!ATTLIST div
+  %attrs;
+  %TextAlign;
+  >
+
+<!--=================== Paragraphs =======================================-->
+
+<!ELEMENT p %Inline;>
+<!ATTLIST p
+  %attrs;
+  %TextAlign;
+  >
+
+<!--=================== Headings =========================================-->
+
+<!--
+  There are six levels of headings from h1 (the most important)
+  to h6 (the least important).
+-->
+
+<!ELEMENT h1  %Inline;>
+<!ATTLIST h1
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h2 %Inline;>
+<!ATTLIST h2
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h3 %Inline;>
+<!ATTLIST h3
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h4 %Inline;>
+<!ATTLIST h4
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h5 %Inline;>
+<!ATTLIST h5
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h6 %Inline;>
+<!ATTLIST h6
+  %attrs;
+  %TextAlign;
+  >
+
+<!--=================== Lists ============================================-->
+
+<!-- Unordered list bullet styles -->
+
+<!ENTITY % ULStyle "(disc|square|circle)">
+
+<!-- Unordered list -->
+
+<!ELEMENT ul (li)+>
+<!ATTLIST ul
+  %attrs;
+  type        %ULStyle;     #IMPLIED
+  compact     (compact)     #IMPLIED
+  >
+
+<!-- Ordered list numbering style
+
+    1   arabic numbers      1, 2, 3, ...
+    a   lower alpha         a, b, c, ...
+    A   upper alpha         A, B, C, ...
+    i   lower roman         i, ii, iii, ...
+    I   upper roman         I, II, III, ...
+
+    The style is applied to the sequence number which by default
+    is reset to 1 for the first list item in an ordered list.
+-->
+<!ENTITY % OLStyle "CDATA">
+
+<!-- Ordered (numbered) list -->
+
+<!ELEMENT ol (li)+>
+<!ATTLIST ol
+  %attrs;
+  type        %OLStyle;      #IMPLIED
+  compact     (compact)      #IMPLIED
+  start       %Number;       #IMPLIED
+  >
+
+<!-- single column list (DEPRECATED) --> 
+<!ELEMENT menu (li)+>
+<!ATTLIST menu
+  %attrs;
+  compact     (compact)     #IMPLIED
+  >
+
+<!-- multiple column list (DEPRECATED) --> 
+<!ELEMENT dir (li)+>
+<!ATTLIST dir
+  %attrs;
+  compact     (compact)     #IMPLIED
+  >
+
+<!-- LIStyle is constrained to: "(%ULStyle;|%OLStyle;)" -->
+<!ENTITY % LIStyle "CDATA">
+
+<!-- list item -->
+
+<!ELEMENT li %Flow;>
+<!ATTLIST li
+  %attrs;
+  type        %LIStyle;      #IMPLIED
+  value       %Number;       #IMPLIED
+  >
+
+<!-- definition lists - dt for term, dd for its definition -->
+
+<!ELEMENT dl (dt|dd)+>
+<!ATTLIST dl
+  %attrs;
+  compact     (compact)      #IMPLIED
+  >
+
+<!ELEMENT dt %Inline;>
+<!ATTLIST dt
+  %attrs;
+  >
+
+<!ELEMENT dd %Flow;>
+<!ATTLIST dd
+  %attrs;
+  >
+
+<!--=================== Address ==========================================-->
+
+<!-- information on author -->
+
+<!ELEMENT address (#PCDATA | %inline; | %misc.inline; | p)*>
+<!ATTLIST address
+  %attrs;
+  >
+
+<!--=================== Horizontal Rule ==================================-->
+
+<!ELEMENT hr EMPTY>
+<!ATTLIST hr
+  %attrs;
+  align       (left|center|right) #IMPLIED
+  noshade     (noshade)      #IMPLIED
+  size        %Pixels;       #IMPLIED
+  width       %Length;       #IMPLIED
+  >
+
+<!--=================== Preformatted Text ================================-->
+
+<!-- content is %Inline; excluding 
+        "img|object|applet|big|small|sub|sup|font|basefont" -->
+
+<!ELEMENT pre %pre.content;>
+<!ATTLIST pre
+  %attrs;
+  width       %Number;      #IMPLIED
+  xml:space   (preserve)    #FIXED 'preserve'
+  >
+
+<!--=================== Block-like Quotes ================================-->
+
+<!ELEMENT blockquote %Flow;>
+<!ATTLIST blockquote
+  %attrs;
+  cite        %URI;          #IMPLIED
+  >
+
+<!--=================== Text alignment ===================================-->
+
+<!-- center content -->
+<!ELEMENT center %Flow;>
+<!ATTLIST center
+  %attrs;
+  >
+
+<!--=================== Inserted/Deleted Text ============================-->
+
+<!--
+  ins/del are allowed in block and inline content, but its
+  inappropriate to include block content within an ins element
+  occurring in inline content.
+-->
+<!ELEMENT ins %Flow;>
+<!ATTLIST ins
+  %attrs;
+  cite        %URI;          #IMPLIED
+  datetime    %Datetime;     #IMPLIED
+  >
+
+<!ELEMENT del %Flow;>
+<!ATTLIST del
+  %attrs;
+  cite        %URI;          #IMPLIED
+  datetime    %Datetime;     #IMPLIED
+  >
+
+<!--================== The Anchor Element ================================-->
+
+<!-- content is %Inline; except that anchors shouldn't be nested -->
+
+<!ELEMENT a %a.content;>
+<!ATTLIST a
+  %attrs;
+  %focus;
+  charset     %Charset;      #IMPLIED
+  type        %ContentType;  #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  href        %URI;          #IMPLIED
+  hreflang    %LanguageCode; #IMPLIED
+  rel         %LinkTypes;    #IMPLIED
+  rev         %LinkTypes;    #IMPLIED
+  shape       %Shape;        "rect"
+  coords      %Coords;       #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!--===================== Inline Elements ================================-->
+
+<!ELEMENT span %Inline;> <!-- generic language/style container -->
+<!ATTLIST span
+  %attrs;
+  >
+
+<!ELEMENT bdo %Inline;>  <!-- I18N BiDi over-ride -->
+<!ATTLIST bdo
+  %coreattrs;
+  %events;
+  lang        %LanguageCode; #IMPLIED
+  xml:lang    %LanguageCode; #IMPLIED
+  dir         (ltr|rtl)      #REQUIRED
+  >
+
+<!ELEMENT br EMPTY>   <!-- forced line break -->
+<!ATTLIST br
+  %coreattrs;
+  clear       (left|all|right|none) "none"
+  >
+
+<!ELEMENT em %Inline;>   <!-- emphasis -->
+<!ATTLIST em %attrs;>
+
+<!ELEMENT strong %Inline;>   <!-- strong emphasis -->
+<!ATTLIST strong %attrs;>
+
+<!ELEMENT dfn %Inline;>   <!-- definitional -->
+<!ATTLIST dfn %attrs;>
+
+<!ELEMENT code %Inline;>   <!-- program code -->
+<!ATTLIST code %attrs;>
+
+<!ELEMENT samp %Inline;>   <!-- sample -->
+<!ATTLIST samp %attrs;>
+
+<!ELEMENT kbd %Inline;>  <!-- something user would type -->
+<!ATTLIST kbd %attrs;>
+
+<!ELEMENT var %Inline;>   <!-- variable -->
+<!ATTLIST var %attrs;>
+
+<!ELEMENT cite %Inline;>   <!-- citation -->
+<!ATTLIST cite %attrs;>
+
+<!ELEMENT abbr %Inline;>   <!-- abbreviation -->
+<!ATTLIST abbr %attrs;>
+
+<!ELEMENT acronym %Inline;>   <!-- acronym -->
+<!ATTLIST acronym %attrs;>
+
+<!ELEMENT q %Inline;>   <!-- inlined quote -->
+<!ATTLIST q
+  %attrs;
+  cite        %URI;          #IMPLIED
+  >
+
+<!ELEMENT sub %Inline;> <!-- subscript -->
+<!ATTLIST sub %attrs;>
+
+<!ELEMENT sup %Inline;> <!-- superscript -->
+<!ATTLIST sup %attrs;>
+
+<!ELEMENT tt %Inline;>   <!-- fixed pitch font -->
+<!ATTLIST tt %attrs;>
+
+<!ELEMENT i %Inline;>   <!-- italic font -->
+<!ATTLIST i %attrs;>
+
+<!ELEMENT b %Inline;>   <!-- bold font -->
+<!ATTLIST b %attrs;>
+
+<!ELEMENT big %Inline;>   <!-- bigger font -->
+<!ATTLIST big %attrs;>
+
+<!ELEMENT small %Inline;>   <!-- smaller font -->
+<!ATTLIST small %attrs;>
+
+<!ELEMENT u %Inline;>   <!-- underline -->
+<!ATTLIST u %attrs;>
+
+<!ELEMENT s %Inline;>   <!-- strike-through -->
+<!ATTLIST s %attrs;>
+
+<!ELEMENT strike %Inline;>   <!-- strike-through -->
+<!ATTLIST strike %attrs;>
+
+<!ELEMENT basefont EMPTY>  <!-- base font size -->
+<!ATTLIST basefont
+  id          ID             #IMPLIED
+  size        CDATA          #REQUIRED
+  color       %Color;        #IMPLIED
+  face        CDATA          #IMPLIED
+  >
+
+<!ELEMENT font %Inline;> <!-- local change to font -->
+<!ATTLIST font
+  %coreattrs;
+  %i18n;
+  size        CDATA          #IMPLIED
+  color       %Color;        #IMPLIED
+  face        CDATA          #IMPLIED
+  >
+
+<!--==================== Object ======================================-->
+<!--
+  object is used to embed objects as part of HTML pages.
+  param elements should precede other content. Parameters
+  can also be expressed as attribute/value pairs on the
+  object element itself when brevity is desired.
+-->
+
+<!ELEMENT object (#PCDATA | param | %block; | form | %inline; | %misc;)*>
+<!ATTLIST object
+  %attrs;
+  declare     (declare)      #IMPLIED
+  classid     %URI;          #IMPLIED
+  codebase    %URI;          #IMPLIED
+  data        %URI;          #IMPLIED
+  type        %ContentType;  #IMPLIED
+  codetype    %ContentType;  #IMPLIED
+  archive     %UriList;      #IMPLIED
+  standby     %Text;         #IMPLIED
+  height      %Length;       #IMPLIED
+  width       %Length;       #IMPLIED
+  usemap      %URI;          #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  align       %ImgAlign;     #IMPLIED
+  border      %Pixels;       #IMPLIED
+  hspace      %Pixels;       #IMPLIED
+  vspace      %Pixels;       #IMPLIED
+  >
+
+<!--
+  param is used to supply a named property value.
+  In XML it would seem natural to follow RDF and support an
+  abbreviated syntax where the param elements are replaced
+  by attribute value pairs on the object start tag.
+-->
+<!ELEMENT param EMPTY>
+<!ATTLIST param
+  id          ID             #IMPLIED
+  name        CDATA          #REQUIRED
+  value       CDATA          #IMPLIED
+  valuetype   (data|ref|object) "data"
+  type        %ContentType;  #IMPLIED
+  >
+
+<!--=================== Java applet ==================================-->
+<!--
+  One of code or object attributes must be present.
+  Place param elements before other content.
+-->
+<!ELEMENT applet (#PCDATA | param | %block; | form | %inline; | %misc;)*>
+<!ATTLIST applet
+  %coreattrs;
+  codebase    %URI;          #IMPLIED
+  archive     CDATA          #IMPLIED
+  code        CDATA          #IMPLIED
+  object      CDATA          #IMPLIED
+  alt         %Text;         #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  width       %Length;       #REQUIRED
+  height      %Length;       #REQUIRED
+  align       %ImgAlign;     #IMPLIED
+  hspace      %Pixels;       #IMPLIED
+  vspace      %Pixels;       #IMPLIED
+  >
+
+<!--=================== Images ===========================================-->
+
+<!--
+   To avoid accessibility problems for people who aren't
+   able to see the image, you should provide a text
+   description using the alt and longdesc attributes.
+   In addition, avoid the use of server-side image maps.
+-->
+
+<!ELEMENT img EMPTY>
+<!ATTLIST img
+  %attrs;
+  src         %URI;          #REQUIRED
+  alt         %Text;         #REQUIRED
+  name        NMTOKEN        #IMPLIED
+  longdesc    %URI;          #IMPLIED
+  height      %Length;       #IMPLIED
+  width       %Length;       #IMPLIED
+  usemap      %URI;          #IMPLIED
+  ismap       (ismap)        #IMPLIED
+  align       %ImgAlign;     #IMPLIED
+  border      %Length;       #IMPLIED
+  hspace      %Pixels;       #IMPLIED
+  vspace      %Pixels;       #IMPLIED
+  >
+
+<!-- usemap points to a map element which may be in this document
+  or an external document, although the latter is not widely supported -->
+
+<!--================== Client-side image maps ============================-->
+
+<!-- These can be placed in the same document or grouped in a
+     separate document although this isn't yet widely supported -->
+
+<!ELEMENT map ((%block; | form | %misc;)+ | area+)>
+<!ATTLIST map
+  %i18n;
+  %events;
+  id          ID             #REQUIRED
+  class       CDATA          #IMPLIED
+  style       %StyleSheet;   #IMPLIED
+  title       %Text;         #IMPLIED
+  name        CDATA          #IMPLIED
+  >
+
+<!ELEMENT area EMPTY>
+<!ATTLIST area
+  %attrs;
+  %focus;
+  shape       %Shape;        "rect"
+  coords      %Coords;       #IMPLIED
+  href        %URI;          #IMPLIED
+  nohref      (nohref)       #IMPLIED
+  alt         %Text;         #REQUIRED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!--================ Forms ===============================================-->
+
+<!ELEMENT form %form.content;>   <!-- forms shouldn't be nested -->
+
+<!ATTLIST form
+  %attrs;
+  action      %URI;          #REQUIRED
+  method      (get|post)     "get"
+  name        NMTOKEN        #IMPLIED
+  enctype     %ContentType;  "application/x-www-form-urlencoded"
+  onsubmit    %Script;       #IMPLIED
+  onreset     %Script;       #IMPLIED
+  accept      %ContentTypes; #IMPLIED
+  accept-charset %Charsets;  #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!--
+  Each label must not contain more than ONE field
+  Label elements shouldn't be nested.
+-->
+<!ELEMENT label %Inline;>
+<!ATTLIST label
+  %attrs;
+  for         IDREF          #IMPLIED
+  accesskey   %Character;    #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED
+  >
+
+<!ENTITY % InputType
+  "(text | password | checkbox |
+    radio | submit | reset |
+    file | hidden | image | button)"
+   >
+
+<!-- the name attribute is required for all but submit & reset -->
+
+<!ELEMENT input EMPTY>     <!-- form control -->
+<!ATTLIST input
+  %attrs;
+  %focus;
+  type        %InputType;    "text"
+  name        CDATA          #IMPLIED
+  value       CDATA          #IMPLIED
+  checked     (checked)      #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  readonly    (readonly)     #IMPLIED
+  size        CDATA          #IMPLIED
+  maxlength   %Number;       #IMPLIED
+  src         %URI;          #IMPLIED
+  alt         CDATA          #IMPLIED
+  usemap      %URI;          #IMPLIED
+  onselect    %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  accept      %ContentTypes; #IMPLIED
+  align       %ImgAlign;     #IMPLIED
+  >
+
+<!ELEMENT select (optgroup|option)+>  <!-- option selector -->
+<!ATTLIST select
+  %attrs;
+  name        CDATA          #IMPLIED
+  size        %Number;       #IMPLIED
+  multiple    (multiple)     #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  >
+
+<!ELEMENT optgroup (option)+>   <!-- option group -->
+<!ATTLIST optgroup
+  %attrs;
+  disabled    (disabled)     #IMPLIED
+  label       %Text;         #REQUIRED
+  >
+
+<!ELEMENT option (#PCDATA)>     <!-- selectable choice -->
+<!ATTLIST option
+  %attrs;
+  selected    (selected)     #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  label       %Text;         #IMPLIED
+  value       CDATA          #IMPLIED
+  >
+
+<!ELEMENT textarea (#PCDATA)>     <!-- multi-line text field -->
+<!ATTLIST textarea
+  %attrs;
+  %focus;
+  name        CDATA          #IMPLIED
+  rows        %Number;       #REQUIRED
+  cols        %Number;       #REQUIRED
+  disabled    (disabled)     #IMPLIED
+  readonly    (readonly)     #IMPLIED
+  onselect    %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  >
+
+<!--
+  The fieldset element is used to group form fields.
+  Only one legend element should occur in the content
+  and if present should only be preceded by whitespace.
+-->
+<!ELEMENT fieldset (#PCDATA | legend | %block; | form | %inline; | %misc;)*>
+<!ATTLIST fieldset
+  %attrs;
+  >
+
+<!ENTITY % LAlign "(top|bottom|left|right)">
+
+<!ELEMENT legend %Inline;>     <!-- fieldset label -->
+<!ATTLIST legend
+  %attrs;
+  accesskey   %Character;    #IMPLIED
+  align       %LAlign;       #IMPLIED
+  >
+
+<!--
+ Content is %Flow; excluding a, form, form controls, iframe
+--> 
+<!ELEMENT button %button.content;>  <!-- push button -->
+<!ATTLIST button
+  %attrs;
+  %focus;
+  name        CDATA          #IMPLIED
+  value       CDATA          #IMPLIED
+  type        (button|submit|reset) "submit"
+  disabled    (disabled)     #IMPLIED
+  >
+
+<!-- single-line text input control (DEPRECATED) -->
+<!ELEMENT isindex EMPTY>
+<!ATTLIST isindex
+  %coreattrs;
+  %i18n;
+  prompt      %Text;         #IMPLIED
+  >
+
+<!--======================= Tables =======================================-->
+
+<!-- Derived from IETF HTML table standard, see [RFC1942] -->
+
+<!--
+ The border attribute sets the thickness of the frame around the
+ table. The default units are screen pixels.
+
+ The frame attribute specifies which parts of the frame around
+ the table should be rendered. The values are not the same as
+ CALS to avoid a name clash with the valign attribute.
+-->
+<!ENTITY % TFrame "(void|above|below|hsides|lhs|rhs|vsides|box|border)">
+
+<!--
+ The rules attribute defines which rules to draw between cells:
+
+ If rules is absent then assume:
+     "none" if border is absent or border="0" otherwise "all"
+-->
+
+<!ENTITY % TRules "(none | groups | rows | cols | all)">
+  
+<!-- horizontal placement of table relative to document -->
+<!ENTITY % TAlign "(left|center|right)">
+
+<!-- horizontal alignment attributes for cell contents
+
+  char        alignment char, e.g. char=':'
+  charoff     offset for alignment char
+-->
+<!ENTITY % cellhalign
+  "align      (left|center|right|justify|char) #IMPLIED
+   char       %Character;    #IMPLIED
+   charoff    %Length;       #IMPLIED"
+  >
+
+<!-- vertical alignment attributes for cell contents -->
+<!ENTITY % cellvalign
+  "valign     (top|middle|bottom|baseline) #IMPLIED"
+  >
+
+<!ELEMENT table
+     (caption?, (col*|colgroup*), thead?, tfoot?, (tbody+|tr+))>
+<!ELEMENT caption  %Inline;>
+<!ELEMENT thead    (tr)+>
+<!ELEMENT tfoot    (tr)+>
+<!ELEMENT tbody    (tr)+>
+<!ELEMENT colgroup (col)*>
+<!ELEMENT col      EMPTY>
+<!ELEMENT tr       (th|td)+>
+<!ELEMENT th       %Flow;>
+<!ELEMENT td       %Flow;>
+
+<!ATTLIST table
+  %attrs;
+  summary     %Text;         #IMPLIED
+  width       %Length;       #IMPLIED
+  border      %Pixels;       #IMPLIED
+  frame       %TFrame;       #IMPLIED
+  rules       %TRules;       #IMPLIED
+  cellspacing %Length;       #IMPLIED
+  cellpadding %Length;       #IMPLIED
+  align       %TAlign;       #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  >
+
+<!ENTITY % CAlign "(top|bottom|left|right)">
+
+<!ATTLIST caption
+  %attrs;
+  align       %CAlign;       #IMPLIED
+  >
+
+<!--
+colgroup groups a set of col elements. It allows you to group
+several semantically related columns together.
+-->
+<!ATTLIST colgroup
+  %attrs;
+  span        %Number;       "1"
+  width       %MultiLength;  #IMPLIED
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!--
+ col elements define the alignment properties for cells in
+ one or more columns.
+
+ The width attribute specifies the width of the columns, e.g.
+
+     width=64        width in screen pixels
+     width=0.5*      relative width of 0.5
+
+ The span attribute causes the attributes of one
+ col element to apply to more than one column.
+-->
+<!ATTLIST col
+  %attrs;
+  span        %Number;       "1"
+  width       %MultiLength;  #IMPLIED
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!--
+    Use thead to duplicate headers when breaking table
+    across page boundaries, or for static headers when
+    tbody sections are rendered in scrolling panel.
+
+    Use tfoot to duplicate footers when breaking table
+    across page boundaries, or for static footers when
+    tbody sections are rendered in scrolling panel.
+
+    Use multiple tbody sections when rules are needed
+    between groups of table rows.
+-->
+<!ATTLIST thead
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tfoot
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tbody
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tr
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  bgcolor     %Color;        #IMPLIED
+  >
+
+<!-- Scope is simpler than headers attribute for common tables -->
+<!ENTITY % Scope "(row|col|rowgroup|colgroup)">
+
+<!-- th is for headers, td for data and for cells acting as both -->
+
+<!ATTLIST th
+  %attrs;
+  abbr        %Text;         #IMPLIED
+  axis        CDATA          #IMPLIED
+  headers     IDREFS         #IMPLIED
+  scope       %Scope;        #IMPLIED
+  rowspan     %Number;       "1"
+  colspan     %Number;       "1"
+  %cellhalign;
+  %cellvalign;
+  nowrap      (nowrap)       #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  width       %Length;       #IMPLIED
+  height      %Length;       #IMPLIED
+  >
+
+<!ATTLIST td
+  %attrs;
+  abbr        %Text;         #IMPLIED
+  axis        CDATA          #IMPLIED
+  headers     IDREFS         #IMPLIED
+  scope       %Scope;        #IMPLIED
+  rowspan     %Number;       "1"
+  colspan     %Number;       "1"
+  %cellhalign;
+  %cellvalign;
+  nowrap      (nowrap)       #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  width       %Length;       #IMPLIED
+  height      %Length;       #IMPLIED
+  >
+

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-attribs-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-attribs-1.mod
@@ -1,0 +1,142 @@
+<!-- ...................................................................... -->
+<!-- XHTML Common Attributes Module  ...................................... -->
+<!-- file: xhtml-attribs-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-attribs-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES XHTML Common Attributes 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-attribs-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Common Attributes
+
+     This module declares many of the common attributes for the XHTML DTD.
+     %NS.decl.attrib; is declared in the XHTML Qname module.
+
+	 Note that this file was extended in XHTML Modularization 1.1 to 
+	 include declarations of "global" versions of the attribute collections.
+	 The global versions of the attributes are for use on elements in other 
+	 namespaces.  The global version of "common" includes the xmlns declaration
+	 for the prefixed version of the xhtml namespace.  If you are only using a
+	 specific attribute or an individual attribute collection, you must also
+	 include the XHTML.xmlns.attrib.prefixed PE on your elements.
+-->
+
+<!ENTITY % id.attrib
+     "id           ID                       #IMPLIED"
+>
+
+<![%XHTML.global.attrs.prefixed;[
+<!ENTITY % XHTML.global.id.attrib
+     "%XHTML.prefix;:id           ID        #IMPLIED"
+>
+]]>
+
+<!ENTITY % class.attrib
+     "class        CDATA                 #IMPLIED"
+>
+
+<![%XHTML.global.attrs.prefixed;[
+<!ENTITY % XHTML.global.class.attrib
+     "%XHTML.prefix;:class        CDATA                 #IMPLIED"
+>
+]]>
+
+<!ENTITY % title.attrib
+     "title        %Text.datatype;          #IMPLIED"
+>
+
+<![%XHTML.global.attrs.prefixed;[
+<!ENTITY % XHTML.global.title.attrib
+     "%XHTML.prefix;:title        %Text.datatype;          #IMPLIED"
+>
+]]>
+
+<!ENTITY % Core.extra.attrib "" >
+
+<!ENTITY % Core.attrib
+     "%XHTML.xmlns.attrib;
+      %id.attrib;
+      %class.attrib;
+      %title.attrib;
+      xml:space    ( preserve )             #FIXED 'preserve'
+      %Core.extra.attrib;"
+>
+
+<!ENTITY % XHTML.global.core.extra.attrib "" >
+
+<![%XHTML.global.attrs.prefixed;[
+
+<!ENTITY % XHTML.global.core.attrib
+     "%XHTML.global.id.attrib;
+      %XHTML.global.class.attrib;
+      %XHTML.global.title.attrib;
+      %XHTML.global.core.extra.attrib;"
+>
+]]>
+
+<!ENTITY % XHTML.global.core.attrib "" >
+
+
+<!ENTITY % lang.attrib
+     "xml:lang     %LanguageCode.datatype;  #IMPLIED"
+>
+
+<![%XHTML.bidi;[
+<!ENTITY % dir.attrib
+     "dir          ( ltr | rtl )            #IMPLIED"
+>
+
+<!ENTITY % I18n.attrib
+     "%dir.attrib;
+      %lang.attrib;"
+>
+
+<![%XHTML.global.attrs.prefixed;[
+<!ENTITY XHTML.global.i18n.attrib
+     "%XHTML.prefix;:dir          ( ltr | rtl )            #IMPLIED
+      %lang.attrib;"
+>
+]]>
+<!ENTITY XHTML.global.i18n.attrib "" >
+
+]]>
+<!ENTITY % I18n.attrib
+     "%lang.attrib;"
+>
+<!ENTITY % XHTML.global.i18n.attrib
+     "%lang.attrib;"
+>
+
+<!ENTITY % Common.extra.attrib "" >
+<!ENTITY % XHTML.global.common.extra.attrib "" >
+
+<!-- intrinsic event attributes declared previously
+-->
+<!ENTITY % Events.attrib "" >
+
+<!ENTITY % XHTML.global.events.attrib "" >
+
+<!ENTITY % Common.attrib
+     "%Core.attrib;
+      %I18n.attrib;
+      %Events.attrib;
+      %Common.extra.attrib;"
+>
+
+<!ENTITY % XHTML.global.common.attrib
+     "%XHTML.xmlns.attrib.prefixed;
+      %XHTML.global.core.attrib;
+	  %XHTML.global.i18n.attrib;
+	  %XHTML.global.events.attrib;
+	  %XHTML.global.common.extra.attrib;"
+>
+
+<!-- end of xhtml-attribs-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-base-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-base-1.mod
@@ -1,0 +1,53 @@
+<!-- ...................................................................... -->
+<!-- XHTML Base Element Module  ........................................... -->
+<!-- file: xhtml-base-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-base-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Base Element 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-base-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Base element
+
+        base
+
+     This module declares the base element type and its attributes,
+     used to define a base URI against which relative URIs in the
+     document will be resolved.
+
+     Note that this module also redeclares the content model for
+     the head element to include the base element.
+-->
+
+<!-- base: Document Base URI ........................... -->
+
+<!ENTITY % base.element  "INCLUDE" >
+<![%base.element;[
+<!ENTITY % base.content  "EMPTY" >
+<!ENTITY % base.qname  "base" >
+<!ELEMENT %base.qname;  %base.content; >
+<!-- end of base.element -->]]>
+
+<!ENTITY % base.attlist  "INCLUDE" >
+<![%base.attlist;[
+<!ATTLIST %base.qname;
+      %XHTML.xmlns.attrib;
+      href         %URI.datatype;           #REQUIRED
+>
+<!-- end of base.attlist -->]]>
+
+<!ENTITY % head.content
+    "( %HeadOpts.mix;,
+     ( ( %title.qname;, %HeadOpts.mix;, ( %base.qname;, %HeadOpts.mix; )? )
+     | ( %base.qname;, %HeadOpts.mix;, ( %title.qname;, %HeadOpts.mix; ))))"
+>
+
+<!-- end of xhtml-base-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-bdo-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-bdo-1.mod
@@ -1,0 +1,47 @@
+<!-- ...................................................................... -->
+<!-- XHTML BDO Element Module ............................................. -->
+<!-- file: xhtml-bdo-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-bdo-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML BDO Element 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-bdo-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Bidirectional Override (bdo) Element
+
+     This modules declares the element 'bdo', used to override the
+     Unicode bidirectional algorithm for selected fragments of text.
+
+     DEPENDENCIES:
+     Relies on the conditional section keyword %XHTML.bidi; declared
+     as "INCLUDE". Bidirectional text support includes both the bdo
+     element and the 'dir' attribute.
+-->
+
+<!ENTITY % bdo.element  "INCLUDE" >
+<![%bdo.element;[
+<!ENTITY % bdo.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % bdo.qname  "bdo" >
+<!ELEMENT %bdo.qname;  %bdo.content; >
+<!-- end of bdo.element -->]]>
+
+<!ENTITY % bdo.attlist  "INCLUDE" >
+<![%bdo.attlist;[
+<!ATTLIST %bdo.qname;
+      %Core.attrib;
+	  %lang.attrib;
+      dir          ( ltr | rtl )            #REQUIRED
+>
+]]>
+
+<!-- end of xhtml-bdo-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-blkphras-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-blkphras-1.mod
@@ -1,0 +1,164 @@
+<!-- ...................................................................... -->
+<!-- XHTML Block Phrasal Module  .......................................... -->
+<!-- file: xhtml-blkphras-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-blkphras-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Block Phrasal 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-blkphras-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Block Phrasal
+
+        address, blockquote, pre, h1, h2, h3, h4, h5, h6
+
+     This module declares the elements and their attributes used to
+     support block-level phrasal markup.
+-->
+
+<!ENTITY % address.element  "INCLUDE" >
+<![%address.element;[
+<!ENTITY % address.content
+     "( #PCDATA | %Inline.mix; )*" >
+<!ENTITY % address.qname  "address" >
+<!ELEMENT %address.qname;  %address.content; >
+<!-- end of address.element -->]]>
+
+<!ENTITY % address.attlist  "INCLUDE" >
+<![%address.attlist;[
+<!ATTLIST %address.qname;
+      %Common.attrib;
+>
+<!-- end of address.attlist -->]]>
+
+<!ENTITY % blockquote.element  "INCLUDE" >
+<![%blockquote.element;[
+<!ENTITY % blockquote.content
+     "( %Block.mix; )*"
+>
+<!ENTITY % blockquote.qname  "blockquote" >
+<!ELEMENT %blockquote.qname;  %blockquote.content; >
+<!-- end of blockquote.element -->]]>
+
+<!ENTITY % blockquote.attlist  "INCLUDE" >
+<![%blockquote.attlist;[
+<!ATTLIST %blockquote.qname;
+      %Common.attrib;
+      cite         %URI.datatype;           #IMPLIED
+>
+<!-- end of blockquote.attlist -->]]>
+
+<!ENTITY % pre.element  "INCLUDE" >
+<![%pre.element;[
+<!ENTITY % pre.content
+     "( #PCDATA
+      | %InlStruct.class;
+      %InlPhras.class;
+      | %tt.qname; | %i.qname; | %b.qname;
+      %I18n.class;
+      %Anchor.class;
+      | %map.qname;
+      %Misc.class;
+      %Inline.extra; )*"
+>
+<!ENTITY % pre.qname  "pre" >
+<!ELEMENT %pre.qname;  %pre.content; >
+<!-- end of pre.element -->]]>
+
+<!ENTITY % pre.attlist  "INCLUDE" >
+<![%pre.attlist;[
+<!ATTLIST %pre.qname;
+      %Common.attrib;
+>
+<!-- end of pre.attlist -->]]>
+
+<!-- ...................  Heading Elements  ................... -->
+
+<!ENTITY % Heading.content  "( #PCDATA | %Inline.mix; )*" >
+
+<!ENTITY % h1.element  "INCLUDE" >
+<![%h1.element;[
+<!ENTITY % h1.qname  "h1" >
+<!ELEMENT %h1.qname;  %Heading.content; >
+<!-- end of h1.element -->]]>
+
+<!ENTITY % h1.attlist  "INCLUDE" >
+<![%h1.attlist;[
+<!ATTLIST %h1.qname;
+      %Common.attrib;
+>
+<!-- end of h1.attlist -->]]>
+
+<!ENTITY % h2.element  "INCLUDE" >
+<![%h2.element;[
+<!ENTITY % h2.qname  "h2" >
+<!ELEMENT %h2.qname;  %Heading.content; >
+<!-- end of h2.element -->]]>
+
+<!ENTITY % h2.attlist  "INCLUDE" >
+<![%h2.attlist;[
+<!ATTLIST %h2.qname;
+      %Common.attrib;
+>
+<!-- end of h2.attlist -->]]>
+
+<!ENTITY % h3.element  "INCLUDE" >
+<![%h3.element;[
+<!ENTITY % h3.qname  "h3" >
+<!ELEMENT %h3.qname;  %Heading.content; >
+<!-- end of h3.element -->]]>
+
+<!ENTITY % h3.attlist  "INCLUDE" >
+<![%h3.attlist;[
+<!ATTLIST %h3.qname;
+      %Common.attrib;
+>
+<!-- end of h3.attlist -->]]>
+
+<!ENTITY % h4.element  "INCLUDE" >
+<![%h4.element;[
+<!ENTITY % h4.qname  "h4" >
+<!ELEMENT %h4.qname;  %Heading.content; >
+<!-- end of h4.element -->]]>
+
+<!ENTITY % h4.attlist  "INCLUDE" >
+<![%h4.attlist;[
+<!ATTLIST %h4.qname;
+      %Common.attrib;
+>
+<!-- end of h4.attlist -->]]>
+
+<!ENTITY % h5.element  "INCLUDE" >
+<![%h5.element;[
+<!ENTITY % h5.qname  "h5" >
+<!ELEMENT %h5.qname;  %Heading.content; >
+<!-- end of h5.element -->]]>
+
+<!ENTITY % h5.attlist  "INCLUDE" >
+<![%h5.attlist;[
+<!ATTLIST %h5.qname;
+      %Common.attrib;
+>
+<!-- end of h5.attlist -->]]>
+
+<!ENTITY % h6.element  "INCLUDE" >
+<![%h6.element;[
+<!ENTITY % h6.qname  "h6" >
+<!ELEMENT %h6.qname;  %Heading.content; >
+<!-- end of h6.element -->]]>
+
+<!ENTITY % h6.attlist  "INCLUDE" >
+<![%h6.attlist;[
+<!ATTLIST %h6.qname;
+      %Common.attrib;
+>
+<!-- end of h6.attlist -->]]>
+
+<!-- end of xhtml-blkphras-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-blkpres-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-blkpres-1.mod
@@ -1,0 +1,40 @@
+<!-- ...................................................................... -->
+<!-- XHTML Block Presentation Module  ..................................... -->
+<!-- file: xhtml-blkpres-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-blkpres-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Block Presentation 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-blkpres-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Block Presentational Elements
+
+        hr
+
+     This module declares the elements and their attributes used to
+     support block-level presentational markup.
+-->
+
+<!ENTITY % hr.element  "INCLUDE" >
+<![%hr.element;[
+<!ENTITY % hr.content  "EMPTY" >
+<!ENTITY % hr.qname  "hr" >
+<!ELEMENT %hr.qname;  %hr.content; >
+<!-- end of hr.element -->]]>
+
+<!ENTITY % hr.attlist  "INCLUDE" >
+<![%hr.attlist;[
+<!ATTLIST %hr.qname;
+      %Common.attrib;
+>
+<!-- end of hr.attlist -->]]>
+
+<!-- end of xhtml-blkpres-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-blkstruct-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-blkstruct-1.mod
@@ -1,0 +1,57 @@
+<!-- ...................................................................... -->
+<!-- XHTML Block Structural Module  ....................................... -->
+<!-- file: xhtml-blkstruct-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-blkstruct-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Block Structural 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-blkstruct-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Block Structural
+
+        div, p
+
+     This module declares the elements and their attributes used to
+     support block-level structural markup.
+-->
+
+<!ENTITY % div.element  "INCLUDE" >
+<![%div.element;[
+<!ENTITY % div.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ENTITY % div.qname  "div" >
+<!ELEMENT %div.qname;  %div.content; >
+<!-- end of div.element -->]]>
+
+<!ENTITY % div.attlist  "INCLUDE" >
+<![%div.attlist;[
+<!ATTLIST %div.qname;
+      %Common.attrib;
+>
+<!-- end of div.attlist -->]]>
+
+<!ENTITY % p.element  "INCLUDE" >
+<![%p.element;[
+<!ENTITY % p.content
+     "( #PCDATA | %Inline.mix; )*" >
+<!ENTITY % p.qname  "p" >
+<!ELEMENT %p.qname;  %p.content; >
+<!-- end of p.element -->]]>
+
+<!ENTITY % p.attlist  "INCLUDE" >
+<![%p.attlist;[
+<!ATTLIST %p.qname;
+      %Common.attrib;
+>
+<!-- end of p.attlist -->]]>
+
+<!-- end of xhtml-blkstruct-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-charent-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-charent-1.mod
@@ -1,0 +1,39 @@
+<!-- ...................................................................... -->
+<!-- XHTML Character Entities Module  ......................................... -->
+<!-- file: xhtml-charent-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-charent-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES XHTML Character Entities 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-charent-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Character Entities for XHTML
+
+     This module declares the set of character entities for XHTML,
+     including the Latin 1, Symbol and Special character collections.
+-->
+
+<!ENTITY % xhtml-lat1
+    PUBLIC "-//W3C//ENTITIES Latin 1 for XHTML//EN"
+           "xhtml-lat1.ent" >
+%xhtml-lat1;
+
+<!ENTITY % xhtml-symbol
+    PUBLIC "-//W3C//ENTITIES Symbols for XHTML//EN"
+           "xhtml-symbol.ent" >
+%xhtml-symbol;
+
+<!ENTITY % xhtml-special
+    PUBLIC "-//W3C//ENTITIES Special for XHTML//EN"
+           "xhtml-special.ent" >
+%xhtml-special;
+
+<!-- end of xhtml-charent-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-csismap-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-csismap-1.mod
@@ -1,0 +1,114 @@
+<!-- ...................................................................... -->
+<!-- XHTML Client-side Image Map Module  .................................. -->
+<!-- file: xhtml-csismap-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-csismap-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Client-side Image Maps 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-csismap-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Client-side Image Maps
+
+        area, map
+
+     This module declares elements and attributes to support client-side
+     image maps. This requires that the Image Module (or a module
+     declaring the img element type) be included in the DTD.
+
+     These can be placed in the same document or grouped in a
+     separate document, although the latter isn't widely supported
+-->
+
+<!ENTITY % area.element  "INCLUDE" >
+<![%area.element;[
+<!ENTITY % area.content  "EMPTY" >
+<!ENTITY % area.qname  "area" >
+<!ELEMENT %area.qname;  %area.content; >
+<!-- end of area.element -->]]>
+
+<!ENTITY % Shape.datatype "( rect | circle | poly | default )">
+<!ENTITY % Coords.datatype "CDATA" >
+
+<!ENTITY % area.attlist  "INCLUDE" >
+<![%area.attlist;[
+<!ATTLIST %area.qname;
+      %Common.attrib;
+      href         %URI.datatype;           #IMPLIED
+      shape        %Shape.datatype;         'rect'
+      coords       %Coords.datatype;        #IMPLIED
+      nohref       ( nohref )               #IMPLIED
+      alt          %Text.datatype;          #REQUIRED
+      tabindex     %Number.datatype;        #IMPLIED
+      accesskey    %Character.datatype;     #IMPLIED
+>
+<!-- end of area.attlist -->]]>
+
+<!-- modify anchor attribute definition list
+     to allow for client-side image maps
+-->
+<!ATTLIST %a.qname;
+      shape        %Shape.datatype;         'rect'
+      coords       %Coords.datatype;        #IMPLIED
+>
+
+<!-- modify img attribute definition list
+     to allow for client-side image maps
+-->
+<!ATTLIST %img.qname;
+      usemap       %URIREF.datatype;        #IMPLIED
+>
+
+<!-- modify form input attribute definition list
+     to allow for client-side image maps
+-->
+<!ATTLIST %input.qname;
+      usemap       %URIREF.datatype;        #IMPLIED
+>
+
+<!-- modify object attribute definition list
+     to allow for client-side image maps
+-->
+<!ATTLIST %object.qname;
+      usemap       %URIREF.datatype;        #IMPLIED
+>
+
+<!-- 'usemap' points to the 'id' attribute of a <map> element,
+     which must be in the same document; support for external
+     document maps was not widely supported in HTML and is
+     eliminated in XHTML.
+
+     It is considered an error for the element pointed to by
+     a usemap URIREF to occur in anything but a <map> element.
+-->
+
+<!ENTITY % map.element  "INCLUDE" >
+<![%map.element;[
+<!ENTITY % map.content
+     "(( %Block.mix; ) | %area.qname; )+"
+>
+<!ENTITY % map.qname  "map" >
+<!ELEMENT %map.qname;  %map.content; >
+<!-- end of map.element -->]]>
+
+<!ENTITY % map.attlist  "INCLUDE" >
+<![%map.attlist;[
+<!ATTLIST %map.qname;
+      %XHTML.xmlns.attrib;
+      id           ID                       #REQUIRED
+      %class.attrib;
+      %title.attrib;
+      %Core.extra.attrib;
+      %I18n.attrib;
+      %Events.attrib;
+>
+<!-- end of map.attlist -->]]>
+
+<!-- end of xhtml-csismap-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-datatypes-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-datatypes-1.mod
@@ -1,0 +1,103 @@
+<!-- ...................................................................... -->
+<!-- XHTML Datatypes Module  .............................................. -->
+<!-- file: xhtml-datatypes-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-datatypes-1.mod,v 4.1 2001/04/06 19:23:32 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES XHTML Datatypes 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-datatypes-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Datatypes
+
+     defines containers for the following datatypes, many of
+     these imported from other specifications and standards.
+-->
+
+<!-- Length defined for cellpadding/cellspacing -->
+
+<!-- nn for pixels or nn% for percentage length -->
+<!ENTITY % Length.datatype "CDATA" >
+
+<!-- space-separated list of link types -->
+<!ENTITY % LinkTypes.datatype "NMTOKENS" >
+
+<!-- single or comma-separated list of media descriptors -->
+<!ENTITY % MediaDesc.datatype "CDATA" >
+
+<!-- pixel, percentage, or relative -->
+<!ENTITY % MultiLength.datatype "CDATA" >
+
+<!-- one or more digits (NUMBER) -->
+<!ENTITY % Number.datatype "CDATA" >
+
+<!-- integer representing length in pixels -->
+<!ENTITY % Pixels.datatype "CDATA" >
+
+<!-- script expression -->
+<!ENTITY % Script.datatype "CDATA" >
+
+<!-- textual content -->
+<!ENTITY % Text.datatype "CDATA" >
+
+<!-- Placeholder Compact URI-related types -->
+<!ENTITY % CURIE.datatype "CDATA" >
+<!ENTITY % CURIEs.datatype "CDATA" >
+<!ENTITY % SafeCURIE.datatype "CDATA" >
+<!ENTITY % SafeCURIEs.datatype "CDATA" >
+<!ENTITY % URIorSafeCURIE.datatype "CDATA" >
+<!ENTITY % URIorSafeCURIEs.datatype "CDATA" >
+
+<!-- Imported Datatypes ................................ -->
+
+<!-- a single character from [ISO10646] -->
+<!ENTITY % Character.datatype "CDATA" >
+
+<!-- a character encoding, as per [RFC2045] -->
+<!ENTITY % Charset.datatype "CDATA" >
+
+<!-- a space separated list of character encodings, as per [RFC2045] -->
+<!ENTITY % Charsets.datatype "CDATA" >
+
+<!-- Color specification using color name or sRGB (#RRGGBB) values -->
+<!ENTITY % Color.datatype "CDATA" >
+
+<!-- media type, as per [RFC2045] -->
+<!ENTITY % ContentType.datatype "CDATA" >
+
+<!-- comma-separated list of media types, as per [RFC2045] -->
+<!ENTITY % ContentTypes.datatype "CDATA" >
+
+<!-- date and time information. ISO date format -->
+<!ENTITY % Datetime.datatype "CDATA" >
+
+<!-- formal public identifier, as per [ISO8879] -->
+<!ENTITY % FPI.datatype "CDATA" >
+
+<!-- a language code, as per [RFC3066] or its successor -->
+<!ENTITY % LanguageCode.datatype "CDATA" >
+
+<!-- a comma separated list of language code ranges -->
+<!ENTITY % LanguageCodes.datatype "CDATA" >
+
+<!-- a qualified name , as per [XMLNS] or its successor -->
+<!ENTITY % QName.datatype "CDATA" >
+<!ENTITY % QNames.datatype "CDATA" >
+
+<!-- a Uniform Resource Identifier, see [URI] -->
+<!ENTITY % URI.datatype "CDATA" >
+
+<!-- a space-separated list of Uniform Resource Identifiers, see [URI] -->
+<!ENTITY % URIs.datatype "CDATA" >
+
+<!-- a relative URI reference consisting of an initial '#' and a fragment ID -->
+<!ENTITY % URIREF.datatype "CDATA" >
+
+<!-- end of xhtml-datatypes-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-edit-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-edit-1.mod
@@ -1,0 +1,66 @@
+<!-- ...................................................................... -->
+<!-- XHTML Editing Elements Module  ....................................... -->
+<!-- file: xhtml-edit-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-edit-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Editing Markup 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-edit-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Editing Elements
+
+        ins, del
+
+     This module declares element types and attributes used to indicate
+     inserted and deleted content while editing a document.
+-->
+
+<!-- ins: Inserted Text  ............................... -->
+
+<!ENTITY % ins.element  "INCLUDE" >
+<![%ins.element;[
+<!ENTITY % ins.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ENTITY % ins.qname  "ins" >
+<!ELEMENT %ins.qname;  %ins.content; >
+<!-- end of ins.element -->]]>
+
+<!ENTITY % ins.attlist  "INCLUDE" >
+<![%ins.attlist;[
+<!ATTLIST %ins.qname;
+      %Common.attrib;
+      cite         %URI.datatype;           #IMPLIED
+      datetime     %Datetime.datatype;      #IMPLIED
+>
+<!-- end of ins.attlist -->]]>
+
+<!-- del: Deleted Text  ................................ -->
+
+<!ENTITY % del.element  "INCLUDE" >
+<![%del.element;[
+<!ENTITY % del.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ENTITY % del.qname  "del" >
+<!ELEMENT %del.qname;  %del.content; >
+<!-- end of del.element -->]]>
+
+<!ENTITY % del.attlist  "INCLUDE" >
+<![%del.attlist;[
+<!ATTLIST %del.qname;
+      %Common.attrib;
+      cite         %URI.datatype;           #IMPLIED
+      datetime     %Datetime.datatype;      #IMPLIED
+>
+<!-- end of del.attlist -->]]>
+
+<!-- end of xhtml-edit-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-events-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-events-1.mod
@@ -1,0 +1,135 @@
+<!-- ...................................................................... -->
+<!-- XHTML Intrinsic Events Module  ....................................... -->
+<!-- file: xhtml-events-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-events-1.mod,v 4.1 2001/04/10 09:42:30 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES XHTML Intrinsic Events 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-events-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Intrinsic Event Attributes
+
+     These are the event attributes defined in HTML 4,
+     Section 18.2.3 "Intrinsic Events". This module must be
+     instantiated prior to the Attributes Module but after
+     the Datatype Module in the Modular Framework module.
+
+    "Note: Authors of HTML documents are advised that changes
+     are likely to occur in the realm of intrinsic events
+     (e.g., how scripts are bound to events). Research in
+     this realm is carried on by members of the W3C Document
+     Object Model Working Group (see the W3C Web site at
+     http://www.w3.org/ for more information)."
+-->
+<!-- NOTE: Because the ATTLIST declarations in this module occur
+     before their respective ELEMENT declarations in other
+     modules, there may be a dependency on this module that
+     should be considered if any of the parameter entities used
+     for element type names (eg., %a.qname;) are redeclared.
+-->
+
+<!ENTITY % Events.attrib
+     "onclick      %Script.datatype;        #IMPLIED
+      ondblclick   %Script.datatype;        #IMPLIED
+      onmousedown  %Script.datatype;        #IMPLIED
+      onmouseup    %Script.datatype;        #IMPLIED
+      onmouseover  %Script.datatype;        #IMPLIED
+      onmousemove  %Script.datatype;        #IMPLIED
+      onmouseout   %Script.datatype;        #IMPLIED
+      onkeypress   %Script.datatype;        #IMPLIED
+      onkeydown    %Script.datatype;        #IMPLIED
+      onkeyup      %Script.datatype;        #IMPLIED"
+>
+
+<![%XHTML.global.attrs.prefixed;[
+<!ENTITY % XHTML.global.events.attrib
+     "%XHTML.prefix;:onclick      %Script.datatype;        #IMPLIED
+      %XHTML.prefix;:ondblclick   %Script.datatype;        #IMPLIED
+      %XHTML.prefix;:onmousedown  %Script.datatype;        #IMPLIED
+      %XHTML.prefix;:onmouseup    %Script.datatype;        #IMPLIED
+      %XHTML.prefix;:onmouseover  %Script.datatype;        #IMPLIED
+      %XHTML.prefix;:onmousemove  %Script.datatype;        #IMPLIED
+      %XHTML.prefix;:onmouseout   %Script.datatype;        #IMPLIED
+      %XHTML.prefix;:onkeypress   %Script.datatype;        #IMPLIED
+      %XHTML.prefix;:onkeydown    %Script.datatype;        #IMPLIED
+      %XHTML.prefix;:onkeyup      %Script.datatype;        #IMPLIED"
+>
+]]>
+
+<!-- additional attributes on anchor element
+-->
+<!ATTLIST %a.qname;
+     onfocus      %Script.datatype;         #IMPLIED
+     onblur       %Script.datatype;         #IMPLIED
+>
+
+<!-- additional attributes on form element
+-->
+<!ATTLIST %form.qname;
+      onsubmit     %Script.datatype;        #IMPLIED
+      onreset      %Script.datatype;        #IMPLIED
+>
+
+<!-- additional attributes on label element
+-->
+<!ATTLIST %label.qname;
+      onfocus      %Script.datatype;        #IMPLIED
+      onblur       %Script.datatype;        #IMPLIED
+>
+
+<!-- additional attributes on input element
+-->
+<!ATTLIST %input.qname;
+      onfocus      %Script.datatype;        #IMPLIED
+      onblur       %Script.datatype;        #IMPLIED
+      onselect     %Script.datatype;        #IMPLIED
+      onchange     %Script.datatype;        #IMPLIED
+>
+
+<!-- additional attributes on select element
+-->
+<!ATTLIST %select.qname;
+      onfocus      %Script.datatype;        #IMPLIED
+      onblur       %Script.datatype;        #IMPLIED
+      onchange     %Script.datatype;        #IMPLIED
+>
+
+<!-- additional attributes on textarea element
+-->
+<!ATTLIST %textarea.qname;
+      onfocus      %Script.datatype;        #IMPLIED
+      onblur       %Script.datatype;        #IMPLIED
+      onselect     %Script.datatype;        #IMPLIED
+      onchange     %Script.datatype;        #IMPLIED
+>
+
+<!-- additional attributes on button element
+-->
+<!ATTLIST %button.qname;
+      onfocus      %Script.datatype;        #IMPLIED
+      onblur       %Script.datatype;        #IMPLIED
+>
+
+<!-- additional attributes on body element
+-->
+<!ATTLIST %body.qname;
+      onload       %Script.datatype;        #IMPLIED
+      onunload     %Script.datatype;        #IMPLIED
+>
+
+<!-- additional attributes on area element
+-->
+<!ATTLIST %area.qname;
+      onfocus      %Script.datatype;        #IMPLIED
+      onblur       %Script.datatype;        #IMPLIED
+>
+
+<!-- end of xhtml-events-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-form-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-form-1.mod
@@ -1,0 +1,292 @@
+<!-- ...................................................................... -->
+<!-- XHTML Forms Module  .................................................. -->
+<!-- file: xhtml-form-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-form-1.mod,v 4.1 2001/04/10 09:42:30 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Forms 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-form-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Forms
+
+        form, label, input, select, optgroup, option,
+        textarea, fieldset, legend, button
+
+     This module declares markup to provide support for online
+     forms, based on the features found in HTML 4 forms.
+-->
+
+<!-- declare qualified element type names:
+-->
+<!ENTITY % form.qname  "form" >
+<!ENTITY % label.qname  "label" >
+<!ENTITY % input.qname  "input" >
+<!ENTITY % select.qname  "select" >
+<!ENTITY % optgroup.qname  "optgroup" >
+<!ENTITY % option.qname  "option" >
+<!ENTITY % textarea.qname  "textarea" >
+<!ENTITY % fieldset.qname  "fieldset" >
+<!ENTITY % legend.qname  "legend" >
+<!ENTITY % button.qname  "button" >
+
+<!-- %BlkNoForm.mix; includes all non-form block elements,
+     plus %Misc.class;
+-->
+<!ENTITY % BlkNoForm.mix
+     "%Heading.class;
+      | %List.class;
+      | %BlkStruct.class;
+      %BlkPhras.class;
+      %BlkPres.class;
+      %Table.class;
+      %Block.extra;
+      %Misc.class;"
+>
+
+<!-- form: Form Element ................................ -->
+
+<!ENTITY % form.element  "INCLUDE" >
+<![%form.element;[
+<!ENTITY % form.content
+     "( %BlkNoForm.mix;
+      | %fieldset.qname; )+"
+>
+<!ELEMENT %form.qname;  %form.content; >
+<!-- end of form.element -->]]>
+
+<!ENTITY % form.attlist  "INCLUDE" >
+<![%form.attlist;[
+<!ATTLIST %form.qname;
+      %Common.attrib;
+      action       %URI.datatype;           #REQUIRED
+      method       ( get | post )           'get'
+      name         CDATA                    #IMPLIED
+      enctype      %ContentType.datatype;   'application/x-www-form-urlencoded'
+      accept-charset %Charsets.datatype;    #IMPLIED
+      accept       %ContentTypes.datatype;  #IMPLIED
+>
+<!-- end of form.attlist -->]]>
+
+<!-- label: Form Field Label Text ...................... -->
+
+<!-- Each label must not contain more than ONE field
+-->
+
+<!ENTITY % label.element  "INCLUDE" >
+<![%label.element;[
+<!ENTITY % label.content
+     "( #PCDATA
+      | %input.qname; | %select.qname; | %textarea.qname; | %button.qname;
+      | %InlStruct.class;
+      %InlPhras.class;
+      %I18n.class;
+      %InlPres.class;
+      %Anchor.class;
+      %InlSpecial.class;
+      %Inline.extra;
+      %Misc.class; )*"
+>
+<!ELEMENT %label.qname;  %label.content; >
+<!-- end of label.element -->]]>
+
+<!ENTITY % label.attlist  "INCLUDE" >
+<![%label.attlist;[
+<!ATTLIST %label.qname;
+      %Common.attrib;
+      for          IDREF                    #IMPLIED
+      accesskey    %Character.datatype;     #IMPLIED
+>
+<!-- end of label.attlist -->]]>
+
+<!-- input: Form Control ............................... -->
+
+<!ENTITY % input.element  "INCLUDE" >
+<![%input.element;[
+<!ENTITY % input.content  "EMPTY" >
+<!ELEMENT %input.qname;  %input.content; >
+<!-- end of input.element -->]]>
+
+<!ENTITY % input.attlist  "INCLUDE" >
+<![%input.attlist;[
+<!ENTITY % InputType.class
+     "( text | password | checkbox | radio | submit
+      | reset | file | hidden | image | button )"
+>
+<!-- attribute 'name' required for all but submit & reset
+-->
+<!ATTLIST %input.qname;
+      %Common.attrib;
+      type         %InputType.class;        'text'
+      name         CDATA                    #IMPLIED
+      value        CDATA                    #IMPLIED
+      checked      ( checked )              #IMPLIED
+      disabled     ( disabled )             #IMPLIED
+      readonly     ( readonly )             #IMPLIED
+      size         %Number.datatype;        #IMPLIED
+      maxlength    %Number.datatype;        #IMPLIED
+      src          %URI.datatype;           #IMPLIED
+      alt          %Text.datatype;          #IMPLIED
+      tabindex     %Number.datatype;        #IMPLIED
+      accesskey    %Character.datatype;     #IMPLIED
+      accept       %ContentTypes.datatype;  #IMPLIED
+>
+<!-- end of input.attlist -->]]>
+
+<!-- select: Option Selector ........................... -->
+
+<!ENTITY % select.element  "INCLUDE" >
+<![%select.element;[
+<!ENTITY % select.content
+     "( %optgroup.qname; | %option.qname; )+"
+>
+<!ELEMENT %select.qname;  %select.content; >
+<!-- end of select.element -->]]>
+
+<!ENTITY % select.attlist  "INCLUDE" >
+<![%select.attlist;[
+<!ATTLIST %select.qname;
+      %Common.attrib;
+      name         CDATA                    #IMPLIED
+      size         %Number.datatype;        #IMPLIED
+      multiple     ( multiple )             #IMPLIED
+      disabled     ( disabled )             #IMPLIED
+      tabindex     %Number.datatype;        #IMPLIED
+>
+<!-- end of select.attlist -->]]>
+
+<!-- optgroup: Option Group ............................ -->
+
+<!ENTITY % optgroup.element  "INCLUDE" >
+<![%optgroup.element;[
+<!ENTITY % optgroup.content  "( %option.qname; )+" >
+<!ELEMENT %optgroup.qname;  %optgroup.content; >
+<!-- end of optgroup.element -->]]>
+
+<!ENTITY % optgroup.attlist  "INCLUDE" >
+<![%optgroup.attlist;[
+<!ATTLIST %optgroup.qname;
+      %Common.attrib;
+      disabled     ( disabled )             #IMPLIED
+      label        %Text.datatype;          #REQUIRED
+>
+<!-- end of optgroup.attlist -->]]>
+
+<!-- option: Selectable Choice ......................... -->
+
+<!ENTITY % option.element  "INCLUDE" >
+<![%option.element;[
+<!ENTITY % option.content  "( #PCDATA )" >
+<!ELEMENT %option.qname;  %option.content; >
+<!-- end of option.element -->]]>
+
+<!ENTITY % option.attlist  "INCLUDE" >
+<![%option.attlist;[
+<!ATTLIST %option.qname;
+      %Common.attrib;
+      selected     ( selected )             #IMPLIED
+      disabled     ( disabled )             #IMPLIED
+      label        %Text.datatype;          #IMPLIED
+      value        CDATA                    #IMPLIED
+>
+<!-- end of option.attlist -->]]>
+
+<!-- textarea: Multi-Line Text Field ................... -->
+
+<!ENTITY % textarea.element  "INCLUDE" >
+<![%textarea.element;[
+<!ENTITY % textarea.content  "( #PCDATA )" >
+<!ELEMENT %textarea.qname;  %textarea.content; >
+<!-- end of textarea.element -->]]>
+
+<!ENTITY % textarea.attlist  "INCLUDE" >
+<![%textarea.attlist;[
+<!ATTLIST %textarea.qname;
+      %Common.attrib;
+      name         CDATA                    #IMPLIED
+      rows         %Number.datatype;        #REQUIRED
+      cols         %Number.datatype;        #REQUIRED
+      disabled     ( disabled )             #IMPLIED
+      readonly     ( readonly )             #IMPLIED
+      tabindex     %Number.datatype;        #IMPLIED
+      accesskey    %Character.datatype;     #IMPLIED
+>
+<!-- end of textarea.attlist -->]]>
+
+<!-- fieldset: Form Control Group ...................... -->
+
+<!-- #PCDATA is to solve the mixed content problem,
+     per specification only whitespace is allowed
+-->
+
+<!ENTITY % fieldset.element  "INCLUDE" >
+<![%fieldset.element;[
+<!ENTITY % fieldset.content
+     "( #PCDATA | %legend.qname; | %Flow.mix; )*"
+>
+<!ELEMENT %fieldset.qname;  %fieldset.content; >
+<!-- end of fieldset.element -->]]>
+
+<!ENTITY % fieldset.attlist  "INCLUDE" >
+<![%fieldset.attlist;[
+<!ATTLIST %fieldset.qname;
+      %Common.attrib;
+>
+<!-- end of fieldset.attlist -->]]>
+
+<!-- legend: Fieldset Legend ........................... -->
+
+<!ENTITY % legend.element  "INCLUDE" >
+<![%legend.element;[
+<!ENTITY % legend.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ELEMENT %legend.qname;  %legend.content; >
+<!-- end of legend.element -->]]>
+
+<!ENTITY % legend.attlist  "INCLUDE" >
+<![%legend.attlist;[
+<!ATTLIST %legend.qname;
+      %Common.attrib;
+      accesskey    %Character.datatype;     #IMPLIED
+>
+<!-- end of legend.attlist -->]]>
+
+<!-- button: Push Button ............................... -->
+
+<!ENTITY % button.element  "INCLUDE" >
+<![%button.element;[
+<!ENTITY % button.content
+     "( #PCDATA
+      | %BlkNoForm.mix;
+      | %InlStruct.class;
+      %InlPhras.class;
+      %InlPres.class;
+      %I18n.class;
+      %InlSpecial.class;
+      %Inline.extra; )*"
+>
+<!ELEMENT %button.qname;  %button.content; >
+<!-- end of button.element -->]]>
+
+<!ENTITY % button.attlist  "INCLUDE" >
+<![%button.attlist;[
+<!ATTLIST %button.qname;
+      %Common.attrib;
+      name         CDATA                    #IMPLIED
+      value        CDATA                    #IMPLIED
+      type         ( button | submit | reset ) 'submit'
+      disabled     ( disabled )             #IMPLIED
+      tabindex     %Number.datatype;        #IMPLIED
+      accesskey    %Character.datatype;     #IMPLIED
+>
+<!-- end of button.attlist -->]]>
+
+<!-- end of xhtml-form-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-framework-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-framework-1.mod
@@ -1,0 +1,97 @@
+<!-- ...................................................................... -->
+<!-- XHTML Modular Framework Module  ...................................... -->
+<!-- file: xhtml-framework-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-framework-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES XHTML Modular Framework 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-framework-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Modular Framework
+
+     This required module instantiates the modules needed
+     to support the XHTML modularization model, including:
+
+        +  datatypes
+        +  namespace-qualified names
+        +  common attributes
+        +  document model
+        +  character entities
+
+     The Intrinsic Events module is ignored by default but
+     occurs in this module because it must be instantiated
+     prior to Attributes but after Datatypes.
+-->
+
+<!ENTITY % xhtml-arch.module "IGNORE" >
+<![%xhtml-arch.module;[
+<!ENTITY % xhtml-arch.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Base Architecture 1.0//EN"
+            "xhtml-arch-1.mod" >
+%xhtml-arch.mod;]]>
+
+<!ENTITY % xhtml-notations.module "IGNORE" >
+<![%xhtml-notations.module;[
+<!ENTITY % xhtml-notations.mod
+     PUBLIC "-//W3C//NOTATIONS XHTML Notations 1.0//EN"
+            "xhtml-notations-1.mod" >
+%xhtml-notations.mod;]]>
+
+<!ENTITY % xhtml-datatypes.module "INCLUDE" >
+<![%xhtml-datatypes.module;[
+<!ENTITY % xhtml-datatypes.mod
+     PUBLIC "-//W3C//ENTITIES XHTML Datatypes 1.0//EN"
+            "xhtml-datatypes-1.mod" >
+%xhtml-datatypes.mod;]]>
+
+<!-- placeholder for XLink support module -->
+<!ENTITY % xhtml-xlink.mod "" >
+%xhtml-xlink.mod;
+
+<!ENTITY % xhtml-qname.module "INCLUDE" >
+<![%xhtml-qname.module;[
+<!ENTITY % xhtml-qname.mod
+     PUBLIC "-//W3C//ENTITIES XHTML Qualified Names 1.0//EN"
+            "xhtml-qname-1.mod" >
+%xhtml-qname.mod;]]>
+
+<!ENTITY % xhtml-events.module "IGNORE" >
+<![%xhtml-events.module;[
+<!ENTITY % xhtml-events.mod
+     PUBLIC "-//W3C//ENTITIES XHTML Intrinsic Events 1.0//EN"
+            "xhtml-events-1.mod" >
+%xhtml-events.mod;]]>
+
+<!ENTITY % xhtml-attribs.module "INCLUDE" >
+<![%xhtml-attribs.module;[
+<!ENTITY % xhtml-attribs.mod
+     PUBLIC "-//W3C//ENTITIES XHTML Common Attributes 1.0//EN"
+            "xhtml-attribs-1.mod" >
+%xhtml-attribs.mod;]]>
+
+<!-- placeholder for content model redeclarations -->
+<!ENTITY % xhtml-model.redecl "" >
+%xhtml-model.redecl;
+
+<!ENTITY % xhtml-model.module "INCLUDE" >
+<![%xhtml-model.module;[
+<!-- instantiate the Document Model module declared in the DTD driver
+-->
+%xhtml-model.mod;]]>
+
+<!ENTITY % xhtml-charent.module "INCLUDE" >
+<![%xhtml-charent.module;[
+<!ENTITY % xhtml-charent.mod
+     PUBLIC "-//W3C//ENTITIES XHTML Character Entities 1.0//EN"
+            "xhtml-charent-1.mod" >
+%xhtml-charent.mod;]]>
+
+<!-- end of xhtml-framework-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-hypertext-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-hypertext-1.mod
@@ -1,0 +1,54 @@
+<!-- ...................................................................... -->
+<!-- XHTML Hypertext Module  .............................................. -->
+<!-- file: xhtml-hypertext-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-hypertext-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Hypertext 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-hypertext-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Hypertext
+
+        a
+
+     This module declares the anchor ('a') element type, which
+     defines the source of a hypertext link. The destination
+     (or link 'target') is identified via its 'id' attribute
+     rather than the 'name' attribute as was used in HTML.
+-->
+
+<!-- ............  Anchor Element  ............ -->
+
+<!ENTITY % a.element  "INCLUDE" >
+<![%a.element;[
+<!ENTITY % a.content
+     "( #PCDATA | %InlNoAnchor.mix; )*"
+>
+<!ENTITY % a.qname  "a" >
+<!ELEMENT %a.qname;  %a.content; >
+<!-- end of a.element -->]]>
+
+<!ENTITY % a.attlist  "INCLUDE" >
+<![%a.attlist;[
+<!ATTLIST %a.qname;
+      %Common.attrib;
+      href         %URI.datatype;           #IMPLIED
+      charset      %Charset.datatype;       #IMPLIED
+      type         %ContentType.datatype;   #IMPLIED
+      hreflang     %LanguageCode.datatype;  #IMPLIED
+      rel          %LinkTypes.datatype;     #IMPLIED
+      rev          %LinkTypes.datatype;     #IMPLIED
+      accesskey    %Character.datatype;     #IMPLIED
+      tabindex     %Number.datatype;        #IMPLIED
+>
+<!-- end of a.attlist -->]]>
+
+<!-- end of xhtml-hypertext-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-image-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-image-1.mod
@@ -1,0 +1,51 @@
+<!-- ...................................................................... -->
+<!-- XHTML Images Module  ................................................. -->
+<!-- file: xhtml-image-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Rovision: $Id: xhtml-image-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Images 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-image-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Images
+
+        img
+
+     This module provides markup to support basic image embedding.
+-->
+
+<!-- To avoid problems with text-only UAs as well as to make
+     image content understandable and navigable to users of
+     non-visual UAs, you need to provide a description with
+     the 'alt' attribute, and avoid server-side image maps.
+-->
+
+<!ENTITY % img.element  "INCLUDE" >
+<![%img.element;[
+<!ENTITY % img.content  "EMPTY" >
+<!ENTITY % img.qname  "img" >
+<!ELEMENT %img.qname;  %img.content; >
+<!-- end of img.element -->]]>
+
+<!ENTITY % img.attlist  "INCLUDE" >
+<![%img.attlist;[
+<!ATTLIST %img.qname;
+      %Common.attrib;
+      src          %URI.datatype;           #REQUIRED
+      alt          %Text.datatype;          #REQUIRED
+      longdesc     %URI.datatype;           #IMPLIED
+      name         CDATA                    #IMPLIED
+      height       %Length.datatype;        #IMPLIED
+      width        %Length.datatype;        #IMPLIED
+>
+<!-- end of img.attlist -->]]>
+
+<!-- end of xhtml-image-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-inlphras-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-inlphras-1.mod
@@ -1,0 +1,203 @@
+<!-- ...................................................................... -->
+<!-- XHTML Inline Phrasal Module  ......................................... -->
+<!-- file: xhtml-inlphras-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-inlphras-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Inline Phrasal 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-inlphras-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Inline Phrasal
+
+        abbr, acronym, cite, code, dfn, em, kbd, q, samp, strong, var
+
+     This module declares the elements and their attributes used to
+     support inline-level phrasal markup.
+-->
+
+<!ENTITY % abbr.element  "INCLUDE" >
+<![%abbr.element;[
+<!ENTITY % abbr.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % abbr.qname  "abbr" >
+<!ELEMENT %abbr.qname;  %abbr.content; >
+<!-- end of abbr.element -->]]>
+
+<!ENTITY % abbr.attlist  "INCLUDE" >
+<![%abbr.attlist;[
+<!ATTLIST %abbr.qname;
+      %Common.attrib;
+>
+<!-- end of abbr.attlist -->]]>
+
+<!ENTITY % acronym.element  "INCLUDE" >
+<![%acronym.element;[
+<!ENTITY % acronym.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % acronym.qname  "acronym" >
+<!ELEMENT %acronym.qname;  %acronym.content; >
+<!-- end of acronym.element -->]]>
+
+<!ENTITY % acronym.attlist  "INCLUDE" >
+<![%acronym.attlist;[
+<!ATTLIST %acronym.qname;
+      %Common.attrib;
+>
+<!-- end of acronym.attlist -->]]>
+
+<!ENTITY % cite.element  "INCLUDE" >
+<![%cite.element;[
+<!ENTITY % cite.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % cite.qname  "cite" >
+<!ELEMENT %cite.qname;  %cite.content; >
+<!-- end of cite.element -->]]>
+
+<!ENTITY % cite.attlist  "INCLUDE" >
+<![%cite.attlist;[
+<!ATTLIST %cite.qname;
+      %Common.attrib;
+>
+<!-- end of cite.attlist -->]]>
+
+<!ENTITY % code.element  "INCLUDE" >
+<![%code.element;[
+<!ENTITY % code.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % code.qname  "code" >
+<!ELEMENT %code.qname;  %code.content; >
+<!-- end of code.element -->]]>
+
+<!ENTITY % code.attlist  "INCLUDE" >
+<![%code.attlist;[
+<!ATTLIST %code.qname;
+      %Common.attrib;
+>
+<!-- end of code.attlist -->]]>
+
+<!ENTITY % dfn.element  "INCLUDE" >
+<![%dfn.element;[
+<!ENTITY % dfn.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % dfn.qname  "dfn" >
+<!ELEMENT %dfn.qname;  %dfn.content; >
+<!-- end of dfn.element -->]]>
+
+<!ENTITY % dfn.attlist  "INCLUDE" >
+<![%dfn.attlist;[
+<!ATTLIST %dfn.qname;
+      %Common.attrib;
+>
+<!-- end of dfn.attlist -->]]>
+
+<!ENTITY % em.element  "INCLUDE" >
+<![%em.element;[
+<!ENTITY % em.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % em.qname  "em" >
+<!ELEMENT %em.qname;  %em.content; >
+<!-- end of em.element -->]]>
+
+<!ENTITY % em.attlist  "INCLUDE" >
+<![%em.attlist;[
+<!ATTLIST %em.qname;
+      %Common.attrib;
+>
+<!-- end of em.attlist -->]]>
+
+<!ENTITY % kbd.element  "INCLUDE" >
+<![%kbd.element;[
+<!ENTITY % kbd.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % kbd.qname  "kbd" >
+<!ELEMENT %kbd.qname;  %kbd.content; >
+<!-- end of kbd.element -->]]>
+
+<!ENTITY % kbd.attlist  "INCLUDE" >
+<![%kbd.attlist;[
+<!ATTLIST %kbd.qname;
+      %Common.attrib;
+>
+<!-- end of kbd.attlist -->]]>
+
+<!ENTITY % q.element  "INCLUDE" >
+<![%q.element;[
+<!ENTITY % q.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % q.qname  "q" >
+<!ELEMENT %q.qname;  %q.content; >
+<!-- end of q.element -->]]>
+
+<!ENTITY % q.attlist  "INCLUDE" >
+<![%q.attlist;[
+<!ATTLIST %q.qname;
+      %Common.attrib;
+      cite         %URI.datatype;           #IMPLIED
+>
+<!-- end of q.attlist -->]]>
+
+<!ENTITY % samp.element  "INCLUDE" >
+<![%samp.element;[
+<!ENTITY % samp.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % samp.qname  "samp" >
+<!ELEMENT %samp.qname;  %samp.content; >
+<!-- end of samp.element -->]]>
+
+<!ENTITY % samp.attlist  "INCLUDE" >
+<![%samp.attlist;[
+<!ATTLIST %samp.qname;
+      %Common.attrib;
+>
+<!-- end of samp.attlist -->]]>
+
+<!ENTITY % strong.element  "INCLUDE" >
+<![%strong.element;[
+<!ENTITY % strong.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % strong.qname  "strong" >
+<!ELEMENT %strong.qname;  %strong.content; >
+<!-- end of strong.element -->]]>
+
+<!ENTITY % strong.attlist  "INCLUDE" >
+<![%strong.attlist;[
+<!ATTLIST %strong.qname;
+      %Common.attrib;
+>
+<!-- end of strong.attlist -->]]>
+
+<!ENTITY % var.element  "INCLUDE" >
+<![%var.element;[
+<!ENTITY % var.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % var.qname  "var" >
+<!ELEMENT %var.qname;  %var.content; >
+<!-- end of var.element -->]]>
+
+<!ENTITY % var.attlist  "INCLUDE" >
+<![%var.attlist;[
+<!ATTLIST %var.qname;
+      %Common.attrib;
+>
+<!-- end of var.attlist -->]]>
+
+<!-- end of xhtml-inlphras-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-inlpres-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-inlpres-1.mod
@@ -1,0 +1,138 @@
+<!-- ...................................................................... -->
+<!-- XHTML Inline Presentation Module  .................................... -->
+<!-- file: xhtml-inlpres-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-inlpres-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Inline Presentation 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-inlpres-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Inline Presentational Elements
+
+        b, big, i, small, sub, sup, tt
+
+     This module declares the elements and their attributes used to
+     support inline-level presentational markup.
+-->
+
+<!ENTITY % b.element  "INCLUDE" >
+<![%b.element;[
+<!ENTITY % b.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % b.qname  "b" >
+<!ELEMENT %b.qname;  %b.content; >
+<!-- end of b.element -->]]>
+
+<!ENTITY % b.attlist  "INCLUDE" >
+<![%b.attlist;[
+<!ATTLIST %b.qname;
+      %Common.attrib;
+>
+<!-- end of b.attlist -->]]>
+
+<!ENTITY % big.element  "INCLUDE" >
+<![%big.element;[
+<!ENTITY % big.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % big.qname  "big" >
+<!ELEMENT %big.qname;  %big.content; >
+<!-- end of big.element -->]]>
+
+<!ENTITY % big.attlist  "INCLUDE" >
+<![%big.attlist;[
+<!ATTLIST %big.qname;
+      %Common.attrib;
+>
+<!-- end of big.attlist -->]]>
+
+<!ENTITY % i.element  "INCLUDE" >
+<![%i.element;[
+<!ENTITY % i.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % i.qname  "i" >
+<!ELEMENT %i.qname;  %i.content; >
+<!-- end of i.element -->]]>
+
+<!ENTITY % i.attlist  "INCLUDE" >
+<![%i.attlist;[
+<!ATTLIST %i.qname;
+      %Common.attrib;
+>
+<!-- end of i.attlist -->]]>
+
+<!ENTITY % small.element  "INCLUDE" >
+<![%small.element;[
+<!ENTITY % small.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % small.qname  "small" >
+<!ELEMENT %small.qname;  %small.content; >
+<!-- end of small.element -->]]>
+
+<!ENTITY % small.attlist  "INCLUDE" >
+<![%small.attlist;[
+<!ATTLIST %small.qname;
+      %Common.attrib;
+>
+<!-- end of small.attlist -->]]>
+
+<!ENTITY % sub.element  "INCLUDE" >
+<![%sub.element;[
+<!ENTITY % sub.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % sub.qname  "sub" >
+<!ELEMENT %sub.qname;  %sub.content; >
+<!-- end of sub.element -->]]>
+
+<!ENTITY % sub.attlist  "INCLUDE" >
+<![%sub.attlist;[
+<!ATTLIST %sub.qname;
+      %Common.attrib;
+>
+<!-- end of sub.attlist -->]]>
+
+<!ENTITY % sup.element  "INCLUDE" >
+<![%sup.element;[
+<!ENTITY % sup.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % sup.qname  "sup" >
+<!ELEMENT %sup.qname;  %sup.content; >
+<!-- end of sup.element -->]]>
+
+<!ENTITY % sup.attlist  "INCLUDE" >
+<![%sup.attlist;[
+<!ATTLIST %sup.qname;
+      %Common.attrib;
+>
+<!-- end of sup.attlist -->]]>
+
+<!ENTITY % tt.element  "INCLUDE" >
+<![%tt.element;[
+<!ENTITY % tt.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % tt.qname  "tt" >
+<!ELEMENT %tt.qname;  %tt.content; >
+<!-- end of tt.element -->]]>
+
+<!ENTITY % tt.attlist  "INCLUDE" >
+<![%tt.attlist;[
+<!ATTLIST %tt.qname;
+      %Common.attrib;
+>
+<!-- end of tt.attlist -->]]>
+
+<!-- end of xhtml-inlpres-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-inlstruct-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-inlstruct-1.mod
@@ -1,0 +1,62 @@
+<!-- ...................................................................... -->
+<!-- XHTML Inline Structural Module  ...................................... -->
+<!-- file: xhtml-inlstruct-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-inlstruct-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Inline Structural 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-inlstruct-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Inline Structural
+
+        br, span
+
+     This module declares the elements and their attributes
+     used to support inline-level structural markup.
+-->
+
+<!-- br: forced line break ............................. -->
+
+<!ENTITY % br.element  "INCLUDE" >
+<![%br.element;[
+
+<!ENTITY % br.content  "EMPTY" >
+<!ENTITY % br.qname  "br" >
+<!ELEMENT %br.qname;  %br.content; >
+
+<!-- end of br.element -->]]>
+
+<!ENTITY % br.attlist  "INCLUDE" >
+<![%br.attlist;[
+<!ATTLIST %br.qname;
+      %Core.attrib;
+>
+<!-- end of br.attlist -->]]>
+
+<!-- span: generic inline container .................... -->
+
+<!ENTITY % span.element  "INCLUDE" >
+<![%span.element;[
+<!ENTITY % span.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % span.qname  "span" >
+<!ELEMENT %span.qname;  %span.content; >
+<!-- end of span.element -->]]>
+
+<!ENTITY % span.attlist  "INCLUDE" >
+<![%span.attlist;[
+<!ATTLIST %span.qname;
+      %Common.attrib;
+>
+<!-- end of span.attlist -->]]>
+
+<!-- end of xhtml-inlstruct-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-inlstyle-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-inlstyle-1.mod
@@ -1,0 +1,34 @@
+<!-- ...................................................................... -->
+<!-- XHTML Inline Style Module  ........................................... -->
+<!-- file: xhtml-inlstyle-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-inlstyle-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-inlstyle-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Inline Style
+
+     This module declares the 'style' attribute, used to support inline
+     style markup. This module must be instantiated prior to the XHTML
+     Common Attributes module in order to be included in %Core.attrib;.
+-->
+
+<!ENTITY % style.attrib
+     "style        CDATA                    #IMPLIED"
+>
+
+
+<!ENTITY % Core.extra.attrib
+     "%style.attrib;"
+>
+
+<!-- end of xhtml-inlstyle-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-legacy-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-legacy-1.mod
@@ -1,0 +1,400 @@
+<!-- ...................................................................... -->
+<!-- XHTML Legacy Markup Module ........................................... -->
+<!-- file: xhtml-legacy-1.mod
+
+     This is an extension of XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-legacy-1.mod,v 4.1 2001/04/10 09:42:30 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Legacy Markup 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-legacy-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- HTML Legacy Markup
+
+        font, basefont, center, s, strike, u, dir, menu, isindex
+
+          (plus additional datatypes and attributes)
+
+     This optional module declares additional markup for simple
+     presentation-related markup based on features found in the
+     HTML 4 Transitional and Frameset DTDs. This relies on
+     inclusion of the Legacy Redeclarations module. This module
+     also declares the frames, inline frames and object modules.
+
+     This is to allow XHTML 1.1 documents to be transformed for
+     display on HTML browsers where CSS support is inconsistent
+     or unavailable.
+-->
+<!-- Constructing a Legacy DTD
+
+     To construct a DTD driver obtaining a close approximation
+     of the HTML 4 Transitional and Frameset DTDs, declare the
+     Legacy Redeclarations module as the pre-framework redeclaration
+     parameter entity (%xhtml-prefw-redecl.mod;) and INCLUDE its
+     conditional section:
+
+        ...
+        <!ENTITY % xhtml-prefw-redecl.module "INCLUDE" >
+        <![%xhtml-prefw-redecl.module;[
+        <!ENTITY % xhtml-prefw-redecl.mod
+            PUBLIC "-//W3C//ELEMENTS XHTML Legacy Redeclarations 1.0//EN"
+                   "xhtml-legacy-redecl-1.mod" >
+        %xhtml-prefw-redecl.mod;]]>
+
+     Such a DTD should be named with a variant FPI and redeclare
+     the value of the %XHTML.version; parameter entity to that FPI:
+
+         "-//Your Name Here//DTD XHTML Legacy 1.1//EN"
+
+     IMPORTANT:  see also the notes included in the Legacy Redeclarations
+     Module for information on how to construct a DTD using this module.
+-->
+
+
+<!-- Additional Element Types .................................... -->
+
+<!-- font: Local Font Modifier  ........................ -->
+
+<!ENTITY % font.element  "INCLUDE" >
+<![%font.element;[
+<!ENTITY % font.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % font.qname  "font" >
+<!ELEMENT %font.qname;  %font.content; >
+<!-- end of font.element -->]]>
+
+<!ENTITY % font.attlist  "INCLUDE" >
+<![%font.attlist;[
+<!ATTLIST %font.qname;
+      %Core.attrib;
+      %I18n.attrib;
+      size         CDATA                    #IMPLIED
+      color        %Color.datatype;         #IMPLIED
+      face         CDATA                    #IMPLIED
+>
+<!-- end of font.attlist -->]]>
+
+<!-- basefont: Base Font Size  ......................... -->
+
+<!ENTITY % basefont.element  "INCLUDE" >
+<![%basefont.element;[
+<!ENTITY % basefont.content "EMPTY" >
+<!ENTITY % basefont.qname  "basefont" >
+<!ELEMENT %basefont.qname;  %basefont.content; >
+<!-- end of basefont.element -->]]>
+
+<!ENTITY % basefont.attlist  "INCLUDE" >
+<![%basefont.attlist;[
+<!ATTLIST %basefont.qname;
+      %id.attrib;
+      size         CDATA                    #REQUIRED
+      color        %Color.datatype;         #IMPLIED
+      face         CDATA                    #IMPLIED
+>
+<!-- end of basefont.attlist -->]]>
+
+<!-- center: Center Alignment  ......................... -->
+
+<!ENTITY % center.element  "INCLUDE" >
+<![%center.element;[
+<!ENTITY % center.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ENTITY % center.qname  "center" >
+<!ELEMENT %center.qname;  %center.content; >
+<!-- end of center.element -->]]>
+
+<!ENTITY % center.attlist  "INCLUDE" >
+<![%center.attlist;[
+<!ATTLIST %center.qname;
+      %Common.attrib;
+>
+<!-- end of center.attlist -->]]>
+
+<!-- s: Strike-Thru Text Style  ........................ -->
+
+<!ENTITY % s.element  "INCLUDE" >
+<![%s.element;[
+<!ENTITY % s.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % s.qname  "s" >
+<!ELEMENT %s.qname;  %s.content; >
+<!-- end of s.element -->]]>
+
+<!ENTITY % s.attlist  "INCLUDE" >
+<![%s.attlist;[
+<!ATTLIST %s.qname;
+      %Common.attrib;
+>
+<!-- end of s.attlist -->]]>
+
+<!-- strike: Strike-Thru Text Style  ....................-->
+
+<!ENTITY % strike.element  "INCLUDE" >
+<![%strike.element;[
+<!ENTITY % strike.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % strike.qname  "strike" >
+<!ELEMENT %strike.qname;  %strike.content; >
+<!-- end of strike.element -->]]>
+
+<!ENTITY % strike.attlist  "INCLUDE" >
+<![%strike.attlist;[
+<!ATTLIST %strike.qname;
+      %Common.attrib;
+>
+<!-- end of strike.attlist -->]]>
+
+<!-- u: Underline Text Style  ...........................-->
+
+<!ENTITY % u.element  "INCLUDE" >
+<![%u.element;[
+<!ENTITY % u.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ENTITY % u.qname  "u" >
+<!ELEMENT %u.qname;  %u.content; >
+<!-- end of u.element -->]]>
+
+<!ENTITY % u.attlist  "INCLUDE" >
+<![%u.attlist;[
+<!ATTLIST %u.qname;
+      %Common.attrib;
+>
+<!-- end of u.attlist -->]]>
+
+<!-- dir: Directory List  .............................. -->
+
+<!-- NOTE: the content model for <dir> in HTML 4 excluded %Block.mix;
+-->
+<!ENTITY % dir.element  "INCLUDE" >
+<![%dir.element;[
+<!ENTITY % dir.content
+     "( %li.qname; )+"
+>
+<!ENTITY % dir.qname  "dir" >
+<!ELEMENT %dir.qname;  %dir.content; >
+<!-- end of dir.element -->]]>
+
+<!ENTITY % dir.attlist  "INCLUDE" >
+<![%dir.attlist;[
+<!ATTLIST %dir.qname;
+      %Common.attrib;
+      compact      ( compact )              #IMPLIED
+>
+<!-- end of dir.attlist -->]]>
+
+<!-- menu: Menu List  .................................. -->
+
+<!-- NOTE: the content model for <menu> in HTML 4 excluded %Block.mix;
+-->
+<!ENTITY % menu.element  "INCLUDE" >
+<![%menu.element;[
+<!ENTITY % menu.content
+     "( %li.qname; )+"
+>
+<!ENTITY % menu.qname  "menu" >
+<!ELEMENT %menu.qname;  %menu.content; >
+<!-- end of menu.element -->]]>
+
+<!ENTITY % menu.attlist  "INCLUDE" >
+<![%menu.attlist;[
+<!ATTLIST %menu.qname;
+      %Common.attrib;
+      compact      ( compact )              #IMPLIED
+>
+<!-- end of menu.attlist -->]]>
+
+<!-- isindex: Single-Line Prompt  ...................... -->
+
+<!ENTITY % isindex.element  "INCLUDE" >
+<![%isindex.element;[
+<!ENTITY % isindex.content "EMPTY" >
+<!ENTITY % isindex.qname  "isindex" >
+<!ELEMENT %isindex.qname;  %isindex.content; >
+<!-- end of isindex.element -->]]>
+
+<!ENTITY % isindex.attlist  "INCLUDE" >
+<![%isindex.attlist;[
+<!ATTLIST %isindex.qname;
+      %Core.attrib;
+      %I18n.attrib;
+      prompt       %Text.datatype;          #IMPLIED
+>
+<!-- end of isindex.attlist -->]]>
+
+
+<!-- Additional Attributes ....................................... -->
+
+<!-- Alignment attribute for Transitional use in HTML browsers
+     (this functionality is generally well-supported in CSS,
+     except within some contexts)
+-->
+<!ENTITY % align.attrib
+     "align        ( left | center | right | justify ) #IMPLIED"
+>
+
+<!ATTLIST %applet.qname;
+      align       ( top | middle | bottom | left | right ) #IMPLIED
+      hspace      %Pixels.datatype;         #IMPLIED
+      vspace      %Pixels.datatype;         #IMPLIED
+>
+
+<!ATTLIST %body.qname;
+      background   %URI.datatype;           #IMPLIED
+      bgcolor      %Color.datatype;         #IMPLIED
+      text         %Color.datatype;         #IMPLIED
+      link         %Color.datatype;         #IMPLIED
+      vlink        %Color.datatype;         #IMPLIED
+      alink        %Color.datatype;         #IMPLIED
+>
+
+<!ATTLIST %br.qname;
+      clear        ( left | all | right | none ) 'none'
+>
+
+<!ATTLIST %caption.qname;
+      align        ( top | bottom | left | right ) #IMPLIED
+>
+
+<!ATTLIST %div.qname;
+      %align.attrib;
+>
+
+<!ATTLIST %h1.qname;
+      %align.attrib;
+>
+
+<!ATTLIST %h2.qname;
+      %align.attrib;
+>
+
+<!ATTLIST %h3.qname;
+      %align.attrib;
+>
+
+<!ATTLIST %h4.qname;
+      %align.attrib;
+>
+
+<!ATTLIST %h5.qname;
+      %align.attrib;
+>
+
+<!ATTLIST %h6.qname;
+      %align.attrib;
+>
+
+<!ATTLIST %hr.qname;
+      align        ( left | center | right ) #IMPLIED
+      noshade      ( noshade )              #IMPLIED
+      size         %Pixels.datatype;        #IMPLIED
+      width        %Length.datatype;        #IMPLIED
+>
+
+<!ATTLIST %img.qname;
+      align       ( top | middle | bottom | left | right ) #IMPLIED
+      border      %Pixels.datatype;         #IMPLIED
+      hspace      %Pixels.datatype;         #IMPLIED
+      vspace      %Pixels.datatype;         #IMPLIED
+>
+
+<!ATTLIST %input.qname;
+      align       ( top | middle | bottom | left | right ) #IMPLIED
+>
+
+<!ATTLIST %legend.qname;
+      align        ( top | bottom | left | right ) #IMPLIED
+>
+
+<!ATTLIST %li.qname;
+      type         CDATA                     #IMPLIED
+      value        %Number.datatype;         #IMPLIED
+>
+
+<!ATTLIST %object.qname;
+      align        ( top | middle | bottom | left | right ) #IMPLIED
+      border       %Pixels.datatype;         #IMPLIED
+      hspace       %Pixels.datatype;         #IMPLIED
+      vspace       %Pixels.datatype;         #IMPLIED
+>
+
+<!ATTLIST %dl.qname;
+      compact      ( compact )              #IMPLIED
+>
+
+<!ATTLIST %ol.qname;
+      type         CDATA                    #IMPLIED
+      compact      ( compact )              #IMPLIED
+      start        %Number.datatype;        #IMPLIED
+>
+
+<!ATTLIST %p.qname;
+      %align.attrib;
+>
+
+<!ATTLIST %pre.qname;
+      width        %Length.datatype;        #IMPLIED
+>
+
+<!ATTLIST %script.qname;
+      language     %ContentType.datatype;   #IMPLIED
+>
+
+<!ATTLIST %table.qname;
+      align        ( left | center | right ) #IMPLIED
+      bgcolor      %Color.datatype;         #IMPLIED
+>
+
+<!ATTLIST %tr.qname;
+      bgcolor     %Color.datatype;          #IMPLIED
+>
+
+<!ATTLIST %th.qname;
+      nowrap      ( nowrap )                #IMPLIED
+      bgcolor     %Color.datatype;          #IMPLIED
+      width       %Length.datatype;         #IMPLIED
+      height      %Length.datatype;         #IMPLIED
+>
+
+<!ATTLIST %td.qname;
+      nowrap      ( nowrap )                #IMPLIED
+      bgcolor     %Color.datatype;          #IMPLIED
+      width       %Length.datatype;         #IMPLIED
+      height      %Length.datatype;         #IMPLIED
+>
+
+<!ATTLIST %ul.qname;
+      type         CDATA                    #IMPLIED
+      compact      ( compact )              #IMPLIED
+>
+
+<!-- Frames Module ............................................... -->
+<!ENTITY % xhtml-frames.module "IGNORE" >
+<![%xhtml-frames.module;[
+<!ENTITY % xhtml-frames.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Frames 1.0//EN"
+            "xhtml-frames-1.mod" >
+%xhtml-frames.mod;]]>
+
+<!-- Inline Frames Module ........................................ -->
+<!ENTITY % xhtml-iframe.module "INCLUDE" >
+<![%xhtml-iframe.module;[
+<!ATTLIST %iframe.qname;
+      align        ( top | middle | bottom | left | right ) #IMPLIED
+>
+<!ENTITY % xhtml-iframe.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Inline Frame Element 1.0//EN"
+            "xhtml-iframe-1.mod" >
+%xhtml-iframe.mod;]]>
+
+<!-- end of xhtml-legacy-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-link-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-link-1.mod
@@ -1,0 +1,59 @@
+<!-- ...................................................................... -->
+<!-- XHTML Link Element Module  ........................................... -->
+<!-- file: xhtml-link-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-link-1.mod,v 4.1 2001/04/05 06:57:40 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Link Element 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-link-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Link element
+
+        link
+
+     This module declares the link element type and its attributes,
+     which could (in principle) be used to define document-level links
+     to external resources such as:
+
+     a) for document specific toolbars/menus, e.g. start, contents,
+        previous, next, index, end, help
+     b) to link to a separate style sheet (rel="stylesheet")
+     c) to make a link to a script (rel="script")
+     d) by style sheets to control how collections of html nodes are
+        rendered into printed documents
+     e) to make a link to a printable version of this document
+        e.g. a postscript or pdf version (rel="alternate" media="print")
+-->
+
+<!-- link: Media-Independent Link ...................... -->
+
+<!ENTITY % link.element  "INCLUDE" >
+<![%link.element;[
+<!ENTITY % link.content  "EMPTY" >
+<!ENTITY % link.qname  "link" >
+<!ELEMENT %link.qname;  %link.content; >
+<!-- end of link.element -->]]>
+
+<!ENTITY % link.attlist  "INCLUDE" >
+<![%link.attlist;[
+<!ATTLIST %link.qname;
+      %Common.attrib;
+      charset      %Charset.datatype;       #IMPLIED
+      href         %URI.datatype;           #IMPLIED
+      hreflang     %LanguageCode.datatype;  #IMPLIED
+      type         %ContentType.datatype;   #IMPLIED
+      rel          %LinkTypes.datatype;     #IMPLIED
+      rev          %LinkTypes.datatype;     #IMPLIED
+      media        %MediaDesc.datatype;     #IMPLIED
+>
+<!-- end of link.attlist -->]]>
+
+<!-- end of xhtml-link-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-list-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-list-1.mod
@@ -1,0 +1,129 @@
+<!-- ...................................................................... -->
+<!-- XHTML Lists Module  .................................................. -->
+<!-- file: xhtml-list-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-list-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Lists 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-list-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Lists
+
+        dl, dt, dd, ol, ul, li
+
+     This module declares the list-oriented element types
+     and their attributes.
+-->
+
+<!ENTITY % dl.qname  "dl" >
+<!ENTITY % dt.qname  "dt" >
+<!ENTITY % dd.qname  "dd" >
+<!ENTITY % ol.qname  "ol" >
+<!ENTITY % ul.qname  "ul" >
+<!ENTITY % li.qname  "li" >
+
+<!-- dl: Definition List ............................... -->
+
+<!ENTITY % dl.element  "INCLUDE" >
+<![%dl.element;[
+<!ENTITY % dl.content  "( %dt.qname; | %dd.qname; )+" >
+<!ELEMENT %dl.qname;  %dl.content; >
+<!-- end of dl.element -->]]>
+
+<!ENTITY % dl.attlist  "INCLUDE" >
+<![%dl.attlist;[
+<!ATTLIST %dl.qname;
+      %Common.attrib;
+>
+<!-- end of dl.attlist -->]]>
+
+<!-- dt: Definition Term ............................... -->
+
+<!ENTITY % dt.element  "INCLUDE" >
+<![%dt.element;[
+<!ENTITY % dt.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ELEMENT %dt.qname;  %dt.content; >
+<!-- end of dt.element -->]]>
+
+<!ENTITY % dt.attlist  "INCLUDE" >
+<![%dt.attlist;[
+<!ATTLIST %dt.qname;
+      %Common.attrib;
+>
+<!-- end of dt.attlist -->]]>
+
+<!-- dd: Definition Description ........................ -->
+
+<!ENTITY % dd.element  "INCLUDE" >
+<![%dd.element;[
+<!ENTITY % dd.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ELEMENT %dd.qname;  %dd.content; >
+<!-- end of dd.element -->]]>
+
+<!ENTITY % dd.attlist  "INCLUDE" >
+<![%dd.attlist;[
+<!ATTLIST %dd.qname;
+      %Common.attrib;
+>
+<!-- end of dd.attlist -->]]>
+
+<!-- ol: Ordered List (numbered styles) ................ -->
+
+<!ENTITY % ol.element  "INCLUDE" >
+<![%ol.element;[
+<!ENTITY % ol.content  "( %li.qname; )+" >
+<!ELEMENT %ol.qname;  %ol.content; >
+<!-- end of ol.element -->]]>
+
+<!ENTITY % ol.attlist  "INCLUDE" >
+<![%ol.attlist;[
+<!ATTLIST %ol.qname;
+      %Common.attrib;
+>
+<!-- end of ol.attlist -->]]>
+
+<!-- ul: Unordered List (bullet styles) ................ -->
+
+<!ENTITY % ul.element  "INCLUDE" >
+<![%ul.element;[
+<!ENTITY % ul.content  "( %li.qname; )+" >
+<!ELEMENT %ul.qname;  %ul.content; >
+<!-- end of ul.element -->]]>
+
+<!ENTITY % ul.attlist  "INCLUDE" >
+<![%ul.attlist;[
+<!ATTLIST %ul.qname;
+      %Common.attrib;
+>
+<!-- end of ul.attlist -->]]>
+
+<!-- li: List Item ..................................... -->
+
+<!ENTITY % li.element  "INCLUDE" >
+<![%li.element;[
+<!ENTITY % li.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ELEMENT %li.qname;  %li.content; >
+<!-- end of li.element -->]]>
+
+<!ENTITY % li.attlist  "INCLUDE" >
+<![%li.attlist;[
+<!ATTLIST %li.qname;
+      %Common.attrib;
+>
+<!-- end of li.attlist -->]]>
+
+<!-- end of xhtml-list-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-meta-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-meta-1.mod
@@ -1,0 +1,47 @@
+<!-- ...................................................................... -->
+<!-- XHTML Document Metainformation Module  ............................... -->
+<!-- file: xhtml-meta-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-meta-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Metainformation 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-meta-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Meta Information
+
+        meta
+
+     This module declares the meta element type and its attributes,
+     used to provide declarative document metainformation.
+-->
+
+<!-- meta: Generic Metainformation ..................... -->
+
+<!ENTITY % meta.element  "INCLUDE" >
+<![%meta.element;[
+<!ENTITY % meta.content  "EMPTY" >
+<!ENTITY % meta.qname  "meta" >
+<!ELEMENT %meta.qname;  %meta.content; >
+<!-- end of meta.element -->]]>
+
+<!ENTITY % meta.attlist  "INCLUDE" >
+<![%meta.attlist;[
+<!ATTLIST %meta.qname;
+      %XHTML.xmlns.attrib;
+      %I18n.attrib;
+      http-equiv   NMTOKEN                  #IMPLIED
+      name         NMTOKEN                  #IMPLIED
+      content      CDATA                    #REQUIRED
+      scheme       CDATA                    #IMPLIED
+>
+<!-- end of meta.attlist -->]]>
+
+<!-- end of xhtml-meta-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-object-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-object-1.mod
@@ -1,0 +1,60 @@
+<!-- ...................................................................... -->
+<!-- XHTML Embedded Object Module  ........................................ -->
+<!-- file: xhtml-object-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-object-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Embedded Object 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-object-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Embedded Objects
+
+        object
+
+     This module declares the object element type and its attributes, used
+     to embed external objects as part of XHTML pages. In the document,
+     place param elements prior to other content within the object element.
+
+     Note that use of this module requires instantiation of the Param
+     Element Module.
+-->
+
+<!-- object: Generic Embedded Object ................... -->
+
+<!ENTITY % object.element  "INCLUDE" >
+<![%object.element;[
+<!ENTITY % object.content
+     "( #PCDATA | %Flow.mix; | %param.qname; )*"
+>
+<!ENTITY % object.qname  "object" >
+<!ELEMENT %object.qname;  %object.content; >
+<!-- end of object.element -->]]>
+
+<!ENTITY % object.attlist  "INCLUDE" >
+<![%object.attlist;[
+<!ATTLIST %object.qname;
+      %Common.attrib;
+      declare      ( declare )              #IMPLIED
+      classid      %URI.datatype;           #IMPLIED
+      codebase     %URI.datatype;           #IMPLIED
+      data         %URI.datatype;           #IMPLIED
+      type         %ContentType.datatype;   #IMPLIED
+      codetype     %ContentType.datatype;   #IMPLIED
+      archive      %URIs.datatype;          #IMPLIED
+      standby      %Text.datatype;          #IMPLIED
+      height       %Length.datatype;        #IMPLIED
+      width        %Length.datatype;        #IMPLIED
+      name         CDATA                    #IMPLIED
+      tabindex     %Number.datatype;        #IMPLIED
+>
+<!-- end of object.attlist -->]]>
+
+<!-- end of xhtml-object-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-param-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-param-1.mod
@@ -1,0 +1,48 @@
+<!-- ...................................................................... -->
+<!-- XHTML Param Element Module  ..................................... -->
+<!-- file: xhtml-param-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-param-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Param Element 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-param-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Parameters for Java Applets and Embedded Objects
+
+        param
+
+     This module provides declarations for the param element,
+     used to provide named property values for the applet
+     and object elements.
+-->
+
+<!-- param: Named Property Value ....................... -->
+
+<!ENTITY % param.element  "INCLUDE" >
+<![%param.element;[
+<!ENTITY % param.content  "EMPTY" >
+<!ENTITY % param.qname  "param" >
+<!ELEMENT %param.qname;  %param.content; >
+<!-- end of param.element -->]]>
+
+<!ENTITY % param.attlist  "INCLUDE" >
+<![%param.attlist;[
+<!ATTLIST %param.qname;
+      %XHTML.xmlns.attrib;
+      %id.attrib;
+      name         CDATA                    #REQUIRED
+      value        CDATA                    #IMPLIED
+      valuetype    ( data | ref | object )  'data'
+      type         %ContentType.datatype;   #IMPLIED
+>
+<!-- end of param.attlist -->]]>
+
+<!-- end of xhtml-param-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-pres-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-pres-1.mod
@@ -1,0 +1,38 @@
+<!-- ...................................................................... -->
+<!-- XHTML Presentation Module ............................................ -->
+<!-- file: xhtml-pres-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-pres-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Presentation 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-pres-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Presentational Elements
+
+     This module defines elements and their attributes for
+     simple presentation-related markup.
+-->
+
+<!ENTITY % xhtml-inlpres.module "INCLUDE" >
+<![%xhtml-inlpres.module;[
+<!ENTITY % xhtml-inlpres.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Inline Presentation 1.0//EN"
+            "xhtml-inlpres-1.mod" >
+%xhtml-inlpres.mod;]]>
+
+<!ENTITY % xhtml-blkpres.module "INCLUDE" >
+<![%xhtml-blkpres.module;[
+<!ENTITY % xhtml-blkpres.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Block Presentation 1.0//EN"
+            "xhtml-blkpres-1.mod" >
+%xhtml-blkpres.mod;]]>
+
+<!-- end of xhtml-pres-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-qname-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-qname-1.mod
@@ -1,0 +1,318 @@
+<!-- ....................................................................... -->
+<!-- XHTML Qname Module  ................................................... -->
+<!-- file: xhtml-qname-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-qname-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES XHTML Qualified Names 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-qname-1.mod"
+
+     Revisions:
+	   #2000-10-22: added qname declarations for ruby elements
+     ....................................................................... -->
+
+<!-- XHTML Qname (Qualified Name) Module
+
+     This module is contained in two parts, labeled Section 'A' and 'B':
+
+       Section A declares parameter entities to support namespace-
+       qualified names, namespace declarations, and name prefixing
+       for XHTML and extensions.
+
+       Section B declares parameter entities used to provide
+       namespace-qualified names for all XHTML element types:
+
+         %applet.qname;   the xmlns-qualified name for <applet>
+         %base.qname;     the xmlns-qualified name for <base>
+         ...
+
+     XHTML extensions would create a module similar to this one.
+     Included in the XHTML distribution is a template module
+     ('template-qname-1.mod') suitable for this purpose.
+-->
+
+<!-- Section A: XHTML XML Namespace Framework :::::::::::::::::::: -->
+
+<!-- 1. Declare a %XHTML.prefixed; conditional section keyword, used
+        to activate namespace prefixing. The default value should
+        inherit '%NS.prefixed;' from the DTD driver, so that unless
+        overridden, the default behaviour follows the overall DTD
+        prefixing scheme.
+-->
+<!ENTITY % NS.prefixed "IGNORE" >
+<!ENTITY % XHTML.prefixed "%NS.prefixed;" >
+
+<!-- By default, we always permit XHTML attribute collections to have
+     namespace-qualified prefixes as well.
+-->
+<!ENTITY % XHTML.global.attrs.prefixed "INCLUDE" >
+<!-- By default, we allow the XML Schema attributes on the root
+     element.
+-->
+<!ENTITY % XHTML.xsi.attrs "INCLUDE" >
+
+<!-- 2. Declare a parameter entity (eg., %XHTML.xmlns;) containing
+        the URI reference used to identify the XHTML namespace:
+-->
+<!ENTITY % XHTML.xmlns  "http://www.w3.org/1999/xhtml" >
+
+<!-- 3. Declare parameter entities (eg., %XHTML.prefix;) containing
+        the default namespace prefix string(s) to use when prefixing
+        is enabled. This may be overridden in the DTD driver or the
+        internal subset of an document instance. If no default prefix
+        is desired, this may be declared as an empty string.
+
+     NOTE: As specified in [XMLNAMES], the namespace prefix serves
+     as a proxy for the URI reference, and is not in itself significant.
+-->
+<!ENTITY % XHTML.prefix  "xhtml" >
+
+<!-- 4. Declare parameter entities (eg., %XHTML.pfx;) containing the
+        colonized prefix(es) (eg., '%XHTML.prefix;:') used when
+        prefixing is active, an empty string when it is not.
+-->
+<![%XHTML.prefixed;[
+<!ENTITY % XHTML.pfx  "%XHTML.prefix;:" >
+]]>
+<!ENTITY % XHTML.pfx  "" >
+
+<!-- declare qualified name extensions here ............ -->
+<!ENTITY % xhtml-qname-extra.mod "" >
+%xhtml-qname-extra.mod;
+
+<!-- 5. The parameter entity %XHTML.xmlns.extra.attrib; may be
+        redeclared to contain any non-XHTML namespace declaration
+        attributes for namespaces embedded in XHTML. The default
+        is an empty string.  XLink should be included here if used
+        in the DTD.
+-->
+<!ENTITY % XHTML.xmlns.extra.attrib "" >
+
+<!-- The remainder of Section A is only followed in XHTML, not extensions. -->
+
+<!-- Declare a parameter entity %NS.decl.attrib; containing
+     all XML Namespace declarations used in the DTD, plus the
+     xmlns declaration for XHTML, its form dependent on whether
+     prefixing is active.
+-->
+<!ENTITY % XHTML.xmlns.attrib.prefixed
+     "xmlns:%XHTML.prefix;  %URI.datatype;   #FIXED '%XHTML.xmlns;'"
+>
+<![%XHTML.prefixed;[
+<!ENTITY % NS.decl.attrib
+     "%XHTML.xmlns.attrib.prefixed;
+      %XHTML.xmlns.extra.attrib;"
+>
+]]>
+<!ENTITY % NS.decl.attrib
+     "%XHTML.xmlns.extra.attrib;"
+>
+
+<!-- Declare a parameter entity %XSI.prefix as a prefix to use for XML
+     Schema Instance attributes.
+-->
+<!ENTITY % XSI.prefix "xsi" >
+
+<!ENTITY % XSI.xmlns "http://www.w3.org/2001/XMLSchema-instance" >
+
+<!-- Declare a parameter entity %XSI.xmlns.attrib as support for the
+     schemaLocation attribute, since this is legal throughout the DTD.
+-->
+<!ENTITY % XSI.xmlns.attrib
+     "xmlns:%XSI.prefix;  %URI.datatype;   #FIXED '%XSI.xmlns;'" >
+
+<!-- This is a placeholder for future XLink support.
+-->
+<!ENTITY % XLINK.xmlns.attrib "" >
+
+<!-- This is the attribute for the XML Schema namespace - XHTML
+     Modularization is also expressed in XML Schema, and it needs to
+	 be legal to declare the XML Schema namespace and the
+	 schemaLocation attribute on the root element of XHTML family
+	 documents.
+-->
+<![%XHTML.xsi.attrs;[
+<!ENTITY % XSI.prefix "xsi" >
+<!ENTITY % XSI.pfx "%XSI.prefix;:" >
+<!ENTITY % XSI.xmlns "http://www.w3.org/2001/XMLSchema-instance" >
+
+<!ENTITY % XSI.xmlns.attrib
+     "xmlns:%XSI.prefix;  %URI.datatype;    #FIXED '%XSI.xmlns;'"
+>
+]]>
+<!ENTITY % XSI.prefix "" >
+<!ENTITY % XSI.pfx "" >
+<!ENTITY % XSI.xmlns.attrib "" >
+
+
+<!-- Declare a parameter entity %NS.decl.attrib; containing all
+     XML namespace declaration attributes used by XHTML, including
+     a default xmlns attribute when prefixing is inactive.
+-->
+<![%XHTML.prefixed;[
+<!ENTITY % XHTML.xmlns.attrib
+     "%NS.decl.attrib;
+      %XSI.xmlns.attrib;
+      %XLINK.xmlns.attrib;"
+>
+]]>
+<!ENTITY % XHTML.xmlns.attrib
+     "xmlns        %URI.datatype;           #FIXED '%XHTML.xmlns;'
+      %NS.decl.attrib;
+      %XSI.xmlns.attrib;
+      %XLINK.xmlns.attrib;"
+>
+
+<!-- placeholder for qualified name redeclarations -->
+<!ENTITY % xhtml-qname.redecl "" >
+%xhtml-qname.redecl;
+
+<!-- Section B: XHTML Qualified Names ::::::::::::::::::::::::::::: -->
+
+<!-- 6. This section declares parameter entities used to provide
+        namespace-qualified names for all XHTML element types.
+-->
+
+<!-- module:  xhtml-applet-1.mod -->
+<!ENTITY % applet.qname  "%XHTML.pfx;applet" >
+
+<!-- module:  xhtml-base-1.mod -->
+<!ENTITY % base.qname    "%XHTML.pfx;base" >
+
+<!-- module:  xhtml-bdo-1.mod -->
+<!ENTITY % bdo.qname     "%XHTML.pfx;bdo" >
+
+<!-- module:  xhtml-blkphras-1.mod -->
+<!ENTITY % address.qname "%XHTML.pfx;address" >
+<!ENTITY % blockquote.qname  "%XHTML.pfx;blockquote" >
+<!ENTITY % pre.qname     "%XHTML.pfx;pre" >
+<!ENTITY % h1.qname      "%XHTML.pfx;h1" >
+<!ENTITY % h2.qname      "%XHTML.pfx;h2" >
+<!ENTITY % h3.qname      "%XHTML.pfx;h3" >
+<!ENTITY % h4.qname      "%XHTML.pfx;h4" >
+<!ENTITY % h5.qname      "%XHTML.pfx;h5" >
+<!ENTITY % h6.qname      "%XHTML.pfx;h6" >
+
+<!-- module:  xhtml-blkpres-1.mod -->
+<!ENTITY % hr.qname      "%XHTML.pfx;hr" >
+
+<!-- module:  xhtml-blkstruct-1.mod -->
+<!ENTITY % div.qname     "%XHTML.pfx;div" >
+<!ENTITY % p.qname       "%XHTML.pfx;p" >
+
+<!-- module:  xhtml-edit-1.mod -->
+<!ENTITY % ins.qname     "%XHTML.pfx;ins" >
+<!ENTITY % del.qname     "%XHTML.pfx;del" >
+
+<!-- module:  xhtml-form-1.mod -->
+<!ENTITY % form.qname    "%XHTML.pfx;form" >
+<!ENTITY % label.qname   "%XHTML.pfx;label" >
+<!ENTITY % input.qname   "%XHTML.pfx;input" >
+<!ENTITY % select.qname  "%XHTML.pfx;select" >
+<!ENTITY % optgroup.qname  "%XHTML.pfx;optgroup" >
+<!ENTITY % option.qname  "%XHTML.pfx;option" >
+<!ENTITY % textarea.qname  "%XHTML.pfx;textarea" >
+<!ENTITY % fieldset.qname  "%XHTML.pfx;fieldset" >
+<!ENTITY % legend.qname  "%XHTML.pfx;legend" >
+<!ENTITY % button.qname  "%XHTML.pfx;button" >
+
+<!-- module:  xhtml-hypertext-1.mod -->
+<!ENTITY % a.qname       "%XHTML.pfx;a" >
+
+<!-- module:  xhtml-image-1.mod -->
+<!ENTITY % img.qname     "%XHTML.pfx;img" >
+
+<!-- module:  xhtml-inlphras-1.mod -->
+<!ENTITY % abbr.qname    "%XHTML.pfx;abbr" >
+<!ENTITY % acronym.qname "%XHTML.pfx;acronym" >
+<!ENTITY % cite.qname    "%XHTML.pfx;cite" >
+<!ENTITY % code.qname    "%XHTML.pfx;code" >
+<!ENTITY % dfn.qname     "%XHTML.pfx;dfn" >
+<!ENTITY % em.qname      "%XHTML.pfx;em" >
+<!ENTITY % kbd.qname     "%XHTML.pfx;kbd" >
+<!ENTITY % q.qname       "%XHTML.pfx;q" >
+<!ENTITY % samp.qname    "%XHTML.pfx;samp" >
+<!ENTITY % strong.qname  "%XHTML.pfx;strong" >
+<!ENTITY % var.qname     "%XHTML.pfx;var" >
+
+<!-- module:  xhtml-inlpres-1.mod -->
+<!ENTITY % b.qname       "%XHTML.pfx;b" >
+<!ENTITY % big.qname     "%XHTML.pfx;big" >
+<!ENTITY % i.qname       "%XHTML.pfx;i" >
+<!ENTITY % small.qname   "%XHTML.pfx;small" >
+<!ENTITY % sub.qname     "%XHTML.pfx;sub" >
+<!ENTITY % sup.qname     "%XHTML.pfx;sup" >
+<!ENTITY % tt.qname      "%XHTML.pfx;tt" >
+
+<!-- module:  xhtml-inlstruct-1.mod -->
+<!ENTITY % br.qname      "%XHTML.pfx;br" >
+<!ENTITY % span.qname    "%XHTML.pfx;span" >
+
+<!-- module:  xhtml-ismap-1.mod (also csismap, ssismap) -->
+<!ENTITY % map.qname     "%XHTML.pfx;map" >
+<!ENTITY % area.qname    "%XHTML.pfx;area" >
+
+<!-- module:  xhtml-link-1.mod -->
+<!ENTITY % link.qname    "%XHTML.pfx;link" >
+
+<!-- module:  xhtml-list-1.mod -->
+<!ENTITY % dl.qname      "%XHTML.pfx;dl" >
+<!ENTITY % dt.qname      "%XHTML.pfx;dt" >
+<!ENTITY % dd.qname      "%XHTML.pfx;dd" >
+<!ENTITY % ol.qname      "%XHTML.pfx;ol" >
+<!ENTITY % ul.qname      "%XHTML.pfx;ul" >
+<!ENTITY % li.qname      "%XHTML.pfx;li" >
+
+<!-- module:  xhtml-meta-1.mod -->
+<!ENTITY % meta.qname    "%XHTML.pfx;meta" >
+
+<!-- module:  xhtml-param-1.mod -->
+<!ENTITY % param.qname   "%XHTML.pfx;param" >
+
+<!-- module:  xhtml-object-1.mod -->
+<!ENTITY % object.qname  "%XHTML.pfx;object" >
+
+<!-- module:  xhtml-script-1.mod -->
+<!ENTITY % script.qname  "%XHTML.pfx;script" >
+<!ENTITY % noscript.qname  "%XHTML.pfx;noscript" >
+
+<!-- module:  xhtml-struct-1.mod -->
+<!ENTITY % html.qname    "%XHTML.pfx;html" >
+<!ENTITY % head.qname    "%XHTML.pfx;head" >
+<!ENTITY % title.qname   "%XHTML.pfx;title" >
+<!ENTITY % body.qname    "%XHTML.pfx;body" >
+
+<!-- module:  xhtml-style-1.mod -->
+<!ENTITY % style.qname   "%XHTML.pfx;style" >
+
+<!-- module:  xhtml-table-1.mod -->
+<!ENTITY % table.qname   "%XHTML.pfx;table" >
+<!ENTITY % caption.qname "%XHTML.pfx;caption" >
+<!ENTITY % thead.qname   "%XHTML.pfx;thead" >
+<!ENTITY % tfoot.qname   "%XHTML.pfx;tfoot" >
+<!ENTITY % tbody.qname   "%XHTML.pfx;tbody" >
+<!ENTITY % colgroup.qname  "%XHTML.pfx;colgroup" >
+<!ENTITY % col.qname     "%XHTML.pfx;col" >
+<!ENTITY % tr.qname      "%XHTML.pfx;tr" >
+<!ENTITY % th.qname      "%XHTML.pfx;th" >
+<!ENTITY % td.qname      "%XHTML.pfx;td" >
+
+<!-- module:  xhtml-ruby-1.mod -->
+
+<!ENTITY % ruby.qname    "%XHTML.pfx;ruby" >
+<!ENTITY % rbc.qname     "%XHTML.pfx;rbc" >
+<!ENTITY % rtc.qname     "%XHTML.pfx;rtc" >
+<!ENTITY % rb.qname      "%XHTML.pfx;rb" >
+<!ENTITY % rt.qname      "%XHTML.pfx;rt" >
+<!ENTITY % rp.qname      "%XHTML.pfx;rp" >
+
+<!-- Provisional XHTML 2.0 Qualified Names  ...................... -->
+
+<!-- module:  xhtml-image-2.mod -->
+<!ENTITY % alt.qname     "%XHTML.pfx;alt" >
+
+<!-- end of xhtml-qname-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-ruby-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-ruby-1.mod
@@ -1,0 +1,242 @@
+<!-- ...................................................................... -->
+<!-- XHTML Ruby Module .................................................... -->
+<!-- file: xhtml-ruby-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1999-2001 W3C (MIT, INRIA, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-ruby-1.mod,v 1.1 2008/06/21 19:42:10 smccarro Exp $
+
+     This module is based on the W3C Ruby Annotation Specification:
+
+        http://www.w3.org/TR/ruby
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Ruby 1.0//EN"
+       SYSTEM "http://www.w3.org/TR/ruby/xhtml-ruby-1.mod"
+
+     ...................................................................... -->
+
+<!-- Ruby Elements
+
+        ruby, rbc, rtc, rb, rt, rp
+
+     This module declares the elements and their attributes used to
+     support ruby annotation markup.
+-->
+
+<!-- declare qualified element type names:
+-->
+<!ENTITY % ruby.qname  "ruby" >
+<!ENTITY % rbc.qname  "rbc" >
+<!ENTITY % rtc.qname  "rtc" >
+<!ENTITY % rb.qname  "rb" >
+<!ENTITY % rt.qname  "rt" >
+<!ENTITY % rp.qname  "rp" >
+
+<!-- rp fallback is included by default.
+-->
+<!ENTITY % Ruby.fallback "INCLUDE" >
+<!ENTITY % Ruby.fallback.mandatory "IGNORE" >
+
+<!-- Complex ruby is included by default; it may be 
+     overridden by other modules to ignore it.
+-->
+<!ENTITY % Ruby.complex "INCLUDE" >
+
+<!-- Fragments for the content model of the ruby element -->
+<![%Ruby.fallback;[
+<![%Ruby.fallback.mandatory;[
+<!ENTITY % Ruby.content.simple 
+     "( %rb.qname;, %rp.qname;, %rt.qname;, %rp.qname; )"
+>
+]]>
+<!ENTITY % Ruby.content.simple 
+     "( %rb.qname;, ( %rt.qname; | ( %rp.qname;, %rt.qname;, %rp.qname; ) ) )"
+>
+]]>
+<!ENTITY % Ruby.content.simple "( %rb.qname;, %rt.qname; )" >
+
+<![%Ruby.complex;[
+<!ENTITY % Ruby.content.complex 
+     "| ( %rbc.qname;, %rtc.qname;, %rtc.qname;? )"
+>
+]]>
+<!ENTITY % Ruby.content.complex "" >
+
+<!-- Content models of the rb and the rt elements are intended to
+     allow other inline-level elements of its parent markup language,
+     but it should not include ruby descendent elements. The following
+     parameter entity %NoRuby.content; can be used to redefine
+     those content models with minimum effort.  It's defined as
+     '( #PCDATA )' by default.
+-->
+<!ENTITY % NoRuby.content "( #PCDATA )" >
+
+<!-- one or more digits (NUMBER) -->
+<!ENTITY % Number.datatype "CDATA" >
+
+<!-- ruby element ...................................... -->
+
+<!ENTITY % ruby.element  "INCLUDE" >
+<![%ruby.element;[
+<!ENTITY % ruby.content
+     "( %Ruby.content.simple; %Ruby.content.complex; )"
+>
+<!ELEMENT %ruby.qname;  %ruby.content; >
+<!-- end of ruby.element -->]]>
+
+<![%Ruby.complex;[
+<!-- rbc (ruby base component) element ................. -->
+
+<!ENTITY % rbc.element  "INCLUDE" >
+<![%rbc.element;[
+<!ENTITY % rbc.content
+     "(%rb.qname;)+"
+>
+<!ELEMENT %rbc.qname;  %rbc.content; >
+<!-- end of rbc.element -->]]>
+
+<!-- rtc (ruby text component) element ................. -->
+
+<!ENTITY % rtc.element  "INCLUDE" >
+<![%rtc.element;[
+<!ENTITY % rtc.content
+     "(%rt.qname;)+"
+>
+<!ELEMENT %rtc.qname;  %rtc.content; >
+<!-- end of rtc.element -->]]>
+]]>
+
+<!-- rb (ruby base) element ............................ -->
+
+<!ENTITY % rb.element  "INCLUDE" >
+<![%rb.element;[
+<!-- %rb.content; uses %NoRuby.content; as its content model,
+     which is '( #PCDATA )' by default. It may be overridden
+     by other modules to allow other inline-level elements
+     of its parent markup language, but it should not include
+     ruby descendent elements.
+-->
+<!ENTITY % rb.content "%NoRuby.content;" >
+<!ELEMENT %rb.qname;  %rb.content; >
+<!-- end of rb.element -->]]>
+
+<!-- rt (ruby text) element ............................ -->
+
+<!ENTITY % rt.element  "INCLUDE" >
+<![%rt.element;[
+<!-- %rt.content; uses %NoRuby.content; as its content model,
+     which is '( #PCDATA )' by default. It may be overridden
+     by other modules to allow other inline-level elements
+     of its parent markup language, but it should not include
+     ruby descendent elements.
+-->
+<!ENTITY % rt.content "%NoRuby.content;" >
+
+<!ELEMENT %rt.qname;  %rt.content; >
+<!-- end of rt.element -->]]>
+
+<!-- rbspan attribute is used for complex ruby only ...... -->
+<![%Ruby.complex;[
+<!ENTITY % rt.attlist  "INCLUDE" >
+<![%rt.attlist;[
+<!ATTLIST %rt.qname;
+      rbspan         %Number.datatype;      "1"
+>
+<!-- end of rt.attlist -->]]>
+]]>
+
+<!-- rp (ruby parenthesis) element ..................... -->
+
+<![%Ruby.fallback;[
+<!ENTITY % rp.element  "INCLUDE" >
+<![%rp.element;[
+<!ENTITY % rp.content
+     "( #PCDATA )"
+>
+<!ELEMENT %rp.qname;  %rp.content; >
+<!-- end of rp.element -->]]>
+]]>
+
+<!-- Ruby Common Attributes
+
+     The following optional ATTLIST declarations provide an easy way
+     to define common attributes for ruby elements.  These declarations
+     are ignored by default.
+
+     Ruby elements are intended to have common attributes of its
+     parent markup language.  For example, if a markup language defines
+     common attributes as a parameter entity %attrs;, you may add
+     those attributes by just declaring the following parameter entities
+
+         <!ENTITY % Ruby.common.attlists  "INCLUDE" >
+         <!ENTITY % Ruby.common.attrib  "%attrs;" >
+
+     before including the Ruby module.
+-->
+
+<!ENTITY % Ruby.common.attlists  "IGNORE" >
+<![%Ruby.common.attlists;[
+<!ENTITY % Ruby.common.attrib  "" >
+
+<!-- common attributes for ruby ........................ -->
+
+<!ENTITY % Ruby.common.attlist  "INCLUDE" >
+<![%Ruby.common.attlist;[
+<!ATTLIST %ruby.qname;
+      %Ruby.common.attrib;
+>
+<!-- end of Ruby.common.attlist -->]]>
+
+<![%Ruby.complex;[
+<!-- common attributes for rbc ......................... -->
+
+<!ENTITY % Rbc.common.attlist  "INCLUDE" >
+<![%Rbc.common.attlist;[
+<!ATTLIST %rbc.qname;
+      %Ruby.common.attrib;
+>
+<!-- end of Rbc.common.attlist -->]]>
+
+<!-- common attributes for rtc ......................... -->
+
+<!ENTITY % Rtc.common.attlist  "INCLUDE" >
+<![%Rtc.common.attlist;[
+<!ATTLIST %rtc.qname;
+      %Ruby.common.attrib;
+>
+<!-- end of Rtc.common.attlist -->]]>
+]]>
+
+<!-- common attributes for rb .......................... -->
+
+<!ENTITY % Rb.common.attlist  "INCLUDE" >
+<![%Rb.common.attlist;[
+<!ATTLIST %rb.qname;
+      %Ruby.common.attrib;
+>
+<!-- end of Rb.common.attlist -->]]>
+
+<!-- common attributes for rt .......................... -->
+
+<!ENTITY % Rt.common.attlist  "INCLUDE" >
+<![%Rt.common.attlist;[
+<!ATTLIST %rt.qname;
+      %Ruby.common.attrib;
+>
+<!-- end of Rt.common.attlist -->]]>
+
+<![%Ruby.fallback;[
+<!-- common attributes for rp .......................... -->
+
+<!ENTITY % Rp.common.attlist  "INCLUDE" >
+<![%Rp.common.attlist;[
+<!ATTLIST %rp.qname;
+      %Ruby.common.attrib;
+>
+<!-- end of Rp.common.attlist -->]]>
+]]>
+]]>
+
+<!-- end of xhtml-ruby-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-script-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-script-1.mod
@@ -1,0 +1,67 @@
+<!-- ...................................................................... -->
+<!-- XHTML Document Scripting Module  ..................................... -->
+<!-- file: xhtml-script-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-script-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Scripting 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-script-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Scripting
+
+        script, noscript
+
+     This module declares element types and attributes used to provide
+     support for executable scripts as well as an alternate content
+     container where scripts are not supported.
+-->
+
+<!-- script: Scripting Statement ....................... -->
+
+<!ENTITY % script.element  "INCLUDE" >
+<![%script.element;[
+<!ENTITY % script.content  "( #PCDATA )" >
+<!ENTITY % script.qname  "script" >
+<!ELEMENT %script.qname;  %script.content; >
+<!-- end of script.element -->]]>
+
+<!ENTITY % script.attlist  "INCLUDE" >
+<![%script.attlist;[
+<!ATTLIST %script.qname;
+      %XHTML.xmlns.attrib;
+	  %id.attrib;
+      xml:space    ( preserve )             #FIXED 'preserve'
+      charset      %Charset.datatype;       #IMPLIED
+      type         %ContentType.datatype;   #REQUIRED
+      src          %URI.datatype;           #IMPLIED
+      defer        ( defer )                #IMPLIED
+>
+<!-- end of script.attlist -->]]>
+
+<!-- noscript: No-Script Alternate Content ............. -->
+
+<!ENTITY % noscript.element  "INCLUDE" >
+<![%noscript.element;[
+<!ENTITY % noscript.content
+     "( %Block.mix; )+"
+>
+<!ENTITY % noscript.qname  "noscript" >
+<!ELEMENT %noscript.qname;  %noscript.content; >
+<!-- end of noscript.element -->]]>
+
+<!ENTITY % noscript.attlist  "INCLUDE" >
+<![%noscript.attlist;[
+<!ATTLIST %noscript.qname;
+      %Common.attrib;
+>
+<!-- end of noscript.attlist -->]]>
+
+<!-- end of xhtml-script-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-ssismap-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-ssismap-1.mod
@@ -1,0 +1,32 @@
+<!-- ...................................................................... -->
+<!-- XHTML Server-side Image Map Module  .................................. -->
+<!-- file: xhtml-ssismap-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-ssismap-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Server-side Image Maps 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-ssismap-1.mod"
+
+     Revisions:
+#2000-10-22: added declaration for 'ismap' on <input>
+     ....................................................................... -->
+
+<!-- Server-side Image Maps
+
+     This adds the 'ismap' attribute to the img and input elements
+     to support server-side processing of a user selection.
+-->
+
+<!ATTLIST %img.qname;
+      ismap        ( ismap )                #IMPLIED
+>
+
+<!ATTLIST %input.qname;
+      ismap        ( ismap )                #IMPLIED
+>
+
+<!-- end of xhtml-ssismap-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-struct-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-struct-1.mod
@@ -1,0 +1,136 @@
+<!-- ...................................................................... -->
+<!-- XHTML Structure Module  .............................................. -->
+<!-- file: xhtml-struct-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-struct-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Document Structure 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-struct-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Document Structure
+
+        title, head, body, html
+
+     The Structure Module defines the major structural elements and
+     their attributes.
+
+     Note that the content model of the head element type is redeclared
+     when the Base Module is included in the DTD.
+
+     The parameter entity containing the XML namespace URI value used
+     for XHTML is '%XHTML.xmlns;', defined in the Qualified Names module.
+-->
+
+<!-- title: Document Title ............................. -->
+
+<!-- The title element is not considered part of the flow of text.
+     It should be displayed, for example as the page header or
+     window title. Exactly one title is required per document.
+-->
+
+<!ENTITY % title.element  "INCLUDE" >
+<![%title.element;[
+<!ENTITY % title.content  "( #PCDATA )" >
+<!ENTITY % title.qname  "title" >
+<!ELEMENT %title.qname;  %title.content; >
+<!-- end of title.element -->]]>
+
+<!ENTITY % title.attlist  "INCLUDE" >
+<![%title.attlist;[
+<!ATTLIST %title.qname;
+      %XHTML.xmlns.attrib;
+      %I18n.attrib;
+>
+<!-- end of title.attlist -->]]>
+
+<!-- head: Document Head ............................... -->
+
+<!ENTITY % head.element  "INCLUDE" >
+<![%head.element;[
+<!ENTITY % head.content
+    "( %HeadOpts.mix;, %title.qname;, %HeadOpts.mix; )"
+>
+<!ENTITY % head.qname  "head" >
+<!ELEMENT %head.qname;  %head.content; >
+<!-- end of head.element -->]]>
+
+<!ENTITY % head.attlist  "INCLUDE" >
+<![%head.attlist;[
+<!-- reserved for future use with document profiles
+-->
+<!ENTITY % profile.attrib
+     "profile      %URIs.datatype;           #IMPLIED"
+>
+
+<!ATTLIST %head.qname;
+      %XHTML.xmlns.attrib;
+      %I18n.attrib;
+      %profile.attrib;
+      %id.attrib;
+>
+<!-- end of head.attlist -->]]>
+
+<!-- body: Document Body ............................... -->
+
+<!ENTITY % body.element  "INCLUDE" >
+<![%body.element;[
+<!ENTITY % body.content
+     "( %Block.mix; )*"
+>
+<!ENTITY % body.qname  "body" >
+<!ELEMENT %body.qname;  %body.content; >
+<!-- end of body.element -->]]>
+
+<!ENTITY % body.attlist  "INCLUDE" >
+<![%body.attlist;[
+<!ATTLIST %body.qname;
+      %Common.attrib;
+>
+<!-- end of body.attlist -->]]>
+
+<!-- html: XHTML Document Element ...................... -->
+
+<!ENTITY % html.element  "INCLUDE" >
+<![%html.element;[
+<!ENTITY % html.content  "( %head.qname;, %body.qname; )" >
+<!ENTITY % html.qname  "html" >
+<!ELEMENT %html.qname;  %html.content; >
+<!-- end of html.element -->]]>
+
+<![%XHTML.xsi.attrs;[
+<!-- define a parameter for the XSI schemaLocation attribute -->
+<!ENTITY % XSI.schemaLocation.attrib
+     "%XSI.pfx;schemaLocation  %URIs.datatype;    #IMPLIED"
+>
+]]>
+<!ENTITY % XSI.schemaLocation.attrib "">
+
+<!ENTITY % html.attlist  "INCLUDE" >
+<![%html.attlist;[
+<!-- version attribute value defined in driver
+-->
+<!ENTITY % XHTML.version.attrib
+     "version      %FPI.datatype;           #FIXED '%XHTML.version;'"
+>
+
+<!-- see the Qualified Names module for information
+     on how to extend XHTML using XML namespaces
+-->
+<!ATTLIST %html.qname;
+      %XHTML.xmlns.attrib;
+      %XSI.schemaLocation.attrib;
+      %XHTML.version.attrib;
+      %I18n.attrib;
+      %id.attrib;
+>
+<!-- end of html.attlist -->]]>
+
+<!-- end of xhtml-struct-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-style-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-style-1.mod
@@ -1,0 +1,48 @@
+<!-- ...................................................................... -->
+<!-- XHTML Document Style Sheet Module  ................................... -->
+<!-- file: xhtml-style-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-style-1.mod,v 4.1 2001/04/05 06:57:40 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//DTD XHTML Style Sheets 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-style-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Style Sheets
+
+        style
+
+     This module declares the style element type and its attributes,
+     used to embed style sheet information in the document head element.
+-->
+
+<!-- style: Style Sheet Information .................... -->
+
+<!ENTITY % style.element  "INCLUDE" >
+<![%style.element;[
+<!ENTITY % style.content  "( #PCDATA )" >
+<!ENTITY % style.qname  "style" >
+<!ELEMENT %style.qname;  %style.content; >
+<!-- end of style.element -->]]>
+
+<!ENTITY % style.attlist  "INCLUDE" >
+<![%style.attlist;[
+<!ATTLIST %style.qname;
+      %XHTML.xmlns.attrib;
+      %id.attrib;
+      %title.attrib;
+      %I18n.attrib;
+      xml:space    ( preserve )             #FIXED 'preserve'
+      type         %ContentType.datatype;   #REQUIRED
+      media        %MediaDesc.datatype;     #IMPLIED
+>
+<!-- end of style.attlist -->]]>
+
+<!-- end of xhtml-style-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-table-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-table-1.mod
@@ -1,0 +1,333 @@
+<!-- ...................................................................... -->
+<!-- XHTML Table Module  .................................................. -->
+<!-- file: xhtml-table-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-table-1.mod,v 4.1 2001/04/10 09:42:30 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-table-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Tables
+
+        table, caption, thead, tfoot, tbody, colgroup, col, tr, th, td
+
+     This module declares element types and attributes used to provide
+     table markup similar to HTML 4, including features that enable
+     better accessibility for non-visual user agents.
+-->
+
+<!-- declare qualified element type names:
+-->
+<!ENTITY % table.qname  "table" >
+<!ENTITY % caption.qname  "caption" >
+<!ENTITY % thead.qname  "thead" >
+<!ENTITY % tfoot.qname  "tfoot" >
+<!ENTITY % tbody.qname  "tbody" >
+<!ENTITY % colgroup.qname  "colgroup" >
+<!ENTITY % col.qname  "col" >
+<!ENTITY % tr.qname  "tr" >
+<!ENTITY % th.qname  "th" >
+<!ENTITY % td.qname  "td" >
+
+<!-- The frame attribute specifies which parts of the frame around
+     the table should be rendered. The values are not the same as
+     CALS to avoid a name clash with the valign attribute.
+-->
+<!ENTITY % frame.attrib
+     "frame        ( void
+                   | above
+                   | below
+                   | hsides
+                   | lhs
+                   | rhs
+                   | vsides
+                   | box
+                   | border )               #IMPLIED"
+>
+
+<!-- The rules attribute defines which rules to draw between cells:
+
+     If rules is absent then assume:
+
+       "none" if border is absent or border="0" otherwise "all"
+-->
+<!ENTITY % rules.attrib
+     "rules        ( none
+                   | groups
+                   | rows
+                   | cols
+                   | all )                  #IMPLIED"
+>
+
+<!-- horizontal alignment attributes for cell contents
+-->
+<!ENTITY % CellHAlign.attrib
+     "align        ( left
+                   | center
+                   | right
+                   | justify
+                   | char )                 #IMPLIED
+      char         %Character.datatype;     #IMPLIED
+      charoff      %Length.datatype;        #IMPLIED"
+>
+
+<!-- vertical alignment attribute for cell contents
+-->
+<!ENTITY % CellVAlign.attrib
+     "valign       ( top
+                   | middle
+                   | bottom
+                   | baseline )             #IMPLIED"
+>
+
+<!-- scope is simpler than axes attribute for common tables
+-->
+<!ENTITY % scope.attrib
+     "scope        ( row
+                   | col
+                   | rowgroup
+                   | colgroup )             #IMPLIED"
+>
+
+<!-- table: Table Element .............................. -->
+
+<!ENTITY % table.element  "INCLUDE" >
+<![%table.element;[
+<!ENTITY % table.content
+     "( %caption.qname;?, ( %col.qname;* | %colgroup.qname;* ),
+      (( %thead.qname;?, %tfoot.qname;?, %tbody.qname;+ ) | ( %tr.qname;+ )))"
+>
+<!ELEMENT %table.qname;  %table.content; >
+<!-- end of table.element -->]]>
+
+<!ENTITY % table.attlist  "INCLUDE" >
+<![%table.attlist;[
+<!ATTLIST %table.qname;
+      %Common.attrib;
+      summary      %Text.datatype;          #IMPLIED
+      width        %Length.datatype;        #IMPLIED
+      border       %Pixels.datatype;        #IMPLIED
+      %frame.attrib;
+      %rules.attrib;
+      cellspacing  %Length.datatype;        #IMPLIED
+      cellpadding  %Length.datatype;        #IMPLIED
+>
+<!-- end of table.attlist -->]]>
+
+<!-- caption: Table Caption ............................ -->
+
+<!ENTITY % caption.element  "INCLUDE" >
+<![%caption.element;[
+<!ENTITY % caption.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ELEMENT %caption.qname;  %caption.content; >
+<!-- end of caption.element -->]]>
+
+<!ENTITY % caption.attlist  "INCLUDE" >
+<![%caption.attlist;[
+<!ATTLIST %caption.qname;
+      %Common.attrib;
+>
+<!-- end of caption.attlist -->]]>
+
+<!-- thead: Table Header ............................... -->
+
+<!-- Use thead to duplicate headers when breaking table
+     across page boundaries, or for static headers when
+     tbody sections are rendered in scrolling panel.
+-->
+
+<!ENTITY % thead.element  "INCLUDE" >
+<![%thead.element;[
+<!ENTITY % thead.content  "( %tr.qname; )+" >
+<!ELEMENT %thead.qname;  %thead.content; >
+<!-- end of thead.element -->]]>
+
+<!ENTITY % thead.attlist  "INCLUDE" >
+<![%thead.attlist;[
+<!ATTLIST %thead.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of thead.attlist -->]]>
+
+<!-- tfoot: Table Footer ............................... -->
+
+<!-- Use tfoot to duplicate footers when breaking table
+     across page boundaries, or for static footers when
+     tbody sections are rendered in scrolling panel.
+-->
+
+<!ENTITY % tfoot.element  "INCLUDE" >
+<![%tfoot.element;[
+<!ENTITY % tfoot.content  "( %tr.qname; )+" >
+<!ELEMENT %tfoot.qname;  %tfoot.content; >
+<!-- end of tfoot.element -->]]>
+
+<!ENTITY % tfoot.attlist  "INCLUDE" >
+<![%tfoot.attlist;[
+<!ATTLIST %tfoot.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of tfoot.attlist -->]]>
+
+<!-- tbody: Table Body ................................. -->
+
+<!-- Use multiple tbody sections when rules are needed
+     between groups of table rows.
+-->
+
+<!ENTITY % tbody.element  "INCLUDE" >
+<![%tbody.element;[
+<!ENTITY % tbody.content  "( %tr.qname; )+" >
+<!ELEMENT %tbody.qname;  %tbody.content; >
+<!-- end of tbody.element -->]]>
+
+<!ENTITY % tbody.attlist  "INCLUDE" >
+<![%tbody.attlist;[
+<!ATTLIST %tbody.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of tbody.attlist -->]]>
+
+<!-- colgroup: Table Column Group ...................... -->
+
+<!-- colgroup groups a set of col elements. It allows you
+     to group several semantically-related columns together.
+-->
+
+<!ENTITY % colgroup.element  "INCLUDE" >
+<![%colgroup.element;[
+<!ENTITY % colgroup.content  "( %col.qname; )*" >
+<!ELEMENT %colgroup.qname;  %colgroup.content; >
+<!-- end of colgroup.element -->]]>
+
+<!ENTITY % colgroup.attlist  "INCLUDE" >
+<![%colgroup.attlist;[
+<!ATTLIST %colgroup.qname;
+      %Common.attrib;
+      span         %Number.datatype;        '1'
+      width        %MultiLength.datatype;   #IMPLIED
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of colgroup.attlist -->]]>
+
+<!-- col: Table Column ................................. -->
+
+<!-- col elements define the alignment properties for
+     cells in one or more columns.
+
+     The width attribute specifies the width of the
+     columns, e.g.
+
+       width="64"        width in screen pixels
+       width="0.5*"      relative width of 0.5
+
+     The span attribute causes the attributes of one
+     col element to apply to more than one column.
+-->
+
+<!ENTITY % col.element  "INCLUDE" >
+<![%col.element;[
+<!ENTITY % col.content  "EMPTY" >
+<!ELEMENT %col.qname;  %col.content; >
+<!-- end of col.element -->]]>
+
+<!ENTITY % col.attlist  "INCLUDE" >
+<![%col.attlist;[
+<!ATTLIST %col.qname;
+      %Common.attrib;
+      span         %Number.datatype;        '1'
+      width        %MultiLength.datatype;   #IMPLIED
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of col.attlist -->]]>
+
+<!-- tr: Table Row ..................................... -->
+
+<!ENTITY % tr.element  "INCLUDE" >
+<![%tr.element;[
+<!ENTITY % tr.content  "( %th.qname; | %td.qname; )+" >
+<!ELEMENT %tr.qname;  %tr.content; >
+<!-- end of tr.element -->]]>
+
+<!ENTITY % tr.attlist  "INCLUDE" >
+<![%tr.attlist;[
+<!ATTLIST %tr.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of tr.attlist -->]]>
+
+<!-- th: Table Header Cell ............................. -->
+
+<!-- th is for header cells, td for data,
+     but for cells acting as both use td
+-->
+
+<!ENTITY % th.element  "INCLUDE" >
+<![%th.element;[
+<!ENTITY % th.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ELEMENT %th.qname;  %th.content; >
+<!-- end of th.element -->]]>
+
+<!ENTITY % th.attlist  "INCLUDE" >
+<![%th.attlist;[
+<!ATTLIST %th.qname;
+      %Common.attrib;
+      abbr         %Text.datatype;          #IMPLIED
+      axis         CDATA                    #IMPLIED
+      headers      IDREFS                   #IMPLIED
+      %scope.attrib;
+      rowspan      %Number.datatype;        '1'
+      colspan      %Number.datatype;        '1'
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of th.attlist -->]]>
+
+<!-- td: Table Data Cell ............................... -->
+
+<!ENTITY % td.element  "INCLUDE" >
+<![%td.element;[
+<!ENTITY % td.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ELEMENT %td.qname;  %td.content; >
+<!-- end of td.element -->]]>
+
+<!ENTITY % td.attlist  "INCLUDE" >
+<![%td.attlist;[
+<!ATTLIST %td.qname;
+      %Common.attrib;
+      abbr         %Text.datatype;          #IMPLIED
+      axis         CDATA                    #IMPLIED
+      headers      IDREFS                   #IMPLIED
+      %scope.attrib;
+      rowspan      %Number.datatype;        '1'
+      colspan      %Number.datatype;        '1'
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of td.attlist -->]]>
+
+<!-- end of xhtml-table-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-text-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml-text-1.mod
@@ -1,0 +1,52 @@
+<!-- ...................................................................... -->
+<!-- XHTML Text Module  ................................................... -->
+<!-- file: xhtml-text-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-text-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Text 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-text-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Textual Content
+
+     The Text module includes declarations for all core
+     text container elements and their attributes.
+-->
+
+<!ENTITY % xhtml-inlstruct.module "INCLUDE" >
+<![%xhtml-inlstruct.module;[
+<!ENTITY % xhtml-inlstruct.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Inline Structural 1.0//EN"
+            "xhtml-inlstruct-1.mod" >
+%xhtml-inlstruct.mod;]]>
+
+<!ENTITY % xhtml-inlphras.module "INCLUDE" >
+<![%xhtml-inlphras.module;[
+<!ENTITY % xhtml-inlphras.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Inline Phrasal 1.0//EN"
+            "xhtml-inlphras-1.mod" >
+%xhtml-inlphras.mod;]]>
+
+<!ENTITY % xhtml-blkstruct.module "INCLUDE" >
+<![%xhtml-blkstruct.module;[
+<!ENTITY % xhtml-blkstruct.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Block Structural 1.0//EN"
+            "xhtml-blkstruct-1.mod" >
+%xhtml-blkstruct.mod;]]>
+
+<!ENTITY % xhtml-blkphras.module "INCLUDE" >
+<![%xhtml-blkphras.module;[
+<!ENTITY % xhtml-blkphras.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Block Phrasal 1.0//EN"
+            "xhtml-blkphras-1.mod" >
+%xhtml-blkphras.mod;]]>
+
+<!-- end of xhtml-text-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml11-model-1.mod
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml11-model-1.mod
@@ -1,0 +1,250 @@
+<!-- ....................................................................... -->
+<!-- XHTML 1.1 Document Model Module  ...................................... -->
+<!-- file: xhtml11-model-1.mod
+
+     This is XHTML 1.1, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2008 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml11-model-1.mod,v 1.18 2009/06/24 17:24:55 ahby Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES XHTML 1.1 Document Model 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml11-model-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- XHTML 1.1 Document Model
+
+     This module describes the groupings of elements that make up
+     common content models for XHTML elements.
+
+     XHTML has three basic content models:
+
+         %Inline.mix;  character-level elements
+         %Block.mix;   block-like elements, eg., paragraphs and lists
+         %Flow.mix;    any block or inline elements
+
+     Any parameter entities declared in this module may be used
+     to create element content models, but the above three are
+     considered 'global' (insofar as that term applies here).
+
+     The reserved word '#PCDATA' (indicating a text string) is now
+     included explicitly with each element declaration that is
+     declared as mixed content, as XML requires that this token
+     occur first in a content model specification.
+-->
+<!-- Extending the Model
+
+     While in some cases this module may need to be rewritten to
+     accommodate changes to the document model, minor extensions
+     may be accomplished by redeclaring any of the three *.extra;
+     parameter entities to contain extension element types as follows:
+
+         %Misc.extra;    whose parent may be any block or
+                         inline element.
+
+         %Inline.extra;  whose parent may be any inline element.
+
+         %Block.extra;   whose parent may be any block element.
+
+     If used, these parameter entities must be an OR-separated
+     list beginning with an OR separator ("|"), eg., "| a | b | c"
+
+     All block and inline *.class parameter entities not part
+     of the *struct.class classes begin with "| " to allow for
+     exclusion from mixes.
+-->
+
+<!-- ..............  Optional Elements in head  .................. -->
+
+<!ENTITY % HeadOpts.mix
+     "( %script.qname; | %style.qname; | %meta.qname;
+      | %link.qname; | %object.qname; )*"
+>
+
+<!-- .................  Miscellaneous Elements  .................. -->
+
+<!-- ins and del are used to denote editing changes
+-->
+<!ENTITY % Edit.class "| %ins.qname; | %del.qname;" >
+
+<!-- script and noscript are used to contain scripts
+     and alternative content
+-->
+<!ENTITY % Script.class "| %script.qname; | %noscript.qname;" >
+
+<!ENTITY % Misc.extra "" >
+
+<!-- These elements are neither block nor inline, and can
+     essentially be used anywhere in the document body.
+-->
+<!ENTITY % Misc.class
+     "%Edit.class;
+      %Script.class;
+      %Misc.extra;"
+>
+
+<!-- ....................  Inline Elements  ...................... -->
+
+<!ENTITY % InlStruct.class "%br.qname; | %span.qname;" >
+
+<!ENTITY % InlPhras.class
+     "| %em.qname; | %strong.qname; | %dfn.qname; | %code.qname;
+      | %samp.qname; | %kbd.qname; | %var.qname; | %cite.qname;
+      | %abbr.qname; | %acronym.qname; | %q.qname;" >
+
+<!ENTITY % InlPres.class
+     "| %tt.qname; | %i.qname; | %b.qname; | %big.qname;
+      | %small.qname; | %sub.qname; | %sup.qname;" >
+
+<!ENTITY % I18n.class "| %bdo.qname;" >
+
+<!ENTITY % Anchor.class "| %a.qname;" >
+
+<!ENTITY % InlSpecial.class
+     "| %img.qname; | %map.qname;
+      | %object.qname;" >
+
+<!ENTITY % InlForm.class
+     "| %input.qname; | %select.qname; | %textarea.qname;
+      | %label.qname; | %button.qname;" >
+
+<!ENTITY % Inline.extra "" >
+
+<!ENTITY % Ruby.class "| %ruby.qname;" >
+
+<!-- %Inline.class; includes all inline elements,
+     used as a component in mixes
+-->
+<!ENTITY % Inline.class
+     "%InlStruct.class;
+      %InlPhras.class;
+      %InlPres.class;
+      %I18n.class;
+      %Anchor.class;
+      %InlSpecial.class;
+      %InlForm.class;
+      %Ruby.class;
+      %Inline.extra;"
+>
+
+<!-- %InlNoRuby.class; includes all inline elements
+     except ruby, used as a component in mixes
+-->
+<!ENTITY % InlNoRuby.class
+     "%InlStruct.class;
+      %InlPhras.class;
+      %InlPres.class;
+      %I18n.class;
+      %Anchor.class;
+      %InlSpecial.class;
+      %InlForm.class;
+      %Inline.extra;"
+>
+
+<!-- %NoRuby.content; includes all inlines except ruby
+-->
+<!ENTITY % NoRuby.content
+     "( #PCDATA
+      | %InlNoRuby.class;
+      %Misc.class; )*"
+>
+
+<!-- %InlNoAnchor.class; includes all non-anchor inlines,
+     used as a component in mixes
+-->
+<!ENTITY % InlNoAnchor.class
+     "%InlStruct.class;
+      %InlPhras.class;
+      %InlPres.class;
+      %I18n.class;
+      %InlSpecial.class;
+      %InlForm.class;
+      %Ruby.class;
+      %Inline.extra;"
+>
+
+<!-- %InlNoAnchor.mix; includes all non-anchor inlines
+-->
+<!ENTITY % InlNoAnchor.mix
+     "%InlNoAnchor.class;
+      %Misc.class;"
+>
+
+<!-- %Inline.mix; includes all inline elements, including %Misc.class;
+-->
+<!ENTITY % Inline.mix
+     "%Inline.class;
+      %Misc.class;"
+>
+
+<!-- .....................  Block Elements  ...................... -->
+
+<!-- In the HTML 4.0 DTD, heading and list elements were included
+     in the %block; parameter entity. The %Heading.class; and
+     %List.class; parameter entities must now be included explicitly
+     on element declarations where desired.
+-->
+
+<!ENTITY % Heading.class
+     "%h1.qname; | %h2.qname; | %h3.qname;
+      | %h4.qname; | %h5.qname; | %h6.qname;" >
+
+<!ENTITY % List.class "%ul.qname; | %ol.qname; | %dl.qname;" >
+
+<!ENTITY % Table.class "| %table.qname;" >
+
+<!ENTITY % Form.class  "| %form.qname;" >
+
+<!ENTITY % Fieldset.class  "| %fieldset.qname;" >
+
+<!ENTITY % BlkStruct.class "%p.qname; | %div.qname;" >
+
+<!ENTITY % BlkPhras.class
+     "| %pre.qname; | %blockquote.qname; | %address.qname;" >
+
+<!ENTITY % BlkPres.class "| %hr.qname;" >
+
+<!ENTITY % BlkSpecial.class
+     "%Table.class;
+      %Form.class;
+      %Fieldset.class;"
+>
+
+<!ENTITY % Block.extra "" >
+
+<!-- %Block.class; includes all block elements,
+     used as an component in mixes
+-->
+<!ENTITY % Block.class
+     "%BlkStruct.class;
+      %BlkPhras.class;
+      %BlkPres.class;
+      %BlkSpecial.class;
+      %Block.extra;"
+>
+
+<!-- %Block.mix; includes all block elements plus %Misc.class;
+-->
+<!ENTITY % Block.mix
+     "%Heading.class;
+      | %List.class;
+      | %Block.class;
+      %Misc.class;"
+>
+
+<!-- ................  All Content Elements  .................. -->
+
+<!-- %Flow.mix; includes all text content, block and inline
+-->
+<!ENTITY % Flow.mix
+     "%Heading.class;
+      | %List.class;
+      | %Block.class;
+      | %Inline.class;
+      %Misc.class;"
+>
+
+<!-- end of xhtml11-model-1.mod -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml11.dtd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xhtml11/xhtml11.dtd
@@ -1,0 +1,323 @@
+<!-- ....................................................................... -->
+<!-- XHTML 1.1 DTD  ........................................................ -->
+<!-- file: xhtml11.dtd
+-->
+
+<!-- XHTML 1.1 DTD
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+
+     The Extensible HyperText Markup Language (XHTML)
+     Copyright 1998-2008 World Wide Web Consortium
+        (Massachusetts Institute of Technology, European Research Consortium
+         for Informatics and Mathematics, Keio University).
+         All Rights Reserved.
+
+     Permission to use, copy, modify and distribute the XHTML DTD and its 
+     accompanying documentation for any purpose and without fee is hereby 
+     granted in perpetuity, provided that the above copyright notice and 
+     this paragraph appear in all copies.  The copyright holders make no 
+     representation about the suitability of the DTD for any purpose.
+
+     It is provided "as is" without expressed or implied warranty.
+
+        Author:     Murray M. Altheim <altheim@eng.sun.com>
+        Revision:   $Id: xhtml11.dtd,v 1.1 2010/11/24 20:56:19 bertails Exp $
+
+-->
+<!-- This is the driver file for version 1.1 of the XHTML DTD.
+
+     Please use this public identifier to identify it:
+
+         "-//W3C//DTD XHTML 1.1//EN"
+-->
+<!ENTITY % XHTML.version  "-//W3C//DTD XHTML 1.1//EN" >
+
+<!-- Use this URI to identify the default namespace:
+
+         "http://www.w3.org/1999/xhtml"
+
+     See the Qualified Names module for information
+     on the use of namespace prefixes in the DTD.
+
+	 Note that XHTML namespace elements are not prefixed by default,
+	 but the XHTML namespace prefix is defined as "xhtml" so that
+	 other markup languages can extend this one and use the XHTML
+	 prefixed global attributes if required.
+
+-->
+<!ENTITY % NS.prefixed "IGNORE" >
+<!ENTITY % XHTML.prefix "xhtml" >
+
+<!-- Be sure to include prefixed global attributes - we don't need
+     them, but languages that extend XHTML 1.1 might.
+-->
+<!ENTITY % XHTML.global.attrs.prefixed "INCLUDE" >
+
+<!-- Reserved for use with the XLink namespace:
+-->
+<!ENTITY % XLINK.xmlns "" >
+<!ENTITY % XLINK.xmlns.attrib "" >
+
+<!-- For example, if you are using XHTML 1.1 directly, use the public
+     identifier in the DOCTYPE declaration, with the namespace declaration
+     on the document element to identify the default namespace:
+
+       <?xml version="1.0"?>
+       <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+                             "http://www.w3.org/MarkUp/DTD/xhtml11.dtd">
+       <html xmlns="http://www.w3.org/1999/xhtml"
+             xml:lang="en">
+       ...
+       </html>
+
+     Revisions:
+     (none)
+-->
+
+<!-- reserved for future use with document profiles -->
+<!ENTITY % XHTML.profile  "" >
+
+<!-- ensure XHTML Notations are disabled -->
+<!ENTITY % xhtml-notations.module "IGNORE" >
+
+<!-- Bidirectional Text features
+     This feature-test entity is used to declare elements
+     and attributes used for bidirectional text support.
+-->
+<!ENTITY % XHTML.bidi  "INCLUDE" >
+
+<?doc type="doctype" role="title" { XHTML 1.1 } ?>
+
+<!-- ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: -->
+
+<!-- Pre-Framework Redeclaration placeholder  .................... -->
+<!-- this serves as a location to insert markup declarations
+     into the DTD prior to the framework declarations.
+-->
+<!ENTITY % xhtml-prefw-redecl.module "IGNORE" >
+<![%xhtml-prefw-redecl.module;[
+%xhtml-prefw-redecl.mod;
+<!-- end of xhtml-prefw-redecl.module -->]]>
+
+<!ENTITY % xhtml-events.module "INCLUDE" >
+
+<!-- Inline Style Module  ........................................ -->
+<!ENTITY % xhtml-inlstyle.module "INCLUDE" >
+<![%xhtml-inlstyle.module;[
+<!ENTITY % xhtml-inlstyle.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Inline Style 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-inlstyle-1.mod" >
+%xhtml-inlstyle.mod;]]>
+
+<!-- declare Document Model module instantiated in framework
+-->
+<!ENTITY % xhtml-model.mod
+     PUBLIC "-//W3C//ENTITIES XHTML 1.1 Document Model 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml11-model-1.mod" >
+
+<!-- adding the lang attribute into the I18N collection -->
+
+<!ENTITY % xhtml-datatypes.module "INCLUDE" >
+<![%xhtml-datatypes.module;[
+<!ENTITY % xhtml-datatypes.mod
+     PUBLIC "-//W3C//ENTITIES XHTML Datatypes 1.0//EN"
+            "xhtml-datatypes-1.mod" >
+%xhtml-datatypes.mod;]]>
+
+<!ENTITY % lang.attrib
+     "xml:lang     %LanguageCode.datatype;  #IMPLIED
+      lang         %LanguageCode.datatype;  #IMPLIED"
+>
+
+<!-- Modular Framework Module (required) ......................... -->
+<!ENTITY % xhtml-framework.module "INCLUDE" >
+<![%xhtml-framework.module;[
+<!ENTITY % xhtml-framework.mod
+     PUBLIC "-//W3C//ENTITIES XHTML Modular Framework 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-framework-1.mod" >
+%xhtml-framework.mod;]]>
+
+<!-- Post-Framework Redeclaration placeholder  ................... -->
+<!-- this serves as a location to insert markup declarations
+     into the DTD following the framework declarations.
+-->
+<!ENTITY % xhtml-postfw-redecl.module "IGNORE" >
+<![%xhtml-postfw-redecl.module;[
+%xhtml-postfw-redecl.mod;
+<!-- end of xhtml-postfw-redecl.module -->]]>
+
+<!-- Text Module (Required)  ..................................... -->
+<!ENTITY % xhtml-text.module "INCLUDE" >
+<![%xhtml-text.module;[
+<!ENTITY % xhtml-text.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Text 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-text-1.mod" >
+%xhtml-text.mod;]]>
+
+<!-- Hypertext Module (required) ................................. -->
+<!ENTITY % xhtml-hypertext.module "INCLUDE" >
+<![%xhtml-hypertext.module;[
+<!ENTITY % xhtml-hypertext.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Hypertext 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-hypertext-1.mod" >
+%xhtml-hypertext.mod;]]>
+
+<!-- Lists Module (required)  .................................... -->
+<!ENTITY % xhtml-list.module "INCLUDE" >
+<![%xhtml-list.module;[
+<!ENTITY % xhtml-list.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Lists 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-list-1.mod" >
+%xhtml-list.mod;]]>
+
+<!-- ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: -->
+
+<!-- Edit Module  ................................................ -->
+<!ENTITY % xhtml-edit.module "INCLUDE" >
+<![%xhtml-edit.module;[
+<!ENTITY % xhtml-edit.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Editing Elements 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-edit-1.mod" >
+%xhtml-edit.mod;]]>
+
+<!-- BIDI Override Module  ....................................... -->
+<!ENTITY % xhtml-bdo.module "%XHTML.bidi;" >
+<![%xhtml-bdo.module;[
+<!ENTITY % xhtml-bdo.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML BIDI Override Element 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-bdo-1.mod" >
+%xhtml-bdo.mod;]]>
+
+<!-- Ruby Module  ................................................ -->
+<!ENTITY % Ruby.common.attlists "INCLUDE" >
+<!ENTITY % Ruby.common.attrib "%Common.attrib;" >
+<!ENTITY % xhtml-ruby.module "INCLUDE" >
+<![%xhtml-ruby.module;[
+<!ENTITY % xhtml-ruby.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Ruby 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-ruby-1.mod" >
+%xhtml-ruby.mod;]]>
+
+<!-- Presentation Module  ........................................ -->
+<!ENTITY % xhtml-pres.module "INCLUDE" >
+<![%xhtml-pres.module;[
+<!ENTITY % xhtml-pres.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Presentation 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-pres-1.mod" >
+%xhtml-pres.mod;]]>
+
+<!-- Link Element Module  ........................................ -->
+<!ENTITY % xhtml-link.module "INCLUDE" >
+<![%xhtml-link.module;[
+<!ENTITY % xhtml-link.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Link Element 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-link-1.mod" >
+%xhtml-link.mod;]]>
+
+<!-- Document Metainformation Module  ............................ -->
+<!ENTITY % xhtml-meta.module "INCLUDE" >
+<![%xhtml-meta.module;[
+<!ENTITY % xhtml-meta.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Metainformation 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-meta-1.mod" >
+%xhtml-meta.mod;]]>
+
+<!-- Base Element Module  ........................................ -->
+<!ENTITY % xhtml-base.module "INCLUDE" >
+<![%xhtml-base.module;[
+<!ENTITY % xhtml-base.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Base Element 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-base-1.mod" >
+%xhtml-base.mod;]]>
+
+<!-- Scripting Module  ........................................... -->
+<!ENTITY % xhtml-script.module "INCLUDE" >
+<![%xhtml-script.module;[
+<!ENTITY % xhtml-script.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Scripting 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-script-1.mod" >
+%xhtml-script.mod;]]>
+
+<!-- Style Sheets Module  ......................................... -->
+<!ENTITY % xhtml-style.module "INCLUDE" >
+<![%xhtml-style.module;[
+<!ENTITY % xhtml-style.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Style Sheets 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-style-1.mod" >
+%xhtml-style.mod;]]>
+
+<!-- Image Module  ............................................... -->
+<!ENTITY % xhtml-image.module "INCLUDE" >
+<![%xhtml-image.module;[
+<!ENTITY % xhtml-image.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Images 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-image-1.mod" >
+%xhtml-image.mod;]]>
+
+<!-- Client-side Image Map Module  ............................... -->
+<!ENTITY % xhtml-csismap.module "INCLUDE" >
+<![%xhtml-csismap.module;[
+<!ENTITY % xhtml-csismap.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Client-side Image Maps 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-csismap-1.mod" >
+%xhtml-csismap.mod;]]>
+
+<!-- Server-side Image Map Module  ............................... -->
+<!ENTITY % xhtml-ssismap.module "INCLUDE" >
+<![%xhtml-ssismap.module;[
+<!ENTITY % xhtml-ssismap.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Server-side Image Maps 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-ssismap-1.mod" >
+%xhtml-ssismap.mod;]]>
+
+<!-- Param Element Module  ....................................... -->
+<!ENTITY % xhtml-param.module "INCLUDE" >
+<![%xhtml-param.module;[
+<!ENTITY % xhtml-param.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Param Element 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-param-1.mod" >
+%xhtml-param.mod;]]>
+
+<!-- Embedded Object Module  ..................................... -->
+<!ENTITY % xhtml-object.module "INCLUDE" >
+<![%xhtml-object.module;[
+<!ENTITY % xhtml-object.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Embedded Object 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-object-1.mod" >
+%xhtml-object.mod;]]>
+
+<!-- Tables Module ............................................... -->
+<!ENTITY % xhtml-table.module "INCLUDE" >
+<![%xhtml-table.module;[
+<!ENTITY % xhtml-table.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-table-1.mod" >
+%xhtml-table.mod;]]>
+
+<!-- Forms Module  ............................................... -->
+<!ENTITY % xhtml-form.module "INCLUDE" >
+<![%xhtml-form.module;[
+<!ENTITY % xhtml-form.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Forms 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-form-1.mod" >
+%xhtml-form.mod;]]>
+
+<!-- Legacy Markup ............................................... -->
+<!ENTITY % xhtml-legacy.module "IGNORE" >
+<![%xhtml-legacy.module;[
+<!ENTITY % xhtml-legacy.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Legacy Markup 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-legacy-1.mod" >
+%xhtml-legacy.mod;]]>
+
+<!-- Document Structure Module (required)  ....................... -->
+<!ENTITY % xhtml-struct.module "INCLUDE" >
+<![%xhtml-struct.module;[
+<!ENTITY % xhtml-struct.mod
+     PUBLIC "-//W3C//ELEMENTS XHTML Document Structure 1.0//EN"
+            "http://www.w3.org/MarkUp/DTD/xhtml-struct-1.mod" >
+%xhtml-struct.mod;]]>
+
+<!-- end of XHTML 1.1 DTD  ................................................. -->
+<!-- ....................................................................... -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xmlspec2_10/xmlspec.dtd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/dtd/xmlspec2_10/xmlspec.dtd
@@ -1,0 +1,2778 @@
+<!-- ............................................................... -->
+<!-- XML specification DTD ......................................... -->
+<!-- ............................................................... -->
+
+<!-- $Id: xmlspec.dtd,v 1.20 2005/10/13 15:30:39 NormanWalsh Exp $ -->
+
+<!--
+TYPICAL INVOCATION:
+#  <!DOCTYPE spec PUBLIC
+#       "-//W3C//DTD Specification V2.10//EN"
+#       "http://www.w3.org/2002/xmlspec/dtd/2.10/xmlspec.dtd">
+
+PURPOSE:
+  This XML DTD is for W3C specifications and other technical reports.
+  It is based in part on the TEI Lite and Sweb DTDs.
+
+COPYRIGHT:
+
+  Copyright (C) 2000, 2001, 2002, 2003 Sun Microsystems, Inc. All Rights Reserved.
+  This document is governed by the W3C Software License[3] as
+  described in the FAQ[4].
+
+    [1] http://www.w3.org/TR/xslt
+    [2] http://www.w3.org/XML/1998/06/xmlspec-report-v21.htm
+    [3] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    [4] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+
+DEPENDENCIES:
+  None.
+
+CHANGE HISTORY:
+  The list of historical changes is at the end of the DTD. For recent changes,
+  see the CVS log.
+
+  For all details, see the design report at:
+
+  <http://www.w3.org/XML/1998/06/xmlspec-report-v21.htm>
+
+  This report is now out-of-date, but no more recent report has been prepared.
+
+#2003-06-25: nwalsh: Added translationloc, preverrataloc, rfc2119
+
+#2003-05-28: nwalsh: Added errataloc, fixed IE bug. Added @num to prod.
+
+             Published V2.4
+
+#2003-03-12: nwalsh: Added local.* PEs to a number of additional
+             places to make customization layers easier.
+
+             Published V2.3
+
+#2002-09-04: nwalsh: Added 'phrase' to title, subtitle, version,
+             w3c-designation, w3c-doctype, day, month, year, name,
+             affiliation, email, language, role, lhs, rhs, com,
+             typename, date, loc, nt, sub, sup, term, termref,
+             titleref, xnt, xspecref, xtermref
+
+             This is *solely* to support automated diffing. Users
+             are explicitly forbidden from using this as an escape
+             hatch to get extra markup in these contexts.
+
+#2001-10-08: nwalsh: Added local.arg.att and local.proto.att
+
+#2002-08-14: nwalsh: Published V2.2
+
+  Added marked sections around element and attlist declarations and
+  added the altlocs element
+
+MAINTAINERS:
+  Norman Walsh
+  Sun Microsystems, Inc.
+  Norman.Walsh@Sun.COM
+  voice: +1 413 256 6985
+  fax:   +1 413 256 6985
+
+  Eve Maler
+  Sun Microsystems, Inc.
+  elm@east.sun.com
+  voice: +1 781 442 3190
+  fax:   +1 781 442 1437
+-->
+
+<!-- ............................................................... -->
+<!-- Entities for characters and symbols ........................... -->
+<!-- ............................................................... -->
+
+<!--
+#1998-03-10: maler: Added &ldquo; and &rdquo;.
+#                   Used 8879:1986-compatible decimal character
+#                   references.
+#                   Merged charent.mod file back into main file.
+#1998-05-14: maler: Fixed ldquo and rdquo.  Gave mdash a real number.
+#1998-12-03: maler: Escaped the leading ampersands.
+-->
+
+<!ENTITY lt     "&#38;#60;">
+<!ENTITY gt     "&#62;">
+<!ENTITY amp    "&#38;#38;">
+<!ENTITY apos   "&#39;">
+<!ENTITY quot   "&#34;">
+<!ENTITY nbsp   "&#160;">
+<!ENTITY mdash  "&#38;#x2014;">
+<!ENTITY ldquo  "&#38;#x201C;">
+<!ENTITY rdquo  "&#38;#x201D;">
+
+<!-- ............................................................... -->
+<!-- Entities for classes of standalone elements ................... -->
+<!-- ............................................................... -->
+
+<!--
+#1997-10-16: maler: Added table to %illus.class;.
+#1997-11-28: maler: Added htable to %illus.class;.
+#1997-12-29: maler: IGNOREd table.
+#1998-03-10: maler: Removed SGML Open-specific %illus.class;.
+#                   Added "local" entities for customization.
+#1998-05-14: maler: Added issue to %note.class;.
+#                   Removed %[local.]statusp.class;.
+#1998-05-21: maler: Added constraintnote to %note.class;.
+#1998-08-22: maler: Changed htable to table in %illus.class;.
+#                   Added definitions to %illus.class;.
+#2000-03-07: maler: Added proto and example to %illus.class;.
+-->
+
+<!ENTITY % local.p.class        " ">
+<!ENTITY % p.class              "p
+                                %local.p.class;">
+
+<!ENTITY % local.list.class     " ">
+<!ENTITY % list.class           "ulist|olist|slist|glist
+                                %local.list.class;">
+
+<!ENTITY % local.speclist.class " ">
+<!ENTITY % speclist.class       "orglist|blist
+                                %local.speclist.class;">
+
+<!ENTITY % local.note.class     " ">
+<!ENTITY % note.class           "note|issue|wfcnote|vcnote
+                                |constraintnote %local.note.class;">
+
+<!ENTITY % local.illus.class    " ">
+<!ENTITY % illus.class          "eg|graphic|scrap|table|definitions
+                                |proto|example
+                                %local.illus.class;">
+
+<!-- ............................................................... -->
+<!-- Entities for classes of phrase-level elements ................. -->
+<!-- ............................................................... -->
+
+<!--
+#1997-12-29: maler: Added xspecref to %ref.class;.
+#1998-03-10: maler: Added %ednote.class;.
+#                   Added "local" entities for customization.
+#2000-03-07: maler: Added function, var, el, att, and attval to
+#                   %tech.class;.
+#                   Added sub, sup, and phrase to %emph.class;.
+-->
+
+<!ENTITY % local.annot.class    " ">
+<!ENTITY % annot.class          "footnote
+                                %local.annot.class;">
+
+<!ENTITY % local.termdef.class  " ">
+<!ENTITY % termdef.class        "termdef|term
+                                %local.termdef.class;">
+
+<!ENTITY % local.emph.class     " ">
+<!ENTITY % emph.class           "emph|phrase|rfc2119|quote|sub|sup
+                                %local.emph.class;">
+
+<!ENTITY % local.ref.class      " ">
+<!ENTITY % ref.class            "bibref|specref|termref|titleref
+                                |xspecref|xtermref
+                                %local.ref.class;">
+
+<!ENTITY % local.loc.class      " ">
+<!ENTITY % loc.class            "loc
+                                %local.loc.class;">
+
+<!ENTITY % local.tech.class     " ">
+<!ENTITY % tech.class           "kw|nt|xnt|code|function|var
+                                |el|att|attval
+                                %local.tech.class;">
+
+<!ENTITY % local.ednote.class   " ">
+<!ENTITY % ednote.class         "ednote
+                                %local.ednote.class;">
+
+<!-- ............................................................... -->
+<!-- Entities for mixtures of standalone elements .................. -->
+<!-- ............................................................... -->
+
+<!--
+#1997-09-30: maler: Created %p.mix; to eliminate p from self.
+#1997-09-30: maler: Added %speclist.class; to %obj.mix; and %p.mix;.
+#1997-09-30: maler: Added %note.class; to %obj.mix; and %p.mix;.
+#1997-10-16: maler: Created %entry.mix;.  Note that some elements
+#                   left out here are still allowed in termdef,
+#                   which entry can contain through %p.pcd.mix;.
+#1997-11-28: maler: Added %p.class; to %statusobj.mix;.
+#1998-03-10: maler: Added %ednote.class; to all mixtures, except
+#                   %p.mix; and %statusobj.mix;, because paragraphs
+#                   and status paragraphs will contain ednote
+#                   through %p.pcd.mix;.
+#1998-03-23: maler: Added %termdef.mix; (broken out from
+#                    %termdef.pcd.mix;).
+#1998-05-14: maler: Removed %statusobj.mix; and all mentions of
+#                   %statusp.mix;.
+-->
+
+<!ENTITY % local.div.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % div.mix
+        "%p.class;|%list.class;|%speclist.class;|%note.class;
+        |%illus.class;|%ednote.class;%local.div.mix;">
+
+<!ENTITY % local.obj.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % obj.mix
+        "%p.class;|%list.class;|%speclist.class;|%note.class;
+        |%illus.class;|%ednote.class;%local.obj.mix;">
+
+<!ENTITY % local.p.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % p.mix
+        "%list.class;|%speclist.class;|%note.class;|%illus.class;%local.p.mix;">
+
+<!ENTITY % local.entry.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % entry.mix
+        "%list.class;|note|eg|graphic|%ednote.class;%local.entry.mix;">
+
+<!ENTITY % local.hdr.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % hdr.mix
+        "%p.class;|%list.class;|%ednote.class;%local.hdr.mix;">
+
+<!ENTITY % local.termdef.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % termdef.mix
+        "%note.class;|%illus.class;%local.termdef.mix;">
+
+<!-- ............................................................... -->
+<!-- Entities for mixtures of #PCDATA and phrase-level elements .... -->
+<!-- ............................................................... -->
+
+<!--    Note that %termdef.pcd.mix contains %note.class;
+        and %illus.class;, considered standalone elements. -->
+
+<!--
+#1997-09-30: maler: Added scrap and %note.class; to %termdef.pcd.mix;.
+#1997-11-28: maler: Added %loc.class; to %p.pcd.mix;.
+#1998-03-10: maler: Added %ednote.class; to all mixtures.
+#1998-03-23: maler: Moved some %termdef.pcd.mix; stuff out to
+#                   %termdef.mix;.
+#1998-05-14: maler: Removed %statusp.pcd.mix;.
+#1998-05-21: maler: Added constraint element to %eg.pcd.mix;.
+#1999-07-02: maler: Added %loc.class; to %head.pcd.mix;,
+#                   %label.pcd.mix;, %eg.pcd.mix;, %termdef.pcd.mix;,
+#                   %tech.pcd.mix; (net: all PCD mixes have it).
+#                   Removed unused %loc.pcd.mix;.
+-->
+
+<!ENTITY % local.p.pcd.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % p.pcd.mix
+        "#PCDATA|%annot.class;|%termdef.class;|%emph.class;
+        |%ref.class;|%tech.class;|%loc.class;|%ednote.class;%local.p.pcd.mix;">
+
+<!ENTITY % local.head.pcd.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % head.pcd.mix
+        "#PCDATA|%annot.class;|%emph.class;|%tech.class;
+        |%loc.class;|%ednote.class;%local.head.pcd.mix;">
+
+<!ENTITY % local.label.pcd.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % label.pcd.mix
+        "#PCDATA|%annot.class;|%termdef.class;|%emph.class;
+        |%tech.class;|%loc.class;|%ednote.class;%local.label.pcd.mix;">
+
+<!ENTITY % local.eg.pcd.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % eg.pcd.mix
+        "#PCDATA|%annot.class;|%emph.class;|%loc.class;
+        |%ednote.class;|constraint %local.eg.pcd.mix;">
+
+<!ENTITY % local.termdef.pcd.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % termdef.pcd.mix
+        "#PCDATA|term|%emph.class;|%ref.class;|%tech.class;
+        |%loc.class;|%ednote.class;%local.termdef.pcd.mix;">
+
+<!ENTITY % local.bibl.pcd.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % bibl.pcd.mix
+        "#PCDATA|%emph.class;|%ref.class;|%loc.class;|%ednote.class;%local.bibl.pcd.mix;">
+
+<!ENTITY % local.tech.pcd.mix " "> <!-- compensate for IE bug; suggested by ht -->
+<!ENTITY % tech.pcd.mix
+        "#PCDATA|%loc.class;|%ednote.class;|phrase|rfc2119 %local.tech.pcd.mix;">
+
+<!-- ............................................................... -->
+<!-- Entities for customizable content models ...................... -->
+<!-- ............................................................... -->
+
+<!--
+#1998-03-10: maler: Added customization entities.
+#1998-05-14: maler: Allowed prevlocs and latestloc in either order.
+#1999-07-02: maler: Made version optional; added copyright element.
+#2000-03-07: maler: Allowed status and abstract in opposite order.
+-->
+
+<!ENTITY % spec.mdl
+        "header, front?, body, back?">
+
+<!ENTITY % header.mdl
+        "title, subtitle?, version?, w3c-designation, w3c-doctype,
+        pubdate, notice*, publoc, altlocs?, ((prevlocs, latestloc?) |
+        (latestloc, prevlocs?))?, authlist, errataloc?, preverrataloc?,
+        translationloc?, copyright?,
+        ((status, abstract) | (abstract, status)), pubstmt?,
+        sourcedesc?, langusage, revisiondesc">
+
+<!ENTITY % pubdate.mdl
+        "day?, month, year">
+
+<!-- ............................................................... -->
+<!-- Entities for common attributes ................................ -->
+<!-- ............................................................... -->
+
+<!--
+#2000-03-07: maler: Added %argtypes;.
+-->
+
+<!--    argtypes:
+        Values for function prototype argument datatypes. -->
+<!ENTITY % argtypes
+        '(boolean
+         |expression
+         |location-set
+         |node-set
+         |number
+         |object
+         |point
+         |range
+         |string)'>
+
+<!--    key attribute:
+        Optionally provides a sorting or indexing key, for cases when
+        the element content is inappropriate for this purpose. -->
+<!ENTITY % key.att
+        'key                    CDATA           #IMPLIED'>
+
+<!--    def attribute:
+        Points to the element where the relevant definition can be
+        found, using the IDREF mechanism.  %def.att; is for optional
+        def attributes, and %def-req.att; is for required def
+        attributes. -->
+<!ENTITY % def.att
+        'def                    IDREF           #IMPLIED'>
+<!ENTITY % def-req.att
+        'def                    IDREF           #REQUIRED'>
+
+<!--    ref attribute:
+        Points to the element where more information can be found,
+        using the IDREF mechanism.  %ref.att; is for optional
+        ref attributes, and %ref-req.att; is for required ref
+        attributes. -->
+<!ENTITY % ref.att
+        'ref                    IDREF           #IMPLIED'>
+<!ENTITY % ref-req.att
+        'ref                    IDREF           #REQUIRED'>
+
+<!--
+#1998-03-23: maler: Added show and actuate attributes to href.
+#                   Added semi-common xml:space attribute.
+#1998-08-22: maler: Used new xlink:form and #IMPLIED features.
+#1999-07-02: maler: Reorganized XLink-related entities completely;
+#                   added xmlns:xlink attribute to the mix.
+#2000-03-07: maler: Updated XLink usage to February 2000 draft,
+#                   except that href still has no namespace prefix.
+-->
+
+<!--    xmlns:xlink and xlink:type attributes:
+        xmlns:xlink declares the association of the xlink prefix
+        with the namespace created by the XLink specification.
+        xlink:type identifies an element as an XLink "simple" linking
+        element. -->
+<!ENTITY % simple-xlink.att
+        'xmlns:xlink            CDATA   #FIXED
+                                        "http://www.w3.org/1999/xlink"
+        xlink:type              CDATA   #FIXED "simple" '>
+
+<!--    href attributes:
+        The href attribute locates the remote-resource half of a
+        simple link; the element on which the href appears is the
+        local-resource half.  Some elements are usable links only if
+        the author chooses to supply a functional href.  The attribute
+        name should really be xlink:href, but is kept without the
+        prefix for now in order to be backwards-compatible. -->
+
+<!ENTITY % href.att
+        'href                   CDATA           #IMPLIED '>
+<!ENTITY % href-req.att
+        'href                   CDATA           #REQUIRED '>
+
+<!--    xlink:show and xlink:actuate attributes:
+        These attributes offer instructions to the display engine
+        about how to handle traversal to resource indicated by an
+        href locator. -->
+<!ENTITY % auto-embed.att
+        'xlink:show             CDATA           #FIXED "embed"
+        xlink:actuate           CDATA           #FIXED "onLoad" '>
+<!ENTITY % user-replace.att
+        'xlink:show             CDATA           #FIXED "replace"
+        xlink:actuate           CDATA           #FIXED "onRequest" '>
+<!ENTITY % user-new.att
+        'xlink:show             CDATA           #FIXED "new"
+        xlink:actuate           CDATA           #FIXED "onRequest" '>
+
+<!--    xml:space attribute:
+        Indicates that the element contains whitespace that the
+        formatter or other application should retain, as appropriate
+        to its function. -->
+<!ENTITY % xmlspace.att
+        'xml:space              (default
+                                |preserve)      #FIXED "preserve" '>
+
+<!--
+#2000-03-07: maler: Added common diff attribute.  Made %role.att;.
+-->
+
+<!--    diff attribute:
+        Indicates in what way the element has changed.  When a value
+        is not provided, that subelement should inherit a value from
+        its parent.  If the root element has no value supplied,
+        assume "off". -->
+<!ENTITY % diff.att
+        'diff                   (chg
+                                |add
+                                |del
+                                |off)           #IMPLIED'>
+
+<!--    role attribute:
+        Extends the useful life of the DTD by allowing authors to
+        make a subtype of any element.  No default. -->
+<!ENTITY % role.att
+        'role                   NMTOKEN         #IMPLIED'>
+
+<!--    Common attributes:
+        Every element has an ID attribute for links, a role
+        attribute, and a diff attribute. %common.att; is for
+        common attributes where the ID is optional, and
+        %common-idreq.att; is for common attributes where the
+        ID is required. -->
+
+<!ENTITY % local.common.att " ">
+<!ENTITY % common.att
+        'id                     ID              #IMPLIED
+        %role.att;
+        %diff.att;
+        %local.common.att;'>
+
+<!ENTITY % local.common-idreq.att " ">
+<!ENTITY % common-idreq.att
+        'id                     ID              #REQUIRED
+        %role.att;
+        %diff.att;
+        %local.common-idreq.att;'>
+
+<!-- ............................................................... -->
+<!-- Common elements ............................................... -->
+<!-- ............................................................... -->
+
+<!--    head: Title on divisions, productions, and the like -->
+<!ENTITY % head.element "INCLUDE">
+<![%head.element;[
+<!ELEMENT head (%head.pcd.mix;)*>
+]]>
+<!ENTITY % head.attlist "INCLUDE">
+<![%head.attlist;[
+<!ATTLIST head %common.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- Major specification structure ................................. -->
+<!-- ............................................................... -->
+
+<!--
+#1998-03-10: maler: Made spec content model easily customizable.
+#1999-07-02: maler: Added doctype atts and status att.
+#2000-03-07: maler: Added cr, issues, and dispcmts to w3c-doctype.
+-->
+
+<!ENTITY % spec.element "INCLUDE">
+<![%spec.element;[
+<!ELEMENT spec (%spec.mdl;)>
+]]>
+<!--    w3c-doctype attributes:
+        Indicates the type of document, so that the appropriate
+        stylesheet or workflow routing can be applied.  Should
+        *not* generate any text (such as the "REC-" or "NOTE-"
+        prefix on the W3C designation content).  No default.  If
+        w3c-doctype is "other", other-doctype should be filled in.
+
+        status attribute:
+        Indicates the stage of review of the document.  May affect
+        the stylesheet's treatment of ednotes (e.g., whether to
+        output them).  No default. -->
+
+<!ENTITY % local.spec.att " ">
+<!ENTITY % spec.attlist "INCLUDE">
+<![%spec.attlist;[
+<!ATTLIST spec
+        %common.att;
+        %local.spec.att;
+        w3c-doctype     (cr
+                        |dispcmts
+                        |issues
+                        |wgnote
+                        |memsub
+                        |teamsub
+                        |note
+                        |other
+                        |pr
+                        |per
+                        |rec
+                        |wd
+                        |review)                #IMPLIED
+        other-doctype   CDATA                   #IMPLIED
+        status          (int-review
+                        |ext-review
+                        |final)                 #IMPLIED
+>
+]]>
+
+<!ENTITY % front.element "INCLUDE">
+<![%front.element;[
+<!ELEMENT front (div1+)>
+]]>
+<!ENTITY % front.attlist "INCLUDE">
+<![%front.attlist;[
+<!ATTLIST front %common.att;>
+]]>
+
+<!ENTITY % body.element "INCLUDE">
+<![%body.element;[
+<!ELEMENT body (div1+)>
+]]>
+<!ENTITY % body.attlist "INCLUDE">
+<![%body.attlist;[
+<!ATTLIST body %common.att;>
+]]>
+
+<!--
+#1997-09-30: maler: Added inform-div1 to back content.
+-->
+
+<!ENTITY % back.element "INCLUDE">
+<![%back.element;[
+<!ELEMENT back ((div1+, inform-div1*) | inform-div1+)>
+]]>
+<!ENTITY % back.attlist "INCLUDE">
+<![%back.attlist;[
+<!ATTLIST back %common.att;>
+]]>
+
+<!ENTITY % div1.element "INCLUDE">
+<![%div1.element;[
+<!ELEMENT div1 (head, (%div.mix;)*, div2*)>
+]]>
+<!ENTITY % div1.attlist "INCLUDE">
+<![%div1.attlist;[
+<!ATTLIST div1 %common.att;>
+]]>
+
+<!--
+#1997-09-30: maler: Added inform-div1 declarations.
+#2000-03-07: maler: Added div5 level.
+-->
+
+<!--    inform-div1: Non-normative division in back matter -->
+<!ENTITY % inform-div1.element "INCLUDE">
+<![%inform-div1.element;[
+<!ELEMENT inform-div1 (head, (%div.mix;)*, div2*)>
+]]>
+<!ENTITY % inform-div1.attlist "INCLUDE">
+<![%inform-div1.attlist;[
+<!ATTLIST inform-div1 %common.att;>
+]]>
+
+<!ENTITY % div2.element "INCLUDE">
+<![%div2.element;[
+<!ELEMENT div2 (head, (%div.mix;)*, div3*)>
+]]>
+<!ENTITY % div2.attlist "INCLUDE">
+<![%div2.attlist;[
+<!ATTLIST div2 %common.att;>
+]]>
+
+<!ENTITY % div3.element "INCLUDE">
+<![%div3.element;[
+<!ELEMENT div3 (head, (%div.mix;)*, div4*)>
+]]>
+<!ENTITY % div3.attlist "INCLUDE">
+<![%div3.attlist;[
+<!ATTLIST div3 %common.att;>
+]]>
+
+<!ENTITY % div4.element "INCLUDE">
+<![%div4.element;[
+<!ELEMENT div4 (head, (%div.mix;)*, div5*)>
+]]>
+<!ENTITY % div4.attlist "INCLUDE">
+<![%div4.attlist;[
+<!ATTLIST div4 %common.att;>
+]]>
+
+<!ENTITY % div5.element "INCLUDE">
+<![%div5.element;[
+<!ELEMENT div5 (head, (%div.mix;)*)>
+]]>
+<!ENTITY % div5.attlist "INCLUDE">
+<![%div5.attlist;[
+<!ATTLIST div5 %common.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- Specification header .......................................... -->
+<!-- ............................................................... -->
+
+<!--
+#1998-03-10: maler: Made header content model easily customizable.
+-->
+
+<!ENTITY % header.element "INCLUDE">
+<![%header.element;[
+<!ELEMENT header (%header.mdl;)>
+]]>
+<!ENTITY % header.attlist "INCLUDE">
+<![%header.attlist;[
+<!ATTLIST header %common.att;>
+]]>
+
+<!--    Example of title: "Extensible Cheese Language (XCL)" -->
+<!ENTITY % title.element "INCLUDE">
+<![%title.element;[
+<!ELEMENT title (#PCDATA|phrase)*>
+]]>
+<!ENTITY % title.attlist "INCLUDE">
+<![%title.attlist;[
+<!ATTLIST title %common.att;>
+]]>
+
+<!--    Example of subtitle: "A Cheesy Specification" -->
+<!ENTITY % subtitle.element "INCLUDE">
+<![%subtitle.element;[
+<!ELEMENT subtitle (#PCDATA|phrase)*>
+]]>
+<!ENTITY % subtitle.attlist "INCLUDE">
+<![%subtitle.attlist;[
+<!ATTLIST subtitle %common.att;>
+]]>
+
+<!--    Example of version: "Version 666.0" -->
+<!ENTITY % version.element "INCLUDE">
+<![%version.element;[
+<!ELEMENT version (#PCDATA|phrase)*>
+]]>
+<!ENTITY % version.attlist "INCLUDE">
+<![%version.attlist;[
+<!ATTLIST version %common.att;>
+]]>
+
+<!--    Example of w3c-designation: "WD-xcl-19991231" -->
+<!ENTITY % w3c-designation.element "INCLUDE">
+<![%w3c-designation.element;[
+<!ELEMENT w3c-designation (#PCDATA|phrase)*>
+]]>
+<!ENTITY % w3c-designation.attlist "INCLUDE">
+<![%w3c-designation.attlist;[
+<!ATTLIST w3c-designation %common.att;>
+]]>
+
+<!--    Example of w3c-doctype: "W3C Working Draft" -->
+<!ENTITY % w3c-doctype.element "INCLUDE">
+<![%w3c-doctype.element;[
+<!ELEMENT w3c-doctype (#PCDATA|phrase)*>
+]]>
+<!ENTITY % w3c-doctype.attlist "INCLUDE">
+<![%w3c-doctype.attlist;[
+<!ATTLIST w3c-doctype %common.att;>
+]]>
+
+<!--
+#1998-03-10: maler: Made pubdate content model easily customizable.
+-->
+
+<!ENTITY % pubdate.element "INCLUDE">
+<![%pubdate.element;[
+<!ELEMENT pubdate (%pubdate.mdl;)>
+]]>
+<!ENTITY % pubdate.attlist "INCLUDE">
+<![%pubdate.attlist;[
+<!ATTLIST pubdate %common.att;>
+]]>
+
+<!ENTITY % day.element "INCLUDE">
+<![%day.element;[
+<!ELEMENT day (#PCDATA|phrase)*>
+]]>
+<!ENTITY % day.attlist "INCLUDE">
+<![%day.attlist;[
+<!ATTLIST day %common.att;>
+]]>
+
+<!ENTITY % month.element "INCLUDE">
+<![%month.element;[
+<!ELEMENT month (#PCDATA|phrase)*>
+]]>
+<!ENTITY % month.attlist "INCLUDE">
+<![%month.attlist;[
+<!ATTLIST month %common.att;>
+]]>
+
+<!ENTITY % year.element "INCLUDE">
+<![%year.element;[
+<!ELEMENT year (#PCDATA|phrase)*>
+]]>
+<!ENTITY % year.attlist "INCLUDE">
+<![%year.attlist;[
+<!ATTLIST year %common.att;>
+]]>
+
+<!--
+#1999-07-02: maler: Declared copyright element.
+-->
+
+<!ENTITY % copyright.element "INCLUDE">
+<![%copyright.element;[
+<!ELEMENT copyright (%hdr.mix;)+>
+]]>
+<!ENTITY % copyright.attlist "INCLUDE">
+<![%copyright.attlist;[
+<!ATTLIST copyright %common.att;>
+]]>
+
+<!--    Example of notice: "This draft is for public comment..." -->
+<!ENTITY % notice.element "INCLUDE">
+<![%notice.element;[
+<!ELEMENT notice (%hdr.mix;)+>
+]]>
+<!ENTITY % notice.attlist "INCLUDE">
+<![%notice.attlist;[
+<!ATTLIST notice %common.att;>
+]]>
+
+<!--
+#2000-03-07: maler: Broadened models of *loc to %p.pcd.mix;.
+-->
+
+<!ENTITY % publoc.element "INCLUDE">
+<![%publoc.element;[
+<!ELEMENT publoc (%p.pcd.mix;)*>
+]]>
+<!ENTITY % publoc.attlist "INCLUDE">
+<![%publoc.attlist;[
+<!ATTLIST publoc %common.att;>
+]]>
+
+<!--
+#2002-08-15: nwalsh: Added altlocs element.
+  The semantics of the altlocs are equivalent to the Dublin Core relation element
+  with type="hasVersion". Each of the loc elements inside altlocs should identify
+  an alternate version of the resource described by the document, for example
+  HTML, XML, and PDF forms.
+-->
+<!ENTITY % altlocs.element "INCLUDE">
+<![%altlocs.element;[
+<!ELEMENT altlocs (loc+)>
+]]>
+<!ENTITY % altlocs.attlist "INCLUDE">
+<![%altlocs.attlist;[
+<!ATTLIST altlocs %common.att;>
+]]>
+
+<!ENTITY % prevlocs.element "INCLUDE">
+<![%prevlocs.element;[
+<!ELEMENT prevlocs (%p.pcd.mix;)*>
+]]>
+<!ENTITY % prevlocs.attlist "INCLUDE">
+<![%prevlocs.attlist;[
+<!ATTLIST prevlocs %common.att;>
+]]>
+
+<!--
+#2005-10-13: nwalsh: restrict latestloc content model.
+  New pubrules allows for multiple latestlocs. For some reason, this element
+  used to allow PCDATA. Now it allows only loc elements. If this causes
+  trouble, tell Norm.
+-->
+<!ENTITY % latestloc.element "INCLUDE">
+<![%latestloc.element;[
+<!ELEMENT latestloc (loc+)>
+]]>
+<!ENTITY % latestloc.attlist "INCLUDE">
+<![%latestloc.attlist;[
+<!ATTLIST latestloc %common.att;>
+]]>
+
+<!ENTITY % errataloc.element "INCLUDE">
+<![%errataloc.element;[
+<!ELEMENT errataloc EMPTY>
+]]>
+<!ENTITY % errataloc.attlist "INCLUDE">
+<![%errataloc.attlist;[
+<!ATTLIST errataloc
+	%common.att;
+        %simple-xlink.att;
+	%href-req.att;
+>
+]]>
+
+<!ENTITY % preverrataloc.element "INCLUDE">
+<![%preverrataloc.element;[
+<!ELEMENT preverrataloc EMPTY>
+]]>
+<!ENTITY % preverrataloc.attlist "INCLUDE">
+<![%preverrataloc.attlist;[
+<!ATTLIST preverrataloc
+	%common.att;
+        %simple-xlink.att;
+	%href-req.att;
+>
+]]>
+
+<!ENTITY % translationloc.element "INCLUDE">
+<![%translationloc.element;[
+<!ELEMENT translationloc EMPTY>
+]]>
+<!ENTITY % translationloc.attlist "INCLUDE">
+<![%translationloc.attlist;[
+<!ATTLIST translationloc
+	%common.att;
+        %simple-xlink.att;
+	%href-req.att;
+>
+]]>
+
+<!--      loc (defined in "Phrase-level elements" below) -->
+
+<!ENTITY % authlist.element "INCLUDE">
+<![%authlist.element;[
+<!ELEMENT authlist (author+)>
+]]>
+<!ENTITY % authlist.attlist "INCLUDE">
+<![%authlist.attlist;[
+<!ATTLIST authlist %common.att;>
+]]>
+
+<!--
+#1997-09-30: maler: Made affiliation optional.
+#1998-03-10: maler: Made email optional.
+-->
+
+<!ENTITY % author.element "INCLUDE">
+<![%author.element;[
+<!ELEMENT author (name, affiliation?, email?)>
+]]>
+<!ENTITY % author.attlist "INCLUDE">
+<![%author.attlist;[
+<!ATTLIST author %common.att;>
+]]>
+
+<!ENTITY % name.element "INCLUDE">
+<![%name.element;[
+<!ELEMENT name (#PCDATA|phrase)*>
+]]>
+<!ENTITY % name.attlist "INCLUDE">
+<![%name.attlist;[
+<!ATTLIST name
+        %common.att;
+        %key.att;>
+]]>
+
+<!ENTITY % affiliation.element "INCLUDE">
+<![%affiliation.element;[
+<!ELEMENT affiliation (#PCDATA|phrase)*>
+]]>
+<!ENTITY % affiliation.attlist "INCLUDE">
+<![%affiliation.attlist;[
+<!ATTLIST affiliation %common.att;>
+]]>
+
+<!--
+#1999-07-02: maler: Added show/actuate attributes and default values.
+-->
+
+
+<!ENTITY % email.element "INCLUDE">
+<![%email.element;[
+<!ELEMENT email (#PCDATA|phrase)*>
+]]>
+<!--    href attribute:
+        email functions as a hypertext reference through this
+        required attribute.  Typically the reference would use
+        the mailto: scheme.  E.g.:
+
+<email href="mailto:elm@arbortext.com">elm@arbortext.com</email>
+        -->
+
+<!ENTITY % email.attlist "INCLUDE">
+<![%email.attlist;[
+<!ATTLIST email
+        %common.att;
+        %simple-xlink.att;
+        %href-req.att;
+        %user-new.att;>
+]]>
+
+<!--
+#1998-05-15: maler: Changed status content from %statusobj.mix;
+#                   to plain %obj.mix;.  statusp is obsolete.
+-->
+
+<!ENTITY % status.element "INCLUDE">
+<![%status.element;[
+<!ELEMENT status (%obj.mix;)+>
+]]>
+<!ENTITY % status.attlist "INCLUDE">
+<![%status.attlist;[
+<!ATTLIST status %common.att;>
+]]>
+
+<!ENTITY % abstract.element "INCLUDE">
+<![%abstract.element;[
+<!ELEMENT abstract (%hdr.mix;)*>
+]]>
+<!ENTITY % abstract.attlist "INCLUDE">
+<![%abstract.attlist;[
+<!ATTLIST abstract %common.att;>
+]]>
+
+<!ENTITY % pubstmt.element "INCLUDE">
+<![%pubstmt.element;[
+<!ELEMENT pubstmt (%hdr.mix;)+>
+]]>
+<!ENTITY % pubstmt.attlist "INCLUDE">
+<![%pubstmt.attlist;[
+<!ATTLIST pubstmt %common.att;>
+]]>
+
+<!ENTITY % sourcedesc.element "INCLUDE">
+<![%sourcedesc.element;[
+<!ELEMENT sourcedesc (%hdr.mix;)+>
+]]>
+<!ENTITY % sourcedesc.attlist "INCLUDE">
+<![%sourcedesc.attlist;[
+<!ATTLIST sourcedesc %common.att;>
+]]>
+
+<!ENTITY % langusage.element "INCLUDE">
+<![%langusage.element;[
+<!ELEMENT langusage (language+)>
+]]>
+<!ENTITY % langusage.attlist "INCLUDE">
+<![%langusage.attlist;[
+<!ATTLIST langusage %common.att;>
+]]>
+
+<!ENTITY % language.element "INCLUDE">
+<![%language.element;[
+<!ELEMENT language (#PCDATA|phrase)*>
+]]>
+<!ENTITY % language.attlist "INCLUDE">
+<![%language.attlist;[
+<!ATTLIST language %common.att;>
+]]>
+
+<!ENTITY % revisiondesc.element "INCLUDE">
+<![%revisiondesc.element;[
+<!ELEMENT revisiondesc (%hdr.mix;)+>
+]]>
+<!ENTITY % revisiondesc.attlist "INCLUDE">
+<![%revisiondesc.attlist;[
+<!ATTLIST revisiondesc %common.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- Paragraph ..................................................... -->
+<!-- ............................................................... -->
+
+<!--
+#1997-09-30: maler: Changed from %obj.mix; to %p.mix;.
+#1997-12-29: maler: Changed order of %p.mix; and %p.pcd.mix;
+#                   references.
+#1997-12-29: maler: Changed order of %statusobj.mix; and
+#                   %statusp.pcd.mix; references.
+#1998-05-14: maler: Removed statusp declarations.
+-->
+
+<!ENTITY % p.element "INCLUDE">
+<![%p.element;[
+<!ELEMENT p (%p.pcd.mix;|%p.mix;)*>
+]]>
+<!ENTITY % p.attlist "INCLUDE">
+<![%p.attlist;[
+<!ATTLIST p %common.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- Regular lists ................................................. -->
+<!-- ............................................................... -->
+
+<!--    ulist: Unordered list, typically bulleted. -->
+<!ENTITY % ulist.element "INCLUDE">
+<![%ulist.element;[
+<!ELEMENT ulist (item+)>
+]]>
+<!--    spacing attribute:
+        Use "normal" to get normal vertical spacing for items;
+        use "compact" to get less spacing.  The default is dependent
+        on the stylesheet. -->
+<!ENTITY % ulist.attlist "INCLUDE">
+<![%ulist.attlist;[
+<!ATTLIST ulist
+        %common.att;
+        spacing         (normal|compact)        #IMPLIED>
+]]>
+
+<!--    olist: Ordered list, typically numbered. -->
+<!ENTITY % olist.element "INCLUDE">
+<![%olist.element;[
+<!ELEMENT olist (item+)>
+]]>
+<!--    spacing attribute:
+        Use "normal" to get normal vertical spacing for items;
+        use "compact" to get less spacing.  The default is dependent
+        on the stylesheet. -->
+<!ENTITY % olist.attlist "INCLUDE">
+<![%olist.attlist;[
+<!ATTLIST olist
+        %common.att;
+        spacing         (normal|compact)        #IMPLIED>
+]]>
+
+<!ENTITY % item.element "INCLUDE">
+<![%item.element;[
+<!ELEMENT item (%obj.mix;)+>
+]]>
+<!ENTITY % item.attlist "INCLUDE">
+<![%item.attlist;[
+<!ATTLIST item %common.att;>
+]]>
+
+<!--    slist: Simple list, typically with no mark. -->
+<!ENTITY % slist.element "INCLUDE">
+<![%slist.element;[
+<!ELEMENT slist (sitem+)>
+]]>
+<!ENTITY % slist.attlist "INCLUDE">
+<![%slist.attlist;[
+<!ATTLIST slist %common.att;>
+]]>
+
+<!ENTITY % sitem.element "INCLUDE">
+<![%sitem.element;[
+<!ELEMENT sitem (%p.pcd.mix;)*>
+]]>
+<!ENTITY % sitem.attlist "INCLUDE">
+<![%sitem.attlist;[
+<!ATTLIST sitem %common.att;>
+]]>
+
+<!--    glist: Glossary list, typically two-column. -->
+<!ENTITY % glist.element "INCLUDE">
+<![%glist.element;[
+<!ELEMENT glist (gitem+)>
+]]>
+<!ENTITY % glist.attlist "INCLUDE">
+<![%glist.attlist;[
+<!ATTLIST glist %common.att;>
+]]>
+
+<!ENTITY % gitem.element "INCLUDE">
+<![%gitem.element;[
+<!ELEMENT gitem (label, def)>
+]]>
+<!ENTITY % gitem.attlist "INCLUDE">
+<![%gitem.attlist;[
+<!ATTLIST gitem %common.att;>
+]]>
+
+<!ENTITY % label.element "INCLUDE">
+<![%label.element;[
+<!ELEMENT label (%label.pcd.mix;)*>
+]]>
+<!ENTITY % label.attlist "INCLUDE">
+<![%label.attlist;[
+<!ATTLIST label %common.att;>
+]]>
+
+<!ENTITY % def.element "INCLUDE">
+<![%def.element;[
+<!ELEMENT def (%obj.mix;)*>
+]]>
+<!ENTITY % def.attlist "INCLUDE">
+<![%def.attlist;[
+<!ATTLIST def %common.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- Special lists ................................................. -->
+<!-- ............................................................... -->
+
+<!--    blist: Bibliography list. -->
+<!ENTITY % blist.element "INCLUDE">
+<![%blist.element;[
+<!ELEMENT blist (bibl+)>
+]]>
+<!ENTITY % blist.attlist "INCLUDE">
+<![%blist.attlist;[
+<!ATTLIST blist %common.att;>
+]]>
+
+<!--
+#1999-07-02: maler: Added show/actuate attributes and default values.
+-->
+
+<!ENTITY % bibl.element "INCLUDE">
+<![%bibl.element;[
+<!ELEMENT bibl (%bibl.pcd.mix;)*>
+]]>
+<!--    href attribute:
+        bibl optionally functions as a hypertext reference to the
+        referred-to resource through this attribute.  E.g.:
+
+        <bibl href="http://www.my.com/doc.htm">My Document</bibl>
+        -->
+<!ENTITY % bibl.attlist "INCLUDE">
+<![%bibl.attlist;[
+<!ATTLIST bibl
+        %common.att;
+        %simple-xlink.att;
+        %href.att;
+        %user-replace.att;
+        %key.att;>
+]]>
+
+<!--    orglist: Organization member list. -->
+<!ENTITY % orglist.element "INCLUDE">
+<![%orglist.element;[
+<!ELEMENT orglist (member+)>
+]]>
+<!ENTITY % orglist.attlist "INCLUDE">
+<![%orglist.attlist;[
+<!ATTLIST orglist %common.att;>
+]]>
+
+<!--
+#1997-09-30: maler: Added optional affiliation.
+-->
+
+<!ENTITY % member.element "INCLUDE">
+<![%member.element;[
+<!ELEMENT member (name, affiliation?, role?)>
+]]>
+<!ENTITY % member.attlist "INCLUDE">
+<![%member.attlist;[
+<!ATTLIST member %common.att;>
+]]>
+
+<!--      name (defined in "Specification header" above) -->
+<!--      affiliation (defined in "Specification header" above) -->
+
+<!ENTITY % role.element "INCLUDE">
+<![%role.element;[
+<!ELEMENT role (#PCDATA|phrase)*>
+]]>
+<!ENTITY % role.attlist "INCLUDE">
+<![%role.attlist;[
+<!ATTLIST role %common.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- Notes ......................................................... -->
+<!-- ............................................................... -->
+
+<!ENTITY % note.element "INCLUDE">
+<![%note.element;[
+<!ELEMENT note (%obj.mix;)+>
+]]>
+<!ENTITY % note.attlist "INCLUDE">
+<![%note.attlist;[
+<!ATTLIST note %common.att;>
+]]>
+
+<!--
+#1998-05-14: maler: Declared issue element.
+#2000-03-07: maler: Added head, source, resolution, and status.
+-->
+
+<!ENTITY % issue.element "INCLUDE">
+<![%issue.element;[
+<!ELEMENT issue (head?, source*, (%obj.mix;)+, resolution?)>
+]]>
+<!--    status attribute:
+        Indicates whether the issue is open or closed.  Note that
+        the lack of a resolution element does not necessarily mean
+        that the issue is still open. -->
+<!ENTITY % issue.attlist "INCLUDE">
+<![%issue.attlist;[
+<!ATTLIST issue
+        id              ID              #REQUIRED
+        %role.att;
+        %diff.att;
+        status          (open
+                        |closed)        "open"
+>
+]]>
+
+<!ENTITY % source.element "INCLUDE">
+<![%source.element;[
+<!ELEMENT source (%p.pcd.mix;)*>
+]]>
+<!ENTITY % source.attlist "INCLUDE">
+<![%source.attlist;[
+<!ATTLIST source
+        %common.att;>
+]]>
+
+<!ENTITY % resolution.element "INCLUDE">
+<![%resolution.element;[
+<!ELEMENT resolution (%obj.mix;)+>
+]]>
+<!ENTITY % resolution.attlist "INCLUDE">
+<![%resolution.attlist;[
+<!ATTLIST resolution %common.att;>
+]]>
+
+<!--    wfcnote: Well-formedness constraint note. -->
+<!ENTITY % wfcnote.element "INCLUDE">
+<![%wfcnote.element;[
+<!ELEMENT wfcnote (head, (%obj.mix;)+)>
+]]>
+<!--    ID attribute:
+        wfcnote must have an ID so that it can be pointed to
+        from a wfc element in a production. -->
+<!ENTITY % wfcnote.attlist "INCLUDE">
+<![%wfcnote.attlist;[
+<!ATTLIST wfcnote
+        %common-idreq.att;>
+]]>
+
+<!--    vcnote: Validity constraint note. -->
+<!ENTITY % vcnote.element "INCLUDE">
+<![%vcnote.element;[
+<!ELEMENT vcnote (head, (%obj.mix;)+)>
+]]>
+<!--    ID attribute:
+        vcnote must have an ID so that it can be pointed to
+        from a vc element in a production. -->
+<!ENTITY % vcnote.attlist "INCLUDE">
+<![%vcnote.attlist;[
+<!ATTLIST vcnote
+        %common-idreq.att;>
+]]>
+
+<!--
+#1998-05-21: maler: Declared generic constraintnote element.
+-->
+
+<!--    constraintnote: Generic constraint note. -->
+<!ENTITY % constraintnote.element "INCLUDE">
+<![%constraintnote.element;[
+<!ELEMENT constraintnote (head, (%obj.mix;)+)>
+]]>
+<!--    ID attribute:
+        constraintnote must have an ID so that it can be
+        pointed to from a constraint element in a production. -->
+<!--    type attribute:
+        constraintnote must have a type value keyword so that
+        it can be correctly characterized in the specification. -->
+<!ENTITY % constraintnote.attlist "INCLUDE">
+<![%constraintnote.attlist;[
+<!ATTLIST constraintnote
+        %common-idreq.att;
+        type            NMTOKEN         #REQUIRED>
+]]>
+
+<!-- ............................................................... -->
+<!-- Basic display elements ........................................ -->
+<!-- ............................................................... -->
+
+<!--
+#1998-03-23: maler: Added xml:space attribute.
+-->
+
+<!--    eg: Example element, with whitespace respected. -->
+<!ENTITY % eg.element "INCLUDE">
+<![%eg.element;[
+<!ELEMENT eg (%eg.pcd.mix;)*>
+]]>
+<!ENTITY % eg.attlist "INCLUDE">
+<![%eg.attlist;[
+<!ATTLIST eg
+        %common.att;
+        %xmlspace.att;>
+]]>
+
+<!--
+#2000-03-07: maler: Removed the xml:attributes attribute.
+#                   Added %local.graphic.att;.
+-->
+
+<!--    graphic: Displayed graphic.  Graphic data should be
+        displayed at the point where it is referenced.  Not
+        actually conforming to XLink right now. -->
+<!ENTITY % graphic.element "INCLUDE">
+<![%graphic.element;[
+<!ELEMENT graphic EMPTY>
+]]>
+<!--    source attribute:
+        The graphic data must reside at the location pointed to. -->
+<!ENTITY % local.graphic.att " ">
+<!ENTITY % graphic.attlist "INCLUDE">
+<![%graphic.attlist;[
+<!ATTLIST graphic
+        %common.att;
+        %simple-xlink.att;
+        source                  CDATA           #REQUIRED
+        %auto-embed.att;
+        alt                     CDATA           #IMPLIED
+        %local.graphic.att;>
+]]>
+
+<!--
+#2000-03-07: maler: Added proto element structure.
+-->
+
+<!--    proto: Function prototype, in the XPath/XPointer style. -->
+<!ENTITY % proto.element "INCLUDE">
+<![%proto.element;[
+<!ELEMENT proto (arg*)>
+]]>
+
+<!ENTITY % local.proto.att " ">
+<!ENTITY % proto.attlist "INCLUDE">
+<![%proto.attlist;[
+<!ATTLIST proto
+        %common.att;
+	%local.proto.att;
+        name            NMTOKEN         #REQUIRED
+        return-type     %argtypes;      #REQUIRED
+>
+]]>
+
+<!ENTITY % local.arg.att " ">
+<!ENTITY % arg.element "INCLUDE">
+<![%arg.element;[
+<!ELEMENT arg EMPTY>
+]]>
+<!ENTITY % arg.attlist "INCLUDE">
+<![%arg.attlist;[
+<!ATTLIST arg
+        %common.att;
+	%local.arg.att;
+        type            %argtypes;      #REQUIRED
+        occur           (opt|req)       #IMPLIED
+>
+]]>
+
+<!--
+#2000-03-07: maler: Added example element.
+-->
+
+<!ENTITY % example.element "INCLUDE">
+<![%example.element;[
+<!ELEMENT example (head?, (%obj.mix;)+)>
+]]>
+<!ENTITY % example.attlist "INCLUDE">
+<![%example.attlist;[
+<!ATTLIST example %common.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- EBNF .......................................................... -->
+<!-- ............................................................... -->
+
+<!--
+#1997-11-28: maler: Added prodgroup to scrap and defined it.
+#1998-05-21: maler: Added constraint to prod.
+#1999-07-02: maler: Added prodrecap to scrap; broadened scrap model.
+#                   Added headstyle attribute to scrap.
+-->
+
+<!--    scrap: Collection of EBNF language productions. -->
+<!ENTITY % scrap.element "INCLUDE">
+<![%scrap.element;[
+<!ELEMENT scrap (head, (prodgroup | prod | bnf | prodrecap)+)>
+]]>
+<!--    lang attribute:
+        The scrap can link to a description of the language used,
+        found in a language element in the header.
+        headstyle attribute:
+        Allows a scrap title to be suppressed from output.  To be
+        used only when a scrap title directly next to a section
+        title is distracting or repetetive. -->
+<!ENTITY % scrap.attlist "INCLUDE">
+<![%scrap.attlist;[
+<!ATTLIST scrap
+        %common.att;
+        lang            IDREF           #IMPLIED
+        headstyle       (show|suppress) "show"
+>
+]]>
+
+<!--    prodgroup: Sub-collection of productions, needed for
+        formatting reasons. -->
+<!ENTITY % prodgroup.element "INCLUDE">
+<![%prodgroup.element;[
+<!ELEMENT prodgroup (prod+)>
+]]>
+<!--    pcw<n> attributes:
+        Presentational attributes to control the width
+        of the "pseudo-table" columns used to output
+        groups of productions. -->
+<!ENTITY % prodgroup.attlist "INCLUDE">
+<![%prodgroup.attlist;[
+<!ATTLIST prodgroup
+        %common.att;
+        pcw1            CDATA           #IMPLIED
+        pcw2            CDATA           #IMPLIED
+        pcw3            CDATA           #IMPLIED
+        pcw4            CDATA           #IMPLIED
+        pcw5            CDATA           #IMPLIED
+>
+]]>
+
+<!--    prod: EBNF language production. -->
+<!ENTITY % prod.element "INCLUDE">
+<![%prod.element;[
+<!ELEMENT prod (lhs, (rhs, (com|wfc|vc|constraint)*)+)>
+]]>
+<!--    ID attribute:
+        The production must have an ID so that cross-references
+        (specref) and mentions of nonterminals (nt) can link to
+        it. -->
+<!ENTITY % prod.attlist "INCLUDE">
+<![%prod.attlist;[
+<!ATTLIST prod
+        %common-idreq.att;
+	num	CDATA	#IMPLIED>
+]]>
+
+<!--    lhs: Left-hand side of production. -->
+<!ENTITY % lhs.element "INCLUDE">
+<![%lhs.element;[
+<!ELEMENT lhs (#PCDATA|phrase)*>
+]]>
+<!ENTITY % lhs.attlist "INCLUDE">
+<![%lhs.attlist;[
+<!ATTLIST lhs %common.att;>
+]]>
+
+<!--    rhs: Right-hand side of production; may have many
+        "right-hand sides," one to a line. -->
+<!ENTITY % rhs.element "INCLUDE">
+<![%rhs.element;[
+<!ELEMENT rhs (#PCDATA|phrase|nt|xnt|com)*>
+]]>
+<!ENTITY % rhs.attlist "INCLUDE">
+<![%rhs.attlist;[
+<!ATTLIST rhs %common.att;>
+]]>
+
+<!--      nt and xnt (defined in "Phrase-level elements" below) -->
+
+<!--
+#1997-11-28: maler: Added loc and bibref to com content.
+-->
+
+<!--    com: Production comment. -->
+<!ENTITY % com.element "INCLUDE">
+<![%com.element;[
+<!ELEMENT com (#PCDATA|phrase|loc|bibref)*>
+]]>
+<!ENTITY % com.attlist "INCLUDE">
+<![%com.attlist;[
+<!ATTLIST com %common.att;>
+]]>
+
+<!--    wfc: Reference to a well-formedness constraint; should
+        generate the head of the wfcnote pointed to. -->
+<!ENTITY % wfc.element "INCLUDE">
+<![%wfc.element;[
+<!ELEMENT wfc EMPTY>
+]]>
+<!--    def attribute:
+        Each well formedness tagline in a production must link to the
+        wfcnote that defines it. -->
+<!ENTITY % wfc.attlist "INCLUDE">
+<![%wfc.attlist;[
+<!ATTLIST wfc
+        %def-req.att;
+        %common.att;>
+]]>
+
+<!--    vc: Reference to a validity constraint; should generate
+        the head of the vcnote pointed to. -->
+<!ENTITY % vc.element "INCLUDE">
+<![%vc.element;[
+<!ELEMENT vc EMPTY>
+]]>
+<!--    def attribute:
+        Each validity tagline in a production must link to the vcnote
+        that defines it. -->
+<!ENTITY % vc.attlist "INCLUDE">
+<![%vc.attlist;[
+<!ATTLIST vc
+        %def-req.att;
+        %common.att;>
+]]>
+
+<!--
+#1998-05-21: maler: Declared generic constraint element.
+-->
+
+<!--    constraint: Reference to a generic constraint; should
+        generate the head of the constraintnote pointed to. -->
+<!ENTITY % constraint.element "INCLUDE">
+<![%constraint.element;[
+<!ELEMENT constraint EMPTY>
+]]>
+<!--    def attribute:
+        Each constraint tagline in a production must link to the
+        constraint note that defines it. -->
+<!ENTITY % constraint.attlist "INCLUDE">
+<![%constraint.attlist;[
+<!ATTLIST constraint
+        %def-req.att;
+        %common.att;>
+]]>
+
+<!--
+#1998-03-23: maler: Added xml:space attribute.
+-->
+
+<!--    bnf: Un-marked-up EBNF production, with whitespace
+        respected. -->
+<!ENTITY % bnf.element "INCLUDE">
+<![%bnf.element;[
+<!ELEMENT bnf (%eg.pcd.mix;)*>
+]]>
+<!ENTITY % bnf.attlist "INCLUDE">
+<![%bnf.attlist;[
+<!ATTLIST bnf
+        %common.att;
+        %xmlspace.att;>
+]]>
+
+<!--
+#1999-07-02: maler: Declared prodrecap.
+-->
+
+<!--    prodrecap: Reference to production or bnf that appears
+        in its "normative" form elsewhere in the spec; should
+        generate a copy of the original production, without
+        a production number next to it. -->
+<!ENTITY % prodrecap.element "INCLUDE">
+<![%prodrecap.element;[
+<!ELEMENT prodrecap EMPTY>
+]]>
+<!ENTITY % prodrecap.attlist "INCLUDE">
+<![%prodrecap.attlist;[
+<!ATTLIST prodrecap
+        %common.att;
+        %ref-req.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- Table ......................................................... -->
+<!-- ............................................................... -->
+
+<!--
+#1997-10-16: maler: Added table mechanism.
+#1997-11-28: maler: Added non-null system ID to entity declaration.
+#                   Added HTML table module.
+#1997-12-29: maler: IGNOREd SGML Open table model.
+#1998-03-10: maler: Removed SGML Open table model.
+#                   Merged html-tbl.mod file into main file.
+#                   Added %common.att; to all HTML table elements.
+#1998-05-14: maler: Replaced table model with full HTML 4.0 model.
+#                   Removed htable in favor of table.
+#                   Removed htbody in favor of tbody.
+-->
+
+<!ENTITY % cellhalign.att
+        'align          (left|center
+                        |right|justify
+                        |char)          #IMPLIED
+        char            CDATA           #IMPLIED
+        charoff         CDATA           #IMPLIED'>
+
+<!ENTITY % cellvalign.att
+        'valign         (top|middle
+                        |bottom
+                        |baseline)      #IMPLIED'>
+
+<!ENTITY % thtd.att
+        'abbr           CDATA           #IMPLIED
+        axis            CDATA           #IMPLIED
+        headers         IDREFS          #IMPLIED
+        scope           (row
+                        |col
+                        |rowgroup
+                        |colgroup)      #IMPLIED
+        rowspan         NMTOKEN         "1"
+        colspan         NMTOKEN         "1"'>
+
+<!ENTITY % width.att
+        'width          CDATA           #IMPLIED'>
+
+<!ENTITY % span.att
+        'span           NMTOKEN         "1"'>
+
+<!--    table: HTML-based geometric table model. -->
+<!ENTITY % table.element "INCLUDE">
+<![%table.element;[
+<!ELEMENT table
+        (caption?, (col*|colgroup*), thead?, tfoot?, tbody+)>
+]]>
+<!ENTITY % table.attlist "INCLUDE">
+<![%table.attlist;[
+<!ATTLIST table
+        %common.att;
+        %width.att;
+        summary         CDATA           #IMPLIED
+        border          CDATA           #IMPLIED
+        frame           (void|above
+                        |below|hsides
+                        |lhs|rhs
+                        |vsides|box
+                        |border)        #IMPLIED
+        rules           (none|groups
+                        |rows|cols
+                        |all)           #IMPLIED
+        cellspacing     CDATA           #IMPLIED
+        cellpadding     CDATA           #IMPLIED>
+]]>
+
+<!ENTITY % caption.element "INCLUDE">
+<![%caption.element;[
+<!ELEMENT caption (%p.pcd.mix;)*>
+]]>
+<!ENTITY % caption.attlist "INCLUDE">
+<![%caption.attlist;[
+<!ATTLIST caption %common.att;>
+]]>
+
+<!ENTITY % col.element "INCLUDE">
+<![%col.element;[
+<!ELEMENT col EMPTY>
+]]>
+<!ENTITY % col.attlist "INCLUDE">
+<![%col.attlist;[
+<!ATTLIST col
+        %common.att;
+        %span.att;
+        %width.att;
+        %cellhalign.att;
+        %cellvalign.att;>
+]]>
+
+<!ENTITY % colgroup.element "INCLUDE">
+<![%colgroup.element;[
+<!ELEMENT colgroup (col)*>
+]]>
+<!ENTITY % colgroup.attlist "INCLUDE">
+<![%colgroup.attlist;[
+<!ATTLIST colgroup
+        %common.att;
+        %span.att;
+        %width.att;
+        %cellhalign.att;
+        %cellvalign.att;>
+]]>
+
+<!ENTITY % thead.element "INCLUDE">
+<![%thead.element;[
+<!ELEMENT thead (tr)+>
+]]>
+<!ENTITY % thead.attlist "INCLUDE">
+<![%thead.attlist;[
+<!ATTLIST thead
+        %common.att;
+        %cellhalign.att;
+        %cellvalign.att;>
+]]>
+
+<!ENTITY % tfoot.element "INCLUDE">
+<![%tfoot.element;[
+<!ELEMENT tfoot (tr)+>
+]]>
+<!ENTITY % tfoot.attlist "INCLUDE">
+<![%tfoot.attlist;[
+<!ATTLIST tfoot
+        %common.att;
+        %cellhalign.att;
+        %cellvalign.att;>
+]]>
+
+<!ENTITY % tbody.element "INCLUDE">
+<![%tbody.element;[
+<!ELEMENT tbody (tr)+>
+]]>
+<!ENTITY % tbody.attlist "INCLUDE">
+<![%tbody.attlist;[
+<!ATTLIST tbody
+        %common.att;
+        %cellhalign.att;
+        %cellvalign.att;>
+]]>
+
+<!ENTITY % tr.element "INCLUDE">
+<![%tr.element;[
+<!ELEMENT tr (th|td)+>
+]]>
+<!ENTITY % tr.attlist "INCLUDE">
+<![%tr.attlist;[
+<!ATTLIST tr
+        %common.att;
+        %cellhalign.att;
+        %cellvalign.att;>
+]]>
+
+<!ENTITY % th.element "INCLUDE">
+<![%th.element;[
+<!ELEMENT th (%p.pcd.mix;|%p.mix;)*>
+]]>
+<!ENTITY % th.attlist "INCLUDE">
+<![%th.attlist;[
+<!ATTLIST th
+        %common.att;
+        %thtd.att;
+        %cellhalign.att;
+        %cellvalign.att;>
+]]>
+
+<!ENTITY % td.element "INCLUDE">
+<![%td.element;[
+<!ELEMENT td (%p.pcd.mix;|%p.mix;)*>
+]]>
+<!ENTITY % td.attlist "INCLUDE">
+<![%td.attlist;[
+<!ATTLIST td
+        %common.att;
+        %thtd.att;
+        %cellhalign.att;
+        %cellvalign.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- IDL structures for DOM specifications ......................... -->
+<!-- ............................................................... -->
+
+<!-- ............................................................... -->
+<!-- Specialized entities for classes .............................. -->
+
+<!ENTITY % idl-desc.class
+        "p|note">
+
+<!ENTITY % idl-tdef.class
+        "typedef|constant|exception|reference|group">
+
+<!ENTITY % idl-mod.class
+        "module|interface">
+
+<!ENTITY % idl-struct.class
+        "struct|enum|sequence|union|typename">
+
+<!ENTITY % idl-meth.class
+        "method|attribute">
+
+<!-- ............................................................... -->
+<!-- Specialized entities for mixtures ............................. -->
+
+<!--    Quick reference to content model mixtures:
+
+                        desc tdef mod struct meth
+group                     x    x   x    x      x
+definitions, module       x    x   x
+interface                 x    x               x
+typedef, case, component                x
+-->
+
+<!ENTITY % idl-grp.mix
+        "%idl-desc.class;|%idl-tdef.class;|%idl-mod.class;
+        |%idl-struct.class;|%idl-meth.class;">
+
+<!ENTITY % idl-defn.mix
+        "%idl-desc.class;|%idl-tdef.class;|%idl-mod.class;">
+
+<!ENTITY % idl-intfc.mix
+        "%idl-desc.class;|%idl-tdef.class;|%idl-meth.class;">
+
+<!ENTITY % idl-type.mix
+        "%idl-struct.class;">
+
+<!-- ............................................................... -->
+<!-- Specialized entities for common attributes .................... -->
+
+<!--    name attribute:
+        Provides a name.  Required. -->
+<!ENTITY % idl-name.att
+        'name                   CDATA           #REQUIRED'>
+
+<!--    type attribute:
+        Provides a type.  Required. -->
+<!ENTITY % idl-type.att
+        'type                   CDATA           #REQUIRED'>
+
+<!-- ............................................................... -->
+<!-- Common IDL element ............................................ -->
+
+<!ENTITY % descr.element "INCLUDE">
+<![%descr.element;[
+<!ELEMENT descr ((%obj.mix;)*)>
+]]>
+<!ENTITY % descr.attlist "INCLUDE">
+<![%descr.attlist;[
+<!ATTLIST descr %common.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- IDL definition elements ....................................... -->
+
+<!--    definitions: Top-level element for definitions. -->
+<!ENTITY % definitions.element "INCLUDE">
+<![%definitions.element;[
+<!ELEMENT definitions (%idl-defn.mix;)+>
+]]>
+<!ENTITY % definitions.attlist "INCLUDE">
+<![%definitions.attlist;[
+<!ATTLIST definitions %common.att;>
+]]>
+
+<!--    group: Element used to group a set of definitions. -->
+
+<!ENTITY % group.element "INCLUDE">
+<![%group.element;[
+<!ELEMENT group (descr, (%idl-grp.mix;)*)>
+]]>
+<!ENTITY % group.attlist "INCLUDE">
+<![%group.attlist;[
+<!ATTLIST group
+        %common.att;
+        %idl-name.att;>
+]]>
+
+<!--    interface: Definition of an interface. -->
+<!ENTITY % interface.element "INCLUDE">
+<![%interface.element;[
+<!ELEMENT interface (descr, (%idl-intfc.mix;)*)>
+]]>
+<!ENTITY % interface.attlist "INCLUDE">
+<![%interface.attlist;[
+<!ATTLIST interface
+        %common.att;
+        %idl-name.att;
+        inherits        CDATA           #IMPLIED>
+]]>
+
+<!--    module: Definition of a module. -->
+<!ENTITY % module.element "INCLUDE">
+<![%module.element;[
+<!ELEMENT module (descr, (%idl-defn.mix;)*)>
+]]>
+<!ENTITY % module.attlist "INCLUDE">
+<![%module.attlist;[
+<!ATTLIST module
+        %common.att;
+        %idl-name.att;>
+]]>
+
+<!--    reference: Reference to some other declaration. -->
+<!ENTITY % reference.element "INCLUDE">
+<![%reference.element;[
+<!ELEMENT reference EMPTY>
+]]>
+<!ENTITY % reference.attlist "INCLUDE">
+<![%reference.attlist;[
+<!ATTLIST reference
+        %common.att;
+        declaration     IDREF           #REQUIRED>
+]]>
+
+<!--    typedef: Definition of a named type. -->
+<!ENTITY % typedef.element "INCLUDE">
+<![%typedef.element;[
+<!ELEMENT typedef (descr, (%idl-type.mix;))>
+]]>
+<!ENTITY % typedef.attlist "INCLUDE">
+<![%typedef.attlist;[
+<!ATTLIST typedef
+        %common.att;
+        %idl-name.att;
+        array.size      NMTOKEN         #IMPLIED>
+]]>
+
+<!--    struct: Declaration of a struct type. -->
+<!ENTITY % struct.element "INCLUDE">
+<![%struct.element;[
+<!ELEMENT struct (descr, component+)>
+]]>
+<!ENTITY % struct.attlist "INCLUDE">
+<![%struct.attlist;[
+<!ATTLIST struct
+        %common.att;
+        %idl-name.att;>
+]]>
+
+<!--    component: Declaration of a structural member. -->
+<!ENTITY % component.element "INCLUDE">
+<![%component.element;[
+<!ELEMENT component (%idl-type.mix;)>
+]]>
+<!ENTITY % component.attlist "INCLUDE">
+<![%component.attlist;[
+<!ATTLIST component
+        %common.att;
+        %idl-name.att;>
+]]>
+
+<!--    union: Declaration of a union type. -->
+<!ENTITY % union.element "INCLUDE">
+<![%union.element;[
+<!ELEMENT union (descr, case+)>
+]]>
+<!ENTITY % union.attlist "INCLUDE">
+<![%union.attlist;[
+<!ATTLIST union
+        %common.att;
+        %idl-name.att;
+        switch.type     CDATA           #REQUIRED>
+]]>
+
+<!ENTITY % case.element "INCLUDE">
+<![%case.element;[
+<!ELEMENT case (descr, (%idl-type.mix;))>
+]]>
+<!ENTITY % case.attlist "INCLUDE">
+<![%case.attlist;[
+<!ATTLIST case
+        %common.att;
+        labels          CDATA           #REQUIRED>
+]]>
+
+<!--    enum: Declaration of an enum type. -->
+<!ENTITY % enum.element "INCLUDE">
+<![%enum.element;[
+<!ELEMENT enum (descr, enumerator+)>
+]]>
+<!ENTITY % enum.attlist "INCLUDE">
+<![%enum.attlist;[
+<!ATTLIST enum
+        %common.att;
+        %idl-name.att;>
+]]>
+
+<!ENTITY % enumerator.element "INCLUDE">
+<![%enumerator.element;[
+<!ELEMENT enumerator (descr)>
+]]>
+<!ENTITY % enumerator.attlist "INCLUDE">
+<![%enumerator.attlist;[
+<!ATTLIST enumerator
+        %common.att;
+        %idl-name.att;>
+]]>
+
+<!--    sequence: Declaration of a sequence type (not named). -->
+<!ENTITY % sequence.element "INCLUDE">
+<![%sequence.element;[
+<!ELEMENT sequence (sequence*)>
+]]>
+<!ENTITY % sequence.attlist "INCLUDE">
+<![%sequence.attlist;[
+<!ATTLIST sequence
+        %common.att;
+        %idl-type.att;
+        size            NMTOKEN         #IMPLIED>
+]]>
+
+<!--    constant: Declaration of a named constant. -->
+<!ENTITY % constant.element "INCLUDE">
+<![%constant.element;[
+<!ELEMENT constant (descr)>
+]]>
+<!ENTITY % constant.attlist "INCLUDE">
+<![%constant.attlist;[
+<!ATTLIST constant
+        %common.att;
+        %idl-name.att;
+        %idl-type.att;
+        value           CDATA           #REQUIRED>
+]]>
+
+<!--    exception: Declaration of an exception. -->
+<!ENTITY % exception.element "INCLUDE">
+<![%exception.element;[
+<!ELEMENT exception (descr, component*)>
+]]>
+<!ENTITY % exception.attlist "INCLUDE">
+<![%exception.attlist;[
+<!ATTLIST exception
+        %common.att;
+        %idl-name.att;>
+]]>
+<!-- component (defined under struct, above)-->
+
+<!--    attribute: Declaration of an attribute (data member). -->
+<!ENTITY % attribute.element "INCLUDE">
+<![%attribute.element;[
+<!ELEMENT attribute (descr)>
+]]>
+<!ENTITY % attribute.attlist "INCLUDE">
+<![%attribute.attlist;[
+<!ATTLIST attribute
+        %common.att;
+        %idl-name.att;
+        %idl-type.att;
+        readonly        (yes
+                        |no)            "no">
+]]>
+
+<!--    method: Declaration of a method. -->
+<!ENTITY % method.element "INCLUDE">
+<![%method.element;[
+<!ELEMENT method (descr, parameters, returns, raises)>
+]]>
+<!ENTITY % method.attlist "INCLUDE">
+<![%method.attlist;[
+<!ATTLIST method
+        %common.att;
+        %idl-name.att;>
+]]>
+
+<!ENTITY % parameters.element "INCLUDE">
+<![%parameters.element;[
+<!ELEMENT parameters (param*)>
+]]>
+<!ENTITY % parameters.attlist "INCLUDE">
+<![%parameters.attlist;[
+<!ATTLIST parameters %common.att;>
+]]>
+
+<!ENTITY % param.element "INCLUDE">
+<![%param.element;[
+<!ELEMENT param (descr)>
+]]>
+<!ENTITY % param.attlist "INCLUDE">
+<![%param.attlist;[
+<!ATTLIST param
+        %common.att;
+        %idl-name.att;
+        %idl-type.att;
+        attr            (in
+                        |out
+                        |inout)         "inout">
+]]>
+
+<!ENTITY % returns.element "INCLUDE">
+<![%returns.element;[
+<!ELEMENT returns (descr)>
+]]>
+<!ENTITY % returns.attlist "INCLUDE">
+<![%returns.attlist;[
+<!ATTLIST returns
+        %common.att;
+        %idl-type.att;>
+]]>
+
+<!ENTITY % raises.element "INCLUDE">
+<![%raises.element;[
+<!ELEMENT raises (exception*)>
+]]>
+<!-- exception (defined under constant, above)-->
+
+<!ENTITY % typename.element "INCLUDE">
+<![%typename.element;[
+<!ELEMENT typename (#PCDATA|phrase)*>
+]]>
+<!ENTITY % typename.attlist "INCLUDE">
+<![%typename.attlist;[
+<!ATTLIST typename %common.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- Phrase-level elements ......................................... -->
+<!-- ............................................................... -->
+
+<!--
+#2000-03-07: maler: Added att and attval elements.
+-->
+
+<!--    att: Attribute name. -->
+<!ENTITY % att.element "INCLUDE">
+<![%att.element;[
+<!ELEMENT att (%tech.pcd.mix;)*>
+]]>
+<!ENTITY % att.attlist "INCLUDE">
+<![%att.attlist;[
+<!ATTLIST att %common.att;>
+]]>
+
+<!--    attval: Attribute value. -->
+<!ENTITY % attval.element "INCLUDE">
+<![%attval.element;[
+<!ELEMENT attval (%tech.pcd.mix;)*>
+]]>
+<!ENTITY % attval.attlist "INCLUDE">
+<![%attval.attlist;[
+<!ATTLIST attval %common.att;>
+]]>
+
+<!--    bibref: Reference to a bibliography list entry; should
+        generate, in square brackets, "key" on bibl. -->
+<!ENTITY % bibref.element "INCLUDE">
+<![%bibref.element;[
+<!ELEMENT bibref EMPTY>
+]]>
+<!--    ref attribute:
+        A bibliography reference must link to the bibl element that
+        describes the resource. -->
+<!ENTITY % bibref.attlist "INCLUDE">
+<![%bibref.attlist;[
+<!ATTLIST bibref
+        %common.att;
+        %ref-req.att;>
+]]>
+
+<!ENTITY % code.element "INCLUDE">
+<![%code.element;[
+<!ELEMENT code (%tech.pcd.mix;)*>
+]]>
+<!ENTITY % code.attlist "INCLUDE">
+<![%code.attlist;[
+<!ATTLIST code %common.att;>
+]]>
+
+<!--
+#1998-03-10: maler: Declared ednote and related elements.
+#1999-07-02: maler: Changed edtext content from #PCDATA to %p.pcd.mix;.
+-->
+
+<!--    ednote: Editorial note for communication among editors. -->
+<!ENTITY % ednote.element "INCLUDE">
+<![%ednote.element;[
+<!ELEMENT ednote (name?, date?, edtext)>
+]]>
+<!ENTITY % ednote.attlist "INCLUDE">
+<![%ednote.attlist;[
+<!ATTLIST ednote %common.att;>
+]]>
+
+<!ENTITY % date.element "INCLUDE">
+<![%date.element;[
+<!ELEMENT date (#PCDATA|phrase)*>
+]]>
+<!ENTITY % date.attlist "INCLUDE">
+<![%date.attlist;[
+<!ATTLIST date %common.att;>
+]]>
+
+<!ENTITY % edtext.element "INCLUDE">
+<![%edtext.element;[
+<!ELEMENT edtext (%p.pcd.mix;)*>
+]]>
+<!ENTITY % edtext.attlist "INCLUDE">
+<![%edtext.attlist;[
+<!ATTLIST edtext %common.att;>
+]]>
+
+<!--
+#2000-03-07: maler: Added el element.
+-->
+
+<!--    el: Element type name (GI). -->
+<!ENTITY % el.element "INCLUDE">
+<![%el.element;[
+<!ELEMENT el (%tech.pcd.mix;)*>
+]]>
+<!ENTITY % el.attlist "INCLUDE">
+<![%el.attlist;[
+<!ATTLIST el %common.att;>
+]]>
+
+<!--
+#2000-03-07: maler: Expanded emph to %p.pcd.mix;.
+-->
+
+<!ENTITY % emph.element "INCLUDE">
+<![%emph.element;[
+<!ELEMENT emph (%p.pcd.mix;)*>
+]]>
+<!ENTITY % emph.attlist "INCLUDE">
+<![%emph.attlist;[
+<!ATTLIST emph %common.att;>
+]]>
+
+<!--    footnote: Both footnote content and call to footnote. -->
+<!ENTITY % footnote.element "INCLUDE">
+<![%footnote.element;[
+<!ELEMENT footnote (%obj.mix;)+>
+]]>
+<!ENTITY % footnote.attlist "INCLUDE">
+<![%footnote.attlist;[
+<!ATTLIST footnote %common.att;>
+]]>
+
+<!--
+#2000-03-07: maler: Added function and gave it content of
+#                   %tech.pcd.mix; instead of XPath's #PCDATA.
+-->
+
+<!ENTITY % function.element "INCLUDE">
+<![%function.element;[
+<!ELEMENT function (%tech.pcd.mix;)*>
+]]>
+<!ENTITY % function.attlist "INCLUDE">
+<![%function.attlist;[
+<!ATTLIST function %common.att;>
+]]>
+
+<!ENTITY % kw.element "INCLUDE">
+<![%kw.element;[
+<!ELEMENT kw (%tech.pcd.mix;)*>
+]]>
+<!ENTITY % kw.attlist "INCLUDE">
+<![%kw.attlist;[
+<!ATTLIST kw %common.att;>
+]]>
+
+<!--
+#1999-07-02: maler: Added show/actuate attributes and default values.
+-->
+
+<!--    loc: Generic link to a Web resource, similar to HTML's A. -->
+<!ENTITY % loc.element "INCLUDE">
+<![%loc.element;[
+<!ELEMENT loc (#PCDATA|phrase)*>
+]]>
+<!--    href attribute:
+        The purpose of a loc element is to function as a A-like
+        hypertext link to a resource.  (Ideally, the content of loc
+        will also mention the URI of the resource, so that readers of
+        the printed version will be able to locate the resource.) E.g.:
+
+<loc href="http://www.my.com/doc.htm">http://www.my.com/doc.htm</loc>
+        -->
+<!ENTITY % loc.attlist "INCLUDE">
+<![%loc.attlist;[
+<!ATTLIST loc
+        %common.att;
+        %simple-xlink.att;
+        %href-req.att;
+        %user-replace.att;>
+]]>
+
+<!--    nt: Mention of a nonterminal in text, along with a link to
+        the production in the current document that defines it. -->
+<!ENTITY % nt.element "INCLUDE">
+<![%nt.element;[
+<!ELEMENT nt (#PCDATA|phrase)*>
+]]>
+<!--    def attribute:
+        The nonterminal must link to the production that defines
+        it. -->
+<!ENTITY % nt.attlist "INCLUDE">
+<![%nt.attlist;[
+<!ATTLIST nt
+        %common.att;
+        %def-req.att;>
+]]>
+
+<!--
+#2000-03-07: maler: Declared phrase.
+-->
+
+<!--    phrase: "Attribute hanger" for small bits of (e.g.) differenced
+        text in a paragraph or similar, when another element isn't handy.
+        Beware that its content model may allow more nested elements than
+        would normally be allowed in some contexts. -->
+<!ENTITY % phrase.element "INCLUDE">
+<![%phrase.element;[
+<!ELEMENT phrase (%p.pcd.mix;)*>
+]]>
+<!ENTITY % phrase.attlist "INCLUDE">
+<![%phrase.attlist;[
+<!ATTLIST phrase %common.att;>
+]]>
+
+<!--
+#2003-06-25: nwalsh: RFC2119 elements
+-->
+
+<!ENTITY % rfc2119.element "INCLUDE">
+<![%rfc2119.element;[
+<!ELEMENT rfc2119 (#PCDATA|phrase)*>
+]]>
+<!ENTITY % rfc2119.attlist "INCLUDE">
+<![%rfc2119.attlist;[
+<!ATTLIST rfc2119 %common.att;>
+]]>
+
+<!--
+#1998-03-10: maler: Declared quote.
+-->
+
+<!--    quote: Scare quotes and other purely presentational quotes. -->
+<!ENTITY % quote.element "INCLUDE">
+<![%quote.element;[
+<!ELEMENT quote (%p.pcd.mix;)*>
+]]>
+<!ENTITY % quote.attlist "INCLUDE">
+<![%quote.attlist;[
+<!ATTLIST quote %common.att;>
+]]>
+
+<!--    specref: Reference to a div, olist item, prod, or issue
+        in the current document; should generate italic "[n.n],
+        Section Title" for div, "n" for numbered item, "[n]" for
+        production, or "Issue id" for issue. -->
+<!ENTITY % specref.element "INCLUDE">
+<![%specref.element;[
+<!ELEMENT specref EMPTY>
+]]>
+<!--    ref attribute:
+        The purpose of a specref element is to link to a div, item
+        in an olist, or production in the current spec. -->
+<!ENTITY % specref.attlist "INCLUDE">
+<![%specref.attlist;[
+<!ATTLIST specref
+        %common.att;
+        %ref-req.att;>
+]]>
+
+<!--
+#2000-03-07: maler: Added sub and sup.
+-->
+
+<!--    sub: Subscript. -->
+<!ENTITY % sub.element "INCLUDE">
+<![%sub.element;[
+<!ELEMENT sub (#PCDATA|phrase)*>
+]]>
+<!ENTITY % sub.attlist "INCLUDE">
+<![%sub.attlist;[
+<!ATTLIST sub %common.att;>
+]]>
+
+<!--    sup: Superscript. -->
+<!ENTITY % sup.element "INCLUDE">
+<![%sup.element;[
+<!ELEMENT sup (#PCDATA|phrase)*>
+]]>
+<!ENTITY % sup.attlist "INCLUDE">
+<![%sup.attlist;[
+<!ATTLIST sup %common.att;>
+]]>
+
+<!--    term: The term in text that is being defined in text. -->
+<!ENTITY % term.element "INCLUDE">
+<![%term.element;[
+<!ELEMENT term (#PCDATA|phrase)*>
+]]>
+<!ENTITY % term.attlist "INCLUDE">
+<![%term.attlist;[
+<!ATTLIST term %common.att;>
+]]>
+
+<!--    termdef: Definition of a term in text. -->
+<!ENTITY % termdef.element "INCLUDE">
+<![%termdef.element;[
+<!ELEMENT termdef (%termdef.pcd.mix;|%termdef.mix;)*>
+]]>
+<!--    ID attribute:
+        A term definition must have an ID so that it can be linked
+        to from termref elements. -->
+<!--    term attribute:
+        The canonical form of the term or phrase being defined must
+        appear in this attribute, even if the term or phrase also
+        appears in the element content in identical form (e.g., in
+        the term element). -->
+<!ENTITY % termdef.attlist "INCLUDE">
+<![%termdef.attlist;[
+<!ATTLIST termdef
+        %common-idreq.att;
+        term            CDATA           #REQUIRED>
+]]>
+
+<!--    termref: Mention of a term, along with a link to the
+        definition in the current document. -->
+<!ENTITY % termref.element "INCLUDE">
+<![%termref.element;[
+<!ELEMENT termref (#PCDATA|phrase)*>
+]]>
+<!--    ref attribute:
+        A term reference must link to the termdef element that
+        defines the term. -->
+<!ENTITY % termref.attlist "INCLUDE">
+<![%termref.attlist;[
+<!ATTLIST termref
+        %common.att;
+        %def-req.att;>
+]]>
+
+<!--
+#1999-07-02: maler: Added show/actuate attributes and default values.
+-->
+
+<!--    titleref: Citation of another document, which can also
+        link to that document if it is a Web resource. -->
+<!ENTITY % titleref.element "INCLUDE">
+<![%titleref.element;[
+<!ELEMENT titleref (#PCDATA|phrase)*>
+]]>
+<!--    href attribute:
+        A title reference can optionally function as a hypertext
+        link to the resource with this title.  E.g.:
+
+<loc href="http://www.my.com/doc.htm">http://www.my.com/doc.htm</loc>
+        -->
+
+<!ENTITY % titleref.attlist "INCLUDE">
+<![%titleref.attlist;[
+<!ATTLIST titleref
+        %common.att;
+        %simple-xlink.att;
+        %href.att;
+        %user-new.att;>
+]]>
+
+<!--
+#2000-03-07: maler: Added var.
+-->
+
+<!--    var: String standing for a variable value that the user
+        or system will supply.  For example: "For each node
+        <var>x</var> in this node-set..." -->
+<!ENTITY % var.element "INCLUDE">
+<![%var.element;[
+<!ELEMENT var (%tech.pcd.mix;)*>
+]]>
+<!ENTITY % var.attlist "INCLUDE">
+<![%var.attlist;[
+<!ATTLIST var %common.att;>
+]]>
+
+<!--
+#1999-07-02: maler: Added show/actuate attributes and default values.
+-->
+
+<!--    xnt: Mention of a nonterminal in text, along with a link to
+        the production in another document that defines it. -->
+<!ENTITY % xnt.element "INCLUDE">
+<![%xnt.element;[
+<!ELEMENT xnt (#PCDATA|phrase)*>
+]]>
+<!--    href attribute:
+        The nonterminal must hyperlink to a resource that serves
+        to define it (e.g., a production in a related XML
+        specification).  E.g.:
+
+<xnt href="http://www.w3.org/TR/spec.htm#prod3">Name</xnt>
+        -->
+
+<!ENTITY % xnt.attlist "INCLUDE">
+<![%xnt.attlist;[
+<!ATTLIST xnt
+        %common.att;
+        %simple-xlink.att;
+        %href-req.att;
+        %user-new.att;>
+]]>
+
+<!--
+#1997-12-29: maler: Declared xspecref.
+#1999-07-02: maler: Added show/actuate attributes and default values.
+-->
+
+<!--    xspecref: Reference to a div, olist item, prod, or issue
+        in a related specification document; should generate
+        no special text. -->
+<!ENTITY % xspecref.element "INCLUDE">
+<![%xspecref.element;[
+<!ELEMENT xspecref (#PCDATA|phrase)*>
+]]>
+<!--    href attribute:
+        The spec reference must hyperlink to the resource to
+        cross-refer to (e.g., a section in a related XML
+        specification).  E.g.:
+
+<xspecref href="http://www.w3.org/TR/spec.htm#sec2">
+the section on constraints</xspecref>
+        -->
+
+<!ENTITY % xspecref.attlist "INCLUDE">
+<![%xspecref.attlist;[
+<!ATTLIST xspecref
+        %common.att;
+        %simple-xlink.att;
+        %href-req.att;
+        %user-new.att;>
+]]>
+
+<!--
+#1999-07-02: maler: Added show/actuate attributes and default values.
+-->
+
+<!--    termref: Mention of a term, along with a link to the
+        definition in a related document. -->
+<!ENTITY % xtermref.element "INCLUDE">
+<![%xtermref.element;[
+<!ELEMENT xtermref (#PCDATA|phrase)*>
+]]>
+<!--    href attribute:
+        The term reference must hyperlink to the resource that
+        serves to define the term (e.g., a term definition in
+        a related XML specification).  E.g.:
+
+<xtermref href="http://www.w3.org/TR/spec.htm#term5">
+entity
+</xtermref>
+        -->
+
+<!ENTITY % xtermref.attlist "INCLUDE">
+<![%xtermref.attlist;[
+<!ATTLIST xtermref
+        %common.att;
+        %simple-xlink.att;
+        %href-req.att;
+        %user-new.att;>
+]]>
+
+<!-- ............................................................... -->
+<!-- Unused elements for ADEPT ..................................... -->
+<!-- ............................................................... -->
+
+<!--
+#1997-09-30: maler: Added unusued elements.
+#1997-10-14: maler: Fixed div to move nested div to the mixture.
+#1998-05-14: maler: Added key-term, htable, and htbody.
+#1998-11-30: maler: Added para, listitem, itemizedlist, and orderedlist.
+-->
+
+<!--    The following elements are purposely declared but never
+        referenced.  Declaring them allows them to be pasted from
+        an HTML document, an earlier version of an XMLspec document,
+        or a DocBook document into a document using this DTD in ADEPT.
+        The ATD Context Transformation mechanism will try to convert
+        them to the appropriate element for this DTD.  While this
+        conversion will not work for all fragments, it does allow many
+        cases to work reasonably well. -->
+
+<!ENTITY % div.element "INCLUDE">
+<![%div.element;[
+<!ELEMENT div
+        (head?, (%div.mix;|ul|ol|h1|h2|h3|h4|h5|h6|div)*)>
+]]>
+<!ENTITY % h1.element "INCLUDE">
+<![%h1.element;[
+<!ELEMENT h1 (%head.pcd.mix;|em|a)*>
+]]>
+<!ENTITY % h2.element "INCLUDE">
+<![%h2.element;[
+<!ELEMENT h2 (%head.pcd.mix;|em|a)*>
+]]>
+<!ENTITY % h3.element "INCLUDE">
+<![%h3.element;[
+<!ELEMENT h3 (%head.pcd.mix;|em|a)*>
+]]>
+<!ENTITY % h4.element "INCLUDE">
+<![%h4.element;[
+<!ELEMENT h4 (%head.pcd.mix;|em|a)*>
+]]>
+<!ENTITY % h5.element "INCLUDE">
+<![%h5.element;[
+<!ELEMENT h5 (%head.pcd.mix;|em|a)*>
+]]>
+<!ENTITY % h6.element "INCLUDE">
+<![%h6.element;[
+<!ELEMENT h6 (%head.pcd.mix;|em|a)*>
+]]>
+<!ENTITY % pre.element "INCLUDE">
+<![%pre.element;[
+<!ELEMENT pre (%eg.pcd.mix;|em)*>
+]]>
+<!ENTITY % ul.element "INCLUDE">
+<![%ul.element;[
+<!ELEMENT ul (item|li)*>
+]]>
+<!ENTITY % ol.element "INCLUDE">
+<![%ol.element;[
+<!ELEMENT ol (item|li)*>
+]]>
+<!ENTITY % li.element "INCLUDE">
+<![%li.element;[
+<!ELEMENT li (#PCDATA|%obj.mix;)*>
+]]>
+<!ENTITY % em.element "INCLUDE">
+<![%em.element;[
+<!ELEMENT em (#PCDATA)*>
+]]>
+<!ENTITY % a.element "INCLUDE">
+<![%a.element;[
+<!ELEMENT a (#PCDATA)*>
+]]>
+
+<!ENTITY % key-term.element "INCLUDE">
+<![%key-term.element;[
+<!ELEMENT key-term (#PCDATA)*>
+]]>
+<!ENTITY % htable.element "INCLUDE">
+<![%htable.element;[
+<!ELEMENT htable
+        (caption?, (col*|colgroup*), thead?, tfoot?, tbody+)>
+]]>
+<!ENTITY % htbody.element "INCLUDE">
+<![%htbody.element;[
+<!ELEMENT htbody (tr)+>
+]]>
+<!ENTITY % statusp.element "INCLUDE">
+<![%statusp.element;[
+<!ELEMENT statusp (%p.pcd.mix;|%p.mix;)*>
+]]>
+
+<!ENTITY % itemizedlist.element "INCLUDE">
+<![%itemizedlist.element;[
+<!ELEMENT itemizedlist (listitem*)>
+]]>
+<!ENTITY % orderedlist.element "INCLUDE">
+<![%orderedlist.element;[
+<!ELEMENT orderedlist (listitem*)>
+]]>
+<!ENTITY % listitem.element "INCLUDE">
+<![%listitem.element;[
+<!ELEMENT listitem (para*)>
+]]>
+<!ENTITY % para.element "INCLUDE">
+<![%para.element;[
+<!ELEMENT para (#PCDATA)*>
+]]>
+
+<!-- ............................................................... -->
+<!-- Change history ................................................ -->
+<!-- ............................................................... -->
+
+<!--
+#This revision history is no longer being maintained. See the CVS log
+#for detailed revisions history.
+#####################################################################
+#1997-08-18: maler
+#- Did a major revision.
+#1997-09-10: maler
+#- Updated FPI.
+#- Removed namekey element and put key attribute on name element.
+#- Made statusp element and supporting entities.
+#- Added slist element with sitem+ content.
+#- Required head on scrap and added new bnf subelement.
+#- Added an xnt element and allowed it and nt in regular text and rhs.
+#- Removed the ntref element.
+#- Added back the com element to the content of rhs.
+#- Added a key attribute to bibl.
+#- Removed the ident element.
+#- Added a term element to be used inside termdef.
+#- Added an xtermref element parallel to termref.
+#- Beefed up DTD comments.
+#1997-09-12: maler
+#- Allowed term element in general text.
+#- Changed bibref to EMPTY.
+#- Added ref.class to termdef.pcd.mix.
+#1997-09-14: maler
+#- Changed main attribute of xtermref from def to href.
+#- Added termdef.class to label contents.
+#1997-09-30: maler
+#- Added character entity module and added new entities.
+#- Removed p from appearing directly in self; created %p.mix;.
+#- Added inform-div (non-normative division) element.
+#- Fixed xtermref comment to mention href, not ref.
+#- Extended orglist model to allow optional affiliation.
+#- Modified author to make affiliation optional.
+#- Added %speclist.class; and %note.class; to %obj.mix; and %p.mix;.
+#- Added %note.class; and %illus.class; to %termdef.pcd.mix;.
+#- Added unused HTML elements.
+#- Put empty system ID next to public ID in entity declarations.
+#1997-10-14: maler
+#- Fixed "unused" div content model to move nested div to mixture.
+#1997-10-16: maler
+#- Added SGML Open Exchange tables.
+#1997-11-28: maler
+#- Added support for prodgroup and its attributes.
+#- Added support for HTML tables.
+#- Added loc and bibref to content of com.
+#- Added loc to general p content models.
+#- Allowed p as alternative to statusp in status.
+#- Added non-null system IDs to external parameter entity declarations.
+#- (Modified the SGML Open table module to make it XML-compliant.)
+#- (Modified the character entity module.)
+#1997-12-29: maler
+#- Moved #PCDATA occurrences to come before GIs in content models.
+#- Removed use of the SGML Open table module.
+#- Added xspecref element.
+#- Ensured that all FPIs contain 4-digit year.
+#- (Modified the character entity module.)
+#1998-03-10: maler
+#- Merged the character entity and table modules into the main file.
+#- Added ldquo and rdquo entities.
+#- Added common attributes to prodgroup.
+#- Made the email element in header optional.
+#- Removed reference to the SGML Open table model.
+#- Added ednote element.
+#- Added quote element.
+#- Updated XLink usage to reflect 3 March 1998 WD.
+#- Added "local" entities to the class entities for customization.
+#- Parameterized several content models to allow for customization.
+#1998-03-23: maler
+#- Cleaned up some comments and removed some others.
+#- Added xml:space semi-common attribute to eg and bnf elements.
+#- Added show and embed attributes on all the uses of href.
+#- Added %common.att; to all HTML table elements.
+#- Added a real URI to the "typical invocation" comment.
+#1998-05-14: maler
+#- Fixed mdash, ldquo, and rdquo character entities.
+#- Switched to the full HTML 4.0 table model.
+#- Removed htable/htbody elements and replaced them with table/tbody.
+#- Added issue element to %note.class; and declared it.
+#- Allowed prevlocs and latestloc in either order.
+#- Added key-term, htable, htbody, and statusp as unused elements.
+#- Removed real statusp element in favor of plain p.
+#1998-05-21: maler
+#- Declared generic constraint and constraintnote elements.
+#- Added constraintnote to %note.class;.
+#- Added constraint to %eg.pcd.mix; and prod content model.
+#1998-08-22: maler
+#- Fixed %illus.class; to mention table instead of htable.
+#- Added definitions to %illus.class; for DOM model.
+#- Added DOM definitions element and its substructure.
+#- Updated XLink usage in %href.att; to use xlink:form and #IMPLIED.
+#- Added clarifying comments to href-using elements.
+#1998-11-30: maler
+#- Added new unused elements to support DocBook translation.
+#- Updated maler phone numbers.
+#1998-12-3: maler
+#- Fixed character entities with respect to escaping of ampersands.
+#- Added many more explanatory comments.
+#1999-07-02: maler
+#- Added %loc.class; to all PCD mixes that didn't already have it.
+#- Removed unused %loc.pcd.mix;.
+#- Made version in spec header optional.
+#- Added three new attributes to spec.
+#- Broadened content of edtext.
+#- Added optional copyright element to header.
+#- Reorganized XLink-related parameter entities; added xmlns:xlink.
+#- Changed edtext content from #PCDATA to %p.pcd.mix;.
+#- Added show/actuate atts and default values to all href elements.
+#- Changed versioning scheme from 8-digit dates to version numbers.
+#- Added w3c-doctype, other-doctype, status atts to spec element.
+#- Added prodrecap element inside scrap.
+#- Added headstyle attribute to scrap.
+#2000-03-07: maler
+#- Added proto element, its arg subelement, and the %argtypes; entity.
+#- Added function, var, sub, sup, phrase, el, att, attval elements.
+#- Expanded emph to %p.pcd.mix;.
+#- Allowed status and abstract to appear in the opposite order.
+#- Updated XLink usage to the latest WD, except for href and source.
+#- Removed the xml:attributes attribute from graphic.
+#- Added %local.graphic.att; to graphic.
+#- Added common diff attribute.
+#- Added div5 element.
+#- Broadened content models of publoc, prevlocs, and latestloc.
+#- Added head, source, resolution, and status attribute to issue.
+#- Added cr, issues, and dispcmts to w3c-doctype attribute on spec.
+#- Added example element.
+-->
+
+<!-- ............................................................... -->
+<!-- End of XML specification DTD .................................. -->
+<!-- ............................................................... -->

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/schema10/XMLSchema-datatypes.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/schema10/XMLSchema-datatypes.xsd
@@ -1,0 +1,154 @@
+<?xml version='1.0'?>
+<!-- XML Schema schema for XML Schemas: Part 2: Datatypes -->
+<!DOCTYPE schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd" [
+<!ENTITY % s ''>
+<!ENTITY % p ''>
+]>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.w3.org/2001/XMLSchema-datatypes"
+	version="$Id: XMLSchema-datatypes.xsd,v 1.5 2001/03/16 20:53:32 ht Exp $">
+  <annotation>
+   <documentation>Note this schema is NOT a normative schema - -
+     It contains types derived from all the builtin simple type definitions
+     with the same local name but in a distinct namespace, for use
+     by applications which do no wish to import the full XMLSchema
+     schema.  Since derivation is not symmetric, unexpected results may
+     follow from mixing references to these definitions with references
+     to the definitions in the XMLSchema namespace.  For example,
+     although dt:positiveInteger is derived from xs:integer, the converse
+     does not hold.</documentation>
+  </annotation>
+
+  <simpleType name="string">
+   <restriction base="string"/>
+  </simpleType>
+  <simpleType name="boolean">
+   <restriction base="boolean"/>
+  </simpleType>
+  <simpleType name="float">
+   <restriction base="float"/>
+  </simpleType>
+  <simpleType name="double">
+   <restriction base="double"/>
+  </simpleType>
+  <simpleType name="decimal">
+   <restriction base="decimal"/>
+  </simpleType>
+  <simpleType name="dateTime">
+   <restriction base="dateTime"/>
+  </simpleType>
+  <simpleType name="duration">
+   <restriction base="duration"/>
+  </simpleType>
+  <simpleType name="hexBinary">
+   <restriction base="hexBinary"/>
+  </simpleType>
+  <simpleType name="base64Binary">
+   <restriction base="base64Binary"/>
+  </simpleType>
+  <simpleType name="anyURI">
+   <restriction base="anyURI"/>
+  </simpleType>
+  <simpleType name="ID">
+   <restriction base="ID"/>
+  </simpleType>
+  <simpleType name="IDREF">
+   <restriction base="IDREF"/>
+  </simpleType>
+  <simpleType name="ENTITY">
+   <restriction base="ENTITY"/>
+  </simpleType>
+  <simpleType name="NOTATION">
+   <restriction base="NOTATION"/>
+  </simpleType>
+  <simpleType name="normalizedString">
+   <restriction base="normalizedString"/>
+  </simpleType>
+  <simpleType name="token">
+   <restriction base="token"/>
+  </simpleType>
+  <simpleType name="language">
+   <restriction base="language"/>
+  </simpleType>
+  <simpleType name="IDREFS">
+   <restriction base="IDREFS"/>
+  </simpleType>
+  <simpleType name="ENTITIES">
+   <restriction base="ENTITIES"/>
+  </simpleType>
+  <simpleType name="NMTOKEN">
+   <restriction base="NMTOKEN"/>
+  </simpleType>
+  <simpleType name="NMTOKENS">
+   <restriction base="NMTOKENS"/>
+  </simpleType>
+  <simpleType name="Name">
+   <restriction base="Name"/>
+  </simpleType>
+  <simpleType name="QName">
+   <restriction base="QName"/>
+  </simpleType>
+  <simpleType name="NCName">
+   <restriction base="NCName"/>
+  </simpleType>
+  <simpleType name="integer">
+   <restriction base="integer"/>
+  </simpleType>
+  <simpleType name="nonNegativeInteger">
+   <restriction base="nonNegativeInteger"/>
+  </simpleType>
+  <simpleType name="positiveInteger">
+   <restriction base="positiveInteger"/>
+  </simpleType>
+  <simpleType name="nonPositiveInteger">
+   <restriction base="nonPositiveInteger"/>
+  </simpleType>
+  <simpleType name="negativeInteger">
+   <restriction base="negativeInteger"/>
+  </simpleType>
+  <simpleType name="byte">
+   <restriction base="byte"/>
+  </simpleType>
+  <simpleType name="int">
+   <restriction base="int"/>
+  </simpleType>
+  <simpleType name="long">
+   <restriction base="long"/>
+  </simpleType>
+  <simpleType name="short">
+   <restriction base="short"/>
+  </simpleType>
+  <simpleType name="unsignedByte">
+   <restriction base="unsignedByte"/>
+  </simpleType>
+  <simpleType name="unsignedInt">
+   <restriction base="unsignedInt"/>
+  </simpleType>
+  <simpleType name="unsignedLong">
+   <restriction base="unsignedLong"/>
+  </simpleType>
+  <simpleType name="unsignedShort">
+   <restriction base="unsignedShort"/>
+  </simpleType>
+  <simpleType name="date">
+   <restriction base="date"/>
+  </simpleType>
+  <simpleType name="time">
+   <restriction base="time"/>
+  </simpleType>
+  <simpleType name="gYearMonth">
+   <restriction base="gYearMonth"/>
+  </simpleType>
+  <simpleType name="gYear">
+   <restriction base="gYear"/>
+  </simpleType>
+  <simpleType name="gMonthDay">
+   <restriction base="gMonthDay"/>
+  </simpleType>
+  <simpleType name="gDay">
+   <restriction base="gDay"/>
+  </simpleType>
+  <simpleType name="gMonth">
+   <restriction base="gMonth"/>
+  </simpleType>
+
+</schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/schema10/XMLSchema.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/schema10/XMLSchema.xsd
@@ -1,0 +1,2364 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- XML Schema schema for XML Schemas: Part 1: Structures -->
+<!-- Note this schema is NOT the normative structures schema. -->
+<!-- The prose copy in the structures REC is the normative -->
+<!-- version (which shouldn't differ from this one except for -->
+<!-- this comment and entity expansions, but just in case -->
+<!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd">
+<xs:schema targetNamespace="http://www.w3.org/2001/XMLSchema" blockDefault="#all" elementFormDefault="qualified" version="1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="EN" xmlns:hfp="http://www.w3.org/2001/XMLSchema-hasFacetAndProperty">
+ <xs:annotation>
+  <xs:documentation>
+    Part 1 version: Id: structures.xsd,v 1.2 2004/01/15 11:34:25 ht Exp 
+    Part 2 version: Id: datatypes.xsd,v 1.3 2004/01/23 18:11:13 ht Exp 
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/2004/PER-xmlschema-1-20040318/structures.html">
+   The schema corresponding to this document is normative,
+   with respect to the syntactic constraints it expresses in the
+   XML Schema language.  The documentation (within &lt;documentation&gt; elements)
+   below, is not normative, but rather highlights important aspects of
+   the W3C Recommendation of which this is a part</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+   <xs:documentation>
+   The simpleType element and all of its members are defined
+      towards the end of this schema document</xs:documentation>
+ </xs:annotation>
+
+ <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd">
+   <xs:annotation>
+     <xs:documentation>
+       Get access to the xml: attribute groups for xml:lang
+       as declared on 'schema' and 'documentation' below
+     </xs:documentation>
+   </xs:annotation>
+ </xs:import>
+
+ <xs:complexType name="openAttrs">
+   <xs:annotation>
+     <xs:documentation>
+       This type is extended by almost all schema types
+       to allow attributes from other namespaces to be
+       added to user schemas.
+     </xs:documentation>
+   </xs:annotation>
+   <xs:complexContent>
+     <xs:restriction base="xs:anyType">
+       <xs:anyAttribute namespace="##other" processContents="lax"/>
+     </xs:restriction>
+   </xs:complexContent>
+ </xs:complexType>
+
+ <xs:complexType name="annotated">
+   <xs:annotation>
+     <xs:documentation>
+       This type is extended by all types which allow annotation
+       other than &lt;schema&gt; itself
+     </xs:documentation>
+   </xs:annotation>
+   <xs:complexContent>
+     <xs:extension base="xs:openAttrs">
+       <xs:sequence>
+         <xs:element ref="xs:annotation" minOccurs="0"/>
+       </xs:sequence>
+       <xs:attribute name="id" type="xs:ID"/>
+     </xs:extension>
+   </xs:complexContent>
+ </xs:complexType>
+
+ <xs:group name="schemaTop">
+  <xs:annotation>
+   <xs:documentation>
+   This group is for the
+   elements which occur freely at the top level of schemas.
+   All of their types are based on the "annotated" type by extension.</xs:documentation>
+  </xs:annotation>
+  <xs:choice>
+   <xs:group ref="xs:redefinable"/>
+   <xs:element ref="xs:element"/>
+   <xs:element ref="xs:attribute"/>
+   <xs:element ref="xs:notation"/>
+  </xs:choice>
+ </xs:group>
+ 
+ <xs:group name="redefinable">
+  <xs:annotation>
+   <xs:documentation>
+   This group is for the
+   elements which can self-redefine (see &lt;redefine&gt; below).</xs:documentation>
+  </xs:annotation>
+  <xs:choice>
+   <xs:element ref="xs:simpleType"/>
+   <xs:element ref="xs:complexType"/>
+   <xs:element ref="xs:group"/>
+   <xs:element ref="xs:attributeGroup"/>
+  </xs:choice>
+ </xs:group>
+
+ <xs:simpleType name="formChoice">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:NMTOKEN">
+   <xs:enumeration value="qualified"/>
+   <xs:enumeration value="unqualified"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+ <xs:simpleType name="reducedDerivationControl">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:derivationControl">
+   <xs:enumeration value="extension"/>
+   <xs:enumeration value="restriction"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+ <xs:simpleType name="derivationSet">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+   <xs:documentation>
+   #all or (possibly empty) subset of {extension, restriction}</xs:documentation>
+  </xs:annotation>
+  <xs:union>
+   <xs:simpleType>    
+    <xs:restriction base="xs:token">
+     <xs:enumeration value="#all"/>
+    </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType>
+    <xs:list itemType="xs:reducedDerivationControl"/>
+   </xs:simpleType>
+  </xs:union>
+ </xs:simpleType>
+
+ <xs:simpleType name="typeDerivationControl">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:derivationControl">
+   <xs:enumeration value="extension"/>
+   <xs:enumeration value="restriction"/>
+   <xs:enumeration value="list"/>
+   <xs:enumeration value="union"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+  <xs:simpleType name="fullDerivationSet">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+   <xs:documentation>
+   #all or (possibly empty) subset of {extension, restriction, list, union}</xs:documentation>
+  </xs:annotation>
+  <xs:union>
+   <xs:simpleType>    
+    <xs:restriction base="xs:token">
+     <xs:enumeration value="#all"/>
+    </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType>
+    <xs:list itemType="xs:typeDerivationControl"/>
+   </xs:simpleType>
+  </xs:union>
+ </xs:simpleType>
+
+ <xs:element name="schema" id="schema">
+  <xs:annotation>
+    <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-schema"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:openAttrs">
+     <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+       <xs:element ref="xs:include"/>
+       <xs:element ref="xs:import"/>
+       <xs:element ref="xs:redefine"/>
+       <xs:element ref="xs:annotation"/>
+      </xs:choice>
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+       <xs:group ref="xs:schemaTop"/>
+       <xs:element ref="xs:annotation" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+     </xs:sequence>
+     <xs:attribute name="targetNamespace" type="xs:anyURI"/>
+     <xs:attribute name="version" type="xs:token"/>
+     <xs:attribute name="finalDefault" type="xs:fullDerivationSet" use="optional" default=""/>
+     <xs:attribute name="blockDefault" type="xs:blockSet" use="optional" default=""/>
+     <xs:attribute name="attributeFormDefault" type="xs:formChoice" use="optional" default="unqualified"/>
+     <xs:attribute name="elementFormDefault" type="xs:formChoice" use="optional" default="unqualified"/>
+     <xs:attribute name="id" type="xs:ID"/>
+     <xs:attribute ref="xml:lang"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+
+  <xs:key name="element">
+   <xs:selector xpath="xs:element"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+
+  <xs:key name="attribute">
+   <xs:selector xpath="xs:attribute"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+
+  <xs:key name="type">
+   <xs:selector xpath="xs:complexType|xs:simpleType"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+ 
+  <xs:key name="group">
+   <xs:selector xpath="xs:group"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+ 
+  <xs:key name="attributeGroup">
+   <xs:selector xpath="xs:attributeGroup"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+ 
+  <xs:key name="notation">
+   <xs:selector xpath="xs:notation"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+
+  <xs:key name="identityConstraint">
+   <xs:selector xpath=".//xs:key|.//xs:unique|.//xs:keyref"/>
+   <xs:field xpath="@name"/>
+  </xs:key>
+
+ </xs:element>
+
+ <xs:simpleType name="allNNI">
+  <xs:annotation><xs:documentation>
+   for maxOccurs</xs:documentation></xs:annotation>
+  <xs:union memberTypes="xs:nonNegativeInteger">
+   <xs:simpleType>
+    <xs:restriction base="xs:NMTOKEN">
+     <xs:enumeration value="unbounded"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:union>
+ </xs:simpleType>
+
+ <xs:attributeGroup name="occurs">
+  <xs:annotation><xs:documentation>
+   for all particles</xs:documentation></xs:annotation>
+  <xs:attribute name="minOccurs" type="xs:nonNegativeInteger" use="optional" default="1"/>
+  <xs:attribute name="maxOccurs" type="xs:allNNI" use="optional" default="1"/>
+ </xs:attributeGroup>
+
+ <xs:attributeGroup name="defRef">
+  <xs:annotation><xs:documentation>
+   for element, group and attributeGroup,
+   which both define and reference</xs:documentation></xs:annotation>
+  <xs:attribute name="name" type="xs:NCName"/>
+  <xs:attribute name="ref" type="xs:QName"/>
+ </xs:attributeGroup>
+
+ <xs:group name="typeDefParticle">
+  <xs:annotation>
+    <xs:documentation>
+   'complexType' uses this</xs:documentation></xs:annotation>
+  <xs:choice>
+   <xs:element name="group" type="xs:groupRef"/>
+   <xs:element ref="xs:all"/>
+   <xs:element ref="xs:choice"/>
+   <xs:element ref="xs:sequence"/>
+  </xs:choice>
+ </xs:group>
+ 
+ 
+
+ <xs:group name="nestedParticle">
+  <xs:choice>
+   <xs:element name="element" type="xs:localElement"/>
+   <xs:element name="group" type="xs:groupRef"/>
+   <xs:element ref="xs:choice"/>
+   <xs:element ref="xs:sequence"/>
+   <xs:element ref="xs:any"/>
+  </xs:choice>
+ </xs:group>
+ 
+ <xs:group name="particle">
+  <xs:choice>
+   <xs:element name="element" type="xs:localElement"/>
+   <xs:element name="group" type="xs:groupRef"/>
+   <xs:element ref="xs:all"/>
+   <xs:element ref="xs:choice"/>
+   <xs:element ref="xs:sequence"/>
+   <xs:element ref="xs:any"/>
+  </xs:choice>
+ </xs:group>
+ 
+ <xs:complexType name="attribute">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:sequence>
+     <xs:element name="simpleType" minOccurs="0" type="xs:localSimpleType"/>
+    </xs:sequence>
+    <xs:attributeGroup ref="xs:defRef"/>
+    <xs:attribute name="type" type="xs:QName"/>
+    <xs:attribute name="use" use="optional" default="optional">
+     <xs:simpleType>
+      <xs:restriction base="xs:NMTOKEN">
+       <xs:enumeration value="prohibited"/>
+       <xs:enumeration value="optional"/>
+       <xs:enumeration value="required"/>
+      </xs:restriction>
+     </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="default" type="xs:string"/>
+    <xs:attribute name="fixed" type="xs:string"/>
+    <xs:attribute name="form" type="xs:formChoice"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="topLevelAttribute">
+  <xs:complexContent>
+   <xs:restriction base="xs:attribute">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:element name="simpleType" minOccurs="0" type="xs:localSimpleType"/>
+    </xs:sequence>
+    <xs:attribute name="ref" use="prohibited"/>
+    <xs:attribute name="form" use="prohibited"/>
+    <xs:attribute name="use" use="prohibited"/>
+    <xs:attribute name="name" use="required" type="xs:NCName"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:group name="attrDecls">
+  <xs:sequence>
+   <xs:choice minOccurs="0" maxOccurs="unbounded">
+    <xs:element name="attribute" type="xs:attribute"/>
+    <xs:element name="attributeGroup" type="xs:attributeGroupRef"/>
+   </xs:choice>
+   <xs:element ref="xs:anyAttribute" minOccurs="0"/>
+  </xs:sequence>
+ </xs:group>
+
+ <xs:element name="anyAttribute" type="xs:wildcard" id="anyAttribute">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-anyAttribute"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:group name="complexTypeModel">
+  <xs:choice>
+      <xs:element ref="xs:simpleContent"/>
+      <xs:element ref="xs:complexContent"/>
+      <xs:sequence>
+       <xs:annotation>
+        <xs:documentation>
+   This branch is short for
+   &lt;complexContent&gt;
+   &lt;restriction base="xs:anyType"&gt;
+   ...
+   &lt;/restriction&gt;
+   &lt;/complexContent&gt;</xs:documentation>
+       </xs:annotation>
+       <xs:group ref="xs:typeDefParticle" minOccurs="0"/>
+       <xs:group ref="xs:attrDecls"/>
+      </xs:sequence>
+  </xs:choice>
+ </xs:group>
+
+ <xs:complexType name="complexType" abstract="true">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:group ref="xs:complexTypeModel"/>
+    <xs:attribute name="name" type="xs:NCName">
+     <xs:annotation>
+      <xs:documentation>
+      Will be restricted to required or forbidden</xs:documentation>
+     </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="mixed" type="xs:boolean" use="optional" default="false">
+     <xs:annotation>
+      <xs:documentation>
+      Not allowed if simpleContent child is chosen.
+      May be overriden by setting on complexContent child.</xs:documentation>
+    </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="abstract" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="final" type="xs:derivationSet"/>
+    <xs:attribute name="block" type="xs:derivationSet"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="topLevelComplexType">
+  <xs:complexContent>
+   <xs:restriction base="xs:complexType">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:complexTypeModel"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:NCName" use="required"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="localComplexType">
+  <xs:complexContent>
+   <xs:restriction base="xs:complexType">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:complexTypeModel"/>
+    </xs:sequence>
+    <xs:attribute name="name" use="prohibited"/>
+    <xs:attribute name="abstract" use="prohibited"/>
+    <xs:attribute name="final" use="prohibited"/>
+    <xs:attribute name="block" use="prohibited"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="restrictionType">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:sequence>
+     <xs:choice minOccurs="0">
+      <xs:group ref="xs:typeDefParticle"/>
+      <xs:group ref="xs:simpleRestrictionModel"/>
+     </xs:choice>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+    <xs:attribute name="base" type="xs:QName" use="required"/>
+   </xs:extension>
+  </xs:complexContent>       
+ </xs:complexType>
+
+ <xs:complexType name="complexRestrictionType">
+  <xs:complexContent>
+   <xs:restriction base="xs:restrictionType">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:choice minOccurs="0">
+      <xs:annotation>
+       <xs:documentation>This choice is added simply to
+                   make this a valid restriction per the REC</xs:documentation>
+      </xs:annotation>
+      <xs:group ref="xs:typeDefParticle"/>
+     </xs:choice>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>       
+ </xs:complexType>
+
+ <xs:complexType name="extensionType">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:sequence>
+     <xs:group ref="xs:typeDefParticle" minOccurs="0"/>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+    <xs:attribute name="base" type="xs:QName" use="required"/>
+   </xs:extension>
+  </xs:complexContent>       
+ </xs:complexType>
+
+ <xs:element name="complexContent" id="complexContent">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-complexContent"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:annotated">
+     <xs:choice>
+      <xs:element name="restriction" type="xs:complexRestrictionType"/>
+      <xs:element name="extension" type="xs:extensionType"/>
+     </xs:choice>     
+     <xs:attribute name="mixed" type="xs:boolean">
+      <xs:annotation>
+       <xs:documentation>
+       Overrides any setting on complexType parent.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:complexType name="simpleRestrictionType">
+  <xs:complexContent>
+   <xs:restriction base="xs:restrictionType">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:choice minOccurs="0">
+      <xs:annotation>
+       <xs:documentation>This choice is added simply to
+                   make this a valid restriction per the REC</xs:documentation>
+      </xs:annotation>
+      <xs:group ref="xs:simpleRestrictionModel"/>
+     </xs:choice>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:complexType name="simpleExtensionType">
+  <xs:complexContent>
+   <xs:restriction base="xs:extensionType">
+    <xs:sequence>
+     <xs:annotation>
+      <xs:documentation>
+      No typeDefParticle group reference</xs:documentation>
+     </xs:annotation>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:element name="simpleContent" id="simpleContent">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-simpleContent"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:annotated">
+     <xs:choice>
+      <xs:element name="restriction" type="xs:simpleRestrictionType"/>
+      <xs:element name="extension" type="xs:simpleExtensionType"/>
+     </xs:choice>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+ 
+ <xs:element name="complexType" type="xs:topLevelComplexType" id="complexType">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-complexType"/>
+  </xs:annotation>
+ </xs:element>
+
+
+  <xs:simpleType name="blockSet">
+   <xs:annotation>
+    <xs:documentation>
+    A utility type, not for public use</xs:documentation>
+    <xs:documentation>
+    #all or (possibly empty) subset of {substitution, extension,
+    restriction}</xs:documentation>
+   </xs:annotation>
+   <xs:union>
+    <xs:simpleType>    
+     <xs:restriction base="xs:token">
+      <xs:enumeration value="#all"/>
+     </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType>
+     <xs:list>
+      <xs:simpleType>
+       <xs:restriction base="xs:derivationControl">
+        <xs:enumeration value="extension"/>
+        <xs:enumeration value="restriction"/>
+        <xs:enumeration value="substitution"/>
+       </xs:restriction>
+      </xs:simpleType>
+     </xs:list>
+    </xs:simpleType>
+   </xs:union>  
+  </xs:simpleType>
+
+ <xs:complexType name="element" abstract="true">
+  <xs:annotation>
+   <xs:documentation>
+   The element element can be used either
+   at the top level to define an element-type binding globally,
+   or within a content model to either reference a globally-defined
+   element or type or declare an element-type binding locally.
+   The ref form is not allowed at the top level.</xs:documentation>
+  </xs:annotation>
+
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:sequence>
+     <xs:choice minOccurs="0">
+      <xs:element name="simpleType" type="xs:localSimpleType"/>
+      <xs:element name="complexType" type="xs:localComplexType"/>
+     </xs:choice>
+     <xs:group ref="xs:identityConstraint" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attributeGroup ref="xs:defRef"/>
+    <xs:attribute name="type" type="xs:QName"/>
+    <xs:attribute name="substitutionGroup" type="xs:QName"/>
+    <xs:attributeGroup ref="xs:occurs"/>
+    <xs:attribute name="default" type="xs:string"/>
+    <xs:attribute name="fixed" type="xs:string"/>
+    <xs:attribute name="nillable" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="abstract" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="final" type="xs:derivationSet"/>
+    <xs:attribute name="block" type="xs:blockSet"/>
+    <xs:attribute name="form" type="xs:formChoice"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="topLevelElement">
+  <xs:complexContent>
+   <xs:restriction base="xs:element">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:choice minOccurs="0">
+      <xs:element name="simpleType" type="xs:localSimpleType"/>
+      <xs:element name="complexType" type="xs:localComplexType"/>
+     </xs:choice>
+     <xs:group ref="xs:identityConstraint" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="ref" use="prohibited"/>
+    <xs:attribute name="form" use="prohibited"/>
+    <xs:attribute name="minOccurs" use="prohibited"/>
+    <xs:attribute name="maxOccurs" use="prohibited"/>
+    <xs:attribute name="name" use="required" type="xs:NCName"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="localElement">
+  <xs:complexContent>
+   <xs:restriction base="xs:element">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:choice minOccurs="0">
+      <xs:element name="simpleType" type="xs:localSimpleType"/>
+      <xs:element name="complexType" type="xs:localComplexType"/>
+     </xs:choice>
+     <xs:group ref="xs:identityConstraint" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="substitutionGroup" use="prohibited"/>
+    <xs:attribute name="final" use="prohibited"/>
+    <xs:attribute name="abstract" use="prohibited"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:element name="element" type="xs:topLevelElement" id="element">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-element"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:complexType name="group" abstract="true">
+  <xs:annotation>
+   <xs:documentation>
+   group type for explicit groups, named top-level groups and
+   group references</xs:documentation>
+  </xs:annotation>
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:group ref="xs:particle" minOccurs="0" maxOccurs="unbounded"/>
+    <xs:attributeGroup ref="xs:defRef"/>
+    <xs:attributeGroup ref="xs:occurs"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="realGroup">
+  <xs:complexContent>
+   <xs:restriction base="xs:group">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:choice minOccurs="0" maxOccurs="1">
+      <xs:element ref="xs:all"/>
+      <xs:element ref="xs:choice"/>
+      <xs:element ref="xs:sequence"/>
+     </xs:choice>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:complexType name="namedGroup">
+  <xs:complexContent>
+   <xs:restriction base="xs:realGroup">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:choice minOccurs="1" maxOccurs="1">
+      <xs:element name="all">
+       <xs:complexType>
+        <xs:complexContent>
+         <xs:restriction base="xs:all">
+          <xs:group ref="xs:allModel"/>
+          <xs:attribute name="minOccurs" use="prohibited"/>
+          <xs:attribute name="maxOccurs" use="prohibited"/>
+          <xs:anyAttribute namespace="##other" processContents="lax"/>
+         </xs:restriction>
+        </xs:complexContent>
+       </xs:complexType>
+      </xs:element>
+      <xs:element name="choice" type="xs:simpleExplicitGroup"/>
+      <xs:element name="sequence" type="xs:simpleExplicitGroup"/>
+     </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="name" use="required" type="xs:NCName"/>
+    <xs:attribute name="ref" use="prohibited"/>
+    <xs:attribute name="minOccurs" use="prohibited"/>
+    <xs:attribute name="maxOccurs" use="prohibited"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:complexType name="groupRef">
+  <xs:complexContent>
+   <xs:restriction base="xs:realGroup">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="ref" use="required" type="xs:QName"/>
+    <xs:attribute name="name" use="prohibited"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:complexType name="explicitGroup">
+  <xs:annotation>
+   <xs:documentation>
+   group type for the three kinds of group</xs:documentation>
+  </xs:annotation>
+  <xs:complexContent>
+   <xs:restriction base="xs:group">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:nestedParticle" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:NCName" use="prohibited"/>
+    <xs:attribute name="ref" type="xs:QName" use="prohibited"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="simpleExplicitGroup">
+  <xs:complexContent>
+   <xs:restriction base="xs:explicitGroup">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:nestedParticle" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="minOccurs" use="prohibited"/>
+    <xs:attribute name="maxOccurs" use="prohibited"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:group name="allModel">
+  <xs:sequence>
+      <xs:element ref="xs:annotation" minOccurs="0"/>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+       <xs:annotation>
+        <xs:documentation>This choice with min/max is here to
+                          avoid a pblm with the Elt:All/Choice/Seq
+                          Particle derivation constraint</xs:documentation>
+       </xs:annotation>
+       <xs:element name="element" type="xs:narrowMaxMin"/>
+      </xs:choice>
+     </xs:sequence>
+ </xs:group>
+ 
+ 
+ <xs:complexType name="narrowMaxMin">
+  <xs:annotation>
+   <xs:documentation>restricted max/min</xs:documentation>
+  </xs:annotation>
+  <xs:complexContent>
+   <xs:restriction base="xs:localElement">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:choice minOccurs="0">
+      <xs:element name="simpleType" type="xs:localSimpleType"/>
+      <xs:element name="complexType" type="xs:localComplexType"/>
+     </xs:choice>
+     <xs:group ref="xs:identityConstraint" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="minOccurs" use="optional" default="1">
+     <xs:simpleType>
+      <xs:restriction base="xs:nonNegativeInteger">
+       <xs:enumeration value="0"/>
+       <xs:enumeration value="1"/>
+      </xs:restriction>
+     </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="maxOccurs" use="optional" default="1">
+     <xs:simpleType>
+      <xs:restriction base="xs:allNNI">
+       <xs:enumeration value="0"/>
+       <xs:enumeration value="1"/>
+      </xs:restriction>
+     </xs:simpleType>
+    </xs:attribute>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+  <xs:complexType name="all">
+   <xs:annotation>
+    <xs:documentation>
+   Only elements allowed inside</xs:documentation>
+   </xs:annotation>
+   <xs:complexContent>
+    <xs:restriction base="xs:explicitGroup">
+     <xs:group ref="xs:allModel"/>
+     <xs:attribute name="minOccurs" use="optional" default="1">
+      <xs:simpleType>
+       <xs:restriction base="xs:nonNegativeInteger">
+        <xs:enumeration value="0"/>
+        <xs:enumeration value="1"/>
+       </xs:restriction>
+      </xs:simpleType>
+     </xs:attribute>
+     <xs:attribute name="maxOccurs" use="optional" default="1">
+      <xs:simpleType>
+       <xs:restriction base="xs:allNNI">
+        <xs:enumeration value="1"/>
+       </xs:restriction>
+      </xs:simpleType>
+     </xs:attribute>
+     <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:restriction>
+   </xs:complexContent>
+  </xs:complexType>
+
+ <xs:element name="all" id="all" type="xs:all">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-all"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:element name="choice" type="xs:explicitGroup" id="choice">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-choice"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:element name="sequence" type="xs:explicitGroup" id="sequence">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-sequence"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:element name="group" type="xs:namedGroup" id="group">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-group"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:complexType name="wildcard">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:attribute name="namespace" type="xs:namespaceList" use="optional" default="##any"/>
+    <xs:attribute name="processContents" use="optional" default="strict">
+     <xs:simpleType>
+      <xs:restriction base="xs:NMTOKEN">
+       <xs:enumeration value="skip"/>
+       <xs:enumeration value="lax"/>
+       <xs:enumeration value="strict"/>
+      </xs:restriction>
+     </xs:simpleType>
+    </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:element name="any" id="any">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-any"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:wildcard">
+     <xs:attributeGroup ref="xs:occurs"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+  <xs:annotation>
+   <xs:documentation>
+   simple type for the value of the 'namespace' attr of
+   'any' and 'anyAttribute'</xs:documentation>
+  </xs:annotation>
+  <xs:annotation>
+   <xs:documentation>
+   Value is
+              ##any      - - any non-conflicting WFXML/attribute at all
+
+              ##other    - - any non-conflicting WFXML/attribute from
+                              namespace other than targetNS
+
+              ##local    - - any unqualified non-conflicting WFXML/attribute 
+
+              one or     - - any non-conflicting WFXML/attribute from
+              more URI        the listed namespaces
+              references
+              (space separated)
+
+    ##targetNamespace or ##local may appear in the above list, to
+        refer to the targetNamespace of the enclosing
+        schema or an absent targetNamespace respectively</xs:documentation>
+  </xs:annotation>
+
+ <xs:simpleType name="namespaceList">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+  </xs:annotation>
+  <xs:union>
+   <xs:simpleType>
+    <xs:restriction base="xs:token">
+     <xs:enumeration value="##any"/>
+     <xs:enumeration value="##other"/>
+    </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType>
+    <xs:list>
+     <xs:simpleType>
+      <xs:union memberTypes="xs:anyURI">
+       <xs:simpleType>
+        <xs:restriction base="xs:token">
+         <xs:enumeration value="##targetNamespace"/>
+         <xs:enumeration value="##local"/>
+        </xs:restriction>
+       </xs:simpleType>
+      </xs:union>
+     </xs:simpleType>
+    </xs:list>
+   </xs:simpleType>
+  </xs:union>
+ </xs:simpleType>
+
+ <xs:element name="attribute" type="xs:topLevelAttribute" id="attribute">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-attribute"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:complexType name="attributeGroup" abstract="true">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:group ref="xs:attrDecls"/>
+    <xs:attributeGroup ref="xs:defRef"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ 
+ <xs:complexType name="namedAttributeGroup">
+  <xs:complexContent>
+   <xs:restriction base="xs:attributeGroup">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+     <xs:group ref="xs:attrDecls"/>
+    </xs:sequence>
+    <xs:attribute name="name" use="required" type="xs:NCName"/>
+    <xs:attribute name="ref" use="prohibited"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:complexType name="attributeGroupRef">
+  <xs:complexContent>
+   <xs:restriction base="xs:attributeGroup">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="ref" use="required" type="xs:QName"/>
+    <xs:attribute name="name" use="prohibited"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:element name="attributeGroup" type="xs:namedAttributeGroup" id="attributeGroup">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-attributeGroup"/>
+  </xs:annotation>
+ </xs:element>
+
+ <xs:element name="include" id="include">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-include"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:annotated">
+     <xs:attribute name="schemaLocation" type="xs:anyURI" use="required"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:element name="redefine" id="redefine">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-redefine"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:openAttrs">
+     <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="xs:annotation"/>
+      <xs:group ref="xs:redefinable"/>
+     </xs:choice>
+     <xs:attribute name="schemaLocation" type="xs:anyURI" use="required"/>
+     <xs:attribute name="id" type="xs:ID"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:element name="import" id="import">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-import"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:annotated">
+     <xs:attribute name="namespace" type="xs:anyURI"/>
+     <xs:attribute name="schemaLocation" type="xs:anyURI"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:element name="selector" id="selector">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-selector"/>
+  </xs:annotation>
+  <xs:complexType>
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+     <xs:attribute name="xpath" use="required">
+      <xs:simpleType>
+       <xs:annotation>
+        <xs:documentation>A subset of XPath expressions for use
+in selectors</xs:documentation>
+        <xs:documentation>A utility type, not for public
+use</xs:documentation>
+       </xs:annotation>
+       <xs:restriction base="xs:token">
+        <xs:annotation>
+         <xs:documentation>The following pattern is intended to allow XPath
+                           expressions per the following EBNF:
+          Selector    ::=    Path ( '|' Path )*  
+          Path    ::=    ('.//')? Step ( '/' Step )*  
+          Step    ::=    '.' | NameTest  
+          NameTest    ::=    QName | '*' | NCName ':' '*'  
+                           child:: is also allowed
+         </xs:documentation>
+        </xs:annotation>
+        <xs:pattern value="(\.//)?(((child::)?((\i\c*:)?(\i\c*|\*)))|\.)(/(((child::)?((\i\c*:)?(\i\c*|\*)))|\.))*(\|(\.//)?(((child::)?((\i\c*:)?(\i\c*|\*)))|\.)(/(((child::)?((\i\c*:)?(\i\c*|\*)))|\.))*)*">
+        </xs:pattern>
+       </xs:restriction>
+      </xs:simpleType>
+     </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ </xs:element>
+
+ <xs:element name="field" id="field">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-field"/>
+  </xs:annotation>
+  <xs:complexType>
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+     <xs:attribute name="xpath" use="required">
+      <xs:simpleType>
+       <xs:annotation>
+        <xs:documentation>A subset of XPath expressions for use
+in fields</xs:documentation>
+        <xs:documentation>A utility type, not for public
+use</xs:documentation>
+       </xs:annotation>
+       <xs:restriction base="xs:token">
+        <xs:annotation>
+         <xs:documentation>The following pattern is intended to allow XPath
+                           expressions per the same EBNF as for selector,
+                           with the following change:
+          Path    ::=    ('.//')? ( Step '/' )* ( Step | '@' NameTest ) 
+         </xs:documentation>
+        </xs:annotation>
+        <xs:pattern value="(\.//)?((((child::)?((\i\c*:)?(\i\c*|\*)))|\.)/)*((((child::)?((\i\c*:)?(\i\c*|\*)))|\.)|((attribute::|@)((\i\c*:)?(\i\c*|\*))))(\|(\.//)?((((child::)?((\i\c*:)?(\i\c*|\*)))|\.)/)*((((child::)?((\i\c*:)?(\i\c*|\*)))|\.)|((attribute::|@)((\i\c*:)?(\i\c*|\*)))))*">
+        </xs:pattern>
+       </xs:restriction>
+      </xs:simpleType>
+     </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ </xs:element>
+
+ <xs:complexType name="keybase">
+  <xs:complexContent>
+   <xs:extension base="xs:annotated">
+    <xs:sequence>
+     <xs:element ref="xs:selector"/>
+     <xs:element ref="xs:field" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:NCName" use="required"/>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+
+ <xs:group name="identityConstraint">
+  <xs:annotation>
+   <xs:documentation>The three kinds of identity constraints, all with
+                     type of or derived from 'keybase'.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:choice>
+   <xs:element ref="xs:unique"/>
+   <xs:element ref="xs:key"/>
+   <xs:element ref="xs:keyref"/>
+  </xs:choice>
+ </xs:group>
+
+ <xs:element name="unique" type="xs:keybase" id="unique">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-unique"/>
+  </xs:annotation>
+ </xs:element>
+ <xs:element name="key" type="xs:keybase" id="key">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-key"/>
+  </xs:annotation>
+ </xs:element>
+ <xs:element name="keyref" id="keyref">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-keyref"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:keybase">
+     <xs:attribute name="refer" type="xs:QName" use="required"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:element name="notation" id="notation">
+  <xs:annotation>
+   <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-notation"/>
+  </xs:annotation>
+  <xs:complexType>
+   <xs:complexContent>
+    <xs:extension base="xs:annotated">
+     <xs:attribute name="name" type="xs:NCName" use="required"/>
+     <xs:attribute name="public" type="xs:public"/>
+     <xs:attribute name="system" type="xs:anyURI"/>
+    </xs:extension>
+   </xs:complexContent>
+  </xs:complexType>
+ </xs:element>
+
+ <xs:simpleType name="public">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+   <xs:documentation>
+   A public identifier, per ISO 8879</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:token"/>
+ </xs:simpleType>
+
+ <xs:element name="appinfo" id="appinfo">
+   <xs:annotation>
+     <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-appinfo"/>
+   </xs:annotation>
+   <xs:complexType mixed="true">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+     <xs:any processContents="lax"/>
+    </xs:sequence>
+    <xs:attribute name="source" type="xs:anyURI"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:complexType>
+ </xs:element>
+
+ <xs:element name="documentation" id="documentation">
+   <xs:annotation>
+     <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-documentation"/>
+   </xs:annotation>
+   <xs:complexType mixed="true">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+     <xs:any processContents="lax"/>
+    </xs:sequence>
+    <xs:attribute name="source" type="xs:anyURI"/>
+    <xs:attribute ref="xml:lang"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:complexType>
+ </xs:element>
+
+ <xs:element name="annotation" id="annotation">
+   <xs:annotation>
+     <xs:documentation source="http://www.w3.org/TR/xmlschema-1/#element-annotation"/>
+   </xs:annotation>
+   <xs:complexType>
+    <xs:complexContent>
+     <xs:extension base="xs:openAttrs">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+       <xs:element ref="xs:appinfo"/>
+       <xs:element ref="xs:documentation"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+     </xs:extension>
+    </xs:complexContent>
+   </xs:complexType>
+ </xs:element>
+
+ <xs:annotation>
+  <xs:documentation>
+   notations for use within XML Schema schemas</xs:documentation>
+ </xs:annotation>
+
+ <xs:notation name="XMLSchemaStructures" public="structures" system="http://www.w3.org/2000/08/XMLSchema.xsd"/>
+ <xs:notation name="XML" public="REC-xml-19980210" system="http://www.w3.org/TR/1998/REC-xml-19980210"/>
+  
+ <xs:complexType name="anyType" mixed="true">
+  <xs:annotation>
+   <xs:documentation>
+   Not the real urType, but as close an approximation as we can
+   get in the XML representation</xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+  </xs:sequence>
+  <xs:anyAttribute processContents="lax"/>
+ </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+      First the built-in primitive datatypes.  These definitions are for
+      information only, the real built-in definitions are magic.
+    </xs:documentation>
+
+    <xs:documentation>
+      For each built-in datatype in this schema (both primitive and
+      derived) can be uniquely addressed via a URI constructed
+      as follows:
+        1) the base URI is the URI of the XML Schema namespace
+        2) the fragment identifier is the name of the datatype
+
+      For example, to address the int datatype, the URI is:
+
+        http://www.w3.org/2001/XMLSchema#int
+
+      Additionally, each facet definition element can be uniquely
+      addressed via a URI constructed as follows:
+        1) the base URI is the URI of the XML Schema namespace
+        2) the fragment identifier is the name of the facet
+
+      For example, to address the maxInclusive facet, the URI is:
+
+        http://www.w3.org/2001/XMLSchema#maxInclusive
+
+      Additionally, each facet usage in a built-in datatype definition
+      can be uniquely addressed via a URI constructed as follows:
+        1) the base URI is the URI of the XML Schema namespace
+        2) the fragment identifier is the name of the datatype, followed
+           by a period (".") followed by the name of the facet
+
+      For example, to address the usage of the maxInclusive facet in
+      the definition of int, the URI is:
+
+        http://www.w3.org/2001/XMLSchema#int.maxInclusive
+
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="string" id="string">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="length"/>
+        <hfp:hasFacet name="minLength"/>
+        <hfp:hasFacet name="maxLength"/>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasProperty name="ordered" value="false"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#string"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="preserve" id="string.preserve"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="boolean" id="boolean">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasProperty name="ordered" value="false"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="finite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#boolean"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="boolean.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="float" id="float">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="total"/>
+        <hfp:hasProperty name="bounded" value="true"/>
+        <hfp:hasProperty name="cardinality" value="finite"/>
+        <hfp:hasProperty name="numeric" value="true"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#float"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="float.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="double" id="double">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="total"/>
+        <hfp:hasProperty name="bounded" value="true"/>
+        <hfp:hasProperty name="cardinality" value="finite"/>
+        <hfp:hasProperty name="numeric" value="true"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#double"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="double.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="decimal" id="decimal">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="totalDigits"/>
+        <hfp:hasFacet name="fractionDigits"/>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="total"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="true"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#decimal"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="decimal.whiteSpace"/>
+    </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="duration" id="duration">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="partial"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#duration"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="duration.whiteSpace"/>
+    </xs:restriction>
+   </xs:simpleType>
+
+ <xs:simpleType name="dateTime" id="dateTime">
+    <xs:annotation>
+    <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="partial"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#dateTime"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="dateTime.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="time" id="time">
+    <xs:annotation>
+    <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="partial"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#time"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="time.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="date" id="date">
+   <xs:annotation>
+    <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="partial"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#date"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="date.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="gYearMonth" id="gYearMonth">
+   <xs:annotation>
+    <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="partial"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#gYearMonth"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="gYearMonth.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="gYear" id="gYear">
+    <xs:annotation>
+    <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="partial"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#gYear"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="gYear.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+ <xs:simpleType name="gMonthDay" id="gMonthDay">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="partial"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+       <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#gMonthDay"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+         <xs:whiteSpace value="collapse" fixed="true" id="gMonthDay.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="gDay" id="gDay">
+    <xs:annotation>
+  <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="partial"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#gDay"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+         <xs:whiteSpace value="collapse" fixed="true" id="gDay.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+ <xs:simpleType name="gMonth" id="gMonth">
+    <xs:annotation>
+  <xs:appinfo>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="maxInclusive"/>
+        <hfp:hasFacet name="maxExclusive"/>
+        <hfp:hasFacet name="minInclusive"/>
+        <hfp:hasFacet name="minExclusive"/>
+        <hfp:hasProperty name="ordered" value="partial"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#gMonth"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+         <xs:whiteSpace value="collapse" fixed="true" id="gMonth.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+   <xs:simpleType name="hexBinary" id="hexBinary">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="length"/>
+        <hfp:hasFacet name="minLength"/>
+        <hfp:hasFacet name="maxLength"/>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasProperty name="ordered" value="false"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#binary"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="hexBinary.whiteSpace"/>
+    </xs:restriction>
+   </xs:simpleType>
+
+ <xs:simpleType name="base64Binary" id="base64Binary">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="length"/>
+        <hfp:hasFacet name="minLength"/>
+        <hfp:hasFacet name="maxLength"/>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasProperty name="ordered" value="false"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#base64Binary"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="base64Binary.whiteSpace"/>
+    </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="anyURI" id="anyURI">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="length"/>
+        <hfp:hasFacet name="minLength"/>
+        <hfp:hasFacet name="maxLength"/>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasProperty name="ordered" value="false"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#anyURI"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="anyURI.whiteSpace"/>
+    </xs:restriction>
+   </xs:simpleType>
+
+  <xs:simpleType name="QName" id="QName">
+    <xs:annotation>
+        <xs:appinfo>
+        <hfp:hasFacet name="length"/>
+        <hfp:hasFacet name="minLength"/>
+        <hfp:hasFacet name="maxLength"/>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasProperty name="ordered" value="false"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#QName"/>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="QName.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+   <xs:simpleType name="NOTATION" id="NOTATION">
+    <xs:annotation>
+        <xs:appinfo>
+        <hfp:hasFacet name="length"/>
+        <hfp:hasFacet name="minLength"/>
+        <hfp:hasFacet name="maxLength"/>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasProperty name="ordered" value="false"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#NOTATION"/>
+      <xs:documentation>
+        NOTATION cannot be used directly in a schema; rather a type
+        must be derived from it by specifying at least one enumeration
+        facet whose value is the name of a NOTATION declared in the
+        schema.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:anySimpleType">
+      <xs:whiteSpace value="collapse" fixed="true" id="NOTATION.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:annotation>
+    <xs:documentation>
+      Now the derived primitive types
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="normalizedString" id="normalizedString">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#normalizedString"/>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:whiteSpace value="replace" id="normalizedString.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="token" id="token">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#token"/>
+    </xs:annotation>
+    <xs:restriction base="xs:normalizedString">
+      <xs:whiteSpace value="collapse" id="token.whiteSpace"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="language" id="language">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#language"/>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:pattern value="[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*" id="language.pattern">
+        <xs:annotation>
+          <xs:documentation source="http://www.ietf.org/rfc/rfc3066.txt">
+            pattern specifies the content of section 2.12 of XML 1.0e2
+            and RFC 3066 (Revised version of RFC 1766).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:pattern>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="IDREFS" id="IDREFS">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="length"/>
+        <hfp:hasFacet name="minLength"/>
+        <hfp:hasFacet name="maxLength"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasProperty name="ordered" value="false"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#IDREFS"/>
+    </xs:annotation>
+    <xs:restriction>
+      <xs:simpleType>
+        <xs:list itemType="xs:IDREF"/>
+      </xs:simpleType>
+        <xs:minLength value="1" id="IDREFS.minLength"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ENTITIES" id="ENTITIES">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="length"/>
+        <hfp:hasFacet name="minLength"/>
+        <hfp:hasFacet name="maxLength"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasProperty name="ordered" value="false"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#ENTITIES"/>
+    </xs:annotation>
+    <xs:restriction>
+      <xs:simpleType>
+        <xs:list itemType="xs:ENTITY"/>
+      </xs:simpleType>
+        <xs:minLength value="1" id="ENTITIES.minLength"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="NMTOKEN" id="NMTOKEN">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#NMTOKEN"/>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:pattern value="\c+" id="NMTOKEN.pattern">
+        <xs:annotation>
+          <xs:documentation source="http://www.w3.org/TR/REC-xml#NT-Nmtoken">
+            pattern matches production 7 from the XML spec
+          </xs:documentation>
+        </xs:annotation>
+      </xs:pattern>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="NMTOKENS" id="NMTOKENS">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasFacet name="length"/>
+        <hfp:hasFacet name="minLength"/>
+        <hfp:hasFacet name="maxLength"/>
+        <hfp:hasFacet name="enumeration"/>
+        <hfp:hasFacet name="whiteSpace"/>
+        <hfp:hasFacet name="pattern"/>
+        <hfp:hasProperty name="ordered" value="false"/>
+        <hfp:hasProperty name="bounded" value="false"/>
+        <hfp:hasProperty name="cardinality" value="countably infinite"/>
+        <hfp:hasProperty name="numeric" value="false"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#NMTOKENS"/>
+    </xs:annotation>
+    <xs:restriction>
+      <xs:simpleType>
+        <xs:list itemType="xs:NMTOKEN"/>
+      </xs:simpleType>
+        <xs:minLength value="1" id="NMTOKENS.minLength"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Name" id="Name">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#Name"/>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:pattern value="\i\c*" id="Name.pattern">
+        <xs:annotation>
+          <xs:documentation source="http://www.w3.org/TR/REC-xml#NT-Name">
+            pattern matches production 5 from the XML spec
+          </xs:documentation>
+        </xs:annotation>
+      </xs:pattern>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="NCName" id="NCName">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#NCName"/>
+    </xs:annotation>
+    <xs:restriction base="xs:Name">
+      <xs:pattern value="[\i-[:]][\c-[:]]*" id="NCName.pattern">
+        <xs:annotation>
+          <xs:documentation source="http://www.w3.org/TR/REC-xml-names/#NT-NCName">
+            pattern matches production 4 from the Namespaces in XML spec
+          </xs:documentation>
+        </xs:annotation>
+      </xs:pattern>
+    </xs:restriction>
+  </xs:simpleType>
+
+   <xs:simpleType name="ID" id="ID">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#ID"/>
+    </xs:annotation>
+    <xs:restriction base="xs:NCName"/>
+   </xs:simpleType>
+
+   <xs:simpleType name="IDREF" id="IDREF">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#IDREF"/>
+    </xs:annotation>
+    <xs:restriction base="xs:NCName"/>
+   </xs:simpleType>
+
+   <xs:simpleType name="ENTITY" id="ENTITY">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#ENTITY"/>
+    </xs:annotation>
+    <xs:restriction base="xs:NCName"/>
+   </xs:simpleType>
+
+  <xs:simpleType name="integer" id="integer">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#integer"/>
+    </xs:annotation>
+    <xs:restriction base="xs:decimal">
+      <xs:fractionDigits value="0" fixed="true" id="integer.fractionDigits"/>
+      <xs:pattern value="[\-+]?[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="nonPositiveInteger" id="nonPositiveInteger">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#nonPositiveInteger"/>
+    </xs:annotation>
+    <xs:restriction base="xs:integer">
+      <xs:maxInclusive value="0" id="nonPositiveInteger.maxInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="negativeInteger" id="negativeInteger">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#negativeInteger"/>
+    </xs:annotation>
+    <xs:restriction base="xs:nonPositiveInteger">
+      <xs:maxInclusive value="-1" id="negativeInteger.maxInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="long" id="long">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasProperty name="bounded" value="true"/>
+        <hfp:hasProperty name="cardinality" value="finite"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#long"/>
+    </xs:annotation>
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="-9223372036854775808" id="long.minInclusive"/>
+      <xs:maxInclusive value="9223372036854775807" id="long.maxInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="int" id="int">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#int"/>
+    </xs:annotation>
+    <xs:restriction base="xs:long">
+      <xs:minInclusive value="-2147483648" id="int.minInclusive"/>
+      <xs:maxInclusive value="2147483647" id="int.maxInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="short" id="short">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#short"/>
+    </xs:annotation>
+    <xs:restriction base="xs:int">
+      <xs:minInclusive value="-32768" id="short.minInclusive"/>
+      <xs:maxInclusive value="32767" id="short.maxInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="byte" id="byte">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#byte"/>
+    </xs:annotation>
+    <xs:restriction base="xs:short">
+      <xs:minInclusive value="-128" id="byte.minInclusive"/>
+      <xs:maxInclusive value="127" id="byte.maxInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="nonNegativeInteger" id="nonNegativeInteger">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#nonNegativeInteger"/>
+    </xs:annotation>
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="0" id="nonNegativeInteger.minInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="unsignedLong" id="unsignedLong">
+    <xs:annotation>
+      <xs:appinfo>
+        <hfp:hasProperty name="bounded" value="true"/>
+        <hfp:hasProperty name="cardinality" value="finite"/>
+      </xs:appinfo>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#unsignedLong"/>
+    </xs:annotation>
+    <xs:restriction base="xs:nonNegativeInteger">
+      <xs:maxInclusive value="18446744073709551615" id="unsignedLong.maxInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="unsignedInt" id="unsignedInt">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#unsignedInt"/>
+    </xs:annotation>
+    <xs:restriction base="xs:unsignedLong">
+      <xs:maxInclusive value="4294967295" id="unsignedInt.maxInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="unsignedShort" id="unsignedShort">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#unsignedShort"/>
+    </xs:annotation>
+    <xs:restriction base="xs:unsignedInt">
+      <xs:maxInclusive value="65535" id="unsignedShort.maxInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="unsignedByte" id="unsignedByte">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#unsignedByte"/>
+    </xs:annotation>
+    <xs:restriction base="xs:unsignedShort">
+      <xs:maxInclusive value="255" id="unsignedByte.maxInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="positiveInteger" id="positiveInteger">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#positiveInteger"/>
+    </xs:annotation>
+    <xs:restriction base="xs:nonNegativeInteger">
+      <xs:minInclusive value="1" id="positiveInteger.minInclusive"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+ <xs:simpleType name="derivationControl">
+  <xs:annotation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:NMTOKEN">
+   <xs:enumeration value="substitution"/>
+   <xs:enumeration value="extension"/>
+   <xs:enumeration value="restriction"/>
+   <xs:enumeration value="list"/>
+   <xs:enumeration value="union"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+ <xs:group name="simpleDerivation">
+  <xs:choice>
+    <xs:element ref="xs:restriction"/>
+    <xs:element ref="xs:list"/>
+    <xs:element ref="xs:union"/>
+  </xs:choice>
+ </xs:group>
+
+ <xs:simpleType name="simpleDerivationSet">
+  <xs:annotation>
+   <xs:documentation>
+   #all or (possibly empty) subset of {restriction, union, list}
+   </xs:documentation>
+   <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+  </xs:annotation>
+  <xs:union>
+   <xs:simpleType>
+    <xs:restriction base="xs:token">
+     <xs:enumeration value="#all"/>
+    </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType>
+    <xs:list>
+     <xs:simpleType>
+      <xs:restriction base="xs:derivationControl">
+       <xs:enumeration value="list"/>
+       <xs:enumeration value="union"/>
+       <xs:enumeration value="restriction"/>
+      </xs:restriction>
+     </xs:simpleType>
+    </xs:list>
+   </xs:simpleType>
+  </xs:union>
+ </xs:simpleType>
+
+  <xs:complexType name="simpleType" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:group ref="xs:simpleDerivation"/>
+        <xs:attribute name="final" type="xs:simpleDerivationSet"/>
+        <xs:attribute name="name" type="xs:NCName">
+          <xs:annotation>
+            <xs:documentation>
+              Can be restricted to required or forbidden
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="topLevelSimpleType">
+    <xs:complexContent>
+      <xs:restriction base="xs:simpleType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:simpleDerivation"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:NCName">
+          <xs:annotation>
+            <xs:documentation>
+              Required at the top level
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+       <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="localSimpleType">
+    <xs:complexContent>
+      <xs:restriction base="xs:simpleType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:simpleDerivation"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="prohibited">
+          <xs:annotation>
+            <xs:documentation>
+              Forbidden when nested
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="final" use="prohibited"/>
+       <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="simpleType" type="xs:topLevelSimpleType" id="simpleType">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-simpleType"/>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:group name="facets">
+   <xs:annotation>
+    <xs:documentation>
+       We should use a substitution group for facets, but
+       that's ruled out because it would allow users to
+       add their own, which we're not ready for yet.
+    </xs:documentation>
+   </xs:annotation>
+   <xs:choice>
+    <xs:element ref="xs:minExclusive"/>
+    <xs:element ref="xs:minInclusive"/>
+    <xs:element ref="xs:maxExclusive"/>
+    <xs:element ref="xs:maxInclusive"/>
+    <xs:element ref="xs:totalDigits"/>
+    <xs:element ref="xs:fractionDigits"/>
+    <xs:element ref="xs:length"/>
+    <xs:element ref="xs:minLength"/>
+    <xs:element ref="xs:maxLength"/>
+    <xs:element ref="xs:enumeration"/>
+    <xs:element ref="xs:whiteSpace"/>
+    <xs:element ref="xs:pattern"/>
+   </xs:choice>
+  </xs:group>
+
+  <xs:group name="simpleRestrictionModel">
+   <xs:sequence>
+    <xs:element name="simpleType" type="xs:localSimpleType" minOccurs="0"/>
+    <xs:group ref="xs:facets" minOccurs="0" maxOccurs="unbounded"/>
+   </xs:sequence>
+  </xs:group>
+
+  <xs:element name="restriction" id="restriction">
+   <xs:complexType>
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-restriction">
+          base attribute and simpleType child are mutually
+          exclusive, but one or other is required
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+         <xs:group ref="xs:simpleRestrictionModel"/>
+         <xs:attribute name="base" type="xs:QName" use="optional"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="list" id="list">
+   <xs:complexType>
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-list">
+          itemType attribute and simpleType child are mutually
+          exclusive, but one or other is required
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:sequence>
+            <xs:element name="simpleType" type="xs:localSimpleType" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="itemType" type="xs:QName" use="optional"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="union" id="union">
+   <xs:complexType>
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-union">
+          memberTypes attribute must be non-empty or there must be
+          at least one simpleType child
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:sequence>
+            <xs:element name="simpleType" type="xs:localSimpleType" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="memberTypes" use="optional">
+            <xs:simpleType>
+              <xs:list itemType="xs:QName"/>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="facet">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:attribute name="value" use="required"/>
+        <xs:attribute name="fixed" type="xs:boolean" use="optional" default="false"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+ <xs:complexType name="noFixedFacet">
+  <xs:complexContent>
+   <xs:restriction base="xs:facet">
+    <xs:sequence>
+     <xs:element ref="xs:annotation" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="fixed" use="prohibited"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:restriction>
+  </xs:complexContent>
+ </xs:complexType>
+
+  <xs:element name="minExclusive" id="minExclusive" type="xs:facet">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-minExclusive"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="minInclusive" id="minInclusive" type="xs:facet">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-minInclusive"/>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="maxExclusive" id="maxExclusive" type="xs:facet">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-maxExclusive"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="maxInclusive" id="maxInclusive" type="xs:facet">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-maxInclusive"/>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:complexType name="numFacet">
+    <xs:complexContent>
+      <xs:restriction base="xs:facet">
+       <xs:sequence>
+         <xs:element ref="xs:annotation" minOccurs="0"/>
+       </xs:sequence>
+       <xs:attribute name="value" type="xs:nonNegativeInteger" use="required"/>
+       <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="totalDigits" id="totalDigits">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-totalDigits"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:restriction base="xs:numFacet">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="value" type="xs:positiveInteger" use="required"/>
+         <xs:anyAttribute namespace="##other" processContents="lax"/>
+        </xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fractionDigits" id="fractionDigits" type="xs:numFacet">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-fractionDigits"/>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="length" id="length" type="xs:numFacet">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-length"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="minLength" id="minLength" type="xs:numFacet">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-minLength"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="maxLength" id="maxLength" type="xs:numFacet">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-maxLength"/>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="enumeration" id="enumeration" type="xs:noFixedFacet">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-enumeration"/>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="whiteSpace" id="whiteSpace">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-whiteSpace"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:restriction base="xs:facet">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="value" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:NMTOKEN">
+                <xs:enumeration value="preserve"/>
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="collapse"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+         <xs:anyAttribute namespace="##other" processContents="lax"/>
+        </xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="pattern" id="pattern">
+    <xs:annotation>
+      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#element-pattern"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:restriction base="xs:noFixedFacet">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+         <xs:anyAttribute namespace="##other" processContents="lax"/>
+        </xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml10/xhtml1-frameset.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml10/xhtml1-frameset.xsd
@@ -1,0 +1,2847 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema version="1.0" xml:lang="en"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://www.w3.org/1999/xhtml"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    elementFormDefault="qualified">
+
+  <xs:annotation>
+    <xs:documentation>
+    XHTML 1.0 (Second Edition) Frameset in XML Schema
+
+    This is the same as HTML 4 Frameset except for
+    changes due to the differences between XML and SGML.
+
+    Namespace = http://www.w3.org/1999/xhtml
+
+    For further information, see: http://www.w3.org/TR/xhtml1
+
+    Copyright (c) 1998-2002 W3C (MIT, INRIA, Keio),
+    All Rights Reserved. 
+
+    The DTD version is identified by the PUBLIC and SYSTEM identifiers:
+
+    PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd"
+
+    $Id: xhtml1-frameset.xsd,v 1.5 2002/08/28 09:53:29 mimasa Exp $
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Character mnemonic entities =========================
+
+    XHTML entity sets are identified by the PUBLIC and SYSTEM identifiers:
+  
+    PUBLIC "-//W3C//ENTITIES Latin 1 for XHTML//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent"
+
+    PUBLIC "-//W3C//ENTITIES Special for XHTML//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent"
+
+    PUBLIC "-//W3C//ENTITIES Symbols for XHTML//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent"
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Imported Names ====================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="ContentType">
+    <xs:annotation>
+      <xs:documentation>
+      media type, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="ContentTypes">
+    <xs:annotation>
+      <xs:documentation>
+      comma-separated list of media types, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Charset">
+    <xs:annotation>
+      <xs:documentation>
+      a character encoding, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Charsets">
+    <xs:annotation>
+      <xs:documentation>
+      a space separated list of character encodings, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="LanguageCode">
+    <xs:annotation>
+      <xs:documentation>
+      a language code, as per [RFC3066]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:language"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Character">
+    <xs:annotation>
+      <xs:documentation>
+      a single character, as per section 2.2 of [XML]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:length value="1" fixed="true"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Number">
+    <xs:annotation>
+      <xs:documentation>
+      one or more digits
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:nonNegativeInteger">
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="tabindexNumber">
+    <xs:annotation>
+      <xs:documentation>
+      tabindex attribute specifies the position of the current element
+      in the tabbing order for the current document. This value must be
+      a number between 0 and 32767. User agents should ignore leading zeros. 
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="Number">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="32767"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="LinkTypes">
+    <xs:annotation>
+      <xs:documentation>
+      space-separated list of link types
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKENS"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="MediaDesc">
+    <xs:annotation>
+      <xs:documentation>
+      single or comma-separated list of media descriptors
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^,]+(,\s*[^,]+)*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="URI">
+    <xs:annotation>
+      <xs:documentation>
+      a Uniform Resource Identifier, see [RFC2396]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:anyURI"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="UriList">
+    <xs:annotation>
+      <xs:documentation>
+      a space separated list of Uniform Resource Identifiers
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Datetime">
+    <xs:annotation>
+      <xs:documentation>
+      date and time information. ISO date format
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:dateTime"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Script">
+    <xs:annotation>
+      <xs:documentation>
+      script expression
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="StyleSheet">
+    <xs:annotation>
+      <xs:documentation>
+      style sheet data
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Text">
+    <xs:annotation>
+      <xs:documentation>
+      used for titles etc.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="FrameTarget">
+    <xs:annotation>
+      <xs:documentation>
+      render in this frame
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:pattern value="_(blank|self|parent|top)|[A-Za-z]\c*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Length">
+    <xs:annotation>
+      <xs:documentation>
+      nn for pixels or nn% for percentage length
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[-+]?(\d+|\d+(\.\d+)?%)"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="MultiLength">
+    <xs:annotation>
+      <xs:documentation>
+      pixel, percentage, or relative
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[-+]?(\d+|\d+(\.\d+)?%)|[1-9]?(\d+)?\*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="MultiLengths">
+    <xs:annotation>
+      <xs:documentation>
+      comma-separated list of MultiLength
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern
+          value="[-+]?(\d+|\d+(\.\d+)?%)|[1-9]?(\d+)?\*(,\s*[-+]?(\d+|\d+(\.\d+)?%)|[1-9]?(\d+)?\*)*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Pixels">
+    <xs:annotation>
+      <xs:documentation>
+      integer representing length in pixels
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:nonNegativeInteger"/>
+  </xs:simpleType>
+
+  <xs:annotation>
+    <xs:documentation>
+    these are used for image maps
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="Shape">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="rect"/>
+      <xs:enumeration value="circle"/>
+      <xs:enumeration value="poly"/>
+      <xs:enumeration value="default"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Coords">
+    <xs:annotation>
+      <xs:documentation>
+      comma separated list of lengths
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern
+          value="[-+]?(\d+|\d+(\.\d+)?%)(,\s*[-+]?(\d+|\d+(\.\d+)?%))*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ImgAlign">
+    <xs:annotation>
+      <xs:documentation>
+      used for object, applet, img, input and iframe
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="top"/>
+      <xs:enumeration value="middle"/>
+      <xs:enumeration value="bottom"/>
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="right"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Color">
+    <xs:annotation>
+      <xs:documentation>
+      a color using sRGB: #RRGGBB as Hex values
+
+      There are also 16 widely known color names with their sRGB values:
+
+      Black  = #000000    Green  = #008000
+      Silver = #C0C0C0    Lime   = #00FF00
+      Gray   = #808080    Olive  = #808000
+      White  = #FFFFFF    Yellow = #FFFF00
+      Maroon = #800000    Navy   = #000080
+      Red    = #FF0000    Blue   = #0000FF
+      Purple = #800080    Teal   = #008080
+      Fuchsia= #FF00FF    Aqua   = #00FFFF
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[A-Za-z]+|#[0-9A-Fa-f]{3}|#[0-9A-Fa-f]{6}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Generic Attributes ===============================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attributeGroup name="coreattrs">
+    <xs:annotation>
+      <xs:documentation>
+      core attributes common to most elements
+      id       document-wide unique id
+      class    space separated list of classes
+      style    associated style info
+      title    advisory title/amplification
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="id" type="xs:ID"/>
+    <xs:attribute name="class" type="xs:NMTOKENS"/>
+    <xs:attribute name="style" type="StyleSheet"/>
+    <xs:attribute name="title" type="Text"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="i18n">
+    <xs:annotation>
+      <xs:documentation>
+      internationalization attributes
+      lang        language code (backwards compatible)
+      xml:lang    language code (as per XML 1.0 spec)
+      dir         direction for weak/neutral text
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="lang" type="LanguageCode"/>
+    <xs:attribute ref="xml:lang"/>
+    <xs:attribute name="dir">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="ltr"/>
+          <xs:enumeration value="rtl"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="events">
+    <xs:annotation>
+      <xs:documentation>
+      attributes for common UI events
+      onclick     a pointer button was clicked
+      ondblclick  a pointer button was double clicked
+      onmousedown a pointer button was pressed down
+      onmouseup   a pointer button was released
+      onmousemove a pointer was moved onto the element
+      onmouseout  a pointer was moved away from the element
+      onkeypress  a key was pressed and released
+      onkeydown   a key was pressed down
+      onkeyup     a key was released
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="onclick" type="Script"/>
+    <xs:attribute name="ondblclick" type="Script"/>
+    <xs:attribute name="onmousedown" type="Script"/>
+    <xs:attribute name="onmouseup" type="Script"/>
+    <xs:attribute name="onmouseover" type="Script"/>
+    <xs:attribute name="onmousemove" type="Script"/>
+    <xs:attribute name="onmouseout" type="Script"/>
+    <xs:attribute name="onkeypress" type="Script"/>
+    <xs:attribute name="onkeydown" type="Script"/>
+    <xs:attribute name="onkeyup" type="Script"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="focus">
+    <xs:annotation>
+      <xs:documentation>
+      attributes for elements that can get the focus
+      accesskey   accessibility key character
+      tabindex    position in tabbing order
+      onfocus     the element got the focus
+      onblur      the element lost the focus
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="accesskey" type="Character"/>
+    <xs:attribute name="tabindex" type="tabindexNumber"/>
+    <xs:attribute name="onfocus" type="Script"/>
+    <xs:attribute name="onblur" type="Script"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="attrs">
+    <xs:attributeGroup ref="coreattrs"/>
+    <xs:attributeGroup ref="i18n"/>
+    <xs:attributeGroup ref="events"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="TextAlign">
+    <xs:annotation>
+      <xs:documentation>
+      text alignment for p, div, h1-h6. The default is
+      align="left" for ltr headings, "right" for rtl
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="align">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="left"/>
+          <xs:enumeration value="center"/>
+          <xs:enumeration value="right"/>
+          <xs:enumeration value="justify"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Text Elements ====================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:group name="special.extra">
+    <xs:choice>
+      <xs:element ref="object"/>
+      <xs:element ref="applet"/>
+      <xs:element ref="img"/>
+      <xs:element ref="map"/>
+      <xs:element ref="iframe"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="special.basic">
+    <xs:choice>
+      <xs:element ref="br"/>
+      <xs:element ref="span"/>
+      <xs:element ref="bdo"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="special">
+    <xs:choice>
+      <xs:group ref="special.basic"/>
+      <xs:group ref="special.extra"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="fontstyle.extra">
+    <xs:choice>
+      <xs:element ref="big"/>
+      <xs:element ref="small"/>
+      <xs:element ref="font"/>
+      <xs:element ref="basefont"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="fontstyle.basic">
+    <xs:choice>
+      <xs:element ref="tt"/>
+      <xs:element ref="i"/>
+      <xs:element ref="b"/>
+      <xs:element ref="u"/>
+      <xs:element ref="s"/>
+      <xs:element ref="strike"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="fontstyle">
+    <xs:choice>
+      <xs:group ref="fontstyle.basic"/>
+      <xs:group ref="fontstyle.extra"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="phrase.extra">
+    <xs:choice>
+      <xs:element ref="sub"/>
+      <xs:element ref="sup"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="phrase.basic">
+    <xs:choice>
+      <xs:element ref="em"/>
+      <xs:element ref="strong"/>
+      <xs:element ref="dfn"/>
+      <xs:element ref="code"/>
+      <xs:element ref="q"/>
+      <xs:element ref="samp"/>
+      <xs:element ref="kbd"/>
+      <xs:element ref="var"/>
+      <xs:element ref="cite"/>
+      <xs:element ref="abbr"/>
+      <xs:element ref="acronym"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="phrase">
+    <xs:choice>
+      <xs:group ref="phrase.basic"/>
+      <xs:group ref="phrase.extra"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="inline.forms">
+    <xs:choice>
+      <xs:element ref="input"/>
+      <xs:element ref="select"/>
+      <xs:element ref="textarea"/>
+      <xs:element ref="label"/>
+      <xs:element ref="button"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="misc.inline">
+    <xs:annotation>
+      <xs:documentation>
+      these can only occur at block level
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element ref="ins"/>
+      <xs:element ref="del"/>
+      <xs:element ref="script"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="misc">
+    <xs:annotation>
+      <xs:documentation>
+      these can only occur at block level
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element ref="noscript"/>
+      <xs:group ref="misc.inline"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="inline">
+    <xs:choice>
+      <xs:element ref="a"/>
+      <xs:group ref="special"/>
+      <xs:group ref="fontstyle"/>
+      <xs:group ref="phrase"/>
+      <xs:group ref="inline.forms"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:complexType name="Inline" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      "Inline" covers inline or "text-level" element
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="inline"/>
+      <xs:group ref="misc.inline"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Block level elements ==============================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:group name="heading">
+    <xs:choice>
+      <xs:element ref="h1"/>
+      <xs:element ref="h2"/>
+      <xs:element ref="h3"/>
+      <xs:element ref="h4"/>
+      <xs:element ref="h5"/>
+      <xs:element ref="h6"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="lists">
+    <xs:choice>
+      <xs:element ref="ul"/>
+      <xs:element ref="ol"/>
+      <xs:element ref="dl"/>
+      <xs:element ref="menu"/>
+      <xs:element ref="dir"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="blocktext">
+    <xs:choice>
+      <xs:element ref="pre"/>
+      <xs:element ref="hr"/>
+      <xs:element ref="blockquote"/>
+      <xs:element ref="address"/>
+      <xs:element ref="center"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="block">
+    <xs:choice>
+      <xs:element ref="p"/>
+      <xs:group ref="heading"/>
+      <xs:element ref="div"/>
+      <xs:group ref="lists"/>
+      <xs:group ref="blocktext"/>
+      <xs:element ref="isindex"/>
+      <xs:element ref="fieldset"/>
+      <xs:element ref="table"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:complexType name="Flow" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      "Flow" mixes block and inline and is used for list items etc.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="block"/>
+      <xs:element ref="form"/>
+      <xs:group ref="inline"/>
+      <xs:group ref="misc"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Content models for exclusions =====================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:complexType name="a.content" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      a elements use "Inline" excluding a
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="special"/>
+      <xs:group ref="fontstyle"/>
+      <xs:group ref="phrase"/>
+      <xs:group ref="inline.forms"/>
+      <xs:group ref="misc.inline"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="pre.content" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      pre uses "Inline" excluding img, object, applet, big, small,
+      sub, sup, font, or basefont
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="a"/>
+      <xs:group ref="special.basic"/>
+      <xs:group ref="fontstyle.basic"/>
+      <xs:group ref="phrase.basic"/>
+      <xs:group ref="inline.forms"/>
+      <xs:group ref="misc.inline"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="form.content" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      form uses "Flow" excluding form
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="block"/>
+      <xs:group ref="inline"/>
+      <xs:group ref="misc"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="button.content" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      button uses "Flow" but excludes a, form, form controls, iframe
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="p"/>
+      <xs:group ref="heading"/>
+      <xs:element ref="div"/>
+      <xs:group ref="lists"/>
+      <xs:group ref="blocktext"/>
+      <xs:element ref="table"/>
+      <xs:element ref="br"/>
+      <xs:element ref="span"/>
+      <xs:element ref="bdo"/>
+      <xs:element ref="object"/>
+      <xs:element ref="applet"/>
+      <xs:element ref="img"/>
+      <xs:element ref="map"/>
+      <xs:group ref="fontstyle"/>
+      <xs:group ref="phrase"/>
+      <xs:group ref="misc"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Document Structure ==================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="html">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="head"/>
+        <xs:element ref="frameset"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Document Head =======================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:group name="head.misc">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="script"/>
+        <xs:element ref="style"/>
+        <xs:element ref="meta"/>
+        <xs:element ref="link"/>
+        <xs:element ref="object"/>
+        <xs:element ref="isindex"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:element name="head">
+    <xs:annotation>
+      <xs:documentation>
+      content model is "head.misc" combined with a single
+      title and an optional base element in any order
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:group ref="head.misc"/>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element ref="title"/>
+            <xs:group ref="head.misc"/>
+            <xs:sequence minOccurs="0">
+              <xs:element ref="base"/>
+              <xs:group ref="head.misc"/>
+            </xs:sequence>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element ref="base"/>
+            <xs:group ref="head.misc"/>
+            <xs:element ref="title"/>
+            <xs:group ref="head.misc"/>
+          </xs:sequence>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="profile" type="URI"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="title">
+    <xs:annotation>
+      <xs:documentation>
+      The title element is not considered part of the flow of text.
+      It should be displayed, for example as the page header or
+      window title. Exactly one title is required per document.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="base">
+    <xs:annotation>
+      <xs:documentation>
+      document base URI
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="href" type="URI"/>
+      <xs:attribute name="target" type="FrameTarget"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="meta">
+    <xs:annotation>
+      <xs:documentation>
+      generic metainformation
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="http-equiv"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="content" use="required"/>
+      <xs:attribute name="scheme"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="link">
+    <xs:annotation>
+      <xs:documentation>
+      Relationship values can be used in principle:
+
+      a) for document specific toolbars/menus when used
+         with the link element in document head e.g.
+           start, contents, previous, next, index, end, help
+      b) to link to a separate style sheet (rel="stylesheet")
+      c) to make a link to a script (rel="script")
+      d) by stylesheets to control how collections of
+         html nodes are rendered into printed documents
+      e) to make a link to a printable version of this document
+         e.g. a PostScript or PDF version (rel="alternate" media="print")
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="charset" type="Charset"/>
+      <xs:attribute name="href" type="URI"/>
+      <xs:attribute name="hreflang" type="LanguageCode"/>
+      <xs:attribute name="type" type="ContentType"/>
+      <xs:attribute name="rel" type="LinkTypes"/>
+      <xs:attribute name="rev" type="LinkTypes"/>
+      <xs:attribute name="media" type="MediaDesc"/>
+      <xs:attribute name="target" type="FrameTarget"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="style">
+    <xs:annotation>
+      <xs:documentation>
+      style info, which may include CDATA sections
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="type" use="required" type="ContentType"/>
+      <xs:attribute name="media" type="MediaDesc"/>
+      <xs:attribute name="title" type="Text"/>
+      <xs:attribute ref="xml:space" fixed="preserve"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="script">
+    <xs:annotation>
+      <xs:documentation>
+      script statements, which may include CDATA sections
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="charset" type="Charset"/>
+      <xs:attribute name="type" use="required" type="ContentType"/>
+      <xs:attribute name="language"/>
+      <xs:attribute name="src" type="URI"/>
+      <xs:attribute name="defer">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="defer"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="xml:space" fixed="preserve"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="noscript">
+    <xs:annotation>
+      <xs:documentation>
+      alternate content container for non script-based rendering
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ======================= Frames =======================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="frameset">
+    <xs:annotation>
+      <xs:documentation>
+      only one noframes element permitted per document
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="frameset"/>
+        <xs:element ref="frame"/>
+        <xs:element ref="noframes"/>
+      </xs:choice>
+      <xs:attributeGroup ref="coreattrs"/>
+      <xs:attribute name="rows" type="MultiLengths"/>
+      <xs:attribute name="cols" type="MultiLengths"/>
+      <xs:attribute name="onload" type="Script"/>
+      <xs:attribute name="onunload" type="Script"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    reserved frame names start with "_" otherwise starts with letter
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="frame">
+    <xs:annotation>
+      <xs:documentation>
+      tiled window within frameset
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="coreattrs"/>
+      <xs:attribute name="longdesc" type="URI"/>
+      <xs:attribute name="name" type="xs:NMTOKEN"/>
+      <xs:attribute name="src" type="URI"/>
+      <xs:attribute name="frameborder" default="1">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="marginwidth" type="Pixels"/>
+      <xs:attribute name="marginheight" type="Pixels"/>
+      <xs:attribute name="noresize">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="noresize"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="scrolling" default="auto">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+            <xs:enumeration value="auto"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="iframe">
+    <xs:annotation>
+      <xs:documentation>
+      inline subwindow
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="coreattrs"/>
+          <xs:attribute name="longdesc" type="URI"/>
+          <xs:attribute name="name" type="xs:NMTOKEN"/>
+          <xs:attribute name="src" type="URI"/>
+          <xs:attribute name="frameborder" default="1">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="1"/>
+                <xs:enumeration value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="marginwidth" type="Pixels"/>
+          <xs:attribute name="marginheight" type="Pixels"/>
+          <xs:attribute name="scrolling" default="auto">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="yes"/>
+                <xs:enumeration value="no"/>
+                <xs:enumeration value="auto"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="align" type="ImgAlign"/>
+          <xs:attribute name="height" type="Length"/>
+          <xs:attribute name="width" type="Length"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+<!--
+  <xs:element name="noframes">
+    <xs:annotation>
+      <xs:documentation>
+      alternate content container for non frame-based rendering
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="body">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+-->
+  <xs:element name="noframes">
+    <xs:annotation>
+      <xs:documentation>
+      alternate content container for non frame-based rendering
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="body"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Document Body ====================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="body">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="onload" type="Script"/>
+          <xs:attribute name="onunload" type="Script"/>
+          <xs:attribute name="background" type="URI"/>
+          <xs:attribute name="bgcolor" type="Color"/>
+          <xs:attribute name="text" type="Color"/>
+          <xs:attribute name="link" type="Color"/>
+          <xs:attribute name="vlink" type="Color"/>
+          <xs:attribute name="alink" type="Color"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="div">
+    <xs:annotation>
+      <xs:documentation>
+      generic language/style container      
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Paragraphs =======================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="p">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Headings =========================================
+
+    There are six levels of headings from h1 (the most important)
+    to h6 (the least important).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="h1">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h2">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h3">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h4">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h5">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h6">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Lists ============================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="ULStyle">
+    <xs:annotation>
+      <xs:documentation>
+      Unordered list bullet styles
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="disc"/>
+      <xs:enumeration value="square"/>
+      <xs:enumeration value="circle"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="ul">
+    <xs:annotation>
+      <xs:documentation>
+      Unordered list
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="li"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="type" type="ULStyle"/>
+      <xs:attribute name="compact">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="OLStyle">
+    <xs:annotation>
+      <xs:documentation>
+      Ordered list numbering style
+
+      1   arabic numbers      1, 2, 3, ...
+      a   lower alpha         a, b, c, ...
+      A   upper alpha         A, B, C, ...
+      i   lower roman         i, ii, iii, ...
+      I   upper roman         I, II, III, ...
+
+      The style is applied to the sequence number which by default
+      is reset to 1 for the first list item in an ordered list.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:element name="ol">
+    <xs:annotation>
+      <xs:documentation>
+      Ordered (numbered) list
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="li"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="type" type="OLStyle"/>
+      <xs:attribute name="compact">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="start" type="Number"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="menu">
+    <xs:annotation>
+      <xs:documentation>
+      single column list (DEPRECATED)
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="li"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="compact">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dir">
+    <xs:annotation>
+      <xs:documentation>
+      multiple column list (DEPRECATED)
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="li"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="compact">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="LIStyle">
+    <xs:annotation>
+      <xs:documentation>
+      LIStyle is constrained to: "(ULStyle|OLStyle)"
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:element name="li">
+    <xs:annotation>
+      <xs:documentation>
+      list item
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="type" type="LIStyle"/>
+          <xs:attribute name="value" type="Number"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    definition lists - dt for term, dd for its definition
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="dl">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="dt"/>
+        <xs:element ref="dd"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="compact">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dt">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dd">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Address ==========================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="address">
+    <xs:annotation>
+      <xs:documentation>
+      information on author
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="inline"/>
+        <xs:group ref="misc.inline"/>
+        <xs:element ref="p"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Horizontal Rule ==================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="hr">
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="noshade">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="noshade"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="size" type="Pixels"/>
+      <xs:attribute name="width" type="Length"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Preformatted Text ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="pre">
+    <xs:annotation>
+      <xs:documentation>
+      content is "Inline" excluding 
+         "img|object|applet|big|small|sub|sup|font|basefont"
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="pre.content">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="width" type="Number"/>
+          <xs:attribute ref="xml:space" fixed="preserve"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Block-like Quotes ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="blockquote">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Text alignment ===================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="center">
+    <xs:annotation>
+      <xs:documentation>
+      center content
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Inserted/Deleted Text ============================
+
+    ins/del are allowed in block and inline content, but its
+    inappropriate to include block content within an ins element
+    occurring in inline content.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="ins">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+          <xs:attribute name="datetime" type="Datetime"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="del">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+          <xs:attribute name="datetime" type="Datetime"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== The Anchor Element ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="a">
+    <xs:annotation>
+      <xs:documentation>
+      content is "Inline" except that anchors shouldn't be nested
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="a.content">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="focus"/>
+          <xs:attribute name="charset" type="Charset"/>
+          <xs:attribute name="type" type="ContentType"/>
+          <xs:attribute name="name" type="xs:NMTOKEN"/>
+          <xs:attribute name="href" type="URI"/>
+          <xs:attribute name="hreflang" type="LanguageCode"/>
+          <xs:attribute name="rel" type="LinkTypes"/>
+          <xs:attribute name="rev" type="LinkTypes"/>
+          <xs:attribute name="shape" default="rect" type="Shape"/>
+          <xs:attribute name="coords" type="Coords"/>
+          <xs:attribute name="target" type="FrameTarget"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ===================== Inline Elements ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="span">
+    <xs:annotation>
+      <xs:documentation>
+      generic language/style container
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="bdo">
+    <xs:annotation>
+      <xs:documentation>
+      I18N BiDi over-ride
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="coreattrs"/>
+          <xs:attributeGroup ref="events"/>
+          <xs:attribute name="lang" type="LanguageCode"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="dir" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="ltr"/>
+                <xs:enumeration value="rtl"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="br">
+    <xs:annotation>
+      <xs:documentation>
+      forced line break
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="coreattrs"/>
+      <xs:attribute name="clear" default="none">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="all"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="none"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="em">
+    <xs:annotation>
+      <xs:documentation>
+      emphasis
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="strong">
+    <xs:annotation>
+      <xs:documentation>
+      strong emphasis
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dfn">
+    <xs:annotation>
+      <xs:documentation>
+      definitional
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="code">
+    <xs:annotation>
+      <xs:documentation>
+      program code
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="samp">
+    <xs:annotation>
+      <xs:documentation>
+      sample
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="kbd">
+    <xs:annotation>
+      <xs:documentation>
+      something user would type
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="var">
+    <xs:annotation>
+      <xs:documentation>
+      variable
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="cite">
+    <xs:annotation>
+      <xs:documentation>
+      citation
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="abbr">
+    <xs:annotation>
+      <xs:documentation>
+      abbreviation
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="acronym">
+    <xs:annotation>
+      <xs:documentation>
+      acronym
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="q">
+    <xs:annotation>
+      <xs:documentation>
+      inlined quote
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sub">
+    <xs:annotation>
+      <xs:documentation>
+      subscript
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sup">
+    <xs:annotation>
+      <xs:documentation>
+      superscript
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tt">
+    <xs:annotation>
+      <xs:documentation>
+      fixed pitch font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="i">
+    <xs:annotation>
+      <xs:documentation>
+      italic font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="b">
+    <xs:annotation>
+      <xs:documentation>
+      bold font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="big">
+    <xs:annotation>
+      <xs:documentation>
+      bigger font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="small">
+    <xs:annotation>
+      <xs:documentation>
+      smaller font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="u">
+    <xs:annotation>
+      <xs:documentation>
+      underline
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="s">
+    <xs:annotation>
+      <xs:documentation>
+      strike-through
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="strike">
+    <xs:annotation>
+      <xs:documentation>
+      strike-through
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="basefont">
+    <xs:annotation>
+      <xs:documentation>
+      base font size
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="size" use="required"/>
+      <xs:attribute name="color" type="Color"/>
+      <xs:attribute name="face"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="font">
+    <xs:annotation>
+      <xs:documentation>
+      local change to font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="coreattrs"/>
+          <xs:attributeGroup ref="i18n"/>
+          <xs:attribute name="size"/>
+          <xs:attribute name="color" type="Color"/>
+          <xs:attribute name="face"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ==================== Object ======================================
+
+    object is used to embed objects as part of HTML pages.
+    param elements should precede other content. Parameters
+    can also be expressed as attribute/value pairs on the
+    object element itself when brevity is desired.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="object">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="param"/>
+        <xs:group ref="block"/>
+        <xs:element ref="form"/>
+        <xs:group ref="inline"/>
+        <xs:group ref="misc"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="declare">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="declare"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="classid" type="URI"/>
+      <xs:attribute name="codebase" type="URI"/>
+      <xs:attribute name="data" type="URI"/>
+      <xs:attribute name="type" type="ContentType"/>
+      <xs:attribute name="codetype" type="ContentType"/>
+      <xs:attribute name="archive" type="UriList"/>
+      <xs:attribute name="standby" type="Text"/>
+      <xs:attribute name="height" type="Length"/>
+      <xs:attribute name="width" type="Length"/>
+      <xs:attribute name="usemap" type="URI"/>
+      <xs:attribute name="name" type="xs:NMTOKEN"/>
+      <xs:attribute name="tabindex" type="Number"/>
+      <xs:attribute name="align" type="ImgAlign"/>
+      <xs:attribute name="border" type="Pixels"/>
+      <xs:attribute name="hspace" type="Pixels"/>
+      <xs:attribute name="vspace" type="Pixels"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="param">
+    <xs:annotation>
+      <xs:documentation>
+      param is used to supply a named property value.
+      In XML it would seem natural to follow RDF and support an
+      abbreviated syntax where the param elements are replaced
+      by attribute value pairs on the object start tag.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="name" use="required"/>
+      <xs:attribute name="value"/>
+      <xs:attribute name="valuetype" default="data">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="data"/>
+            <xs:enumeration value="ref"/>
+            <xs:enumeration value="object"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="type" type="ContentType"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Java applet ==================================
+
+    One of code or object attributes must be present.
+    Place param elements before other content.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="applet">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="param"/>
+        <xs:group ref="block"/>
+        <xs:element ref="form"/>
+        <xs:group ref="inline"/>
+        <xs:group ref="misc"/>
+      </xs:choice>
+      <xs:attributeGroup ref="coreattrs"/>
+      <xs:attribute name="codebase" type="URI"/>
+      <xs:attribute name="archive"/>
+      <xs:attribute name="code"/>
+      <xs:attribute name="object"/>
+      <xs:attribute name="alt" type="Text"/>
+      <xs:attribute name="name" type="xs:NMTOKEN"/>
+      <xs:attribute name="width" use="required" type="Length"/>
+      <xs:attribute name="height" use="required" type="Length"/>
+      <xs:attribute name="align" type="ImgAlign"/>
+      <xs:attribute name="hspace" type="Pixels"/>
+      <xs:attribute name="vspace" type="Pixels"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Images ===========================================
+
+    To avoid accessibility problems for people who aren't
+    able to see the image, you should provide a text
+    description using the alt and longdesc attributes.
+    In addition, avoid the use of server-side image maps.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="img">
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="src" use="required" type="URI"/>
+      <xs:attribute name="alt" use="required" type="Text"/>
+      <xs:attribute name="name" type="xs:NMTOKEN"/>
+      <xs:attribute name="longdesc" type="URI"/>
+      <xs:attribute name="height" type="Length"/>
+      <xs:attribute name="width" type="Length"/>
+      <xs:attribute name="usemap" type="URI">
+	<xs:annotation>
+	  <xs:documentation>
+          usemap points to a map element which may be in this document
+          or an external document, although the latter is not widely supported
+          </xs:documentation>
+	</xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ismap">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="ismap"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align" type="ImgAlign"/>
+      <xs:attribute name="border" type="Length"/>
+      <xs:attribute name="hspace" type="Pixels"/>
+      <xs:attribute name="vspace" type="Pixels"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Client-side image maps ============================
+
+    These can be placed in the same document or grouped in a
+    separate document although this isn't yet widely supported
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="map">
+    <xs:complexType>
+      <xs:choice>
+        <xs:choice maxOccurs="unbounded">
+          <xs:group ref="block"/>
+          <xs:element ref="form"/>
+          <xs:group ref="misc"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="area"/>
+      </xs:choice>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attributeGroup ref="events"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style" type="StyleSheet"/>
+      <xs:attribute name="title" type="Text"/>
+      <xs:attribute name="name"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="area">
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="focus"/>
+      <xs:attribute name="shape" default="rect" type="Shape"/>
+      <xs:attribute name="coords" type="Coords"/>
+      <xs:attribute name="href" type="URI"/>
+      <xs:attribute name="nohref">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="nohref"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" use="required" type="Text"/>
+      <xs:attribute name="target" type="FrameTarget"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Forms ===============================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="form">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="form.content">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="action" use="required" type="URI"/>
+          <xs:attribute name="method" default="get">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="get"/>
+                <xs:enumeration value="post"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="enctype" type="ContentType"
+              default="application/x-www-form-urlencoded"/>
+          <xs:attribute name="onsubmit" type="Script"/>
+          <xs:attribute name="onreset" type="Script"/>
+          <xs:attribute name="accept" type="ContentTypes"/>
+          <xs:attribute name="accept-charset" type="Charsets"/>
+          <xs:attribute name="target" type="FrameTarget"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="label">
+    <xs:annotation>
+      <xs:documentation>
+      Each label must not contain more than ONE field
+      Label elements shouldn't be nested.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="for" type="xs:IDREF"/>
+          <xs:attribute name="accesskey" type="Character"/>
+          <xs:attribute name="onfocus" type="Script"/>
+          <xs:attribute name="onblur" type="Script"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="InputType">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="text"/>
+      <xs:enumeration value="password"/>
+      <xs:enumeration value="checkbox"/>
+      <xs:enumeration value="radio"/>
+      <xs:enumeration value="submit"/>
+      <xs:enumeration value="reset"/>
+      <xs:enumeration value="file"/>
+      <xs:enumeration value="hidden"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="button"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="input">
+    <xs:annotation>
+      <xs:documentation>
+      form control
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="focus"/>
+      <xs:attribute name="type" default="text" type="InputType"/>
+      <xs:attribute name="name">
+	<xs:annotation>
+	  <xs:documentation>
+          the name attribute is required for all but submit &amp; reset
+          </xs:documentation>
+	</xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="value"/>
+      <xs:attribute name="checked">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="checked"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="readonly">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="readonly"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="size"/>
+      <xs:attribute name="maxlength" type="Number"/>
+      <xs:attribute name="src" type="URI"/>
+      <xs:attribute name="alt"/>
+      <xs:attribute name="usemap" type="URI"/>
+      <xs:attribute name="onselect" type="Script"/>
+      <xs:attribute name="onchange" type="Script"/>
+      <xs:attribute name="accept" type="ContentTypes"/>
+      <xs:attribute name="align" type="ImgAlign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="select">
+    <xs:annotation>
+      <xs:documentation>
+      option selector
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="optgroup"/>
+        <xs:element ref="option"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="size" type="Number"/>
+      <xs:attribute name="multiple">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="multiple"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="tabindex" type="tabindexNumber"/>
+      <xs:attribute name="onfocus" type="Script"/>
+      <xs:attribute name="onblur" type="Script"/>
+      <xs:attribute name="onchange" type="Script"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="optgroup">
+    <xs:annotation>
+      <xs:documentation>
+      option group
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="option"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="label" use="required" type="Text"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="option">
+    <xs:annotation>
+      <xs:documentation>
+      selectable choice
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="selected">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="selected"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="label" type="Text"/>
+      <xs:attribute name="value"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="textarea">
+    <xs:annotation>
+      <xs:documentation>
+      multi-line text field
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="focus"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="rows" use="required" type="Number"/>
+      <xs:attribute name="cols" use="required" type="Number"/>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="readonly">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="readonly"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="onselect" type="Script"/>
+      <xs:attribute name="onchange" type="Script"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="fieldset">
+    <xs:annotation>
+      <xs:documentation>
+      The fieldset element is used to group form fields.
+      Only one legend element should occur in the content
+      and if present should only be preceded by whitespace.
+
+      NOTE: this content model is different from the XHTML 1.0 DTD,
+      closer to the intended content model in HTML4 DTD
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element ref="legend"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:group ref="block"/>
+          <xs:element ref="form"/>
+          <xs:group ref="inline"/>
+          <xs:group ref="misc"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="LAlign">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="top"/>
+      <xs:enumeration value="bottom"/>
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="right"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="legend">
+    <xs:annotation>
+      <xs:documentation>
+      fieldset label
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="accesskey" type="Character"/>
+          <xs:attribute name="align" type="LAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="button">
+    <xs:annotation>
+      <xs:documentation>
+      Content is "Flow" excluding a, form and form controls
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="button.content">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="focus"/>
+          <xs:attribute name="name"/>
+          <xs:attribute name="value"/>
+          <xs:attribute name="type" default="submit">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="button"/>
+                <xs:enumeration value="submit"/>
+                <xs:enumeration value="reset"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="disabled">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="disabled"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="isindex">
+    <xs:annotation>
+      <xs:documentation>
+      single-line text input control (DEPRECATED)
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="coreattrs"/>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="prompt" type="Text"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ======================= Tables =======================================
+
+    Derived from IETF HTML table standard, see [RFC1942]
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="TFrame">
+    <xs:annotation>
+      <xs:documentation>
+      The border attribute sets the thickness of the frame around the
+      table. The default units are screen pixels.
+
+      The frame attribute specifies which parts of the frame around
+      the table should be rendered. The values are not the same as
+      CALS to avoid a name clash with the valign attribute.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="void"/>
+      <xs:enumeration value="above"/>
+      <xs:enumeration value="below"/>
+      <xs:enumeration value="hsides"/>
+      <xs:enumeration value="lhs"/>
+      <xs:enumeration value="rhs"/>
+      <xs:enumeration value="vsides"/>
+      <xs:enumeration value="box"/>
+      <xs:enumeration value="border"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="TRules">
+    <xs:annotation>
+      <xs:documentation>
+      The rules attribute defines which rules to draw between cells:
+
+      If rules is absent then assume:
+          "none" if border is absent or border="0" otherwise "all"
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="groups"/>
+      <xs:enumeration value="rows"/>
+      <xs:enumeration value="cols"/>
+      <xs:enumeration value="all"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="TAlign">
+    <xs:annotation>
+      <xs:documentation>
+      horizontal placement of table relative to document
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="center"/>
+      <xs:enumeration value="right"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:attributeGroup name="cellhalign">
+    <xs:annotation>
+      <xs:documentation>
+      horizontal alignment attributes for cell contents
+
+      char        alignment char, e.g. char=":"
+      charoff     offset for alignment char
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="align">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="left"/>
+          <xs:enumeration value="center"/>
+          <xs:enumeration value="right"/>
+          <xs:enumeration value="justify"/>
+          <xs:enumeration value="char"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="char" type="Character"/>
+    <xs:attribute name="charoff" type="Length"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="cellvalign">
+    <xs:annotation>
+      <xs:documentation>
+      vertical alignment attributes for cell contents
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="valign">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="top"/>
+          <xs:enumeration value="middle"/>
+          <xs:enumeration value="bottom"/>
+          <xs:enumeration value="baseline"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:element name="table">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="caption"/>
+        <xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="col"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="colgroup"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="thead"/>
+        <xs:element minOccurs="0" ref="tfoot"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="tbody"/>
+          <xs:element maxOccurs="unbounded" ref="tr"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="summary" type="Text"/>
+      <xs:attribute name="width" type="Length"/>
+      <xs:attribute name="border" type="Pixels"/>
+      <xs:attribute name="frame" type="TFrame"/>
+      <xs:attribute name="rules" type="TRules"/>
+      <xs:attribute name="cellspacing" type="Length"/>
+      <xs:attribute name="cellpadding" type="Length"/>
+      <xs:attribute name="align" type="TAlign"/>
+      <xs:attribute name="bgcolor" type="Color"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="CAlign">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="top"/>
+      <xs:enumeration value="bottom"/>
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="right"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="caption">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="align" type="CAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    Use thead to duplicate headers when breaking table
+    across page boundaries, or for static headers when
+    tbody sections are rendered in scrolling panel.
+
+    Use tfoot to duplicate footers when breaking table
+    across page boundaries, or for static footers when
+    tbody sections are rendered in scrolling panel.
+
+    Use multiple tbody sections when rules are needed
+    between groups of table rows.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="thead">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tfoot">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tbody">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="colgroup">
+    <xs:annotation>
+      <xs:documentation>
+      colgroup groups a set of col elements. It allows you to group
+      several semantically related columns together.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="col"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="span" default="1" type="Number"/>
+      <xs:attribute name="width" type="MultiLength"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="col">
+    <xs:annotation>
+      <xs:documentation>
+      col elements define the alignment properties for cells in
+      one or more columns.
+
+      The width attribute specifies the width of the columns, e.g.
+
+          width=64        width in screen pixels
+          width=0.5*      relative width of 0.5
+
+      The span attribute causes the attributes of one
+      col element to apply to more than one column.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="span" default="1" type="Number"/>
+      <xs:attribute name="width" type="MultiLength"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tr">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="th"/>
+        <xs:element ref="td"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+      <xs:attribute name="bgcolor" type="Color"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="Scope">
+    <xs:annotation>
+      <xs:documentation>
+      Scope is simpler than headers attribute for common tables
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="row"/>
+      <xs:enumeration value="col"/>
+      <xs:enumeration value="rowgroup"/>
+      <xs:enumeration value="colgroup"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:annotation>
+    <xs:documentation>
+    th is for headers, td for data and for cells acting as both
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="th">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="abbr" type="Text"/>
+          <xs:attribute name="axis"/>
+          <xs:attribute name="headers" type="xs:IDREFS"/>
+          <xs:attribute name="scope" type="Scope"/>
+          <xs:attribute name="rowspan" default="1" type="Number"/>
+          <xs:attribute name="colspan" default="1" type="Number"/>
+          <xs:attributeGroup ref="cellhalign"/>
+          <xs:attributeGroup ref="cellvalign"/>
+          <xs:attribute name="nowrap">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="nowrap"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="bgcolor" type="Color"/>
+          <xs:attribute name="width" type="Length"/>
+          <xs:attribute name="height" type="Length"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="td">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="abbr" type="Text"/>
+          <xs:attribute name="axis"/>
+          <xs:attribute name="headers" type="xs:IDREFS"/>
+          <xs:attribute name="scope" type="Scope"/>
+          <xs:attribute name="rowspan" default="1" type="Number"/>
+          <xs:attribute name="colspan" default="1" type="Number"/>
+          <xs:attributeGroup ref="cellhalign"/>
+          <xs:attributeGroup ref="cellvalign"/>
+          <xs:attribute name="nowrap">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="nowrap"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="bgcolor" type="Color"/>
+          <xs:attribute name="width" type="Length"/>
+          <xs:attribute name="height" type="Length"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml10/xhtml1-strict.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml10/xhtml1-strict.xsd
@@ -1,0 +1,2211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema version="1.0" xml:lang="en"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://www.w3.org/1999/xhtml"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    elementFormDefault="qualified">
+
+  <xs:annotation>
+    <xs:documentation>
+    XHTML 1.0 (Second Edition) Strict in XML Schema
+
+    This is the same as HTML 4 Strict except for
+    changes due to the differences between XML and SGML.
+
+    Namespace = http://www.w3.org/1999/xhtml
+
+    For further information, see: http://www.w3.org/TR/xhtml1
+
+    Copyright (c) 1998-2002 W3C (MIT, INRIA, Keio),
+    All Rights Reserved. 
+
+    The DTD version is identified by the PUBLIC and SYSTEM identifiers:
+
+    PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
+
+    $Id: xhtml1-strict.xsd,v 1.2 2002/08/28 08:05:44 mimasa Exp $
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Character mnemonic entities =========================
+
+    XHTML entity sets are identified by the PUBLIC and SYSTEM identifiers:
+  
+    PUBLIC "-//W3C//ENTITIES Latin 1 for XHTML//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent"
+
+    PUBLIC "-//W3C//ENTITIES Special for XHTML//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent"
+
+    PUBLIC "-//W3C//ENTITIES Symbols for XHTML//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent"
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Imported Names ====================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="ContentType">
+    <xs:annotation>
+      <xs:documentation>
+      media type, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="ContentTypes">
+    <xs:annotation>
+      <xs:documentation>
+      comma-separated list of media types, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Charset">
+    <xs:annotation>
+      <xs:documentation>
+      a character encoding, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Charsets">
+    <xs:annotation>
+      <xs:documentation>
+      a space separated list of character encodings, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="LanguageCode">
+    <xs:annotation>
+      <xs:documentation>
+      a language code, as per [RFC3066]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:language"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Character">
+    <xs:annotation>
+      <xs:documentation>
+      a single character, as per section 2.2 of [XML]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:length value="1" fixed="true"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Number">
+    <xs:annotation>
+      <xs:documentation>
+      one or more digits
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:nonNegativeInteger">
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="tabindexNumber">
+    <xs:annotation>
+      <xs:documentation>
+      tabindex attribute specifies the position of the current element
+      in the tabbing order for the current document. This value must be
+      a number between 0 and 32767. User agents should ignore leading zeros. 
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="Number">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="32767"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="LinkTypes">
+    <xs:annotation>
+      <xs:documentation>
+      space-separated list of link types
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKENS"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="MediaDesc">
+    <xs:annotation>
+      <xs:documentation>
+      single or comma-separated list of media descriptors
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^,]+(,\s*[^,]+)*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="URI">
+    <xs:annotation>
+      <xs:documentation>
+      a Uniform Resource Identifier, see [RFC2396]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:anyURI"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="UriList">
+    <xs:annotation>
+      <xs:documentation>
+      a space separated list of Uniform Resource Identifiers
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Datetime">
+    <xs:annotation>
+      <xs:documentation>
+      date and time information. ISO date format
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:dateTime"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Script">
+    <xs:annotation>
+      <xs:documentation>
+      script expression
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="StyleSheet">
+    <xs:annotation>
+      <xs:documentation>
+      style sheet data
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Text">
+    <xs:annotation>
+      <xs:documentation>
+      used for titles etc.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Length">
+    <xs:annotation>
+      <xs:documentation>
+      nn for pixels or nn% for percentage length
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[-+]?(\d+|\d+(\.\d+)?%)"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="MultiLength">
+    <xs:annotation>
+      <xs:documentation>
+      pixel, percentage, or relative
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[-+]?(\d+|\d+(\.\d+)?%)|[1-9]?(\d+)?\*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Pixels">
+    <xs:annotation>
+      <xs:documentation>
+      integer representing length in pixels
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:nonNegativeInteger"/>
+  </xs:simpleType>
+
+  <xs:annotation>
+    <xs:documentation>
+    these are used for image maps
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="Shape">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="rect"/>
+      <xs:enumeration value="circle"/>
+      <xs:enumeration value="poly"/>
+      <xs:enumeration value="default"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Coords">
+    <xs:annotation>
+      <xs:documentation>
+      comma separated list of lengths
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern
+          value="[-+]?(\d+|\d+(\.\d+)?%)(,\s*[-+]?(\d+|\d+(\.\d+)?%))*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Generic Attributes ===============================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attributeGroup name="coreattrs">
+    <xs:annotation>
+      <xs:documentation>
+      core attributes common to most elements
+      id       document-wide unique id
+      class    space separated list of classes
+      style    associated style info
+      title    advisory title/amplification
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="id" type="xs:ID"/>
+    <xs:attribute name="class" type="xs:NMTOKENS"/>
+    <xs:attribute name="style" type="StyleSheet"/>
+    <xs:attribute name="title" type="Text"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="i18n">
+    <xs:annotation>
+      <xs:documentation>
+      internationalization attributes
+      lang        language code (backwards compatible)
+      xml:lang    language code (as per XML 1.0 spec)
+      dir         direction for weak/neutral text
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="lang" type="LanguageCode"/>
+    <xs:attribute ref="xml:lang"/>
+    <xs:attribute name="dir">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="ltr"/>
+          <xs:enumeration value="rtl"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="events">
+    <xs:annotation>
+      <xs:documentation>
+      attributes for common UI events
+      onclick     a pointer button was clicked
+      ondblclick  a pointer button was double clicked
+      onmousedown a pointer button was pressed down
+      onmouseup   a pointer button was released
+      onmousemove a pointer was moved onto the element
+      onmouseout  a pointer was moved away from the element
+      onkeypress  a key was pressed and released
+      onkeydown   a key was pressed down
+      onkeyup     a key was released
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="onclick" type="Script"/>
+    <xs:attribute name="ondblclick" type="Script"/>
+    <xs:attribute name="onmousedown" type="Script"/>
+    <xs:attribute name="onmouseup" type="Script"/>
+    <xs:attribute name="onmouseover" type="Script"/>
+    <xs:attribute name="onmousemove" type="Script"/>
+    <xs:attribute name="onmouseout" type="Script"/>
+    <xs:attribute name="onkeypress" type="Script"/>
+    <xs:attribute name="onkeydown" type="Script"/>
+    <xs:attribute name="onkeyup" type="Script"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="focus">
+    <xs:annotation>
+      <xs:documentation>
+      attributes for elements that can get the focus
+      accesskey   accessibility key character
+      tabindex    position in tabbing order
+      onfocus     the element got the focus
+      onblur      the element lost the focus
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="accesskey" type="Character"/>
+    <xs:attribute name="tabindex" type="tabindexNumber"/>
+    <xs:attribute name="onfocus" type="Script"/>
+    <xs:attribute name="onblur" type="Script"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="attrs">
+    <xs:attributeGroup ref="coreattrs"/>
+    <xs:attributeGroup ref="i18n"/>
+    <xs:attributeGroup ref="events"/>
+  </xs:attributeGroup>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Text Elements ====================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:group name="special.pre">
+    <xs:choice>
+      <xs:element ref="br"/>
+      <xs:element ref="span"/>
+      <xs:element ref="bdo"/>
+      <xs:element ref="map"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="special">
+    <xs:choice>
+      <xs:group ref="special.pre"/>
+      <xs:element ref="object"/>
+      <xs:element ref="img"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="fontstyle">
+    <xs:choice>
+      <xs:element ref="tt"/>
+      <xs:element ref="i"/>
+      <xs:element ref="b"/>
+      <xs:element ref="big"/>
+      <xs:element ref="small"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="phrase">
+    <xs:choice>
+      <xs:element ref="em"/>
+      <xs:element ref="strong"/>
+      <xs:element ref="dfn"/>
+      <xs:element ref="code"/>
+      <xs:element ref="q"/>
+      <xs:element ref="samp"/>
+      <xs:element ref="kbd"/>
+      <xs:element ref="var"/>
+      <xs:element ref="cite"/>
+      <xs:element ref="abbr"/>
+      <xs:element ref="acronym"/>
+      <xs:element ref="sub"/>
+      <xs:element ref="sup"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="inline.forms">
+    <xs:choice>
+      <xs:element ref="input"/>
+      <xs:element ref="select"/>
+      <xs:element ref="textarea"/>
+      <xs:element ref="label"/>
+      <xs:element ref="button"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="misc.inline">
+    <xs:choice>
+      <xs:element ref="ins"/>
+      <xs:element ref="del"/>
+      <xs:element ref="script"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="misc">
+    <xs:annotation>
+      <xs:documentation>
+      these can only occur at block level
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element ref="noscript"/>
+      <xs:group ref="misc.inline"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="inline">
+    <xs:choice>
+      <xs:element ref="a"/>
+      <xs:group ref="special"/>
+      <xs:group ref="fontstyle"/>
+      <xs:group ref="phrase"/>
+      <xs:group ref="inline.forms"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:complexType name="Inline" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      "Inline" covers inline or "text-level" elements
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="inline"/>
+      <xs:group ref="misc.inline"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Block level elements ==============================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:group name="heading">
+    <xs:choice>
+      <xs:element ref="h1"/>
+      <xs:element ref="h2"/>
+      <xs:element ref="h3"/>
+      <xs:element ref="h4"/>
+      <xs:element ref="h5"/>
+      <xs:element ref="h6"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="lists">
+    <xs:choice>
+      <xs:element ref="ul"/>
+      <xs:element ref="ol"/>
+      <xs:element ref="dl"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="blocktext">
+    <xs:choice>
+      <xs:element ref="pre"/>
+      <xs:element ref="hr"/>
+      <xs:element ref="blockquote"/>
+      <xs:element ref="address"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="block">
+    <xs:choice>
+      <xs:element ref="p"/>
+      <xs:group ref="heading"/>
+      <xs:element ref="div"/>
+      <xs:group ref="lists"/>
+      <xs:group ref="blocktext"/>
+      <xs:element ref="fieldset"/>
+      <xs:element ref="table"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:complexType name="Block">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="block"/>
+      <xs:element ref="form"/>
+      <xs:group ref="misc"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="Flow" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      "Flow" mixes block and inline and is used for list items etc.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="block"/>
+      <xs:element ref="form"/>
+      <xs:group ref="inline"/>
+      <xs:group ref="misc"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Content models for exclusions =====================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:complexType name="a.content" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      a elements use "Inline" excluding a
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="special"/>
+      <xs:group ref="fontstyle"/>
+      <xs:group ref="phrase"/>
+      <xs:group ref="inline.forms"/>
+      <xs:group ref="misc.inline"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="pre.content" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      pre uses "Inline" excluding big, small, sup or sup
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="a"/>
+      <xs:group ref="fontstyle"/>
+      <xs:group ref="phrase"/>
+      <xs:group ref="special.pre"/>
+      <xs:group ref="misc.inline"/>
+      <xs:group ref="inline.forms"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="form.content">
+    <xs:annotation>
+      <xs:documentation>
+      form uses "Block" excluding form
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="block"/>
+      <xs:group ref="misc"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="button.content" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      button uses "Flow" but excludes a, form and form controls
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="p"/>
+      <xs:group ref="heading"/>
+      <xs:element ref="div"/>
+      <xs:group ref="lists"/>
+      <xs:group ref="blocktext"/>
+      <xs:element ref="table"/>
+      <xs:group ref="special"/>
+      <xs:group ref="fontstyle"/>
+      <xs:group ref="phrase"/>
+      <xs:group ref="misc"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Document Structure ==================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="html">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="head"/>
+        <xs:element ref="body"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Document Head =======================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:group name="head.misc">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="script"/>
+        <xs:element ref="style"/>
+        <xs:element ref="meta"/>
+        <xs:element ref="link"/>
+        <xs:element ref="object"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:element name="head">
+    <xs:annotation>
+      <xs:documentation>
+      content model is "head.misc" combined with a single
+      title and an optional base element in any order
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:group ref="head.misc"/>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element ref="title"/>
+            <xs:group ref="head.misc"/>
+            <xs:sequence minOccurs="0">
+              <xs:element ref="base"/>
+              <xs:group ref="head.misc"/>
+            </xs:sequence>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element ref="base"/>
+            <xs:group ref="head.misc"/>
+            <xs:element ref="title"/>
+            <xs:group ref="head.misc"/>
+          </xs:sequence>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="profile" type="URI"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="title">
+    <xs:annotation>
+      <xs:documentation>
+      The title element is not considered part of the flow of text.
+      It should be displayed, for example as the page header or
+      window title. Exactly one title is required per document.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="base">
+    <xs:annotation>
+      <xs:documentation>
+      document base URI
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="href" use="required" type="URI"/>
+      <xs:attribute name="id" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="meta">
+    <xs:annotation>
+      <xs:documentation>
+      generic metainformation
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="http-equiv"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="content" use="required"/>
+      <xs:attribute name="scheme"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="link">
+    <xs:annotation>
+      <xs:documentation>
+      Relationship values can be used in principle:
+
+      a) for document specific toolbars/menus when used
+         with the link element in document head e.g.
+           start, contents, previous, next, index, end, help
+      b) to link to a separate style sheet (rel="stylesheet")
+      c) to make a link to a script (rel="script")
+      d) by stylesheets to control how collections of
+         html nodes are rendered into printed documents
+      e) to make a link to a printable version of this document
+         e.g. a PostScript or PDF version (rel="alternate" media="print")
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="charset" type="Charset"/>
+      <xs:attribute name="href" type="URI"/>
+      <xs:attribute name="hreflang" type="LanguageCode"/>
+      <xs:attribute name="type" type="ContentType"/>
+      <xs:attribute name="rel" type="LinkTypes"/>
+      <xs:attribute name="rev" type="LinkTypes"/>
+      <xs:attribute name="media" type="MediaDesc"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="style">
+    <xs:annotation>
+      <xs:documentation>
+      style info, which may include CDATA sections
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="type" use="required" type="ContentType"/>
+      <xs:attribute name="media" type="MediaDesc"/>
+      <xs:attribute name="title" type="Text"/>
+      <xs:attribute ref="xml:space" fixed="preserve"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="script">
+    <xs:annotation>
+      <xs:documentation>
+      script statements, which may include CDATA sections
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="charset" type="Charset"/>
+      <xs:attribute name="type" use="required" type="ContentType"/>
+      <xs:attribute name="src" type="URI"/>
+      <xs:attribute name="defer">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="defer"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="xml:space" fixed="preserve"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="noscript">
+    <xs:annotation>
+      <xs:documentation>
+      alternate content container for non script-based rendering
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="Block">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Document Body ====================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="body">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="Block">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="onload" type="Script"/>
+          <xs:attribute name="onunload" type="Script"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="div">
+    <xs:annotation>
+      <xs:documentation>
+      generic language/style container      
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Paragraphs =======================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="p">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Headings =========================================
+
+    There are six levels of headings from h1 (the most important)
+    to h6 (the least important).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="h1">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h2">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h3">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h4">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h5">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h6">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Lists ============================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="ul">
+    <xs:annotation>
+      <xs:documentation>
+      Unordered list
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="li"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ol">
+    <xs:annotation>
+      <xs:documentation>
+      Ordered (numbered) list
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="li"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="li">
+    <xs:annotation>
+      <xs:documentation>
+      list item
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    definition lists - dt for term, dd for its definition
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="dl">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="dt"/>
+        <xs:element ref="dd"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dt">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dd">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Address ==========================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="address">
+    <xs:annotation>
+      <xs:documentation>
+      information on author
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Horizontal Rule ==================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="hr">
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Preformatted Text ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="pre">
+    <xs:annotation>
+      <xs:documentation>
+      content is "Inline" excluding "img|object|big|small|sub|sup"
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="pre.content">
+           <xs:attributeGroup ref="attrs"/>
+           <xs:attribute ref="xml:space" fixed="preserve"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Block-like Quotes ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="blockquote">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="Block">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Inserted/Deleted Text ============================
+
+    ins/del are allowed in block and inline content, but its
+    inappropriate to include block content within an ins element
+    occurring in inline content.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="ins">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+          <xs:attribute name="datetime" type="Datetime"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="del">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+          <xs:attribute name="datetime" type="Datetime"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== The Anchor Element ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="a">
+    <xs:annotation>
+      <xs:documentation>
+      content is "Inline" except that anchors shouldn't be nested
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="a.content">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="focus"/>
+          <xs:attribute name="charset" type="Charset"/>
+          <xs:attribute name="type" type="ContentType"/>
+          <xs:attribute name="name" type="xs:NMTOKEN"/>
+          <xs:attribute name="href" type="URI"/>
+          <xs:attribute name="hreflang" type="LanguageCode"/>
+          <xs:attribute name="rel" type="LinkTypes"/>
+          <xs:attribute name="rev" type="LinkTypes"/>
+          <xs:attribute name="shape" default="rect" type="Shape"/>
+          <xs:attribute name="coords" type="Coords"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ===================== Inline Elements ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="span">
+    <xs:annotation>
+      <xs:documentation>
+      generic language/style container
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="bdo">
+    <xs:annotation>
+      <xs:documentation>
+      I18N BiDi over-ride
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="coreattrs"/>
+          <xs:attributeGroup ref="events"/>
+          <xs:attribute name="lang" type="LanguageCode"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="dir" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="ltr"/>
+                <xs:enumeration value="rtl"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="br">
+    <xs:annotation>
+      <xs:documentation>
+      forced line break
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="coreattrs"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="em">
+    <xs:annotation>
+      <xs:documentation>
+      emphasis
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="strong">
+    <xs:annotation>
+      <xs:documentation>
+      strong emphasis
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dfn">
+    <xs:annotation>
+      <xs:documentation>
+      definitional
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="code">
+    <xs:annotation>
+      <xs:documentation>
+      program code
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="samp">
+    <xs:annotation>
+      <xs:documentation>
+      sample
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="kbd">
+    <xs:annotation>
+      <xs:documentation>
+      something user would type
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="var">
+    <xs:annotation>
+      <xs:documentation>
+      variable
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="cite">
+    <xs:annotation>
+      <xs:documentation>
+      citation
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="abbr">
+    <xs:annotation>
+      <xs:documentation>
+      abbreviation
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="acronym">
+    <xs:annotation>
+      <xs:documentation>
+      acronym
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="q">
+    <xs:annotation>
+      <xs:documentation>
+      inlined quote
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sub">
+    <xs:annotation>
+      <xs:documentation>
+      subscript
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sup">
+    <xs:annotation>
+      <xs:documentation>
+      superscript
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tt">
+    <xs:annotation>
+      <xs:documentation>
+      fixed pitch font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="i">
+    <xs:annotation>
+      <xs:documentation>
+      italic font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="b">
+    <xs:annotation>
+      <xs:documentation>
+      bold font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="big">
+    <xs:annotation>
+      <xs:documentation>
+      bigger font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="small">
+    <xs:annotation>
+      <xs:documentation>
+      smaller font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ==================== Object ======================================
+
+    object is used to embed objects as part of HTML pages.
+    param elements should precede other content. Parameters
+    can also be expressed as attribute/value pairs on the
+    object element itself when brevity is desired.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="object">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="param"/>
+        <xs:group ref="block"/>
+        <xs:element ref="form"/>
+        <xs:group ref="inline"/>
+        <xs:group ref="misc"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="declare">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="declare"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="classid" type="URI"/>
+      <xs:attribute name="codebase" type="URI"/>
+      <xs:attribute name="data" type="URI"/>
+      <xs:attribute name="type" type="ContentType"/>
+      <xs:attribute name="codetype" type="ContentType"/>
+      <xs:attribute name="archive" type="UriList"/>
+      <xs:attribute name="standby" type="Text"/>
+      <xs:attribute name="height" type="Length"/>
+      <xs:attribute name="width" type="Length"/>
+      <xs:attribute name="usemap" type="URI"/>
+      <xs:attribute name="name" type="xs:NMTOKEN"/>
+      <xs:attribute name="tabindex" type="tabindexNumber"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="param">
+    <xs:annotation>
+      <xs:documentation>
+      param is used to supply a named property value.
+      In XML it would seem natural to follow RDF and support an
+      abbreviated syntax where the param elements are replaced
+      by attribute value pairs on the object start tag.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="value"/>
+      <xs:attribute name="valuetype" default="data">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="data"/>
+            <xs:enumeration value="ref"/>
+            <xs:enumeration value="object"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="type" type="ContentType"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Images ===========================================
+
+    To avoid accessibility problems for people who aren't
+    able to see the image, you should provide a text
+    description using the alt and longdesc attributes.
+    In addition, avoid the use of server-side image maps.
+    Note that in this DTD there is no name attribute. That
+    is only available in the transitional and frameset DTD.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="img">
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="src" use="required" type="URI"/>
+      <xs:attribute name="alt" use="required" type="Text"/>
+      <xs:attribute name="longdesc" type="URI"/>
+      <xs:attribute name="height" type="Length"/>
+      <xs:attribute name="width" type="Length"/>
+      <xs:attribute name="usemap" type="URI">
+	<xs:annotation>
+	  <xs:documentation>
+          usemap points to a map element which may be in this document
+          or an external document, although the latter is not widely supported
+          </xs:documentation>
+	</xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ismap">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="ismap"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Client-side image maps ============================
+
+    These can be placed in the same document or grouped in a
+    separate document although this isn't yet widely supported
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="map">
+    <xs:complexType>
+      <xs:choice>
+        <xs:choice maxOccurs="unbounded">
+          <xs:group ref="block"/>
+          <xs:element ref="form"/>
+          <xs:group ref="misc"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="area"/>
+      </xs:choice>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attributeGroup ref="events"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style" type="StyleSheet"/>
+      <xs:attribute name="title" type="Text"/>
+      <xs:attribute name="name" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="area">
+    <xs:complexType>
+        <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="focus"/>
+      <xs:attribute name="shape" default="rect" type="Shape"/>
+      <xs:attribute name="coords" type="Coords"/>
+      <xs:attribute name="href" type="URI"/>
+      <xs:attribute name="nohref">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="nohref"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" use="required" type="Text"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Forms ===============================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="form">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="form.content">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="action" use="required" type="URI"/>
+          <xs:attribute name="method" default="get">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="get"/>
+                <xs:enumeration value="post"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="enctype" type="ContentType"
+              default="application/x-www-form-urlencoded"/>
+          <xs:attribute name="onsubmit" type="Script"/>
+          <xs:attribute name="onreset" type="Script"/>
+          <xs:attribute name="accept" type="ContentTypes"/>
+          <xs:attribute name="accept-charset" type="Charsets"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="label">
+    <xs:annotation>
+      <xs:documentation>
+      Each label must not contain more than ONE field
+      Label elements shouldn't be nested.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="for" type="xs:IDREF"/>
+          <xs:attribute name="accesskey" type="Character"/>
+          <xs:attribute name="onfocus" type="Script"/>
+          <xs:attribute name="onblur" type="Script"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="InputType">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="text"/>
+      <xs:enumeration value="password"/>
+      <xs:enumeration value="checkbox"/>
+      <xs:enumeration value="radio"/>
+      <xs:enumeration value="submit"/>
+      <xs:enumeration value="reset"/>
+      <xs:enumeration value="file"/>
+      <xs:enumeration value="hidden"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="button"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="input">
+    <xs:annotation>
+      <xs:documentation>
+      form control
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="focus"/>
+      <xs:attribute name="type" default="text" type="InputType"/>
+      <xs:attribute name="name">
+	<xs:annotation>
+	  <xs:documentation>
+          the name attribute is required for all but submit &amp; reset
+          </xs:documentation>
+	</xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="value"/>
+      <xs:attribute name="checked">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="checked"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="readonly">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="readonly"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="size"/>
+      <xs:attribute name="maxlength" type="Number"/>
+      <xs:attribute name="src" type="URI"/>
+      <xs:attribute name="alt"/>
+      <xs:attribute name="usemap" type="URI"/>
+      <xs:attribute name="onselect" type="Script"/>
+      <xs:attribute name="onchange" type="Script"/>
+      <xs:attribute name="accept" type="ContentTypes"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="select">
+    <xs:annotation>
+      <xs:documentation>
+      option selector
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="optgroup"/>
+        <xs:element ref="option"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="size" type="Number"/>
+      <xs:attribute name="multiple">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="multiple"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="tabindex" type="tabindexNumber"/>
+      <xs:attribute name="onfocus" type="Script"/>
+      <xs:attribute name="onblur" type="Script"/>
+      <xs:attribute name="onchange" type="Script"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="optgroup">
+    <xs:annotation>
+      <xs:documentation>
+      option group
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="option"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="label" use="required" type="Text"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="option">
+    <xs:annotation>
+      <xs:documentation>
+      selectable choice
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="selected">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="selected"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="label" type="Text"/>
+      <xs:attribute name="value"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="textarea">
+    <xs:annotation>
+      <xs:documentation>
+      multi-line text field
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="focus"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="rows" use="required" type="Number"/>
+      <xs:attribute name="cols" use="required" type="Number"/>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="readonly">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="readonly"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="onselect" type="Script"/>
+      <xs:attribute name="onchange" type="Script"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="fieldset">
+    <xs:annotation>
+      <xs:documentation>
+      The fieldset element is used to group form fields.
+      Only one legend element should occur in the content
+      and if present should only be preceded by whitespace.
+
+      NOTE: this content model is different from the XHTML 1.0 DTD,
+      closer to the intended content model in HTML4 DTD
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element ref="legend"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:group ref="block"/>
+          <xs:element ref="form"/>
+          <xs:group ref="inline"/>
+          <xs:group ref="misc"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="legend">
+    <xs:annotation>
+      <xs:documentation>
+      fieldset label
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="accesskey" type="Character"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="button">
+    <xs:annotation>
+      <xs:documentation>
+      Content is "Flow" excluding a, form and form controls
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="button.content">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="focus"/>
+          <xs:attribute name="name"/>
+          <xs:attribute name="value"/>
+          <xs:attribute name="type" default="submit">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="button"/>
+                <xs:enumeration value="submit"/>
+                <xs:enumeration value="reset"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="disabled">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="disabled"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ======================= Tables =======================================
+
+    Derived from IETF HTML table standard, see [RFC1942]
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="TFrame">
+    <xs:annotation>
+      <xs:documentation>
+      The border attribute sets the thickness of the frame around the
+      table. The default units are screen pixels.
+
+      The frame attribute specifies which parts of the frame around
+      the table should be rendered. The values are not the same as
+      CALS to avoid a name clash with the valign attribute.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="void"/>
+      <xs:enumeration value="above"/>
+      <xs:enumeration value="below"/>
+      <xs:enumeration value="hsides"/>
+      <xs:enumeration value="lhs"/>
+      <xs:enumeration value="rhs"/>
+      <xs:enumeration value="vsides"/>
+      <xs:enumeration value="box"/>
+      <xs:enumeration value="border"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="TRules">
+    <xs:annotation>
+      <xs:documentation>
+      The rules attribute defines which rules to draw between cells:
+
+      If rules is absent then assume:
+          "none" if border is absent or border="0" otherwise "all"
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="groups"/>
+      <xs:enumeration value="rows"/>
+      <xs:enumeration value="cols"/>
+      <xs:enumeration value="all"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:attributeGroup name="cellhalign">
+    <xs:annotation>
+      <xs:documentation>
+      horizontal alignment attributes for cell contents
+
+      char        alignment char, e.g. char=':'
+      charoff     offset for alignment char
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="align">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="left"/>
+          <xs:enumeration value="center"/>
+          <xs:enumeration value="right"/>
+          <xs:enumeration value="justify"/>
+          <xs:enumeration value="char"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="char" type="Character"/>
+    <xs:attribute name="charoff" type="Length"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="cellvalign">
+    <xs:annotation>
+      <xs:documentation>
+      vertical alignment attributes for cell contents
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="valign">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="top"/>
+          <xs:enumeration value="middle"/>
+          <xs:enumeration value="bottom"/>
+          <xs:enumeration value="baseline"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:element name="table">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="caption"/>
+        <xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="col"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="colgroup"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="thead"/>
+        <xs:element minOccurs="0" ref="tfoot"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="tbody"/>
+          <xs:element maxOccurs="unbounded" ref="tr"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="summary" type="Text"/>
+      <xs:attribute name="width" type="Length"/>
+      <xs:attribute name="border" type="Pixels"/>
+      <xs:attribute name="frame" type="TFrame"/>
+      <xs:attribute name="rules" type="TRules"/>
+      <xs:attribute name="cellspacing" type="Length"/>
+      <xs:attribute name="cellpadding" type="Length"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="caption">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    Use thead to duplicate headers when breaking table
+    across page boundaries, or for static headers when
+    tbody sections are rendered in scrolling panel.
+
+    Use tfoot to duplicate footers when breaking table
+    across page boundaries, or for static footers when
+    tbody sections are rendered in scrolling panel.
+
+    Use multiple tbody sections when rules are needed
+    between groups of table rows.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="thead">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tfoot">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tbody">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="colgroup">
+    <xs:annotation>
+      <xs:documentation>
+      colgroup groups a set of col elements. It allows you to group
+      several semantically related columns together.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="col"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="span" default="1" type="Number"/>
+      <xs:attribute name="width" type="MultiLength"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="col">
+    <xs:annotation>
+      <xs:documentation>
+      col elements define the alignment properties for cells in
+      one or more columns.
+
+      The width attribute specifies the width of the columns, e.g.
+
+          width=64        width in screen pixels
+          width=0.5*      relative width of 0.5
+
+      The span attribute causes the attributes of one
+      col element to apply to more than one column.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="span" default="1" type="Number"/>
+      <xs:attribute name="width" type="MultiLength"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tr">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="th"/>
+        <xs:element ref="td"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="Scope">
+    <xs:annotation>
+      <xs:documentation>
+      Scope is simpler than headers attribute for common tables
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="row"/>
+      <xs:enumeration value="col"/>
+      <xs:enumeration value="rowgroup"/>
+      <xs:enumeration value="colgroup"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:annotation>
+    <xs:documentation>
+    th is for headers, td for data and for cells acting as both
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="th">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="abbr" type="Text"/>
+          <xs:attribute name="axis"/>
+          <xs:attribute name="headers" type="xs:IDREFS"/>
+          <xs:attribute name="scope" type="Scope"/>
+          <xs:attribute name="rowspan" default="1" type="Number"/>
+          <xs:attribute name="colspan" default="1" type="Number"/>
+          <xs:attributeGroup ref="cellhalign"/>
+          <xs:attributeGroup ref="cellvalign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="td">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="abbr" type="Text"/>
+          <xs:attribute name="axis"/>
+          <xs:attribute name="headers" type="xs:IDREFS"/>
+          <xs:attribute name="scope" type="Scope"/>
+          <xs:attribute name="rowspan" default="1" type="Number"/>
+          <xs:attribute name="colspan" default="1" type="Number"/>
+          <xs:attributeGroup ref="cellhalign"/>
+          <xs:attributeGroup ref="cellvalign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml10/xhtml1-transitional.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml10/xhtml1-transitional.xsd
@@ -1,0 +1,2755 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema version="1.0" xml:lang="en"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://www.w3.org/1999/xhtml"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    elementFormDefault="qualified">
+
+  <xs:annotation>
+    <xs:documentation>
+    XHTML 1.0 (Second Edition) Transitional in XML Schema
+
+    This is the same as HTML 4 Transitional except for
+    changes due to the differences between XML and SGML.
+
+    Namespace = http://www.w3.org/1999/xhtml
+
+    For further information, see: http://www.w3.org/TR/xhtml1
+
+    Copyright (c) 1998-2002 W3C (MIT, INRIA, Keio),
+    All Rights Reserved. 
+
+    The DTD version is identified by the PUBLIC and SYSTEM identifiers:
+
+    PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+
+    $Id: xhtml1-transitional.xsd,v 1.5 2002/08/28 09:53:29 mimasa Exp $
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Character mnemonic entities =========================
+
+    XHTML entity sets are identified by the PUBLIC and SYSTEM identifiers:
+  
+    PUBLIC "-//W3C//ENTITIES Latin 1 for XHTML//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent"
+
+    PUBLIC "-//W3C//ENTITIES Special for XHTML//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent"
+
+    PUBLIC "-//W3C//ENTITIES Symbols for XHTML//EN"
+    SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent"
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Imported Names ====================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="ContentType">
+    <xs:annotation>
+      <xs:documentation>
+      media type, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="ContentTypes">
+    <xs:annotation>
+      <xs:documentation>
+      comma-separated list of media types, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Charset">
+    <xs:annotation>
+      <xs:documentation>
+      a character encoding, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Charsets">
+    <xs:annotation>
+      <xs:documentation>
+      a space separated list of character encodings, as per [RFC2045]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="LanguageCode">
+    <xs:annotation>
+      <xs:documentation>
+      a language code, as per [RFC3066]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:language"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Character">
+    <xs:annotation>
+      <xs:documentation>
+      a single character, as per section 2.2 of [XML]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:length value="1" fixed="true"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Number">
+    <xs:annotation>
+      <xs:documentation>
+      one or more digits
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:nonNegativeInteger">
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="tabindexNumber">
+    <xs:annotation>
+      <xs:documentation>
+      tabindex attribute specifies the position of the current element
+      in the tabbing order for the current document. This value must be
+      a number between 0 and 32767. User agents should ignore leading zeros. 
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="Number">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="32767"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="LinkTypes">
+    <xs:annotation>
+      <xs:documentation>
+      space-separated list of link types
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKENS"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="MediaDesc">
+    <xs:annotation>
+      <xs:documentation>
+      single or comma-separated list of media descriptors
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^,]+(,\s*[^,]+)*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="URI">
+    <xs:annotation>
+      <xs:documentation>
+      a Uniform Resource Identifier, see [RFC2396]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:anyURI"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="UriList">
+    <xs:annotation>
+      <xs:documentation>
+      a space separated list of Uniform Resource Identifiers
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Datetime">
+    <xs:annotation>
+      <xs:documentation>
+      date and time information. ISO date format
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:dateTime"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Script">
+    <xs:annotation>
+      <xs:documentation>
+      script expression
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="StyleSheet">
+    <xs:annotation>
+      <xs:documentation>
+      style sheet data
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="Text">
+    <xs:annotation>
+      <xs:documentation>
+      used for titles etc.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="FrameTarget">
+    <xs:annotation>
+      <xs:documentation>
+      render in this frame
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:pattern value="_(blank|self|parent|top)|[A-Za-z]\c*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Length">
+    <xs:annotation>
+      <xs:documentation>
+      nn for pixels or nn% for percentage length
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[-+]?(\d+|\d+(\.\d+)?%)"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="MultiLength">
+    <xs:annotation>
+      <xs:documentation>
+      pixel, percentage, or relative
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[-+]?(\d+|\d+(\.\d+)?%)|[1-9]?(\d+)?\*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Pixels">
+    <xs:annotation>
+      <xs:documentation>
+      integer representing length in pixels
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:nonNegativeInteger"/>
+  </xs:simpleType>
+
+  <xs:annotation>
+    <xs:documentation>
+    these are used for image maps
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="Shape">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="rect"/>
+      <xs:enumeration value="circle"/>
+      <xs:enumeration value="poly"/>
+      <xs:enumeration value="default"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Coords">
+    <xs:annotation>
+      <xs:documentation>
+      comma separated list of lengths
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern
+          value="[-+]?(\d+|\d+(\.\d+)?%)(,\s*[-+]?(\d+|\d+(\.\d+)?%))*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ImgAlign">
+    <xs:annotation>
+      <xs:documentation>
+      used for object, applet, img, input and iframe
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="top"/>
+      <xs:enumeration value="middle"/>
+      <xs:enumeration value="bottom"/>
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="right"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="Color">
+    <xs:annotation>
+      <xs:documentation>
+      a color using sRGB: #RRGGBB as Hex values
+
+      There are also 16 widely known color names with their sRGB values:
+
+      Black  = #000000    Green  = #008000
+      Silver = #C0C0C0    Lime   = #00FF00
+      Gray   = #808080    Olive  = #808000
+      White  = #FFFFFF    Yellow = #FFFF00
+      Maroon = #800000    Navy   = #000080
+      Red    = #FF0000    Blue   = #0000FF
+      Purple = #800080    Teal   = #008080
+      Fuchsia= #FF00FF    Aqua   = #00FFFF
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[A-Za-z]+|#[0-9A-Fa-f]{3}|#[0-9A-Fa-f]{6}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Generic Attributes ===============================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attributeGroup name="coreattrs">
+    <xs:annotation>
+      <xs:documentation>
+      core attributes common to most elements
+      id       document-wide unique id
+      class    space separated list of classes
+      style    associated style info
+      title    advisory title/amplification
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="id" type="xs:ID"/>
+    <xs:attribute name="class" type="xs:NMTOKENS"/>
+    <xs:attribute name="style" type="StyleSheet"/>
+    <xs:attribute name="title" type="Text"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="i18n">
+    <xs:annotation>
+      <xs:documentation>
+      internationalization attributes
+      lang        language code (backwards compatible)
+      xml:lang    language code (as per XML 1.0 spec)
+      dir         direction for weak/neutral text
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="lang" type="LanguageCode"/>
+    <xs:attribute ref="xml:lang"/>
+    <xs:attribute name="dir">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="ltr"/>
+          <xs:enumeration value="rtl"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="events">
+    <xs:annotation>
+      <xs:documentation>
+      attributes for common UI events
+      onclick     a pointer button was clicked
+      ondblclick  a pointer button was double clicked
+      onmousedown a pointer button was pressed down
+      onmouseup   a pointer button was released
+      onmousemove a pointer was moved onto the element
+      onmouseout  a pointer was moved away from the element
+      onkeypress  a key was pressed and released
+      onkeydown   a key was pressed down
+      onkeyup     a key was released
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="onclick" type="Script"/>
+    <xs:attribute name="ondblclick" type="Script"/>
+    <xs:attribute name="onmousedown" type="Script"/>
+    <xs:attribute name="onmouseup" type="Script"/>
+    <xs:attribute name="onmouseover" type="Script"/>
+    <xs:attribute name="onmousemove" type="Script"/>
+    <xs:attribute name="onmouseout" type="Script"/>
+    <xs:attribute name="onkeypress" type="Script"/>
+    <xs:attribute name="onkeydown" type="Script"/>
+    <xs:attribute name="onkeyup" type="Script"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="focus">
+    <xs:annotation>
+      <xs:documentation>
+      attributes for elements that can get the focus
+      accesskey   accessibility key character
+      tabindex    position in tabbing order
+      onfocus     the element got the focus
+      onblur      the element lost the focus
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="accesskey" type="Character"/>
+    <xs:attribute name="tabindex" type="tabindexNumber"/>
+    <xs:attribute name="onfocus" type="Script"/>
+    <xs:attribute name="onblur" type="Script"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="attrs">
+    <xs:attributeGroup ref="coreattrs"/>
+    <xs:attributeGroup ref="i18n"/>
+    <xs:attributeGroup ref="events"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="TextAlign">
+    <xs:annotation>
+      <xs:documentation>
+      text alignment for p, div, h1-h6. The default is
+      align="left" for ltr headings, "right" for rtl
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="align">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="left"/>
+          <xs:enumeration value="center"/>
+          <xs:enumeration value="right"/>
+          <xs:enumeration value="justify"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Text Elements ====================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:group name="special.extra">
+    <xs:choice>
+      <xs:element ref="object"/>
+      <xs:element ref="applet"/>
+      <xs:element ref="img"/>
+      <xs:element ref="map"/>
+      <xs:element ref="iframe"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="special.basic">
+    <xs:choice>
+      <xs:element ref="br"/>
+      <xs:element ref="span"/>
+      <xs:element ref="bdo"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="special">
+    <xs:choice>
+      <xs:group ref="special.basic"/>
+      <xs:group ref="special.extra"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="fontstyle.extra">
+    <xs:choice>
+      <xs:element ref="big"/>
+      <xs:element ref="small"/>
+      <xs:element ref="font"/>
+      <xs:element ref="basefont"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="fontstyle.basic">
+    <xs:choice>
+      <xs:element ref="tt"/>
+      <xs:element ref="i"/>
+      <xs:element ref="b"/>
+      <xs:element ref="u"/>
+      <xs:element ref="s"/>
+      <xs:element ref="strike"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="fontstyle">
+    <xs:choice>
+      <xs:group ref="fontstyle.basic"/>
+      <xs:group ref="fontstyle.extra"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="phrase.extra">
+    <xs:choice>
+      <xs:element ref="sub"/>
+      <xs:element ref="sup"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="phrase.basic">
+    <xs:choice>
+      <xs:element ref="em"/>
+      <xs:element ref="strong"/>
+      <xs:element ref="dfn"/>
+      <xs:element ref="code"/>
+      <xs:element ref="q"/>
+      <xs:element ref="samp"/>
+      <xs:element ref="kbd"/>
+      <xs:element ref="var"/>
+      <xs:element ref="cite"/>
+      <xs:element ref="abbr"/>
+      <xs:element ref="acronym"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="phrase">
+    <xs:choice>
+      <xs:group ref="phrase.basic"/>
+      <xs:group ref="phrase.extra"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="inline.forms">
+    <xs:choice>
+      <xs:element ref="input"/>
+      <xs:element ref="select"/>
+      <xs:element ref="textarea"/>
+      <xs:element ref="label"/>
+      <xs:element ref="button"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="misc.inline">
+    <xs:annotation>
+      <xs:documentation>
+      these can only occur at block level
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element ref="ins"/>
+      <xs:element ref="del"/>
+      <xs:element ref="script"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="misc">
+    <xs:annotation>
+      <xs:documentation>
+      these can only occur at block level
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element ref="noscript"/>
+      <xs:group ref="misc.inline"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="inline">
+    <xs:choice>
+      <xs:element ref="a"/>
+      <xs:group ref="special"/>
+      <xs:group ref="fontstyle"/>
+      <xs:group ref="phrase"/>
+      <xs:group ref="inline.forms"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:complexType name="Inline" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      "Inline" covers inline or "text-level" element
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="inline"/>
+      <xs:group ref="misc.inline"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Block level elements ==============================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:group name="heading">
+    <xs:choice>
+      <xs:element ref="h1"/>
+      <xs:element ref="h2"/>
+      <xs:element ref="h3"/>
+      <xs:element ref="h4"/>
+      <xs:element ref="h5"/>
+      <xs:element ref="h6"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="lists">
+    <xs:choice>
+      <xs:element ref="ul"/>
+      <xs:element ref="ol"/>
+      <xs:element ref="dl"/>
+      <xs:element ref="menu"/>
+      <xs:element ref="dir"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="blocktext">
+    <xs:choice>
+      <xs:element ref="pre"/>
+      <xs:element ref="hr"/>
+      <xs:element ref="blockquote"/>
+      <xs:element ref="address"/>
+      <xs:element ref="center"/>
+      <xs:element ref="noframes"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="block">
+    <xs:choice>
+      <xs:element ref="p"/>
+      <xs:group ref="heading"/>
+      <xs:element ref="div"/>
+      <xs:group ref="lists"/>
+      <xs:group ref="blocktext"/>
+      <xs:element ref="isindex"/>
+      <xs:element ref="fieldset"/>
+      <xs:element ref="table"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:complexType name="Flow" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      "Flow" mixes block and inline and is used for list items etc.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="block"/>
+      <xs:element ref="form"/>
+      <xs:group ref="inline"/>
+      <xs:group ref="misc"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Content models for exclusions =====================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:complexType name="a.content" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      a elements use "Inline" excluding a
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="special"/>
+      <xs:group ref="fontstyle"/>
+      <xs:group ref="phrase"/>
+      <xs:group ref="inline.forms"/>
+      <xs:group ref="misc.inline"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="pre.content" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      pre uses "Inline" excluding img, object, applet, big, small,
+      font, or basefont
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="a"/>
+      <xs:group ref="special.basic"/>
+      <xs:group ref="fontstyle.basic"/>
+      <xs:group ref="phrase.basic"/>
+      <xs:group ref="inline.forms"/>
+      <xs:group ref="misc.inline"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="form.content" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      form uses "Flow" excluding form
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="block"/>
+      <xs:group ref="inline"/>
+      <xs:group ref="misc"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="button.content" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+      button uses "Flow" but excludes a, form, form controls, iframe
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="p"/>
+      <xs:group ref="heading"/>
+      <xs:element ref="div"/>
+      <xs:group ref="lists"/>
+      <xs:group ref="blocktext"/>
+      <xs:element ref="table"/>
+      <xs:element ref="br"/>
+      <xs:element ref="span"/>
+      <xs:element ref="bdo"/>
+      <xs:element ref="object"/>
+      <xs:element ref="applet"/>
+      <xs:element ref="img"/>
+      <xs:element ref="map"/>
+      <xs:group ref="fontstyle"/>
+      <xs:group ref="phrase"/>
+      <xs:group ref="misc"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Document Structure ==================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="html">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="head"/>
+        <xs:element ref="body"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Document Head =======================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:group name="head.misc">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="script"/>
+        <xs:element ref="style"/>
+        <xs:element ref="meta"/>
+        <xs:element ref="link"/>
+        <xs:element ref="object"/>
+        <xs:element ref="isindex"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:element name="head">
+    <xs:annotation>
+      <xs:documentation>
+      content model is "head.misc" combined with a single
+      title and an optional base element in any order
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:group ref="head.misc"/>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element ref="title"/>
+            <xs:group ref="head.misc"/>
+            <xs:sequence minOccurs="0">
+              <xs:element ref="base"/>
+              <xs:group ref="head.misc"/>
+            </xs:sequence>
+          </xs:sequence>
+          <xs:sequence>
+            <xs:element ref="base"/>
+            <xs:group ref="head.misc"/>
+            <xs:element ref="title"/>
+            <xs:group ref="head.misc"/>
+          </xs:sequence>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="profile" type="URI"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="title">
+    <xs:annotation>
+      <xs:documentation>
+      The title element is not considered part of the flow of text.
+      It should be displayed, for example as the page header or
+      window title. Exactly one title is required per document.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="base">
+    <xs:annotation>
+      <xs:documentation>
+      document base URI
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="href" type="URI"/>
+      <xs:attribute name="target" type="FrameTarget"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="meta">
+    <xs:annotation>
+      <xs:documentation>
+      generic metainformation
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="http-equiv"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="content" use="required"/>
+      <xs:attribute name="scheme"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="link">
+    <xs:annotation>
+      <xs:documentation>
+      Relationship values can be used in principle:
+
+      a) for document specific toolbars/menus when used
+         with the link element in document head e.g.
+           start, contents, previous, next, index, end, help
+      b) to link to a separate style sheet (rel="stylesheet")
+      c) to make a link to a script (rel="script")
+      d) by stylesheets to control how collections of
+         html nodes are rendered into printed documents
+      e) to make a link to a printable version of this document
+         e.g. a PostScript or PDF version (rel="alternate" media="print")
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="charset" type="Charset"/>
+      <xs:attribute name="href" type="URI"/>
+      <xs:attribute name="hreflang" type="LanguageCode"/>
+      <xs:attribute name="type" type="ContentType"/>
+      <xs:attribute name="rel" type="LinkTypes"/>
+      <xs:attribute name="rev" type="LinkTypes"/>
+      <xs:attribute name="media" type="MediaDesc"/>
+      <xs:attribute name="target" type="FrameTarget"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="style">
+    <xs:annotation>
+      <xs:documentation>
+      style info, which may include CDATA sections
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="type" use="required" type="ContentType"/>
+      <xs:attribute name="media" type="MediaDesc"/>
+      <xs:attribute name="title" type="Text"/>
+      <xs:attribute ref="xml:space" fixed="preserve"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="script">
+    <xs:annotation>
+      <xs:documentation>
+      script statements, which may include CDATA sections
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="charset" type="Charset"/>
+      <xs:attribute name="type" use="required" type="ContentType"/>
+      <xs:attribute name="language"/>
+      <xs:attribute name="src" type="URI"/>
+      <xs:attribute name="defer">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="defer"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="xml:space" fixed="preserve"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="noscript">
+    <xs:annotation>
+      <xs:documentation>
+      alternate content container for non script-based rendering
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ======================= Frames =======================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="iframe">
+    <xs:annotation>
+      <xs:documentation>
+      inline subwindow
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="coreattrs"/>
+          <xs:attribute name="longdesc" type="URI"/>
+          <xs:attribute name="name" type="xs:NMTOKEN"/>
+          <xs:attribute name="src" type="URI"/>
+          <xs:attribute name="frameborder" default="1">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="1"/>
+                <xs:enumeration value="0"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="marginwidth" type="Pixels"/>
+          <xs:attribute name="marginheight" type="Pixels"/>
+          <xs:attribute name="scrolling" default="auto">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="yes"/>
+                <xs:enumeration value="no"/>
+                <xs:enumeration value="auto"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="align" type="ImgAlign"/>
+          <xs:attribute name="height" type="Length"/>
+          <xs:attribute name="width" type="Length"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="noframes">
+    <xs:annotation>
+      <xs:documentation>
+      alternate content container for non frame-based rendering
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Document Body ====================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="body">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="onload" type="Script"/>
+          <xs:attribute name="onunload" type="Script"/>
+          <xs:attribute name="background" type="URI"/>
+          <xs:attribute name="bgcolor" type="Color"/>
+          <xs:attribute name="text" type="Color"/>
+          <xs:attribute name="link" type="Color"/>
+          <xs:attribute name="vlink" type="Color"/>
+          <xs:attribute name="alink" type="Color"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="div">
+    <xs:annotation>
+      <xs:documentation>
+      generic language/style container      
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Paragraphs =======================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="p">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Headings =========================================
+
+    There are six levels of headings from h1 (the most important)
+    to h6 (the least important).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="h1">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h2">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h3">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h4">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h5">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="h6">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="TextAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Lists ============================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="ULStyle">
+    <xs:annotation>
+      <xs:documentation>
+      Unordered list bullet styles
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="disc"/>
+      <xs:enumeration value="square"/>
+      <xs:enumeration value="circle"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="ul">
+    <xs:annotation>
+      <xs:documentation>
+      Unordered list
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="li"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="type" type="ULStyle"/>
+      <xs:attribute name="compact">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="OLStyle">
+    <xs:annotation>
+      <xs:documentation>
+      Ordered list numbering style
+
+      1   arabic numbers      1, 2, 3, ...
+      a   lower alpha         a, b, c, ...
+      A   upper alpha         A, B, C, ...
+      i   lower roman         i, ii, iii, ...
+      I   upper roman         I, II, III, ...
+
+      The style is applied to the sequence number which by default
+      is reset to 1 for the first list item in an ordered list.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:element name="ol">
+    <xs:annotation>
+      <xs:documentation>
+      Ordered (numbered) list
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="li"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="type" type="OLStyle"/>
+      <xs:attribute name="compact">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="start" type="Number"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="menu">
+    <xs:annotation>
+      <xs:documentation>
+      single column list (DEPRECATED)
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="li"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="compact">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dir">
+    <xs:annotation>
+      <xs:documentation>
+      multiple column list (DEPRECATED)
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="li"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="compact">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="LIStyle">
+    <xs:annotation>
+      <xs:documentation>
+      LIStyle is constrained to: "(ULStyle|OLStyle)"
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+
+  <xs:element name="li">
+    <xs:annotation>
+      <xs:documentation>
+      list item
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="type" type="LIStyle"/>
+          <xs:attribute name="value" type="Number"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    definition lists - dt for term, dd for its definition
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="dl">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="dt"/>
+        <xs:element ref="dd"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="compact">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="compact"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dt">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dd">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Address ==========================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="address">
+    <xs:annotation>
+      <xs:documentation>
+      information on author
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="inline"/>
+        <xs:group ref="misc.inline"/>
+        <xs:element ref="p"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Horizontal Rule ==================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="hr">
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="noshade">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="noshade"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="size" type="Pixels"/>
+      <xs:attribute name="width" type="Length"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Preformatted Text ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="pre">
+    <xs:annotation>
+      <xs:documentation>
+      content is "Inline" excluding 
+         "img|object|applet|big|small|sub|sup|font|basefont"
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="pre.content">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="width" type="Number"/>
+          <xs:attribute ref="xml:space" fixed="preserve"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Block-like Quotes ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="blockquote">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Text alignment ===================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="center">
+    <xs:annotation>
+      <xs:documentation>
+      center content
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Inserted/Deleted Text ============================
+
+    ins/del are allowed in block and inline content, but its
+    inappropriate to include block content within an ins element
+    occurring in inline content.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="ins">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+          <xs:attribute name="datetime" type="Datetime"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="del">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+          <xs:attribute name="datetime" type="Datetime"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== The Anchor Element ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="a">
+    <xs:annotation>
+      <xs:documentation>
+      content is "Inline" except that anchors shouldn't be nested
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="a.content">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="focus"/>
+          <xs:attribute name="charset" type="Charset"/>
+          <xs:attribute name="type" type="ContentType"/>
+          <xs:attribute name="name" type="xs:NMTOKEN"/>
+          <xs:attribute name="href" type="URI"/>
+          <xs:attribute name="hreflang" type="LanguageCode"/>
+          <xs:attribute name="rel" type="LinkTypes"/>
+          <xs:attribute name="rev" type="LinkTypes"/>
+          <xs:attribute name="shape" default="rect" type="Shape"/>
+          <xs:attribute name="coords" type="Coords"/>
+          <xs:attribute name="target" type="FrameTarget"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ===================== Inline Elements ================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="span">
+    <xs:annotation>
+      <xs:documentation>
+      generic language/style container
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="bdo">
+    <xs:annotation>
+      <xs:documentation>
+      I18N BiDi over-ride
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="coreattrs"/>
+          <xs:attributeGroup ref="events"/>
+          <xs:attribute name="lang" type="LanguageCode"/>
+          <xs:attribute ref="xml:lang"/>
+          <xs:attribute name="dir" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="ltr"/>
+                <xs:enumeration value="rtl"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="br">
+    <xs:annotation>
+      <xs:documentation>
+      forced line break
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="coreattrs"/>
+      <xs:attribute name="clear" default="none">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="all"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="none"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="em">
+    <xs:annotation>
+      <xs:documentation>
+      emphasis
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="strong">
+    <xs:annotation>
+      <xs:documentation>
+      strong emphasis
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dfn">
+    <xs:annotation>
+      <xs:documentation>
+      definitional
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="code">
+    <xs:annotation>
+      <xs:documentation>
+      program code
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="samp">
+    <xs:annotation>
+      <xs:documentation>
+      sample
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="kbd">
+    <xs:annotation>
+      <xs:documentation>
+      something user would type
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="var">
+    <xs:annotation>
+      <xs:documentation>
+      variable
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="cite">
+    <xs:annotation>
+      <xs:documentation>
+      citation
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="abbr">
+    <xs:annotation>
+      <xs:documentation>
+      abbreviation
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="acronym">
+    <xs:annotation>
+      <xs:documentation>
+      acronym
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="q">
+    <xs:annotation>
+      <xs:documentation>
+      inlined quote
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="cite" type="URI"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sub">
+    <xs:annotation>
+      <xs:documentation>
+      subscript
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sup">
+    <xs:annotation>
+      <xs:documentation>
+      superscript
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tt">
+    <xs:annotation>
+      <xs:documentation>
+      fixed pitch font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="i">
+    <xs:annotation>
+      <xs:documentation>
+      italic font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="b">
+    <xs:annotation>
+      <xs:documentation>
+      bold font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="big">
+    <xs:annotation>
+      <xs:documentation>
+      bigger font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="small">
+    <xs:annotation>
+      <xs:documentation>
+      smaller font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="u">
+    <xs:annotation>
+      <xs:documentation>
+      underline
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="s">
+    <xs:annotation>
+      <xs:documentation>
+      strike-through
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="strike">
+    <xs:annotation>
+      <xs:documentation>
+      strike-through
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="basefont">
+    <xs:annotation>
+      <xs:documentation>
+      base font size
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="size" use="required"/>
+      <xs:attribute name="color" type="Color"/>
+      <xs:attribute name="face"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="font">
+    <xs:annotation>
+      <xs:documentation>
+      local change to font
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="coreattrs"/>
+          <xs:attributeGroup ref="i18n"/>
+          <xs:attribute name="size"/>
+          <xs:attribute name="color" type="Color"/>
+          <xs:attribute name="face"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ==================== Object ======================================
+
+    object is used to embed objects as part of HTML pages.
+    param elements should precede other content. Parameters
+    can also be expressed as attribute/value pairs on the
+    object element itself when brevity is desired.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="object">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="param"/>
+        <xs:group ref="block"/>
+        <xs:element ref="form"/>
+        <xs:group ref="inline"/>
+        <xs:group ref="misc"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="declare">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="declare"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="classid" type="URI"/>
+      <xs:attribute name="codebase" type="URI"/>
+      <xs:attribute name="data" type="URI"/>
+      <xs:attribute name="type" type="ContentType"/>
+      <xs:attribute name="codetype" type="ContentType"/>
+      <xs:attribute name="archive" type="UriList"/>
+      <xs:attribute name="standby" type="Text"/>
+      <xs:attribute name="height" type="Length"/>
+      <xs:attribute name="width" type="Length"/>
+      <xs:attribute name="usemap" type="URI"/>
+      <xs:attribute name="name" type="xs:NMTOKEN"/>
+      <xs:attribute name="tabindex" type="Number"/>
+      <xs:attribute name="align" type="ImgAlign"/>
+      <xs:attribute name="border" type="Pixels"/>
+      <xs:attribute name="hspace" type="Pixels"/>
+      <xs:attribute name="vspace" type="Pixels"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="param">
+    <xs:annotation>
+      <xs:documentation>
+      param is used to supply a named property value.
+      In XML it would seem natural to follow RDF and support an
+      abbreviated syntax where the param elements are replaced
+      by attribute value pairs on the object start tag.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="name" use="required"/>
+      <xs:attribute name="value"/>
+      <xs:attribute name="valuetype" default="data">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="data"/>
+            <xs:enumeration value="ref"/>
+            <xs:enumeration value="object"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="type" type="ContentType"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Java applet ==================================
+
+    One of code or object attributes must be present.
+    Place param elements before other content.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="applet">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="param"/>
+        <xs:group ref="block"/>
+        <xs:element ref="form"/>
+        <xs:group ref="inline"/>
+        <xs:group ref="misc"/>
+      </xs:choice>
+      <xs:attributeGroup ref="coreattrs"/>
+      <xs:attribute name="codebase" type="URI"/>
+      <xs:attribute name="archive"/>
+      <xs:attribute name="code"/>
+      <xs:attribute name="object"/>
+      <xs:attribute name="alt" type="Text"/>
+      <xs:attribute name="name" type="xs:NMTOKEN"/>
+      <xs:attribute name="width" use="required" type="Length"/>
+      <xs:attribute name="height" use="required" type="Length"/>
+      <xs:attribute name="align" type="ImgAlign"/>
+      <xs:attribute name="hspace" type="Pixels"/>
+      <xs:attribute name="vspace" type="Pixels"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    =================== Images ===========================================
+
+    To avoid accessibility problems for people who aren't
+    able to see the image, you should provide a text
+    description using the alt and longdesc attributes.
+    In addition, avoid the use of server-side image maps.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="img">
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="src" use="required" type="URI"/>
+      <xs:attribute name="alt" use="required" type="Text"/>
+      <xs:attribute name="name" type="xs:NMTOKEN"/>
+      <xs:attribute name="longdesc" type="URI"/>
+      <xs:attribute name="height" type="Length"/>
+      <xs:attribute name="width" type="Length"/>
+      <xs:attribute name="usemap" type="URI">
+	<xs:annotation>
+	  <xs:documentation>
+          usemap points to a map element which may be in this document
+          or an external document, although the latter is not widely supported
+          </xs:documentation>
+	</xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ismap">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="ismap"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align" type="ImgAlign"/>
+      <xs:attribute name="border" type="Length"/>
+      <xs:attribute name="hspace" type="Pixels"/>
+      <xs:attribute name="vspace" type="Pixels"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================== Client-side image maps ============================
+
+    These can be placed in the same document or grouped in a
+    separate document although this isn't yet widely supported
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="map">
+    <xs:complexType>
+      <xs:choice>
+        <xs:choice maxOccurs="unbounded">
+          <xs:group ref="block"/>
+          <xs:element ref="form"/>
+          <xs:group ref="misc"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="area"/>
+      </xs:choice>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attributeGroup ref="events"/>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="class"/>
+      <xs:attribute name="style" type="StyleSheet"/>
+      <xs:attribute name="title" type="Text"/>
+      <xs:attribute name="name"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="area">
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="focus"/>
+      <xs:attribute name="shape" default="rect" type="Shape"/>
+      <xs:attribute name="coords" type="Coords"/>
+      <xs:attribute name="href" type="URI"/>
+      <xs:attribute name="nohref">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="nohref"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alt" use="required" type="Text"/>
+      <xs:attribute name="target" type="FrameTarget"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ================ Forms ===============================================
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="form">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="form.content">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="action" use="required" type="URI"/>
+          <xs:attribute name="method" default="get">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="get"/>
+                <xs:enumeration value="post"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="enctype" type="ContentType"
+              default="application/x-www-form-urlencoded"/>
+          <xs:attribute name="onsubmit" type="Script"/>
+          <xs:attribute name="onreset" type="Script"/>
+          <xs:attribute name="accept" type="ContentTypes"/>
+          <xs:attribute name="accept-charset" type="Charsets"/>
+          <xs:attribute name="target" type="FrameTarget"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="label">
+    <xs:annotation>
+      <xs:documentation>
+      Each label must not contain more than ONE field
+      Label elements shouldn't be nested.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="for" type="xs:IDREF"/>
+          <xs:attribute name="accesskey" type="Character"/>
+          <xs:attribute name="onfocus" type="Script"/>
+          <xs:attribute name="onblur" type="Script"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="InputType">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="text"/>
+      <xs:enumeration value="password"/>
+      <xs:enumeration value="checkbox"/>
+      <xs:enumeration value="radio"/>
+      <xs:enumeration value="submit"/>
+      <xs:enumeration value="reset"/>
+      <xs:enumeration value="file"/>
+      <xs:enumeration value="hidden"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="button"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="input">
+    <xs:annotation>
+      <xs:documentation>
+      form control
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="focus"/>
+      <xs:attribute name="type" default="text" type="InputType"/>
+      <xs:attribute name="name">
+	<xs:annotation>
+	  <xs:documentation>
+          the name attribute is required for all but submit &amp; reset
+          </xs:documentation>
+	</xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="value"/>
+      <xs:attribute name="checked">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="checked"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="readonly">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="readonly"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="size"/>
+      <xs:attribute name="maxlength" type="Number"/>
+      <xs:attribute name="src" type="URI"/>
+      <xs:attribute name="alt"/>
+      <xs:attribute name="usemap" type="URI"/>
+      <xs:attribute name="onselect" type="Script"/>
+      <xs:attribute name="onchange" type="Script"/>
+      <xs:attribute name="accept" type="ContentTypes"/>
+      <xs:attribute name="align" type="ImgAlign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="select">
+    <xs:annotation>
+      <xs:documentation>
+      option selector
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="optgroup"/>
+        <xs:element ref="option"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="size" type="Number"/>
+      <xs:attribute name="multiple">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="multiple"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="tabindex" type="tabindexNumber"/>
+      <xs:attribute name="onfocus" type="Script"/>
+      <xs:attribute name="onblur" type="Script"/>
+      <xs:attribute name="onchange" type="Script"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="optgroup">
+    <xs:annotation>
+      <xs:documentation>
+      option group
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="option"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="label" use="required" type="Text"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="option">
+    <xs:annotation>
+      <xs:documentation>
+      selectable choice
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="selected">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="selected"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="label" type="Text"/>
+      <xs:attribute name="value"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="textarea">
+    <xs:annotation>
+      <xs:documentation>
+      multi-line text field
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="focus"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="rows" use="required" type="Number"/>
+      <xs:attribute name="cols" use="required" type="Number"/>
+      <xs:attribute name="disabled">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="readonly">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="readonly"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="onselect" type="Script"/>
+      <xs:attribute name="onchange" type="Script"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="fieldset">
+    <xs:annotation>
+      <xs:documentation>
+      The fieldset element is used to group form fields.
+      Only one legend element should occur in the content
+      and if present should only be preceded by whitespace.
+
+      NOTE: this content model is different from the XHTML 1.0 DTD,
+      closer to the intended content model in HTML4 DTD
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element ref="legend"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:group ref="block"/>
+          <xs:element ref="form"/>
+          <xs:group ref="inline"/>
+          <xs:group ref="misc"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="LAlign">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="top"/>
+      <xs:enumeration value="bottom"/>
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="right"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="legend">
+    <xs:annotation>
+      <xs:documentation>
+      fieldset label
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="accesskey" type="Character"/>
+          <xs:attribute name="align" type="LAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="button">
+    <xs:annotation>
+      <xs:documentation>
+      Content is "Flow" excluding a, form and form controls
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="button.content">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attributeGroup ref="focus"/>
+          <xs:attribute name="name"/>
+          <xs:attribute name="value"/>
+          <xs:attribute name="type" default="submit">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="button"/>
+                <xs:enumeration value="submit"/>
+                <xs:enumeration value="reset"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="disabled">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="disabled"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="isindex">
+    <xs:annotation>
+      <xs:documentation>
+      single-line text input control (DEPRECATED)
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="coreattrs"/>
+      <xs:attributeGroup ref="i18n"/>
+      <xs:attribute name="prompt" type="Text"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    ======================= Tables =======================================
+
+    Derived from IETF HTML table standard, see [RFC1942]
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="TFrame">
+    <xs:annotation>
+      <xs:documentation>
+      The border attribute sets the thickness of the frame around the
+      table. The default units are screen pixels.
+
+      The frame attribute specifies which parts of the frame around
+      the table should be rendered. The values are not the same as
+      CALS to avoid a name clash with the valign attribute.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="void"/>
+      <xs:enumeration value="above"/>
+      <xs:enumeration value="below"/>
+      <xs:enumeration value="hsides"/>
+      <xs:enumeration value="lhs"/>
+      <xs:enumeration value="rhs"/>
+      <xs:enumeration value="vsides"/>
+      <xs:enumeration value="box"/>
+      <xs:enumeration value="border"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="TRules">
+    <xs:annotation>
+      <xs:documentation>
+      The rules attribute defines which rules to draw between cells:
+
+      If rules is absent then assume:
+          "none" if border is absent or border="0" otherwise "all"
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="groups"/>
+      <xs:enumeration value="rows"/>
+      <xs:enumeration value="cols"/>
+      <xs:enumeration value="all"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="TAlign">
+    <xs:annotation>
+      <xs:documentation>
+      horizontal placement of table relative to document
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="center"/>
+      <xs:enumeration value="right"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:attributeGroup name="cellhalign">
+    <xs:annotation>
+      <xs:documentation>
+      horizontal alignment attributes for cell contents
+
+      char        alignment char, e.g. char=':'
+      charoff     offset for alignment char
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="align">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="left"/>
+          <xs:enumeration value="center"/>
+          <xs:enumeration value="right"/>
+          <xs:enumeration value="justify"/>
+          <xs:enumeration value="char"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="char" type="Character"/>
+    <xs:attribute name="charoff" type="Length"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="cellvalign">
+    <xs:annotation>
+      <xs:documentation>
+      vertical alignment attributes for cell contents
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="valign">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="top"/>
+          <xs:enumeration value="middle"/>
+          <xs:enumeration value="bottom"/>
+          <xs:enumeration value="baseline"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:element name="table">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="caption"/>
+        <xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="col"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="colgroup"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="thead"/>
+        <xs:element minOccurs="0" ref="tfoot"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" ref="tbody"/>
+          <xs:element maxOccurs="unbounded" ref="tr"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="summary" type="Text"/>
+      <xs:attribute name="width" type="Length"/>
+      <xs:attribute name="border" type="Pixels"/>
+      <xs:attribute name="frame" type="TFrame"/>
+      <xs:attribute name="rules" type="TRules"/>
+      <xs:attribute name="cellspacing" type="Length"/>
+      <xs:attribute name="cellpadding" type="Length"/>
+      <xs:attribute name="align" type="TAlign"/>
+      <xs:attribute name="bgcolor" type="Color"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="CAlign">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="top"/>
+      <xs:enumeration value="bottom"/>
+      <xs:enumeration value="left"/>
+      <xs:enumeration value="right"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="caption">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Inline">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="align" type="CAlign"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+    Use thead to duplicate headers when breaking table
+    across page boundaries, or for static headers when
+    tbody sections are rendered in scrolling panel.
+
+    Use tfoot to duplicate footers when breaking table
+    across page boundaries, or for static footers when
+    tbody sections are rendered in scrolling panel.
+
+    Use multiple tbody sections when rules are needed
+    between groups of table rows.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="thead">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tfoot">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tbody">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="colgroup">
+    <xs:annotation>
+      <xs:documentation>
+      colgroup groups a set of col elements. It allows you to group
+      several semantically related columns together.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="col"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="span" default="1" type="Number"/>
+      <xs:attribute name="width" type="MultiLength"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="col">
+    <xs:annotation>
+      <xs:documentation>
+      col elements define the alignment properties for cells in
+      one or more columns.
+
+      The width attribute specifies the width of the columns, e.g.
+
+          width=64        width in screen pixels
+          width=0.5*      relative width of 0.5
+
+      The span attribute causes the attributes of one
+      col element to apply to more than one column.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attribute name="span" default="1" type="Number"/>
+      <xs:attribute name="width" type="MultiLength"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="tr">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="th"/>
+        <xs:element ref="td"/>
+      </xs:choice>
+      <xs:attributeGroup ref="attrs"/>
+      <xs:attributeGroup ref="cellhalign"/>
+      <xs:attributeGroup ref="cellvalign"/>
+      <xs:attribute name="bgcolor" type="Color"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="Scope">
+    <xs:annotation>
+      <xs:documentation>
+      Scope is simpler than headers attribute for common tables
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="row"/>
+      <xs:enumeration value="col"/>
+      <xs:enumeration value="rowgroup"/>
+      <xs:enumeration value="colgroup"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:annotation>
+    <xs:documentation>
+    th is for headers, td for data and for cells acting as both
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="th">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="abbr" type="Text"/>
+          <xs:attribute name="axis"/>
+          <xs:attribute name="headers" type="xs:IDREFS"/>
+          <xs:attribute name="scope" type="Scope"/>
+          <xs:attribute name="rowspan" default="1" type="Number"/>
+          <xs:attribute name="colspan" default="1" type="Number"/>
+          <xs:attributeGroup ref="cellhalign"/>
+          <xs:attributeGroup ref="cellvalign"/>
+          <xs:attribute name="nowrap">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="nowrap"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="bgcolor" type="Color"/>
+          <xs:attribute name="width" type="Length"/>
+          <xs:attribute name="height" type="Length"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="td">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="Flow">
+          <xs:attributeGroup ref="attrs"/>
+          <xs:attribute name="abbr" type="Text"/>
+          <xs:attribute name="axis"/>
+          <xs:attribute name="headers" type="xs:IDREFS"/>
+          <xs:attribute name="scope" type="Scope"/>
+          <xs:attribute name="rowspan" default="1" type="Number"/>
+          <xs:attribute name="colspan" default="1" type="Number"/>
+          <xs:attributeGroup ref="cellhalign"/>
+          <xs:attributeGroup ref="cellvalign"/>
+          <xs:attribute name="nowrap">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="nowrap"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="bgcolor" type="Color"/>
+          <xs:attribute name="width" type="Length"/>
+          <xs:attribute name="height" type="Length"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-attribs-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-attribs-1.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema common attributes module for XHTML
+      $Id: xhtml-attribs-1.xsd,v 1.9 2009/11/18 17:59:51 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_commonatts"/>
+    </xs:annotation>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+             schemaLocation="http://www.w3.org/2001/xml.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        This import brings in the XML namespace attributes
+        The module itself does not provide the schemaLocation
+        and expects the driver schema to provide the
+        actual SchemaLocation.
+      </xs:documentation>
+        </xs:annotation>
+    </xs:import>
+    <xs:attributeGroup name="xhtml.id">
+        <xs:attribute name="id" type="xs:ID"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.class">
+        <xs:attribute name="class" type="xs:string"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.title">
+        <xs:attribute name="title" type="xs:string"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.Core.attrib">
+        <xs:attribute ref="xml:space" fixed="preserve"/>
+        <xs:attributeGroup ref="xhtml.id"/>
+        <xs:attributeGroup ref="xhtml.class"/>
+        <xs:attributeGroup ref="xhtml.title"/>
+        <xs:attributeGroup ref="xhtml.Core.extra.attrib"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.I18n.attrib">
+        <xs:attribute ref="xml:lang" />
+        <xs:attributeGroup ref="xhtml.I18n.extra.attrib"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.Common.attrib">
+        <xs:attributeGroup ref="xhtml.Core.attrib"/>
+        <xs:attributeGroup ref="xhtml.I18n.attrib"/>
+        <xs:attributeGroup ref="xhtml.Common.extra"/>
+    </xs:attributeGroup>
+    <!-- Global attributes -->
+    <xs:attribute name="id" type="xs:ID"/>
+    <xs:attribute name="class" type="xs:string"/>
+    <xs:attribute name="title" type="xs:string"/>
+    <xs:attributeGroup name="xhtml.Global.core.attrib">
+        <xs:attribute ref="id"/>
+        <xs:attribute ref="class"/>
+        <xs:attribute ref="title"/>
+        <xs:attributeGroup ref="xhtml.Global.core.extra.attrib" />
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.Global.i18n.attrib">
+        <xs:attribute ref="xml:lang" />
+        <xs:attributeGroup ref="xhtml.Global.I18n.extra.attrib"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.Global.common.attrib">
+        <xs:attributeGroup ref="xhtml.Global.core.attrib"/>
+        <xs:attributeGroup ref="xhtml.Global.i18n.attrib"/>
+        <xs:attributeGroup ref="xhtml.Global.Common.extra"/>
+    </xs:attributeGroup>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-base-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-base-1.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+        Base element
+        This is the XML Schema Base Element module for XHTML      
+                
+          * base
+
+        This module declares the base element type and its attributes,        
+        used to define a base URI against which relative URIs in the
+        document will be resolved.
+
+        $Id: xhtml-base-1.xsd,v 1.2 2005/09/26 22:54:53 ahby Exp $
+      </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_basemodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.base.attlist">
+        <xs:attribute name="href" type="xh11d:URI" use="required"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.base.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.base.type">
+        <xs:group ref="xhtml.base.content"/>
+        <xs:attributeGroup ref="xhtml.base.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-bdo-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-bdo-1.xsd
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+          Bidirectional Override (bdo) Element
+          This is the XML Schema BDO Element module for XHTML
+
+          This modules declares the element 'bdo' and 'dir' attributes,
+          Used to override the  Unicode bidirectional algorithm for selected
+          fragments of text.
+          Bidirectional text support includes both the bdo element and
+          the 'dir' attribute.
+
+          $Id: xhtml-bdo-1.xsd,v 1.6 2009/11/18 17:59:51 ahby Exp $
+      </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_bdomodule"/>
+    </xs:annotation>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+             schemaLocation="http://www.w3.org/2001/xml.xsd">
+        <xs:annotation>
+            <xs:documentation>
+           This import brings in the XML namespace attributes
+           The module itself does not provide the schemaLocation
+           and expects the driver schema to provide the
+           actual SchemaLocation.
+         </xs:documentation>
+        </xs:annotation>
+    </xs:import>
+    <xs:attributeGroup name="xhtml.bdo.attlist">
+        <xs:attributeGroup ref="xhtml.Core.attrib"/>
+        <xs:attributeGroup ref="xhtml.I18n.extra.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.bdo.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.bdo.type" mixed="true">
+        <xs:group ref="xhtml.bdo.content"/>
+        <xs:attributeGroup ref="xhtml.bdo.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.dir.attrib">
+        <xs:attribute name="dir">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="ltr"/>
+                    <xs:enumeration value="rtl"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <!-- Global dir attribute -->
+    <xs:attribute name="dir">
+        <xs:simpleType>
+            <xs:restriction base="xs:NMTOKEN">
+                <xs:enumeration value="ltr"/>
+                <xs:enumeration value="rtl"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:attribute>
+    <xs:attributeGroup name="xhtml.Global.bdo.attrib">
+        <xs:attribute ref="dir"/>
+    </xs:attributeGroup>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-blkphras-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-blkphras-1.xsd
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:include schemaLocation="xhtml-attribs-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+          This is the XML Schema Block Phrasal support module for XHTML
+          $Id: xhtml-blkphras-1.xsd,v 1.7 2008/07/05 04:11:00 ahby Exp $
+       </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+           Block Phrasal
+           This module declares the elements and their attributes used to
+           support block-level phrasal markup.
+           This is the XML Schema block phrasal elements module for XHTML
+
+            * address, blockquote, pre, h1, h2, h3, h4, h5, h6
+      </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_textmodule"/>
+    </xs:annotation>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+             schemaLocation="http://www.w3.org/2001/xml.xsd">
+        <xs:annotation>
+            <xs:documentation>
+          This import brings in the XML namespace attributes 
+          The module itself does not provide the schemaLocation
+          and expects the driver schema to provide the 
+          actual SchemaLocation.
+        </xs:documentation>
+        </xs:annotation>
+    </xs:import>
+    <!-- address -->
+    <xs:attributeGroup name="xhtml.address.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.address.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.address.type" mixed="true">
+        <xs:group ref="xhtml.address.content"/>
+        <xs:attributeGroup ref="xhtml.address.attlist"/>
+    </xs:complexType>
+    <!-- blockquote -->
+    <xs:attributeGroup name="xhtml.blockquote.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="cite" type="xh11d:URI"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.blockquote.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Block.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.blockquote.type">
+        <xs:group ref="xhtml.blockquote.content"/>
+        <xs:attributeGroup ref="xhtml.blockquote.attlist"/>
+    </xs:complexType>
+    <!-- pre -->
+    <xs:attributeGroup name="xhtml.pre.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.pre.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.InlinePre.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.pre.type" mixed="true">
+        <xs:group ref="xhtml.pre.content"/>
+        <xs:attributeGroup ref="xhtml.pre.attlist"/>
+    </xs:complexType>
+    <!-- Heading Elements  -->
+    <xs:attributeGroup name="xhtml.heading.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:complexType name="xhtml.heading.type" mixed="true">
+        <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:attributeGroup ref="xhtml.heading.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.h1.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.h1.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.h1.type" mixed="true">
+        <xs:group ref="xhtml.h1.content"/>
+        <xs:attributeGroup ref="xhtml.h1.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.h2.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.h2.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.h2.type" mixed="true">
+        <xs:group ref="xhtml.h2.content"/>
+        <xs:attributeGroup ref="xhtml.h2.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.h3.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.h3.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.h3.type" mixed="true">
+        <xs:group ref="xhtml.h3.content"/>
+        <xs:attributeGroup ref="xhtml.h3.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.h4.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.h4.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.h4.type" mixed="true">
+        <xs:group ref="xhtml.h4.content"/>
+        <xs:attributeGroup ref="xhtml.h4.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.h5.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.h5.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.h5.type" mixed="true">
+        <xs:group ref="xhtml.h5.content"/>
+        <xs:attributeGroup ref="xhtml.h5.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.h6.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.h6.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.h6.type" mixed="true">
+        <xs:group ref="xhtml.h6.content"/>
+        <xs:attributeGroup ref="xhtml.h6.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-blkpres-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-blkpres-1.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML SchemaBlock presentation element module for XHTML
+      $Id: xhtml-blkpres-1.xsd,v 1.2 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Block Presentational Elements
+  
+        * hr
+  
+      This module declares the elements and their attributes used to
+      support block-level presentational markup.
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_presentationmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.hr.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.hr.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.hr.type">
+        <xs:group ref="xhtml.hr.content"/>
+        <xs:attributeGroup ref="xhtml.hr.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-blkstruct-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-blkstruct-1.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      Block Structural
+
+        * div, p
+  
+      This module declares the elements and their attributes used to
+      support block-level structural markup.            
+          
+      This is the XML Schema Block Structural module for XHTML
+      $Id: xhtml-blkstruct-1.xsd,v 1.3 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <!-- div -->
+    <xs:attributeGroup name="xhtml.div.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.div.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Flow.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.div.type" mixed="true">
+        <xs:group ref="xhtml.div.content"/>
+        <xs:attributeGroup ref="xhtml.div.attlist"/>
+    </xs:complexType>
+    <!-- p -->
+    <xs:attributeGroup name="xhtml.p.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.p.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.p.type" mixed="true">
+        <xs:group ref="xhtml.p.content"/>
+        <xs:attributeGroup ref="xhtml.p.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-copyright-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-copyright-1.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+  <xs:annotation>
+    <xs:documentation>
+      This is XHTML, a reformulation of HTML as a modular XML application
+      The Extensible HyperText Markup Language (XHTML)
+      Copyright &#169;1998-2005 World Wide Web Consortium
+      (Massachusetts Institute of Technology, European Research Consortium
+       for Informatics and Mathematics, Keio University).
+      All Rights Reserved.
+    
+      Permission to use, copy, modify and distribute the XHTML Schema
+      modules and their accompanying xs:documentation for any purpose
+      and without fee is hereby granted in perpetuity, provided that the above
+      copyright notice and this paragraph appear in all copies.  
+      The copyright holders make no representation about the suitability of
+      these XML Schema modules for any purpose.
+    
+      They are provided "as is" without expressed or implied warranty.
+    </xs:documentation>
+  </xs:annotation>
+
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-csismap-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-csismap-1.xsd
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+      Client-side Image Maps    
+      This is the XML Schema Client-side Image Maps module for XHTML
+
+        * area, map      
+
+      This module declares elements and attributes to support client-side
+      image maps. 
+      
+      $Id: xhtml-csismap-1.xsd,v 1.3 2009/09/30 15:12:48 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_imapmodule"/>
+    </xs:annotation>
+    <xs:simpleType name="xhtml.Shape.Datatype">
+        <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="rect"/>
+            <xs:enumeration value="circle"/>
+            <xs:enumeration value="poly"/>
+            <xs:enumeration value="default"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="xhtml.Coords.Datatype">
+        <xs:restriction base="xh11d:Text"/>
+    </xs:simpleType>
+    <!-- modify anchor attribute definition list -->
+    <xs:attributeGroup name="xhtml.a.csim.attlist">
+        <xs:attribute name="shape" type="xhtml.Shape.Datatype" default="rect"/>
+        <xs:attribute name="coords" type="xhtml.Coords.Datatype"/>
+    </xs:attributeGroup>
+    <!-- modify img attribute definition list -->
+    <xs:attributeGroup name="xhtml.img.csim.attlist">
+        <xs:attribute name="usemap" type="xh11d:URIREF"/>
+    </xs:attributeGroup>
+    <!-- modify form input attribute definition list -->
+    <xs:attributeGroup name="xhtml.input.csim.attlist">
+        <xs:attribute name="usemap" type="xh11d:URIREF"/>
+    </xs:attributeGroup>
+    <!-- modify object attribute definition list -->
+    <xs:attributeGroup name="xhtml.object.csim.attlist">
+        <xs:attribute name="usemap" type="xh11d:URIREF"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.area.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="href" type="xh11d:URI"/>
+        <xs:attribute name="shape" type="xhtml.Shape.Datatype" default="rect"/>
+        <xs:attribute name="coords" type="xhtml.Coords.Datatype"/>
+        <xs:attribute name="nohref">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="nohref"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="alt" type="xh11d:Text" use="required"/>
+        <xs:attribute name="tabindex" type="xh11d:Number"/>
+        <xs:attribute name="accesskey" type="xh11d:Character"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.area.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.area.type">
+        <xs:group ref="xhtml.area.content"/>
+        <xs:attributeGroup ref="xhtml.area.attlist"/>
+    </xs:complexType>
+    <!-- map -->
+    <xs:attributeGroup name="xhtml.map.attlist">
+        <xs:attribute name="id" type="xs:ID" use="required"/>
+        <xs:attributeGroup ref="xhtml.class"/>
+        <xs:attributeGroup ref="xhtml.title"/>
+        <xs:attributeGroup ref="xhtml.Core.extra.attrib"/>
+        <xs:attributeGroup ref="xhtml.I18n.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.map.content">
+        <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+                <xs:group ref="xhtml.Block.mix"/>
+                <xs:element name="area" type="xhtml.area.type"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.map.type">
+        <xs:group ref="xhtml.map.content"/>
+        <xs:attributeGroup ref="xhtml.map.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-datatypes-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-datatypes-1.xsd
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ xmlns="http://www.w3.org/1999/xhtml/datatypes/"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+ targetNamespace="http://www.w3.org/1999/xhtml/datatypes/"
+ elementFormDefault="qualified"
+>
+    <xs:annotation>
+        <xs:documentation>
+          XHTML Datatypes
+          This is the XML Schema datatypes module for XHTML
+          
+          Defines containers for the XHTML datatypes, many of
+          these imported from other specifications and standards.
+          
+          $Id: xhtml-datatypes-1.xsd,v 1.12 2009/09/30 15:12:48 ahby Exp $
+        </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstraction.html#s_common_attrtypes"/>
+    </xs:annotation>
+
+    <!-- nn for pixels or nn% for percentage length -->
+    <xs:simpleType name="Length">
+        <xs:union memberTypes="xs:nonNegativeInteger">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:pattern value="\d+[%]|\d*\.\d+[%]"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+    <!-- space-separated list of link types -->
+    <xs:simpleType name="LinkTypes">
+        <xs:list itemType="xs:NMTOKEN"/>
+    </xs:simpleType>
+    <!-- single or comma-separated list of media descriptors -->
+    <xs:simpleType name="MediaDesc">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <!-- pixel, percentage, or relative -->
+    <xs:simpleType name="MultiLength">
+        <xs:union memberTypes="xh11d:Length">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:pattern value="\d*\*"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+    <!-- one or more digits (NUMBER) -->
+    <xs:simpleType name="Number">
+        <xs:restriction base="xs:nonNegativeInteger"/>
+    </xs:simpleType>
+    <!-- integer representing length in pixels -->
+    <xs:simpleType name="Pixels">
+        <xs:restriction base="xs:nonNegativeInteger"/>
+    </xs:simpleType>
+    <!-- script expression -->
+    <xs:simpleType name="Script">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <!-- sixteen color names or RGB color expression-->
+    <xs:simpleType name="Color">
+        <xs:union memberTypes="xs:NMTOKEN">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:pattern value="#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+    <!-- textual content -->
+    <xs:simpleType name="Text">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <!-- Imported Datatypes  -->
+    <!-- a single character, as per section 2.2 of [XML] -->
+    <xs:simpleType name="Character">
+        <xs:restriction base="xs:string">
+            <xs:length value="1" fixed="true"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- a character encoding, as per [RFC2045] -->
+    <xs:simpleType name="Charset">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <!-- a space separated list of character encodings, as per [RFC2045] -->
+    <xs:simpleType name="Charsets">
+        <xs:list itemType="Charset"/>
+    </xs:simpleType>
+    <!-- media type, as per [RFC2045] -->
+    <xs:simpleType name="ContentType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <!-- comma-separated list of media types, as per [RFC2045] -->
+    <xs:simpleType name="ContentTypes">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <!-- date and time information. ISO date format -->
+    <xs:simpleType name="Datetime">
+        <xs:restriction base="xs:dateTime"/>
+    </xs:simpleType>
+    <!-- formal public identifier, as per [ISO8879] -->
+    <xs:simpleType name="FPI">
+        <xs:restriction base="xs:normalizedString"/>
+    </xs:simpleType>
+
+    <!-- a window name as used in the target attribute -->
+    <xs:simpleType name="FrameTarget">
+      <xs:union>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="_blank"/>
+            <xs:enumeration value="_self"/>
+            <xs:enumeration value="_parent"/>
+            <xs:enumeration value="_top"/>
+          </xs:restriction>
+        </xs:simpleType>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="[a-zA-Z].*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:union>
+    </xs:simpleType>
+    
+    <!-- a language code, as per [RFC3066] -->
+    <xs:simpleType name="LanguageCode">
+     <xs:union memberTypes="xs:language">
+       <xs:simpleType>    
+         <xs:restriction base="xs:string">
+           <xs:enumeration value=""/>
+         </xs:restriction>
+       </xs:simpleType>
+     </xs:union>
+    </xs:simpleType>
+    <!-- a comma separated list of language ranges -->
+    <xs:simpleType name="LanguageCodes">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <!-- a Uniform Resource Identifier, see [URI] -->
+    <xs:simpleType name="URI">
+        <xs:restriction base="xs:anyURI"/>
+    </xs:simpleType>
+    <!-- a space-separated list of Uniform Resource Identifiers, see [URI] -->
+    <xs:simpleType name="URIs">
+        <xs:list itemType="xs:anyURI"/>
+    </xs:simpleType>
+    <!-- a relative URI reference to a fragment ID -->
+    <xs:simpleType name="URIREF">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="#\c*" />
+            <xs:minLength value="1"/>
+        </xs:restriction>
+    </xs:simpleType> 
+    <!-- comma-separated list of MultiLength -->
+    <xs:simpleType name="MultiLengths">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <!-- character Data -->
+    <xs:simpleType name="CDATA">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <!-- CURIE placeholder datatypes -->
+    <xs:simpleType name="CURIE">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="(([\i-[:]][\c-[:]]*)?:)?(/[^\s/][^\s]*|[^\s/][^\s]*|[^\s]?)" />
+            <xs:minLength value="1"/>
+        </xs:restriction>
+    </xs:simpleType> 
+
+    <xs:simpleType name="CURIEs">
+        <xs:list itemType="xh11d:CURIE"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="SafeCURIE">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\[(([\i-[:]][\c-[:]]*)?:)?(/[^\s/][^\s]*|[^\s/][^\s]*|[^\s]?)\]" />
+            <xs:minLength value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="SafeCURIEs">
+        <xs:list itemType="xh11d:SafeCURIE"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="URIorSafeCURIE">
+        <xs:union memberTypes="xs:anyURI xh11d:SafeCURIE" />
+    </xs:simpleType>
+    <xs:simpleType name="URIorSafeCURIEs">
+        <xs:list itemType="xh11d:URIorSafeCURIE"/>
+    </xs:simpleType>
+
+    <!-- RDFa Core 1.1 Datatypes -->
+    <xs:simpleType name="PREFIX">
+        <xs:restriction base="xs:Name">
+            <xs:pattern value="[\i-[:]][\c-[:]]*: [\i-[:]][\c-[:]]+:.+" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="PREFIXes">
+        <xs:list itemType="xh11d:PREFIX"/>
+    </xs:simpleType> 
+
+    <xs:simpleType name="TERM">
+      <xs:restriction base="xs:Name">
+        <xs:pattern value="[\i-[:]][/\c-[:]]*" />
+      </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="CURIEorIRI">
+        <xs:union memberTypes="xh11d:CURIE xs:anyURI" />
+    </xs:simpleType>
+
+    <xs:simpleType name="CURIEorIRIs">
+        <xs:list itemType="xh11d:CURIEorIRI"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="SafeCURIEorCURIEorIRI">
+        <xs:union memberTypes="xh11d:SafeCURIE xh11d:CURIE xs:anyURI" />
+    </xs:simpleType>
+
+    <xs:simpleType name="SafeCURIEorCURIEorIRIs">
+        <xs:list itemType="xh11d:SafeCURIEorCURIEorIRI"/>
+    </xs:simpleType>
+
+    <xs:simpleType name='AbsIRI'>
+        <xs:restriction base='xs:string'>
+            <xs:pattern value="[\i-[:]][\c-[:]]+:.+" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="TERMorCURIEorAbsIRI">
+        <xs:union memberTypes="xh11d:TERM xh11d:CURIE xh11d:AbsIRI" />
+    </xs:simpleType>
+
+    <xs:simpleType name="TERMorCURIEorAbsIRIs">
+        <xs:list itemType="xh11d:TERMorCURIEorAbsIRI"/>
+    </xs:simpleType>
+
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-edit-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-edit-1.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+          Editing Elements
+          This is the XML Schema Editing Markup module for XHTML
+
+           * ins, del
+  
+         This module declares element types and attributes used to indicate
+         inserted and deleted content while editing a document.
+
+          $Id: xhtml-edit-1.xsd,v 1.2 2005/09/26 22:54:53 ahby Exp $
+        </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_editmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.edit.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="cite" type="xh11d:URI"/>
+        <xs:attribute name="datetime" type="xh11d:Datetime"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.edit.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Flow.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.edit.type" mixed="true">
+        <xs:group ref="xhtml.edit.content"/>
+        <xs:attributeGroup ref="xhtml.edit.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-events-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-events-1.xsd
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema Intrinsic Events module for XHTML
+      $Id: xhtml-events-1.xsd,v 1.4 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Intrinsic Event Attributes
+      These are the event attributes defined in HTML 4,
+      Section 18.2.3 "Intrinsic Events".
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_intrinsiceventsmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.Events.attrib">
+        <xs:attribute name="onclick" type="xh11d:Script"/>
+        <xs:attribute name="ondblclick" type="xh11d:Script"/>
+        <xs:attribute name="onmousedown" type="xh11d:Script"/>
+        <xs:attribute name="onmouseup" type="xh11d:Script"/>
+        <xs:attribute name="onmouseover" type="xh11d:Script"/>
+        <xs:attribute name="onmousemove" type="xh11d:Script"/>
+        <xs:attribute name="onmouseout" type="xh11d:Script"/>
+        <xs:attribute name="onkeypress" type="xh11d:Script"/>
+        <xs:attribute name="onkeydown" type="xh11d:Script"/>
+        <xs:attribute name="onkeyup" type="xh11d:Script"/>
+    </xs:attributeGroup>
+    <!--
+    additional attributes on anchor element
+-->
+    <xs:attributeGroup name="xhtml.a.events.attlist">
+        <xs:attribute name="onfocus" type="xh11d:Script"/>
+        <xs:attribute name="onblur" type="xh11d:Script"/>
+    </xs:attributeGroup>
+    <!--
+    additional attributes on form element
+-->
+    <xs:attributeGroup name="xhtml.form.events.attlist">
+        <xs:attribute name="onsubmit" type="xh11d:Script"/>
+        <xs:attribute name="onreset" type="xh11d:Script"/>
+    </xs:attributeGroup>
+    <!--
+    additional attributes on label element
+-->
+    <xs:attributeGroup name="xhtml.label.events.attlist">
+        <xs:attribute name="onfocus" type="xh11d:Script"/>
+        <xs:attribute name="onblur" type="xh11d:Script"/>
+    </xs:attributeGroup>
+    <!--
+    additional attributes on input element
+-->
+    <xs:attributeGroup name="xhtml.input.events.attlist">
+        <xs:attribute name="onfocus" type="xh11d:Script"/>
+        <xs:attribute name="onblur" type="xh11d:Script"/>
+        <xs:attribute name="onselect" type="xh11d:Script"/>
+        <xs:attribute name="onchange" type="xh11d:Script"/>
+    </xs:attributeGroup>
+    <!--
+    additional attributes on select element
+-->
+    <xs:attributeGroup name="xhtml.select.events.attlist">
+        <xs:attribute name="onfocus" type="xh11d:Script"/>
+        <xs:attribute name="onblur" type="xh11d:Script"/>
+        <xs:attribute name="onchange" type="xh11d:Script"/>
+    </xs:attributeGroup>
+    <!--
+    additional attributes on textarea element
+-->
+    <xs:attributeGroup name="xhtml.textarea.events.attlist">
+        <xs:attribute name="onfocus" type="xh11d:Script"/>
+        <xs:attribute name="onblur" type="xh11d:Script"/>
+        <xs:attribute name="onselect" type="xh11d:Script"/>
+        <xs:attribute name="onchange" type="xh11d:Script"/>
+    </xs:attributeGroup>
+    <!--
+    additional attributes on button element
+-->
+    <xs:attributeGroup name="xhtml.button.events.attlist">
+        <xs:attribute name="onfocus" type="xh11d:Script"/>
+        <xs:attribute name="onblur" type="xh11d:Script"/>
+    </xs:attributeGroup>
+    <!--
+    additional attributes on body element
+-->
+    <xs:attributeGroup name="xhtml.body.events.attlist">
+        <xs:attribute name="onload" type="xh11d:Script"/>
+        <xs:attribute name="onunload" type="xh11d:Script"/>
+    </xs:attributeGroup>
+    <!--
+    additional attributes on area element
+-->
+    <xs:attributeGroup name="xhtml.area.events.attlist">
+        <xs:attribute name="onfocus" type="xh11d:Script"/>
+        <xs:attribute name="onblur" type="xh11d:Script"/>
+    </xs:attributeGroup>
+    <!--
+   Global Events Attributes
+-->
+    <xs:attribute name="onclick" type="xh11d:Script"/>
+    <xs:attribute name="ondblclick" type="xh11d:Script"/>
+    <xs:attribute name="onmousedown" type="xh11d:Script"/>
+    <xs:attribute name="onmouseup" type="xh11d:Script"/>
+    <xs:attribute name="onmouseover" type="xh11d:Script"/>
+    <xs:attribute name="onmousemove" type="xh11d:Script"/>
+    <xs:attribute name="onmouseout" type="xh11d:Script"/>
+    <xs:attribute name="onkeypress" type="xh11d:Script"/>
+    <xs:attribute name="onkeydown" type="xh11d:Script"/>
+    <xs:attribute name="onkeyup" type="xh11d:Script"/>
+    <xs:attributeGroup name="xhtml.Global.events.attrib">
+        <xs:attribute ref="onclick"/>
+        <xs:attribute ref="ondblclick"/>
+        <xs:attribute ref="onmousedown"/>
+        <xs:attribute ref="onmouseup"/>
+        <xs:attribute ref="onmouseover"/>
+        <xs:attribute ref="onmousemove"/>
+        <xs:attribute ref="onmouseout"/>
+        <xs:attribute ref="onkeypress"/>
+        <xs:attribute ref="onkeydown"/>
+        <xs:attribute ref="onkeyup"/>
+    </xs:attributeGroup>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-form-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-form-1.xsd
@@ -1,0 +1,327 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+      Forms    
+      This is the XML Schema Forms module for XHTML      
+  
+        * form, label, input, select, optgroup, option,
+          textarea, fieldset, legend, button
+    
+      This module declares markup to provide support for online
+      forms, based on the features found in HTML 4.0 forms.
+          
+    
+      $Id: xhtml-form-1.xsd,v 1.4 2009/09/30 15:22:38 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_extformsmodule"/>
+    </xs:annotation>
+    <!-- form: Form Element -->
+    <xs:attributeGroup name="xhtml.form.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="action" type="xh11d:URI" use="required"/>
+        <xs:attribute name="method" default="get">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="get"/>
+                    <xs:enumeration value="post"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="name" type="xh11d:CDATA"/>
+        <xs:attribute name="enctype" type="xh11d:ContentType" default="application/x-www-form-urlencoded"/>
+        <xs:attribute name="accept-charset" type="xh11d:Charsets"/>
+        <xs:attribute name="accept" type="xh11d:ContentTypes"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.form.content">
+        <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+                <xs:group ref="xhtml.BlkNoForm.mix"/>
+                <xs:element name="fieldset" type="xhtml.fieldset.type"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.form.type">
+        <xs:group ref="xhtml.form.content"/>
+        <xs:attributeGroup ref="xhtml.form.attlist"/>
+    </xs:complexType>
+    <!-- 
+    label: Form Field Label Text 
+    Note: Each label must not contain more than ONE field
+-->
+    <xs:group name="xhtml.label.content">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="input" type="xhtml.input.type"/>
+                <xs:element name="select" type="xhtml.select.type"/>
+                <xs:element name="textarea" type="xhtml.textarea.type"/>
+                <xs:element name="button" type="xhtml.button.type"/>
+                <xs:group ref="xhtml.InlStruct.class"/>
+                <xs:group ref="xhtml.InlPhras.class"/>
+                <xs:group ref="xhtml.I18n.class"/>
+                <xs:group ref="xhtml.InlPres.class"/>
+                <xs:group ref="xhtml.InlSpecial.class"/>
+                <xs:group ref="xhtml.Inline.extra"/>
+                <xs:group ref="xhtml.Misc.class"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <xs:attributeGroup name="xhtml.label.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="for" type="xs:IDREF"/>
+        <xs:attribute name="accesskey" type="xh11d:Character"/>
+    </xs:attributeGroup>
+    <xs:complexType name="xhtml.label.type" mixed="true">
+        <xs:group ref="xhtml.label.content"/>
+        <xs:attributeGroup ref="xhtml.label.attlist"/>
+    </xs:complexType>
+    <!-- input: Form Control -->
+    <xs:simpleType name="xhtml.InputType.class">
+        <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="text"/>
+            <xs:enumeration value="password"/>
+            <xs:enumeration value="checkbox"/>
+            <xs:enumeration value="radio"/>
+            <xs:enumeration value="submit"/>
+            <xs:enumeration value="reset"/>
+            <xs:enumeration value="hidden"/>
+            <xs:enumeration value="image"/>
+            <xs:enumeration value="button"/>
+            <xs:enumeration value="file"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- 
+    attribute 'name' required for all but submit & reset
+-->
+    <xs:attributeGroup name="xhtml.input.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="type" type="xhtml.InputType.class" default="text"/>
+        <xs:attribute name="name" type="xh11d:CDATA"/>
+        <xs:attribute name="value" type="xh11d:CDATA"/>
+        <xs:attribute name="checked">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="checked"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="disabled">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="disabled"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="readonly">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="readonly"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="size" type="xh11d:Number"/>
+        <xs:attribute name="maxlength" type="xh11d:Number"/>
+        <xs:attribute name="src" type="xh11d:URI"/>
+        <xs:attribute name="alt" type="xh11d:Text"/>
+        <xs:attribute name="tabindex" type="xh11d:Number"/>
+        <xs:attribute name="accesskey" type="xh11d:Character"/>
+        <xs:attribute name="accept" type="xh11d:ContentTypes"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.input.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.input.type">
+        <xs:group ref="xhtml.input.content"/>
+        <xs:attributeGroup ref="xhtml.input.attlist"/>
+    </xs:complexType>
+    <!-- select: Option Selector  -->
+    <xs:attributeGroup name="xhtml.select.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="name" type="xh11d:CDATA"/>
+        <xs:attribute name="size" type="xh11d:Number"/>
+        <xs:attribute name="multiple">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="multiple"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="disabled">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="disabled"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="tabindex" type="xh11d:Number"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.select.content">
+        <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="optgroup" type="xhtml.optgroup.type"/>
+                <xs:element name="option" type="xhtml.option.type"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.select.type">
+        <xs:group ref="xhtml.select.content"/>
+        <xs:attributeGroup ref="xhtml.select.attlist"/>
+    </xs:complexType>
+    <!-- optgroup: Option Group  -->
+    <xs:attributeGroup name="xhtml.optgroup.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="disabled">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="disabled"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="label" type="xh11d:Text" use="required"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.optgroup.content">
+        <xs:sequence>
+            <xs:element name="option" type="xhtml.option.type" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.optgroup.type">
+        <xs:group ref="xhtml.optgroup.content"/>
+        <xs:attributeGroup ref="xhtml.optgroup.attlist"/>
+    </xs:complexType>
+    <!-- option: Selectable Choice  -->
+    <xs:attributeGroup name="xhtml.option.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="selected">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="selected"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="disabled">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="disabled"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="label" type="xh11d:Text"/>
+        <xs:attribute name="value" type="xh11d:CDATA"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.option.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.option.type" mixed="true">
+        <xs:group ref="xhtml.option.content"/>
+        <xs:attributeGroup ref="xhtml.option.attlist"/>
+    </xs:complexType>
+    <!-- textarea: Multi-Line Text Field  -->
+    <xs:attributeGroup name="xhtml.textarea.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="name" type="xh11d:CDATA"/>
+        <xs:attribute name="rows" type="xh11d:Number" use="required"/>
+        <xs:attribute name="cols" type="xh11d:Number" use="required"/>
+        <xs:attribute name="disabled">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="disabled"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="readonly">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="readonly"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="tabindex" type="xh11d:Number"/>
+        <xs:attribute name="accesskey" type="xh11d:Character"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.textarea.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.textarea.type" mixed="true">
+        <xs:group ref="xhtml.textarea.content"/>
+        <xs:attributeGroup ref="xhtml.textarea.attlist"/>
+    </xs:complexType>
+    <!-- fieldset: Form Control Group  -->
+    <xs:attributeGroup name="xhtml.fieldset.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.fieldset.content">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="legend" type="xhtml.legend.type"/>
+                <xs:group ref="xhtml.Flow.mix"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.fieldset.type" mixed="true">
+        <xs:group ref="xhtml.fieldset.content"/>
+        <xs:attributeGroup ref="xhtml.fieldset.attlist"/>
+    </xs:complexType>
+    <!-- legend: Fieldset Legend  -->
+    <xs:attributeGroup name="xhtml.legend.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="accesskey" type="xh11d:Character"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.legend.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.legend.type" mixed="true">
+        <xs:group ref="xhtml.legend.content"/>
+        <xs:attributeGroup ref="xhtml.legend.attlist"/>
+    </xs:complexType>
+    <!-- button: Push Button  -->
+    <xs:attributeGroup name="xhtml.button.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="name" type="xh11d:CDATA"/>
+        <xs:attribute name="value" type="xh11d:CDATA"/>
+        <xs:attribute name="type" default="submit">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="button"/>
+                    <xs:enumeration value="submit"/>
+                    <xs:enumeration value="reset"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="disabled">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="disabled"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="tabindex" type="xh11d:Number"/>
+        <xs:attribute name="accesskey" type="xh11d:Character"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.button.content">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="xhtml.BlkNoForm.mix"/>
+                <xs:group ref="xhtml.InlStruct.class"/>
+                <xs:group ref="xhtml.InlPhras.class"/>
+                <xs:group ref="xhtml.InlPres.class"/>
+                <xs:group ref="xhtml.I18n.class"/>
+                <xs:group ref="xhtml.InlSpecial.class"/>
+                <xs:group ref="xhtml.Inline.extra"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.button.type" mixed="true">
+        <xs:group ref="xhtml.button.content"/>
+        <xs:attributeGroup ref="xhtml.button.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-framework-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-framework-1.xsd
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+ elementFormDefault="qualified"
+>
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema Modular Framework support module for XHTML
+      $Id: xhtml-framework-1.xsd,v 1.5 2005/09/26 23:37:47 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      XHTML Modular Framework
+      This required module instantiates the necessary modules
+      needed to support the XHTML modularization framework.
+
+      The Schema modules instantiated are:
+        +  notations
+        +  datatypes
+        +  common attributes
+        +  character entities
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_commonatts"/>
+    </xs:annotation>
+    <!-- xs:include schemaLocation="xhtml-notations-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+         Notations module
+         Declares XHTML notations for Attribute data types
+      </xs:documentation>
+        </xs:annotation>
+    </xs:include -->
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" schemaLocation="xhtml-datatypes-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        This module defines XHTML Attribute DataTypes
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstraction.html#s_common_attrtypes"/>
+        </xs:annotation>
+    </xs:import>
+    <xs:include schemaLocation="xhtml-attribs-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        This module defines Common attributes for XHTML
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_commonatts"/>
+        </xs:annotation>
+    </xs:include>
+    <!-- xs:include schemaLocation="xhtml-charent-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Character entities module
+        Note: Entities are not supported in XML Schema
+        The Schema Module uses DTDs to define Entities
+
+        This module defines
+          + XHTML Latin 1 Character Entities
+          + XHTML Special Characters
+          + XHTML Mathematical, Greek, and Symbolic Characters
+    </xs:documentation>
+        </xs:annotation>
+    </xs:include -->
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-hypertext-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-hypertext-1.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+      Hypertext Module
+      This is the XML Schema Hypertext module for XHTML
+            
+        * a
+            
+      This module declares the anchor ('a') element type, which
+      defines the source of a hypertext link. The destination
+      (or link 'target') is identified via its 'id' attribute 
+      rather than the 'name' attribute as was used in HTML.
+
+      $Id: xhtml-hypertext-1.xsd,v 1.4 2005/09/26 23:37:47 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_hypertextmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.a.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="href" type="xh11d:URI"/>
+        <xs:attribute name="charset" type="xh11d:Charset"/>
+        <xs:attribute name="type" type="xh11d:ContentType"/>
+        <xs:attribute name="hreflang" type="xh11d:LanguageCode"/>
+        <xs:attribute name="rel" type="xh11d:LinkTypes"/>
+        <xs:attribute name="rev" type="xh11d:LinkTypes"/>
+        <xs:attribute name="accesskey" type="xh11d:Character"/>
+        <xs:attribute name="tabindex" type="xh11d:Number"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.a.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.InlNoAnchor.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.a.type" mixed="true">
+        <xs:group ref="xhtml.a.content"/>
+        <xs:attributeGroup ref="xhtml.a.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-image-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-image-1.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+      Images    
+      This is the XML Schema Images module for XHTML
+    
+        * img
+    
+      This module provides markup to support basic image embedding.
+      
+      To avoid problems with text-only UAs as well as to make
+      image content understandable and navigable to users of
+      non-visual UAs, you need to provide a description with
+      the 'alt' attribute, and avoid server-side image maps.
+      
+      
+      $Id: xhtml-image-1.xsd,v 1.3 2009/09/30 15:22:38 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_imagemodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.img.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="src" type="xh11d:URI" use="required"/>
+        <xs:attribute name="alt" type="xh11d:Text" use="required"/>
+        <xs:attribute name="longdesc" type="xh11d:URI"/>
+        <xs:attribute name="name" type="xh11d:CDATA"/>
+        <xs:attribute name="height" type="xh11d:Length"/>
+        <xs:attribute name="width" type="xh11d:Length"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.img.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.img.type">
+        <xs:group ref="xhtml.img.content"/>
+        <xs:attributeGroup ref="xhtml.img.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-inlphras-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-inlphras-1.xsd
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+         This is the XML Schema Inline Phrasal support module for XHTML
+         $Id: xhtml-inlphras-1.xsd,v 1.4 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Inline Phrasal.
+      This module declares the elements and their attributes used to
+      support inline-level phrasal markup.
+      This is the XML Schema Inline Phrasal module for XHTML
+
+        * abbr, acronym, cite, code, dfn, em, kbd, q, samp, strong, var
+
+      $Id: xhtml-inlphras-1.xsd,v 1.4 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_textmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.abbr.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.abbr.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.abbr.type" mixed="true">
+        <xs:group ref="xhtml.abbr.content"/>
+        <xs:attributeGroup ref="xhtml.abbr.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.acronym.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.acronym.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.acronym.type" mixed="true">
+        <xs:group ref="xhtml.acronym.content"/>
+        <xs:attributeGroup ref="xhtml.acronym.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.cite.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.cite.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.cite.type" mixed="true">
+        <xs:group ref="xhtml.cite.content"/>
+        <xs:attributeGroup ref="xhtml.cite.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.code.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.code.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.code.type" mixed="true">
+        <xs:group ref="xhtml.code.content"/>
+        <xs:attributeGroup ref="xhtml.code.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.dfn.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.dfn.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.dfn.type" mixed="true">
+        <xs:group ref="xhtml.dfn.content"/>
+        <xs:attributeGroup ref="xhtml.dfn.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.em.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.em.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.em.type" mixed="true">
+        <xs:group ref="xhtml.em.content"/>
+        <xs:attributeGroup ref="xhtml.em.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.kbd.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.kbd.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.kbd.type" mixed="true">
+        <xs:group ref="xhtml.kbd.content"/>
+        <xs:attributeGroup ref="xhtml.kbd.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.samp.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.samp.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.samp.type" mixed="true">
+        <xs:group ref="xhtml.samp.content"/>
+        <xs:attributeGroup ref="xhtml.samp.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.strong.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.strong.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.strong.type" mixed="true">
+        <xs:group ref="xhtml.strong.content"/>
+        <xs:attributeGroup ref="xhtml.strong.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.var.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.var.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.var.type" mixed="true">
+        <xs:group ref="xhtml.var.content"/>
+        <xs:attributeGroup ref="xhtml.var.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.q.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="cite" type="xh11d:URI"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.q.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.q.type" mixed="true">
+        <xs:group ref="xhtml.q.content"/>
+        <xs:attributeGroup ref="xhtml.q.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-inlpres-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-inlpres-1.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema Inline Presentation element module for XHTML
+      $Id: xhtml-inlpres-1.xsd,v 1.2 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Inline Presentational Elements
+    
+        * b, big, i, small, sub, sup, tt
+    
+      This module declares the elements and their attributes used to
+      support inline-level presentational markup.
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_presentationmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.InlPres.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.InlPres.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.InlPres.type" mixed="true">
+        <xs:group ref="xhtml.InlPres.content"/>
+        <xs:attributeGroup ref="xhtml.InlPres.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-inlstruct-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-inlstruct-1.xsd
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+         This is the XML Schema Inline Structural support module for XHTML
+         $Id: xhtml-inlstruct-1.xsd,v 1.4 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Inline Structural.
+      This module declares the elements and their attributes 
+      used to support inline-level structural markup.      
+      This is the XML Schema Inline Structural element module for XHTML
+
+        * br, span
+      
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_textmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.br.attlist">
+        <xs:attributeGroup ref="xhtml.Core.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.br.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.br.type">
+        <xs:group ref="xhtml.br.content"/>
+        <xs:attributeGroup ref="xhtml.br.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.span.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.span.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.span.type" mixed="true">
+        <xs:group ref="xhtml.span.content"/>
+        <xs:attributeGroup ref="xhtml.span.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-inlstyle-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-inlstyle-1.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      Inline Style module    
+      This is the XML Schema Inline Style module for XHTML
+      
+         * styloe attribute
+
+      This module declares the 'style' attribute, used to support inline 
+      style markup. 
+
+      $Id: xhtml-inlstyle-1.xsd,v 1.2 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_styleattributemodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.style.attrib">
+        <xs:attribute name="style" type="xh11d:CDATA"/>
+    </xs:attributeGroup>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-link-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-link-1.xsd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema Link Element module for XHTML
+      $Id: xhtml-link-1.xsd,v 1.2 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Link element
+    
+        * link
+    
+      This module declares the link element type and its attributes,
+      which could (in principle) be used to define document-level links
+      to external resources.
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_linkmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.link.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="charset" type="xh11d:Charset"/>
+        <xs:attribute name="href" type="xh11d:URI"/>
+        <xs:attribute name="hreflang" type="xh11d:LanguageCode"/>
+        <xs:attribute name="type" type="xh11d:ContentType"/>
+        <xs:attribute name="rel" type="xh11d:LinkTypes"/>
+        <xs:attribute name="rev" type="xh11d:LinkTypes"/>
+        <xs:attribute name="media" type="xh11d:MediaDesc"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.link.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.link.type">
+        <xs:group ref="xhtml.link.content"/>
+        <xs:attributeGroup ref="xhtml.link.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-list-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-list-1.xsd
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      List Module
+      This is the XML Schema Lists module for XHTML
+      List Module Elements
+    
+        * dl, dt, dd, ol, ul, li
+    
+      This module declares the list-oriented element types
+      and their attributes.
+      $Id: xhtml-list-1.xsd,v 1.2 2005/09/26 22:54:53 ahby Exp $      
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_listmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.dt.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.dt.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.dt.type" mixed="true">
+        <xs:group ref="xhtml.dt.content"/>
+        <xs:attributeGroup ref="xhtml.dt.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.dd.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.dd.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Flow.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.dd.type" mixed="true">
+        <xs:group ref="xhtml.dd.content"/>
+        <xs:attributeGroup ref="xhtml.dd.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.dl.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.dl.content">
+        <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="dt" type="xhtml.dt.type"/>
+                <xs:element name="dd" type="xhtml.dd.type"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.dl.type">
+        <xs:group ref="xhtml.dl.content"/>
+        <xs:attributeGroup ref="xhtml.dl.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.li.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.li.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Flow.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.li.type" mixed="true">
+        <xs:group ref="xhtml.li.content"/>
+        <xs:attributeGroup ref="xhtml.li.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.ol.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.ol.content">
+        <xs:sequence>
+            <xs:element name="li" type="xhtml.li.type" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.ol.type">
+        <xs:group ref="xhtml.ol.content"/>
+        <xs:attributeGroup ref="xhtml.ol.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.ul.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.ul.content">
+        <xs:sequence>
+            <xs:element name="li" type="xhtml.li.type" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.ul.type">
+        <xs:group ref="xhtml.ul.content"/>
+        <xs:attributeGroup ref="xhtml.ul.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-meta-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-meta-1.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema Metainformation module for XHTML
+      $Id: xhtml-meta-1.xsd,v 1.3 2008/07/05 04:11:00 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Meta Information
+
+        * meta
+
+      This module declares the meta element type and its attributes,
+      used to provide declarative document metainformation.
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_metamodule"/>
+    </xs:annotation>
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+        schemaLocation="http://www.w3.org/2001/xml.xsd">
+        <xs:annotation>
+            <xs:documentation>
+                This import brings in the XML namespace attributes
+                The module itself does not provide the schemaLocation
+                and expects the driver schema to provide the
+                actual SchemaLocation.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:import>
+    <xs:attributeGroup name="xhtml.meta.attlist">
+        <xs:attributeGroup ref="xhtml.I18n.attrib"/>
+        <xs:attribute ref="xml:space"/>
+        <xs:attribute name="http-equiv" type="xs:NMTOKEN"/>
+        <xs:attribute name="name" type="xs:NMTOKEN"/>
+        <xs:attribute name="content" type="xh11d:CDATA" use="required"/>
+        <xs:attribute name="scheme" type="xh11d:CDATA"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.meta.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.meta.type">
+        <xs:group ref="xhtml.meta.content"/>
+        <xs:attributeGroup ref="xhtml.meta.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-notations-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-notations-1.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      Notations module
+      This is the XML Schema module for data type notations for XHTML
+      $Id: xhtml-notations-1.xsd,v 1.5 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Notations module
+      Defines the XHTML notations, many of these imported from 
+      other specifications and standards. When an existing FPI is
+      known, it is incorporated here.            
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstraction.html#s_common_attrtypes"/>
+    </xs:annotation>
+    <!-- W3C XML 1.0 Recommendation -->
+    <xs:notation name="w3c-xml" public="ISO 8879//NOTATION Extensible Markup Language (XML) 1.0//EN"/>
+    <!-- XML 1.0 CDATA -->
+    <xs:notation name="cdata" public="-//W3C//NOTATION XML 1.0: CDATA//EN"/>
+    <!-- SGML Formal Public Identifiers -->
+    <xs:notation name="fpi" public="ISO 8879:1986//NOTATION Formal Public Identifier//EN"/>
+    <!-- XHTML Notations ... -->
+    <!-- Length defined for cellpadding/cellspacing -->
+    <!-- nn for pixels or nn% for percentage length -->
+    <!-- a single character, as per section 2.2 of [XML] -->
+    <xs:notation name="character" public="-//W3C//NOTATION XHTML Datatype: Character//EN"/>
+    <!-- a character encoding, as per [RFC2045] -->
+    <xs:notation name="charset" public="-//W3C//NOTATION XHTML Datatype: Charset//EN"/>
+    <!-- a space separated list of character encodings, as per [RFC2045] -->
+    <xs:notation name="charsets" public="-//W3C//NOTATION XHTML Datatype: Charsets//EN"/>
+    <!-- media type, as per [RFC2045] -->
+    <xs:notation name="contentType" public="-//W3C//NOTATION XHTML Datatype: ContentType//EN"/>
+    <!-- comma-separated list of media types, as per [RFC2045] -->
+    <xs:notation name="contentTypes" public="-//W3C//NOTATION XHTML Datatype: ContentTypes//EN"/>
+    <!-- date and time information. ISO date format -->
+    <xs:notation name="datetime" public="-//W3C//NOTATION XHTML Datatype: Datetime//EN"/>
+    <!-- a language code, as per [RFC3066] -->
+    <xs:notation name="languageCode" public="-//W3C//NOTATION XHTML Datatype: LanguageCode//EN"/>
+    <!-- nn for pixels or nn% for percentage length -->
+    <xs:notation name="length" public="-//W3C//NOTATION XHTML Datatype: Length//EN"/>
+    <!-- space-separated list of link types -->
+    <xs:notation name="linkTypes" public="-//W3C//NOTATION XHTML Datatype: LinkTypes//EN"/>
+    <!-- single or comma-separated list of media descriptors -->
+    <xs:notation name="mediaDesc" public="-//W3C//NOTATION XHTML Datatype: MediaDesc//EN"/>
+    <!-- pixel, percentage, or relative -->
+    <xs:notation name="multiLength" public="-//W3C//NOTATION XHTML Datatype: MultiLength//EN"/>
+    <!-- one or more digits (NUMBER) -->
+    <xs:notation name="number" public="-//W3C//NOTATION XHTML Datatype: Number//EN"/>
+    <!-- one or more digits (NUMBER) -->
+    <xs:notation name="pixels" public="-//W3C//NOTATION XHTML Datatype: Pixels//EN"/>
+    <!-- script expression -->
+    <xs:notation name="script" public="-//W3C//NOTATION XHTML Datatype: Script//EN"/>
+    <!-- textual content -->
+    <xs:notation name="text" public="-//W3C//NOTATION XHTML Datatype: Text//EN"/>
+    <!-- a Uniform Resource Identifier, see [URI] -->
+    <xs:notation name="uri" public="-//W3C//NOTATION XHTML Datatype: URI//EN"/>
+    <!-- a space-separated list of Uniform Resource Identifiers, see [URI] -->
+    <xs:notation name="uris" public="-//W3C//NOTATION XHTML Datatype: URIs//EN"/>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-object-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-object-1.xsd
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+	<xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+	<xs:annotation>
+		<xs:documentation>
+      This is the XML Schema Embedded Object module for XHTML
+      $Id: xhtml-object-1.xsd,v 1.2 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+		<xs:documentation source="xhtml-copyright-1.xsd"/>
+	</xs:annotation>
+	<xs:annotation>
+		<xs:documentation>
+      This module declares the object element type and its attributes,
+      used to embed external objects as part of XHTML pages. In the
+      document, place param elements prior to the object elements 
+      that require their content.
+          
+      Note that use of this module requires instantiation of the 
+      Param Element Module prior to this module.
+      
+      Elements defined here: 
+      
+        * object (param)
+    </xs:documentation>
+		<xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_objectmodule"/>
+	</xs:annotation>
+	<xs:include schemaLocation="xhtml-param-1.xsd">
+		<xs:annotation>
+			<xs:documentation>
+        Param module
+        
+        Elements defined here:
+          * param
+      </xs:documentation>
+		</xs:annotation>
+	</xs:include>
+	<xs:attributeGroup name="xhtml.object.attlist">
+		<xs:attributeGroup ref="xhtml.Common.attrib"/>
+		<xs:attribute name="declare">
+			<xs:simpleType>
+				<xs:restriction base="xs:NMTOKEN">
+					<xs:enumeration value="declare"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="classid" type="xh11d:URI"/>
+		<xs:attribute name="codebase" type="xh11d:URI"/>
+		<xs:attribute name="data" type="xh11d:URI"/>
+		<xs:attribute name="type" type="xh11d:ContentType"/>
+		<xs:attribute name="codetype" type="xh11d:ContentType"/>
+		<xs:attribute name="archive" type="xh11d:URIs"/>
+		<xs:attribute name="standby" type="xh11d:Text"/>
+		<xs:attribute name="height" type="xh11d:Length"/>
+		<xs:attribute name="width" type="xh11d:Length"/>
+		<xs:attribute name="name" type="xh11d:CDATA"/>
+		<xs:attribute name="tabindex" type="xh11d:Number"/>
+	</xs:attributeGroup>
+	<xs:group name="xhtml.object.content">
+		<xs:sequence>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="param" type="xhtml.param.type"/>
+				<xs:group ref="xhtml.Flow.mix"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:group>
+	<xs:complexType name="xhtml.object.type" mixed="true">
+		<xs:group ref="xhtml.object.content"/>
+		<xs:attributeGroup ref="xhtml.object.attlist"/>
+	</xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-param-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-param-1.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema Param Element module for XHTML
+      $Id: xhtml-param-1.xsd,v 1.3 2005/09/26 22:54:53 ahby Exp $
+      </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Parameters for Java Applets and Embedded Objects
+
+        * param
+
+      This module provides declarations for the param element,
+      used to provide named property values for the applet
+      and object elements.
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_objectmodule"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_appletmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.param.attlist">
+        <xs:attributeGroup ref="xhtml.id"/>
+        <xs:attribute name="name" type="xh11d:CDATA" use="required"/>
+        <xs:attribute name="value" type="xh11d:CDATA"/>
+        <xs:attribute name="valuetype" default="data">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="data"/>
+                    <xs:enumeration value="ref"/>
+                    <xs:enumeration value="object"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="type" type="xh11d:ContentType"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.param.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.param.type">
+        <xs:group ref="xhtml.param.content"/>
+        <xs:attributeGroup ref="xhtml.param.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-pres-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-pres-1.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema Presentation module for XHTML
+      This is a REQUIRED module.
+      $Id: xhtml-pres-1.xsd,v 1.2 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Presentational Elements
+
+      This module defines elements and their attributes for
+      simple presentation-related markup.
+ 
+      Elements defined here:
+
+        * hr
+        * b, big, i, small, sub, sup, tt
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_presentationmodule"/>
+    </xs:annotation>
+    <xs:include schemaLocation="xhtml-blkpres-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Block Presentational module
+        Elements defined here:
+ 
+         * hr
+      </xs:documentation>
+        </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="xhtml-inlpres-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Inline Presentational module
+        Elements defined here:
+
+          * b, big, i, small, sub, sup, tt
+    </xs:documentation>
+        </xs:annotation>
+    </xs:include>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-ruby-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-ruby-1.xsd
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/">
+    <xs:import
+        namespace="http://www.w3.org/1999/xhtml/datatypes/"
+        schemaLocation="xhtml-datatypes-1.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+      This is the Ruby module for XHTML
+      $Id: xhtml-ruby-1.xsd,v 1.7 2010/05/02 17:22:08 ahby Exp $
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      "Ruby" are short runs of text alongside the base text, typically
+      used in East Asian documents to indicate pronunciation or to
+      provide a short annotation. The full specification for Ruby is here:
+      
+        http://www.w3.org/TR/2001/REC-ruby-20010531/
+      
+      This module defines "Ruby " or "complex Ruby" as described
+      in the specification:
+      
+        http://www.w3.org/TR/2001/REC-ruby-20010531/#complex
+    
+      Simple or Basic Ruby are defined in a separate module.
+      
+      This module declares the elements and their attributes used to
+      support complex ruby annotation markup. Elements defined here
+            * ruby, rbc, rtc, rb, rt, rp
+      
+      This module expects the document model to define the
+      following content models
+        + InlNoRuby.mix                 
+    </xs:documentation>
+    <xs:documentation
+         source="http://www.w3.org/TR/2001/REC-ruby-20010531/"/>    
+  </xs:annotation>
+
+  <xs:group name="xhtml.ruby.content.simple">
+      <xs:sequence>
+          <xs:element name="rb" type="xhtml.rb.type"/>
+          <xs:choice>
+              <xs:element name="rt" type="xhtml.rt.type"/>
+              <xs:sequence>
+                  <xs:element name="rp" type="xhtml.rp.type"/>
+                  <xs:element name="rt" type="xhtml.rt.type"/>
+                  <xs:element name="rp" type="xhtml.rp.type"/>
+              </xs:sequence>
+          </xs:choice>
+      </xs:sequence>
+  </xs:group>
+
+  <xs:group name="xhtml.ruby.content.complex">
+    <xs:sequence>
+      <xs:element name="rbc" type="xhtml.rbc.type"/>
+      <xs:element name="rtc" type="xhtml.rtc.type" maxOccurs="2"/>
+    </xs:sequence>
+  </xs:group>
+
+  <!--
+   add to this group any common attributes for all Ruby elements
+  -->
+  <xs:attributeGroup name="xhtml.ruby.common.attrib"/>
+  
+  <xs:group name="xhtml.ruby.content">
+    <xs:choice>
+      <xs:group ref="xhtml.ruby.content.simple"/>
+      <xs:group ref="xhtml.ruby.content.complex"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:complexType name="xhtml.ruby.type">
+    <xs:group ref="xhtml.ruby.content"/>
+    <xs:attributeGroup ref="xhtml.ruby.common.attrib"/>
+  </xs:complexType>
+
+  <!--
+   rbc (ruby base component) element 
+  -->
+  <xs:attributeGroup name="xhtml.rbc.attlist">
+    <xs:attributeGroup ref="xhtml.ruby.common.attrib"/>
+  </xs:attributeGroup>
+  
+  <xs:group name="xhtml.rbc.content">
+    <xs:sequence>
+      <xs:element name="rb" type="xhtml.rb.type" />
+    </xs:sequence>
+  </xs:group>  
+
+  <xs:complexType name="xhtml.rbc.type">
+    <xs:group ref="xhtml.rbc.content"/>
+    <xs:attributeGroup ref="xhtml.rbc.attlist"/>
+  </xs:complexType>
+
+  <!--
+   rtc (ruby text component) element
+  -->
+  <xs:attributeGroup name="xhtml.rtc.attlist">
+    <xs:attributeGroup ref="xhtml.ruby.common.attrib"/>
+  </xs:attributeGroup>
+  
+  <xs:group name="xhtml.rtc.content">
+    <xs:sequence>
+      <xs:element name="rt" type="xhtml.rt.type" maxOccurs="unbounded"/>
+    </xs:sequence>  
+  </xs:group>    
+
+  <xs:complexType name="xhtml.rtc.type">
+    <xs:group ref="xhtml.rt.content"/>  
+    <xs:attributeGroup ref="xhtml.rtc.attlist"/>
+  </xs:complexType>
+
+  <!--
+   rb (ruby base) element 
+  -->
+  <xs:attributeGroup name="xhtml.rb.attlist">
+    <xs:attributeGroup ref="xhtml.ruby.common.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:group name="xhtml.rb.content">
+    <xs:sequence>
+       <xs:group ref="xhtml.InlNoRuby.mix" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:group>      
+
+  <xs:complexType name="xhtml.rb.type" mixed="true">
+    <xs:group ref="xhtml.rb.content"/>
+    <xs:attributeGroup ref="xhtml.rb.attlist"/>
+  </xs:complexType>
+    
+  <!--
+   rt (ruby text) element 
+  -->
+  <xs:attributeGroup name="xhtml.rt.attlist">
+    <xs:attributeGroup ref="xhtml.ruby.common.attrib"/>
+    <xs:attribute name="rbspan" type="xh11d:Number" default="1"/>
+  </xs:attributeGroup>
+
+  <xs:group name="xhtml.rt.content">
+    <xs:sequence>
+       <xs:group ref="xhtml.InlNoRuby.mix" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:group>      
+  
+  <xs:complexType name="xhtml.rt.type" mixed="true">
+    <xs:group ref="xhtml.rt.content"/>  
+    <xs:attributeGroup ref="xhtml.rt.attlist"/>
+  </xs:complexType>
+
+  <!-- rp (ruby parenthesis) element  -->
+  <xs:attributeGroup name="xhtml.rp.attlist">
+    <xs:attributeGroup ref="xhtml.ruby.common.attrib"/>
+  </xs:attributeGroup>
+  
+  <xs:group name="xhtml.rp.content">
+    <xs:sequence/>
+  </xs:group>      
+  
+
+  <xs:complexType name="xhtml.rp.type" mixed="true">
+    <xs:group ref="xhtml.rp.content"/>
+    <xs:attributeGroup ref="xhtml.rp.attlist"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-script-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-script-1.xsd
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema Scripting module for XHTML
+      $Id: xhtml-script-1.xsd,v 1.5 2006/09/11 08:50:41 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Scripting
+      
+        * script, noscript
+      
+      This module declares element types and attributes used to provide
+      support for executable scripts as well as an alternate content
+      container where scripts are not supported.
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_scriptmodule"/>
+    </xs:annotation>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+             schemaLocation="http://www.w3.org/2001/xml.xsd">
+        <xs:annotation>
+            <xs:documentation>
+          This import brings in the XML namespace attributes 
+          The module itself does not provide the schemaLocation
+          and expects the driver schema to provide the 
+          actual SchemaLocation.
+        </xs:documentation>
+        </xs:annotation>
+    </xs:import>
+    <xs:attributeGroup name="xhtml.script.attlist">
+        <xs:attributeGroup ref="xhtml.id"/>
+        <xs:attribute name="charset" type="xh11d:Charset"/>
+        <xs:attribute name="type" type="xh11d:ContentType" use="required"/>
+        <xs:attribute name="src" type="xh11d:URI"/>
+        <xs:attribute name="defer">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="defer"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.script.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.script.type" mixed="true">
+        <xs:group ref="xhtml.script.content"/>
+        <xs:attributeGroup ref="xhtml.script.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.noscript.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.noscript.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Block.mix" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.noscript.type">
+        <xs:group ref="xhtml.noscript.content"/>
+        <xs:attributeGroup ref="xhtml.noscript.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-ssismap-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-ssismap-1.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema Server-side Image Maps module for XHTML
+      $Id: xhtml-ssismap-1.xsd,v 1.3 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Server-side Image Maps
+      
+      This adds the 'ismap' attribute to the img element to 
+      support server-side processing of a user selection.
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_servermapmodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.img.ssimap.attlist">
+        <xs:attribute name="ismap">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="ismap"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.input.ssimap.attlist">
+        <xs:attribute name="ismap">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="ismap"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-struct-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-struct-1.xsd
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/">
+    <xs:import
+        namespace="http://www.w3.org/1999/xhtml/datatypes/"
+        schemaLocation="xhtml-datatypes-1.xsd"/>
+    <xs:annotation>
+        <xs:documentation>
+        This is the XML Schema Document Structure module for XHTML
+        Document Structure
+    
+          * title, head, body, html
+    
+        The Structure Module defines the major structural elements and 
+        their attributes.
+        
+        $Id: xhtml-struct-1.xsd,v 1.11 2009/09/30 14:13:35 ahby Exp $     
+      </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_structuremodule"/>
+    </xs:annotation>
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+        schemaLocation="http://www.w3.org/2001/xml.xsd">
+        <xs:annotation>
+            <xs:documentation>
+                This import brings in the XML namespace attributes
+                The module itself does not provide the schemaLocation
+                and expects the driver schema to provide the
+                actual SchemaLocation.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:import>
+    <xs:attributeGroup
+        name="xhtml.title.attlist">
+        <xs:attributeGroup
+            ref="xhtml.I18n.attrib"/>
+        <xs:attributeGroup ref="xhtml.id"/>
+        <xs:attribute ref="xml:space"/>
+    </xs:attributeGroup>
+    <xs:group
+        name="xhtml.title.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType
+        name="xhtml.title.type"
+        mixed="true">
+        <xs:group
+            ref="xhtml.title.content"/>
+        <xs:attributeGroup
+            ref="xhtml.title.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup
+        name="xhtml.profile.attrib">
+        <xs:attribute
+            name="profile"
+            type="xh11d:URIs"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup
+        name="xhtml.head.attlist">
+        <xs:attributeGroup
+            ref="xhtml.profile.attrib"/>
+        <xs:attributeGroup
+            ref="xhtml.I18n.attrib"/>
+        <xs:attributeGroup ref="xhtml.id"/>
+        <xs:attribute ref="xml:space"/>
+    </xs:attributeGroup>
+    <xs:complexType
+        name="xhtml.head.type">
+        <xs:group
+            ref="xhtml.head.content"/>
+        <xs:attributeGroup
+            ref="xhtml.head.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup
+        name="xhtml.body.attlist">
+        <xs:attributeGroup
+            ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group
+        name="xhtml.body.content">
+        <xs:sequence>
+            <xs:group
+                ref="xhtml.Block.mix"
+                minOccurs="0"
+                maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType
+        name="xhtml.body.type">
+        <xs:group
+            ref="xhtml.body.content"/>
+        <xs:attributeGroup
+            ref="xhtml.body.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup
+        name="xhtml.version.attrib">
+        <xs:attribute
+            name="version"
+            type="xh11d:CDATA"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup
+        name="xhtml.html.attlist">
+        <xs:attributeGroup
+            ref="xhtml.version.attrib"/>
+        <xs:attributeGroup
+            ref="xhtml.I18n.attrib"/>
+        <xs:attributeGroup ref="xhtml.id"/>
+        <xs:attribute ref="xml:space"/>
+    </xs:attributeGroup>
+    <xs:group
+        name="xhtml.html.content">
+        <xs:sequence>
+            <xs:element
+                name="head"
+                type="xhtml.head.type"/>
+            <xs:element
+                name="body"
+                type="xhtml.body.type"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType
+        name="xhtml.html.type">
+        <xs:group
+            ref="xhtml.html.content"/>
+        <xs:attributeGroup
+            ref="xhtml.html.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-style-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-style-1.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema Stylesheets module for XHTML
+      $Id: xhtml-style-1.xsd,v 1.5 2006/09/11 10:14:57 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      Stylesheets
+      
+        * style
+      
+      This module declares the style element type and its attributes,
+      used to embed stylesheet information in the document head element.
+    </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_stylemodule"/>
+    </xs:annotation>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+             schemaLocation="http://www.w3.org/2001/xml.xsd">
+        <xs:annotation>
+            <xs:documentation>
+          This import brings in the XML namespace attributes 
+          The module itself does not provide the schemaLocation
+          and expects the driver schema to provide the 
+          actual SchemaLocation.
+        </xs:documentation>
+        </xs:annotation>
+    </xs:import>
+    <xs:attributeGroup name="xhtml.style.attlist">
+        <xs:attributeGroup ref="xhtml.id"/>
+        <xs:attributeGroup ref="xhtml.title"/>
+        <xs:attributeGroup ref="xhtml.I18n.attrib"/>
+        <xs:attribute name="type" type="xh11d:ContentType" use="required"/>
+        <xs:attribute name="media" type="xh11d:MediaDesc"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.style.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.style.type" mixed="true">
+        <xs:group ref="xhtml.style.content"/>
+        <xs:attributeGroup ref="xhtml.style.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-table-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-table-1.xsd
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+          This is the XML Schema Tables module for XHTML
+          $Id: xhtml-table-1.xsd,v 1.3 2005/09/26 22:54:53 ahby Exp $
+        </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+          Tables
+      
+           * table, caption, thead, tfoot, tbody, colgroup, col, tr, th, td
+      
+          This module declares element types and attributes used to provide
+          table markup similar to HTML 4.0, including features that enable
+          better accessibility for non-visual user agents.
+        </xs:documentation>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_tablemodule"/>
+    </xs:annotation>
+    <xs:attributeGroup name="xhtml.frame.attrib">
+        <xs:attribute name="frame">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="void"/>
+                    <xs:enumeration value="above"/>
+                    <xs:enumeration value="below"/>
+                    <xs:enumeration value="hsides"/>
+                    <xs:enumeration value="lhs"/>
+                    <xs:enumeration value="rhs"/>
+                    <xs:enumeration value="vsides"/>
+                    <xs:enumeration value="box"/>
+                    <xs:enumeration value="border"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.rules.attrib">
+        <xs:attribute name="rules">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="none"/>
+                    <xs:enumeration value="groups"/>
+                    <xs:enumeration value="rows"/>
+                    <xs:enumeration value="cols"/>
+                    <xs:enumeration value="all"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.CellVAlign.attrib">
+        <xs:attribute name="valign">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="top"/>
+                    <xs:enumeration value="middle"/>
+                    <xs:enumeration value="bottom"/>
+                    <xs:enumeration value="baseline"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.CellHAlign.attrib">
+        <xs:attribute name="align">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="left"/>
+                    <xs:enumeration value="center"/>
+                    <xs:enumeration value="right"/>
+                    <xs:enumeration value="justify"/>
+                    <xs:enumeration value="char"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="char" type="xh11d:Character"/>
+        <xs:attribute name="charoff" type="xh11d:Length"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.scope.attrib">
+        <xs:attribute name="scope">
+            <xs:simpleType>
+                <xs:restriction base="xs:NMTOKEN">
+                    <xs:enumeration value="row"/>
+                    <xs:enumeration value="col"/>
+                    <xs:enumeration value="rowgroup"/>
+                    <xs:enumeration value="colgroup"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="xhtml.td.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="abbr" type="xh11d:Text"/>
+        <xs:attribute name="axis" type="xh11d:CDATA"/>
+        <xs:attribute name="headers" type="xs:IDREFS"/>
+        <xs:attributeGroup ref="xhtml.scope.attrib"/>
+        <xs:attribute name="rowspan" type="xh11d:Number" default="1"/>
+        <xs:attribute name="colspan" type="xh11d:Number" default="1"/>
+        <xs:attributeGroup ref="xhtml.CellHAlign.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.td.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Flow.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.td.type" mixed="true">
+        <xs:group ref="xhtml.td.content"/>
+        <xs:attributeGroup ref="xhtml.td.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.th.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="abbr" type="xh11d:Text"/>
+        <xs:attribute name="axis" type="xh11d:CDATA"/>
+        <xs:attribute name="headers" type="xs:IDREFS"/>
+        <xs:attributeGroup ref="xhtml.scope.attrib"/>
+        <xs:attribute name="rowspan" type="xh11d:Number" default="1"/>
+        <xs:attribute name="colspan" type="xh11d:Number" default="1"/>
+        <xs:attributeGroup ref="xhtml.CellHAlign.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.th.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Flow.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.th.type" mixed="true">
+        <xs:group ref="xhtml.th.content"/>
+        <xs:attributeGroup ref="xhtml.th.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.tr.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellHAlign.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.tr.content">
+        <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="th" type="xhtml.th.type"/>
+                <xs:element name="td" type="xhtml.td.type"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.tr.type">
+        <xs:group ref="xhtml.tr.content"/>
+        <xs:attributeGroup ref="xhtml.tr.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.col.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="span" type="xh11d:Number" default="1"/>
+        <xs:attribute name="width" type="xh11d:MultiLength"/>
+        <xs:attributeGroup ref="xhtml.CellHAlign.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.col.content">
+        <xs:sequence/>
+    </xs:group>
+    <xs:complexType name="xhtml.col.type">
+        <xs:group ref="xhtml.col.content"/>
+        <xs:attributeGroup ref="xhtml.col.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.colgroup.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="span" type="xh11d:Number" default="1"/>
+        <xs:attribute name="width" type="xh11d:MultiLength"/>
+        <xs:attributeGroup ref="xhtml.CellHAlign.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.colgroup.content">
+        <xs:sequence>
+            <xs:element name="col" type="xhtml.col.type" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.colgroup.type">
+        <xs:group ref="xhtml.colgroup.content"/>
+        <xs:attributeGroup ref="xhtml.colgroup.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.tbody.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellHAlign.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.tbody.content">
+        <xs:sequence>
+            <xs:element name="tr" type="xhtml.tr.type" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.tbody.type">
+        <xs:group ref="xhtml.tbody.content"/>
+        <xs:attributeGroup ref="xhtml.tbody.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.tfoot.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellHAlign.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.tfoot.content">
+        <xs:sequence>
+            <xs:element name="tr" type="xhtml.tr.type" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.tfoot.type">
+        <xs:group ref="xhtml.tfoot.content"/>
+        <xs:attributeGroup ref="xhtml.tfoot.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.thead.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellHAlign.attrib"/>
+        <xs:attributeGroup ref="xhtml.CellVAlign.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.thead.content">
+        <xs:sequence>
+            <xs:element name="tr" type="xhtml.tr.type" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.thead.type">
+        <xs:group ref="xhtml.thead.content"/>
+        <xs:attributeGroup ref="xhtml.thead.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.caption.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.caption.content">
+        <xs:sequence>
+            <xs:group ref="xhtml.Inline.mix" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.caption.type" mixed="true">
+        <xs:group ref="xhtml.caption.content"/>
+        <xs:attributeGroup ref="xhtml.caption.attlist"/>
+    </xs:complexType>
+    <xs:attributeGroup name="xhtml.table.attlist">
+        <xs:attributeGroup ref="xhtml.Common.attrib"/>
+        <xs:attribute name="summary" type="xh11d:Text"/>
+        <xs:attribute name="width" type="xh11d:Length"/>
+        <xs:attribute name="border" type="xh11d:Pixels"/>
+        <xs:attributeGroup ref="xhtml.frame.attrib"/>
+        <xs:attributeGroup ref="xhtml.rules.attrib"/>
+        <xs:attribute name="cellspacing" type="xh11d:Length"/>
+        <xs:attribute name="cellpadding" type="xh11d:Length"/>
+    </xs:attributeGroup>
+    <xs:group name="xhtml.table.content">
+        <xs:sequence>
+            <xs:element name="caption" type="xhtml.caption.type" minOccurs="0"/>
+            <xs:choice>
+                <xs:element name="col" type="xhtml.col.type" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="colgroup" type="xhtml.colgroup.type" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:choice>
+            <xs:choice>
+                <xs:sequence>
+                    <xs:element name="thead" type="xhtml.thead.type" minOccurs="0"/>
+                    <xs:element name="tfoot" type="xhtml.tfoot.type" minOccurs="0"/>
+                    <xs:element name="tbody" type="xhtml.tbody.type" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:choice>
+                    <xs:element name="tr" type="xhtml.tr.type" maxOccurs="unbounded"/>
+                </xs:choice>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="xhtml.table.type">
+        <xs:group ref="xhtml.table.content"/>
+        <xs:attributeGroup ref="xhtml.table.attlist"/>
+    </xs:complexType>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-target-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-target-1.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+  <xs:annotation>
+    <xs:documentation>
+      This is the XML Schema Target module for XHTML
+      $Id: xhtml-target-1.xsd,v 1.3 2007/04/03 18:27:01 ahby Exp $
+    </xs:documentation>
+    <xs:documentation source="xhtml-copyright-1.xsd"/>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      Target 
+      
+        * target
+      
+      This module declares the 'target' attribute used for opening windows
+    </xs:documentation>
+    <xs:documentation 
+         source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_targetmodule"/>
+  </xs:annotation>
+  
+  <xs:attributeGroup name="xhtml.base.target.attlist">
+    <xs:attribute name="target" type="xh11d:FrameTarget"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="xhtml.form.target.attlist">
+    <xs:attribute name="target" type="xh11d:FrameTarget"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="xhtml.link.target.attlist">
+    <xs:attribute name="target" type="xh11d:FrameTarget"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="xhtml.area.target.attlist">
+    <xs:attribute name="target" type="xh11d:FrameTarget"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="xhtml.a.target.attlist">
+    <xs:attribute name="target" type="xh11d:FrameTarget"/>
+  </xs:attributeGroup>
+
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-text-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml-text-1.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ elementFormDefault="qualified"
+ xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+>
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+               schemaLocation="xhtml-datatypes-1.xsd" />
+    <xs:annotation>
+        <xs:documentation>
+      Textual Content
+      This is the XML Schema Text module for XHTML
+
+      The Text module includes declarations for all core
+      text container elements and their attributes.
+    
+        +  block phrasal
+        +  block structural
+        +  inline phrasal
+        +  inline structural
+      
+      $Id: xhtml-text-1.xsd,v 1.2 2005/09/26 22:54:53 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+        <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_textmodule"/>
+    </xs:annotation>
+    <xs:include schemaLocation="xhtml-blkphras-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Block Phrasal module
+        Elements defined here:
+
+          * address, blockquote, pre, h1, h2, h3, h4, h5, h6
+    </xs:documentation>
+        </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="xhtml-blkstruct-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Block Structural module 
+        Elements defined here:
+
+          * div, p
+    </xs:documentation>
+        </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="xhtml-inlphras-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Inline Phrasal module
+        Elements defined here:
+
+          * abbr, acronym, cite, code, dfn, em, kbd, q, samp, strong, var
+    </xs:documentation>
+        </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="xhtml-inlstruct-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Inline Structural module 
+        Elements defined here:
+
+          * br,span
+    </xs:documentation>
+        </xs:annotation>
+    </xs:include>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml11-model-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml11-model-1.xsd
@@ -1,0 +1,716 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+    elementFormDefault="qualified" >
+    <xs:import
+        namespace="http://www.w3.org/1999/xhtml/datatypes/"
+        schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-datatypes-1.xsd"/>
+    <xs:annotation>
+        <xs:documentation> 
+            This is the XML Schema module of common content models for XHTML11 
+            
+            $Id: xhtml11-model-1.xsd,v 1.9 2009/02/03 15:14:49 ahby Exp $ 
+        </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation> 
+            XHTML Document Model 
+            This module describes the groupings of elements/attributes 
+            that make up common content models for XHTML elements. 
+            XHTML has following basic content models: 
+               xhtml.Inline.mix; character-level elements
+               xhtml.Block.mix; block-like elements, e.g., paragraphs and lists
+               xhtml.Flow.mix; any block or inline elements 
+               xhtml.HeadOpts.mix; Head Elements 
+               xhtml.InlinePre.mix; Special class for pre content model 
+               xhtml.InlineNoAnchor.mix; Content model for Anchor 
+            
+            Any groups declared in this module may be used to create 
+            element content models, but the above are considered 'global' 
+            (insofar as that term applies here). XHTML has the
+            following Attribute Groups 
+               xhtml.Core.extra.attrib 
+               xhtml.I18n.extra.attrib
+               xhtml.Common.extra 
+            
+            The above attribute Groups are considered Global 
+        </xs:documentation>
+    </xs:annotation>
+    <xs:attributeGroup
+        name="xhtml.I18n.extra.attrib">
+        <xs:annotation>
+            <xs:documentation> Extended I18n attribute </xs:documentation>
+        </xs:annotation>
+        <xs:attributeGroup
+            ref="xhtml.dir.attrib">
+            <xs:annotation>
+                <xs:documentation> 
+                "dir" Attribute from Bi Directional Text (bdo) Module
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attributeGroup>
+        <xs:attribute name="lang" type="xh11d:LanguageCode" />
+    </xs:attributeGroup>
+    <xs:attributeGroup
+        name="xhtml.Common.extra">
+        <xs:annotation>
+            <xs:documentation> Extended Common Attributes </xs:documentation>
+        </xs:annotation>
+        <xs:attributeGroup
+            ref="xhtml.style.attrib">
+            <xs:annotation>
+                <xs:documentation> 
+                "style" attribute from Inline Style Module 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attributeGroup>
+    	<xs:attributeGroup ref="xhtml.Events.attrib">
+			<xs:annotation>
+				<xs:documentation> 
+				Attributes from Events Module
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attributeGroup>
+	</xs:attributeGroup>
+    <xs:attributeGroup
+        name="xhtml.Core.extra.attrib">
+        <xs:annotation>
+            <xs:documentation> Extend Core Attributes </xs:documentation>
+        </xs:annotation>
+    </xs:attributeGroup>
+    <xs:attributeGroup
+        name="xhtml.Global.core.extra.attrib">
+        <xs:annotation>
+            <xs:documentation> Extended Global Core Attributes </xs:documentation>
+        </xs:annotation>
+    </xs:attributeGroup>
+    <xs:attributeGroup
+        name="xhtml.Global.I18n.extra.attrib">
+        <xs:annotation>
+            <xs:documentation> Extended Global I18n attributes </xs:documentation>
+        </xs:annotation>
+    </xs:attributeGroup>
+    <xs:attributeGroup
+        name="xhtml.Global.Common.extra">
+        <xs:annotation>
+            <xs:documentation> Extended Global Common Attributes </xs:documentation>
+        </xs:annotation>
+    </xs:attributeGroup>
+    <xs:group
+        name="xhtml.Head.extra">
+        <xs:sequence/>
+    </xs:group>
+    <xs:group
+        name="xhtml.HeadOpts.mix">
+        <xs:choice>
+            <xs:element
+                name="script"
+                type="xhtml.script.type"/>
+            <xs:element
+                name="style"
+                type="xhtml.style.type"/>
+            <xs:element
+                name="meta"
+                type="xhtml.meta.type"/>
+            <xs:element
+                name="link"
+                type="xhtml.link.type"/>
+            <xs:element
+                name="object"
+                type="xhtml.object.type"/>
+            <xs:group
+                ref="xhtml.Head.extra"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.head.content">
+        <xs:sequence>
+            <xs:group
+                ref="xhtml.HeadOpts.mix"
+                minOccurs="0"
+                maxOccurs="unbounded"/>
+            <xs:choice>
+                <xs:sequence>
+                    <xs:element
+                        name="title"
+                        minOccurs="1"
+                        maxOccurs="1"
+                        type="xhtml.title.type"/>
+                    <xs:group
+                        ref="xhtml.HeadOpts.mix"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+                    <xs:sequence
+                        minOccurs="0">
+                        <xs:element
+                            name="base"
+                            type="xhtml.base.type"/>
+                        <xs:group
+                            ref="xhtml.HeadOpts.mix"
+                            minOccurs="0"
+                            maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:sequence>
+                <xs:sequence>
+                    <xs:element
+                        name="base"
+                        type="xhtml.base.type"
+                        minOccurs="1"
+                        maxOccurs="1"/>
+                    <xs:group
+                        ref="xhtml.HeadOpts.mix"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+                    <xs:element
+                        name="title"
+                        minOccurs="1"
+                        maxOccurs="1"
+                        type="xhtml.title.type"/>
+                    <xs:group
+                        ref="xhtml.HeadOpts.mix"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <!--
+    ins and del are used to denote editing changes
+  -->
+    <xs:group
+        name="xhtml.Edit.class">
+        <xs:choice>
+            <xs:element
+                name="ins"
+                type="xhtml.edit.type"/>
+            <xs:element
+                name="del"
+                type="xhtml.edit.type"/>
+        </xs:choice>
+    </xs:group>
+    <!--
+    script and noscript are used to contain scripts
+    and alternative content
+  -->
+    <xs:group
+        name="xhtml.Script.class">
+        <xs:choice>
+            <xs:element
+                name="script"
+                type="xhtml.script.type"/>
+            <xs:element
+                name="noscript"
+                type="xhtml.noscript.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.Misc.extra">
+        <xs:sequence/>
+    </xs:group>
+    <!--
+    These elements are neither block nor inline, and can
+    essentially be used anywhere in the document body.
+  -->
+    <xs:group
+        name="xhtml.Misc.class">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.Edit.class"/>
+            <xs:group
+                ref="xhtml.Script.class"/>
+            <xs:group
+                ref="xhtml.Misc.extra"/>
+        </xs:choice>
+    </xs:group>
+    <!-- Inline Elements -->
+    <xs:group
+        name="xhtml.InlStruct.class">
+        <xs:choice>
+            <xs:element
+                name="br"
+                type="xhtml.br.type"/>
+            <xs:element
+                name="span"
+                type="xhtml.span.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.InlPhras.class">
+        <xs:choice>
+            <xs:element
+                name="em"
+                type="xhtml.em.type"/>
+            <xs:element
+                name="strong"
+                type="xhtml.strong.type"/>
+            <xs:element
+                name="dfn"
+                type="xhtml.dfn.type"/>
+            <xs:element
+                name="code"
+                type="xhtml.code.type"/>
+            <xs:element
+                name="samp"
+                type="xhtml.samp.type"/>
+            <xs:element
+                name="kbd"
+                type="xhtml.kbd.type"/>
+            <xs:element
+                name="var"
+                type="xhtml.var.type"/>
+            <xs:element
+                name="cite"
+                type="xhtml.cite.type"/>
+            <xs:element
+                name="abbr"
+                type="xhtml.abbr.type"/>
+            <xs:element
+                name="acronym"
+                type="xhtml.acronym.type"/>
+            <xs:element
+                name="q"
+                type="xhtml.q.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.InlPres.class">
+        <xs:choice>
+            <xs:element
+                name="tt"
+                type="xhtml.InlPres.type"/>
+            <xs:element
+                name="i"
+                type="xhtml.InlPres.type"/>
+            <xs:element
+                name="b"
+                type="xhtml.InlPres.type"/>
+            <xs:element
+                name="big"
+                type="xhtml.InlPres.type"/>
+            <xs:element
+                name="small"
+                type="xhtml.InlPres.type"/>
+            <xs:element
+                name="sub"
+                type="xhtml.InlPres.type"/>
+            <xs:element
+                name="sup"
+                type="xhtml.InlPres.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.I18n.class">
+        <xs:sequence>
+            <xs:element
+                name="bdo"
+                type="xhtml.bdo.type"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:group
+        name="xhtml.Anchor.class">
+        <xs:sequence>
+            <xs:element
+                name="a"
+                type="xhtml.a.type"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:group
+        name="xhtml.InlSpecial.class">
+        <xs:choice>
+            <xs:element
+                name="img"
+                type="xhtml.img.type"/>
+            <xs:element
+                name="map"
+                type="xhtml.map.type"/>
+            <xs:element
+                name="object"
+                type="xhtml.object.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.InlForm.class">
+        <xs:choice>
+            <xs:element
+                name="input"
+                type="xhtml.input.type"/>
+            <xs:element
+                name="select"
+                type="xhtml.select.type"/>
+            <xs:element
+                name="textarea"
+                type="xhtml.textarea.type"/>
+            <xs:element
+                name="label"
+                type="xhtml.label.type"/>
+            <xs:element
+                name="button"
+                type="xhtml.button.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.Inline.extra">
+        <xs:sequence/>
+    </xs:group>
+    <xs:group
+        name="xhtml.Ruby.class">
+        <xs:sequence>
+            <xs:element
+                name="ruby"
+                type="xhtml.ruby.type"/>
+        </xs:sequence>
+    </xs:group>
+    <!--
+    Inline.class includes all inline elements,
+    used as a component in mixes
+  -->
+    <xs:group
+        name="xhtml.Inline.class">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.InlStruct.class"/>
+            <xs:group
+                ref="xhtml.InlPhras.class"/>
+            <xs:group
+                ref="xhtml.InlPres.class"/>
+            <xs:group
+                ref="xhtml.I18n.class"/>
+            <xs:group
+                ref="xhtml.Anchor.class"/>
+            <xs:group
+                ref="xhtml.InlSpecial.class"/>
+            <xs:group
+                ref="xhtml.InlForm.class"/>
+            <xs:group
+                ref="xhtml.Ruby.class"/>
+            <xs:group
+                ref="xhtml.Inline.extra"/>
+        </xs:choice>
+    </xs:group>
+    <!--
+     InlNoRuby.class includes all inline elements
+     except ruby
+  -->
+    <xs:group
+        name="xhtml.InlNoRuby.class">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.InlStruct.class"/>
+            <xs:group
+                ref="xhtml.InlPhras.class"/>
+            <xs:group
+                ref="xhtml.InlPres.class"/>
+            <xs:group
+                ref="xhtml.I18n.class"/>
+            <xs:group
+                ref="xhtml.Anchor.class"/>
+            <xs:group
+                ref="xhtml.InlSpecial.class"/>
+            <xs:group
+                ref="xhtml.InlForm.class"/>
+            <xs:group
+                ref="xhtml.Inline.extra"/>
+        </xs:choice>
+    </xs:group>
+    <!--
+    InlinePre.mix
+    Used as a component in pre model
+  -->
+    <xs:group
+        name="xhtml.InlinePre.mix">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.InlStruct.class"/>
+            <xs:group
+                ref="xhtml.InlPhras.class"/>
+            <xs:element
+                name="tt"
+                type="xhtml.InlPres.type"/>
+            <xs:element
+                name="i"
+                type="xhtml.InlPres.type"/>
+            <xs:element
+                name="b"
+                type="xhtml.InlPres.type"/>
+            <xs:group
+                ref="xhtml.I18n.class"/>
+            <xs:group
+                ref="xhtml.Anchor.class"/>
+            <xs:group
+                ref="xhtml.Misc.class"/>
+            <xs:element
+                name="map"
+                type="xhtml.map.type"/>
+            <xs:group
+                ref="xhtml.Inline.extra"/>
+        </xs:choice>
+    </xs:group>
+    <!--
+    InlNoAnchor.class includes all non-anchor inlines,
+    used as a component in mixes
+  -->
+    <xs:group
+        name="xhtml.InlNoAnchor.class">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.InlStruct.class"/>
+            <xs:group
+                ref="xhtml.InlPhras.class"/>
+            <xs:group
+                ref="xhtml.InlPres.class"/>
+            <xs:group
+                ref="xhtml.I18n.class"/>
+            <xs:group
+                ref="xhtml.InlSpecial.class"/>
+            <xs:group
+                ref="xhtml.InlForm.class"/>
+            <xs:group
+                ref="xhtml.Ruby.class"/>
+            <xs:group
+                ref="xhtml.Inline.extra"/>
+        </xs:choice>
+    </xs:group>
+    <!--
+    InlNoAnchor.mix includes all non-anchor inlines
+  -->
+    <xs:group
+        name="xhtml.InlNoAnchor.mix">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.InlNoAnchor.class"/>
+            <xs:group
+                ref="xhtml.Misc.class"/>
+        </xs:choice>
+    </xs:group>
+    <!--
+    Inline.mix includes all inline elements, including Misc.class
+  -->
+    <xs:group
+        name="xhtml.Inline.mix">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.Inline.class"/>
+            <xs:group
+                ref="xhtml.Misc.class"/>
+        </xs:choice>
+    </xs:group>
+    <!--
+   InlNoRuby.mix includes all of inline.mix elements
+   except ruby
+  -->
+    <xs:group
+        name="xhtml.InlNoRuby.mix">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.InlNoRuby.class"/>
+            <xs:group
+                ref="xhtml.Misc.class"/>
+        </xs:choice>
+    </xs:group>
+    <!--
+    In the HTML 4 DTD, heading and list elements were included
+    in the block group. The Heading.class and
+    List.class groups must now be included explicitly
+    on element declarations where desired.
+  -->
+    <xs:group
+        name="xhtml.Heading.class">
+        <xs:choice>
+            <xs:element
+                name="h1"
+                type="xhtml.h1.type"/>
+            <xs:element
+                name="h2"
+                type="xhtml.h2.type"/>
+            <xs:element
+                name="h3"
+                type="xhtml.h3.type"/>
+            <xs:element
+                name="h4"
+                type="xhtml.h4.type"/>
+            <xs:element
+                name="h5"
+                type="xhtml.h5.type"/>
+            <xs:element
+                name="h6"
+                type="xhtml.h6.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.List.class">
+        <xs:choice>
+            <xs:element
+                name="ul"
+                type="xhtml.ul.type"/>
+            <xs:element
+                name="ol"
+                type="xhtml.ol.type"/>
+            <xs:element
+                name="dl"
+                type="xhtml.dl.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.Table.class">
+        <xs:choice>
+            <xs:element
+                name="table"
+                type="xhtml.table.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.Form.class">
+        <xs:choice>
+            <xs:element
+                name="form"
+                type="xhtml.form.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.Fieldset.class">
+        <xs:choice>
+            <xs:element
+                name="fieldset"
+                type="xhtml.fieldset.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.BlkStruct.class">
+        <xs:choice>
+            <xs:element
+                name="p"
+                type="xhtml.p.type"/>
+            <xs:element
+                name="div"
+                type="xhtml.div.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.BlkPhras.class">
+        <xs:choice>
+            <xs:element
+                name="pre"
+                type="xhtml.pre.type"/>
+            <xs:element
+                name="blockquote"
+                type="xhtml.blockquote.type"/>
+            <xs:element
+                name="address"
+                type="xhtml.address.type"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.BlkPres.class">
+        <xs:sequence>
+            <xs:element
+                name="hr"
+                type="xhtml.hr.type"/>
+        </xs:sequence>
+    </xs:group>
+    <xs:group
+        name="xhtml.BlkSpecial.class">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.Table.class"/>
+            <xs:group
+                ref="xhtml.Form.class"/>
+            <xs:group
+                ref="xhtml.Fieldset.class"/>
+        </xs:choice>
+    </xs:group>
+    <xs:group
+        name="xhtml.Block.extra">
+        <xs:sequence/>
+    </xs:group>
+    <!--
+    Block.class includes all block elements,
+    used as an component in mixes
+  -->
+    <xs:group
+        name="xhtml.Block.class">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.BlkStruct.class"/>
+            <xs:group
+                ref="xhtml.BlkPhras.class"/>
+            <xs:group
+                ref="xhtml.BlkPres.class"/>
+            <xs:group
+                ref="xhtml.BlkSpecial.class"/>
+            <xs:group
+                ref="xhtml.Block.extra"/>
+        </xs:choice>
+    </xs:group>
+    <!--
+   Block.mix includes all block elements plus %Misc.class;
+  -->
+    <xs:group
+        name="xhtml.Block.mix">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.Heading.class"/>
+            <xs:group
+                ref="xhtml.List.class"/>
+            <xs:group
+                ref="xhtml.Block.class"/>
+            <xs:group
+                ref="xhtml.Misc.class"/>
+        </xs:choice>
+    </xs:group>
+    <!--
+    All Content Elements
+    Flow.mix includes all text content, block and inline
+    Note that the "any" element included here allows us
+    to add data from any other namespace, a necessity
+    for compound document creation.
+    Note however that it is not possible to add
+    to any head level element without further
+    modification. To add RDF metadata to the head
+    of a document, modify the structure module.
+  -->
+    <xs:group
+        name="xhtml.Flow.mix">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.Heading.class"/>
+            <xs:group
+                ref="xhtml.List.class"/>
+            <xs:group
+                ref="xhtml.Block.class"/>
+            <xs:group
+                ref="xhtml.Inline.class"/>
+            <xs:group
+                ref="xhtml.Misc.class"/>
+        </xs:choice>
+    </xs:group>
+    <!--
+    BlkNoForm.mix includes all non-form block elements,
+    plus Misc.class
+  -->
+    <xs:group
+        name="xhtml.BlkNoForm.mix">
+        <xs:choice>
+            <xs:group
+                ref="xhtml.Heading.class"/>
+            <xs:group
+                ref="xhtml.List.class"/>
+            <xs:group
+                ref="xhtml.BlkStruct.class"/>
+            <xs:group
+                ref="xhtml.BlkPhras.class"/>
+            <xs:group
+                ref="xhtml.BlkPres.class"/>
+            <xs:group
+                ref="xhtml.Table.class"/>
+            <xs:group
+                ref="xhtml.Block.extra"/>
+            <xs:group
+                ref="xhtml.Misc.class"/>
+        </xs:choice>
+    </xs:group>
+    <xs:element
+        name="html"
+        type="xhtml.html.type"/>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml11-modules-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml11-modules-1.xsd
@@ -1,0 +1,605 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           elementFormDefault="qualified" 
+           xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/" >
+    <xs:import namespace="http://www.w3.org/1999/xhtml/datatypes/" 
+        schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-datatypes-1.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+      This schema includes all modules for XHTML1.1 Document Type.
+      $Id: xhtml11-modules-1.xsd,v 1.10 2009/02/03 15:14:49 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+     This schema includes all modules (and redefinitions)
+     for XHTML1.1 Document Type.
+     XHTML1.1 Document Type includes the following Modules
+
+       XHTML Core modules (Required for XHTML Family Conformance)
+            +  text
+            +  hypertext
+            +  lists
+            +  structure
+
+       Other XHTML modules
+            +  Edit
+            +  Bdo
+            +  Presentational
+            +  Link
+            +  Meta
+            +  Base
+            +  Scripting
+            +  Style
+            +  Image
+            +  Applet
+            +  Object
+            +  Param (Applet/Object modules require Param Module)
+            +  Tables
+            +  Target
+            +  Forms
+            +  Client side image maps
+            +  Server side image maps
+
+    </xs:documentation>
+    </xs:annotation>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-framework-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Schema Framework Component Modules:
+            +  notations
+            +  datatypes
+            +  common attributes
+            +  character entities
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_commonatts"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-text-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Text module
+
+        The Text module includes declarations for all core
+        text container elements and their attributes.
+
+            +  block phrasal
+            +  block structural
+            +  inline phrasal
+            +  inline structural
+
+        Elements defined here:
+          * address, blockquote, pre, h1, h2, h3, h4, h5, h6
+          * div, p
+          * abbr, acronym, cite, code, dfn, em, kbd, q, samp, strong, var
+          * br, span
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_textmodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:redefine schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-hypertext-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+         Hypertext module
+
+         Elements defined here:
+          * a
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_hypertextmodule"/>
+        </xs:annotation>
+        <xs:attributeGroup name="xhtml.a.attlist">
+            <xs:attributeGroup ref="xhtml.a.attlist"/>
+            <xs:attributeGroup ref="xhtml.a.csim.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+              Redefinition by Client Side Image Map Module
+            </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.a.events.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+              Redefinition by XHTML Event Attribute Module
+            </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.a.target.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+              Target Module - A Attribute Additions
+            </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+    </xs:redefine>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-list-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Lists module
+
+        Elements defined here:
+          * dt, dd, dl, ol, ul, li
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_listmodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:redefine schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-struct-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Structural module
+
+        Elements defined here:
+          * title, head, body, html
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/2001/REC-xhtml-modularization-20010410/abstract_modules.html#s_structuremodule"/>
+        </xs:annotation>
+        <xs:attributeGroup name="xhtml.version.attrib">
+            <xs:annotation>
+                <xs:documentation>
+            Redefinition by the XHTML11 Markup (for value of version attr)
+         </xs:documentation>
+            </xs:annotation>
+            <xs:attribute name="version" type="xh11d:CDATA" fixed="-//W3C//DTD XHTML 1.1//EN"/>
+        </xs:attributeGroup>
+        <xs:attributeGroup name="xhtml.body.attlist">
+            <xs:attributeGroup ref="xhtml.body.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+              Original Body Attlist
+            </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.body.events.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+              Redefinition by XHTML Event Attribute Module
+            </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+    </xs:redefine>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-edit-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Edit module
+
+        Elements defined here:
+          * ins, del
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_editmodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-bdo-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Bidirectional element module
+
+        Elements defined here:
+          * bdo
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_bdomodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-pres-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Presentational module
+
+         Elements defined here:
+           * hr, b, big, i, small,sub, sup, tt
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_presentationmodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:redefine schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-link-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+                Link module
+
+                Elements defined here:
+                   * link
+            </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_linkmodule"/>
+        </xs:annotation>
+        <xs:attributeGroup name="xhtml.link.attlist">
+            <xs:annotation>
+                <xs:documentation>
+            Changes to XHTML Link Attlist
+          </xs:documentation>
+            </xs:annotation>
+            <xs:attributeGroup ref="xhtml.link.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Original Link Attributes (declared in Link Module)
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.link.target.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                      XHTML Target Module - Attribute additions
+                     </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+    </xs:redefine>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-meta-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Meta module
+
+        Elements defined here:
+        * meta
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_metamodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:redefine schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-base-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Base module
+
+        Elements defined here:
+          * base
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_basemodule"/>
+        </xs:annotation>
+        <xs:attributeGroup name="xhtml.base.attlist">
+            <xs:annotation>
+                <xs:documentation>
+            Changes to XHTML base Attlist
+          </xs:documentation>
+            </xs:annotation>
+            <xs:attributeGroup ref="xhtml.base.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Original Base Attributes (declared in Base Module)
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.base.target.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                XHTML Target Module - Attribute additions
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+    </xs:redefine>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-script-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Scripting module
+
+        Elements defined here:
+          * script, noscript
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_scriptmodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-style-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Style module
+
+        Elements defined here:
+          * style
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_stylemodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-inlstyle-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Style attribute module
+
+        Attribute defined here:
+          * style
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_styleattributemodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:redefine schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-image-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Image module
+
+        Elements defined here:
+          * img
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_imagemodule"/>
+        </xs:annotation>
+        <xs:attributeGroup name="xhtml.img.attlist">
+            <xs:attributeGroup ref="xhtml.img.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Original Image Attributes (in Image Module)
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.img.csim.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Redefinition by Client Side Image Map Module
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.img.ssimap.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Redefinition by Server Side Image Module
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+    </xs:redefine>
+    <xs:redefine schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-csismap-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Client-side mage maps module
+
+        Elements defined here:
+          * area, map
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_imapmodule"/>
+        </xs:annotation>
+        <xs:attributeGroup name="xhtml.area.attlist">
+            <xs:attributeGroup ref="xhtml.area.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Original Area Attributes (in CSI Module)
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.area.events.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Redefinition by Events Attribute Module
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.area.target.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Target Module - Area Attribute Additions
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+    </xs:redefine>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-ssismap-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+       Server-side image maps module
+
+        Attributes defined here:
+          * ismap on img
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_servermapmodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:redefine schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-object-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Object module
+
+        Elements defined here:
+          * object
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_objectmodule"/>
+        </xs:annotation>
+        <xs:attributeGroup name="xhtml.object.attlist">
+            <xs:attributeGroup ref="xhtml.object.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Original Object Attlist
+              </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.object.csim.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Redefinition by Client Image Map Module
+              </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+    </xs:redefine>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-param-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Param module
+
+        Elements defined here:
+          * param
+      </xs:documentation>
+        </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-table-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Tables module
+
+        Elements defined here:
+          * table, caption, thead, tfoot, tbody, colgroup, col, tr, th, td
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_tablemodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:redefine schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-form-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+            Forms module
+
+            Elements defined here:
+              * form, label, input, select, optgroup, option,
+              * textarea, fieldset, legend, button
+          </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_extformsmodule"/>
+        </xs:annotation>
+        <xs:attributeGroup name="xhtml.form.attlist">
+            <xs:annotation>
+                <xs:documentation>
+            Changes to XHTML Form Attlist
+          </xs:documentation>
+            </xs:annotation>
+            <xs:attributeGroup ref="xhtml.form.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Original Form Attributes (declared in Forms Module)
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.form.events.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                XHTML Events Module - Attribute additions
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.form.target.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                      XHTML Target Module - Attribute additions
+                     </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+        <xs:attributeGroup name="xhtml.input.attlist">
+            <xs:annotation>
+                <xs:documentation>
+            Changes to XHTML Form Input Element
+          </xs:documentation>
+            </xs:annotation>
+            <xs:attributeGroup ref="xhtml.input.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Original Input Attributes (in Forms Module)
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.input.csim.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Redefinition by Client Side Image Map Module
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.input.ssimap.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Redefinition by Server Side Image Map Module
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.input.events.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+               Redefinition by Event Attribute Module
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+        <xs:attributeGroup name="xhtml.label.attlist">
+            <xs:attributeGroup ref="xhtml.label.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Original Label Attributes (in Forms Module)
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.label.events.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+               Redefinition by Event Attribute Module
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+        <xs:attributeGroup name="xhtml.select.attlist">
+            <xs:attributeGroup ref="xhtml.select.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Original Select Attributes (in Forms Module)
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.select.events.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+               Redefinition by Event Attribute Module
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+        <xs:attributeGroup name="xhtml.textarea.attlist">
+            <xs:attributeGroup ref="xhtml.textarea.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Original TextArea Attributes (in Forms Module)
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.textarea.events.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+               Redefinition by Event Attribute Module
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+        <xs:attributeGroup name="xhtml.button.attlist">
+            <xs:attributeGroup ref="xhtml.button.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+                Original Button Attributes (in Forms Module)
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+            <xs:attributeGroup ref="xhtml.button.events.attlist">
+                <xs:annotation>
+                    <xs:documentation>
+               Redefinition by Event Attribute Module
+             </xs:documentation>
+                </xs:annotation>
+            </xs:attributeGroup>
+        </xs:attributeGroup>
+    </xs:redefine>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-ruby-1.xsd">
+      <xs:annotation>
+      <xs:documentation>
+        Ruby module
+
+        Elements defined here:
+          * ruby, rbc, rtc, rb, rt, rp
+
+        Note that either Ruby or Basic Ruby should be used but not both
+      </xs:documentation>
+      <xs:documentation source="http://www.w3.org/TR/2001/REC-ruby-20010531/#complex"/>
+      </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-events-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        XHTML Events Modules
+
+        Attributes defined here:
+          XHTML Event Types
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_intrinsiceventsmodule"/>
+        </xs:annotation>
+    </xs:include>
+    <xs:include schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-target-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        XHTML Target Attribute Module
+
+        Attributes defined here:
+          target
+      </xs:documentation>
+            <xs:documentation source="http://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_targetmodule"/>
+        </xs:annotation>
+    </xs:include>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml11.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xhtml11.xsd
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://www.w3.org/1999/xhtml"
+    xmlns:xh11d="http://www.w3.org/1999/xhtml/datatypes/"
+    xmlns="http://www.w3.org/1999/xhtml"
+    elementFormDefault="qualified" >
+    <xs:annotation>
+        <xs:documentation>
+      This is the XML Schema driver for XHTML 1.1.
+      Please use this namespace for XHTML elements:
+
+         "http://www.w3.org/1999/xhtml"
+
+      $Id: xhtml11.xsd,v 1.7 2009/02/03 15:14:49 ahby Exp $
+    </xs:documentation>
+        <xs:documentation source="xhtml-copyright-1.xsd"/>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      This is XHTML, a reformulation of HTML as a modular XML application
+      The Extensible HyperText Markup Language (XHTML)
+      Copyright &#169;1998-2007 World Wide Web Consortium
+      (Massachusetts Institute of Technology, European Research Consortium
+       for Informatics and Mathematics, Keio University).
+      All Rights Reserved.
+
+      Permission to use, copy, modify and distribute the XHTML Schema
+      modules and their accompanying xs:documentation for any purpose
+      and without fee is hereby granted in perpetuity, provided that the above
+      copyright notice and this paragraph appear in all copies.
+      The copyright holders make no representation about the suitability of
+      these XML Schema modules for any purpose.
+
+      They are provided "as is" without expressed or implied warranty.
+    </xs:documentation>
+    </xs:annotation>
+    <xs:annotation>
+        <xs:documentation>
+      This is the Schema Driver file for XHTML1.1
+      Document Type
+
+     This schema
+        + imports external schemas (xml.xsd)
+        + refedines (and include)s schema modules for XHTML1.1 Document Type.
+        + includes Schema for Named content model for the
+          XHTML1.1 Document Type
+
+        XHTML1.1 Document Type includes the following Modules
+           XHTML Core modules (Required for XHTML Family Conformance)
+            +  text
+            +  hypertext
+            +  lists
+            +  structure
+           Other XHTML modules
+            +  Edit
+            +  Bdo
+            +  Presentational
+            +  Link
+            +  Meta
+            +  Base
+            +  Scripting
+            +  Style
+            +  Image
+            +  Applet
+            +  Object
+            +  Param (Applet/Object modules require Param Module)
+            +  Tables
+            +  Forms
+            +  Client side image maps
+            +  Server side image maps
+            +  Ruby
+    </xs:documentation>
+    </xs:annotation>
+    <xs:import
+        namespace="http://www.w3.org/XML/1998/namespace"
+        schemaLocation="http://www.w3.org/2001/xml.xsd">
+        <xs:annotation>
+            <xs:documentation>
+         This import brings in the XML namespace attributes
+         The XML attributes are used by various modules.
+       </xs:documentation>
+        </xs:annotation>
+    </xs:import>
+    <xs:include
+        schemaLocation="xhtml11-model-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Document Model module for the XHTML1.1 Document Type.
+        This schema file defines all named models used by XHTML
+        Modularization Framework for XHTML1.1 Document Type
+      </xs:documentation>
+        </xs:annotation>
+    </xs:include>
+    <xs:include
+        schemaLocation="xhtml11-modules-1.xsd">
+        <xs:annotation>
+            <xs:documentation>
+        Schema that includes all modules (and redefinitions)
+        for XHTML1.1 Document Type.                
+           </xs:documentation>
+        </xs:annotation>
+    </xs:include>
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xml-events-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xml-events-1.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://www.w3.org/2001/xml-events" 
+    xmlns="http://www.w3.org/2001/xml-events" 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="http://www.w3.org/2001/XMLSchema 
+                        http://www.w3.org/2001/XMLSchema.xsd" 
+    elementFormDefault="unqualified" 
+    blockDefault="#all" 
+    finalDefault="#all" 
+    attributeFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:documentation>
+      This is the XML Schema for XML Events
+
+      URI: http://www.w3.org/MarkUp/SCHEMA/xml-events-1.xsd
+      $Id: xml-events-1.xsd,v 1.8 2004/11/22 17:09:15 ahby Exp $
+    </xs:documentation>
+    <xs:documentation source="xml-events-copyright-1.xsd"/>
+  </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation>
+      XML Events element listener
+		
+        This module defines the listener element for XML Events.
+        This element can be used to define event listeners. This
+        module relies upon the XmlEvents.attlist attribute group
+        defined in xml-events-attribs-1.xsd.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attributeGroup name="listener.attlist">
+    <xs:attribute name="event" use="required" type="xs:NMTOKEN"/>
+    <xs:attribute name="observer" type="xs:IDREF"/>
+    <xs:attribute name="target" type="xs:IDREF"/>
+    <xs:attribute name="handler" type="xs:anyURI"/>
+    <xs:attribute name="phase" default="default">
+      <xs:simpleType>
+        <xs:restriction base="xs:NMTOKEN">
+          <xs:enumeration value="capture"/>
+          <xs:enumeration value="default"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="propagate" default="continue">
+      <xs:simpleType>
+        <xs:restriction base="xs:NMTOKEN">
+          <xs:enumeration value="stop"/>
+          <xs:enumeration value="continue"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="defaultAction" default="perform">
+      <xs:simpleType>
+        <xs:restriction base="xs:NMTOKEN">
+          <xs:enumeration value="cancel"/>
+          <xs:enumeration value="perform"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="id" type="xs:ID"/>
+  </xs:attributeGroup>
+
+  <xs:complexType name="listener.type">
+    <xs:attributeGroup ref="listener.attlist"/>
+  </xs:complexType>
+
+  <xs:element name="listener" type="listener.type"/>
+
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xml-events-copyright-1.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xhtml11/xml-events-copyright-1.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema	
+    targetNamespace="http://www.w3.org/2001/xml-events"
+    xmlns="http://www.w3.org/2001/xml-events"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"  
+    elementFormDefault="unqualified" 
+    blockDefault="#all" 
+    finalDefault="#all" 
+    attributeFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:documentation>
+      This is XML Events, a generalized event model for XML-based
+      markup languages. 
+
+        Copyright 2001-2003 World Wide Web Consortium
+            (Massachusetts Institute of Technology, European Research
+            Consortium for Informatics and Mathematics, Keio University).
+            All Rights Reserved.
+		
+        Permission to use, copy, modify and distribute the 
+        XML Events Schema modules and their accompanying xs:documentation 
+        for any purpose and without fee is hereby granted in perpetuity, 
+        provided that the above copyright notice and this paragraph appear 
+        in all copies.  
+
+        The copyright holders make no representation about the suitability of
+        these XML Schema modules for any purpose.
+		
+        They are provided "as is" without expressed or implied warranty.
+    </xs:documentation>
+  </xs:annotation>
+
+</xs:schema>

--- a/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xmlNS2001/xml.xsd
+++ b/src/java.xml/share/classes/jdk/xml/internal/jdkcatalog/w3c/xsd/xmlNS2001/xml.xsd
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd">
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+
+    This schema document describes the XML namespace, in a form
+    suitable for import by other schema documents.  
+
+    Note that local names in this namespace are intended to be defined
+    only by the World Wide Web Consortium or its subgroups.  The
+    following names are currently defined in this namespace and should
+    not be used with conflicting semantics by any Working Group,
+    specification, or document instance:
+
+    base (as an attribute name): denotes an attribute whose value
+         provides a URI to be used as the base for interpreting any
+         relative URIs in the scope of the element on which it
+         appears; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML Base specification.
+
+    lang (as an attribute name): denotes an attribute whose value
+         is a language code for the natural language of the content of
+         any element; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML specification.
+  
+    space (as an attribute name): denotes an attribute whose
+         value is a keyword indicating what whitespace processing
+         discipline is intended for the content of the element; its
+         value is inherited.  This name is reserved by virtue of its
+         definition in the XML specification.
+
+    Father (in any context at all): denotes Jon Bosak, the chair of 
+         the original XML Working Group.  This name is reserved by 
+         the following decision of the W3C XML Plenary and 
+         XML Coordination groups:
+
+             In appreciation for his vision, leadership and dedication
+             the W3C XML Plenary on this 10th day of February, 2000
+             reserves for Jon Bosak in perpetuity the XML name
+             xml:Father
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang or xml:space attributes
+        on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .&gt;
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/03/xml.xsd"/&gt;
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .&gt;
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/&gt;
+ 
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2001/03/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself.  In other words, if the XML Schema namespace changes, the version
+   of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2001/03/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang" type="xs:language">
+  <xs:annotation>
+   <xs:documentation>In due course, we should install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values . . .</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attribute name="space" default="preserve">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+ </xs:attributeGroup>
+
+</xs:schema>

--- a/src/java.xml/share/classes/module-info.java
+++ b/src/java.xml/share/classes/module-info.java
@@ -448,7 +448,10 @@
  * XML Schema Part 2: Datatypes Second Edition
  * </th>
  * <td style="text-align:center">
- * XMLSchema.dtd XMLSchema.xsd datatypes.dtd datatypes.xsd
+ * XMLSchema.dtd<br>
+ * datatypes.dtd<br>
+ * XMLSchema.xsd<br>
+ * datatypes.xsd
  * </td>
  * </tr>
  * <tr>
@@ -456,7 +459,9 @@
  * XHTML&trade; 1.0 The Extensible HyperText Markup Language
  * </th>
  * <td style="text-align:center">
- * xhtml1-frameset.dtd xhtml1-strict.dtd xhtml1-transitional.dtd
+ * xhtml1-frameset.dtd<br>
+ * xhtml1-strict.dtd<br>
+ * xhtml1-transitional.dtd
  * </td>
  * </tr>
  * <tr>
@@ -464,7 +469,9 @@
  * XHTML&trade; 1.0 in XML Schema
  * </th>
  * <td style="text-align:center">
- * xhtml1-frameset.xsd xhtml1-strict.xsd xhtml1-transitional.xsd
+ * xhtml1-frameset.xsd<br>
+ * xhtml1-strict.xsd<br>
+ * xhtml1-transitional.xsd
  * </td>
  * </tr>
  * <tr>
@@ -480,8 +487,7 @@
  * XHTML 1.1 XML Schema Definition
  * </th>
  * <td style="text-align:center">
- * xhtml-attribs-1.xsd xhtml-copyright-1.xsd xhtml-datatypes-1.xsd xhtml-framework-1.xsd<br>
- * xhtml11-model-1.xsd xhtml11-modules-1.xsd xhtml11.xsd
+ * xhtml11.xsd
  * </td>
  * </tr>
  * <tr>

--- a/src/java.xml/share/classes/module-info.java
+++ b/src/java.xml/share/classes/module-info.java
@@ -417,11 +417,91 @@
  * </ul>
  *
  * <h2 id="JDKCATALOG">JDK built-in Catalog</h2>
- * The JDK has a built-in catalog that hosts the following DTDs defined by the Java Platform:
- * <ul>
- * <li>DTD for {@link java.util.prefs.Preferences java.util.prefs.Preferences}, preferences.dtd</li>
- * <li>DTD for {@link java.util.Properties java.util.Properties}, properties.dtd</li>
- * </ul>
+ * The JDK has a built-in catalog that hosts DTDs and XSDs list in the following table.
+ * <table class="plain" id="JDKCatalog">
+ * <caption>DTDs and XSDs in JDK built-in Catalog</caption>
+ * <thead>
+ * <tr>
+ * <th scope="col">Source</th>
+ * <th scope="col">Files</th>
+ * </tr>
+ * </thead>
+ *
+ * <tbody>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="util_preferences">
+ * {@link java.util.prefs.Preferences java.util.prefs.Preferences}</th>
+ * <td style="text-align:center">
+ * preferences.dtd
+ * </td>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="util_properties">
+ * {@link java.util.Properties java.util.Properties}</th>
+ * <td style="text-align:center">
+ * properties.dtd
+ * </td>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="XMLSchema">
+ * XML Schema Part 1: Structures Second Edition<br>
+ * XML Schema Part 2: Datatypes Second Edition
+ * </th>
+ * <td style="text-align:center">
+ * XMLSchema.dtd XMLSchema.xsd datatypes.dtd datatypes.xsd
+ * </td>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="XHTML10">
+ * XHTML&trade; 1.0 The Extensible HyperText Markup Language
+ * </th>
+ * <td style="text-align:center">
+ * xhtml1-frameset.dtd xhtml1-strict.dtd xhtml1-transitional.dtd
+ * </td>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="XHTML10Schema">
+ * XHTML&trade; 1.0 in XML Schema
+ * </th>
+ * <td style="text-align:center">
+ * xhtml1-frameset.xsd xhtml1-strict.xsd xhtml1-transitional.xsd
+ * </td>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="XHTML11">
+ * XHTML&trade; 1.1 - Module-based XHTML - Second Edition
+ * </th>
+ * <td style="text-align:center">
+ * xhtml11.dtd
+ * </td>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="XHTML11Schema">
+ * XHTML 1.1 XML Schema Definition
+ * </th>
+ * <td style="text-align:center">
+ * xhtml-attribs-1.xsd xhtml-copyright-1.xsd xhtml-datatypes-1.xsd xhtml-framework-1.xsd<br>
+ * xhtml11-model-1.xsd xhtml11-modules-1.xsd xhtml11.xsd
+ * </td>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="XMLSPEC">
+ * XML DTD for W3C specifications
+ * </th>
+ * <td style="text-align:center">
+ * xmlspec.dtd
+ * </td>
+ * </tr>
+ * <tr>
+ * <th scope="row" style="font-weight:normal" id="Namespace">
+ * The "xml:" Namespace
+ * </th>
+ * <td style="text-align:center">
+ * xml.xsd
+ * </td>
+ * </tr>
+ * </tbody>
+ * </table>
  * <p>
  * The catalog is loaded once when the first JAXP processor factory is created.
  *

--- a/src/java.xml/share/legal/schema10part1.md
+++ b/src/java.xml/share/legal/schema10part1.md
@@ -6,7 +6,7 @@ Software and Document license - 2023 version
 
 Copied from:  https://www.w3.org/copyright/software-license-2023
 
-License 
+License
 
 By obtaining and/or copying this work, you (the licensee) agree that you have
 read, understood, and will comply with the following terms and conditions.
@@ -27,7 +27,7 @@ modifications:
     [$year-of-document] World Wide Web Consortium.
     https://www.w3.org/copyright/software-license-2023/"
 
-Disclaimers 
+Disclaimers
 
 THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR
 WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF

--- a/src/java.xml/share/legal/schema10part1.md
+++ b/src/java.xml/share/legal/schema10part1.md
@@ -1,0 +1,51 @@
+## XML Schema Part 1: Structures Second Edition
+
+### W3C Software and Document license
+<pre>
+Software and Document license - 2023 version
+
+Copied from:  https://www.w3.org/copyright/software-license-2023
+
+License 
+
+By obtaining and/or copying this work, you (the licensee) agree that you have
+read, understood, and will comply with the following terms and conditions.
+
+Permission to copy, modify, and distribute this work, with or without modification,
+for any purpose and without fee or royalty is hereby granted, provided that you
+include the following on ALL copies of the work or portions thereof, including
+modifications:
+
+    The full text of this NOTICE in a location viewable to users of the
+    redistributed or derivative work.
+    Any pre-existing intellectual property disclaimers, notices, or terms and
+    conditions. If none exist, the W3C software and document short notice should
+    be included.
+    Notice of any changes or modifications, through a copyright statement on the
+    new code or document such as "This software or document includes material
+    copied from or derived from [title and URI of the W3C document]. Copyright ©
+    [$year-of-document] World Wide Web Consortium.
+    https://www.w3.org/copyright/software-license-2023/"
+
+Disclaimers 
+
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR
+WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF
+MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE
+SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
+TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+The name and trademarks of copyright holders may NOT be used in advertising or
+publicity pertaining to the work without specific, written prior permission.
+Title to copyright in this work will at all times remain with copyright holders.
+
+------
+
+Copyright © 2004 W3C® (MIT, ERCIM, Keio), All Rights Reserved. W3C liability,
+trademark and document use rules apply.
+
+
+</pre>

--- a/src/java.xml/share/legal/schema10part2.md
+++ b/src/java.xml/share/legal/schema10part2.md
@@ -1,0 +1,50 @@
+## XML Schema Part 2: Datatypes Second Edition
+
+### W3C Software and Document license
+<pre>
+Software and Document license - 2023 version
+
+Copied from:  https://www.w3.org/copyright/software-license-2023
+
+License 
+
+By obtaining and/or copying this work, you (the licensee) agree that you have
+read, understood, and will comply with the following terms and conditions.
+
+Permission to copy, modify, and distribute this work, with or without modification,
+for any purpose and without fee or royalty is hereby granted, provided that you
+include the following on ALL copies of the work or portions thereof, including
+modifications:
+
+    The full text of this NOTICE in a location viewable to users of the
+    redistributed or derivative work.
+    Any pre-existing intellectual property disclaimers, notices, or terms and
+    conditions. If none exist, the W3C software and document short notice should
+    be included.
+    Notice of any changes or modifications, through a copyright statement on the
+    new code or document such as "This software or document includes material
+    copied from or derived from [title and URI of the W3C document]. Copyright ©
+    [$year-of-document] World Wide Web Consortium.
+    https://www.w3.org/copyright/software-license-2023/"
+
+Disclaimers 
+
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR
+WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF
+MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE
+SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
+TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+The name and trademarks of copyright holders may NOT be used in advertising or
+publicity pertaining to the work without specific, written prior permission.
+Title to copyright in this work will at all times remain with copyright holders.
+
+------
+
+Copyright © 2004 W3C® (MIT, ERCIM, Keio), All Rights Reserved. W3C liability,
+trademark and document use rules apply.
+
+</pre>

--- a/src/java.xml/share/legal/schema10part2.md
+++ b/src/java.xml/share/legal/schema10part2.md
@@ -6,7 +6,7 @@ Software and Document license - 2023 version
 
 Copied from:  https://www.w3.org/copyright/software-license-2023
 
-License 
+License
 
 By obtaining and/or copying this work, you (the licensee) agree that you have
 read, understood, and will comply with the following terms and conditions.
@@ -27,7 +27,7 @@ modifications:
     [$year-of-document] World Wide Web Consortium.
     https://www.w3.org/copyright/software-license-2023/"
 
-Disclaimers 
+Disclaimers
 
 THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR
 WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF

--- a/src/java.xml/share/legal/xhtml10.md
+++ b/src/java.xml/share/legal/xhtml10.md
@@ -1,0 +1,57 @@
+## XHTML™ 1.0 The Extensible HyperText Markup Language
+
+### W3C Software Notice and License
+<pre>
+W3C(R) SOFTWARE NOTICE AND LICENSE
+
+Copyright (c) 1994-2002 World Wide Web Consortium, (Massachusetts
+Institute of Technology, Institut National de Recherche en
+Informatique et en Automatique, Keio University). All Rights
+Reserved. http://www.w3.org/Consortium/Legal/
+
+This W3C work (including software, documents, or other related items)
+is being provided by the copyright holders under the following
+license. By obtaining, using and/or copying this work, you (the
+licensee) agree that you have read, understood, and will comply with
+the following terms and conditions:
+
+Permission to use, copy, modify, and distribute this software and its
+documentation, with or without modification, for any purpose and
+without fee or royalty is hereby granted, provided that you include
+the following on ALL copies of the software and documentation or
+portions thereof, including modifications, that you make:
+
+    The full text of this NOTICE in a location viewable to users of
+    the redistributed or derivative work.
+
+    Any pre-existing intellectual property disclaimers, notices, or
+    terms and conditions. If none exist, a short notice of the following
+    form (hypertext is preferred, text is permitted) should be used within
+    the body of any redistributed or derivative code: "Copyright (C)
+    [$date-of-software] World Wide Web Consortium, (Massachusetts
+    Institute of Technology, Institut National de Recherche en
+    Informatique et en Automatique, Keio University). All Rights
+    Reserved. http://www.w3.org/Consortium/Legal/"
+
+    Notice of any changes or modifications to the W3C files, including
+    the date changes were made. (We recommend you provide URIs to the
+    location from which the code is derived.)
+
+THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT
+HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR
+DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
+TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL
+OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR
+DOCUMENTATION.
+
+The name and trademarks of copyright holders may NOT be used in
+advertising or publicity pertaining to the software without specific,
+written prior permission. Title to copyright in this software and any
+associated documentation will at all times remain with copyright
+holders.
+
+</pre>

--- a/src/java.xml/share/legal/xhtml10schema.md
+++ b/src/java.xml/share/legal/xhtml10schema.md
@@ -1,0 +1,150 @@
+## XHTML™ 1.0 in XML Schema
+
+### W3C® Intellectual Rights Notice and Legal Disclaimers
+<pre>
+Copyright © 1994-2002 W3C ® (Massachusetts Institute of Technology,
+Institut National de Recherche en Informatique et en Automatique, Keio University),
+All Rights Reserved.
+
+World Wide Web Consortium (W3C®) web site pages may contain other proprietary
+notices and copyright information, the terms of which must be observed and
+followed. Specific notices do exist for W3C documents and software. Also, there
+are specific usage policies associated with some of the W3C Icons. Please see
+our Intellectual Rights FAQ for common questions about using materials from our site.
+
+Notice and Disclaimers
+
+1. Unless otherwise noted, all materials contained in this Site are copyrighted
+and may not be used except as provided in these terms and conditions or in the
+copyright notice (documents and software) or other proprietary notice provided
+with the relevant materials.
+
+2. The materials contained in the Site may be downloaded or copied provided that
+ALL copies retain the copyright and any other proprietary notices contained on
+the materials. No material may be modified, edited or taken out of context such
+that its use creates a false or misleading statement or impression as to the
+positions, statements or actions of W3C.
+
+3. The name and trademarks of copyright holders may NOT be used in advertising
+or publicity pertaining to the Web site, its content, specifications, or
+software without specific, written prior permission. Title to copyright in
+Web site documents will at all times remain with copyright holders. Use of W3C
+trademarks and service marks is covered by the W3C Trademark and Servicemark
+License.
+
+4. Caches of W3C materials should comply with the "maximum time to live"
+information provided with the materials. After such materials have expired
+they should not be served from caches without first validating the contents
+of the W3C Site. Organizations that want to mirror W3C content must abide by
+the W3C Mirroring Policy.
+
+W3C®Trademarks and Generic Terms
+Trademarks owned by W3C host institutions on behalf of W3C and generic terms
+used by the W3C
+
+5. The trademarks, logos, and service marks (collectively the "Trademarks")
+displayed on the Site are registered and unregistered Trademarks of the
+Massachusetts Institute of Technology (MIT), Institut National de Recherche
+en Informatique et en Automatique (INRIA), or Keio University (Keio). All use
+of the W3C Trademarks is governed by the W3C Trademark and Servicemark License.
+No additional rights are granted by implication, estoppel, or otherwise. Terms
+which claimed as generic are not governed by any W3C license and are used as
+common descriptors by the W3C.
+
+The following is a list of W3C terms claimed as a trademark or generic term
+by MIT, INRIA, and/or Keio on behalf of the W3C:
+
+    W3C®, World Wide Web Consortium  (registered in numerous countries)
+    Amaya™, a Web Browser
+    CSS™, Cascading Style Sheets Specification
+    DOM™, Document Object Model
+    HTML (generic), HyperText Markup Language
+    HTTP (generic), Hypertext Transfer Protocol
+    MathML™, Mathematical Markup Language
+    Metadata (generic)
+    P3P™, Platform for Privacy Preferences Project
+    PICS™, Platform for Internet Content Selection
+    RDF (generic), Resource Description Framework
+    SMIL™, Synchronized Multimedia Integration Language
+    SVG™, Scalable Vector Graphics
+    WAI™, Web Accessibility Initiative
+    XENC (generic), XML Encryption
+    XHTML™, The Extensible HyperText Markup Language
+    XML (generic), Extensible Markup Language
+    XSL™,  Extensible Stylesheet Language
+
+    ACSS™, Aural Cascading Style Sheets
+    DSig™, Digital Signature Initiative
+    JEPI™, Joint Electronic Payment Initiative
+    Jigsaw™
+    PICSRules™
+    WebFonts™
+
+The absence of a product or service name or logo from this list does not
+constitute a waiver of MIT's, INRIA's, or Keio's trademark or other intellectual
+rights concerning that name or logo.
+
+Any questions concerning the use, status, or standing of W3C trademarks should
+be directed to: site-policy@w3.org or to W3C (c/o Joseph Reagle), Laboratory
+for Computer Science NE43-358, Massachusetts Institute of Technology, 200
+Technology Square, Cambridge, MA 02139.
+
+Non-W3C Trademarks; Member Trademarks
+
+The trademarks, logos, and service marks not owned on behalf of the W3C and
+that are displayed on the Site are the registered and unregistered marks of
+their respective owners. No rights are granted by the W3C to use such marks,
+whether by implication, estoppel, or otherwise.
+
+"METADATA" is a trademark of the Metadata Company. W3C uses the term "metadata"
+in a descriptive sense, meaning "data about data". W3C is not in any way
+affiliated with the Metadata Company.
+Legal Disclaimers
+
+6. W3C has not reviewed any or all of the web sites linked to this Site and is
+not responsible for the content of any off-site pages or any other web sites
+linked to this Site. Please understand that any non-W3C web site is independent
+from W3C, and W3C has no control over the content on that web site.
+In addition, a link to a non-W3C web site does not mean that W3C endorses or
+accepts any responsibility for the content, or the use, of such site. It is
+the user's responsibility to take precautions to ensure that whatever is
+selected is free of such items as viruses, worms, Trojan horses and other
+items of a destructive nature.
+
+7. Information W3C publishes on its Site may contain references or cross
+references to W3C specifications, projects, programs and services that are
+not announced or available in your country. Such references do not imply that
+W3C intends to announce such specifications, projects, programs or services
+in your country.
+
+8. Information on this Site may contain technical inaccuracies or typographical
+errors. Information may be changed or updated without notice. W3C may make
+improvements and/or changes in the materials contained in or described on this
+site at any time without notice. W3C may also make changes in these Terms and
+Conditions without notice. User is bound by such revisions and should therefore
+periodically visit this page to review the then current Terms and Conditions.
+
+9. Limitation on Warranties.
+
+ALL MATERIALS ON THE W3C SITE ARE PROVIDED "AS IS." W3C, MIT, INRIA, AND KEIO
+MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT
+LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+TITLE OR NON-INFRINGEMENT. AS TO DOCUMENTS AND GRAPHICS PUBLISHED ON THIS SITE,
+W3C, MIT, INRIA, AND KEIO MAKE NO REPRESENTATION OR WARRANTY THAT THE CONTENTS
+OF SUCH DOCUMENT OR GRAPHICS ARE FREE FROM ERROR OR SUITABLE FOR ANY PURPOSE;
+NOR THAT IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY
+PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+Please note that some jurisdictions may not allow the exclusion of implied
+ warranties, so some of the above exclusions may not apply to you.
+
+10. Limitation on Liability.
+
+IN NO EVENT WILL W3C, MIT, INRIA, AND KEIO BE LIABLE TO ANY PARTY FOR ANY
+DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES FOR ANY USE OF THIS SITE,
+OR ON ANY OTHER HYPERLINKED WEB SITE, INCLUDING, WITHOUT LIMITATION, ANY LOST
+PROFITS, BUSINESS INTERRUPTION, LOSS OF PROGRAMS OR OTHER DATA ON YOUR
+INFORMATION HANDLING SYSTEM OR OTHERWISE, EVEN IF W3C, MIT, INRIA, OR KEIO
+IS EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+</pre>

--- a/src/java.xml/share/legal/xhtml11.md
+++ b/src/java.xml/share/legal/xhtml11.md
@@ -1,0 +1,68 @@
+## XHTML™ 1.1 - Module-based XHTML - Second Edition
+
+### W3C Document license
+<pre>
+From: https://www.w3.org/copyright/document-license-2023
+
+Copied 10/15/2024
+
+License 
+
+By using and/or copying this document, or the W3C document from which this
+statement is linked, you (the licensee) agree that you have read, understood,
+and will comply with the following terms and conditions:
+
+Permission to copy, and distribute the contents of this document, or the W3C
+document from which this statement is linked, in any medium for any purpose
+and without fee or royalty is hereby granted, provided that you include the
+following on ALL copies of the document, or portions thereof, that you use:
+
+    A link or URL to the original W3C document.
+    The pre-existing copyright notice of the original author, or if it doesn't
+    exist, a notice (hypertext is preferred, but a textual representation is
+    permitted) of the form: "Copyright © [$date-of-document] World Wide Web
+    Consortium. https://www.w3.org/copyright/document-license-2023/"
+    If it exists, the STATUS of the W3C document.
+
+When space permits, inclusion of the full text of this NOTICE should be provided.
+We request that authorship attribution be provided in any software, documents,
+or other items or products that you create pursuant to the implementation of the
+contents of this document, or any portion thereof.
+
+No right to create modifications or derivatives of W3C documents is granted
+pursuant to this license, except as follows: To facilitate implementation of
+the technical specifications set forth in this document, anyone may prepare
+and distribute derivative works and portions of this document in software,
+in supporting materials accompanying software, and in documentation of software,
+PROVIDED that all such works include the notice below. HOWEVER, the publication
+of derivative works of this document for use as a technical specification is
+expressly prohibited.
+
+In addition, "Code Components" —Web IDL in sections clearly marked as Web IDL;
+and W3C-defined markup (HTML, CSS, etc.) and computer programming language code
+clearly marked as code examples— are licensed under the W3C Software License.
+
+The notice is:
+
+"Copyright © 2023 W3C®. This software or document includes material copied from
+or derived from [title and URI of the W3C document]."
+
+Disclaimers §anchor
+
+THIS DOCUMENT IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS
+OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE;
+THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE
+IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS,
+COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE
+OR IMPLEMENTATION OF THE CONTENTS THEREOF.
+
+The name and trademarks of copyright holders may NOT be used in advertising or
+publicity pertaining to this document or its contents without specific, written
+prior permission. Title to copyright in this document will at all times remain
+with copyright holders.
+
+</pre>

--- a/src/java.xml/share/legal/xhtml11.md
+++ b/src/java.xml/share/legal/xhtml11.md
@@ -6,7 +6,7 @@ From: https://www.w3.org/copyright/document-license-2023
 
 Copied 10/15/2024
 
-License 
+License
 
 By using and/or copying this document, or the W3C document from which this
 statement is linked, you (the licensee) agree that you have read, understood,

--- a/src/java.xml/share/legal/xhtml11schema.md
+++ b/src/java.xml/share/legal/xhtml11schema.md
@@ -20,20 +20,20 @@ or royalty is hereby granted, provided that you include the following on ALL
 copies of the software and documentation or portions thereof, including
 modifications, that you make:
 
-1.	The full text of this NOTICE in a location viewable to users of the
-redistributed or derivative work. 
+1.      The full text of this NOTICE in a location viewable to users of the
+redistributed or derivative work.
 
-2.	Any pre-existing intellectual property disclaimers, notices, or terms
+2.      Any pre-existing intellectual property disclaimers, notices, or terms
 and conditions. If none exist, a short notice of the following form (hypertext
 is preferred, text is permitted) should be used within the body of any
 redistributed or derivative code: "Copyright © [$date-of-software] World Wide
 Web Consortium, (Massachusetts Institute of Technology, Institut National de
 Recherche en Informatique et en Automatique, Keio University). All Rights
-Reserved. http://www.w3.org/Consortium/Legal/" 
+Reserved. http://www.w3.org/Consortium/Legal/"
 
-3.	Notice of any changes or modifications to the W3C files, including the
+3.      Notice of any changes or modifications to the W3C files, including the
 date changes were made. (We recommend you provide URIs to the location from
-which the code is derived.) 
+which the code is derived.)
 
 THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE
 NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED

--- a/src/java.xml/share/legal/xhtml11schema.md
+++ b/src/java.xml/share/legal/xhtml11schema.md
@@ -1,0 +1,60 @@
+## XHTML 1.1 XML Schema Definition
+
+### W3C® SOFTWARE NOTICE AND LICENSE
+<pre>
+http://www.w3.org/Consortium/Legal/copyright-software-19980720
+
+W3C® SOFTWARE NOTICE AND LICENSE
+
+Copyright © 1994-2002 World Wide Web Consortium, (Massachusetts Institute of
+Technology, Institut National de Recherche en Informatique et en Automatique,
+Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
+
+This W3C work (including software, documents, or other related items) is
+being provided by the copyright holders under the following license. By
+obtaining, using and/or copying this work, you (the licensee) agree that you
+have read, understood, and will comply with the following terms and conditions:
+Permission to use, copy, modify, and distribute this software and its
+documentation, with or without modification,  for any purpose and without fee
+or royalty is hereby granted, provided that you include the following on ALL
+copies of the software and documentation or portions thereof, including
+modifications, that you make:
+
+1.	The full text of this NOTICE in a location viewable to users of the
+redistributed or derivative work. 
+
+2.	Any pre-existing intellectual property disclaimers, notices, or terms
+and conditions. If none exist, a short notice of the following form (hypertext
+is preferred, text is permitted) should be used within the body of any
+redistributed or derivative code: "Copyright © [$date-of-software] World Wide
+Web Consortium, (Massachusetts Institute of Technology, Institut National de
+Recherche en Informatique et en Automatique, Keio University). All Rights
+Reserved. http://www.w3.org/Consortium/Legal/" 
+
+3.	Notice of any changes or modifications to the W3C files, including the
+date changes were made. (We recommend you provide URIs to the location from
+which the code is derived.) 
+
+THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE
+NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT
+THE USE OF THE SOFTWARE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY
+PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENTATION.
+
+The name and trademarks of copyright holders may NOT be used in advertising or
+publicity pertaining to the software without specific, written prior permission.
+Title to copyright in this software and any associated documentation will at all
+times remain with copyright holders.
+
+The formulation of W3C's notice and license became active on August 14 1998 so
+as to improve compatibility with GPL. This version ensures that W3C software
+licensing terms are no more restrictive than GPL and consequently W3C software
+may be distributed in GPL packages. See the older formulation for the policy
+prior to this date. Please see our Copyright FAQ for common questions about
+using materials from our site, including specific terms and conditions for
+packages like libwww, Amaya, and Jigsaw. Other questions about this notice can
+be directed to site-policy@w3.org.
+
+</pre>

--- a/src/java.xml/share/legal/xmlspec.md
+++ b/src/java.xml/share/legal/xmlspec.md
@@ -1,0 +1,63 @@
+## XML DTD for W3C specifications
+
+### W3C Software Notice and License
+<pre>
+W3C(R) SOFTWARE NOTICE AND LICENSE
+
+Copyright (c) 1994-2002 World Wide Web Consortium, (Massachusetts
+Institute of Technology, Institut National de Recherche en
+Informatique et en Automatique, Keio University). All Rights
+Reserved. http://www.w3.org/Consortium/Legal/
+
+This W3C work (including software, documents, or other related items)
+is being provided by the copyright holders under the following
+license. By obtaining, using and/or copying this work, you (the
+licensee) agree that you have read, understood, and will comply with
+the following terms and conditions:
+
+Permission to use, copy, modify, and distribute this software and its
+documentation, with or without modification, for any purpose and
+without fee or royalty is hereby granted, provided that you include
+the following on ALL copies of the software and documentation or
+portions thereof, including modifications, that you make:
+
+    The full text of this NOTICE in a location viewable to users of
+    the redistributed or derivative work.
+
+    Any pre-existing intellectual property disclaimers, notices, or
+    terms and conditions. If none exist, a short notice of the following
+    form (hypertext is preferred, text is permitted) should be used within
+    the body of any redistributed or derivative code: "Copyright (C)
+    [$date-of-software] World Wide Web Consortium, (Massachusetts
+    Institute of Technology, Institut National de Recherche en
+    Informatique et en Automatique, Keio University). All Rights
+    Reserved. http://www.w3.org/Consortium/Legal/"
+
+    Notice of any changes or modifications to the W3C files, including
+    the date changes were made. (We recommend you provide URIs to the
+    location from which the code is derived.)
+
+THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT
+HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR
+DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
+TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL
+OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR
+DOCUMENTATION.
+
+The name and trademarks of copyright holders may NOT be used in
+advertising or publicity pertaining to the software without specific,
+written prior permission. Title to copyright in this software and any
+associated documentation will at all times remain with copyright
+holders.
+
+----------
+
+COPYRIGHT:
+
+  Copyright (C) 2000, 2001, 2002, 2003 Sun Microsystems, Inc. All Rights Reserved.
+
+</pre>

--- a/src/java.xml/share/legal/xmlxsd.md
+++ b/src/java.xml/share/legal/xmlxsd.md
@@ -1,0 +1,43 @@
+## The "xml:" Namespace
+
+### W3C Software and Document license
+<pre>
+From: https://www.w3.org/copyright/software-license-2023/
+Copied on 2024/10/15
+
+License 
+
+By obtaining and/or copying this work, you (the licensee) agree that you have
+read, understood, and will comply with the following terms and conditions.
+
+Permission to copy, modify, and distribute this work, with or without modification,
+for any purpose and without fee or royalty is hereby granted, provided that you
+include the following on ALL copies of the work or portions thereof, including
+modifications:
+
+    The full text of this NOTICE in a location viewable to users of the
+    redistributed or derivative work.
+    Any pre-existing intellectual property disclaimers, notices, or terms and
+    conditions. If none exist, the W3C software and document short notice should
+    be included.
+    Notice of any changes or modifications, through a copyright statement on the
+    new code or document such as "This software or document includes material
+    copied from or derived from [title and URI of the W3C document]. Copyright ©
+    [$year-of-document] World Wide Web Consortium.
+    https://www.w3.org/copyright/software-license-2023/"
+
+Disclaimers §anchor
+
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR
+WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF
+MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE
+SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
+TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+The name and trademarks of copyright holders may NOT be used in advertising or
+publicity pertaining to the work without specific, written prior permission.
+Title to copyright in this work will at all times remain with copyright holders.
+</pre>

--- a/src/java.xml/share/legal/xmlxsd.md
+++ b/src/java.xml/share/legal/xmlxsd.md
@@ -5,7 +5,7 @@
 From: https://www.w3.org/copyright/software-license-2023/
 Copied on 2024/10/15
 
-License 
+License
 
 By obtaining and/or copying this work, you (the licensee) agree that you have
 read, understood, and will comply with the following terms and conditions.

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport2.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport2.java
@@ -51,7 +51,7 @@ import org.xml.sax.SAXParseException;
 
 /*
  * @test
- * @bug 8158084 8162438 8162442 8163535 8166220
+ * @bug 8158084 8162438 8162442 8163535 8166220 8344800
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @run testng/othervm catalog.CatalogSupport2
  * @summary extends CatalogSupport tests, verifies that the use of the Catalog may
@@ -234,7 +234,7 @@ public class CatalogSupport2 extends CatalogSupportBase {
 
         return new Object[][]{
             // for resolving DTD in xsd
-            {false, true, xml_catalog, xsd_xmlSchema, null},
+            {false, true, xml_catalog, xsd_val_test_dtd, null},
             // for resolving xsd import
             {false, true, xml_catalog, xsd_xmlSchema_import, null},
             // for resolving xsd include

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport3.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport3.java
@@ -51,7 +51,7 @@ import org.xml.sax.SAXParseException;
 
 /*
  * @test
- * @bug 8158084 8162438 8162442 8163535 8166220
+ * @bug 8158084 8162438 8162442 8163535 8166220 8344800
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @run testng/othervm catalog.CatalogSupport3
  * @summary extends CatalogSupport tests, verifies that the use of the Catalog may
@@ -236,7 +236,7 @@ public class CatalogSupport3 extends CatalogSupportBase {
 
         return new Object[][]{
             // for resolving DTD in xsd
-            {true, false, xml_catalog, xsd_xmlSchema, null},
+            {true, false, xml_catalog, xsd_val_test_dtd, null},
             // for resolving xsd import
             {true, false, xml_catalog, xsd_xmlSchema_import, null},
             // for resolving xsd include

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupportBase.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupportBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,7 +126,7 @@ public class CatalogSupportBase {
     // For the xsd import and include
     String xsd_xmlSchema, dtd_xmlSchema, dtd_datatypes;
     String xsd_xmlSchema_import, xsd_xml;
-    String xml_val_test, xml_val_test_id, xsd_val_test;
+    String xml_val_test, xml_val_test_id, xsd_val_test, xsd_val_test_dtd;
     String xsd_include_company, xsd_include_person, xsd_include_product;
     String xsl_include, xsl_includeDTD, xsl_import_html, xsl_include_header, xsl_include_footer;
 
@@ -254,6 +254,7 @@ public class CatalogSupportBase {
         xml_val_test = filepath + "/val_test.xml";
         xml_val_test_id = "file://" + slash + xml_val_test;
         xsd_val_test = filepath + "/val_test.xsd";
+        xsd_val_test_dtd = Paths.get(filepath + "val_test_dtd.xsd").toUri().toASCIIString();
 
         xml_xsl = "<?xml version=\"1.0\"?>\n" +
                 "<content>\n" +
@@ -375,7 +376,11 @@ public class CatalogSupportBase {
             factory.setProperty(CatalogFeatures.Feature.FILES.getPropertyName(), catalog);
         }
 
-        Schema schema = factory.newSchema(new StreamSource(new StringReader(xsd)));
+        if (xsd.endsWith(".xsd")) {
+            Schema schema = factory.newSchema(new StreamSource(xsd));
+        } else {
+            Schema schema = factory.newSchema(new StreamSource(new StringReader(xsd)));
+        }
         success("XMLSchema.dtd and datatypes.dtd are resolved.");
     }
 

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/val_test_dtd.xsd
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/val_test_dtd.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE  xsd:schema  PUBLIC  "-//OPENJDK//XML CATALOG DTD//USECATALOG"  
+     "http://openjdk_java_net/xml/catalog/dtd/usecatalogtest.dtd">
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             targetNamespace="test">
+     <xsd:element name="root">
+         <xsd:complexType>
+             <xsd:sequence>
+                 <xsd:element name="child" type="xsd:anyType"/>
+             </xsd:sequence>
+         </xsd:complexType>
+
+         <xsd:key name="key1">
+             <xsd:selector xpath="."/>
+             <xsd:field xpath="child"/>
+         </xsd:key>
+     </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
Add DTDs and XSDs from the W3C specifications to the JDK built-in Catalog.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8344801](https://bugs.openjdk.org/browse/JDK-8344801) to be approved

### Issues
 * [JDK-8344800](https://bugs.openjdk.org/browse/JDK-8344800): Add W3C DTDs and XSDs to the JDK built-in Catalog (**Enhancement** - P4)
 * [JDK-8344801](https://bugs.openjdk.org/browse/JDK-8344801): Add W3C DTDs and XSDs to the JDK built-in Catalog (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22465/head:pull/22465` \
`$ git checkout pull/22465`

Update a local copy of the PR: \
`$ git checkout pull/22465` \
`$ git pull https://git.openjdk.org/jdk.git pull/22465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22465`

View PR using the GUI difftool: \
`$ git pr show -t 22465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22465.diff">https://git.openjdk.org/jdk/pull/22465.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22465#issuecomment-2508911213)
</details>
