### PR TITLE
8332686: InetAddress.ofLiteral can throw StringIndexOutOfBoundsException

### DIFF
--- a/src/java.base/share/classes/java/net/Inet6Address.java
+++ b/src/java.base/share/classes/java/net/Inet6Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -554,6 +554,10 @@ class Inet6Address extends InetAddress {
      */
     static InetAddress parseAddressString(String addressLiteral, boolean removeSqBrackets)
             throws UnknownHostException {
+        // Empty strings are not parseable
+        if (addressLiteral.isEmpty()) {
+            return null;
+        }
         // Remove trailing and leading square brackets if requested
         if (removeSqBrackets && addressLiteral.charAt(0) == '[' &&
                 addressLiteral.length() > 2 &&

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -1618,6 +1618,9 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      */
     public static InetAddress ofLiteral(String ipAddressLiteral) {
         Objects.requireNonNull(ipAddressLiteral);
+        if (ipAddressLiteral.isEmpty()) {
+            throw IPAddressUtil.invalidIpAddressLiteral(ipAddressLiteral);
+        }
         InetAddress inetAddress;
         try {
             // First try to parse the input as an IPv4 address literal

--- a/test/jdk/java/net/InetAddress/OfLiteralTest.java
+++ b/test/jdk/java/net/InetAddress/OfLiteralTest.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8272215 8315767
+ * @bug 8272215 8315767 8332686
  * @summary Test for ofLiteral, ofPosixLiteral APIs in InetAddress classes
  * @run junit/othervm -Djdk.net.hosts.file=nonExistingHostsFile.txt
  *                     OfLiteralTest
@@ -373,7 +373,12 @@ public class OfLiteralTest {
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, ""),            // empty
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "0x1FFFFFFFF"), // 2^33 - 1 is too large
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "0x100000000"), // 2^32 is too large
-                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "040000000000")
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "040000000000"),
+
+                // Empty literals
+                Arguments.of(InetAddressClass.INET_ADDRESS, ""),
+                Arguments.of(InetAddressClass.INET4_ADDRESS, ""),
+                Arguments.of(InetAddressClass.INET6_ADDRESS, "")
         );
         // Construct arguments for a test case with IPv6-scoped address with scope-id
         // specified as a string with non-existing network interface name

--- a/test/jdk/java/net/InetAddress/OfLiteralTest.java
+++ b/test/jdk/java/net/InetAddress/OfLiteralTest.java
@@ -378,7 +378,13 @@ public class OfLiteralTest {
                 // Empty literals
                 Arguments.of(InetAddressClass.INET_ADDRESS, ""),
                 Arguments.of(InetAddressClass.INET4_ADDRESS, ""),
-                Arguments.of(InetAddressClass.INET6_ADDRESS, "")
+                Arguments.of(InetAddressClass.INET6_ADDRESS, ""),
+
+                // Blank literals
+                Arguments.of(InetAddressClass.INET_ADDRESS, "    "),
+                Arguments.of(InetAddressClass.INET4_ADDRESS, "    "),
+                Arguments.of(InetAddressClass.INET6_ADDRESS, "    "),
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "    ")
         );
         // Construct arguments for a test case with IPv6-scoped address with scope-id
         // specified as a string with non-existing network interface name


### PR DESCRIPTION
The proposed change fixes `InetAddress.ofLiteral` and `Inet6Address.ofLiteral` to throw `IllegalArgumentException` instead of `StringIndexOutOfBoundsException` when an empty IP addres literal string is specified.   
The `Inet4Address.ofLiteral` correctly throws `IllegalArgumentException` when a literal cannot be parsed as an IPv4 address literal. It was addressed before in [JDK-8315767](https://bugs.openjdk.org/browse/JDK-8315767) fix.

Testing: the modified `OfLiteralTest` test and other tests from `jdk-tier1` to `jdk-tier3` tiers

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332686](https://bugs.openjdk.org/browse/JDK-8332686): InetAddress.ofLiteral can throw StringIndexOutOfBoundsException (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22518/head:pull/22518` \
`$ git checkout pull/22518`

Update a local copy of the PR: \
`$ git checkout pull/22518` \
`$ git pull https://git.openjdk.org/jdk.git pull/22518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22518`

View PR using the GUI difftool: \
`$ git pr show -t 22518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22518.diff">https://git.openjdk.org/jdk/pull/22518.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22518#issuecomment-2514958264)
</details>
