### PR TITLE
8345297: test/jdk/javax/swing/Action/8133039/bug8133039.java fails in ubuntu22.04

### DIFF
--- a/test/jdk/javax/swing/Action/8133039/bug8133039.java
+++ b/test/jdk/javax/swing/Action/8133039/bug8133039.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,8 @@ import sun.swing.UIAction;
  * @bug 8133039
  * @summary Provide public API to sun.swing.UIAction#isEnabled(Object)
  * @modules java.desktop/sun.swing
- * @author Alexander Scherbatiy
  */
+
 public class bug8133039 {
 
     private static volatile int ACTION_PERFORMED_CALLS = 0;
@@ -91,6 +91,7 @@ public class bug8133039 {
         Robot robot = new Robot();
         robot.setAutoDelay(100);
         robot.waitForIdle();
+        robot.delay(1000);
 
         robot.keyPress(KeyEvent.VK_A);
         robot.keyRelease(KeyEvent.VK_A);


### PR DESCRIPTION
test/jdk/javax/swing/Action/8133039/bug8133039.java failed in OCI ubuntu 22.04 with exception "Method accept not invoked" 
Seems like robot keypress happened before testframe was visible..Added a delay..
Several iterations passed in OCI linux system..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345297](https://bugs.openjdk.org/browse/JDK-8345297): test/jdk/javax/swing/Action/8133039/bug8133039.java fails in ubuntu22.04 (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22480/head:pull/22480` \
`$ git checkout pull/22480`

Update a local copy of the PR: \
`$ git checkout pull/22480` \
`$ git pull https://git.openjdk.org/jdk.git pull/22480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22480`

View PR using the GUI difftool: \
`$ git pr show -t 22480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22480.diff">https://git.openjdk.org/jdk/pull/22480.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22480#issuecomment-2511473885)
</details>
