### PR TITLE
8343957: Rename ObjectMonitor::owner_from() and JavaThread::_lock_id

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -206,8 +206,8 @@ void C2_MacroAssembler::fast_lock(Register objectReg, Register boxReg, Register 
   // Handle existing monitor.
   bind(object_has_monitor);
 
-  // Try to CAS owner (no owner => current thread's _lock_id).
-  ldr(rscratch2, Address(rthread, JavaThread::lock_id_offset()));
+  // Try to CAS owner (no owner => current thread's _monitor_owner_id).
+  ldr(rscratch2, Address(rthread, JavaThread::monitor_owner_id_offset()));
   add(tmp, disp_hdr, (in_bytes(ObjectMonitor::owner_offset())-markWord::monitor_value));
   cmpxchg(tmp, zr, rscratch2, Assembler::xword, /*acquire*/ true,
           /*release*/ true, /*weak*/ false, tmp3Reg); // Sets flags for result
@@ -469,8 +469,8 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
     // Compute owner address.
     lea(t2_owner_addr, owner_address);
 
-    // Try to CAS owner (no owner => current thread's _lock_id).
-    ldr(rscratch2, Address(rthread, JavaThread::lock_id_offset()));
+    // Try to CAS owner (no owner => current thread's _monitor_owner_id).
+    ldr(rscratch2, Address(rthread, JavaThread::monitor_owner_id_offset()));
     cmpxchg(t2_owner_addr, zr, rscratch2, Assembler::xword, /*acquire*/ true,
             /*release*/ false, /*weak*/ false, t3_owner);
     br(Assembler::EQ, monitor_locked);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -2664,10 +2664,10 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
   // Handle existing monitor.
   bind(object_has_monitor);
 
-  // Try to CAS owner (no owner => current thread's _lock_id).
+  // Try to CAS owner (no owner => current thread's _monitor_owner_id).
   addi(temp, displaced_header, in_bytes(ObjectMonitor::owner_offset()) - markWord::monitor_value);
   Register thread_id = displaced_header;
-  ld(thread_id, in_bytes(JavaThread::lock_id_offset()), R16_thread);
+  ld(thread_id, in_bytes(JavaThread::monitor_owner_id_offset()), R16_thread);
   cmpxchgd(/*flag=*/flag,
            /*current_value=*/current_header,
            /*compare_value=*/(intptr_t)0,
@@ -2944,9 +2944,9 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(ConditionRegister fla
       addi(owner_addr, monitor, in_bytes(ObjectMonitor::owner_offset()));
     }
 
-    // Try to CAS owner (no owner => current thread's _lock_id).
+    // Try to CAS owner (no owner => current thread's _monitor_owner_id).
     assert_different_registers(thread_id, monitor, owner_addr, box, R0);
-    ld(thread_id, in_bytes(JavaThread::lock_id_offset()), R16_thread);
+    ld(thread_id, in_bytes(JavaThread::monitor_owner_id_offset()), R16_thread);
     cmpxchgd(/*flag=*/CCR0,
             /*current_value=*/R0,
             /*compare_value=*/(intptr_t)0,

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -116,10 +116,10 @@ void C2_MacroAssembler::fast_lock(Register objectReg, Register boxReg,
   // Handle existing monitor.
   bind(object_has_monitor);
 
-  // Try to CAS owner (no owner => current thread's _lock_id).
+  // Try to CAS owner (no owner => current thread's _monitor_owner_id).
   add(tmp, disp_hdr, (in_bytes(ObjectMonitor::owner_offset()) - markWord::monitor_value));
   Register tid = tmp4Reg;
-  ld(tid, Address(xthread, JavaThread::lock_id_offset()));
+  ld(tid, Address(xthread, JavaThread::monitor_owner_id_offset()));
   cmpxchg(/*memory address*/tmp, /*expected value*/zr, /*new value*/tid, Assembler::int64,
           Assembler::aq, Assembler::rl, /*result*/tmp3Reg); // cas succeeds if tmp3Reg == zr(expected)
 
@@ -400,9 +400,9 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box,
     // Compute owner address.
     la(tmp2_owner_addr, owner_address);
 
-    // Try to CAS owner (no owner => current thread's _lock_id).
+    // Try to CAS owner (no owner => current thread's _monitor_owner_id).
     Register tid = tmp4;
-    ld(tid, Address(xthread, JavaThread::lock_id_offset()));
+    ld(tid, Address(xthread, JavaThread::monitor_owner_id_offset()));
     cmpxchg(/*addr*/ tmp2_owner_addr, /*expected*/ zr, /*new*/ tid, Assembler::int64,
             /*acquire*/ Assembler::aq, /*release*/ Assembler::relaxed, /*result*/ tmp3_owner);
     beqz(tmp3_owner, monitor_locked);

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3573,11 +3573,11 @@ void MacroAssembler::compiler_fast_lock_object(Register oop, Register box, Regis
   Register zero = temp;
   Register monitor_tagged = displacedHeader; // Tagged with markWord::monitor_value.
 
-  // Try to CAS owner (no owner => current thread's _lock_id).
+  // Try to CAS owner (no owner => current thread's _monitor_owner_id).
   // If csg succeeds then CR=EQ, otherwise, register zero is filled
   // with the current owner.
   z_lghi(zero, 0);
-  z_lg(Z_R0_scratch, Address(Z_thread, JavaThread::lock_id_offset()));
+  z_lg(Z_R0_scratch, Address(Z_thread, JavaThread::monitor_owner_id_offset()));
   z_csg(zero, Z_R0_scratch, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner), monitor_tagged);
 
   // Store a non-null value into the box.
@@ -3652,7 +3652,7 @@ void MacroAssembler::compiler_fast_unlock_object(Register oop, Register box, Reg
   // Handle existing monitor.
   bind(object_has_monitor);
 
-  z_lg(Z_R0_scratch, Address(Z_thread, JavaThread::lock_id_offset()));
+  z_lg(Z_R0_scratch, Address(Z_thread, JavaThread::monitor_owner_id_offset()));
   z_cg(Z_R0_scratch, Address(currentHeader, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)));
   z_brne(done);
 
@@ -6356,11 +6356,11 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(Register obj, Registe
     const Address recursions_address(tmp1_monitor, ObjectMonitor::recursions_offset() - monitor_tag);
 
 
-    // Try to CAS owner (no owner => current thread's _lock_id).
+    // Try to CAS owner (no owner => current thread's _monitor_owner_id).
     // If csg succeeds then CR=EQ, otherwise, register zero is filled
     // with the current owner.
     z_lghi(zero, 0);
-    z_lg(Z_R0_scratch, Address(Z_thread, JavaThread::lock_id_offset()));
+    z_lg(Z_R0_scratch, Address(Z_thread, JavaThread::monitor_owner_id_offset()));
     z_csg(zero, Z_R0_scratch, owner_address);
     z_bre(monitor_locked);
 

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -319,7 +319,7 @@ void C2_MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmp
   movptr(Address(boxReg, 0), checked_cast<int32_t>(markWord::unused_mark().value()));
 
   // It's inflated and we use scrReg for ObjectMonitor* in this section.
-  movptr(boxReg, Address(r15_thread, JavaThread::lock_id_offset()));
+  movptr(boxReg, Address(r15_thread, JavaThread::monitor_owner_id_offset()));
   movq(scrReg, tmpReg);
   xorq(tmpReg, tmpReg);
   lock();
@@ -625,9 +625,9 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
       movptr(Address(box, BasicLock::object_monitor_cache_offset_in_bytes()), monitor);
     }
 
-    // Try to CAS owner (no owner => current thread's _lock_id).
+    // Try to CAS owner (no owner => current thread's _monitor_owner_id).
     xorptr(rax_reg, rax_reg);
-    movptr(box, Address(thread, JavaThread::lock_id_offset()));
+    movptr(box, Address(thread, JavaThread::monitor_owner_id_offset()));
     lock(); cmpxchgptr(box, owner_address);
     jccb(Assembler::equal, monitor_locked);
 

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -227,7 +227,7 @@
   nonstatic_field(JavaThread,                  _vthread,                                      OopHandle)                             \
   nonstatic_field(JavaThread,                  _scopedValueCache,                             OopHandle)                             \
   nonstatic_field(JavaThread,                  _anchor,                                       JavaFrameAnchor)                       \
-  nonstatic_field(JavaThread,                  _lock_id,                                      int64_t)                               \
+  nonstatic_field(JavaThread,                  _monitor_owner_id,                             int64_t)                               \
   nonstatic_field(JavaThread,                  _vm_result,                                    oop)                                   \
   nonstatic_field(JavaThread,                  _stack_overflow_state._stack_overflow_limit,   address)                               \
   volatile_nonstatic_field(JavaThread,         _exception_oop,                                oop)                                   \

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3682,10 +3682,10 @@ bool LibraryCallKit::inline_native_setCurrentThread() {
   const TypePtr *adr_type = _gvn.type(thread_obj_handle)->isa_ptr();
   access_store_at(nullptr, thread_obj_handle, adr_type, arr, _gvn.type(arr), T_OBJECT, IN_NATIVE | MO_UNORDERED);
 
-  // Change the lock_id of the JavaThread
+  // Change the _monitor_owner_id of the JavaThread
   Node* tid = load_field_from_object(arr, "tid", "J");
-  Node* thread_id_offset = basic_plus_adr(thread, in_bytes(JavaThread::lock_id_offset()));
-  Node* tid_memory = store_to_memory(control(), thread_id_offset, tid, T_LONG, MemNode::unordered, true);
+  Node* monitor_owner_id_offset = basic_plus_adr(thread, in_bytes(JavaThread::monitor_owner_id_offset()));
+  store_to_memory(control(), monitor_owner_id_offset, tid, T_LONG, MemNode::unordered, true);
 
   JFR_ONLY(extend_setCurrentThread(thread, arr);)
   return true;

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2977,8 +2977,8 @@ JVM_ENTRY(void, JVM_SetCurrentThread(JNIEnv* env, jobject thisThread,
   oop threadObj = JNIHandles::resolve(theThread);
   thread->set_vthread(threadObj);
 
-  // Set lock id of new current Thread
-  thread->set_lock_id(java_lang_Thread::thread_id(threadObj));
+  // Set _monitor_owner_id of new current Thread
+  thread->set_monitor_owner_id(java_lang_Thread::thread_id(threadObj));
 
   JFR_ONLY(Jfr::on_set_current_thread(thread, threadObj);)
 JVM_END

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -236,8 +236,8 @@ void JavaThread::allocate_threadObj(Handle thread_group, const char* thread_name
   // constructor calls Thread.current(), which must be set here.
   java_lang_Thread::set_thread(thread_oop(), this);
   set_threadOopHandles(thread_oop());
-  // Set the lock_id to the next thread_id temporarily while initialization runs.
-  set_lock_id(ThreadIdentifier::next());
+  // Set the _monitor_owner_id to the next thread_id temporarily while initialization runs.
+  set_monitor_owner_id(ThreadIdentifier::next());
 
   JavaValue result(T_VOID);
   if (thread_name != nullptr) {
@@ -263,8 +263,8 @@ void JavaThread::allocate_threadObj(Handle thread_group, const char* thread_name
                             Handle(),
                             CHECK);
   }
-  // Update the lock_id with the tid value.
-  set_lock_id(java_lang_Thread::thread_id(thread_oop()));
+  // Update the _monitor_owner_id with the tid value.
+  set_monitor_owner_id(java_lang_Thread::thread_id(thread_oop()));
 
   os::set_priority(this, NormPriority);
 
@@ -435,7 +435,7 @@ JavaThread::JavaThread(MemTag mem_tag) :
   _current_waiting_monitor(nullptr),
   _active_handles(nullptr),
   _free_handle_block(nullptr),
-  _lock_id(0),
+  _monitor_owner_id(0),
 
   _suspend_flags(0),
 
@@ -1540,8 +1540,7 @@ void JavaThread::print_on(outputStream *st, bool print_extended_info) const {
   st->print_cr("[" INTPTR_FORMAT "]", (intptr_t)last_Java_sp() & ~right_n_bits(12));
   if (thread_oop != nullptr) {
     if (is_vthread_mounted()) {
-      // _lock_id is the thread ID of the mounted virtual thread
-      st->print_cr("   Carrying virtual thread #" INT64_FORMAT, lock_id());
+      st->print_cr("   Carrying virtual thread #" INT64_FORMAT, java_lang_Thread::thread_id(vthread()));
     } else {
       st->print_cr("   java.lang.Thread.State: %s", java_lang_Thread::thread_status_name(thread_oop));
     }
@@ -1725,7 +1724,7 @@ void JavaThread::prepare(jobject jni_thread, ThreadPriority prio) {
   assert(InstanceKlass::cast(thread_oop->klass())->is_linked(),
          "must be initialized");
   set_threadOopHandles(thread_oop());
-  set_lock_id(java_lang_Thread::thread_id(thread_oop()));
+  set_monitor_owner_id(java_lang_Thread::thread_id(thread_oop()));
 
   if (prio == NoPriority) {
     prio = java_lang_Thread::priority(thread_oop());
@@ -2230,7 +2229,7 @@ void JavaThread::start_internal_daemon(JavaThread* current, JavaThread* target,
 
   // Now bind the thread_oop to the target JavaThread.
   target->set_threadOopHandles(thread_oop());
-  target->set_lock_id(java_lang_Thread::thread_id(thread_oop()));
+  target->set_monitor_owner_id(java_lang_Thread::thread_id(thread_oop()));
 
   Threads::add(target); // target is now visible for safepoint/handshake
   // Publish the JavaThread* in java.lang.Thread after the JavaThread* is

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -169,9 +169,9 @@ class JavaThread: public Thread {
   int64_t _monitor_owner_id;
 
  public:
-  void set_monitor_owner_id(int64_t val) {
-    assert(val >= ThreadIdentifier::initial() && val < ThreadIdentifier::current(), "");
-    _monitor_owner_id = val;
+  void set_monitor_owner_id(int64_t id) {
+    assert(id >= ThreadIdentifier::initial() && id < ThreadIdentifier::current(), "");
+    _monitor_owner_id = id;
   }
   int64_t monitor_owner_id() const { return _monitor_owner_id; }
 

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -166,14 +166,14 @@ class JavaThread: public Thread {
   // ID used as owner for inflated monitors. Same as the j.l.Thread.tid of the
   // current _vthread object, except during creation of the primordial and JNI
   // attached thread cases where this field can have a temporary value.
-  int64_t _lock_id;
+  int64_t _monitor_owner_id;
 
  public:
-  void set_lock_id(int64_t tid) {
-    assert(tid >= ThreadIdentifier::initial() && tid < ThreadIdentifier::current(), "invalid tid");
-    _lock_id = tid;
+  void set_monitor_owner_id(int64_t val) {
+    assert(val >= ThreadIdentifier::initial() && val < ThreadIdentifier::current(), "");
+    _monitor_owner_id = val;
   }
-  int64_t lock_id() const { return _lock_id; }
+  int64_t monitor_owner_id() const { return _monitor_owner_id; }
 
   // For tracking the heavyweight monitor the thread is pending on.
   ObjectMonitor* current_pending_monitor() {
@@ -884,7 +884,7 @@ private:
   static ByteSize doing_unsafe_access_offset() { return byte_offset_of(JavaThread, _doing_unsafe_access); }
   NOT_PRODUCT(static ByteSize requires_cross_modify_fence_offset()  { return byte_offset_of(JavaThread, _requires_cross_modify_fence); })
 
-  static ByteSize lock_id_offset()            { return byte_offset_of(JavaThread, _lock_id); }
+  static ByteSize monitor_owner_id_offset()   { return byte_offset_of(JavaThread, _monitor_owner_id); }
 
   static ByteSize cont_entry_offset()         { return byte_offset_of(JavaThread, _cont_entry); }
   static ByteSize cont_fastpath_offset()      { return byte_offset_of(JavaThread, _cont_fastpath); }

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -124,7 +124,7 @@ ParkEvent* ObjectMonitor::_vthread_unparker_ParkEvent = nullptr;
 //
 // * A thread acquires ownership of a monitor by successfully
 //   CAS()ing the _owner field from NO_OWNER/DEFLATER_MARKER to
-//   its tid (return value from owner_from()).
+//   its owner_id (return value from owner_id_from()).
 //
 // * Invariant: A thread appears on at most one monitor list --
 //   cxq, EntryList or WaitSet -- at any one time.
@@ -331,7 +331,7 @@ bool ObjectMonitor::TryLockWithContentionMark(JavaThread* locking_thread, Object
   if (prev_owner == NO_OWNER) {
     assert(_recursions == 0, "invariant");
     success = true;
-  } else if (prev_owner == owner_from(locking_thread)) {
+  } else if (prev_owner == owner_id_from(locking_thread)) {
     _recursions++;
     success = true;
   } else if (prev_owner == DEFLATER_MARKER) {
@@ -1548,7 +1548,7 @@ void ObjectMonitor::ExitEpilog(JavaThread* current, ObjectWaiter* Wakee) {
 }
 
 // Exits the monitor returning recursion count. _owner should
-// be set to current's tid, i.e. no ANONYMOUS_OWNER allowed.
+// be set to current's owner_id, i.e. no ANONYMOUS_OWNER allowed.
 intx ObjectMonitor::complete_exit(JavaThread* current) {
   assert(InitDone, "Unexpectedly not initialized");
   guarantee(has_owner(current), "complete_exit not owner");
@@ -1580,7 +1580,7 @@ intx ObjectMonitor::complete_exit(JavaThread* current) {
 bool ObjectMonitor::check_owner(TRAPS) {
   JavaThread* current = THREAD;
   int64_t cur = owner_raw();
-  if (cur == owner_from(current)) {
+  if (cur == owner_id_from(current)) {
     return true;
   }
   THROW_MSG_(vmSymbols::java_lang_IllegalMonitorStateException(),

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -170,7 +170,7 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   static const int64_t ANONYMOUS_OWNER = 1;
   static const int64_t DEFLATER_MARKER = 2;
 
-  int64_t volatile _owner;  // Either tid of owner, NO_OWNER, ANONYMOUS_OWNER or DEFLATER_MARKER.
+  int64_t volatile _owner;  // Either owner_id of owner, NO_OWNER, ANONYMOUS_OWNER or DEFLATER_MARKER.
   volatile uint64_t _previous_owner_tid;  // thread id of the previous owner of the monitor
   // Separate _owner and _next_om on different cache lines since
   // both can have busy multi-threaded access. _previous_owner_tid is only
@@ -284,25 +284,25 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   int64_t   owner_raw() const;
 
   // These methods return the value we set in _owner when acquiring
-  // the monitor with the given thread/vthread (tid).
-  static int64_t owner_from(JavaThread* thread);
-  static int64_t owner_from(oop vthread);
+  // the monitor with the given thread/vthread, AKA owner_id.
+  static int64_t owner_id_from(JavaThread* thread);
+  static int64_t owner_id_from(oop vthread);
 
   // Returns true if owner field == DEFLATER_MARKER and false otherwise.
   bool      owner_is_DEFLATER_MARKER() const;
   // Returns true if 'this' is being async deflated and false otherwise.
   bool      is_being_async_deflated();
-  // Clear _owner field; current value must match thread's tid.
+  // Clear _owner field; current value must match thread's owner_id.
   void      release_clear_owner(JavaThread* thread);
   // Simply set _owner field to new_value; current value must match old_value.
   void      set_owner_from_raw(int64_t old_value, int64_t new_value);
-  // Same as above but uses tid of current as new value.
+  // Same as above but uses owner_id of current as new value.
   void      set_owner_from(int64_t old_value, JavaThread* current);
   // Try to set _owner field to new_value if the current value matches
   // old_value, using Atomic::cmpxchg(). Otherwise, does not change the
   // _owner field. Returns the prior value of the _owner field.
   int64_t   try_set_owner_from_raw(int64_t old_value, int64_t new_value);
-  // Same as above but uses tid of current as new_value.
+  // Same as above but uses owner_id of current as new_value.
   int64_t   try_set_owner_from(int64_t old_value, JavaThread* current);
 
   // Methods to check and set _succ. The successor is the thread selected
@@ -316,11 +316,11 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   void      clear_successor();
   int64_t   successor() const;
 
-  // Returns true if _owner field == tid of thread, false otherwise.
-  bool has_owner(JavaThread* thread) const { return owner() == owner_from(thread); }
-  // Set _owner field to tid of thread; current value must be NO_OWNER.
+  // Returns true if _owner field == owner_id of thread, false otherwise.
+  bool has_owner(JavaThread* thread) const { return owner() == owner_id_from(thread); }
+  // Set _owner field to owner_id of thread; current value must be NO_OWNER.
   void set_owner(JavaThread* thread) { set_owner_from(NO_OWNER, thread); }
-  // Try to set _owner field from NO_OWNER to tid of thread.
+  // Try to set _owner field from NO_OWNER to owner_id of thread.
   bool try_set_owner(JavaThread* thread) {
     return try_set_owner_from(NO_OWNER, thread) == NO_OWNER;
   }

--- a/src/hotspot/share/runtime/objectMonitor.inline.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.inline.hpp
@@ -39,16 +39,16 @@
 #include "utilities/checkedCast.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-inline int64_t ObjectMonitor::owner_from(JavaThread* thread) {
-  int64_t tid = thread->lock_id();
-  assert(tid >= ThreadIdentifier::initial() && tid < ThreadIdentifier::current(), "must be reasonable");
-  return tid;
+inline int64_t ObjectMonitor::owner_id_from(JavaThread* thread) {
+  int64_t id = thread->monitor_owner_id();
+  assert(id >= ThreadIdentifier::initial() && id < ThreadIdentifier::current(), "must be reasonable");
+  return id;
 }
 
-inline int64_t ObjectMonitor::owner_from(oop vthread) {
-  int64_t tid = java_lang_Thread::thread_id(vthread);
-  assert(tid >= ThreadIdentifier::initial() && tid < ThreadIdentifier::current(), "must be reasonable");
-  return tid;
+inline int64_t ObjectMonitor::owner_id_from(oop vthread) {
+  int64_t id = java_lang_Thread::thread_id(vthread);
+  assert(id >= ThreadIdentifier::initial() && id < ThreadIdentifier::current(), "must be reasonable");
+  return id;
 }
 
 inline bool ObjectMonitor::is_entered(JavaThread* current) const {
@@ -153,7 +153,7 @@ inline void ObjectMonitor::set_recursions(size_t recursions) {
 
 // Clear _owner field; current value must match old_value.
 inline void ObjectMonitor::release_clear_owner(JavaThread* old_owner) {
-  int64_t old_value = owner_from(old_owner);
+  int64_t old_value = owner_id_from(old_owner);
 #ifdef ASSERT
   int64_t prev = Atomic::load(&_owner);
   assert(prev == old_value, "unexpected prev owner=" INT64_FORMAT
@@ -182,7 +182,7 @@ inline void ObjectMonitor::set_owner_from_raw(int64_t old_value, int64_t new_val
 }
 
 inline void ObjectMonitor::set_owner_from(int64_t old_value, JavaThread* current) {
-  set_owner_from_raw(old_value, owner_from(current));
+  set_owner_from_raw(old_value, owner_id_from(current));
 }
 
 // Try to set _owner field to new_value if the current value matches
@@ -201,7 +201,7 @@ inline int64_t ObjectMonitor::try_set_owner_from_raw(int64_t old_value, int64_t 
 }
 
 inline int64_t ObjectMonitor::try_set_owner_from(int64_t old_value, JavaThread* current) {
-  return try_set_owner_from_raw(old_value, owner_from(current));
+  return try_set_owner_from_raw(old_value, owner_id_from(current));
 }
 
 inline bool ObjectMonitor::has_successor() const {
@@ -209,11 +209,11 @@ inline bool ObjectMonitor::has_successor() const {
 }
 
 inline bool ObjectMonitor::has_successor(JavaThread* thread) const {
-  return owner_from(thread) == Atomic::load(&_succ);
+  return owner_id_from(thread) == Atomic::load(&_succ);
 }
 
 inline void ObjectMonitor::set_successor(JavaThread* thread) {
-  Atomic::store(&_succ, owner_from(thread));
+  Atomic::store(&_succ, owner_id_from(thread));
 }
 
 inline void ObjectMonitor::set_successor(oop vthread) {

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1243,13 +1243,13 @@ void ObjectSynchronizer::owned_monitors_iterate_filtered(MonitorClosure* closure
 // Iterate ObjectMonitors where the owner == thread; this does NOT include
 // ObjectMonitors where owner is set to a stack-lock address in thread.
 void ObjectSynchronizer::owned_monitors_iterate(MonitorClosure* closure, JavaThread* thread) {
-  int64_t key = ObjectMonitor::owner_from(thread);
+  int64_t key = ObjectMonitor::owner_id_from(thread);
   auto thread_filter = [&](ObjectMonitor* monitor) { return monitor->owner() == key; };
   return owned_monitors_iterate_filtered(closure, thread_filter);
 }
 
 void ObjectSynchronizer::owned_monitors_iterate(MonitorClosure* closure, oop vthread) {
-  int64_t key = ObjectMonitor::owner_from(vthread);
+  int64_t key = ObjectMonitor::owner_id_from(vthread);
   auto thread_filter = [&](ObjectMonitor* monitor) { return monitor->owner() == key; };
   return owned_monitors_iterate_filtered(closure, thread_filter);
 }

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -368,7 +368,7 @@ class ObjectMonitorsDump : public MonitorClosure, public ObjectMonitorsView {
 
   // Implements the ObjectMonitorsView interface
   void visit(MonitorClosure* closure, JavaThread* thread) override {
-    int64_t key = ObjectMonitor::owner_from(thread);
+    int64_t key = ObjectMonitor::owner_id_from(thread);
     ObjectMonitorLinkedList* list = get_list(key);
     LinkedListIterator<ObjectMonitor*> iter(list != nullptr ? list->head() : nullptr);
     while (!iter.is_empty()) {

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -664,7 +664,7 @@
   nonstatic_field(JavaThread,                  _vframe_array_head,                            vframeArray*)                          \
   nonstatic_field(JavaThread,                  _vframe_array_last,                            vframeArray*)                          \
   nonstatic_field(JavaThread,                  _active_handles,                               JNIHandleBlock*)                       \
-  nonstatic_field(JavaThread,                  _lock_id,                                      int64_t)                               \
+  nonstatic_field(JavaThread,                  _monitor_owner_id,                             int64_t)                               \
   volatile_nonstatic_field(JavaThread,         _terminated,                                   JavaThread::TerminatedTypes)           \
   nonstatic_field(Thread,                      _osthread,                                     OSThread*)                             \
   nonstatic_field(Thread,                      _resource_area,                                ResourceArea*)                         \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
@@ -55,7 +55,7 @@ public class JavaThread extends Thread {
   private static CIntegerField stackSizeField;
   private static CIntegerField terminatedField;
   private static AddressField activeHandlesField;
-  private static CIntegerField lockIdField;
+  private static CIntegerField monitorOwnerIDField;
   private static long oopPtrSize;
 
   private static JavaThreadPDAccess access;
@@ -102,7 +102,7 @@ public class JavaThread extends Thread {
     stackSizeField    = type.getCIntegerField("_stack_size");
     terminatedField   = type.getCIntegerField("_terminated");
     activeHandlesField = type.getAddressField("_active_handles");
-    lockIdField        = type.getCIntegerField("_lock_id");
+    monitorOwnerIDField = type.getCIntegerField("_monitor_owner_id");
 
     lockStackTopOffset = type.getField("_lock_stack").getOffset() + typeLockStack.getField("_top").getOffset();
     lockStackBaseOffset = type.getField("_lock_stack").getOffset() + typeLockStack.getField("_base[0]").getOffset();
@@ -378,8 +378,8 @@ public class JavaThread extends Thread {
     return OopUtilities.threadOopGetName(threadObj);
   }
 
-  public Address getLockId() {
-    return lockIdField.getAddress(addr);
+  public Address getMonitorOwnerID() {
+    return monitorOwnerIDField.getAddress(addr);
   }
 
   //

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -213,7 +213,7 @@ public class Threads {
         if (o == null) return null;
         for (int i = 0; i < getNumberOfThreads(); i++) {
             JavaThread thread = getJavaThreadAt(i);
-            if (o.equals(thread.getLockId())) {
+            if (o.equals(thread.getMonitorOwnerID())) {
                 return thread;
             }
         }


### PR DESCRIPTION
Please review this small renaming patch. During the review of JDK-8338383 there were some comments about improving the naming for `ObjectMonitor::owner_from()` and `JavaThread::_lock_id`. These originate from the changes introduced to inflated monitors, where we now record the `java.lang.Thread.tid` of the owner in the ObjectMonitor's `_owner` field instead of a `JavaThread*`. I renamed `_lock_id` as `_monitor_owner_id` and `owner_from()` as `owner_id_from()`.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343957](https://bugs.openjdk.org/browse/JDK-8343957): Rename ObjectMonitor::owner_from() and JavaThread::_lock_id (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [108abc2b](https://git.openjdk.org/jdk/pull/22524/files/108abc2b0f150dd620b64dd4d3d2375c5dfecc0b)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22524/head:pull/22524` \
`$ git checkout pull/22524`

Update a local copy of the PR: \
`$ git checkout pull/22524` \
`$ git pull https://git.openjdk.org/jdk.git pull/22524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22524`

View PR using the GUI difftool: \
`$ git pr show -t 22524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22524.diff">https://git.openjdk.org/jdk/pull/22524.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22524#issuecomment-2515456982)
</details>
