### PR TITLE
8345074: java.net.InterfaceAddress constructor could be made private

### DIFF
--- a/src/java.base/share/classes/java/net/InterfaceAddress.java
+++ b/src/java.base/share/classes/java/net/InterfaceAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,10 @@ public class InterfaceAddress {
     private short        maskLength = 0;
 
     /*
-     * Package private constructor. Can't be built directly, instances are
-     * obtained through the NetworkInterface class.
+     * Private constructor. Not to be constructed by Java code, instances
+     * are obtained from native code through the NetworkInterface class.
      */
-    InterfaceAddress() {
+    private InterfaceAddress() {
     }
 
     /**

--- a/src/java.base/share/classes/java/net/InterfaceAddress.java
+++ b/src/java.base/share/classes/java/net/InterfaceAddress.java
@@ -42,8 +42,7 @@ public class InterfaceAddress {
     private short        maskLength = 0;
 
     /*
-     * Private constructor. Not to be constructed by Java code, instances
-     * are obtained from native code through the NetworkInterface class.
+     * This constructor is called via JNI in NetworkInterface.c
      */
     private InterfaceAddress() {
     }


### PR DESCRIPTION
Please review this PR which suggests to make the constructor of `java.net.InterfaceAddress` private.

This constructor is only accessed by native code via the `NetworkInterface` class. Making it private would express the intent of this class as being non-subclassable.

The comment of the constructor is updated to reflect the new access modifier as well as to make it clear that the constructor is not to be invoked from Java code and that instances are obtained from `NetworkInterface` via native code. 

Marking this class final is handled separately in JDK-8344943 via a CSR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345074](https://bugs.openjdk.org/browse/JDK-8345074): java.net.InterfaceAddress constructor could be made private (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22467/head:pull/22467` \
`$ git checkout pull/22467`

Update a local copy of the PR: \
`$ git checkout pull/22467` \
`$ git pull https://git.openjdk.org/jdk.git pull/22467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22467`

View PR using the GUI difftool: \
`$ git pr show -t 22467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22467.diff">https://git.openjdk.org/jdk/pull/22467.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22467#issuecomment-2509136519)
</details>
