### PR TITLE
8345299: C2: some nodes can still have incorrect control after do_range_check()

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2463,7 +2463,7 @@ bool PhaseIdealLoop::is_scaled_iv_plus_extra_offset(Node* exp1, Node* offset3, N
 
 //------------------------------do_range_check---------------------------------
 // Eliminate range-checks and other trip-counter vs loop-invariant tests.
-void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
+void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
 #ifndef PRODUCT
   if (PrintOpto && VerifyLoopOptimizations) {
     tty->print("Range Check Elimination ");
@@ -2527,7 +2527,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
   // have control above the pre loop, but there's no guarantee that they do. There's no guarantee either that the pre
   // loop limit has control that's out of loop (a previous round of range check elimination could have set a limit that's
   // not loop invariant).
-  Node* new_limit_ctrl = dominated_node(pre_ctrl, pre_limit_ctrl);
+  Node* new_limit_ctrl = dominated_node(pre_ctrl, pre_limit_ctrl, compute_early_ctrl(main_limit, main_limit_ctrl));
 
   // Ensure the original loop limit is available from the
   // pre-loop Opaque1 node.
@@ -2778,8 +2778,8 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
   // new pre_limit can push Bool/Cmp/Opaque nodes down (when one of the eliminated condition has parameters that are not
   // loop invariant in the pre loop.
   set_ctrl(pre_opaq, new_limit_ctrl);
-  set_ctrl(pre_end->cmp_node(), new_limit_ctrl);
-  set_ctrl(pre_end->in(1), new_limit_ctrl);
+  set_ctrl(pre_end->cmp_node(), pre_end->in(0));
+  set_ctrl(pre_end->in(1), pre_end->in(0));
 
   _igvn.replace_input_of(pre_opaq, 1, pre_limit);
 
@@ -2822,8 +2822,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
   // new main_limit can push Bool/Cmp nodes down (when one of the eliminated condition has parameters that are not loop
   // invariant in the pre loop.
   set_ctrl(opqzm, new_limit_ctrl);
-  set_ctrl(iffm->in(1)->in(1), new_limit_ctrl);
-  set_ctrl(iffm->in(1), new_limit_ctrl);
+  assert(is_dominator(new_limit_ctrl, get_ctrl(iffm->in(1)->in(1))), "control of cmp should be below control of updated input");
 
   C->print_method(PHASE_AFTER_RANGE_CHECK_ELIMINATION, 4, cl);
 }
@@ -3402,7 +3401,7 @@ bool IdealLoopTree::iteration_split_impl(PhaseIdealLoop *phase, Node_List &old_n
     // with full checks, but the main-loop with no checks.  Remove said checks
     // from the main body.
     if (should_rce) {
-      phase->do_range_check(this, old_new);
+      phase->do_range_check(this);
     }
 
     // Double loop body for unrolling.  Adjust the minimum-trip test (will do

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2526,7 +2526,8 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
   // Range check elimination optimizes out conditions whose parameters are loop invariant in the main loop. They usually
   // have control above the pre loop, but there's no guarantee that they do. There's no guarantee either that the pre
   // loop limit has control that's out of loop (a previous round of range check elimination could have set a limit that's
-  // not loop invariant).
+  // not loop invariant). new_limit_ctrl is used for both the pre and main loops. Early control for the main limit may be
+  // below the pre loop entry and the pre limit and must be taken into account when initializing new_limit_ctrl.
   Node* new_limit_ctrl = dominated_node(pre_ctrl, pre_limit_ctrl, compute_early_ctrl(main_limit, main_limit_ctrl));
 
   // Ensure the original loop limit is available from the
@@ -2820,7 +2821,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree* loop) {
   assert(opqzm->outcnt() == 1, "cannot hack shared node");
   _igvn.replace_input_of(opqzm, 1, main_limit);
   // new main_limit can push Bool/Cmp nodes down (when one of the eliminated condition has parameters that are not loop
-  // invariant in the pre loop.
+  // invariant in the pre loop).
   set_ctrl(opqzm, new_limit_ctrl);
   assert(is_dominator(new_limit_ctrl, get_ctrl(iffm->in(1)->in(1))), "control of cmp should be below control of updated input");
 

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1416,7 +1416,7 @@ public:
   }
 
   // Eliminate range-checks and other trip-counter vs loop-invariant tests.
-  void do_range_check(IdealLoopTree *loop, Node_List &old_new);
+  void do_range_check(IdealLoopTree* loop);
 
   // Clone loop with an invariant test (that does not exit) and
   // insert a clone of the test that selects which version to


### PR DESCRIPTION
8339733 fixed controls for updated pre/main limits during
do_range_check(). However, it missed one issue:

Control for the new limits is computed in `new_limit_ctrl` for both
pre and main loops. `new_limit_ctrl` is currently initialized from the
pre limit control but it also needs to take the main loop limit
control into account as sometimes, the main loop limit control is
below the pre limit and pre loop entry control.

8339733 also introduced a couple bugs. Control of the `Bool`/`Cmp`
nodes are updated for the pre and main loop to `new_limit_ctrl`. But
that's incorrect because `new_limit_ctrl` may be above the pre loop
while the `Bool`/`Cmp` for the pre loop are in the loop (because they
depend on the loop iv) and for the main loop are after the pre loop
(because they depend on the iv out of the pre loop). I fixed this for
the pre loop by setting control for the `Bool`/`Cmp` to be as late as
possible. For the main loop, no change appears to be required as
control computed by c2 is already late enough. I've added an assert
instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345299](https://bugs.openjdk.org/browse/JDK-8345299): C2: some nodes can still have incorrect control after do_range_check() (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22485/head:pull/22485` \
`$ git checkout pull/22485`

Update a local copy of the PR: \
`$ git checkout pull/22485` \
`$ git pull https://git.openjdk.org/jdk.git pull/22485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22485`

View PR using the GUI difftool: \
`$ git pr show -t 22485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22485.diff">https://git.openjdk.org/jdk/pull/22485.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22485#issuecomment-2511625644)
</details>
