### PR TITLE
8344229: Revisit SecurityManager usage in jdk.httpserver after JEP 486 integration

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/spi/HttpServerProvider.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/spi/HttpServerProvider.java
@@ -31,8 +31,6 @@ import com.sun.net.httpserver.HttpsServer;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetSocketAddress;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Iterator;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
@@ -83,12 +81,7 @@ public abstract class HttpServerProvider {
     /**
      * Initializes a new instance of this class.
      */
-    protected HttpServerProvider() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkPermission(new RuntimePermission("httpServerProvider"));
-    }
+    protected HttpServerProvider() {}
 
     private static boolean loadProviderFromProperty() {
         String cn = System.getProperty("com.sun.net.httpserver.HttpServerProvider");
@@ -107,8 +100,7 @@ public abstract class HttpServerProvider {
                  NoSuchMethodException |
                  ClassNotFoundException |
                  IllegalAccessException |
-                 InstantiationException |
-                 SecurityException x) {
+                 InstantiationException x) {
             throw new ServiceConfigurationError(null, x);
         }
     }
@@ -118,20 +110,10 @@ public abstract class HttpServerProvider {
             ServiceLoader.load(HttpServerProvider.class,
                                ClassLoader.getSystemClassLoader())
                 .iterator();
-        for (;;) {
-            try {
-                if (!i.hasNext())
-                    return false;
-                provider = i.next();
-                return true;
-            } catch (ServiceConfigurationError sce) {
-                if (sce.getCause() instanceof SecurityException) {
-                    // Ignore the security exception, try the next provider
-                    continue;
-                }
-                throw sce;
-            }
-        }
+        if (!i.hasNext())
+            return false;
+        provider = i.next();
+        return true;
     }
 
     /**
@@ -170,22 +152,16 @@ public abstract class HttpServerProvider {
      *
      * @return  The system-wide default HttpServerProvider
      */
-    @SuppressWarnings("removal")
     public static HttpServerProvider provider () {
         synchronized (lock) {
             if (provider != null)
                 return provider;
-            return (HttpServerProvider)AccessController
-                .doPrivileged(new PrivilegedAction<Object>() {
-                        public Object run() {
-                            if (loadProviderFromProperty())
-                                return provider;
-                            if (loadProviderAsService())
-                                return provider;
-                            provider = new sun.net.httpserver.DefaultHttpServerProvider();
-                            return provider;
-                        }
-                    });
+            if (loadProviderFromProperty())
+                return provider;
+            if (loadProviderAsService())
+                return provider;
+            provider = new sun.net.httpserver.DefaultHttpServerProvider();
+            return provider;
         }
     }
 

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/AuthFilter.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/AuthFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,6 @@ package sun.net.httpserver;
 
 import com.sun.net.httpserver.*;
 import java.io.*;
-import java.nio.*;
-import java.nio.channels.*;
-import java.util.*;
-import javax.security.auth.*;
-import javax.security.auth.callback.*;
-import javax.security.auth.login.*;
 
 public class AuthFilter extends Filter {
 

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/HttpServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/HttpServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,9 @@ package sun.net.httpserver;
 
 import java.net.*;
 import java.io.*;
-import java.nio.*;
-import java.security.*;
-import java.nio.channels.*;
-import java.util.*;
 import java.util.concurrent.*;
-import javax.net.ssl.*;
+
 import com.sun.net.httpserver.*;
-import com.sun.net.httpserver.spi.*;
 
 public class HttpServerImpl extends HttpServer {
 

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/HttpsServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/HttpsServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,9 @@ package sun.net.httpserver;
 
 import java.net.*;
 import java.io.*;
-import java.nio.*;
-import java.security.*;
-import java.nio.channels.*;
-import java.util.*;
 import java.util.concurrent.*;
-import javax.net.ssl.*;
+
 import com.sun.net.httpserver.*;
-import com.sun.net.httpserver.spi.*;
 
 public class HttpsServerImpl extends HttpsServer {
 

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerConfig.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerConfig.java
@@ -27,14 +27,11 @@ package sun.net.httpserver;
 
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
-import java.security.PrivilegedAction;
 
 /**
  * Parameters that users will not likely need to set
  * but are useful for debugging
  */
-
-@SuppressWarnings("removal")
 class ServerConfig {
 
     private static final int DEFAULT_IDLE_TIMER_SCHEDULE_MILLIS = 10000 ; // 10 sec.
@@ -55,91 +52,71 @@ class ServerConfig {
     private static long idleTimerScheduleMillis;
     private static long idleIntervalMillis;
     // The maximum number of bytes to drain from an inputstream
-    private static long drainAmount;
+    private static final long drainAmount;
     // the maximum number of connections that the server will allow to be open
     // after which it will no longer "accept()" any new connections, till the
     // current connection count goes down due to completion of processing the requests
-    private static int maxConnections;
-    private static int maxIdleConnections;
+    private static final int maxConnections;
+    private static final int maxIdleConnections;
     // The maximum number of request headers allowable
     private static int maxReqHeaders;
     // a maximum value for the header list size. This is the
     // names size + values size + 32 bytes per field line
     private static int maxReqHeadersSize;
     // max time a request or response is allowed to take
-    private static long maxReqTime;
-    private static long maxRspTime;
+    private static final long maxReqTime;
+    private static final long maxRspTime;
     private static long reqRspTimerScheduleMillis;
-    private static boolean debug;
+    private static final boolean debug;
 
     // the value of the TCP_NODELAY socket-level option
-    private static boolean noDelay;
+    private static final boolean noDelay;
 
     static {
-        java.security.AccessController.doPrivileged(
-            new PrivilegedAction<Void>() {
-                @Override
-                public Void run () {
-                    idleIntervalMillis = Long.getLong("sun.net.httpserver.idleInterval",
-                            DEFAULT_IDLE_INTERVAL_IN_SECS) * 1000;
-                    if (idleIntervalMillis <= 0) {
-                        idleIntervalMillis = DEFAULT_IDLE_INTERVAL_IN_SECS * 1000;
-                    }
 
-                    idleTimerScheduleMillis = Long.getLong("sun.net.httpserver.clockTick",
-                            DEFAULT_IDLE_TIMER_SCHEDULE_MILLIS);
-                    if (idleTimerScheduleMillis <= 0) {
-                        // ignore zero or negative value and use the default schedule
-                        idleTimerScheduleMillis = DEFAULT_IDLE_TIMER_SCHEDULE_MILLIS;
-                    }
+        idleIntervalMillis = Long.getLong("sun.net.httpserver.idleInterval", DEFAULT_IDLE_INTERVAL_IN_SECS) * 1000;
+        if (idleIntervalMillis <= 0) {
+            idleIntervalMillis = DEFAULT_IDLE_INTERVAL_IN_SECS * 1000;
+        }
 
-                    maxConnections = Integer.getInteger(
-                            "jdk.httpserver.maxConnections",
-                            DEFAULT_MAX_CONNECTIONS);
+        idleTimerScheduleMillis = Long.getLong("sun.net.httpserver.clockTick", DEFAULT_IDLE_TIMER_SCHEDULE_MILLIS);
+        if (idleTimerScheduleMillis <= 0) {
+            // ignore zero or negative value and use the default schedule
+            idleTimerScheduleMillis = DEFAULT_IDLE_TIMER_SCHEDULE_MILLIS;
+        }
 
-                    maxIdleConnections = Integer.getInteger(
-                            "sun.net.httpserver.maxIdleConnections",
-                            DEFAULT_MAX_IDLE_CONNECTIONS);
+        maxConnections = Integer.getInteger("jdk.httpserver.maxConnections", DEFAULT_MAX_CONNECTIONS);
 
-                    drainAmount = Long.getLong("sun.net.httpserver.drainAmount",
-                            DEFAULT_DRAIN_AMOUNT);
+        maxIdleConnections = Integer.getInteger("sun.net.httpserver.maxIdleConnections", DEFAULT_MAX_IDLE_CONNECTIONS);
 
-                    maxReqHeaders = Integer.getInteger(
-                            "sun.net.httpserver.maxReqHeaders",
-                            DEFAULT_MAX_REQ_HEADERS);
-                    if (maxReqHeaders <= 0) {
-                        maxReqHeaders = DEFAULT_MAX_REQ_HEADERS;
-                    }
+        drainAmount = Long.getLong("sun.net.httpserver.drainAmount", DEFAULT_DRAIN_AMOUNT);
 
-                    // a value <= 0 means unlimited
-                    maxReqHeadersSize = Integer.getInteger(
-                            "sun.net.httpserver.maxReqHeaderSize",
-                            DEFAULT_MAX_REQ_HEADER_SIZE);
-                    if (maxReqHeadersSize <= 0) {
-                        maxReqHeadersSize = 0;
-                    }
+        maxReqHeaders = Integer.getInteger("sun.net.httpserver.maxReqHeaders", DEFAULT_MAX_REQ_HEADERS);
+        if (maxReqHeaders <= 0) {
+            maxReqHeaders = DEFAULT_MAX_REQ_HEADERS;
+        }
 
-                    maxReqTime = Long.getLong("sun.net.httpserver.maxReqTime",
-                            DEFAULT_MAX_REQ_TIME);
+        // a value <= 0 means unlimited
+        maxReqHeadersSize = Integer.getInteger("sun.net.httpserver.maxReqHeaderSize", DEFAULT_MAX_REQ_HEADER_SIZE);
+        if (maxReqHeadersSize <= 0) {
+            maxReqHeadersSize = 0;
+        }
 
-                    maxRspTime = Long.getLong("sun.net.httpserver.maxRspTime",
-                            DEFAULT_MAX_RSP_TIME);
+        maxReqTime = Long.getLong("sun.net.httpserver.maxReqTime", DEFAULT_MAX_REQ_TIME);
 
-                    reqRspTimerScheduleMillis = Long.getLong("sun.net.httpserver.timerMillis",
-                            DEFAULT_REQ_RSP_TIMER_TASK_SCHEDULE_MILLIS);
-                    if (reqRspTimerScheduleMillis <= 0) {
-                        // ignore any negative or zero value for this configuration and reset
-                        // to default schedule
-                        reqRspTimerScheduleMillis = DEFAULT_REQ_RSP_TIMER_TASK_SCHEDULE_MILLIS;
-                    }
+        maxRspTime = Long.getLong("sun.net.httpserver.maxRspTime", DEFAULT_MAX_RSP_TIME);
 
-                    debug = Boolean.getBoolean("sun.net.httpserver.debug");
+        reqRspTimerScheduleMillis = Long.getLong(
+                "sun.net.httpserver.timerMillis",
+                DEFAULT_REQ_RSP_TIMER_TASK_SCHEDULE_MILLIS);
+        if (reqRspTimerScheduleMillis <= 0) {
+            // ignore any negative or zero value for this configuration and reset to default schedule
+            reqRspTimerScheduleMillis = DEFAULT_REQ_RSP_TIMER_TASK_SCHEDULE_MILLIS;
+        }
 
-                    noDelay = Boolean.getBoolean("sun.net.httpserver.nodelay");
+        debug = Boolean.getBoolean("sun.net.httpserver.debug");
 
-                    return null;
-                }
-            });
+        noDelay = Boolean.getBoolean("sun.net.httpserver.nodelay");
 
     }
 
@@ -148,39 +125,22 @@ class ServerConfig {
         // legacy properties that are no longer used
         // print a warning to logger if they are set.
 
-        java.security.AccessController.doPrivileged(
-            new PrivilegedAction<Void>() {
-                public Void run () {
-                    if (System.getProperty("sun.net.httpserver.readTimeout")
-                                                !=null)
-                    {
-                        logger.log (Level.WARNING,
-                            "sun.net.httpserver.readTimeout "+
-                            "property is no longer used. "+
-                            "Use sun.net.httpserver.maxReqTime instead."
-                        );
-                    }
-                    if (System.getProperty("sun.net.httpserver.writeTimeout")
-                                                !=null)
-                    {
-                        logger.log (Level.WARNING,
-                            "sun.net.httpserver.writeTimeout "+
-                            "property is no longer used. Use "+
-                            "sun.net.httpserver.maxRspTime instead."
-                        );
-                    }
-                    if (System.getProperty("sun.net.httpserver.selCacheTimeout")
-                                                !=null)
-                    {
-                        logger.log (Level.WARNING,
-                            "sun.net.httpserver.selCacheTimeout "+
-                            "property is no longer used."
-                        );
-                    }
-                    return null;
-                }
-            }
-        );
+        if (System.getProperty("sun.net.httpserver.readTimeout") != null) {
+            logger.log(
+                    Level.WARNING,
+                    "sun.net.httpserver.readTimeout property is no longer used. " +
+                            "Use sun.net.httpserver.maxReqTime instead.");
+        }
+        if (System.getProperty("sun.net.httpserver.writeTimeout") != null) {
+            logger.log(
+                    Level.WARNING,
+                    "sun.net.httpserver.writeTimeout property is no longer used. " +
+                            "Use sun.net.httpserver.maxRspTime instead.");
+        }
+        if (System.getProperty("sun.net.httpserver.selCacheTimeout") != null) {
+            logger.log(Level.WARNING, "sun.net.httpserver.selCacheTimeout property is no longer used.");
+        }
+
     }
 
     static boolean debugEnabled() {

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerConfig.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerConfig.java
@@ -74,10 +74,11 @@ class ServerConfig {
 
     static {
 
-        long providedIdleIntervalSecs = Long.getLong("sun.net.httpserver.idleInterval", DEFAULT_IDLE_INTERVAL_IN_SECS);
-        idleIntervalMillis = Math.multiplyExact(
-                providedIdleIntervalSecs > 0 ? providedIdleIntervalSecs : DEFAULT_IDLE_INTERVAL_IN_SECS,
-                1000);
+        long providedIdleIntervalMillis =
+                Long.getLong("sun.net.httpserver.idleInterval", DEFAULT_IDLE_INTERVAL_IN_SECS) * 1000;
+        idleIntervalMillis = providedIdleIntervalMillis > 0
+                ? providedIdleIntervalMillis
+                : Math.multiplyExact(DEFAULT_IDLE_INTERVAL_IN_SECS, 1000);
 
         long providedIdleTimerScheduleMillis =
                 Long.getLong("sun.net.httpserver.clockTick", DEFAULT_IDLE_TIMER_SCHEDULE_MILLIS);

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -53,8 +53,6 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -304,16 +302,8 @@ class ServerImpl {
         logger.log (Level.DEBUG, "context removed: " + context.getPath());
     }
 
-    @SuppressWarnings("removal")
     public InetSocketAddress getAddress() {
-        return AccessController.doPrivileged(
-                new PrivilegedAction<InetSocketAddress>() {
-                    public InetSocketAddress run() {
-                        return
-                            (InetSocketAddress)schan.socket()
-                                .getLocalSocketAddress();
-                    }
-                });
+        return (InetSocketAddress) schan.socket().getLocalSocketAddress();
     }
 
     void addEvent (Event r) {

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/FileServerHandler.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/FileServerHandler.java
@@ -25,7 +25,6 @@
 
 package sun.net.httpserver.simpleserver;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -67,12 +66,6 @@ public final class FileServerHandler implements HttpHandler {
 
     private FileServerHandler(Path root, UnaryOperator<String> mimeTable) {
         root = root.normalize();
-
-        @SuppressWarnings("removal")
-        var securityManager = System.getSecurityManager();
-        if (securityManager != null)
-            securityManager.checkRead(pathForSecurityCheck(root.toString()));
-
         if (!Files.exists(root))
             throw new IllegalArgumentException("Path does not exist: " + root);
         if (!root.isAbsolute())
@@ -84,11 +77,6 @@ public final class FileServerHandler implements HttpHandler {
         this.root = root;
         this.mimeTable = mimeTable;
         this.logger = System.getLogger("com.sun.net.httpserver");
-    }
-
-    private static String pathForSecurityCheck(String path) {
-        var separator = String.valueOf(File.separatorChar);
-        return path.endsWith(separator) ? (path + "-") : (path + separator + "-");
     }
 
     private static final HttpHandler NOT_IMPLEMENTED_HANDLER =

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/JWebServer.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/JWebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 package sun.net.httpserver.simpleserver;
 
 import java.io.PrintWriter;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -84,15 +82,9 @@ public class JWebServer {
         }
     }
 
-    @SuppressWarnings("removal")
     static void setMaxConnectionsIfNotSet() {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (System.getProperty(SYS_PROP_MAX_CONNECTIONS) != null) {
-                // an explicit value has already been set, so we don't override it
-                return null;
-            }
+        if (System.getProperty(SYS_PROP_MAX_CONNECTIONS) == null) {
             System.setProperty(SYS_PROP_MAX_CONNECTIONS, DEFAULT_JWEBSERVER_MAX_CONNECTIONS);
-            return null;
-        });
+        }
     }
 }

--- a/test/jdk/com/sun/net/httpserver/FileServerHandler.java
+++ b/test/jdk/com/sun/net/httpserver/FileServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,9 @@
  * questions.
  */
 
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.logging.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import javax.net.ssl.*;
+
 import com.sun.net.httpserver.*;
 
 /**

--- a/test/jdk/com/sun/net/httpserver/HttpsParametersClientAuthTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpsParametersClientAuthTest.java
@@ -31,9 +31,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.security.AccessController;
 import java.security.KeyStore;
-import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -359,21 +357,15 @@ public class HttpsParametersClientAuthTest {
     }
 
     private static KeyStore loadTestKeyStore() throws Exception {
-        return AccessController.doPrivileged(
-                new PrivilegedExceptionAction<KeyStore>() {
-                    @Override
-                    public KeyStore run() throws Exception {
-                        final String testKeys = System.getProperty("test.src")
-                                + "/"
-                                + "../../../../../../test/lib/jdk/test/lib/net/testkeys";
-                        try (final FileInputStream fis = new FileInputStream(testKeys)) {
-                            final char[] passphrase = "passphrase".toCharArray();
-                            final KeyStore ks = KeyStore.getInstance("PKCS12");
-                            ks.load(fis, passphrase);
-                            return ks;
-                        }
-                    }
-                });
+        final String testKeys = System.getProperty("test.src")
+                + "/"
+                + "../../../../../../test/lib/jdk/test/lib/net/testkeys";
+        try (final FileInputStream fis = new FileInputStream(testKeys)) {
+            final char[] passphrase = "passphrase".toCharArray();
+            final KeyStore ks = KeyStore.getInstance("PKCS12");
+            ks.load(fis, passphrase);
+            return ks;
+        }
     }
 
     // no-op implementations of the abstract methods of HttpsParameters

--- a/test/jdk/com/sun/net/httpserver/LogFilter.java
+++ b/test/jdk/com/sun/net/httpserver/LogFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,17 +21,11 @@
  * questions.
  */
 
-import java.net.*;
 import java.util.*;
 import java.text.*;
 import java.io.*;
-import java.nio.*;
-import java.nio.channels.*;
-import java.util.*;
+
 import com.sun.net.httpserver.*;
-import javax.security.auth.*;
-import javax.security.auth.callback.*;
-import javax.security.auth.login.*;
 
 class LogFilter extends Filter {
 

--- a/test/jdk/com/sun/net/httpserver/SelCacheTest.java
+++ b/test/jdk/com/sun/net/httpserver/SelCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,12 +36,9 @@ import com.sun.net.httpserver.*;
 import jdk.test.lib.net.SimpleSSLContext;
 import jdk.test.lib.net.URIBuilder;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import java.security.cert.*;
 import javax.net.ssl.*;
 
 /* basic http/s connectivity test

--- a/test/jdk/com/sun/net/httpserver/SimpleFileServer.java
+++ b/test/jdk/com/sun/net/httpserver/SimpleFileServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,11 @@
  * questions.
  */
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import javax.net.ssl.*;
+
 import com.sun.net.httpserver.*;
 
 /**

--- a/test/jdk/com/sun/net/httpserver/Test14.java
+++ b/test/jdk/com/sun/net/httpserver/Test14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import javax.security.auth.callback.*;
-import javax.net.ssl.*;
+
 import jdk.test.lib.net.URIBuilder;
 
 /**

--- a/test/jdk/com/sun/net/httpserver/Test2.java
+++ b/test/jdk/com/sun/net/httpserver/Test2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import javax.security.auth.callback.*;
-import javax.net.ssl.*;
+
 import jdk.test.lib.net.URIBuilder;
 
 /**

--- a/test/jdk/com/sun/net/httpserver/Test3.java
+++ b/test/jdk/com/sun/net/httpserver/Test3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,14 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.util.regex.*;
-import java.util.regex.Pattern.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import javax.net.ssl.*;
 
 /**
  * Test pipe-lining over http

--- a/test/jdk/com/sun/net/httpserver/Test4.java
+++ b/test/jdk/com/sun/net/httpserver/Test4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.util.regex.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import javax.net.ssl.*;
 
 /**
  * Test pipe-lining (block after read)

--- a/test/jdk/com/sun/net/httpserver/Test5.java
+++ b/test/jdk/com/sun/net/httpserver/Test5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.util.regex.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import javax.net.ssl.*;
 
 /**
  * Test pipe-lining (no block)

--- a/test/jdk/com/sun/net/httpserver/Test6.java
+++ b/test/jdk/com/sun/net/httpserver/Test6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import javax.security.auth.callback.*;
-import javax.net.ssl.*;
+
 import jdk.test.lib.net.URIBuilder;
 
 /**

--- a/test/jdk/com/sun/net/httpserver/Test7.java
+++ b/test/jdk/com/sun/net/httpserver/Test7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import javax.security.auth.callback.*;
-import javax.net.ssl.*;
+
 import jdk.test.lib.net.URIBuilder;
 
 /**

--- a/test/jdk/com/sun/net/httpserver/Test8.java
+++ b/test/jdk/com/sun/net/httpserver/Test8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import javax.security.auth.callback.*;
-import javax.net.ssl.*;
+
 import jdk.test.lib.net.URIBuilder;
 
 /**

--- a/test/jdk/com/sun/net/httpserver/TestLogging.java
+++ b/test/jdk/com/sun/net/httpserver/TestLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,14 +32,11 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import java.security.cert.*;
-import javax.net.ssl.*;
+
 import jdk.test.lib.net.URIBuilder;
 
 public class TestLogging extends Test {

--- a/test/jdk/com/sun/net/httpserver/bugs/B6339483.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6339483.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import java.security.cert.*;
-import javax.net.ssl.*;
+
 import jdk.test.lib.net.URIBuilder;
 
 public class B6339483 {

--- a/test/jdk/com/sun/net/httpserver/bugs/B6341616.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6341616.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import java.security.cert.*;
-import javax.net.ssl.*;
+
 import jdk.test.lib.net.URIBuilder;
 
 public class B6341616 {

--- a/test/jdk/com/sun/net/httpserver/bugs/B6526158.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6526158.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import java.security.cert.*;
-import javax.net.ssl.*;
+
 import jdk.test.lib.net.URIBuilder;
 
 public class B6526158 {

--- a/test/jdk/com/sun/net/httpserver/bugs/B6526913.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6526913.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,13 +33,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import java.security.cert.*;
-import javax.net.ssl.*;
+
 import jdk.test.lib.net.URIBuilder;
 
 public class B6526913 {

--- a/test/jdk/com/sun/net/httpserver/bugs/B6529200.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6529200.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,9 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import java.security.cert.*;
-import javax.net.ssl.*;
 
 public class B6529200 {
 

--- a/test/jdk/com/sun/net/httpserver/bugs/B6744329.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6744329.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,10 @@
 
 import com.sun.net.httpserver.*;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
-import java.security.*;
-import java.security.cert.*;
-import javax.net.ssl.*;
+
 import jdk.test.lib.net.URIBuilder;
 
 public class B6744329 {

--- a/test/jdk/com/sun/net/httpserver/simpleserver/RootDirPermissionsTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/RootDirPermissionsTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @summary Tests for FileServerHandler with SecurityManager
+ * @summary Tests file permission checks during the creation of a `FileServerHandler`
  * @library /test/lib
  * @build jdk.test.lib.net.URIBuilder
  * @run main/othervm -ea RootDirPermissionsTest true
@@ -245,7 +245,6 @@ public class RootDirPermissionsTest {
         }
     }
 
-    @SuppressWarnings("removal")
     private static void testCreateHandler(){
         try {
             SimpleFileServer.createFileServer(LOOPBACK_ADDR, TEST_DIR, OutputLevel.NONE);


### PR DESCRIPTION
Removes `SecurityManager` and friends from `jdk.httpserver`. Successful `tier1..2` results are attached to the ticket.

**Methodology:** Case-insensitively and recursively searched for the occurrences of `("removal"|secu|privi)` in `httpserver`-named folders.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344229](https://bugs.openjdk.org/browse/JDK-8344229): Revisit SecurityManager usage in jdk.httpserver after JEP 486 integration (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22510/head:pull/22510` \
`$ git checkout pull/22510`

Update a local copy of the PR: \
`$ git checkout pull/22510` \
`$ git pull https://git.openjdk.org/jdk.git pull/22510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22510`

View PR using the GUI difftool: \
`$ git pr show -t 22510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22510.diff">https://git.openjdk.org/jdk/pull/22510.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22510#issuecomment-2514201848)
</details>
