### PR TITLE
8345144: Robot does not specify all causes of  IllegalThreadStateException

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -58,7 +58,7 @@ import static sun.java2d.SunGraphicsEnvironment.toDeviceSpaceAbs;
  * queue. For example, {@code Robot.mouseMove} will actually move
  * the mouse cursor instead of just generating mouse move events.
  * <p>
- * Note: {@code waitForIdle()} must not be called on the AWT EDT, and since
+ * Note: {@code waitForIdle()} must not be called on the AWT EDT, since
  * when {@code autoWaitForIdle()} is enabled, mouse and key related methods
  * will implicitly call {@code waitForIdle()} and therefore {@code IllegalThreadStateException}
  * will be thrown. In addition, screen capture operations can be lengthy
@@ -225,7 +225,7 @@ public class Robot {
      * @param x         X position
      * @param y         Y position
      * @throws  IllegalThreadStateException if called on the AWT event dispatching
-     *          thread and autoWaitForIdle is set to true
+     *          thread and {@code isAutoWaitForIdle} would return true
      */
     public synchronized void mouseMove(int x, int y) {
         peer.mouseMove(x, y);
@@ -278,7 +278,7 @@ public class Robot {
      *         and support for extended mouse buttons is {@link Toolkit#areExtraMouseButtonsEnabled() disabled} by Java
      * @throws IllegalArgumentException if the {@code buttons} mask contains the mask for extra mouse button
      *         that does not exist on the mouse and support for extended mouse buttons is {@link Toolkit#areExtraMouseButtonsEnabled() enabled} by Java
-     * @throws IllegalThreadStateException if called on the AWT event dispatching thread and autoWaitForIdle is set to true
+     * @throws  IllegalThreadStateException if called on the AWT event dispatching thread and {@code isAutoWaitForIdle} would return true
      * @see #mouseRelease(int)
      * @see InputEvent#getMaskForButton(int)
      * @see Toolkit#areExtraMouseButtonsEnabled()
@@ -336,7 +336,7 @@ public class Robot {
      *         and support for extended mouse buttons is {@link Toolkit#areExtraMouseButtonsEnabled() disabled} by Java
      * @throws IllegalArgumentException if the {@code buttons} mask contains the mask for extra mouse button
      *         that does not exist on the mouse and support for extended mouse buttons is {@link Toolkit#areExtraMouseButtonsEnabled() enabled} by Java
-     * @throws IllegalThreadStateException if called on the AWT event dispatching thread and autoWaitForIdle is set to true
+     * @throws  IllegalThreadStateException if called on the AWT event dispatching thread and {@code isAutoWaitForIdle} would return true
      * @see #mousePress(int)
      * @see InputEvent#getMaskForButton(int)
      * @see Toolkit#areExtraMouseButtonsEnabled()
@@ -361,8 +361,8 @@ public class Robot {
      * @param wheelAmt  number of "notches" to move the mouse wheel
      *                  Negative values indicate movement up/away from the user,
      *                  positive values indicate movement down/towards the user.
-     * @throws IllegalThreadStateException if called on the AWT event dispatching
-     *         thread and autoWaitForIdle is set to true
+     * @throws  IllegalThreadStateException if called on the AWT event dispatching
+     *          thread and {@code isAutoWaitForIdle} would return true
      *
      * @since 1.4
      */
@@ -382,8 +382,8 @@ public class Robot {
      * @param   keycode Key to press (e.g. {@code KeyEvent.VK_A})
      * @throws  IllegalArgumentException if {@code keycode} is not
      *          a valid key
-     * @throws IllegalThreadStateException if called on the AWT event
-     *         dispatching thread and autoWaitForIdle is set to true
+     * @throws  IllegalThreadStateException if called on the AWT event
+     *          dispatching thread and {@code isAutoWaitForIdle} would return true
      * @see     #keyRelease(int)
      * @see     java.awt.event.KeyEvent
      */
@@ -403,8 +403,9 @@ public class Robot {
      * @param   keycode Key to release (e.g. {@code KeyEvent.VK_A})
      * @throws  IllegalArgumentException if {@code keycode} is not a
      *          valid key
-     * @throws IllegalThreadStateException if called on the AWT event
-     *         dispatching thread and autoWaitForIdle is set to true
+     * @throws  IllegalThreadStateException if called on the AWT event
+     *          dispatching thread and {@code isAutoWaitForIdle} would return true
+
      * @see  #keyPress(int)
      * @see     java.awt.event.KeyEvent
      */
@@ -668,7 +669,7 @@ public class Robot {
      * <p>
      * Caution: setting this to true means you cannot call mouse and key-controlling events
      * on the AWT Event Dispatching Thread
-     * <p>
+     *
      * @param   isOn    Whether {@code waitForIdle} is automatically invoked
      */
     public synchronized void setAutoWaitForIdle(boolean isOn) {

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -405,7 +405,6 @@ public class Robot {
      *          valid key
      * @throws  IllegalThreadStateException if called on the AWT event
      *          dispatching thread and {@code isAutoWaitForIdle} would return true
-
      * @see  #keyPress(int)
      * @see     java.awt.event.KeyEvent
      */

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -58,7 +58,7 @@ import static sun.java2d.SunGraphicsEnvironment.toDeviceSpaceAbs;
  * queue. For example, {@code Robot.mouseMove} will actually move
  * the mouse cursor instead of just generating mouse move events.
  * <p>
- * Note: When {@code autoWaitForIdle()} is enabled, mouse and key related methods
+ * @apiNote When {@code autoWaitForIdle()} is enabled, mouse and key related methods
  * cannot be called on the AWT EDT. This is because when {@code autoWaitForIdle()}
  * is enabled, the mouse and key methods implicitly call {@code waitForIdle()}
  * which will throw {@code IllegalThreadStateException} when called on the AWT EDT.
@@ -667,7 +667,7 @@ public class Robot {
      * Sets whether this Robot automatically invokes {@code waitForIdle}
      * after generating an event.
      * <p>
-     * Caution: setting this to true means you cannot call mouse and key-controlling events
+     * @apiNote Setting this to true means you cannot call mouse and key-controlling events
      * on the AWT Event Dispatching Thread
      *
      * @param   isOn    Whether {@code waitForIdle} is automatically invoked

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -405,7 +405,7 @@ public class Robot {
      *          valid key
      * @throws  IllegalThreadStateException if called on the AWT event
      *          dispatching thread and {@code isAutoWaitForIdle} would return true
-     * @see  #keyPress(int)
+     * @see     #keyPress(int)
      * @see     java.awt.event.KeyEvent
      */
     public synchronized void keyRelease(int keycode) {

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -58,10 +58,11 @@ import static sun.java2d.SunGraphicsEnvironment.toDeviceSpaceAbs;
  * queue. For example, {@code Robot.mouseMove} will actually move
  * the mouse cursor instead of just generating mouse move events.
  * <p>
- * Note: {@code waitForIdle()} must not be called on the AWT EDT, since
- * when {@code autoWaitForIdle()} is enabled, mouse and key related methods
- * will implicitly call {@code waitForIdle()} and therefore {@code IllegalThreadStateException}
- * will be thrown. In addition, screen capture operations can be lengthy
+ * Note: When {@code autoWaitForIdle()} is enabled, mouse and key related methods
+ * cannot be called on the AWT EDT. This is because when {@code autoWaitForIdle()}
+ * is enabled, the mouse and key methods implicitly call {@code waitForIdle()}
+ * which will throw {@code IllegalThreadStateException} when called on the AWT EDT.
+ * In addition, screen capture operations can be lengthy
  * and {@code delay(long ms)} clearly inserts a delay, so these also
  * should not be called on the EDT. Taken together, this means that as much as possible,
  * methods on this class should not be called on the EDT.


### PR DESCRIPTION
When robot.autoWaitForIdle is set to true, all mouse and key-related methods when invoked on the EDT will throw java.lang.IllegalThreadStateException which is not in the Robot specification.

This PR updates the specification by adding warnings to avoid calling lengthy and delay-type methods on EDT and including exceptions thrown when autoWaitForIdle is set to true and mouse/key-handling methods are called on the EDT.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8346687](https://bugs.openjdk.org/browse/JDK-8346687) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8345144](https://bugs.openjdk.org/browse/JDK-8345144): Robot does not specify all causes of  IllegalThreadStateException (**Bug** - P4)
 * [JDK-8346687](https://bugs.openjdk.org/browse/JDK-8346687): Robot does not specify all causes of  IllegalThreadStateException (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22564/head:pull/22564` \
`$ git checkout pull/22564`

Update a local copy of the PR: \
`$ git checkout pull/22564` \
`$ git pull https://git.openjdk.org/jdk.git pull/22564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22564`

View PR using the GUI difftool: \
`$ git pr show -t 22564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22564.diff">https://git.openjdk.org/jdk/pull/22564.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22564#issuecomment-2518701370)
</details>
