### PR TITLE
8345404: [ppc64le] ProblemList TestAllocOutOfMemory.java#large

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -95,7 +95,7 @@ gc/TestAlwaysPreTouchBehavior.java#G1 8334513 generic-all
 gc/TestAlwaysPreTouchBehavior.java#Z 8334513 generic-all
 gc/TestAlwaysPreTouchBehavior.java#Epsilon 8334513 generic-all
 gc/stress/gclocker/TestExcessGCLockerCollections.java 8229120 generic-all
-gc/shenandoah/oom/TestAllocOutOfMemory.java 8344312 linux-ppc64le
+gc/shenandoah/oom/TestAllocOutOfMemory.java#large 8344312 linux-ppc64le
 
 #############################################################################
 


### PR DESCRIPTION
The current problem listing of the test is broken because of [CODETOOLS-7902265](https://bugs.openjdk.org/browse/CODETOOLS-7902265) so we have to adjust it and add '#large' .
Seems the other subtests do not fail so I do not exclude them, just '#large' .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345404](https://bugs.openjdk.org/browse/JDK-8345404): [ppc64le] ProblemList TestAllocOutOfMemory.java#large (**Sub-task** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22520/head:pull/22520` \
`$ git checkout pull/22520`

Update a local copy of the PR: \
`$ git checkout pull/22520` \
`$ git pull https://git.openjdk.org/jdk.git pull/22520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22520`

View PR using the GUI difftool: \
`$ git pr show -t 22520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22520.diff">https://git.openjdk.org/jdk/pull/22520.diff</a>

</details>
