### PR TITLE
8345346: Shenandoah: Description of ShenandoahGCMode still refers to incremental update mode

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -134,7 +134,6 @@
           "GC mode to use.  Among other things, this defines which "        \
           "barriers are in in use. Possible values are:"                    \
           " satb - snapshot-at-the-beginning concurrent GC (three pass mark-evac-update);"  \
-          " iu - incremental-update concurrent GC (three pass mark-evac-update);"  \
           " passive - stop the world GC only (either degenerated or full);" \
           " generational - generational concurrent GC")                     \
                                                                             \
@@ -183,7 +182,7 @@
           range(0,100)                                                      \
                                                                             \
   product(uintx, ShenandoahInitFreeThreshold, 70, EXPERIMENTAL,             \
-          "When less than this amount of memory is free within the"         \
+          "When less than this amount of memory is free within the "        \
           "heap or generation, trigger a learning cycle if we are "         \
           "in learning mode.  Learning mode happens during initialization " \
           "and following a drastic state change, such as following a "      \


### PR DESCRIPTION
The incremental update mode has been removed and is no longer supported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345346](https://bugs.openjdk.org/browse/JDK-8345346): Shenandoah: Description of ShenandoahGCMode still refers to incremental update mode (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22502/head:pull/22502` \
`$ git checkout pull/22502`

Update a local copy of the PR: \
`$ git checkout pull/22502` \
`$ git pull https://git.openjdk.org/jdk.git pull/22502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22502`

View PR using the GUI difftool: \
`$ git pr show -t 22502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22502.diff">https://git.openjdk.org/jdk/pull/22502.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22502#issuecomment-2513145335)
</details>
