### PR TITLE
8345164: Remove residual --enable-preview in FFM tests and benchmarks

### DIFF
--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @summary Basic test for Enable-Native-Access attribute in the
  *          manifest of a main application JAR
@@ -78,7 +78,6 @@ public class TestEnableNativeAccessJarManifest extends TestEnableNativeAccessBas
 
         // java -jar test.jar
         List<String> command = new ArrayList<>(List.of(
-            "--enable-preview",
             "-Djava.library.path=" + System.getProperty("java.library.path")
         ));
         command.addAll(vmArgs);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "--enable-preview", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class ToJavaStringTest {
 
     private MemorySegment strSegment;


### PR DESCRIPTION
This PR proposes to remove redundant `--enable-preview` flags in a test and a benchmark.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345164](https://bugs.openjdk.org/browse/JDK-8345164): Remove residual --enable-preview in FFM tests and benchmarks (**Enhancement** - P5)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22512/head:pull/22512` \
`$ git checkout pull/22512`

Update a local copy of the PR: \
`$ git checkout pull/22512` \
`$ git pull https://git.openjdk.org/jdk.git pull/22512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22512`

View PR using the GUI difftool: \
`$ git pr show -t 22512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22512.diff">https://git.openjdk.org/jdk/pull/22512.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22512#issuecomment-2514380144)
</details>
