### PR TITLE
8345507: Fix build of static launcher

### DIFF
--- a/make/ModuleWrapper.gmk
+++ b/make/ModuleWrapper.gmk
@@ -51,7 +51,7 @@ ifeq ($(MAKEFILE_PREFIX), Lib)
   # which static library files to include. The variable $(MODULE)_INCLUDED_LIBS is
   # added to for each call to SetupJdkLibrary. The file module-included-libs.txt is then
   # read in StaticLibs.gmk.
-  ifneq ($($(MODULE)_JDK_LIBS), )
+  ifneq ($($(MODULE)_INCLUDED_LIBS), )
     LIBLIST := $(SUPPORT_OUTPUTDIR)/modules_static-libs/$(MODULE)/module-included-libs.txt
 
     $(LIBLIST): $(TARGETS)


### PR DESCRIPTION
Unfortunately, [JDK-8339480](https://bugs.openjdk.org/browse/JDK-8339480) as checked in does not work.

One of the very last review updates of [JDK-8339480](https://bugs.openjdk.org/browse/JDK-8339480) was a rename of a make variable. Since this seemed trivial to me, I did not re-test the code after making this change. That was my second mistake. My first mistake was to not discover that this variable was in fact used in another place, so a crucial test never passes and the code does not work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345507](https://bugs.openjdk.org/browse/JDK-8345507): Fix build of static launcher (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22551/head:pull/22551` \
`$ git checkout pull/22551`

Update a local copy of the PR: \
`$ git checkout pull/22551` \
`$ git pull https://git.openjdk.org/jdk.git pull/22551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22551`

View PR using the GUI difftool: \
`$ git pr show -t 22551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22551.diff">https://git.openjdk.org/jdk/pull/22551.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22551#issuecomment-2517957890)
</details>
