### PR TITLE
JDK-8345302

### DIFF
--- a/make/autoconf/boot-jdk.m4
+++ b/make/autoconf/boot-jdk.m4
@@ -470,7 +470,7 @@ AC_DEFUN_ONCE([BOOTJDK_SETUP_BOOT_JDK_ARGUMENTS],
   # Maximum amount of heap memory.
   JVM_HEAP_LIMIT_32="768"
   # Running a 64 bit JVM allows for and requires a bigger heap
-  JVM_HEAP_LIMIT_64="1600"
+  JVM_HEAP_LIMIT_64="2048"
   JVM_HEAP_LIMIT_GLOBAL=`expr $MEMORY_SIZE / 2`
   if test "$JVM_HEAP_LIMIT_GLOBAL" -lt "$JVM_HEAP_LIMIT_32"; then
     JVM_HEAP_LIMIT_32=$JVM_HEAP_LIMIT_GLOBAL


### PR DESCRIPTION
Recently we have started to see OOME being thrown when building the microbenchmarks. See the bug for a closer analysis of why this happens by @shipilev and @mcimadamore. This patch just increases the default mx setting for the "big" java configuration in the build. I think that in 2024, we are ready to bump this to 2048M.

I'm not touching the 32 bit max mx setting as I have no way of testing it.