### PR TITLE
8345065: Cleanup DomainCombiner, SubjectDomainCombiner, Subject, and PrivilegedAction specifications

### DIFF
--- a/src/java.base/share/classes/java/security/DomainCombiner.java
+++ b/src/java.base/share/classes/java/security/DomainCombiner.java
@@ -46,8 +46,7 @@ public interface DomainCombiner {
      * set of Permissions, for example).
      *
      * @param currentDomains the ProtectionDomains associated with the
-     *          current execution thread, up to the most recent
-     *          privileged {@code ProtectionDomain}.
+     *          current execution thread.
      *          The ProtectionDomains are listed in order of execution,
      *          with the most recently executing {@code ProtectionDomain}
      *          residing at the beginning of the array. This parameter may
@@ -55,8 +54,6 @@ public interface DomainCombiner {
      *          has no associated ProtectionDomains.
      *
      * @param assignedDomains an array of inherited ProtectionDomains.
-     *          ProtectionDomains may be inherited from a parent thread,
-     *          or from a privileged {@code AccessControlContext}.
      *          This parameter may be {@code null}
      *          if there are no inherited ProtectionDomains.
      *

--- a/src/java.base/share/classes/java/security/PrivilegedAction.java
+++ b/src/java.base/share/classes/java/security/PrivilegedAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,13 +27,17 @@ package java.security;
 
 
 /**
- * A computation to be performed with privileges enabled.  The computation is
- * performed by invoking {@code AccessController.doPrivileged} on the
+ * A computation to be performed by invoking
+ * {@code AccessController.doPrivileged} on the
  * {@code PrivilegedAction} object.  This interface is used only for
  * computations that do not throw checked exceptions; computations that
  * throw checked exceptions must use {@code PrivilegedExceptionAction}
  * instead.
  * @param <T> the type of the result of running the computation
+ *
+ * @apiNote
+ * This action cannot be performed with privileges enabled as the
+ * Security Manager is no longer supported.
  *
  * @since 1.2
  * @see AccessController
@@ -44,7 +48,7 @@ package java.security;
 public interface PrivilegedAction<T> {
     /**
      * Performs the computation.  This method will be called by
-     * {@code AccessController.doPrivileged} after enabling privileges.
+     * {@code AccessController.doPrivileged}.
      *
      * @return a class-dependent value that may represent the results of the
      *         computation. Each class that implements

--- a/src/java.base/share/classes/java/security/PrivilegedAction.java
+++ b/src/java.base/share/classes/java/security/PrivilegedAction.java
@@ -35,10 +35,6 @@ package java.security;
  * instead.
  * @param <T> the type of the result of running the computation
  *
- * @apiNote
- * This action cannot be performed with privileges enabled as the
- * Security Manager is no longer supported.
- *
  * @since 1.2
  * @see AccessController
  * @see AccessController#doPrivileged(PrivilegedAction)

--- a/src/java.base/share/classes/java/security/PrivilegedActionException.java
+++ b/src/java.base/share/classes/java/security/PrivilegedActionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class PrivilegedActionException extends Exception {
     }
 
     /**
-     * Returns the exception thrown by the privileged computation that
+     * Returns the exception thrown by the computation that
      * resulted in this {@code PrivilegedActionException}.
      *
      * @apiNote
@@ -71,7 +71,7 @@ public class PrivilegedActionException extends Exception {
      * The {@link Throwable#getCause()} method is now the preferred means of
      * obtaining this information.
      *
-     * @return the exception thrown by the privileged computation that
+     * @return the exception thrown by the computation that
      *         resulted in this {@code PrivilegedActionException}.
      * @see PrivilegedExceptionAction
      * @see AccessController#doPrivileged(PrivilegedExceptionAction)
@@ -90,7 +90,7 @@ public class PrivilegedActionException extends Exception {
 
 
     /**
-     * The exception thrown by the privileged computation that resulted
+     * The exception thrown by the computation that resulted
      * in this {@code PrivilegedActionException}.
      *
      * @serialField exception Exception the thrown Exception

--- a/src/java.base/share/classes/java/security/PrivilegedExceptionAction.java
+++ b/src/java.base/share/classes/java/security/PrivilegedExceptionAction.java
@@ -37,7 +37,7 @@ package java.security;
  * @param <T> the type of the result of running the computation
  *
  * @apiNote
- * This action cannot be performed with privileges enabled as the 
+ * This action cannot be performed with privileges enabled as the
  * Security Manager is no longer supported.
  *
  * @since 1.2

--- a/src/java.base/share/classes/java/security/PrivilegedExceptionAction.java
+++ b/src/java.base/share/classes/java/security/PrivilegedExceptionAction.java
@@ -36,10 +36,6 @@ package java.security;
  * checked exceptions should use {@code PrivilegedAction} instead.
  * @param <T> the type of the result of running the computation
  *
- * @apiNote
- * This action cannot be performed with privileges enabled as the
- * Security Manager is no longer supported.
- *
  * @since 1.2
  * @see AccessController
  * @see AccessController#doPrivileged(PrivilegedExceptionAction)

--- a/src/java.base/share/classes/java/security/PrivilegedExceptionAction.java
+++ b/src/java.base/share/classes/java/security/PrivilegedExceptionAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,18 @@ package java.security;
 
 
 /**
- * A computation to be performed with privileges enabled, that throws one or
- * more checked exceptions.  The computation is performed by invoking
+ * A computation to be performed that throws one or more checked exceptions.
+ * The computation is performed by invoking
  * {@code AccessController.doPrivileged} on the
  * {@code PrivilegedExceptionAction} object.  This interface is
  * used only for computations that throw checked exceptions;
  * computations that do not throw
  * checked exceptions should use {@code PrivilegedAction} instead.
  * @param <T> the type of the result of running the computation
+ *
+ * @apiNote
+ * This action cannot be performed with privileges enabled as the 
+ * Security Manager is no longer supported.
  *
  * @since 1.2
  * @see AccessController
@@ -47,7 +51,7 @@ package java.security;
 public interface PrivilegedExceptionAction<T> {
     /**
      * Performs the computation.  This method will be called by
-     * {@code AccessController.doPrivileged} after enabling privileges.
+     * {@code AccessController.doPrivileged}.
      *
      * @return a class-dependent value that may represent the results of the
      *         computation.  Each class that implements

--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -453,7 +453,7 @@ public final class Subject implements java.io.Serializable {
     }
 
     /**
-     * Perform privileged work as a particular {@code Subject}.
+     * Perform work as a particular {@code Subject}.
      *
      * <p> This method launches {@code action} and binds {@code subject} to
      * the period of its execution.
@@ -513,7 +513,7 @@ public final class Subject implements java.io.Serializable {
     }
 
     /**
-     * Perform privileged work as a particular {@code Subject}.
+     * Perform work as a particular {@code Subject}.
      *
      * <p> This method launches {@code action} and binds {@code subject} to
      * the period of its execution.

--- a/src/java.base/share/classes/javax/security/auth/SubjectDomainCombiner.java
+++ b/src/java.base/share/classes/javax/security/auth/SubjectDomainCombiner.java
@@ -112,21 +112,16 @@ public class SubjectDomainCombiner implements java.security.DomainCombiner {
      * In addition, caching of ProtectionDomains may be permitted.
      *
      * @param currentDomains the ProtectionDomains associated with the
-     *          current execution Thread, up to the most recent
-     *          privileged {@code ProtectionDomain}.
+     *          current execution Thread.
      *          The ProtectionDomains are listed in order of execution,
      *          with the most recently executing {@code ProtectionDomain}
      *          residing at the beginning of the array. This parameter may
      *          be {@code null} if the current execution Thread
      *          has no associated ProtectionDomains.
      *
-     * @param assignedDomains the ProtectionDomains inherited from the
-     *          parent Thread, or the ProtectionDomains from the
-     *          privileged {@code context}, if a call to
-     *          {@code AccessController.doPrivileged(..., context)}
-     *          had occurred  This parameter may be {@code null}
-     *          if there were no ProtectionDomains inherited from the
-     *          parent Thread, or from the privileged {@code context}.
+     * @param assignedDomains the inherited ProtectionDomains.
+     *          This parameter may be {@code null}
+     *          if there were no inherited ProtectionDomains.
      *
      * @return a new array consisting of the updated ProtectionDomains,
      *          or {@code null}.


### PR DESCRIPTION
A few additional changes should be made to the API specs for these classes .  These changes are documenting behavior of other APIs that has already been approved as part of JEP 486, so I don't think a CSR is necessary, but opinions on that are welcome.

The `DomainCombiner` and `SubjectDomainCombiner` classes contain wording about "inherited" and"privileged" `ProtectionDomain`s which is no longer  implemented, and so has been removed. The `PrivilegedAction` classes also contained wording about "privileged" computations which is no longer accurate. I also added an API note to these classes, similar to the ones in the `Permission` subclasses. Finally, I removed a couple of instances of "privileged work" from the `Subject` class which no longer applies.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345065](https://bugs.openjdk.org/browse/JDK-8345065): Cleanup DomainCombiner, SubjectDomainCombiner, Subject, and PrivilegedAction specifications (**Bug** - P3)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22500/head:pull/22500` \
`$ git checkout pull/22500`

Update a local copy of the PR: \
`$ git checkout pull/22500` \
`$ git pull https://git.openjdk.org/jdk.git pull/22500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22500`

View PR using the GUI difftool: \
`$ git pr show -t 22500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22500.diff">https://git.openjdk.org/jdk/pull/22500.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22500#issuecomment-2514562615)
</details>
