### PR TITLE
8345435: Eliminate tier1_compiler_not_xcomp group

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -38,10 +38,6 @@ hotspot_all_no_apps = \
 hotspot_compiler = \
   compiler
 
-hotspot_compiler_xcomp = \
-  :hotspot_compiler \
-  -:tier1_compiler_not_xcomp
-
 hotspot_gc = \
   gc
 
@@ -155,8 +151,7 @@ tier1_common = \
 tier1_compiler = \
   :tier1_compiler_1 \
   :tier1_compiler_2 \
-  :tier1_compiler_3 \
-  :tier1_compiler_not_xcomp
+  :tier1_compiler_3
 
 hotspot_not_fast_compiler = \
   :hotspot_compiler \
@@ -214,6 +209,7 @@ tier1_compiler_3 = \
   compiler/macronodes/ \
   compiler/memoryinitialization/ \
   compiler/osr/ \
+  compiler/profiling \
   compiler/regalloc/ \
   compiler/runtime/ \
   compiler/startup/ \
@@ -272,9 +268,6 @@ tier3_compiler = \
   :hotspot_slow_compiler \
   -:tier1_compiler \
   -:tier2_compiler
-
-tier1_compiler_not_xcomp = \
-  compiler/profiling
 
 ctw_1 = \
   applications/ctw/modules/ \

--- a/test/hotspot/jtreg/compiler/profiling/TestMethodHandleInvokesIntrinsic.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestMethodHandleInvokesIntrinsic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8041458
  * @summary profiling of arguments in C1 at MethodHandle invoke of intrinsic tries to profile popped argument.
  *
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
  *                   -XX:TieredStopAtLevel=3
  *                   compiler.profiling.TestMethodHandleInvokesIntrinsic

--- a/test/hotspot/jtreg/compiler/profiling/TestMultiBranchDataOverflow.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestMultiBranchDataOverflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8251458
  * @summary Test int range overflow of MultiBranchData counter.
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -XX:CompileCommand=dontinline,compiler.profiling.TestMultiBranchDataOverflow::test
  *                   -Xbatch -XX:Tier4BackEdgeThreshold=2147483647
  *                   compiler.profiling.TestMultiBranchDataOverflow

--- a/test/hotspot/jtreg/compiler/profiling/TestProfileCounterOverflow.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestProfileCounterOverflow.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Loongson Technology Co. Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -25,6 +26,7 @@
  * @test
  * @bug 8224162
  * @summary Profile counter for a call site may overflow.
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -Xbatch -XX:-UseOnStackReplacement -XX:+IgnoreUnrecognizedVMOptions -XX:MaxTrivialSize=0 -XX:C1MaxTrivialSize=0 compiler.profiling.TestProfileCounterOverflow
  */
 

--- a/test/hotspot/jtreg/compiler/profiling/TestSharedHeadExceptionBackedges.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestSharedHeadExceptionBackedges.java
@@ -25,6 +25,7 @@
  * @test
  * bug 8280842
  * @summary Access violation in ciTypeFlow::profiled_count
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -XX:-BackgroundCompilation TestSharedHeadExceptionBackedges
  */
 

--- a/test/hotspot/jtreg/compiler/profiling/TestSpecTrapClassUnloading.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestSpecTrapClassUnloading.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8031752
  * @summary speculative traps need to be cleaned up at GC
  *
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation
  *                   -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
  *                   -XX:CompileThreshold=10000

--- a/test/hotspot/jtreg/compiler/profiling/TestTypeProfileArgsLimit.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestTypeProfileArgsLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8295406
  * @summary Tests execution with TypeProfileArgsLimit=0 TypeProfileLevel=222.
  *
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -XX:TypeProfileArgsLimit=0 -XX:TypeProfileLevel=222 compiler.profiling.TestTypeProfileArgsLimit
  * @run main/othervm -XX:TypeProfileArgsLimit=0 -XX:TypeProfileLevel=212 compiler.profiling.TestTypeProfileArgsLimit
  * @run main/othervm -XX:TypeProfileArgsLimit=0 -XX:TypeProfileLevel=202 compiler.profiling.TestTypeProfileArgsLimit

--- a/test/hotspot/jtreg/compiler/profiling/TestTypeProfiling.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestTypeProfiling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
   *
   * @comment the test can't be run w/ TieredStopAtLevel < 4
   * @requires vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4
+  * @requires vm.compMode != "Xcomp"
   *
   * @library /test/lib /
   * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/compiler/profiling/TestUnexpectedProfilingMismatch.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestUnexpectedProfilingMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8027631
  * @summary profiling of arguments at calls cannot rely on signature of callee for types
  *
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -XX:-BackgroundCompilation -XX:TieredStopAtLevel=3 -XX:TypeProfileLevel=111
  *                   -XX:Tier3InvocationThreshold=200 -XX:Tier0InvokeNotifyFreqLog=7
  *                   compiler.profiling.TestUnexpectedProfilingMismatch

--- a/test/hotspot/jtreg/compiler/profiling/UnsafeAccess.java
+++ b/test/hotspot/jtreg/compiler/profiling/UnsafeAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @bug 8134918
  * @modules java.base/jdk.internal.misc
  *
+ * @requires vm.compMode != "Xcomp"
  * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:TypeProfileLevel=222 -XX:+UseTypeSpeculation -Xbatch
  *                                 -XX:CompileCommand=dontinline,compiler.profiling.UnsafeAccess::test*
  *                                 compiler.profiling.UnsafeAccess

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
@@ -28,6 +28,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.instrument
  * @requires vm.jvmti & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.profiling.spectrapredefineclass.Agent
  * @run driver jdk.test.lib.helpers.ClassFileInstaller compiler.profiling.spectrapredefineclass.Agent
  * @run driver compiler.profiling.spectrapredefineclass.Launcher

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
@@ -28,6 +28,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.instrument
  * @requires vm.jvmti & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.profiling.spectrapredefineclass_classloaders.Agent
  *        compiler.profiling.spectrapredefineclass_classloaders.Test
  *        compiler.profiling.spectrapredefineclass_classloaders.A

--- a/test/hotspot/jtreg/compiler/profiling/unloadingconflict/TestProfileConflictClassUnloading.java
+++ b/test/hotspot/jtreg/compiler/profiling/unloadingconflict/TestProfileConflictClassUnloading.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary class unloading resets profile, method compiled after the profile is
  * first set and before class loading sets unknown bit with not recorded class
  * @library /
+ * @requires vm.compMode != "Xcomp"
  * @build compiler.profiling.unloadingconflict.B
  * @run main/othervm -XX:TypeProfileLevel=222 -XX:-BackgroundCompilation
  *                   compiler.profiling.unloadingconflict.TestProfileConflictClassUnloading


### PR DESCRIPTION
The fix remove tier1_compiler_not_xcomp group. All profiling tests are marked as non Xcomp and added to tier1.

Verified that :tier1_compiler_3 contains them and that tier1 passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345435](https://bugs.openjdk.org/browse/JDK-8345435): Eliminate tier1_compiler_not_xcomp group (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22563/head:pull/22563` \
`$ git checkout pull/22563`

Update a local copy of the PR: \
`$ git checkout pull/22563` \
`$ git pull https://git.openjdk.org/jdk.git pull/22563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22563`

View PR using the GUI difftool: \
`$ git pr show -t 22563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22563.diff">https://git.openjdk.org/jdk/pull/22563.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22563#issuecomment-2518656107)
</details>
