### PR TITLE
8345335: Add excluded jdk_foreign tests to manual group

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -625,9 +625,7 @@ jdk_core_manual_no_input = \
     java/util/Vector/Bug8148174.java \
     com/sun/net/httpserver/simpleserver/CommandLinePortNotSpecifiedTest.java \
     com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePortNotSpecifiedTest.java \
-    javax/xml/jaxp/datatype/8033980/GregorianCalAndDurSerDataUtil.java \
-    java/foreign/TestMatrix.java \
-    java/foreign/TestUpcallStress.java
+    javax/xml/jaxp/datatype/8033980/GregorianCalAndDurSerDataUtil.java 
 
 jdk_security_manual_no_input = \
     :jdk_security_infra \

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -92,15 +92,15 @@ tier3 = \
     -:jdk_svc_sanity \
     -:svc_tools \
     :jdk_jpackage \
-    :jdk_since_checks \
-    :jdk_foreign_stress
+    :jdk_since_checks
 
 # Everything not in other tiers
 tier4 = \
     / \
    -:tier1 \
    -:tier2 \
-   -:tier3
+   -:tier3 \
+   :jdk_foreign_stress
 
 ###############################################################################
 #
@@ -382,7 +382,9 @@ jdk_svc = \
 
 jdk_foreign = \
     java/foreign \
-    jdk/internal/reflect/CallerSensitive/CheckCSMs.java
+    jdk/internal/reflect/CallerSensitive/CheckCSMs.java \
+    -java/foreign/TestMatrix.java \
+    -java/foreign/TestUpcallStress.java
 
 jdk_foreign_stress = \
     java/foreign/TestMatrix.java \

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -92,7 +92,8 @@ tier3 = \
     -:jdk_svc_sanity \
     -:svc_tools \
     :jdk_jpackage \
-    :jdk_since_checks
+    :jdk_since_checks \
+    :jdk_foreign_stress
 
 # Everything not in other tiers
 tier4 = \
@@ -381,9 +382,11 @@ jdk_svc = \
 
 jdk_foreign = \
     java/foreign \
-    jdk/internal/reflect/CallerSensitive/CheckCSMs.java \
-    -java/foreign/TestMatrix.java \
-    -java/foreign/TestUpcallStress.java
+    jdk/internal/reflect/CallerSensitive/CheckCSMs.java
+
+jdk_foreign_stress = \
+    java/foreign/TestMatrix.java \
+    java/foreign/TestUpcallStress.java
 
 jdk_vector = \
     jdk/incubator/vector

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -620,7 +620,9 @@ jdk_core_manual_no_input = \
     java/util/Vector/Bug8148174.java \
     com/sun/net/httpserver/simpleserver/CommandLinePortNotSpecifiedTest.java \
     com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePortNotSpecifiedTest.java \
-    javax/xml/jaxp/datatype/8033980/GregorianCalAndDurSerDataUtil.java
+    javax/xml/jaxp/datatype/8033980/GregorianCalAndDurSerDataUtil.java \
+    java/foreign/TestMatrix.java \
+    java/foreign/TestUpcallStress.java
 
 jdk_security_manual_no_input = \
     :jdk_security_infra \

--- a/test/jdk/java/foreign/TestMatrix.java
+++ b/test/jdk/java/foreign/TestMatrix.java
@@ -35,7 +35,7 @@
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native/manual
+ * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.DowncallLinker.USE_SPEC=false
  *   -Djdk.internal.foreign.UpcallLinker.USE_SPEC=false

--- a/test/jdk/java/foreign/TestUpcallStress.java
+++ b/test/jdk/java/foreign/TestUpcallStress.java
@@ -31,7 +31,7 @@
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  * @bug 8337753
  *
- * @run testng/native/manual/othervm/timeout=3200
+ * @run testng/native/othervm/timeout=3200
  *   -Xcheck:jni
  *   -XX:+IgnoreUnrecognizedVMOptions
  *   -XX:-VerifyDependencies

--- a/test/jdk/java/foreign/TestUpcallStress.java
+++ b/test/jdk/java/foreign/TestUpcallStress.java
@@ -31,7 +31,7 @@
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  * @bug 8337753
  *
- * @run testng/native/othervm/timeout=3200
+ * @run testng/native/manual/othervm/timeout=3200
  *   -Xcheck:jni
  *   -XX:+IgnoreUnrecognizedVMOptions
  *   -XX:-VerifyDependencies


### PR DESCRIPTION
@AlanBateman @mahendrachhipa @bwhuang-us @serhiysachkov @mcimadamore @JornVernee 

adding as manual tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345335](https://bugs.openjdk.org/browse/JDK-8345335): Add excluded jdk_foreign tests to manual group (**Task** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22580/head:pull/22580` \
`$ git checkout pull/22580`

Update a local copy of the PR: \
`$ git checkout pull/22580` \
`$ git pull https://git.openjdk.org/jdk.git pull/22580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22580`

View PR using the GUI difftool: \
`$ git pr show -t 22580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22580.diff">https://git.openjdk.org/jdk/pull/22580.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22580#issuecomment-2520848252)
</details>
