### PR TITLE
8345396: Fix headers after JDK-8345164

### DIFF
--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Headers are not compliant after [JDK-8345164](https://bugs.openjdk.org/browse/JDK-8345164) (a `,` is missing)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345396](https://bugs.openjdk.org/browse/JDK-8345396): Fix headers after JDK-8345164 (**Bug** - P2)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22515/head:pull/22515` \
`$ git checkout pull/22515`

Update a local copy of the PR: \
`$ git checkout pull/22515` \
`$ git pull https://git.openjdk.org/jdk.git pull/22515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22515`

View PR using the GUI difftool: \
`$ git pr show -t 22515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22515.diff">https://git.openjdk.org/jdk/pull/22515.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22515#issuecomment-2514710477)
</details>
