### PR TITLE
8343932: Error when parsing qualified generic type test pattern in switch

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3428,7 +3428,7 @@ public class JavacParser implements Parser {
                 case GTGT: typeDepth--;
                 case GT:
                     typeDepth--;
-                    if (typeDepth == 0) {
+                    if (typeDepth == 0 && !peekToken(lookahead, DOT)) {
                          return peekToken(lookahead, LAX_IDENTIFIER) ||
                                 peekToken(lookahead, tk -> tk == LPAREN) ? PatternResult.PATTERN
                                                                          : PatternResult.EXPRESSION;

--- a/test/langtools/tools/javac/patterns/T8343932.java
+++ b/test/langtools/tools/javac/patterns/T8343932.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 8343932
+ * @summary Error when parsing qualified generic type test pattern in switch
+ * @compile T8343932.java
+ */
+public class T8343932 {
+    abstract sealed class J<T1, T2> permits X.S, A {}
+    final class A extends J<Integer, Integer> {}
+
+    public class X<T> {
+        final class S<U> extends J<T, U> {
+            abstract sealed class J<T1, T2> permits XX.SS, AA {}
+            final class AA extends J<Integer, Integer> {}
+
+            public class XX<T> {
+                final class SS<U> extends J<T, U> {}
+            }
+        }
+
+        static int test(J<Integer, Integer> ji) {
+            return switch (ji) {
+                case A a -> 42;
+                case X<Integer>.S<Integer> e -> 4200; // level 1
+            };
+        }
+
+        static int test(X<Integer>.S<Integer>.J<Integer, Integer> ji) {
+            return switch (ji) {
+                case X<Integer>.S<Integer>.AA a -> 42;
+                case X<Integer>.S<Integer>.XX<Integer>.SS<Integer> e -> 4200; // level 2
+            };
+        }
+    }
+}


### PR DESCRIPTION
Addressing issue in the`analyzePattern` with qualified type patterns (presence of `DOT`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343932](https://bugs.openjdk.org/browse/JDK-8343932): Error when parsing qualified generic type test pattern in switch (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22487/head:pull/22487` \
`$ git checkout pull/22487`

Update a local copy of the PR: \
`$ git checkout pull/22487` \
`$ git pull https://git.openjdk.org/jdk.git pull/22487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22487`

View PR using the GUI difftool: \
`$ git pr show -t 22487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22487.diff">https://git.openjdk.org/jdk/pull/22487.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22487#issuecomment-2511645594)
</details>
