### PR TITLE
8344559: Log is spammed by missing pandoc warnings when building man pages

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -863,12 +863,12 @@ href="https://www.gnu.org/software/bash">GNU Bash</a>. No other shells
 are supported.</p>
 <p>At least version 3.2 of GNU Bash must be used.</p>
 <h3 id="graphviz-and-pandoc">Graphviz and Pandoc</h3>
-<p>In order to build the full docs (see the
+<p>In order to build man pages and the full docs (see the
 <code>--enable-full-docs</code> configure option) <a
-href="https://www.graphviz.org">Graphviz</a> and <a
-href="https://pandoc.org">Pandoc</a> are required. Any recent versions
-should work. For reference, and subject to change, Oracle builds use
-Graphviz 9.0.0 and Pandoc 2.19.2.</p>
+href="https://pandoc.org">Pandoc</a> is required. For full docs also <a
+href="https://www.graphviz.org">Graphviz</a> is required. Any recent
+versions should work. For reference, and subject to change, Oracle
+builds use Graphviz 9.0.0 and Pandoc 2.19.2.</p>
 <h2 id="running-configure">Running Configure</h2>
 <p>To build the JDK, you need a "configuration", which consists of a
 directory where to store the build output, coupled with information

--- a/doc/building.md
+++ b/doc/building.md
@@ -680,9 +680,9 @@ At least version 3.2 of GNU Bash must be used.
 
 ### Graphviz and Pandoc
 
-In order to build the full docs (see the `--enable-full-docs`
-configure option) [Graphviz](https://www.graphviz.org) and
-[Pandoc](https://pandoc.org) are required. Any recent versions should
+In order to build man pages and the full docs (see the `--enable-full-docs`
+configure option) [Pandoc](https://pandoc.org) is required. For full docs also
+[Graphviz](https://www.graphviz.org) is required. Any recent versions should
 work. For reference, and subject to change, Oracle builds use Graphviz
 9.0.0 and Pandoc 2.19.2.
 

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -121,7 +121,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
   if test "x$DOT" != "x"; then
     AC_MSG_RESULT([yes])
   else
-    AC_MSG_RESULT([no, cannot generate full docs])
+    AC_MSG_RESULT([no, cannot generate full docs or man pages])
     FULL_DOCS_AVAILABLE=false
   fi
 
@@ -129,7 +129,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
   if test "x$ENABLE_PANDOC" = "xtrue"; then
     AC_MSG_RESULT([yes])
   else
-    AC_MSG_RESULT([no, cannot generate full docs])
+    AC_MSG_RESULT([no, cannot generate full docs or man pages])
     FULL_DOCS_AVAILABLE=false
   fi
 

--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -192,9 +192,7 @@ ifeq ($(call isTargetOsType, unix)+$(MAKEFILE_PREFIX), true+Launcher)
   MAN_FILES_MD := $(wildcard $(addsuffix /*.md, $(call FindModuleManDirs, $(MODULE))))
 
   ifneq ($(MAN_FILES_MD), )
-    ifeq ($(ENABLE_PANDOC), false)
-      $(info Warning: pandoc not found. Not generating man pages)
-    else
+    ifeq ($(ENABLE_PANDOC), true)
       # Create dynamic man pages from markdown using pandoc. We need
       # PANDOC_TROFF_MANPAGE_FILTER, a wrapper around
       # PANDOC_TROFF_MANPAGE_FILTER_JAVASCRIPT. This is created by buildtools-jdk.


### PR DESCRIPTION
If the user does not have pandoc installed and configured, the logs are spammed with the warning:

```
Warning: pandoc not found. Not generating man pages
```

once for each man page that should have been generated. 

This is excessive and should be removed. Instead, let configure inform the user that you cannot build man pages without pandoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344559](https://bugs.openjdk.org/browse/JDK-8344559): Log is spammed by missing pandoc warnings when building man pages (**Bug** - P4)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22573/head:pull/22573` \
`$ git checkout pull/22573`

Update a local copy of the PR: \
`$ git checkout pull/22573` \
`$ git pull https://git.openjdk.org/jdk.git pull/22573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22573`

View PR using the GUI difftool: \
`$ git pr show -t 22573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22573.diff">https://git.openjdk.org/jdk/pull/22573.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22573#issuecomment-2519993587)
</details>
