### PR TITLE
8345503: Test EnableNativeAccessCDS.java fails with TEST_THREAD_FACTORY=Virtual

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/module/EnableNativeAccessCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/module/EnableNativeAccessCDS.java
@@ -47,14 +47,14 @@ public class EnableNativeAccessCDS {
         OutputAnalyzer oa = TestCommon.dumpBaseArchive(
             archiveName,
             loggingOption,
-            "--enable-native-access", module0,
+            "--enable-native-access=" + module0,
             "-version");
         oa.shouldHaveExitValue(0);
 
         // same module specified during runtime
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access", module0,
+            "--enable-native-access=" + module0,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("use_full_module_graph = true");
@@ -62,7 +62,7 @@ public class EnableNativeAccessCDS {
         // different module specified during runtime
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access", module1,
+            "--enable-native-access=" + module1,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("Mismatched values for property jdk.module.enable.native.access: runtime jdk.httpserver dump time java.base")
@@ -88,7 +88,7 @@ public class EnableNativeAccessCDS {
         // run with --enable-native-access
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access", module0,
+            "--enable-native-access=" + module0,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("Mismatched values for property jdk.module.enable.native.access: java.base specified during runtime but not during dump time")
@@ -100,14 +100,14 @@ public class EnableNativeAccessCDS {
         oa = TestCommon.dumpBaseArchive(
             archiveName,
             loggingOption,
-            "--enable-native-access", module0 + "," + module1,
+            "--enable-native-access=" + module0 + "," + module1,
             "-version");
         oa.shouldHaveExitValue(0);
 
         // same module specified during runtime but in a different order
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access", module1 + "," + module0,
+            "--enable-native-access=" + module1 + "," + module0,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("use_full_module_graph = true");
@@ -115,8 +115,8 @@ public class EnableNativeAccessCDS {
         // same module specified during runtime but specifying --enable-native-access twice
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access", module0,
-            "--enable-native-access", module1,
+            "--enable-native-access=" + module0,
+            "--enable-native-access=" + module1,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("use_full_module_graph = true");
@@ -124,7 +124,7 @@ public class EnableNativeAccessCDS {
         // run with only one same module
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access", module0,
+            "--enable-native-access=" + module0,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("Mismatched values for property jdk.module.enable.native.access: runtime java.base dump time java.base,jdk.httpserver")

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/module/EnableNativeAccessCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/module/EnableNativeAccessCDS.java
@@ -47,14 +47,14 @@ public class EnableNativeAccessCDS {
         OutputAnalyzer oa = TestCommon.dumpBaseArchive(
             archiveName,
             loggingOption,
-            "--enable-native-access=" + module0,
+            "--enable-native-access", module0,
             "-version");
         oa.shouldHaveExitValue(0);
 
         // same module specified during runtime
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access=" + module0,
+            "--enable-native-access", module0,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("use_full_module_graph = true");
@@ -62,7 +62,7 @@ public class EnableNativeAccessCDS {
         // different module specified during runtime
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access=" + module1,
+            "--enable-native-access", module1,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("Mismatched values for property jdk.module.enable.native.access: runtime jdk.httpserver dump time java.base")
@@ -88,7 +88,7 @@ public class EnableNativeAccessCDS {
         // run with --enable-native-access
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access=" + module0,
+            "--enable-native-access", module0,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("Mismatched values for property jdk.module.enable.native.access: java.base specified during runtime but not during dump time")
@@ -100,14 +100,14 @@ public class EnableNativeAccessCDS {
         oa = TestCommon.dumpBaseArchive(
             archiveName,
             loggingOption,
-            "--enable-native-access=" + module0 + "," + module1,
+            "--enable-native-access", module0 + "," + module1,
             "-version");
         oa.shouldHaveExitValue(0);
 
         // same module specified during runtime but in a different order
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access=" + module1 + "," + module0,
+            "--enable-native-access", module1 + "," + module0,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("use_full_module_graph = true");
@@ -115,8 +115,8 @@ public class EnableNativeAccessCDS {
         // same module specified during runtime but specifying --enable-native-access twice
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access=" + module0,
-            "--enable-native-access=" + module1,
+            "--enable-native-access", module0,
+            "--enable-native-access", module1,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("use_full_module_graph = true");
@@ -124,7 +124,7 @@ public class EnableNativeAccessCDS {
         // run with only one same module
         oa = TestCommon.execCommon(
             loggingOption,
-            "--enable-native-access=" + module0,
+            "--enable-native-access", module0,
             "-version");
         oa.shouldHaveExitValue(0)
           .shouldContain("Mismatched values for property jdk.module.enable.native.access: runtime java.base dump time java.base,jdk.httpserver")

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -392,7 +392,7 @@ public final class ProcessTools {
                 "--dry-run", "--list-modules","--validate-modules", "-m", "--module", "-version");
 
         final List<String> doubleWordArgs = List.of(
-                "--add-opens", "--upgrade-module-path", "--add-modules", "--add-exports",
+                "--add-opens", "--upgrade-module-path", "--add-modules", "--add-exports", "--enable-native-access",
                 "--limit-modules", "--add-reads", "--patch-module", "--module-path", "-p");
 
         ArrayList<String> args = new ArrayList<>();


### PR DESCRIPTION
The JTREG option `TEST_THREAD_FACTORY=Virtual` injects command line arguments into the test and may separate an option from its arguments. In this case, the option was being placed between `--enable-native-access` and it's argument `java.base`. This patch adds `--enable-native-access` to the list of options that takes additional arguments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345503](https://bugs.openjdk.org/browse/JDK-8345503): Test EnableNativeAccessCDS.java fails with TEST_THREAD_FACTORY=Virtual (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22555/head:pull/22555` \
`$ git checkout pull/22555`

Update a local copy of the PR: \
`$ git checkout pull/22555` \
`$ git pull https://git.openjdk.org/jdk.git pull/22555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22555`

View PR using the GUI difftool: \
`$ git pr show -t 22555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22555.diff">https://git.openjdk.org/jdk/pull/22555.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22555#issuecomment-2518268060)
</details>
