### PR TITLE
8345341: Fix incorrect log message in JDI stop002t test

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,7 +180,7 @@ public class stop002t {
             log.display("TEST #5: interrupted = " + Thread.interrupted());
             // We don't expect the exception to be thrown when in vthread mode.
             if (!vthreadMode && t instanceof MyThrowable) {
-                log.display("TEST #5: Caught expected exception while in loop: " + t);
+                log.display("TEST #5: Caught expected exception while in sleep: " + t);
             } else {
                 log.complain("TEST #5: Unexpected exception caught: " + t);
                 t.printStackTrace();


### PR DESCRIPTION
The log message is wrong. Copy-n-paste bug from another part of the test.

I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345341](https://bugs.openjdk.org/browse/JDK-8345341): Fix incorrect log message in JDI stop002t test (**Bug** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22499/head:pull/22499` \
`$ git checkout pull/22499`

Update a local copy of the PR: \
`$ git checkout pull/22499` \
`$ git pull https://git.openjdk.org/jdk.git pull/22499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22499`

View PR using the GUI difftool: \
`$ git pr show -t 22499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22499.diff">https://git.openjdk.org/jdk/pull/22499.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22499#issuecomment-2515253280)
</details>
