### PR TITLE
8345390: [ubsan] systemDictionaryShared.cpp:964: member call on null pointer

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -957,11 +957,17 @@ InstanceKlass* SystemDictionaryShared::get_shared_lambda_proxy_class(InstanceKla
                                                                      Symbol* method_type,
                                                                      Method* member_method,
                                                                      Symbol* instantiated_method_type) {
+  assert(caller_ik != nullptr, "sanity");
+  assert(invoked_name != nullptr, "sanity");
+  assert(invoked_type != nullptr, "sanity");
+  assert(method_type != nullptr, "sanity");
+  assert(instantiated_method_type != nullptr, "sanity");
+
   if (!caller_ik->is_shared()     ||
       !invoked_name->is_shared()  ||
       !invoked_type->is_shared()  ||
       !method_type->is_shared()   ||
-      !member_method->is_shared() ||
+      (member_method != nullptr && !member_method->is_shared()) ||
       !instantiated_method_type->is_shared()) {
     // These can't be represented as u4 offset, but we wouldn't have archived a lambda proxy in this case anyway.
     return nullptr;

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaInvokeVirtual.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaInvokeVirtual.java
@@ -61,13 +61,14 @@ public class LambdaInvokeVirtual {
             .setArchiveName(archiveName);
         CDSTestUtils.createArchiveAndCheck(opts);
 
-        // run with archive
+        // run with archive; make sure the lambda is loaded from the archive
         CDSOptions runOpts = (new CDSOptions())
-            .addPrefix("-cp", appJar)
+            .addPrefix("-cp", appJar, "-Xlog:class+load")
             .setArchiveName(archiveName)
             .setUseVersion(false)
             .addSuffix(mainClass);
         OutputAnalyzer output = CDSTestUtils.runWithArchive(runOpts);
+        output.shouldMatch("LambdaInvokeVirtualApp[$][$]Lambda/.*source: shared objects file");
         output.shouldHaveExitValue(0);
     }
 }


### PR DESCRIPTION
(For JDK 25).

It's possible for the  `member_method` parameter to be `nullptr`. Since `member_method->is_shared()` only checks the range of `this` and doesn't dereference it, we don't have a crash, and the problem was found only when running with ubsan.

However, the code was wrong, as `((Method*)nullptr)->is_shared()` would return `false`, making it impossible to load the archived Lambda class.

After the fix, I modified the test case to ensure that the Lambda class can be correctly loaded from the archive.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345390](https://bugs.openjdk.org/browse/JDK-8345390): [ubsan] systemDictionaryShared.cpp:964: member call on null pointer (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22560/head:pull/22560` \
`$ git checkout pull/22560`

Update a local copy of the PR: \
`$ git checkout pull/22560` \
`$ git pull https://git.openjdk.org/jdk.git pull/22560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22560`

View PR using the GUI difftool: \
`$ git pr show -t 22560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22560.diff">https://git.openjdk.org/jdk/pull/22560.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22560#issuecomment-2518520954)
</details>
