### PR TITLE
8343001: Adjust XSLT and XPath Extension Function Property

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/res/XSLTErrorResources.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/res/XSLTErrorResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -31,7 +31,7 @@ import java.util.ListResourceBundle;
  * Array. You also need to update MAX_CODE for error strings
  * and MAX_WARNING for warnings ( Needed for only information
  * purpose )
- * @LastModified: May 2022
+ * @LastModified: Dec 2024
  */
 public class XSLTErrorResources extends ListResourceBundle
 {
@@ -1197,7 +1197,10 @@ public class XSLTErrorResources extends ListResourceBundle
       "Cannot set the feature ''{0}'' on this TransformerFactory."},
 
     { ER_EXTENSION_ELEMENT_NOT_ALLOWED_IN_SECURE_PROCESSING,
-          "Use of the extension element ''{0}'' is not allowed when the secure processing feature is set to true."},
+        "Use of the extension function ''{0}'' is not allowed when extension "
+              + "functions are disabled by the secure processing feature or "
+              + "the property ''jdk.xml.enableExtensionFunctions''. "
+              + "To enable extension functions, set ''jdk.xml.enableExtensionFunctions'' to ''true''."},
 
     { ER_NAMESPACE_CONTEXT_NULL_NAMESPACE,
       "Cannot get the prefix for a null namespace uri."},

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -57,7 +57,7 @@ import org.xml.sax.XMLReader;
  * @author G. Todd Miller
  * @author Morten Jorgensen
  * @author John Howard (johnh@schemasoft.com)
- * @LastModified: Jan 2022
+ * @LastModified: Dec 2024
  */
 public final class XSLTC {
 
@@ -289,6 +289,10 @@ public final class XSLTC {
         if (_isSecureProcessing && clazz != null && !_externalExtensionFunctions.containsKey(name)) {
             _externalExtensionFunctions.put(name, clazz);
         }
+    }
+
+    boolean hasExtensionClassLoader() {
+        return _extensionClassLoader != null;
     }
 
     /*

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMessages.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMessages.java
@@ -24,7 +24,7 @@ import java.util.ListResourceBundle;
 
 /**
  * @author Morten Jorgensen
- * @LastModified: Nov 2024
+ * @LastModified: Dec 2024
  */
 public class ErrorMessages extends ListResourceBundle {
 
@@ -552,6 +552,15 @@ public class ErrorMessages extends ListResourceBundle {
         {ErrorMsg.DATA_CONVERSION_ERR,
         "Cannot convert data-type ''{0}'' to ''{1}''."},
 
+        /*
+         * Note to translators:  property name "jdk.xml.enableExtensionFunctions"
+         * and value "true" should not be translated.
+         */
+        {ErrorMsg.UNSUPPORTED_EXT_FUNC_ERR,
+        "Use of the extension function ''{0}'' is not allowed when extension "
+              + "functions are disabled by the secure processing feature or "
+              + "the property ''jdk.xml.enableExtensionFunctions''. "
+              + "To enable extension functions, set ''jdk.xml.enableExtensionFunctions'' to ''true''."},
         /*
          * Note to translators:  "Templates" is a Java class name that should
          * not be translated.

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java
@@ -33,7 +33,7 @@ import jdk.xml.internal.SecuritySupport;
  * @author G. Todd Miller
  * @author Erwin Bolwidt <ejb@klomp.org>
  * @author Morten Jorgensen
- * @LastModified: Nov 2024
+ * @LastModified: Dec 2024
  */
 public final class ErrorMsg {
 
@@ -105,6 +105,7 @@ public final class ErrorMsg {
     public static final String ATTR_VAL_TEMPLATE_ERR = "ATTR_VAL_TEMPLATE_ERR";
     public static final String UNKNOWN_SIG_TYPE_ERR = "UNKNOWN_SIG_TYPE_ERR";
     public static final String DATA_CONVERSION_ERR = "DATA_CONVERSION_ERR";
+    public static final String UNSUPPORTED_EXT_FUNC_ERR = "UNSUPPORTED_EXT_FUNC_ERR";
 
     // JAXP/TrAX error messages
     public static final String NO_TRANSLET_CLASS_ERR = "NO_TRANSLET_CLASS_ERR";

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/ErrorMessages.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/ErrorMessages.java
@@ -1,6 +1,5 @@
 /*
- * reserved comment block
- * DO NOT REMOVE OR ALTER!
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -25,6 +24,7 @@ import java.util.ListResourceBundle;
 
 /**
  * @author Morten Jorgensen
+ * @LastModified: Dec 2024
  */
 public class ErrorMessages extends ListResourceBundle {
 
@@ -275,10 +275,16 @@ public class ErrorMessages extends ListResourceBundle {
         "An attribute whose value must be an NCName had the value ''{0}''"},
 
         {BasisLibrary.UNALLOWED_EXTENSION_FUNCTION_ERR,
-        "Use of the extension function ''{0}'' is not allowed when the secure processing feature is set to true."},
+        "Use of the extension function ''{0}'' is not allowed when extension "
+              + "functions are disabled by the secure processing feature or "
+              + "the property ''jdk.xml.enableExtensionFunctions''. "
+              + "To enable extension functions, set ''jdk.xml.enableExtensionFunctions'' to ''true''."},
 
         {BasisLibrary.UNALLOWED_EXTENSION_ELEMENT_ERR,
-        "Use of the extension element ''{0}'' is not allowed when the secure processing feature is set to true."},
+        "Use of the extension function ''{0}'' is not allowed when extension "
+              + "functions are disabled by the secure processing feature or "
+              + "the property ''jdk.xml.enableExtensionFunctions''. "
+              + "To enable extension functions, set ''jdk.xml.enableExtensionFunctions'' to ''true''."},
     };
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/ErrorMessages.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/ErrorMessages.java
@@ -281,7 +281,7 @@ public class ErrorMessages extends ListResourceBundle {
               + "To enable extension functions, set ''jdk.xml.enableExtensionFunctions'' to ''true''."},
 
         {BasisLibrary.UNALLOWED_EXTENSION_ELEMENT_ERR,
-        "Use of the extension function ''{0}'' is not allowed when extension "
+        "Use of the extension element ''{0}'' is not allowed when extension "
               + "functions are disabled by the secure processing feature or "
               + "the property ''jdk.xml.enableExtensionFunctions''. "
               + "To enable extension functions, set ''jdk.xml.enableExtensionFunctions'' to ''true''."},

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
@@ -75,7 +75,6 @@ import jdk.xml.internal.JdkXmlFeatures;
 import jdk.xml.internal.JdkXmlUtils;
 import jdk.xml.internal.JdkProperty.ImplPropMap;
 import jdk.xml.internal.JdkProperty.State;
-import jdk.xml.internal.SecuritySupport;
 import jdk.xml.internal.TransformErrorListener;
 import jdk.xml.internal.XMLSecurityManager;
 import org.xml.sax.InputSource;
@@ -88,7 +87,7 @@ import org.xml.sax.XMLReader;
  * @author G. Todd Miller
  * @author Morten Jorgensen
  * @author Santiago Pericas-Geertsen
- * @LastModified: Nov 2024
+ * @LastModified: Dec 2024
  */
 public class TransformerFactoryImpl
     extends SAXTransformerFactory implements SourceLoader
@@ -216,7 +215,7 @@ public class TransformerFactoryImpl
     /**
      * <p>State of secure processing feature.</p>
      */
-    private boolean _isNotSecureProcessing = true;
+    private boolean _isNotSecureProcessing = false;
     /**
      * <p>State of secure mode.</p>
      */

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -100,7 +100,7 @@ import org.xml.sax.ext.LexicalHandler;
  * @author Morten Jorgensen
  * @author G. Todd Miller
  * @author Santiago Pericas-Geertsen
- * @LastModified: July 2023
+ * @LastModified: Dec 2024
  */
 public final class TransformerImpl extends Transformer
     implements DOMCache
@@ -206,7 +206,7 @@ public final class TransformerImpl extends Transformer
     /**
      * State of the secure processing feature.
      */
-    private boolean _isSecureProcessing = false;
+    private boolean _isSecureProcessing = true;
 
     /**
      * Indicates whether 3rd party parser may be used to override the system-default
@@ -292,6 +292,7 @@ public final class TransformerImpl extends Transformer
         _propertiesClone = (Properties) _properties.clone();
         _indentNumber = indentNumber;
         _tfactory = tfactory;
+        _isSecureProcessing = _tfactory.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING);
         _overrideDefaultParser = _tfactory.overrideDefaultParser();
         _accessExternalDTD = (String)_tfactory.getAttribute(XMLConstants.ACCESS_EXTERNAL_DTD);
         _securityManager = (XMLSecurityManager)_tfactory.getAttribute(JdkConstants.SECURITY_MANAGER);

--- a/src/java.xml/share/classes/jdk/xml/internal/JdkXmlFeatures.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/JdkXmlFeatures.java
@@ -52,7 +52,7 @@ public class JdkXmlFeatures {
          * function is disabled.
          */
         ENABLE_EXTENSION_FUNCTION(ImplPropMap.ENABLEEXTFUNC, null, null, true,
-                null, null, true, false, true, true),
+                null, null, false, false, true, true),
         /**
          * The {@link javax.xml.XMLConstants.USE_CATALOG} feature.
          * FSP: USE_CATALOG is not enforced by FSP.
@@ -382,13 +382,7 @@ public class JdkXmlFeatures {
      */
     private void readSystemProperties() {
         for (XmlFeature feature : XmlFeature.values()) {
-            if (!getSystemProperty(feature, feature.systemProperty())) {
-                //if system property is not found, try the older form if any
-                String oldName = feature.systemPropertyOld();
-                if (oldName != null) {
-                    getSystemProperty(feature, oldName);
-                }
-            }
+            getSystemProperty(feature, feature.systemProperty());
         }
     }
 
@@ -402,6 +396,11 @@ public class JdkXmlFeatures {
     private boolean getSystemProperty(XmlFeature feature, String sysPropertyName) {
         try {
             String value = System.getProperty(sysPropertyName);
+            if (value == null && feature.systemPropertyOld() != null) {
+                // legacy system property
+                value = System.getProperty(feature.systemPropertyOld());
+            }
+
             if (value != null && !value.isEmpty()) {
                 setFeature(feature, State.SYSTEMPROPERTY, Boolean.parseBoolean(value));
                 return true;

--- a/src/java.xml/share/conf/jaxp.properties
+++ b/src/java.xml/share/conf/jaxp.properties
@@ -57,11 +57,10 @@
 # Extension Functions:
 #
 # This property determines whether XSLT and XPath extension functions are allowed.
-# The value type is boolean and the default value is true (allowing
-# extension functions). The following entry overrides the default value and
-# disallows extension functions:
+# The value type is boolean and the default value is false (disallowing
+# extension functions).
 #
-# jdk.xml.enableExtensionFunctions=false
+jdk.xml.enableExtensionFunctions=false
 #
 #
 # Overriding the default parser:

--- a/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPTestUtilities.java
+++ b/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPTestUtilities.java
@@ -51,6 +51,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import org.testng.Assert;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -60,6 +61,15 @@ import org.xml.sax.SAXException;
  * This is an interface provide basic support for JAXP functional test.
  */
 public class JAXPTestUtilities {
+    public static String CLS_DIR = System.getProperty("test.classes");
+    public static String SRC_DIR = System.getProperty("test.src");
+    public static boolean isWindows = false;
+    static {
+        if (System.getProperty("os.name").contains("Windows")) {
+            isWindows = true;
+        }
+    };
+
     /**
      * Prefix for error message.
      */
@@ -371,6 +381,34 @@ public class JAXPTestUtilities {
     @FunctionalInterface
     public interface RunnableWithException {
         void run() throws Exception;
+    }
+
+    /**
+     * Asserts the run does not cause a Throwable. May be replaced with JUnit 5.
+     * @param runnable the runnable
+     * @param message the message if the test fails
+     */
+    public static void assertDoesNotThrow(Assert.ThrowingRunnable runnable, String message) {
+        try {
+            runnable.run();
+        } catch (Throwable t) {
+            Assert.fail(message + "\n Exception thrown: " + t.getMessage());
+        }
+    }
+
+    /**
+     * Returns the System identifier (URI) of the source.
+     * @param path the path to the source
+     * @return the System identifier
+     */
+    public static String getSystemId(String path) {
+        if (path == null) return null;
+        String xmlSysId = "file://" + path;
+        if (isWindows) {
+            path = path.replace('\\', '/');
+            xmlSysId = "file:///" + path;
+        }
+        return xmlSysId;
     }
 
     /**

--- a/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPTestUtilities.java
+++ b/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JAXPTestUtilities.java
@@ -61,15 +61,9 @@ import org.xml.sax.SAXException;
  * This is an interface provide basic support for JAXP functional test.
  */
 public class JAXPTestUtilities {
-    public static String CLS_DIR = System.getProperty("test.classes");
-    public static String SRC_DIR = System.getProperty("test.src");
-    public static boolean isWindows = false;
-    static {
-        if (System.getProperty("os.name").contains("Windows")) {
-            isWindows = true;
-        }
-    };
-
+    public static final String CLS_DIR = System.getProperty("test.classes");
+    public static final String SRC_DIR = System.getProperty("test.src");
+    public static final boolean isWindows = System.getProperty("os.name").contains("Windows");
     /**
      * Prefix for error message.
      */

--- a/test/jaxp/javax/xml/jaxp/unittest/common/config/ImplProperties.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/config/ImplProperties.java
@@ -102,7 +102,7 @@ public class ImplProperties {
         "0", "1000000", "3000000", "10000", "5000", "0", "1000", "10", "100", "10000"},
 
         // default values in JDK 24
-        {"true", "false", "continue", "allow", "2500", "100000",
+        {"false", "false", "continue", "allow", "2500", "100000",
         "100000", "15000", "100000", "200", "5000", "100", "1000", "10", "100", "10000"},
 
         // default values in jaxp-strict.properties.template, since JDK 23

--- a/test/jaxp/javax/xml/jaxp/unittest/transform/Bug6513892.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/transform/Bug6513892.java
@@ -33,28 +33,22 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.w3c.dom.Document;
 
 /*
  * @test
- * @bug 6513892
+ * @bug 6513892 8343001
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @run testng/othervm transform.Bug6513892
  * @summary Test the output encoding of the transform is the same as that of the redirect extension.
  */
 public class Bug6513892 {
-    @BeforeClass
-    public void setup(){
-        if (System.getSecurityManager() != null)
-            System.setSecurityManager(null);
-    }
-
     @Test
     public void test0() {
         try {
             TransformerFactory tf = TransformerFactory.newInstance();
+            tf.setFeature("jdk.xml.enableExtensionFunctions", true);
             Transformer t = tf.newTransformer(new StreamSource(getClass().getResourceAsStream("redirect.xsl"), getClass().getResource("redirect.xsl")
                     .toString()));
 

--- a/test/jaxp/javax/xml/jaxp/unittest/transform/ErrorListenerTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/transform/ErrorListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,9 +50,9 @@ import org.xml.sax.InputSource;
 
 /*
  * @test
- * @bug 8157830 8228854
+ * @bug 8157830 8228854 8343001
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm transform.ErrorListenerTest
+ * @run testng/othervm -Djdk.xml.enableExtensionFunctions=true transform.ErrorListenerTest
  * @summary Verifies that ErrorListeners are handled properly
  */
 public class ErrorListenerTest {

--- a/test/jaxp/javax/xml/jaxp/unittest/transform/XSLTFunctionsTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/transform/XSLTFunctionsTest.java
@@ -159,7 +159,7 @@ public class XSLTFunctionsTest {
      * @param externalDoc Content of the external xml document
      * @param expectedResult Expected transformation result
      **/
-    //@Test(dataProvider = "document")
+    @Test(dataProvider = "document")
     public void testDocument(final String xml, final String xsl,
                              final String externalDoc, final String expectedResult) throws Exception {
         // Prepare sources for transormation

--- a/test/jaxp/javax/xml/jaxp/unittest/transform/XSLTFunctionsTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/transform/XSLTFunctionsTest.java
@@ -23,7 +23,6 @@
 
 package transform;
 
-import java.io.FilePermission;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.file.Files;
@@ -36,16 +35,18 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+import static jaxp.library.JAXPTestUtilities.SRC_DIR;
+import static jaxp.library.JAXPTestUtilities.assertDoesNotThrow;
+import static jaxp.library.JAXPTestUtilities.getSystemId;
+import static jaxp.library.JAXPTestUtilities.getSystemProperty;
 import org.testng.Assert;
+import static org.testng.Assert.assertEquals;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
-import static jaxp.library.JAXPTestUtilities.clearSystemProperty;
-import static jaxp.library.JAXPTestUtilities.setSystemProperty;
-import static jaxp.library.JAXPTestUtilities.getSystemProperty;
 
 /*
  * @test
+ * @bug 8062518 8153082 8165116 8343001
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @compile DocumentExtFunc.java
  * @run testng/othervm transform.XSLTFunctionsTest
@@ -53,6 +54,21 @@ import static jaxp.library.JAXPTestUtilities.getSystemProperty;
  */
 
 public class XSLTFunctionsTest {
+    @DataProvider(name = "propertyName")
+    public static Object[][] getSettings() {
+        return new Object[][] {
+            // legacy property name
+            {ORACLE_ENABLE_EXTENSION_FUNCTION, true, true, null},
+            {ORACLE_ENABLE_EXTENSION_FUNCTION, true, false, TransformerException.class},
+            // legacy system property name
+            {SP_ENABLE_EXTENSION_FUNCTION, false, true, null},
+            {SP_ENABLE_EXTENSION_FUNCTION, false, false, TransformerException.class},
+            // current property and system property name
+            {SP_ENABLE_EXTENSION_FUNCTION_SPEC, true, true, null},
+            {SP_ENABLE_EXTENSION_FUNCTION_SPEC, true, false, TransformerException.class},
+        };
+    }
+
     /**
      * @bug 8165116
      * Verifies that redirect works properly when extension function is enabled
@@ -86,59 +102,50 @@ public class XSLTFunctionsTest {
     }
 
     /**
-     * @bug 8161454
-     * Verifies that the new / correct name is supported, as is the old / incorrect
-     * one for compatibility
+     * @bug 8161454 8343001
+     * Verifies that legacy property names are continually supported for compatibility.
+     *
+     * @param property the property name
+     * @param isAPIProperty indicates whether the property can be set via the factory
+     * @param value the property value
+     * @param expectedThrow the expected throw if the specified DTD can not be
+     *                      resolved.
+     * @throws Exception if the test fails
      */
-    @Test
-    public void testNameChange() {
+    @Test(dataProvider = "propertyName")
+    public void testNameChange(String property, boolean isAPIProperty,
+            boolean value, Class<Throwable> expectedThrow)
+            throws Exception {
+        if (expectedThrow == null) {
+            assertDoesNotThrow(() -> runTransform(property, isAPIProperty, value),
+                    "Extension Functions property is set to " + value + " but exception is thrown.");
+        } else {
+            Assert.assertThrows(expectedThrow,
+                () -> runTransform(property, isAPIProperty, value));
+        }
+    }
 
-        boolean feature;
+    private void runTransform(String property, boolean isAPIProperty, boolean value)
+            throws Exception {
+        StreamSource xslSource = new StreamSource(getSystemId(SRC_DIR + "/SecureProcessingTest.xsl"));
+        StreamSource xmlSource = new StreamSource(getSystemId(SRC_DIR + "/SecureProcessingTest.xml"));
+
+        // the xml result
+        StringWriter xmlResultString = new StringWriter();
+        StreamResult xmlResultStream = new StreamResult(xmlResultString);
+
+        if (!isAPIProperty) {
+            System.setProperty(property, Boolean.toString(value));
+        }
         TransformerFactory tf = TransformerFactory.newInstance();
-        feature = tf.getFeature(ORACLE_ENABLE_EXTENSION_FUNCTION);
-        System.out.println("Default setting: " + feature);
-        // The default: true if no SecurityManager, false otherwise
-        Assert.assertTrue(feature == getDefault());
-
-        setSystemProperty(SP_ENABLE_EXTENSION_FUNCTION, getDefaultOpposite());
-        tf = TransformerFactory.newInstance();
-        feature = tf.getFeature(ORACLE_ENABLE_EXTENSION_FUNCTION);
-        System.out.println("After setting " + SP_ENABLE_EXTENSION_FUNCTION + ": " + feature);
-        clearSystemProperty(SP_ENABLE_EXTENSION_FUNCTION);
-        // old/incorrect name is still supported
-        Assert.assertTrue(feature != getDefault());
-
-        setSystemProperty(SP_ENABLE_EXTENSION_FUNCTION_SPEC, getDefaultOpposite());
-        tf = TransformerFactory.newInstance();
-        feature = tf.getFeature(ORACLE_ENABLE_EXTENSION_FUNCTION);
-        System.out.println("After setting " + SP_ENABLE_EXTENSION_FUNCTION_SPEC + ": " + feature);
-        clearSystemProperty(SP_ENABLE_EXTENSION_FUNCTION_SPEC);
-        // new/correct name is effective
-        Assert.assertTrue(feature != getDefault());
-    }
-
-    final boolean isSecure;
-    {
-        String runSecMngr = getSystemProperty("runSecMngr");
-        isSecure = runSecMngr != null && runSecMngr.equals("true");
-    }
-
-    // The default: true if no SecurityManager, false otherwise
-    private boolean getDefault() {
-        if (isSecure) {
-            return false;
-        } else {
-            return true;
+        if (isAPIProperty) {
+            tf.setFeature(property, value);
         }
-    }
-
-    // Gets a String value that is opposite to the default value
-    private String getDefaultOpposite() {
-        if (isSecure) {
-            return "true";
-        } else {
-            return "false";
+        Transformer transformer = tf.newTransformer(xslSource);
+        if (!isAPIProperty) {
+            System.clearProperty(property);
         }
+        transformer.transform(xmlSource, xmlResultStream);
     }
 
     /**
@@ -152,7 +159,7 @@ public class XSLTFunctionsTest {
      * @param externalDoc Content of the external xml document
      * @param expectedResult Expected transformation result
      **/
-    @Test(dataProvider = "document")
+    //@Test(dataProvider = "document")
     public void testDocument(final String xml, final String xsl,
                              final String externalDoc, final String expectedResult) throws Exception {
         // Prepare sources for transormation

--- a/test/jdk/javax/xml/jaxp/common/8032908/XSLT.java
+++ b/test/jdk/javax/xml/jaxp/common/8032908/XSLT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,12 @@
 
 /**
  * @test
- * @bug 8032908 8081392
+ * @bug 8032908 8081392 8343001
  * @summary Test if Node.getTextContent() function correctly returns children
  * content and also check that Node.getNodeValue() returns null value for
  * Element nodes
  * @compile TestFunc.java XSLT.java
- * @run main/othervm XSLT
+ * @run main/othervm -Djdk.xml.enableExtensionFunctions=true XSLT
  */
 import java.io.ByteArrayOutputStream;
 import javax.xml.transform.Transformer;

--- a/test/jdk/javax/xml/jaxp/parsers/8024707/XSLT.java
+++ b/test/jdk/javax/xml/jaxp/parsers/8024707/XSLT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,10 @@
 
 /**
  * @test
- * @bug 8024707
+ * @bug 8024707 8343001
  * @summary Test for XSLT extension function with 1 element sized nodelist
  * @compile TestFunc.java XSLT.java
- * @run main/othervm XSLT
+ * @run main/othervm -Djdk.xml.enableExtensionFunctions=true XSLT
  * @author aleksej.efimov@oracle.com
  */
 

--- a/test/jdk/javax/xml/jaxp/transform/8004476/XSLTExFuncTest.java
+++ b/test/jdk/javax/xml/jaxp/transform/8004476/XSLTExFuncTest.java
@@ -30,7 +30,7 @@ import org.xml.sax.InputSource;
 
 /**
  * @test
- * @bug 8004476
+ * @bug 8004476 8343001
  * @summary test XSLT extension functions
  * @run main/othervm XSLTExFuncTest
  */
@@ -77,18 +77,18 @@ public class XSLTExFuncTest extends TestBase {
     }
 
     /**
-     * by default, extension function is enabled
+     * As of JDK-8343001, extension function is disabled by default.
      */
     public void testExtFunc() {
         TransformerFactory factory = TransformerFactory.newInstance();
 
         try {
             transform(factory);
-            System.out.println("testExtFunc: OK");
         } catch (TransformerConfigurationException e) {
             fail(e.getMessage());
         } catch (TransformerException ex) {
-            fail(ex.getMessage());
+            //expected since extension function is disallowed
+            System.out.println("testExtFunc: OK");
         }
     }
 


### PR DESCRIPTION
Disables XSLT and XPath Extension Functions by default, setting jdk.xml.enableExtensionFunctions to false.

Adjusted tests accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8343002](https://bugs.openjdk.org/browse/JDK-8343002) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8343001](https://bugs.openjdk.org/browse/JDK-8343001): Adjust XSLT and XPath Extension Function Property (**Enhancement** - P4)
 * [JDK-8343002](https://bugs.openjdk.org/browse/JDK-8343002): Adjust XSLT and XPath Extension Function Property (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) Review applies to [6daac1ed](https://git.openjdk.org/jdk/pull/22504/files/6daac1ed0ca023f6407a0724d4c3d1d262ce8d1f)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22504/head:pull/22504` \
`$ git checkout pull/22504`

Update a local copy of the PR: \
`$ git checkout pull/22504` \
`$ git pull https://git.openjdk.org/jdk.git pull/22504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22504`

View PR using the GUI difftool: \
`$ git pr show -t 22504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22504.diff">https://git.openjdk.org/jdk/pull/22504.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22504#issuecomment-2513321279)
</details>
