### PR TITLE
8345578: New test in JDK-8343622 fails with a promoted build

### DIFF
--- a/test/jdk/sun/security/krb5/NullStringToKey.java
+++ b/test/jdk/sun/security/krb5/NullStringToKey.java
@@ -24,11 +24,8 @@
  * @test
  * @bug 8343622
  * @summary KerberosKey created with null key bytes
- * @library /test/lib
  * @run main/othervm NullStringToKey
  */
-
-import jdk.test.lib.Utils;
 
 import javax.security.auth.kerberos.KerberosKey;
 import javax.security.auth.kerberos.KerberosPrincipal;
@@ -47,8 +44,16 @@ public class NullStringToKey {
                 "aes128-cts-hmac-sha1-96", "aes256-cts-hmac-sha1-96",
                 "aes128-cts-hmac-sha256-128", "aes256-cts-hmac-sha384-192")) {
             System.out.println(alg);
-            Utils.runAndCheckException(() -> new KerberosKey(name, pass, alg),
-                    IllegalArgumentException.class);
+            // Do not use Utils.runAndCheckException as it might call
+            // MessageDigest.getInstance("MD5") at class initialization
+            // and we have already removed the SUN provider.
+            try {
+                new KerberosKey(name, pass, alg);
+                throw new RuntimeException("Didn't get expected exception");
+            } catch (IllegalArgumentException e) {
+                // expected
+                System.out.println(e);
+            }
         }
     }
 }


### PR DESCRIPTION
The test fails with a promoted build because `Utils.<clinit>` calls `MessageDigest.getInstance("MD5")` after the SUN provider is removed. Manually rewrite the functionality of `Utils.runAndCheckException` instead of using the existing helper method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345578](https://bugs.openjdk.org/browse/JDK-8345578): New test in JDK-8343622 fails with a promoted build (**Bug** - P3)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22576/head:pull/22576` \
`$ git checkout pull/22576`

Update a local copy of the PR: \
`$ git checkout pull/22576` \
`$ git pull https://git.openjdk.org/jdk.git pull/22576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22576`

View PR using the GUI difftool: \
`$ git pr show -t 22576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22576.diff">https://git.openjdk.org/jdk/pull/22576.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22576#issuecomment-2520232576)
</details>
