### PR TITLE
8345296: AArch64: VM crashes with SIGILL when prctl is disallowed

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -448,8 +448,9 @@ void VM_Version::initialize() {
     if (vl < 0) {
       warning("Unable to get SVE vector length on this system. Disabling SVE.");
       FLAG_SET_DEFAULT(UseSVE, 0);
+    } else {
+      _initial_sve_vector_length = vl;
     }
-    _initial_sve_vector_length = vl;
   }
 
   // This machine allows unaligned memory accesses

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -444,7 +444,12 @@ void VM_Version::initialize() {
   }
 
   if (UseSVE > 0) {
-    _initial_sve_vector_length = get_current_sve_vector_length();
+    int vl = get_current_sve_vector_length();
+    if (vl < 0) {
+      warning("Unable to get SVE vector length on this system. Disabling SVE.");
+      FLAG_SET_DEFAULT(UseSVE, 0);
+    }
+    _initial_sve_vector_length = vl;
   }
 
   // This machine allows unaligned memory accesses


### PR DESCRIPTION
We have caught this in some prod environments, where prctl is forbidden by the sandboxing mechanism. This fails the JVM, because we have the following code to check for SVE vector length:

```
int VM_Version::get_current_sve_vector_length() {
  assert(VM_Version::supports_sve(), "should not call this");
  return prctl(PR_SVE_GET_VL);
}
```

That code returns `-1` when `prctl` is disallowed, which JVM then blindly interprets as vector length, leading to `SIGILL`.

I looked around other uses of `prctl` around Hotspot, and they all seem to handle the errors correctly.

Additional testing:
 - [ ] Linux AArch64 server fastdebug, with seccomp reproducer
 - [ ] Linux AArch64 server fastdebug, `all`