### PR TITLE
8344768: Consider removing "sun.security.krb5.autodeducerealm" system property

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
@@ -99,7 +99,6 @@ public class PrincipalName implements Cloneable {
      * TGS Name
      */
     public static final String TGS_DEFAULT_SRV_NAME = "krbtgt";
-    public static final int TGS_DEFAULT_NT = KRB_NT_SRV_INST;
 
     public static final char NAME_COMPONENT_SEPARATOR = '/';
     public static final char NAME_REALM_SEPARATOR = '@';
@@ -107,7 +106,6 @@ public class PrincipalName implements Cloneable {
 
     public static final String NAME_COMPONENT_SEPARATOR_STR = "/";
     public static final String NAME_REALM_SEPARATOR_STR = "@";
-    public static final String REALM_COMPONENT_SEPARATOR_STR = ".";
 
     private static final boolean NAME_CASE_SENSITIVE_IN_MATCH
             = "true".equalsIgnoreCase(
@@ -135,12 +133,6 @@ public class PrincipalName implements Cloneable {
     private final Realm nameRealm;      // not null
 
 
-    /**
-     * When constructing a PrincipalName, whether the realm is included in
-     * the input, or deduced from default realm or domain-realm mapping.
-     */
-    private final boolean realmDeduced;
-
     // cached default salt, not used in clone
     private transient String salt = null;
 
@@ -161,7 +153,6 @@ public class PrincipalName implements Cloneable {
         this.nameType = nameType;
         this.nameStrings = nameStrings.clone();
         this.nameRealm = nameRealm;
-        this.realmDeduced = false;
     }
 
     // Warning: called by NativeCreds.c
@@ -251,7 +242,6 @@ public class PrincipalName implements Cloneable {
         if (realm == null) {
             throw new IllegalArgumentException("Null realm not allowed");
         }
-        realmDeduced = false;
         nameRealm = realm;
         DerValue der;
         if (encoding == null) {
@@ -405,9 +395,6 @@ public class PrincipalName implements Cloneable {
             realm = Realm.parseRealmAtSeparator(name);
         }
 
-        // No realm info from parameter and string, must deduce later
-        realmDeduced = realm == null;
-
         switch (type) {
         case KRB_NT_SRV_HST:
             if (nameParts.length >= 2) {
@@ -437,8 +424,8 @@ public class PrincipalName implements Cloneable {
                                 hostName.toLowerCase(Locale.ENGLISH) + ".")) {
                             hostName = canonicalized;
                         }
-                    } catch (UnknownHostException | SecurityException e) {
-                        // not canonicalized or no permission to do so, use old
+                    } catch (UnknownHostException e) {
+                        // not canonicalized, use old
                     }
                     if (hostName.endsWith(".")) {
                         hostName = hostName.substring(0, hostName.length() - 1);
@@ -725,9 +712,5 @@ public class PrincipalName implements Cloneable {
         } catch (KrbException e) {
         }
         return result;
-    }
-
-    public boolean isRealmDeduced() {
-        return realmDeduced;
     }
 }

--- a/src/java.security.jgss/share/classes/sun/security/krb5/Realm.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Realm.java
@@ -47,9 +47,6 @@ import sun.security.krb5.internal.util.KerberosString;
  */
 public class Realm implements Cloneable {
 
-    public static final boolean AUTODEDUCEREALM =
-            Boolean.getBoolean("sun.security.krb5.autodeducerealm");
-
     private final String realm; // not null nor empty
 
     public Realm(String name) throws RealmException {

--- a/test/jdk/sun/security/krb5/name/Constructors.java
+++ b/test/jdk/sun/security/krb5/name/Constructors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,23 +41,22 @@ public class Constructors {
 
         // Good ones
         type = PrincipalName.KRB_NT_UNKNOWN;
-        checkName("a", type, "R", "R", false, "a");
-        checkName("a@R2", type, "R", "R", false, "a");
-        checkName("a/b", type, "R", "R", false, "a", "b");
-        checkName("a/b@R2", type, "R", "R", false, "a", "b");
-        checkName("a/b/c", type, "R", "R", false, "a", "b", "c");
-        checkName("a/b/c@R2", type, "R", "R", false, "a", "b", "c");
+        checkName("a", type, "R", "R", "a");
+        checkName("a@R2", type, "R", "R", "a");
+        checkName("a/b", type, "R", "R", "a", "b");
+        checkName("a/b@R2", type, "R", "R", "a", "b");
+        checkName("a/b/c", type, "R", "R", "a", "b", "c");
+        checkName("a/b/c@R2", type, "R", "R", "a", "b", "c");
         // Weird ones
-        checkName("a\\/b", type, "R", "R", false, "a/b");
-        checkName("a\\/b\\/c", type, "R", "R", false, "a/b/c");
-        checkName("a\\/b\\@R2", type, "R", "R", false, "a/b@R2");
+        checkName("a\\/b", type, "R", "R", "a/b");
+        checkName("a\\/b\\/c", type, "R", "R", "a/b/c");
+        checkName("a\\/b\\@R2", type, "R", "R", "a/b@R2");
         // Bad ones
-        checkName("a", type, "", null, false);
-        checkName("a/", type, "R", null, false);
-        checkName("/a", type, "R", null, false);
-        checkName("a//b", type, "R", null, false);
-        checkName("a@", type, null, null, false);
-        type = PrincipalName.KRB_NT_SRV_HST;
+        checkName("a", type, "", null);
+        checkName("a/", type, "R", null);
+        checkName("/a", type, "R", null);
+        checkName("a//b", type, "R", null);
+        checkName("a@", type, null, null);
 
         // Part 2: on realm choices
 
@@ -78,17 +77,17 @@ public class Constructors {
 
         if (testNoDefaultDomain) {
             type = PrincipalName.KRB_NT_UNKNOWN;
-            checkName("a", type, "R1", "R1", false, "a");      // arg
-            checkName("a@R1", type, null, "R1", false, "a");   // or r in name
-            checkName("a@R2", type, "R1", "R1", false, "a");   // arg over r
-            checkName("a", type, null, null, false);      // fail if none
-            checkName("a/b@R1", type, null, "R1", false, "a", "b");
+            checkName("a", type, "R1", "R1", "a");      // arg
+            checkName("a@R1", type, null, "R1", "a");   // or r in name
+            checkName("a@R2", type, "R1", "R1", "a");   // arg over r
+            checkName("a", type, null, null);      // fail if none
+            checkName("a/b@R1", type, null, "R1", "a", "b");
             type = PrincipalName.KRB_NT_SRV_HST;
             // Let's pray "b.h" won't be canonicalized
-            checkName("a/b.h", type, "R1", "R1", false, "a", "b.h");    // arg
-            checkName("a/b.h@R1", type, null, "R1", false, "a", "b.h"); // or r in name
-            checkName("a/b.h@R1", type, "R2", "R2", false, "a", "b.h"); // arg over r
-            checkName("a/b.h", type, null, null, false);    // fail if none
+            checkName("a/b.h", type, "R1", "R1", "a", "b.h");    // arg
+            checkName("a/b.h@R1", type, null, "R1", "a", "b.h"); // or r in name
+            checkName("a/b.h@R1", type, "R2", "R2", "a", "b.h"); // arg over r
+            checkName("a/b.h", type, null, null);    // fail if none
         }
 
         // When there is default realm
@@ -97,25 +96,25 @@ public class Constructors {
         Config.refresh();
 
         type = PrincipalName.KRB_NT_UNKNOWN;
-        checkName("a", type, "R1", "R1", false, "a");      // arg
-        checkName("a@R1", type, null, "R1", false, "a");   // or r in name
-        checkName("a@R2", type, "R1", "R1", false, "a");   // arg over r
-        checkName("a", type, null, "R", true, "a");       // default
-        checkName("a/b", type, null, "R", true, "a", "b");
+        checkName("a", type, "R1", "R1", "a");      // arg
+        checkName("a@R1", type, null, "R1", "a");   // or r in name
+        checkName("a@R2", type, "R1", "R1", "a");   // arg over r
+        checkName("a", type, null, "R", "a");       // default
+        checkName("a/b", type, null, "R", "a", "b");
         type = PrincipalName.KRB_NT_SRV_HST;
-        checkName("a/b.h3", type, "R1", "R1", false, "a", "b.h3");     // arg
-        checkName("a/b.h@R1", type, null, "R1", false, "a", "b.h");    // or r in name
-        checkName("a/b.h3@R2", type, "R1", "R1", false, "a", "b.h3");  // arg over r
-        checkName("a/b.h2", type, "R1", "R1", false, "a", "b.h2");     // arg over map
-        checkName("a/b.h2@R1", type, null, "R1", false, "a", "b.h2");  // r over map
-        checkName("a/b.h2", type, null, "R2", true, "a", "b.h2");     // map
-        checkName("a/b.h", type, null, "R", true, "a", "b.h");        // default
+        checkName("a/b.h3", type, "R1", "R1", "a", "b.h3");     // arg
+        checkName("a/b.h@R1", type, null, "R1", "a", "b.h");    // or r in name
+        checkName("a/b.h3@R2", type, "R1", "R1", "a", "b.h3");  // arg over r
+        checkName("a/b.h2", type, "R1", "R1", "a", "b.h2");     // arg over map
+        checkName("a/b.h2@R1", type, null, "R1", "a", "b.h2");  // r over map
+        checkName("a/b.h2", type, null, "R2", "a", "b.h2");     // map
+        checkName("a/b.h", type, null, "R", "a", "b.h");        // default
     }
 
     // Check if the creation matches the expected output.
     // Note: realm == null means creation failure
     static void checkName(String n, int t, String s,
-            String realm, boolean deduced, String... parts)
+            String realm, String... parts)
             throws Exception {
         PrincipalName pn = null;
         try {
@@ -131,9 +130,6 @@ public class Constructors {
                 || !Arrays.equals(pn.getNameStrings(), parts)) {
             throw new Exception(pn.toString() + " vs "
                     + Arrays.toString(parts) + "@" + realm);
-        }
-        if (deduced != pn.isRealmDeduced()) {
-            throw new Exception("pn.realmDeduced is " + pn.isRealmDeduced());
         }
     }
 }


### PR DESCRIPTION
The system property was used to signal a case where a certain permission is required. It's now useless.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344768](https://bugs.openjdk.org/browse/JDK-8344768): Consider removing "sun.security.krb5.autodeducerealm" system property (**Bug** - P3)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22492/head:pull/22492` \
`$ git checkout pull/22492`

Update a local copy of the PR: \
`$ git checkout pull/22492` \
`$ git pull https://git.openjdk.org/jdk.git pull/22492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22492`

View PR using the GUI difftool: \
`$ git pr show -t 22492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22492.diff">https://git.openjdk.org/jdk/pull/22492.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22492#issuecomment-2512247947)
</details>
