### PR TITLE
8345465: Fix performance regression on x64 after JDK-8345120

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
@@ -203,15 +203,18 @@ public final class StringSupport {
             segment.scope.checkValidState();
             throw nullNotFound(segment, fromOffset, toOffset);
         }
-        final long longBytes = length & LONG_MASK;
-        final long longLimit = fromOffset + longBytes;
         long offset = fromOffset;
-        for (; offset < longLimit; offset += Long.BYTES) {
-            long val = SCOPED_MEMORY_ACCESS.getLongUnaligned(segment.sessionImpl(), segment.unsafeGetBase(), segment.unsafeGetOffset() + offset, !Architecture.isLittleEndian());
-            if (mightContainZeroInt(val)) {
-                for (int j = 0; j < Long.BYTES; j += Integer.BYTES) {
-                    if (SCOPED_MEMORY_ACCESS.getIntUnaligned(segment.sessionImpl(), segment.unsafeGetBase(), segment.unsafeGetOffset() + offset + j, !Architecture.isLittleEndian()) == 0) {
-                        return requireWithinStringSize(offset + j - fromOffset, segment, fromOffset, toOffset);
+        // For quad words, it does not pay off to use long scanning on x64
+        if (!Architecture.isX64()) {
+            final long longBytes = length & LONG_MASK;
+            final long longLimit = fromOffset + longBytes;
+            for (; offset < longLimit; offset += Long.BYTES) {
+                long val = SCOPED_MEMORY_ACCESS.getLongUnaligned(segment.sessionImpl(), segment.unsafeGetBase(), segment.unsafeGetOffset() + offset, !Architecture.isLittleEndian());
+                if (mightContainZeroInt(val)) {
+                    for (int j = 0; j < Long.BYTES; j += Integer.BYTES) {
+                        if (SCOPED_MEMORY_ACCESS.getIntUnaligned(segment.sessionImpl(), segment.unsafeGetBase(), segment.unsafeGetOffset() + offset + j, !Architecture.isLittleEndian()) == 0) {
+                            return requireWithinStringSize(offset + j - fromOffset, segment, fromOffset, toOffset);
+                        }
                     }
                 }
             }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/InternalStrLen.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/InternalStrLen.java
@@ -55,10 +55,16 @@ import static java.lang.foreign.ValueLayout.*;
                             "--enable-native-access=ALL-UNNAMED"})
 public class InternalStrLen {
 
-    private AbstractMemorySegmentImpl singleByteSegment;
-    private AbstractMemorySegmentImpl singleByteSegmentMisaligned;
-    private AbstractMemorySegmentImpl doubleByteSegment;
-    private AbstractMemorySegmentImpl quadByteSegment;
+    private MemorySegment singleByteSegment;
+    private MemorySegment singleByteSegmentMisaligned;
+    private MemorySegment doubleByteSegment;
+    private MemorySegment quadByteSegment;
+
+    // Aliases for testing internal methods that already have access to AMSI
+    private AbstractMemorySegmentImpl abstractSingleByteSegment;
+    private AbstractMemorySegmentImpl abstractSingleByteSegmentMisaligned;
+    private AbstractMemorySegmentImpl abstractDoubleByteSegment;
+    private AbstractMemorySegmentImpl abstractQuadByteSegment;
 
     @Param({"1", "4", "16", "251", "1024"})
     int size;
@@ -66,9 +72,9 @@ public class InternalStrLen {
     @Setup
     public void setup() {
         var arena = Arena.ofAuto();
-        singleByteSegment = (AbstractMemorySegmentImpl) arena.allocate((size + 1L) * Byte.BYTES);
-        doubleByteSegment = (AbstractMemorySegmentImpl) arena.allocate((size + 1L) * Short.BYTES);
-        quadByteSegment = (AbstractMemorySegmentImpl) arena.allocate((size + 1L) * Integer.BYTES);
+        singleByteSegment = arena.allocate((size + 1L) * Byte.BYTES);
+        doubleByteSegment = arena.allocate((size + 1L) * Short.BYTES);
+        quadByteSegment = arena.allocate((size + 1L) * Integer.BYTES);
         Stream.of(singleByteSegment, doubleByteSegment, quadByteSegment)
                 .forEach(s -> IntStream.range(0, (int) s.byteSize() - 1)
                         .forEach(i -> s.set(
@@ -79,9 +85,13 @@ public class InternalStrLen {
         singleByteSegment.set(ValueLayout.JAVA_BYTE, singleByteSegment.byteSize() - Byte.BYTES, (byte) 0);
         doubleByteSegment.set(ValueLayout.JAVA_SHORT, doubleByteSegment.byteSize() - Short.BYTES, (short) 0);
         quadByteSegment.set(ValueLayout.JAVA_INT, quadByteSegment.byteSize() - Integer.BYTES, 0);
-        singleByteSegmentMisaligned = (AbstractMemorySegmentImpl) arena.allocate(singleByteSegment.byteSize() + 1).
+        singleByteSegmentMisaligned = arena.allocate(singleByteSegment.byteSize() + 1).
                 asSlice(1);
         MemorySegment.copy(singleByteSegment, 0, singleByteSegmentMisaligned, 0, singleByteSegment.byteSize());
+        abstractSingleByteSegment = (AbstractMemorySegmentImpl) singleByteSegment;
+        abstractSingleByteSegmentMisaligned = (AbstractMemorySegmentImpl) singleByteSegmentMisaligned;
+        abstractDoubleByteSegment = (AbstractMemorySegmentImpl) doubleByteSegment;
+        abstractQuadByteSegment = (AbstractMemorySegmentImpl) quadByteSegment;
     }
 
     @Benchmark
@@ -106,22 +116,22 @@ public class InternalStrLen {
 
     @Benchmark
     public int chunkedSingle() {
-        return StringSupport.strlenByte(singleByteSegment, 0, singleByteSegment.byteSize());
+        return StringSupport.strlenByte(abstractSingleByteSegment, 0, singleByteSegment.byteSize());
     }
 
     @Benchmark
     public int chunkedSingleMisaligned() {
-        return StringSupport.strlenByte(singleByteSegmentMisaligned, 0, singleByteSegment.byteSize());
+        return StringSupport.strlenByte(abstractSingleByteSegmentMisaligned, 0, singleByteSegment.byteSize());
     }
 
     @Benchmark
     public int chunkedDouble() {
-        return StringSupport.strlenShort(doubleByteSegment, 0, doubleByteSegment.byteSize());
+        return StringSupport.strlenShort(abstractDoubleByteSegment, 0, doubleByteSegment.byteSize());
     }
 
     @Benchmark
     public int changedElementQuad() {
-        return StringSupport.strlenInt(quadByteSegment, 0, quadByteSegment.byteSize());
+        return StringSupport.strlenInt(abstractQuadByteSegment, 0, quadByteSegment.byteSize());
     }
 
     // These are the legacy methods

--- a/test/micro/org/openjdk/bench/java/lang/foreign/InternalStrLen.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/InternalStrLen.java
@@ -60,12 +60,6 @@ public class InternalStrLen {
     private MemorySegment doubleByteSegment;
     private MemorySegment quadByteSegment;
 
-    // Aliases for testing internal methods that already have access to AMSI
-    private AbstractMemorySegmentImpl abstractSingleByteSegment;
-    private AbstractMemorySegmentImpl abstractSingleByteSegmentMisaligned;
-    private AbstractMemorySegmentImpl abstractDoubleByteSegment;
-    private AbstractMemorySegmentImpl abstractQuadByteSegment;
-
     @Param({"1", "4", "16", "251", "1024"})
     int size;
 
@@ -88,10 +82,6 @@ public class InternalStrLen {
         singleByteSegmentMisaligned = arena.allocate(singleByteSegment.byteSize() + 1).
                 asSlice(1);
         MemorySegment.copy(singleByteSegment, 0, singleByteSegmentMisaligned, 0, singleByteSegment.byteSize());
-        abstractSingleByteSegment = (AbstractMemorySegmentImpl) singleByteSegment;
-        abstractSingleByteSegmentMisaligned = (AbstractMemorySegmentImpl) singleByteSegmentMisaligned;
-        abstractDoubleByteSegment = (AbstractMemorySegmentImpl) doubleByteSegment;
-        abstractQuadByteSegment = (AbstractMemorySegmentImpl) quadByteSegment;
     }
 
     @Benchmark
@@ -116,22 +106,22 @@ public class InternalStrLen {
 
     @Benchmark
     public int chunkedSingle() {
-        return StringSupport.strlenByte(abstractSingleByteSegment, 0, singleByteSegment.byteSize());
+        return StringSupport.strlenByte((AbstractMemorySegmentImpl) singleByteSegment, 0, singleByteSegment.byteSize());
     }
 
     @Benchmark
     public int chunkedSingleMisaligned() {
-        return StringSupport.strlenByte(abstractSingleByteSegmentMisaligned, 0, singleByteSegment.byteSize());
+        return StringSupport.strlenByte((AbstractMemorySegmentImpl) singleByteSegmentMisaligned, 0, singleByteSegment.byteSize());
     }
 
     @Benchmark
     public int chunkedDouble() {
-        return StringSupport.strlenShort(abstractDoubleByteSegment, 0, doubleByteSegment.byteSize());
+        return StringSupport.strlenShort((AbstractMemorySegmentImpl) doubleByteSegment, 0, doubleByteSegment.byteSize());
     }
 
     @Benchmark
     public int changedElementQuad() {
-        return StringSupport.strlenInt(abstractQuadByteSegment, 0, quadByteSegment.byteSize());
+        return StringSupport.strlenInt((AbstractMemorySegmentImpl) quadByteSegment, 0, quadByteSegment.byteSize());
     }
 
     // These are the legacy methods


### PR DESCRIPTION
This PR proposes to fix a performance regression (on x64 platforms) for quad-string words introduced by [JDK-8345120](https://bugs.openjdk.org/browse/JDK-8345120).

The PR also fixes a performance regression in the benchmarks caused by using the wrong type for `MemorySegment`.

Regrettably, this PR uses different code paths for various architectures. This gives optimum performance for all platforms at the expense of slightly more code complexity. 