### PR TITLE
8345287: C2: live in computation is broken

### DIFF
--- a/src/hotspot/share/opto/live.cpp
+++ b/src/hotspot/share/opto/live.cpp
@@ -277,7 +277,7 @@ void PhaseLive::add_liveout(Block_List& worklist, Block* p, IndexSet* lo, Vector
 // Add a vector of live-in values to a given blocks live-in set.
 void PhaseLive::add_livein(Block *p, IndexSet *lo) {
   IndexSet *livein = &_livein[p->_pre_order-1];
-  if (!livein->is_empty()) {
+  if (!lo->is_empty()) {
     IndexSetIterator elements(lo);
     uint r;
     while ((r = elements.next()) != 0) {


### PR DESCRIPTION
8234003 (Improve IndexSet iteration) broke live in computation:

```
@@ -273,23 +276,25 @@ void PhaseLive::add_liveout( Block *p, IndexSet *lo, VectorSet &first_pass ) {
 // Add a vector of live-in values to a given blocks live-in set.
 void PhaseLive::add_livein(Block *p, IndexSet *lo) {
   IndexSet *livein = &_livein[p->_pre_order-1];
-  IndexSetIterator elements(lo);
-  uint r;
-  while ((r = elements.next()) != 0) {
-    livein->insert(r);         // Then add to live-in set
+  if (!livein->is_empty()) {
+    IndexSetIterator elements(lo);
+    uint r;
+    while ((r = elements.next()) != 0) {
+      livein->insert(r);         // Then add to live-in set
+    }
   }
 }
```

`livein` is initially empy and the patch above only adds element to it if:

```
if (!livein->is_empty()) {
```

which is never true.

This doesn't affect correctness as live in sets are only used to drive
scheduling.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345287](https://bugs.openjdk.org/browse/JDK-8345287): C2: live in computation is broken (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22473/head:pull/22473` \
`$ git checkout pull/22473`

Update a local copy of the PR: \
`$ git checkout pull/22473` \
`$ git pull https://git.openjdk.org/jdk.git pull/22473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22473`

View PR using the GUI difftool: \
`$ git pr show -t 22473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22473.diff">https://git.openjdk.org/jdk/pull/22473.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22473#issuecomment-2510960466)
</details>
