### PR TITLE
8343800: Cleanup definition of NULL_WORD

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -560,6 +560,9 @@ const jfloat min_jfloat = jfloat_cast(min_jintFloat);
 const jint max_jintFloat = (jint)(0x7f7fffff);
 const jfloat max_jfloat = jfloat_cast(max_jintFloat);
 
+// A named constant for the integral representation of a Java null.
+const intptr_t NULL_WORD = 0;
+
 //----------------------------------------------------------------------------------------------------
 // JVM spec restrictions
 

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -71,24 +71,6 @@
 #include <sys/time.h>
 #endif // LINUX || _ALLBSD_SOURCE
 
-// NULL vs NULL_WORD:
-// On Linux NULL is defined as a special type '__null'. Assigning __null to
-// integer variable will cause gcc warning. Use NULL_WORD in places where a
-// pointer is stored as integer value.  On some platforms, sizeof(intptr_t) >
-// sizeof(void*), so here we want something which is integer type, but has the
-// same size as a pointer.
-#ifdef __GNUC__
-  #ifdef _LP64
-    #define NULL_WORD  0L
-  #else
-    // Cast 0 to intptr_t rather than int32_t since they are not the same type
-    // on platforms such as Mac OS X.
-    #define NULL_WORD  ((intptr_t)0)
-  #endif
-#else
-  #define NULL_WORD  NULL
-#endif
-
 // checking for nanness
 #if defined(__APPLE__)
 inline int g_isnan(double f) { return isnan(f); }

--- a/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
@@ -72,12 +72,6 @@
 // 64-bit integer-suffix (LL) instead.
 #define NULL 0LL
 
-// NULL vs NULL_WORD:
-// On Linux NULL is defined as a special type '__null'. Assigning __null to
-// integer variable will cause gcc warning. Use NULL_WORD in places where a
-// pointer is stored as integer value.
-#define NULL_WORD NULL
-
 typedef int64_t ssize_t;
 
 // Non-standard stdlib-like stuff:


### PR DESCRIPTION
Please review this change to how NULL_WORD is defined.  Instead of being a
macro whose definition is in compiler-specific files with a conditionally
defined expansion, it is now a simple integral constant with a single shared
definition.

Testing: mach5 tier 1-5, GHA sanity tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343800](https://bugs.openjdk.org/browse/JDK-8343800): Cleanup definition of NULL_WORD (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22468/head:pull/22468` \
`$ git checkout pull/22468`

Update a local copy of the PR: \
`$ git checkout pull/22468` \
`$ git pull https://git.openjdk.org/jdk.git pull/22468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22468`

View PR using the GUI difftool: \
`$ git pr show -t 22468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22468.diff">https://git.openjdk.org/jdk/pull/22468.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22468#issuecomment-2509622580)
</details>
