### PR TITLE
8345524: CHECK_FOR_FILES should properly handle directories

### DIFF
--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -575,7 +575,7 @@ AC_DEFUN([UTIL_CHECK_TYPE_directory],
 
   if test "[x]ARG_CHECK_FOR_FILES" != "x:"; then
     for file in ARG_CHECK_FOR_FILES; do
-      found_files=$($ECHO $(ls $1/$file 2> /dev/null))
+      found_files=$($ECHO $($LS -d $1/$file 2> /dev/null))
       if test "x$found_files" = x; then
         FAILURE="Directory $1 does not contain $file"
         break


### PR DESCRIPTION
In CHECK_FOR_FILES, an `ls` command tries to verify if the given list of files is present. If one of the files is a directory name, this fails. To be able to check for a directory as well, we need to do `ls -d`. 

Also updated raw `ls` to use `$LS`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345524](https://bugs.openjdk.org/browse/JDK-8345524): CHECK_FOR_FILES should properly handle directories (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22559/head:pull/22559` \
`$ git checkout pull/22559`

Update a local copy of the PR: \
`$ git checkout pull/22559` \
`$ git pull https://git.openjdk.org/jdk.git pull/22559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22559`

View PR using the GUI difftool: \
`$ git pr show -t 22559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22559.diff">https://git.openjdk.org/jdk/pull/22559.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22559#issuecomment-2518490723)
</details>
