### PR TITLE
8345468: test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java fails in ubuntu22.04

### DIFF
--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,14 +26,17 @@
  * @key headful
  * @bug 4865918
  * @summary REGRESSION:JCK1.4a-runtime api/javax_swing/interactive/JScrollBarTests.html#JScrollBar
- * @author Andrey Pikalev
  * @run main bug4865918
  */
 
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.*;
-import java.util.*;
+import java.awt.Dimension;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.JScrollBar;
+import javax.swing.SwingUtilities;
+import java.awt.event.MouseEvent;
+
+import java.util.Date;
 
 public class bug4865918 {
 
@@ -43,24 +46,15 @@ public class bug4865918 {
     public static void main(String[] argv) throws Exception {
         try {
             Robot robot = new Robot();
-            SwingUtilities.invokeAndWait(new Runnable() {
-
-                public void run() {
-                    createAndShowGUI();
-                }
-            });
+            SwingUtilities.invokeAndWait(() -> createAndShowGUI());
 
             robot.waitForIdle();
+            robot.delay(1000);
 
-            SwingUtilities.invokeAndWait(new Runnable() {
-
-                @Override
-                public void run() {
-                    sbar.pressMouse();
-                }
-            });
+            SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
 
             robot.waitForIdle();
+            robot.delay(200);
 
             int value = getValue();
 
@@ -95,8 +89,9 @@ public class bug4865918 {
 
         frame.getContentPane().add(sbar);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
-
+        frame.toFront();
     }
 
     static class TestScrollBar extends JScrollBar {
@@ -111,7 +106,7 @@ public class bug4865918 {
             MouseEvent me = new MouseEvent(sbar,
                     MouseEvent.MOUSE_PRESSED,
                     (new Date()).getTime(),
-                    MouseEvent.BUTTON1_MASK,
+                    MouseEvent.BUTTON1_DOWN_MASK,
                     3 * getWidth() / 4, getHeight() / 2,
                     1, true);
             processMouseEvent(me);

--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -56,10 +56,8 @@ public class bug4865918 {
             robot.waitForIdle();
             robot.delay(200);
 
-            int value = getValue();
-
-            if (value != 9) {
-                throw new Error("The scrollbar block increment is incorect");
+            if (getValue() != 9) {
+                throw new RuntimeException("The scrollbar block increment is incorrect");
             }
         } finally {
             if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
@@ -69,11 +67,8 @@ public class bug4865918 {
     private static int getValue() throws Exception {
         final int[] result = new int[1];
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
-                result[0] = sbar.getValue();
-            }
+        SwingUtilities.invokeAndWait(() -> {
+            result[0] = sbar.getValue();
         });
 
         return result[0];


### PR DESCRIPTION
Test is failing in OCI system citing
```
java.lang.Error: The scrollbar block increment is incorect
at bug4865918.main(bug4865918.java:68) 
```
seemingly because focus is not in scrollbar..Added stability delay to make test execution wait after frame visibility and made frame to center of screen.
Test passed in several OCI systems with this modification...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345468](https://bugs.openjdk.org/browse/JDK-8345468): test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java fails in ubuntu22.04 (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22540/head:pull/22540` \
`$ git checkout pull/22540`

Update a local copy of the PR: \
`$ git checkout pull/22540` \
`$ git pull https://git.openjdk.org/jdk.git pull/22540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22540`

View PR using the GUI difftool: \
`$ git pr show -t 22540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22540.diff">https://git.openjdk.org/jdk/pull/22540.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22540#issuecomment-2516667601)
</details>
