### PR TITLE
8345438: Invalid error for return in early construction context lambda

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4083,6 +4083,29 @@ public class Check {
         public void visitClassDef(JCClassDecl tree) {
             // don't descend any further
         }
+
+        @Override
+        public void visitLambda(JCLambda tree) {
+            final boolean constructorPrev = constructor;
+            final boolean firstStatementPrev = firstStatement;
+            final JCReturn earlyReturnPrev = earlyReturn;
+            final Name initCallPrev = initCall;
+            final int scanDepthPrev = scanDepth;
+            constructor = false;
+            firstStatement = false;
+            earlyReturn = null;
+            initCall = null;
+            scanDepth = 0;
+            try {
+                super.visitLambda(tree);
+            } finally {
+                constructor = constructorPrev;
+                firstStatement = firstStatementPrev;
+                earlyReturn = earlyReturnPrev;
+                initCall = initCallPrev;
+                scanDepth = scanDepthPrev;
+            }
+        }
     }
 
 /* *************************************************************************

--- a/test/langtools/tools/javac/SuperInit/EarlyLambdaReturn.java
+++ b/test/langtools/tools/javac/SuperInit/EarlyLambdaReturn.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8345438
+ * @summary Verify 'return' allowed in a lambda declared in an early construction context
+ * @enablePreview
+ */
+public class EarlyLambdaReturn {
+
+    public EarlyLambdaReturn() {
+        Runnable r = () -> {
+            return;
+        };
+        super();
+        r.run();
+    }
+
+    public static void main(String[] args) {
+        new EarlyLambdaReturn();
+    }
+}

--- a/test/langtools/tools/javac/SuperInit/SuperInitFails.java
+++ b/test/langtools/tools/javac/SuperInit/SuperInitFails.java
@@ -186,4 +186,27 @@ public class SuperInitFails extends AtomicReference<Object> implements Iterable<
         Runnable r = () -> this.x = 7;  // this should FAIL
         super();
     }
+
+    public static class Inner4 {
+        Inner4() {
+            Runnable r = () -> {
+                class A {
+                    A() {
+                        return;         // this should FAIL
+                        super();
+                    }
+                    A(int x) {
+                        {
+                            this();     // this should FAIL
+                        }
+                    }
+                    A(char x) {
+                        super();
+                        this();         // this should FAIL
+                    }
+                }
+            };
+            super();
+        };
+    }
 }

--- a/test/langtools/tools/javac/SuperInit/SuperInitFails.out
+++ b/test/langtools/tools/javac/SuperInit/SuperInitFails.out
@@ -27,7 +27,7 @@ SuperInitFails.java:49:33: compiler.err.call.must.only.appear.in.ctor
 SuperInitFails.java:53:32: compiler.err.call.must.only.appear.in.ctor
 SuperInitFails.java:83:18: compiler.err.ctor.calls.not.allowed.here
 SuperInitFails.java:89:13: compiler.err.return.before.superclass.initialized
-SuperInitFails.java:150:18: compiler.err.ctor.calls.not.allowed.here
+SuperInitFails.java:150:18: compiler.err.call.must.only.appear.in.ctor
 - compiler.note.preview.filename: SuperInitFails.java, DEFAULT
 - compiler.note.preview.recompile
 30 errors

--- a/test/langtools/tools/javac/SuperInit/SuperInitFails.out
+++ b/test/langtools/tools/javac/SuperInit/SuperInitFails.out
@@ -19,6 +19,9 @@ SuperInitFails.java:172:17: compiler.err.cant.ref.before.ctor.called: x
 SuperInitFails.java:176:24: compiler.err.cant.ref.before.ctor.called: x
 SuperInitFails.java:180:18: compiler.err.cant.ref.before.ctor.called: x
 SuperInitFails.java:186:28: compiler.err.cant.ref.before.ctor.called: this
+SuperInitFails.java:195:25: compiler.err.return.before.superclass.initialized
+SuperInitFails.java:200:33: compiler.err.ctor.calls.not.allowed.here
+SuperInitFails.java:205:29: compiler.err.redundant.superclass.init
 SuperInitFails.java:33:13: compiler.err.call.must.only.appear.in.ctor
 SuperInitFails.java:37:14: compiler.err.call.must.only.appear.in.ctor
 SuperInitFails.java:41:14: compiler.err.call.must.only.appear.in.ctor
@@ -30,4 +33,4 @@ SuperInitFails.java:89:13: compiler.err.return.before.superclass.initialized
 SuperInitFails.java:150:18: compiler.err.call.must.only.appear.in.ctor
 - compiler.note.preview.filename: SuperInitFails.java, DEFAULT
 - compiler.note.preview.recompile
-30 errors
+33 errors

--- a/test/langtools/tools/javac/SuperInit/SuperInitGood.java
+++ b/test/langtools/tools/javac/SuperInit/SuperInitGood.java
@@ -454,6 +454,41 @@ public class SuperInitGood {
         }
     }
 
+    // Lambdas within constructors
+    public static class Test22 {
+        public Test22() {
+            Runnable r = () -> System.out.println();
+            super();
+            r.run();
+        }
+        public Test22(int x) {
+            Runnable r = () -> System.out.println();
+            r.run();
+            super();
+        }
+        public Test22(char x) {
+            Runnable r = () -> {
+                class A {
+                    A() {
+                        return;
+                    }
+                    A(int x) {
+                        Runnable r2 = () -> {
+                            return;
+                        };
+                        this();
+                        r2.run();
+                    }
+                    A(char x) {
+                        this(0);
+                    }
+                }
+                return;
+            };
+            r.run();
+            super();
+        }
+    }
 
     public static void main(String[] args) {
         new Test0();
@@ -499,5 +534,6 @@ public class SuperInitGood {
         new Test20(123);
         new Test21((int)123);
         new Test21((float)123);
+        new Test22('x');
     }
 }


### PR DESCRIPTION
The "Flexible Constructors" JEP feature allows statements to appear before a `super()` invocation, but some restrictions, one of which is that `return` is not allowed. The compiler check for this was being too strict in that it was incorrectly disallowing a `return` statement that was nested inside a lambda, which is OK.

Please review this patch to the `SuperThisChecker` which fixes this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345438](https://bugs.openjdk.org/browse/JDK-8345438): Invalid error for return in early construction context lambda (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) Review applies to [470684f8](https://git.openjdk.org/jdk/pull/22531/files/470684f87ca2619b1a3ffbb341e71d0fc301e84c)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22531/head:pull/22531` \
`$ git checkout pull/22531`

Update a local copy of the PR: \
`$ git checkout pull/22531` \
`$ git pull https://git.openjdk.org/jdk.git pull/22531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22531`

View PR using the GUI difftool: \
`$ git pr show -t 22531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22531.diff">https://git.openjdk.org/jdk/pull/22531.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22531#issuecomment-2516027010)
</details>
