### PR TITLE
8345547: test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java fails in ubuntu22.04

### DIFF
--- a/test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
+++ b/test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,15 +26,20 @@
  * @key headful
  * @bug 4278839 8233634
  * @summary Incorrect cursor movement between words at the end of line
- * @author Anton Nashatyrev
  * @library ../../../regtesthelpers
  * @build Util
  * @run main bug4278839
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.event.InputEvent;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
 public class bug4278839 {
 
@@ -106,11 +111,8 @@ public class bug4278839 {
     private static void clickMouse() throws Exception {
         final Rectangle result[] = new Rectangle[1];
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
-                result[0] = new Rectangle(area.getLocationOnScreen(), area.getSize());
-            }
+        SwingUtilities.invokeAndWait(() -> {
+            result[0] = new Rectangle(area.getLocationOnScreen(), area.getSize());
         });
 
         Rectangle rect = result[0];

--- a/test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
+++ b/test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
@@ -36,7 +36,7 @@ import java.awt.*;
 import java.awt.event.*;
 import javax.swing.*;
 
-public class bug4278839 extends JFrame {
+public class bug4278839 {
 
     private static boolean passed = true;
     private static JTextArea area;
@@ -47,16 +47,12 @@ public class bug4278839 extends JFrame {
         try {
 
             robo = new Robot();
-            robo.setAutoDelay(200);
+            robo.setAutoDelay(100);
 
-            SwingUtilities.invokeAndWait(new Runnable() {
-                @Override
-                public void run() {
-                    createAndShowGUI();
-                }
-            });
+            SwingUtilities.invokeAndWait(() -> createAndShowGUI());
 
             robo.waitForIdle();
+            robo.delay(1000);
 
             clickMouse();
             robo.waitForIdle();
@@ -100,16 +96,11 @@ public class bug4278839 extends JFrame {
 
         final int[] result = new int[1];
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-
-            @Override
-            public void run() {
-                result[0] = area.getCaretPosition();
-            }
+        SwingUtilities.invokeAndWait(() -> {
+            result[0] = area.getCaretPosition();
         });
 
-        int pos = result[0];
-        return pos;
+        return result[0];
     }
 
     private static void clickMouse() throws Exception {
@@ -125,8 +116,10 @@ public class bug4278839 extends JFrame {
         Rectangle rect = result[0];
 
         robo.mouseMove(rect.x + rect.width / 2, rect.y + rect.width / 2);
-        robo.mousePress(InputEvent.BUTTON1_MASK);
-        robo.mouseRelease(InputEvent.BUTTON1_MASK);
+        robo.waitForIdle();
+        robo.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robo.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robo.waitForIdle();
     }
 
     /**


### PR DESCRIPTION
test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java tests movement of caret between word and fails in OCI citing

```
java.lang.RuntimeException: Test failed.
at bug4278839.main(bug4278839.java:92)
```
which suggests caret is not moved as per expectation..It also seems the focus is not in the frame when the test start executing.
Added robot delay and waitForIdle and it passed in several OCI systems

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345547](https://bugs.openjdk.org/browse/JDK-8345547): test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java fails in ubuntu22.04 (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22566/head:pull/22566` \
`$ git checkout pull/22566`

Update a local copy of the PR: \
`$ git checkout pull/22566` \
`$ git pull https://git.openjdk.org/jdk.git pull/22566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22566`

View PR using the GUI difftool: \
`$ git pr show -t 22566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22566.diff">https://git.openjdk.org/jdk/pull/22566.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22566#issuecomment-2518997254)
</details>
