### PR TITLE
8345614: Improve AnnotationFormatError message for duplicate annotation interfaces

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
@@ -123,7 +123,7 @@ public class AnnotationParser {
                 if (AnnotationType.getInstance(klass).retention() == RetentionPolicy.RUNTIME &&
                     result.put(klass, a) != null) {
                         throw new AnnotationFormatError(
-                            "Duplicate annotation for class: "+klass+": " + a);
+                            "Duplicate annotation " + klass + " in " + container);
             }
         }
         }


### PR DESCRIPTION
I am getting the `Duplication annotation for class` error as mentioned in https://hibernate.atlassian.net/browse/HHH-18901.  The current error message does not include the application class name (e.g. container) that the specified annotation is unexpectedly duplicated.  This pull request is for including the class name that has the (duplicate) annotation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345614](https://bugs.openjdk.org/browse/JDK-8345614): Improve AnnotationFormatError message for duplicate annotation interfaces (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22581/head:pull/22581` \
`$ git checkout pull/22581`

Update a local copy of the PR: \
`$ git checkout pull/22581` \
`$ git pull https://git.openjdk.org/jdk.git pull/22581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22581`

View PR using the GUI difftool: \
`$ git pr show -t 22581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22581.diff">https://git.openjdk.org/jdk/pull/22581.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22581#issuecomment-2521214955)
</details>
