### PR TITLE
8345186: Incorrect @throws doc for MemorySegment::getString

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1278,7 +1278,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         largest string supported by the platform
      * @throws IndexOutOfBoundsException if {@code offset < 0}
      * @throws IndexOutOfBoundsException if no {@code '\0'} terminator is present in
-     *         this segment between the given {@code offset} to the end of this segment.
+     *         this segment between the given {@code offset} and the end of this segment.
      * @throws IllegalStateException if the {@linkplain #scope() scope} associated with
      *         this segment is not {@linkplain Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},
@@ -1315,7 +1315,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         largest string supported by the platform
      * @throws IndexOutOfBoundsException if {@code offset < 0}
      * @throws IndexOutOfBoundsException if no {@code '\0'} terminator is present in
-     *         this segment between the given {@code offset} to the end of this segment.
+     *         this segment between the given {@code offset} and the end of this segment.
      * @throws IllegalStateException if the {@linkplain #scope() scope} associated with
      *         this segment is not {@linkplain Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1277,9 +1277,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalArgumentException if the size of the string is greater than the
      *         largest string supported by the platform
      * @throws IndexOutOfBoundsException if {@code offset < 0}
-     * @throws IndexOutOfBoundsException if {@code offset > byteSize() - (B + 1)}, where
-     *         {@code B} is the size, in bytes, of the string encoded using UTF-8 charset
-     *         {@code str.getBytes(StandardCharsets.UTF_8).length})
+     * @throws IndexOutOfBoundsException if no {@code '\0'} terminator is present in
+     *         this segment between the given {@code offset} to the end of this segment.
      * @throws IllegalStateException if the {@linkplain #scope() scope} associated with
      *         this segment is not {@linkplain Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},
@@ -1315,14 +1314,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalArgumentException  if the size of the string is greater than the
      *         largest string supported by the platform
      * @throws IndexOutOfBoundsException if {@code offset < 0}
-     * @throws IndexOutOfBoundsException if {@code offset > byteSize() - (B + N)}, where:
-     *         <ul>
-     *             <li>{@code B} is the size, in bytes, of the string encoded using the
-     *             provided charset (e.g. {@code str.getBytes(charset).length});</li>
-     *             <li>{@code N} is the size (in bytes) of the terminator char according
-     *             to the provided charset. For instance, this is 1 for
-     *             {@link StandardCharsets#US_ASCII} and 2 for {@link StandardCharsets#UTF_16}.</li>
-     *         </ul>
+     * @throws IndexOutOfBoundsException if no {@code '\0'} terminator is present in
+     *         this segment between the given {@code offset} to the end of this segment.
      * @throws IllegalStateException if the {@linkplain #scope() scope} associated with
      *         this segment is not {@linkplain Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1277,8 +1277,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalArgumentException if the size of the string is greater than the
      *         largest string supported by the platform
      * @throws IndexOutOfBoundsException if {@code offset < 0}
-     * @throws IndexOutOfBoundsException if no {@code '\0'} terminator is present in
-     *         this segment between the given {@code offset} and the end of this segment.
+     * @throws IndexOutOfBoundsException if no string terminator (e.g. {@code '\0'}) is
+     *         present in this segment between the given {@code offset} and the end of
+     *         this segment.
      * @throws IllegalStateException if the {@linkplain #scope() scope} associated with
      *         this segment is not {@linkplain Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},
@@ -1314,8 +1315,10 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalArgumentException  if the size of the string is greater than the
      *         largest string supported by the platform
      * @throws IndexOutOfBoundsException if {@code offset < 0}
-     * @throws IndexOutOfBoundsException if no {@code '\0'} terminator is present in
-     *         this segment between the given {@code offset} and the end of this segment.
+     * @throws IndexOutOfBoundsException if no string terminator (e.g. {@code '\0'}) is
+     *         present in this segment between the given {@code offset} and the end of
+     *         this segment. The byte size of the string terminator depends on the
+     *         selected {@code charset}
      * @throws IllegalStateException if the {@linkplain #scope() scope} associated with
      *         this segment is not {@linkplain Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1318,7 +1318,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IndexOutOfBoundsException if no string terminator (e.g. {@code '\0'}) is
      *         present in this segment between the given {@code offset} and the end of
      *         this segment. The byte size of the string terminator depends on the
-     *         selected {@code charset}
+     *         selected {@code charset}. For instance, this is 1 for
+     *         {@link StandardCharsets#US_ASCII} and 2 for {@link StandardCharsets#UTF_16}
      * @throws IllegalStateException if the {@linkplain #scope() scope} associated with
      *         this segment is not {@linkplain Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},


### PR DESCRIPTION
This PR proposes to correct errors in the `MemorySegment::getString` documentation.

There is a test in https://github.com/openjdk/jdk/pull/22451/files#diff-13a3535a65f1e0664e98bd2584196eb9d9a0ada951fd2dabfac8a484263235d8R271 that actually tests an Exception with the correct message is thrown if no null terminator can be found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8345300](https://bugs.openjdk.org/browse/JDK-8345300) to be approved

### Issues
 * [JDK-8345186](https://bugs.openjdk.org/browse/JDK-8345186): Incorrect @<!---->throws doc for MemorySegment::getString (**Bug** - P3)
 * [JDK-8345300](https://bugs.openjdk.org/browse/JDK-8345300): Incorrect @<!---->throws doc for MemorySegment::getString (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22488/head:pull/22488` \
`$ git checkout pull/22488`

Update a local copy of the PR: \
`$ git checkout pull/22488` \
`$ git pull https://git.openjdk.org/jdk.git pull/22488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22488`

View PR using the GUI difftool: \
`$ git pr show -t 22488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22488.diff">https://git.openjdk.org/jdk/pull/22488.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22488#issuecomment-2514567016)
</details>
