### PR TITLE
8345577: Additional clarification to the com.sun.net.httpserver.HttpExchange.getAttribute() and setAttribute() methods after JDK-8235786

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -233,8 +233,14 @@ public abstract class HttpExchange implements AutoCloseable, Request {
     public abstract String getProtocol();
 
     /**
-     * Returns the attribute's value from this exchange's
-     * {@linkplain HttpContext#getAttributes() context attributes}.
+     * Returns the value for the given attribute {@code name}.
+     *
+     * @implSpec The JDK built-in implementation of this method returns
+     * the attribute value from this exchange's
+     * {@linkplain HttpContext#getAttributes() context attributes}. The attribute
+     * may have been {@linkplain HttpExchange#setAttribute(String, Object) set}
+     * either through this {@code HttpExchange} instance or some
+     * other {@code HttpExchange} belonging to the same {@link HttpContext}.
      *
      * @apiNote {@link Filter} modules may store arbitrary objects as attributes through
      * {@code HttpExchange} instances as an out-of-band communication mechanism. Other filters
@@ -251,8 +257,13 @@ public abstract class HttpExchange implements AutoCloseable, Request {
     public abstract Object getAttribute(String name);
 
     /**
-     * Sets an attribute with the given {@code name} and {@code value} in this exchange's
-     * {@linkplain HttpContext#getAttributes() context attributes}.
+     * Sets an attribute with the given {@code name} and {@code value}.
+     *
+     * @implSpec The JDK built-in implementation of this method sets
+     * the attribute in this exchange's
+     * {@linkplain HttpContext#getAttributes() context attributes}. The attribute
+     * will be {@linkplain HttpExchange#getAttribute(String) available} to all
+     * other {@code HttpExchange}s that belong to the same {@link HttpContext}.
      *
      * @apiNote {@link Filter} modules may store arbitrary objects as attributes through
      * {@code HttpExchange} instances as an out-of-band communication mechanism. Other filters


### PR DESCRIPTION
Can I please get a review of this doc-only change which proposes to address https://bugs.openjdk.org/browse/JDK-8345577?

As noted in that issue, a recent update (in the current JDK mainline) to the javadoc of these methods made some existing external subclasses overridding these methods to contradict the specification of the methods. The update in this current PR relaxes the normative text and clarifies the JDK built-in implementation through a `@implSpec`.

No new tests have been added given the nature of this change. The CSR is ready for review https://bugs.openjdk.org/browse/JDK-8345582.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 25 to be approved (needs to be created)

### Issue
 * [JDK-8345577](https://bugs.openjdk.org/browse/JDK-8345577): Additional clarification to the com.sun.net.httpserver.HttpExchange.getAttribute() and setAttribute() methods after JDK-8235786 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22577/head:pull/22577` \
`$ git checkout pull/22577`

Update a local copy of the PR: \
`$ git checkout pull/22577` \
`$ git pull https://git.openjdk.org/jdk.git pull/22577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22577`

View PR using the GUI difftool: \
`$ git pr show -t 22577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22577.diff">https://git.openjdk.org/jdk/pull/22577.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22577#issuecomment-2520337707)
</details>
