### PR TITLE
8345357: test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java fails in ubuntu22.04

### DIFF
--- a/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
+++ b/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  * @summary  Incorrect radio button behavior when pressing tab key
  * @run main bug8033699
  */
+
 import java.awt.KeyboardFocusManager;
 import java.awt.Robot;
 import java.awt.event.ActionListener;
@@ -57,42 +58,50 @@ public class bug8033699 {
 
     public static void main(String[] args) throws Throwable {
         SwingUtilities.invokeAndWait(() -> {
-                changeLAF();
-                createAndShowGUI();
+            changeLAF();
+            createAndShowGUI();
         });
 
         robot = new Robot();
-        Thread.sleep(100);
-        robot.waitForIdle();
-
         robot.setAutoDelay(100);
+        robot.waitForIdle();
+        robot.delay(1000);
 
         // tab key test grouped radio button
         runTest1();
+        robot.delay(100);
 
         // tab key test non-grouped radio button
         runTest2();
+        robot.delay(100);
 
         // shift tab key test grouped and non-grouped radio button
         runTest3();
+        robot.delay(100);
 
         // left/up key test in grouped radio button
         runTest4();
+        robot.delay(100);
 
         // down/right key test in grouped radio button
         runTest5();
+        robot.delay(100);
 
         // tab from radio button in group to next component in the middle of button group layout
         runTest6();
+        robot.delay(100);
 
         // tab to radio button in group from component in the middle of button group layout
         runTest7();
+        robot.delay(100);
 
         // down key circle back to first button in grouped radio button
         runTest8();
+        robot.delay(100);
 
         // Verify that ActionListener is called when a RadioButton is selected using arrow key.
         runTest9();
+        robot.delay(100);
 
         SwingUtilities.invokeAndWait(() -> mainFrame.dispose());
     }


### PR DESCRIPTION
test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java fails in OCI system citing

```
Radio Button Group Go To Next Component through Tab Key failed
----------System.err:(30/2118)----------
java.lang.reflect.InvocationTargetException
at java.desktop/java.awt.EventQueue.invokeAndWait(EventQueue.java:1371)
at java.desktop/java.awt.EventQueue.invokeAndWait(EventQueue.java:1346)
at java.desktop/javax.swing.SwingUtilities.invokeAndWait(SwingUtilities.java:1480)
at bug8033699.runTest1(bug8033699.java:163)
at bug8033699.main(bug8033699.java:71)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:573)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.lang.RuntimeException: Focus is not on Radio Button Single as Expected 
```

in runTest1, the first subtest which seems to suggest test started before the frame is visible..Added a standard delay after frame visibility..Also added a token delay inbetween 8 subtests so that keypress(es) are not coming in one after other..
Test passed in CI in several OCI systems..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345357](https://bugs.openjdk.org/browse/JDK-8345357): test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java fails in ubuntu22.04 (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22509/head:pull/22509` \
`$ git checkout pull/22509`

Update a local copy of the PR: \
`$ git checkout pull/22509` \
`$ git pull https://git.openjdk.org/jdk.git pull/22509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22509`

View PR using the GUI difftool: \
`$ git pr show -t 22509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22509.diff">https://git.openjdk.org/jdk/pull/22509.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22509#issuecomment-2513743672)
</details>
