### PR TITLE
8345319: Fix the tag type in PoolEntry and AnnotationValue

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
+++ b/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
@@ -456,9 +456,11 @@ public sealed interface AnnotationValue {
      *
      * @apiNote
      * {@code TAG_}-prefixed constants in this class, such as {@link #TAG_INT},
-     * describe the possible return values of this method.
+     * describe the possible return values of this method.  The return type is
+     * {@code int} for consistency with union indicator items in other union
+     * structures in the {@code class} file format.
      */
-    char tag();
+    int tag();
 
     /**
      * {@return an enum value for an element-value pair}

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/PoolEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/PoolEntry.java
@@ -98,7 +98,7 @@ public sealed interface PoolEntry
      * {@code TAG_}-prefixed constants in this class, such as {@link #TAG_UTF8},
      * describe the possible return values of this method.
      */
-    byte tag();
+    int tag();
 
     /**
      * {@return the index within the constant pool corresponding to this entry}

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -104,7 +104,7 @@ public abstract sealed class AbstractPoolEntry {
         return hash;
     }
 
-    public abstract byte tag();
+    public abstract int tag();
 
     public int width() {
         return 1;
@@ -181,7 +181,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_UTF8;
         }
 
@@ -522,7 +522,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_CLASS;
         }
 
@@ -582,7 +582,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_PACKAGE;
         }
 
@@ -613,7 +613,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_MODULE;
         }
 
@@ -645,7 +645,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_NAME_AND_TYPE;
         }
 
@@ -719,7 +719,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_FIELDREF;
         }
 
@@ -737,7 +737,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_METHODREF;
         }
 
@@ -755,7 +755,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_INTERFACE_METHODREF;
         }
 
@@ -849,7 +849,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_INVOKE_DYNAMIC;
         }
 
@@ -874,7 +874,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_DYNAMIC;
         }
 
@@ -905,7 +905,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_METHOD_HANDLE;
         }
 
@@ -964,7 +964,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_METHOD_TYPE;
         }
 
@@ -1002,7 +1002,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_STRING;
         }
 
@@ -1054,7 +1054,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_INTEGER;
         }
 
@@ -1100,7 +1100,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_FLOAT;
         }
 
@@ -1145,7 +1145,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_LONG;
         }
 
@@ -1195,7 +1195,7 @@ public abstract sealed class AbstractPoolEntry {
         }
 
         @Override
-        public byte tag() {
+        public int tag() {
             return TAG_DOUBLE;
         }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationImpl.java
@@ -72,7 +72,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfStringImpl(Utf8Entry constant)
             implements AnnotationValue.OfString {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_STRING;
         }
 
@@ -85,7 +85,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfDoubleImpl(DoubleEntry constant)
             implements AnnotationValue.OfDouble {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_DOUBLE;
         }
 
@@ -98,7 +98,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfFloatImpl(FloatEntry constant)
             implements AnnotationValue.OfFloat {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_FLOAT;
         }
 
@@ -111,7 +111,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfLongImpl(LongEntry constant)
             implements AnnotationValue.OfLong {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_LONG;
         }
 
@@ -124,7 +124,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfIntImpl(IntegerEntry constant)
             implements AnnotationValue.OfInt {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_INT;
         }
 
@@ -137,7 +137,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfShortImpl(IntegerEntry constant)
             implements AnnotationValue.OfShort {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_SHORT;
         }
 
@@ -150,7 +150,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfCharImpl(IntegerEntry constant)
             implements AnnotationValue.OfChar {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_CHAR;
         }
 
@@ -163,7 +163,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfByteImpl(IntegerEntry constant)
             implements AnnotationValue.OfByte {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_BYTE;
         }
 
@@ -176,7 +176,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfBooleanImpl(IntegerEntry constant)
             implements AnnotationValue.OfBoolean {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_BOOLEAN;
         }
 
@@ -193,7 +193,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
         }
 
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_ARRAY;
         }
     }
@@ -201,7 +201,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfEnumImpl(Utf8Entry className, Utf8Entry constantName)
             implements AnnotationValue.OfEnum {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_ENUM;
         }
     }
@@ -209,7 +209,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfAnnotationImpl(Annotation annotation)
             implements AnnotationValue.OfAnnotation {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_ANNOTATION;
         }
     }
@@ -217,7 +217,7 @@ public record AnnotationImpl(Utf8Entry className, List<AnnotationElement> elemen
     public record OfClassImpl(Utf8Entry className)
             implements AnnotationValue.OfClass {
         @Override
-        public char tag() {
+        public int tag() {
             return TAG_CLASS;
         }
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationReader.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationReader.java
@@ -354,7 +354,7 @@ public final class AnnotationReader {
     public static void writeAnnotationValue(BufWriterImpl buf, AnnotationValue value) {
         var tag = value.tag();
         buf.writeU1(tag);
-        switch (value.tag()) {
+        switch (tag) {
             case TAG_BOOLEAN, TAG_BYTE, TAG_CHAR, TAG_DOUBLE, TAG_FLOAT, TAG_INT, TAG_LONG, TAG_SHORT, TAG_STRING ->
                     buf.writeIndex(((AnnotationValue.OfConstant) value).constant());
             case TAG_CLASS -> buf.writeIndex(((AnnotationValue.OfClass) value).className());

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AnnotationWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AnnotationWriter.java
@@ -225,11 +225,12 @@ public class AnnotationWriter extends BasicWriter {
     }
 
     public void write(AnnotationValue value, boolean resolveIndices) {
+        var tagChar = (char) value.tag();
         switch (value) {
             case AnnotationValue.OfConstant ev -> {
                 if (resolveIndices) {
                     var entry = ev.constant();
-                    switch (ev.tag()) {
+                    switch (tagChar) {
                         case 'B':
                             print("(byte) ");
                             print(constantWriter.stringValue(entry));
@@ -258,11 +259,11 @@ public class AnnotationWriter extends BasicWriter {
                             print("\"");
                             break;
                         default:
-                            print(ev.tag() + "#" + entry.index());
+                            print(tagChar + "#" + entry.index());
                             break;
                     }
                 } else {
-                    print(ev.tag() + "#" + ev.constant().index());
+                    print(tagChar + "#" + ev.constant().index());
                 }
             }
             case AnnotationValue.OfEnum ev -> {
@@ -271,7 +272,7 @@ public class AnnotationWriter extends BasicWriter {
                     print(".");
                     writeIndex(ev.constantName(), resolveIndices);
                 } else {
-                    print(ev.tag() + "#" + ev.className().index() + ".#"
+                    print(tagChar + "#" + ev.className().index() + ".#"
                             + ev.constantName().index());
                 }
             }
@@ -280,11 +281,11 @@ public class AnnotationWriter extends BasicWriter {
                     print("class ");
                     writeIndex(ev.className(), resolveIndices);
                 } else {
-                    print(ev.tag() + "#" + ev.className().index());
+                    print(tagChar + "#" + ev.className().index());
                 }
             }
             case AnnotationValue.OfAnnotation ev -> {
-                print(ev.tag());
+                print(tagChar);
                 AnnotationWriter.this.write(ev.annotation(), resolveIndices);
             }
             case AnnotationValue.OfArray ev -> {

--- a/test/langtools/tools/javac/classfiles/attributes/AnnotationDefault/ExpectedValues.java
+++ b/test/langtools/tools/javac/classfiles/attributes/AnnotationDefault/ExpectedValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ExpectedValues {
-    char tag();
+    int tag();
     String name();
     String[] values();
 }


### PR DESCRIPTION
Change the return type of PoolEntry and AnnotationValue tags to int, as in TypeAnnotation TargetType and StackMapFrameInfo frameType.  The main impact is that AnnotationValue tags should be converted to char before printing now.

Please review the associated CSR for this hotfix as well.

Testing: classfile and javap, tier 1-3 in progress

Pinging @lukellmann

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8345321](https://bugs.openjdk.org/browse/JDK-8345321) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8345319](https://bugs.openjdk.org/browse/JDK-8345319): Fix the tag type in PoolEntry and AnnotationValue (**Bug** - P3)
 * [JDK-8345321](https://bugs.openjdk.org/browse/JDK-8345321): Fix the tag type in PoolEntry and AnnotationValue (**CSR**)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22489/head:pull/22489` \
`$ git checkout pull/22489`

Update a local copy of the PR: \
`$ git checkout pull/22489` \
`$ git pull https://git.openjdk.org/jdk.git pull/22489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22489`

View PR using the GUI difftool: \
`$ git pr show -t 22489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22489.diff">https://git.openjdk.org/jdk/pull/22489.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22489#issuecomment-2512152207)
</details>
