### PR TITLE
8345267: Fix memory leak in JVMCIEnv dtor

### DIFF
--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -613,7 +613,7 @@ JVMCIEnv::~JVMCIEnv() {
   if (_init_error_msg != nullptr) {
     // The memory allocated in libjvmci was not allocated with os::malloc
     // so must not be freed with os::free.
-    ALLOW_C_FUNCTION(::free((void*) _init_error_msg));
+    ALLOW_C_FUNCTION(::free, ::free((void*) _init_error_msg);)
   }
   if (_init_error != JNI_OK) {
     return;


### PR DESCRIPTION
The `ALLOW_C_FUNCTION` macro takes the identifier for the relevant C function, followed by a statement containing the use as additional (variadic) macro args. This PR fixes a use of this macro where the leading identifier arg was being omitted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345267](https://bugs.openjdk.org/browse/JDK-8345267): Fix memory leak in JVMCIEnv dtor (**Bug** - P4)


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) Review applies to [c789f049](https://git.openjdk.org/jdk/pull/22471/files/c789f0490a7b13e80d717918012d406aa3ee881b)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22471/head:pull/22471` \
`$ git checkout pull/22471`

Update a local copy of the PR: \
`$ git checkout pull/22471` \
`$ git pull https://git.openjdk.org/jdk.git pull/22471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22471`

View PR using the GUI difftool: \
`$ git pr show -t 22471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22471.diff">https://git.openjdk.org/jdk/pull/22471.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22471#issuecomment-2510744199)
</details>
