### PR TITLE
8345224: Test runtime/cds/appcds/applications/JavacBench.java#dynamic fails after JDK-8344822

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -55,11 +55,7 @@ hotspot_runtime_no_cds = \
 
 hotspot_runtime_non_cds_mode = \
   runtime \
-  -runtime/cds/CheckSharingWithDefaultArchive.java \
-  -runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java \
-  -runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java \
-  -runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java \
-  -runtime/cds/appcds/jcmd
+  -runtime/cds
 
 hotspot_handshake = \
   runtime/handshake


### PR DESCRIPTION
The `hotspot_runtime_non_cds_mode` test group is for running jtreg tests with `-vmoptions:-Xshare:off`. Such a scenario doesn't make sense for the CDS tests, and could cause similar failures in the future.

We should remove all CDS tests from `hotspot_runtime_non_cds_mode`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345224](https://bugs.openjdk.org/browse/JDK-8345224): Test runtime/cds/appcds/applications/JavacBench.java#dynamic fails after JDK-8344822 (**Bug** - P3)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22558/head:pull/22558` \
`$ git checkout pull/22558`

Update a local copy of the PR: \
`$ git checkout pull/22558` \
`$ git pull https://git.openjdk.org/jdk.git pull/22558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22558`

View PR using the GUI difftool: \
`$ git pr show -t 22558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22558.diff">https://git.openjdk.org/jdk/pull/22558.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22558#issuecomment-2518403169)
</details>
