### PR TITLE
8339622: Regression in make open-hotspot-xcode-project

### DIFF
--- a/make/ide/xcode/hotspot/CreateXcodeProject.gmk
+++ b/make/ide/xcode/hotspot/CreateXcodeProject.gmk
@@ -42,7 +42,7 @@ ifeq ($(call isTargetOs, macosx), true)
   PROJECT_FILE_NAME := hotspot.xcodeproj
 
   COMPILE_COMMAND_FILE := $(OUTPUTDIR)/compile_commands.json
-  LINKER_FLAGS_FILE := $(MAKESUPPORT_OUTPUTDIR)/compile-commands/jvm-ldflags.txt
+  LINKER_FLAGS_FILE := $(MAKESUPPORT_OUTPUTDIR)/compile-commands/LIBRARY_hotspot_variant-server_libjvm_libjvm-ldflags.txt
 
   $(eval $(call SetupJavaCompilation, BUILD_PROJECT_CREATOR, \
       TARGET_RELEASE := $(TARGET_RELEASE_BOOTJDK), \
@@ -60,7 +60,7 @@ ifeq ($(call isTargetOs, macosx), true)
     XCODE_PROJ_DEBUG_OPTION := -d
   endif
 
-  XCODE_PROJ_VARDEPS := $(WORKSPACE_ROOT) $(IDE_OUTPUTDIR) \
+  XCODE_PROJ_VARDEPS := $(TOPDIR) $(IDE_OUTPUTDIR) \
       $(PROJECT_MAKER_DIR)/data $(COMPILE_COMMAND_FILE) $(LINKER_FLAGS_FILE)
   XCODE_PROJ_VARDEPS_FILE := $(call DependOnVariable, XCODE_PROJ_VARDEPS, \
     $(TOOLS_OUTPUTDIR)/xcodeproj.vardeps)
@@ -70,7 +70,7 @@ ifeq ($(call isTargetOs, macosx), true)
       DEPS := $(BUILD_PROJECT_CREATOR) $(COMPILE_COMMAND_FILE) \
           $(LINKER_FLAGS_FILE) $(XCODE_PROJ_VARDEPS_FILE), \
       OUTPUT_DIR := $(TOOLS_OUTPUTDIR), \
-      COMMAND := $(PROJECT_CREATOR_TOOL) $(WORKSPACE_ROOT) $(IDE_OUTPUTDIR) \
+      COMMAND := $(PROJECT_CREATOR_TOOL) $(TOPDIR) $(IDE_OUTPUTDIR) \
           $(PROJECT_MAKER_DIR)/data $(COMPILE_COMMAND_FILE) \
           $(LINKER_FLAGS_FILE) $(XCODE_PROJ_DEBUG_OPTION), \
   ))


### PR DESCRIPTION
Since [JDK-8338916](https://bugs.openjdk.org/browse/JDK-8338916), `make open-hotspot-xcode-project` fails with:

```
make[3]: *** No rule to make target `/Users/gerard/Work/bugs/8337563/jdk/build/macosx-aarch64-server-release/make-support/compile-commands/jvm-ldflags.txt', needed by `/Users/gerard/Work/bugs/8337563/jdk/build/macosx-aarch64-server-release/make-support/ide/xcode/_build_xcode_project_exec.marker'. Stop. 
```

The reason was that the ldflags file name changed in JDK-8338916, but this usage was not updated.

Also, when implementing this I had incorrectly used WORKSPACE_ROOT when I should have used TOPDIR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339622](https://bugs.openjdk.org/browse/JDK-8339622): Regression in make open-hotspot-xcode-project (**Bug** - P4)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22571/head:pull/22571` \
`$ git checkout pull/22571`

Update a local copy of the PR: \
`$ git checkout pull/22571` \
`$ git pull https://git.openjdk.org/jdk.git pull/22571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22571`

View PR using the GUI difftool: \
`$ git pr show -t 22571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22571.diff">https://git.openjdk.org/jdk/pull/22571.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22571#issuecomment-2519863083)
</details>
