### PR TITLE
8227493: Return a more useful error message from lookupAllHostAddr if getaddrinfo results in EAI_SYSTEM error

### DIFF
--- a/src/java.base/unix/native/libnet/Inet4AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet4AddressImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,6 +111,8 @@ Java_java_net_Inet4AddressImpl_lookupAllHostAddr(JNIEnv *env, jobject this,
     error = getaddrinfo(hostname, NULL, &hints, &res);
 
     if (error) {
+        // capture the errno from getaddrinfo
+        const int sys_errno = errno;
 #if defined(MACOSX)
         // If getaddrinfo fails try getifaddrs, see bug 8170910.
         // java_net_spi_InetAddressResolver_LookupPolicy_IPV4_FIRST and no ordering is ok
@@ -121,7 +123,7 @@ Java_java_net_Inet4AddressImpl_lookupAllHostAddr(JNIEnv *env, jobject this,
         }
 #endif
         // report error
-        NET_ThrowUnknownHostExceptionWithGaiError(env, hostname, error);
+        NET_ThrowUnknownHostExceptionWithGaiError(env, hostname, error, sys_errno);
         goto cleanupAndReturn;
     } else {
         int i = 0;

--- a/src/java.base/unix/native/libnet/Inet6AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet6AddressImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -230,6 +230,8 @@ Java_java_net_Inet6AddressImpl_lookupAllHostAddr(JNIEnv *env, jobject this,
     error = getaddrinfo(hostname, NULL, &hints, &res);
 
     if (error) {
+        // capture the errno from getaddrinfo
+        const int sys_errno = errno;
 #if defined(MACOSX)
         // if getaddrinfo fails try getifaddrs
         ret = lookupIfLocalhost(env, hostname, JNI_TRUE, characteristics);
@@ -238,7 +240,7 @@ Java_java_net_Inet6AddressImpl_lookupAllHostAddr(JNIEnv *env, jobject this,
         }
 #endif
         // report error
-        NET_ThrowUnknownHostExceptionWithGaiError(env, hostname, error);
+        NET_ThrowUnknownHostExceptionWithGaiError(env, hostname, error, sys_errno);
         goto cleanupAndReturn;
     } else {
         int i = 0, inetCount = 0, inet6Count = 0, inetIndex = 0,

--- a/src/java.base/unix/native/libnet/net_util_md.h
+++ b/src/java.base/unix/native/libnet/net_util_md.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,8 @@ typedef union {
  */
 void NET_ThrowUnknownHostExceptionWithGaiError(JNIEnv *env,
                                                const char* hostname,
-                                               int gai_error);
+                                               int gai_error,
+                                               int sys_errno);
 void NET_ThrowByNameWithLastError(JNIEnv *env, const char *name,
                                   const char *defaultDetail);
 


### PR DESCRIPTION
Can I please get a review of this minor enhancement to the error text that is reported if the `getaddrinfo()` native call returns the `EAI_SYSTEM` error? This addresses https://bugs.openjdk.org/browse/JDK-8227493.

The `java.net.InetAddress` class, in its implementation for resolving addresses for a host name, calls the `getaddrinfo()` native call on *nix platforms. If `getaddrinfo()` returns an error then we use the `gai_strerror()` native call to convert the error number into an error string that is then propagated to the application. Among other errors, the `getaddrinfo()` is specified to return the error code `EAI_SYSTEM` which as per its documentation represents

> EAI_SYSTEM        system error returned in errno

So calling `gai_strerror()` merely returns a generic "System error" text. The real underlying error is present in the `errno` and that has more useful information. 

The commit in this PR checks the error for `EAI_SYSTEM` and if it matches then it additionally gets the error text corresponding to `errno`. So the error text that gets propagated will now be "System error: Illegal byte sequence", assuming `EILSEQ` was the underlying `errno` for the `getaddrinfo` call (my use of `EILSEQ` in this example is arbitrary and it's merely to show what the error text will look like after this change).

Given the nature of this change no new test has been introduced. Existing tests in tier1, tier2 and tier3 continue to pass with this change.
