### PR TITLE
8345016: [ASAN] java.c reported ‘%s’ directive argument is null [-Werror=format-truncation=]

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1018,6 +1018,8 @@ SetClassPath(const char *s)
     if (s == NULL)
         return;
     s = JLI_WildcardExpandClasspath(s);
+    if (s == NULL)
+        return;
     if (sizeof(format) - 2 + JLI_StrLen(s) < JLI_StrLen(s))
         // s is became corrupted after expanding wildcards
         return;
@@ -1025,16 +1027,7 @@ SetClassPath(const char *s)
                        - 2 /* strlen("%s") */
                        + JLI_StrLen(s);
     def = JLI_MemAlloc(defSize);
-#if !defined(__clang_major__) && (__GNUC__ >= 7) && defined(__linux__)
-_Pragma("GCC diagnostic push")
-// Disable -Wstringop-overread which is introduced in GCC 7.
-// https://gcc.gnu.org/gcc-7/changes.html
-_Pragma("GCC diagnostic ignored \"-Wformat-truncation\"")
     snprintf(def, defSize, format, s);
-_Pragma("GCC diagnostic pop")
-#else
-    snprintf(def, defSize, format, s);
-#endif
     AddOption(def, NULL);
     if (s != orig)
         JLI_MemFree((char *) s);

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1025,7 +1025,14 @@ SetClassPath(const char *s)
                        - 2 /* strlen("%s") */
                        + JLI_StrLen(s);
     def = JLI_MemAlloc(defSize);
+_Pragma("GCC diagnostic push")
+// Disable -Wstringop-overread which is introduced in GCC 7.
+// https://gcc.gnu.org/gcc-7/changes.html
+#if !defined(__clang_major__) && (__GNUC__ >= 7)
+_Pragma("GCC diagnostic ignored \"-Wformat-truncation\"")
+#endif
     snprintf(def, defSize, format, s);
+_Pragma("GCC diagnostic pop")
     AddOption(def, NULL);
     if (s != orig)
         JLI_MemFree((char *) s);

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1025,14 +1025,16 @@ SetClassPath(const char *s)
                        - 2 /* strlen("%s") */
                        + JLI_StrLen(s);
     def = JLI_MemAlloc(defSize);
+#if !defined(__clang_major__) && (__GNUC__ >= 7) && defined(__linux__)
 _Pragma("GCC diagnostic push")
 // Disable -Wstringop-overread which is introduced in GCC 7.
 // https://gcc.gnu.org/gcc-7/changes.html
-#if !defined(__clang_major__) && (__GNUC__ >= 7)
 _Pragma("GCC diagnostic ignored \"-Wformat-truncation\"")
-#endif
     snprintf(def, defSize, format, s);
 _Pragma("GCC diagnostic pop")
+#else
+    snprintf(def, defSize, format, s);
+#endif
     AddOption(def, NULL);
     if (s != orig)
         JLI_MemFree((char *) s);


### PR DESCRIPTION
Hi all,
The file src/java.base/share/native/libjli/java.c generate  compile warning by gcc14 with gcc options `-fsanitize=undefined -O2`, and make jdk build error when configure with option `--enable-ubsan`. So I think it's necessory to  make gcc quiet and make jdk build normally with configure option `--enable-ubsan`.

This PR add `NULL` check for `s` after call `s = JLI_WildcardExpandClasspath(s);` to make gcc quiet. There is another solution to disable the compile warning seen as below, but it will disable the compile warning of java.c. So I use the first solution.


```diff
diff --git a/make/modules/java.base/lib/CoreLibraries.gmk b/make/modules/java.base/lib/CoreLibraries.gmk
index 61ac495968a..5bc83cf0978 100644
--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -178,6 +178,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJLI, \
     OPTIMIZATION := HIGH, \
     CFLAGS := $(LIBJLI_CFLAGS) $(LIBZ_CFLAGS), \
     DISABLED_WARNINGS_gcc := unused-function unused-variable, \
+    DISABLED_WARNINGS_gcc_java.c := format-truncation, \
     DISABLED_WARNINGS_clang := deprecated-non-prototype format-nonliteral \
         unused-function, \
     DISABLED_WARNINGS_clang_java_md_macosx.m := unused-variable, \
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345016](https://bugs.openjdk.org/browse/JDK-8345016): [ASAN] java.c reported ‘%s’ directive argument is null [-Werror=format-truncation=] (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22546/head:pull/22546` \
`$ git checkout pull/22546`

Update a local copy of the PR: \
`$ git checkout pull/22546` \
`$ git pull https://git.openjdk.org/jdk.git pull/22546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22546`

View PR using the GUI difftool: \
`$ git pr show -t 22546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22546.diff">https://git.openjdk.org/jdk/pull/22546.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22546#issuecomment-2517689633)
</details>
