### PR TITLE
8345324: Update comment in SourceVersion for language evolution history for changes in 24

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -77,7 +77,10 @@ public enum SourceVersion {
      *      switch in preview, module Import Declarations in preview,
      *      implicitly declared classes and instance main in third
      *      preview, flexible constructor bodies in second preview)
-     *  24: tbd
+     *  24: no changes (primitive Types in Patterns, instanceof, and
+     *      switch in second preview, module Import Declarations in second
+     *      preview, simple source files and instance main in fourth
+     *      preview, flexible constructor bodies in third preview)
      */
 
     /**


### PR DESCRIPTION
Update source-level, in other words non-javadoc, comment to describe the actual language changes made in 24.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345324](https://bugs.openjdk.org/browse/JDK-8345324): Update comment in SourceVersion for language evolution history for changes in 24 (**Enhancement** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22495/head:pull/22495` \
`$ git checkout pull/22495`

Update a local copy of the PR: \
`$ git checkout pull/22495` \
`$ git pull https://git.openjdk.org/jdk.git pull/22495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22495`

View PR using the GUI difftool: \
`$ git pr show -t 22495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22495.diff">https://git.openjdk.org/jdk/pull/22495.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22495#issuecomment-2512434703)
</details>
