### PR TITLE
8341649: Regressions with large metaspace apps after 8338526

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -248,7 +248,7 @@ class InvokerBytecodeGenerator {
             return ClassFile.of().build(classEntry, pool, new Consumer<>() {
                 @Override
                 public void accept(ClassBuilder clb) {
-                    clb.withFlags(ACC_ABSTRACT | ACC_SUPER)
+                    clb.withFlags(ACC_FINAL | ACC_SUPER)
                        .withSuperclass(INVOKER_SUPER_DESC)
                        .with(SourceFileAttribute.of(clb.constantPool().utf8Entry(SOURCE_PREFIX + name)));
                     config.accept(clb);


### PR DESCRIPTION
Putting generated LambdaForm$MH and $DMH in non-class space seems to cause excess dependency checking for c2 compiled code and shows a performance regression in a new JMH performance test for MethodHandles (to be checked in at a later time).

When I made this abstract rather than final, I thought there were a many generated classes but I haven't found in testing more than a small percentage.  For example, Dacapo xalan there are 43/1000 classes that are these generated classes.  In Eric's new JMH test, it was more like 51/681.  Special casing "AllStatic" classes to go in non-class metaspace is a bit too risky at this time.  If it does become a problem with limited class metaspace, we can create another attribute to use.

Tested with tier1-4 and the JMH test.  Thanks Eric Caspole for finding this and all the testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341649](https://bugs.openjdk.org/browse/JDK-8341649): Regressions with large metaspace apps after 8338526 (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22493/head:pull/22493` \
`$ git checkout pull/22493`

Update a local copy of the PR: \
`$ git checkout pull/22493` \
`$ git pull https://git.openjdk.org/jdk.git pull/22493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22493`

View PR using the GUI difftool: \
`$ git pr show -t 22493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22493.diff">https://git.openjdk.org/jdk/pull/22493.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22493#issuecomment-2512271929)
</details>
