### PR TITLE
8345355: [s390x] support for z16 hardware

### DIFF
--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -57,7 +57,7 @@ unsigned int  VM_Version::_Icache_lineSize                             = DEFAULT
 
 // The following list contains the (approximate) announcement/availability
 // dates of the many System z generations in existence as of now.
-// Information compiled from https://www.ibm.com/support/techdocs/atsmastr.nsf/WebIndex/TD105503
+// Information compiled from https://www.ibm.com/support/pages/ibm-mainframe-life-cycle-history
 //   z900: 2000-10
 //   z990: 2003-06
 //   z9:   2005-09
@@ -68,12 +68,13 @@ unsigned int  VM_Version::_Icache_lineSize                             = DEFAULT
 //   z13:  2015-03
 //   z14:  2017-09
 //   z15:  2019-09
+//   z16:  2022-05
 
-static const char* z_gen[]      = {"  ", "G1",         "G2",         "G3",         "G4",         "G5",         "G6",         "G7",         "G8",         "G9"  };
-static const char* z_machine[]  = {"  ", "2064",       "2084",       "2094",       "2097",       "2817",       "2827",       "2964",       "3906",       "8561" };
-static const char* z_name[]     = {"  ", "z900",       "z990",       "z9 EC",      "z10 EC",     "z196 EC",    "ec12",       "z13",        "z14",        "z15" };
-static const char* z_WDFM[]     = {"  ", "2006-06-30", "2008-06-30", "2010-06-30", "2012-06-30", "2014-06-30", "2016-12-31", "2019-06-30", "2021-06-30", "tbd" };
-static const char* z_EOS[]      = {"  ", "2014-12-31", "2014-12-31", "2017-10-31", "2019-12-31", "2021-12-31", "tbd",        "tbd",        "tbd",        "tbd" };
+static const char* z_gen[]      = {"  ", "G1",         "G2",         "G3",         "G4",         "G5",         "G6",         "G7",         "G8",         "G9",         "G10" };
+static const char* z_machine[]  = {"  ", "2064",       "2084",       "2094",       "2097",       "2817",       "2827",       "2964",       "3906",       "8561",       "3931" };
+static const char* z_name[]     = {"  ", "z900",       "z990",       "z9 EC",      "z10 EC",     "z196 EC",    "ec12",       "z13",        "z14",        "z15",        "z16" };
+static const char* z_WDFM[]     = {"  ", "2006-06-30", "2008-06-30", "2010-06-30", "2012-06-30", "2014-06-30", "2016-12-31", "2019-06-30", "2021-06-30", "2024-12-31", "tbd" };
+static const char* z_EOS[]      = {"  ", "2014-12-31", "2014-12-31", "2017-10-31", "2019-12-31", "2021-12-31", "2023-12-31", "2024-12-31", "tbd",        "tbd",        "tbd" };
 static const char* z_features[] = {"  ",
                                    "system-z, g1-z900, ldisp",
                                    "system-z, g2-z990, ldisp_fast",
@@ -83,7 +84,9 @@ static const char* z_features[] = {"  ",
                                    "system-z, g6-ec12, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm",
                                    "system-z, g7-z13, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr",
                                    "system-z, g8-z14, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1",
-                                   "system-z, g9-z15, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1, instrext3, venh2"
+                                   "system-z, g9-z15, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1, instrext3, venh2",
+                                   "system-z, g10-z16, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1, instrext3, venh2,"
+                                       "bear_enh, sort_enh, nnpa_assist, storage_key_removal, vpack_decimal_enh"
                                   };
 
 void VM_Version::initialize() {
@@ -337,6 +340,11 @@ int VM_Version::get_model_index() {
   //      is the index of the oldest detected model.
   int ambiguity = 0;
   int model_ix  = 0;
+  if (is_z16()) {
+    model_ix = 10;
+    ambiguity++;
+  }
+
   if (is_z15()) {
     model_ix = 9;
     ambiguity++;

--- a/src/hotspot/cpu/s390/vm_version_s390.hpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.hpp
@@ -48,8 +48,8 @@ class VM_Version: public Abstract_VM_Version {
 #define  StoreFacilityListExtendedMask  0x0100000000000000UL  // z9
 #define  ETF2Mask                       0x0000800000000000UL  // z900
 #define  CryptoFacilityMask             0x0000400000000000UL  // z990 (aka message-security assist)
-#define  LongDispFacilityMask           0x0000200000000000UL  // z900 with microcode update
-#define  LongDispFacilityHighPerfMask   0x0000300000000000UL  // z990
+#define  LongDispFacilityMask           0x0000200000000000UL  // z900 with microcode update, Bit: 18
+#define  LongDispFacilityHighPerfMask   0x0000100000000000UL  // z990, Bit: 19
 #define  HFPMultiplyAndAddMask          0x0000080000000000UL  // z990
 #define  ExtImmedFacilityMask           0x0000040000000000UL  // z9
 #define  ETF3Mask                       0x0000020000000000UL  // z990/z9 (?)
@@ -64,7 +64,8 @@ class VM_Version: public Abstract_VM_Version {
 #define  ExecuteExtensionsMask          0x0000000010000000UL  // z10
 #define  FPExtensionsMask               0x0000000004000000UL  // z196
 #define  FPSupportEnhancementsMask      0x0000000000400000UL  // z10
-#define  DecimalFloatingPointMask       0x0000000000300000UL  // z10
+#define  DecimalFloatingPointMask       0x0000000000200000UL  // z10, Bit: 42
+#define  DecimalFloatingPointHighPerfMask 0x0000000000100000UL  // z10, Bit: 43
 // z196 begin
 #define  DistinctOpndsMask              0x0000000000040000UL  // z196
 #define  FastBCRSerializationMask       DistinctOpndsMask
@@ -459,6 +460,7 @@ class VM_Version: public Abstract_VM_Version {
   static bool has_FPExtensions()              { return  (_features[0] & FPExtensionsMask)              == FPExtensionsMask; }
   static bool has_FPSupportEnhancements()     { return  (_features[0] & FPSupportEnhancementsMask)     == FPSupportEnhancementsMask; }
   static bool has_DecimalFloatingPoint()      { return  (_features[0] & DecimalFloatingPointMask)      == DecimalFloatingPointMask; }
+  static bool has_DecimalFloatingPointHighPerf() { return  (_features[0] & DecimalFloatingPointHighPerfMask) == DecimalFloatingPointHighPerfMask; }
   static bool has_InterlockedAccessV1()       { return  (_features[0] & InterlockedAccess1Mask)        == InterlockedAccess1Mask; }
   static bool has_LoadAndALUAtomicV1()        { return  (_features[0] & InterlockedAccess1Mask)        == InterlockedAccess1Mask; }
   static bool has_PopCount()                  { return  (_features[0] & PopulationCountMask)           == PopulationCountMask; }
@@ -515,6 +517,7 @@ class VM_Version: public Abstract_VM_Version {
 
   // CPU feature setters (to force model-specific behaviour). Test/debugging only.
   static void set_has_DecimalFloatingPoint()      { _features[0] |= DecimalFloatingPointMask; }
+  static void set_has_DecimalFloatingPointHighPerf() { _features[0] |= DecimalFloatingPointHighPerfMask; }
   static void set_has_FPSupportEnhancements()     { _features[0] |= FPSupportEnhancementsMask; }
   static void set_has_ExecuteExtensions()         { _features[0] |= ExecuteExtensionsMask; }
   static void set_has_MemWithImmALUOps()          { _features[0] |= GnrlInstrExtFacilityMask; }

--- a/src/hotspot/cpu/s390/vm_version_s390.hpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.hpp
@@ -89,9 +89,6 @@ class VM_Version: public Abstract_VM_Version {
 // z13 end
 #define  MiscInstrExt2Mask              0x0000000000000020UL  // z14
 #define  MiscInstrExt3Mask              0x0000000000000004UL  // z15
-
-#define BEAREnhFacilityMask             0x4000000000000000UL  // z16, BEAR-enhancement facility, Bit: 193
-#define NNPAssistFacilityMask           0x0000000004000000UL  // z16, Neural-network-processing-assist facility, Bit: 165
 // ----------------------------------------------
 // --- FeatureBitString Bits  64..127 (DW[1]) ---
 // ----------------------------------------------
@@ -118,6 +115,12 @@ class VM_Version: public Abstract_VM_Version {
 #define  VectorPackedDecimalEnhMask     0x0000008000000000UL  // z15
 #define  CryptoExtension9Mask           0x0000001000000000UL  // z15 (aka message-security assist extension 9)
 #define  DeflateMask                    0x0000010000000000UL  // z15
+#define NNPAssistFacilityMask           0x0000000004000000UL  // z16, Neural-network-processing-assist facility, Bit: 165
+
+// ----------------------------------------------
+// --- FeatureBitString Bits 193..200 (DW[3]) ---
+// ----------------------------------------------
+#define  BEAREnhFacilityMask            0x4000000000000000UL  // z16, BEAR-enhancement facility, Bit: 193
 
   enum {
     _max_cache_levels = 8,    // As limited by ECAG instruction.

--- a/src/hotspot/cpu/s390/vm_version_s390.hpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.hpp
@@ -90,7 +90,7 @@ class VM_Version: public Abstract_VM_Version {
 #define  MiscInstrExt3Mask              0x0000000000000004UL  // z15
 
 #define BEAREnhFacilityMask             0x4000000000000000UL  // z16, BEAR-enhancement facility, Bit: 193
-#define NNPAssistFacilityMask           0x0000000000040000UL  // z16, Neural-network-processing-assist facility, Bit: 165
+#define NNPAssistFacilityMask           0x0000000004000000UL  // z16, Neural-network-processing-assist facility, Bit: 165
 // ----------------------------------------------
 // --- FeatureBitString Bits  64..127 (DW[1]) ---
 // ----------------------------------------------

--- a/src/hotspot/cpu/s390/vm_version_s390.hpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.hpp
@@ -88,6 +88,9 @@ class VM_Version: public Abstract_VM_Version {
 // z13 end
 #define  MiscInstrExt2Mask              0x0000000000000020UL  // z14
 #define  MiscInstrExt3Mask              0x0000000000000004UL  // z15
+
+#define BEAREnhFacilityMask             0x4000000000000000UL  // z16, BEAR-enhancement facility, Bit: 193
+#define NNPAssistFacilityMask           0x0000000000040000UL  // z16, Neural-network-processing-assist facility, Bit: 165
 // ----------------------------------------------
 // --- FeatureBitString Bits  64..127 (DW[1]) ---
 // ----------------------------------------------
@@ -179,9 +182,10 @@ class VM_Version: public Abstract_VM_Version {
   static bool is_z10()  { return has_GnrlInstrExtensions()    && !has_DistinctOpnds(); }
   static bool is_z196() { return has_DistinctOpnds()          && !has_MiscInstrExt(); }
   static bool is_ec12() { return has_MiscInstrExt()           && !has_CryptoExt5(); }
-  static bool is_z13()  { return has_CryptoExt5()             && !has_MiscInstrExt2();}
-  static bool is_z14()  { return has_MiscInstrExt2()          && !has_MiscInstrExt3();}
-  static bool is_z15()  { return has_MiscInstrExt3();}
+  static bool is_z13()  { return has_CryptoExt5()             && !has_MiscInstrExt2(); }
+  static bool is_z14()  { return has_MiscInstrExt2()          && !has_MiscInstrExt3(); }
+  static bool is_z15()  { return has_MiscInstrExt3()          && !has_BEAR_Enh_Facility(); }
+  static bool is_z16()  { return has_BEAR_Enh_Facility(); }
 
   // Need to use nested class with unscoped enum.
   // C++11 declaration "enum class Cipher { ... } is not supported.
@@ -486,6 +490,9 @@ class VM_Version: public Abstract_VM_Version {
   static bool has_VectorPackedDecimal()       { return  (_features[2] & VectorPackedDecimalMask)       == VectorPackedDecimalMask; }
   static bool has_VectorPackedDecimalEnh()    { return  (_features[2] & VectorPackedDecimalEnhMask)    == VectorPackedDecimalEnhMask; }
 
+  static bool has_BEAR_Enh_Facility()         { return  (_features[3] & BEAREnhFacilityMask)           == BEAREnhFacilityMask; }
+  static bool has_NNP_Assist_Facility()       { return  (_features[2] & NNPAssistFacilityMask)         == NNPAssistFacilityMask; }
+
   // Crypto features query functions.
   static bool has_Crypto_AES_GCM128()         { return has_Crypto() && test_feature_bit(&_cipher_features_KMA[0], Cipher::_AES128, Cipher::_featureBits); }
   static bool has_Crypto_AES_GCM192()         { return has_Crypto() && test_feature_bit(&_cipher_features_KMA[0], Cipher::_AES192, Cipher::_featureBits); }
@@ -558,6 +565,8 @@ class VM_Version: public Abstract_VM_Version {
   static void set_has_VectorEnhancements2()       { _features[2] |= VectorEnhancements2Mask; }
   static void set_has_VectorPackedDecimal()       { _features[2] |= VectorPackedDecimalMask; }
   static void set_has_VectorPackedDecimalEnh()    { _features[2] |= VectorPackedDecimalEnhMask; }
+  static void set_has_BEAR_Enh_Facility()         { _features[3] |= BEAREnhFacilityMask;}
+  static void set_has_NNP_Assist_Facility()       { _features[2] |= NNPAssistFacilityMask;}
 
   static void reset_has_VectorFacility()          { _features[2] &= ~VectorFacilityMask; }
 


### PR DESCRIPTION
This was the output for `jdk/bin/java -XX:+Verbose --version` command on a z16 hardware: 

```
CPU Version as detected internally: system-z, g9-z15, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1, instrext3, venh2, out-of-support_as_of_tbd, aes128, aes192, aes256, sha1, sha256, sha512, ghash
```

So the issue is that z16 should be recognized as g10-z16 but instead I got g9-z15. 

This is the output with current changes: 

```
CPU Version as detected internally: system-z, g10-z16, ldisp_fast, extimm, pcrel_load/store, cmpb, cond_load/store, interlocked_update, txm, vectorinstr, instrext2, venh1, instrext3, venh2,bear_enh, sort_enh, nnpa_assist, storage_key_removal, vpack_decimal_enh, out-of-support_as_of_tbd, aes128, aes192, aes256, sha1, sha256, sha512, ghash
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345355](https://bugs.openjdk.org/browse/JDK-8345355): [s390x] support for z16 hardware (**Enhancement** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22508/head:pull/22508` \
`$ git checkout pull/22508`

Update a local copy of the PR: \
`$ git checkout pull/22508` \
`$ git pull https://git.openjdk.org/jdk.git pull/22508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22508`

View PR using the GUI difftool: \
`$ git pr show -t 22508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22508.diff">https://git.openjdk.org/jdk/pull/22508.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22508#issuecomment-2513640772)
</details>
