### PR TITLE
8345433: (fs) Use stream to load FileTypeDetectors in Files.probeContentType

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/spi/AsynchronousChannelProvider.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/AsynchronousChannelProvider.java
@@ -90,7 +90,6 @@ public abstract class AsynchronousChannelProvider {
             ServiceLoader<AsynchronousChannelProvider> sl =
                 ServiceLoader.load(AsynchronousChannelProvider.class,
                                    ClassLoader.getSystemClassLoader());
-            Iterator<AsynchronousChannelProvider> i = sl.iterator();
             return sl.findFirst().orElse(null);
         }
     }

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1509,7 +1509,7 @@ public final class Files {
     }
 
     // lazy loading of default and installed file type detectors
-    private static class FileTypeDetectors{
+    private static class FileTypeDetectors {
         static final FileTypeDetector defaultFileTypeDetector =
             createDefaultFileTypeDetector();
         static final List<FileTypeDetector> installedDetectors =
@@ -1522,13 +1522,10 @@ public final class Files {
 
         // loads all installed file type detectors
         private static List<FileTypeDetector> loadInstalledDetectors() {
-            List<FileTypeDetector> list = new ArrayList<>();
-            ServiceLoader<FileTypeDetector> loader = ServiceLoader
-                .load(FileTypeDetector.class, ClassLoader.getSystemClassLoader());
-            for (FileTypeDetector detector: loader) {
-                list.add(detector);
-            }
-            return list;
+            return ServiceLoader.load(FileTypeDetector.class,
+                                      ClassLoader.getSystemClassLoader())
+                .stream()
+                .map(p -> p.get()).toList();
         }
     }
 

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1525,7 +1525,8 @@ public final class Files {
             return ServiceLoader.load(FileTypeDetector.class,
                                       ClassLoader.getSystemClassLoader())
                 .stream()
-                .map(p -> p.get()).toList();
+                .map(p -> p.get())
+                .toList();
         }
     }
 

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1525,7 +1525,7 @@ public final class Files {
             return ServiceLoader.load(FileTypeDetector.class,
                                       ClassLoader.getSystemClassLoader())
                 .stream()
-                .map(p -> p.get())
+                .map(ServiceLoader.Provider::get)
                 .toList();
         }
     }


### PR DESCRIPTION
Change `FileTypeDetector` list creation to use a stream rather than an iteration and adds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345433](https://bugs.openjdk.org/browse/JDK-8345433): (fs) Use stream to load FileTypeDetectors in Files.probeContentType (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22552/head:pull/22552` \
`$ git checkout pull/22552`

Update a local copy of the PR: \
`$ git checkout pull/22552` \
`$ git pull https://git.openjdk.org/jdk.git pull/22552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22552`

View PR using the GUI difftool: \
`$ git pr show -t 22552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22552.diff">https://git.openjdk.org/jdk/pull/22552.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22552#issuecomment-2517981401)
</details>
