### PR TITLE
8345514: Should use internal class name when calling ClassLoader.getResourceAsByteArray

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2698,8 +2698,8 @@ ClassFileStream* FileMapInfo::get_stream_from_class_loader(Handle class_loader,
                                                            const char* file_name,
                                                            TRAPS) {
   JavaValue result(T_OBJECT);
-  TempNewSymbol class_name_sym = SymbolTable::new_symbol(file_name);
-  Handle ext_class_name = java_lang_String::externalize_classname(class_name_sym, CHECK_NULL);
+  oop class_name = java_lang_String::create_oop_from_str(file_name, THREAD);
+  Handle h_class_name = Handle(THREAD, class_name);
 
   // byte[] ClassLoader.getResourceAsByteArray(String name)
   JavaCalls::call_virtual(&result,
@@ -2707,7 +2707,7 @@ ClassFileStream* FileMapInfo::get_stream_from_class_loader(Handle class_loader,
                           vmClasses::ClassLoader_klass(),
                           vmSymbols::getResourceAsByteArray_name(),
                           vmSymbols::getResourceAsByteArray_signature(),
-                          ext_class_name,
+                          h_class_name,
                           CHECK_NULL);
   assert(result.get_type() == T_OBJECT, "just checking");
   oop obj = result.get_oop();


### PR DESCRIPTION
This patch is for fixing an assert failure in [filemap.cpp](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/cds/filemap.cpp#L2714). It was introduced via JDK-8343427.
The bug is that an external class name (e.g. pkg1.Foo) was passed as the argument when calling the java method `ClassLoader.getResourceAsByteArray()` which expects an internal class name (e.g. pkg1/Foo).
The test case for JDK-8343427 has been updated to include package names in test classes.

Passed tiers 1 - 5 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345514](https://bugs.openjdk.org/browse/JDK-8345514): Should use internal class name when calling ClassLoader.getResourceAsByteArray (**Bug** - P2)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22535/head:pull/22535` \
`$ git checkout pull/22535`

Update a local copy of the PR: \
`$ git checkout pull/22535` \
`$ git pull https://git.openjdk.org/jdk.git pull/22535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22535`

View PR using the GUI difftool: \
`$ git pr show -t 22535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22535.diff">https://git.openjdk.org/jdk/pull/22535.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22535#issuecomment-2518153617)
</details>
