### PR TITLE
8345343: Restore the preview status of java.lang.classfile.components package

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/components/ClassPrinter.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/ClassPrinter.java
@@ -36,6 +36,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import jdk.internal.classfile.impl.ClassPrinterImpl;
+import jdk.internal.javac.PreviewFeature;
 
 /**
  * A printer of classfiles and its elements.
@@ -59,8 +60,9 @@ import jdk.internal.classfile.impl.ClassPrinterImpl;
  * Another use case for {@link ClassPrinter} is to simplify writing of automated tests:
  * {@snippet lang="java" class="PackageSnippets" region="printNodesInTest"}
  *
- * @since 24
+ * @since 22
  */
+@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public final class ClassPrinter {
 
     private ClassPrinter() {
@@ -69,8 +71,9 @@ public final class ClassPrinter {
     /**
      * Level of detail to print or export.
      *
-     * @since 24
+     * @since 22
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public enum Verbosity {
 
         /**
@@ -103,8 +106,9 @@ public final class ClassPrinter {
     /**
      * Named, traversable, and printable node parent.
      *
-     * @since 24
+     * @since 22
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface Node {
 
         /**
@@ -147,8 +151,9 @@ public final class ClassPrinter {
     /**
      * A leaf node holding single printable value.
      *
-     * @since 24
+     * @since 22
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface LeafNode extends Node
             permits ClassPrinterImpl.LeafNodeImpl {
 
@@ -162,8 +167,9 @@ public final class ClassPrinter {
     /**
      * A tree node holding {@link List} of nested nodes.
      *
-     * @since 24
+     * @since 22
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface ListNode extends Node, List<Node>
             permits ClassPrinterImpl.ListNodeImpl {
     }
@@ -173,8 +179,9 @@ public final class ClassPrinter {
      * <p>
      * Each {@link Map.Entry#getKey()} == {@link Map.Entry#getValue()}.{@link #name()}.
      *
-     * @since 24
+     * @since 22
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface MapNode extends Node, Map<ConstantDesc, Node>
             permits ClassPrinterImpl.MapNodeImpl {
     }

--- a/src/java.base/share/classes/java/lang/classfile/components/ClassRemapper.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/ClassRemapper.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import jdk.internal.classfile.impl.ClassRemapperImpl;
+import jdk.internal.javac.PreviewFeature;
 
 import static java.util.Objects.requireNonNull;
 
@@ -54,8 +55,9 @@ import static java.util.Objects.requireNonNull;
  * Arrays of reference types are always decomposed, mapped as the base reference
  * types and composed back to arrays.
  *
- * @since 24
+ * @since 22
  */
+@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassRemapper extends ClassTransform permits ClassRemapperImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeLocalsShifter.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeLocalsShifter.java
@@ -31,6 +31,7 @@ import java.lang.constant.MethodTypeDesc;
 import java.lang.reflect.AccessFlag;
 
 import jdk.internal.classfile.impl.CodeLocalsShifterImpl;
+import jdk.internal.javac.PreviewFeature;
 
 /**
  * {@link CodeLocalsShifter} is a {@link CodeTransform} shifting locals to
@@ -38,8 +39,9 @@ import jdk.internal.classfile.impl.CodeLocalsShifterImpl;
  * Locals pointing to the receiver or to method arguments slots are never shifted.
  * All locals pointing beyond the method arguments are re-indexed in order of appearance.
  *
- * @since 24
+ * @since 22
  */
+@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CodeLocalsShifter extends CodeTransform permits CodeLocalsShifterImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeRelabeler.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeRelabeler.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 
 import jdk.internal.classfile.impl.CodeRelabelerImpl;
+import jdk.internal.javac.PreviewFeature;
 
 import static java.util.Objects.requireNonNull;
 
@@ -45,8 +46,9 @@ import static java.util.Objects.requireNonNull;
  * Repeated injection of the same code block must be relabeled, so each instance of
  * {@link java.lang.classfile.Label} is bound in the target bytecode exactly once.
  *
- * @since 24
+ * @since 22
  */
+@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CodeRelabeler extends CodeTransform permits CodeRelabelerImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Optional;
 
 import jdk.internal.classfile.impl.CodeStackTrackerImpl;
+import jdk.internal.javac.PreviewFeature;
 
 /**
  * {@link CodeStackTracker} is a {@link CodeTransform} tracking stack content
@@ -50,8 +51,9 @@ import jdk.internal.classfile.impl.CodeStackTrackerImpl;
  *     });
  * }
  *
- * @since 24
+ * @since 22
  */
+@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CodeStackTracker extends CodeTransform permits CodeStackTrackerImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/components/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/package-info.java
@@ -113,5 +113,7 @@
  *
  * @since 24
  */
+@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 package java.lang.classfile.components;
 
+import jdk.internal.javac.PreviewFeature;

--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -74,6 +74,7 @@ public @interface PreviewFeature {
         SCOPED_VALUES,
         @JEP(number=499, title="Structured Concurrency", status="Fourth Preview")
         STRUCTURED_CONCURRENCY,
+        @JEP(number=484, title="Class-File API", status="Third Preview")
         CLASSFILE_API,
         STREAM_GATHERERS,
         @JEP(number=494, title="Module Import Declarations", status="Second Preview")


### PR DESCRIPTION
The java.lang.classfile.components package was underused and had almost no usage feedback; as a result, it did not caught attention during the preview process of the Class-File API, until the late adoption when Class-File API is sure to become finalized. In the previous rounds of reviews by other engineers, most of the review efforts were devoted to other core modeling and API classes, and components was largely omitted; a few questions were asked, but no solution were proposed and the questions were forgotten.

To compensate in such a short time to the stabilization of JDK 24, we propose to restore the preview status of the java.lang.classfile.component package and its member classes. This allows us to better consider the role of this package and its members.

See https://mail.openjdk.org/pipermail/classfile-api-dev/2024-November/000611.html for initial problem discovery and https://mail.openjdk.org/pipermail/classfile-api-dev/2024-December/000613.html for revision proposal.

See the CSR for alternative solutions and why they were not chosen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8345344](https://bugs.openjdk.org/browse/JDK-8345344) to be approved

### Issues
 * [JDK-8345343](https://bugs.openjdk.org/browse/JDK-8345343): Restore the preview status of java.lang.classfile.components package (**Bug** - P3)
 * [JDK-8345344](https://bugs.openjdk.org/browse/JDK-8345344): Restore the preview status of java.lang.classfile.components package (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22501/head:pull/22501` \
`$ git checkout pull/22501`

Update a local copy of the PR: \
`$ git checkout pull/22501` \
`$ git pull https://git.openjdk.org/jdk.git pull/22501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22501`

View PR using the GUI difftool: \
`$ git pr show -t 22501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22501.diff">https://git.openjdk.org/jdk/pull/22501.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22501#issuecomment-2515075827)
</details>
