### PR TITLE
8345591: [aarch64] macroAssembler_aarch64.cpp compile fails ceil_log2 not declared

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5290,6 +5290,10 @@ void  MacroAssembler::decode_heap_oop_not_null(Register dst, Register src) {
 
 MacroAssembler::KlassDecodeMode MacroAssembler::_klass_decode_mode(KlassDecodeNone);
 
+int ceil_log2(int x) {
+    return std::ceil(std::log2(x));
+}
+
 MacroAssembler::KlassDecodeMode MacroAssembler::klass_decode_mode() {
   assert(UseCompressedClassPointers, "not using compressed class pointers");
   assert(Metaspace::initialized(), "metaspace not initialized yet");


### PR DESCRIPTION
Hi all,
This PR add the ceil_log2 definition to fix the complie error.