### PR TITLE
8345293: Fix generational Shenandoah with compact headers

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -332,6 +332,11 @@ void ShenandoahHeap::increase_object_age(oop obj, uint additional_age) {
 uint ShenandoahHeap::get_object_age(oop obj) {
   markWord w = obj->mark();
   assert(!w.is_marked(), "must not be forwarded");
+  if (UseObjectMonitorTable) {
+    assert(LockingMode == LM_LIGHTWEIGHT, "Must use LW locking, too");
+    assert(w.age() <= markWord::max_age, "Impossible!");
+    return w.age();
+  }
   if (w.has_monitor()) {
     w = w.monitor()->header();
   } else if (w.is_being_inflated() || w.has_displaced_mark_helper()) {


### PR DESCRIPTION
See bug for crash details.

The problem is in the code that gets the object age out of the mark-word. That code has a special cases for when an object is monitor locked, in which case it fetches the displaced header out of the monitor and extracts the age from there. However, with compact headers, we're running with ObjectMonitorTable, and decoding the monitor-locked mark-word crashes.

The fix is simple: when we are running with ObjectMonitorTable, the mark-word never gets overloaded by locking, so we can return the age straight out of the mark-word.

Testing:
 - [x] hotspot_gc_shenandoah +UCOH