### PR TITLE
8345474: Translation for instanceof is not triggered when patterns are not used in the compilation unit

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -97,6 +97,7 @@ import com.sun.tools.javac.resources.CompilerProperties.Warnings;
 import static com.sun.tools.javac.code.TypeTag.CLASS;
 import static com.sun.tools.javac.main.Option.*;
 import com.sun.tools.javac.tree.JCTree.JCBindingPattern;
+import com.sun.tools.javac.tree.JCTree.JCInstanceOf;
 import static com.sun.tools.javac.util.JCDiagnostic.DiagnosticFlag.*;
 
 import static javax.tools.StandardLocation.CLASS_OUTPUT;
@@ -1548,6 +1549,13 @@ public class JavaCompiler {
             public void visitBindingPattern(JCBindingPattern tree) {
                 hasPatterns = true;
                 super.visitBindingPattern(tree);
+            }
+            @Override
+            public void visitTypeTest(JCInstanceOf tree) {
+                if (tree.pattern.type.isPrimitive()) {
+                    hasPatterns = true;
+                }
+                super.visitTypeTest(tree);
             }
             @Override
             public void visitRecordPattern(JCRecordPattern that) {

--- a/test/langtools/tools/javac/patterns/T8345474.java
+++ b/test/langtools/tools/javac/patterns/T8345474.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8345474
+ * @summary Translation for instanceof is not triggered when patterns are not used in the compilation unit
+ * @enablePreview
+ * @compile T8345474.java
+ * @run main T8345474
+ */
+import java.util.List;
+
+public class T8345474 {
+    public static void main(String[] args) {
+        erasureInstanceofTypeComparisonOperator();
+    }
+
+    public static void erasureInstanceofTypeComparisonOperator() {
+        List<Short> ls = List.of((short) 42);
+
+        assertTrue(ls.get(0) instanceof int);
+    }
+
+    static void assertTrue(boolean actual) {
+        if (!actual) {
+            throw new AssertionError("Expected: true, but got false");
+        }
+    }
+}


### PR DESCRIPTION
Our tests for #21539 covered the case of using `instanceof` as both a type comparison operator and a pattern matching operator in a single compilation unit. That concealed the fact that the translation is getting triggered only when the compilation unit `hasPatterns`. This was evident/reproducible also by experimentation using jshell. This PR addresses this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345474](https://bugs.openjdk.org/browse/JDK-8345474): Translation for instanceof is not triggered when patterns are not used in the compilation unit (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22541/head:pull/22541` \
`$ git checkout pull/22541`

Update a local copy of the PR: \
`$ git checkout pull/22541` \
`$ git pull https://git.openjdk.org/jdk.git pull/22541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22541`

View PR using the GUI difftool: \
`$ git pr show -t 22541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22541.diff">https://git.openjdk.org/jdk/pull/22541.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22541#issuecomment-2516967272)
</details>
