### PR TITLE
8345591: [aarch64] macroAssembler_aarch64.cpp compile fails ceil_log2 not declared

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5305,7 +5305,7 @@ MacroAssembler::KlassDecodeMode MacroAssembler::klass_decode_mode() {
   if (operand_valid_for_logical_immediate(
         /*is32*/false, (uint64_t)CompressedKlassPointers::base())) {
     const size_t range = CompressedKlassPointers::klass_range_end() - CompressedKlassPointers::base();
-    const uint64_t range_mask = right_n_bits(ceil_log2(range));
+    const uint64_t range_mask = right_n_bits(log2i_ceil(range));
     if (((uint64_t)CompressedKlassPointers::base() & range_mask) == 0) {
       return (_klass_decode_mode = KlassDecodeXor);
     }


### PR DESCRIPTION
Please review this trivial change to fix the name of a function in a call.
This change:
JDK-8343699: [aarch64] Bug in MacroAssembler::klass_decode_mode()
used the name ceil_log2, but that function was recently renamed to log2i_ceil by
JDK-8344568.

Testing: mach5 tier1 for linux-aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345591](https://bugs.openjdk.org/browse/JDK-8345591): [aarch64] macroAssembler_aarch64.cpp compile fails ceil_log2 not declared (**Bug** - P1)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22579/head:pull/22579` \
`$ git checkout pull/22579`

Update a local copy of the PR: \
`$ git checkout pull/22579` \
`$ git pull https://git.openjdk.org/jdk.git pull/22579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22579`

View PR using the GUI difftool: \
`$ git pr show -t 22579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22579.diff">https://git.openjdk.org/jdk/pull/22579.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22579#issuecomment-2520629572)
</details>
