### PR TITLE
8345323: Parallel GC does not handle UseLargePages and UseNUMA gracefully

### DIFF
--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -40,7 +40,7 @@ size_t MaxOldSize = 0;
 // If InitialHeapSize or MinHeapSize is not set on cmdline, this variable,
 // together with NewSize, is used to derive them.
 // Using the same value when it was a configurable flag to avoid breakage.
-// See more in JDK-8345323
+// See more in JDK-8346005
 size_t OldSize = ScaleForWordSize(4*M);
 
 size_t GenAlignment = 0;

--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -37,7 +37,11 @@ size_t MinNewSize = 0;
 size_t MinOldSize = 0;
 size_t MaxOldSize = 0;
 
-size_t OldSize = 0;
+// If InitialHeapSize or MinHeapSize is not set on cmdline, this variable,
+// together with NewSize, are used to derive them.
+// Using the same value when it was a configurable flag to avoid breakage.
+// See more in JDK-8345323
+size_t OldSize = ScaleForWordSize(4*M);
 
 size_t GenAlignment = 0;
 

--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -38,7 +38,7 @@ size_t MinOldSize = 0;
 size_t MaxOldSize = 0;
 
 // If InitialHeapSize or MinHeapSize is not set on cmdline, this variable,
-// together with NewSize, are used to derive them.
+// together with NewSize, is used to derive them.
 // Using the same value when it was a configurable flag to avoid breakage.
 // See more in JDK-8345323
 size_t OldSize = ScaleForWordSize(4*M);


### PR DESCRIPTION
This patch reverts the default value of `OldSize` to its previous setting prior to being obsoleted in [JDK-8333962](https://bugs.openjdk.org/browse/JDK-8333962). The change addresses an issue where `OldSize` being set to zero results in a default `MinHeapSize` that is too small to handle LargePages correctly. This problem is exemplified by `ParallelArguments::initialize_heap_flags_and_sizes`, as identified in [JDK-8345323](https://bugs.openjdk.org/browse/JDK-8345323).

Changing the default value of `OldSize` may have broader implications due to the complexity of the logic that determines default values for various flags. Altering one default can lead to cascading effects and potential breakages elsewhere. For these reasons, this patch restores the previous default value of `OldSize` to mitigate such risks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345323](https://bugs.openjdk.org/browse/JDK-8345323): Parallel GC does not handle UseLargePages and UseNUMA gracefully (**Bug** - P3)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22575/head:pull/22575` \
`$ git checkout pull/22575`

Update a local copy of the PR: \
`$ git checkout pull/22575` \
`$ git pull https://git.openjdk.org/jdk.git pull/22575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22575`

View PR using the GUI difftool: \
`$ git pr show -t 22575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22575.diff">https://git.openjdk.org/jdk/pull/22575.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22575#issuecomment-2520143611)
</details>
