### PR TITLE
8333393: PhaseCFG::insert_anti_dependences can fail to raise LCAs and to add necessary anti-dependence edges

### DIFF
--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -492,6 +492,7 @@ class PhaseCFG : public Phase {
   // Used when building the CFG and creating end nodes for blocks.
   MachNode* _goto;
 
+  bool needs_anti_dependence_edge(Node* load, Node* store, int load_alias_idx);
   Block* insert_anti_dependences(Block* LCA, Node* load, bool verify = false);
   void verify_anti_dependences(Block* LCA, Node* load) const {
     assert(LCA == get_block_for_node(load), "should already be scheduled");

--- a/test/hotspot/jtreg/compiler/codegen/TestGCMLoadPlacement.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestGCMLoadPlacement.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.codegen;
+
+/**
+ * @test
+ * @bug 8333393
+ * @summary Test that loads are not scheduled too late.
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,*Test*::test
+ *                   -XX:-TieredCompilation -Xbatch
+ *                   -XX:PerMethodTrapLimit=0
+ *                   -XX:CompileCommand=dontinline,*::dontInline
+ *                   compiler.codegen.TestGCMLoadPlacement
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,*Test*::test
+ *                   -XX:-TieredCompilation -Xbatch
+ *                   -XX:PerMethodTrapLimit=0
+ *                   -XX:CompileCommand=dontinline,*::dontInline
+ *                   -XX:+StressGCM -XX:+StressLCM
+ *                   compiler.codegen.TestGCMLoadPlacement
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:LoopMaxUnroll=0 -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,*Test*::test
+ *                   -XX:-TieredCompilation -Xbatch
+ *                   -XX:PerMethodTrapLimit=0
+ *                   compiler.codegen.TestGCMLoadPlacement
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:LoopMaxUnroll=0 -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,*Test*::test
+ *                   -XX:-TieredCompilation -Xbatch
+ *                   -XX:PerMethodTrapLimit=0
+ *                   -XX:+StressGCM -XX:+StressLCM
+ *                   compiler.codegen.TestGCMLoadPlacement
+ * @run main compiler.codegen.TestGCMLoadPlacement
+ */
+
+public class TestGCMLoadPlacement {
+
+    public static void main(String[] args) {
+        Test1.run();
+        Test2.run();
+        Test3.run();
+        Test4.run();
+        Test5.run();
+    }
+
+    static class Test1 {
+        static boolean flag;
+        volatile byte volFld;
+        int iFld;
+
+        int test() {
+            for (int i = 0; i < 50; ++i)
+                for (int j = 0; j < 50; ++j) {
+                    if (flag) { return 0; } // Forces peeling
+                    iFld = 0;
+                    for (int k = 0; k < 1; ++k) {
+
+                    }
+                }
+            int res = iFld; // This load needs to schedule before the loop below ...
+            for (int i = 0; i < 50; ++i) {
+                volFld = 0;
+                iFld -= 42;
+            }
+            // ... and was incorrectly scheduled here.
+            return res;
+        }
+
+        static void run() {
+            Test1 t = new Test1();
+            for (int i = 0; i < 10; i++) {
+                int res = t.test();
+                if (res != 0) {
+                    throw new RuntimeException("Unexpected result: " + res);
+                }
+            }
+        }
+    }
+
+    static class Test2 {
+        static void run() {
+            for (int i = 0; i < 500; i++) {
+                int res = test();
+                if (res != 0) {
+                    throw new RuntimeException("res = " + res);
+                }
+            }
+        }
+
+        static int test() {
+            int res = 0;
+            int array[] = new int[50];
+            for (int j = 0; j < array.length; j++) {
+                array[j] = 0;
+            }
+            int x = array[0];
+            for (int i = 5; i < 10; i++) {
+                array[0] = 42;
+                for (int j = 0; j < 10; j++) {
+                    dontInline();
+                    res = x;
+                }
+            }
+            return res;
+        }
+
+        static void dontInline() {}
+    }
+
+    static class Test3 {
+        static boolean flag;
+        static int N = 400;
+        long instanceCount;
+        float fFld = 2.957F;
+        volatile short sFld;
+        int iArrFld[] = new int[N];
+
+        int test() {
+            int i22 = 7, i25, i27, i28 = 5, i29, i31, i33;
+            for (i25 = 229; i25 > 2; --i25) {
+                if (flag) { return 9; }
+                iArrFld[1] *= instanceCount;
+                for (i27 = 4; i27 < 116; ++i27) {
+                }
+            }
+            i22 += fFld;
+            for (i29 = 23; 8 < i29; i29--) {
+                for (i31 = 2; i31 < 17; i31++) {
+                    if (flag) { return 9; }
+                    i28 = sFld;
+                }
+                for (i33 = 1; 7 > i33; ++i33) {
+                    if (flag) { return 9; }
+                    fFld = instanceCount;
+                }
+            }
+            return i22;
+        }
+
+        static void run() {
+            Test3 r = new Test3();
+            int result = r.test();
+            if (result != 9) {
+                throw new RuntimeException("Expected 9 but found " + result);
+            }
+        }
+    }
+
+    static class Test4 {
+        static boolean flag;
+        volatile byte volFld;
+        int iFld;
+
+        int test() {
+            for (int j = 0; j < 50; ++j) {
+                iFld = 0;
+                if (flag) { return 0; }
+
+                for (int k = 0; k < 2000; ++k) {
+                }
+            }
+
+            int res = iFld;
+            for (int i = 0; i < 50; ++i) {
+                volFld = 0;
+                iFld -= 1;
+            }
+            return res;
+        }
+
+        static void run() {
+            Test4 t = new Test4();
+            for (int i = 0; i < 10; i++) {
+                int res = t.test();
+                if (res != 0) {
+                    throw new RuntimeException("Unexpected result: " + res);
+                }
+            }
+        }
+    }
+
+    static class Test5 {
+        int a = 1;
+        int test() {
+            int f, g = 0, h[] = new int[a];
+            double j = 72.18064;
+            for (int i = 0; i < 7; ++i)
+                for (int i2 = 0; i2 < 4; i2++) {
+                    g += ++h[0];
+                    while (--j > 0)
+                        ;
+                }
+            int c = 0;
+            for (int k = 0; k < h.length; k++) {
+                c += h[k];
+            }
+            return c;
+        }
+        static void run() {
+            Test5 s = new Test5();
+            int res = s.test();
+            if (res != 28) {
+                throw new RuntimeException("Unexpected result: " + res);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue Summary

We currently add anti dependences and raise LCAs for loads in GCM by walking downwards from the load's memory input (referred to as initial memory below) until we reach memory definitions (e.g., stores) for which anti-dependence edges may be necessary. When we reach memory Phis during the walk, we immediately stop and register that we must raise the LCA above the predecessor from which we arrived at the Phi. This approach is unsound in cases where initial memory is live (i.e., is not overwritten) on each input to the Phi. In such cases, it is necessary to continue through the Phi when searching for anti dependences. Below are two examples of miscompilations resulting from the issue.

#### Example 1
Consider the ideal graph below.

![failure-graph-1](https://github.com/user-attachments/assets/36ea7bfc-1c1e-46bb-99fa-3231375630e4)

Here, we want to add anti-dependence edges for the load (node 183). In our current approach, we go to the load's input memory (107) and walk downwards to node 106. This is a Phi, so we stop and immediately register that we must raise the LCA to the last block in between the blocks for 107 and 106. In the ideal graph block view below, this corresponds to B27 (the successor of B27 is the block for node 106, omitted to keep the illustration at a reasonable size).

![failure-blocks-1](https://github.com/user-attachments/assets/65c4a807-38fa-4874-b05d-6ebf78d38e90)

The earliest possible block for the load is B20, and the initial LCA is B24 (computed earlier during scheduling). As B20 does not dominate B27, we do not raise the LCA at all and leave it at B24. As a result, the load is later scheduled in B24, _after_ a number of anti-dependent stores, the first of which is in block B20. The result is the failure we see in this issue (we load the wrong value).

The correct action in this case is to pin the load to the early block (i.e., raise the LCA to B20) _and_ to add an anti-dependence edge to node 64. It is fairly easy to identify this fact by looking at the graph above. First, note that the memory input 107 is a Phi node, and if we exhaustively trace it upwards (also through other Phi nodes), we conclude that the set of all possible initial memory states for the load is {107, 106, 104, 18, 105, 103}. Second, consider the Phi node 119. The initial memory is live on all of its inputs. Therefore, we need to walk downwards from node 119 to identify the need for an anti-dependence edge to node 64. The block of node 64 is B20, forcing the LCA to B20 as well. Now, the load will schedule correctly in B20, before node 64.

#### Example 2
Consider adding anti-dependence edges for load 100 in the ideal graph below.

![failure-graph-2](https://github.com/user-attachments/assets/33280934-60c5-445d-b95c-d67bcff0ff52)

The initial memory is 18, and in our current approach we stop at the Phis with indices 76 and 77. Looking at the block view below, the path from node 18 to 76 requires raising the LCA above B5 (I've omitted the block for node 18 to keep the illustration at a reasonable size). Similarly, the paths from node 78 and 80 to 77 requires raising the LCA above B19 and B21.

![failure-blocks-2](https://github.com/user-attachments/assets/5d531c18-5466-4153-808e-a1c0ed422201)

Similarly to the previous example, the early block B9 for the load does not dominate any of B5, B19 or B21, and the LCA is left at B11 where it allows the load to schedule after an anti-dependent store in B10.

The correct action is to continue through the Phis at index 77 and 76, as it is clear that initial memory is live on all the inputs. We stop at Phi 75, because initial memory is live only on one input. However, now we mark the last block on the path from 76 to 75, which in the block view is B9. The result is a correct raising of the LCA to B9, the earliest possible block.

### Changeset

- Change `PhaseCFG:insert_anti_dependences` to use the new approach exemplified in the issue summary above. The search for anti dependences is now split into three phases:
   1. Find the _set_ of possible initial memory states for the load we are currently looking at. Specifically (and unlike the current approach), exhaustively search upwards through Phis.
   2. From the initial memory set, search downwards for possible anti-dependent nodes. Unlike the previous approach, continue the search _through_ Phis if we discover that initial memory is live on all its inputs.
   3. Add anti-dependence edges and raise the LCA based on the results from ii.
- To improve readability and reusability, move a large chunk of code in `PhaseCFG:insert_anti_dependences`, that checks if a node may need an anti-dependence edge, to a separate function `PhaseCFG::needs_anti_dependence_edge`.
- Add a new regression test `TestGCMLoadPlacement.java`.

An interesting aspect of this changeset is that it not only solves the correctness issue above, but also (in theory) can lead to less conservative LCAs. A consequence of less conservative LCAs is that we in some cases can schedule loads later compared to the current approach. To test this fact in practice, I ran tier1 on an instrumented build on all Oracle-supported platforms and compared all new and old LCAs computed in `PhaseCFG:insert_anti_dependences`. There are three possible outcomes for every call to `PhaseCFG:insert_anti_dependences` in the experiment:
1. The LCAs are the same (uninteresting).
2. The new LCA dominates the old LCA (resulting in this correctness issue).
3. The old LCA dominates the new LCA (meaning the new approach allows more scheduling freedom).

The count for outcome 2 was 45 (all from the test `PartialPeelingUnswitch.java`) and the count for outcome 3 was 2310 (from a diverse set of tests). The fairly large count for outcome 3 indicates that we could potentially see some performance gains in practice.

### Testing

- [GitHub Actions](https://github.com/dlunde/jdk/actions/runs/12072984782)
- `tier1` to `tier4` (and additional Oracle-internal testing) on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64.
- Performance testing using DaCapo, SPECjbb, and SPECjvm on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64. There are no significant improvements nor regressions.
- C2 compilation time testing using DaCapo. There is a 3.8% regression for the scheduler with the new approach resulting in a 0.16% regression for C2 compilation time overall.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333393](https://bugs.openjdk.org/browse/JDK-8333393): PhaseCFG::insert_anti_dependences can fail to raise LCAs and to add necessary anti-dependence edges (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22486/head:pull/22486` \
`$ git checkout pull/22486`

Update a local copy of the PR: \
`$ git checkout pull/22486` \
`$ git pull https://git.openjdk.org/jdk.git pull/22486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22486`

View PR using the GUI difftool: \
`$ git pr show -t 22486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22486.diff">https://git.openjdk.org/jdk/pull/22486.diff</a>

</details>
