### PR TITLE
8345279: Mistake in javadoc of javax.sql.rowset.BaseRowSet#setBigDecimal

### DIFF
--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/BaseRowSet.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/BaseRowSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1892,7 +1892,7 @@ public abstract class BaseRowSet implements Serializable, Cloneable {
 
     /**
      * Sets the designated parameter to the given
-     * <code>java.lang.BigDecimal</code> value.  The driver converts this to
+     * <code>java.math.BigDecimal</code> value.  The driver converts this to
      * an SQL <code>NUMERIC</code> value when it sends it to the database.
      * <P>
      * The parameter value set by this method is stored internally and


### PR DESCRIPTION
Can I please get a review of this trivial typo fix in the javadoc of `javax.sql.rowset.BaseRowSet#setBigDecimal()` method?

As noted in https://bugs.openjdk.org/browse/JDK-8345279, the javadoc incorrectly mentions `java.lang.BigDecimal` instead of `java.math.BigDecimal`. As part of this change, I had considered using a `{@link}` or a `{@linkplain}` to the `BigDecimal` class in this method's javadoc, but decided not to do so, to keep it consistent with several others methods in this class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345279](https://bugs.openjdk.org/browse/JDK-8345279): Mistake in javadoc of javax.sql.rowset.BaseRowSet#setBigDecimal (**Bug** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22470/head:pull/22470` \
`$ git checkout pull/22470`

Update a local copy of the PR: \
`$ git checkout pull/22470` \
`$ git pull https://git.openjdk.org/jdk.git pull/22470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22470`

View PR using the GUI difftool: \
`$ git pr show -t 22470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22470.diff">https://git.openjdk.org/jdk/pull/22470.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22470#issuecomment-2510550605)
</details>
