### PR TITLE
8345609: [C1] LIR Operations with one input should be implemented as LIR_Op1

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -777,13 +777,11 @@ void LIRGenerator::do_MathIntrinsic(Intrinsic* x) {
         }
         case vmIntrinsics::_floatToFloat16: {
           LIR_Opr tmp = new_register(T_FLOAT);
-          __ move(LIR_OprFact::floatConst(-0.0), tmp);
           __ f2hf(src, dst, tmp);
           break;
         }
         case vmIntrinsics::_float16ToFloat: {
           LIR_Opr tmp = new_register(T_FLOAT);
-          __ move(LIR_OprFact::floatConst(-0.0), tmp);
           __ hf2f(src, dst, tmp);
           break;
         }

--- a/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
@@ -696,8 +696,6 @@ void LIRGenerator::do_MathIntrinsic(Intrinsic* x) {
       value.load_item();
       LIR_Opr dst = rlock_result(x);
       LIR_Opr tmp = new_register(T_FLOAT);
-      // f2hf treats tmp as live_in. Workaround: initialize to some value.
-      __ move(LIR_OprFact::floatConst(-0.0), tmp); // just to satisfy LinearScan
       __ f2hf(value.result(), dst, tmp);
       break;
     }

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -349,11 +349,9 @@ void LIRGenerator::do_NegateOp(NegateOp* x) {
   if (UseAVX > 2 && !VM_Version::supports_avx512vl()) {
     if (x->type()->tag() == doubleTag) {
       tmp = new_register(T_DOUBLE);
-      __ move(LIR_OprFact::doubleConst(-0.0), tmp);
     }
     else if (x->type()->tag() == floatTag) {
       tmp = new_register(T_FLOAT);
-      __ move(LIR_OprFact::floatConst(-0.0), tmp);
     }
   }
 #endif
@@ -834,12 +832,10 @@ void LIRGenerator::do_MathIntrinsic(Intrinsic* x) {
   if (UseAVX > 2 && (!VM_Version::supports_avx512vl()) &&
       (x->id() == vmIntrinsics::_dabs)) {
     tmp = new_register(T_DOUBLE);
-    __ move(LIR_OprFact::doubleConst(-0.0), tmp);
   }
 #endif
   if (x->id() == vmIntrinsics::_floatToFloat16) {
     tmp = new_register(T_FLOAT);
-    __ move(LIR_OprFact::floatConst(-0.0), tmp);
   }
 
   switch(x->id()) {

--- a/src/hotspot/cpu/x86/c1_LinearScan_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LinearScan_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/c1_LinearScan_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LinearScan_x86.cpp
@@ -635,6 +635,24 @@ void FpuStackAllocator::handle_op1(LIR_Op1* op1) {
       break;
     }
 
+    case lir_abs:
+    case lir_sqrt:
+    case lir_neg: {
+      assert(in->is_fpu_register(), "must be");
+      assert(res->is_fpu_register(), "must be");
+      assert(in->is_last_use(), "old value gets destroyed");
+
+      insert_free_if_dead(res, in);
+      insert_exchange(in);
+      do_rename(in, res);
+
+      new_in = to_fpu_stack_top(res);
+      new_res = new_in;
+
+      op1->set_fpu_stack_size(sim()->stack_size());
+      break;
+    }
+
     default: {
       assert(!in->is_float_kind() && !res->is_float_kind(), "missed a fpu-operation");
     }
@@ -753,26 +771,6 @@ void FpuStackAllocator::handle_op2(LIR_Op2* op2) {
       do_rename(right, res);
 
       new_res = to_fpu_stack_top(res);
-      break;
-    }
-
-    case lir_abs:
-    case lir_sqrt:
-    case lir_neg: {
-      // Right argument appears to be unused
-      assert(right->is_illegal(), "must be");
-      assert(left->is_fpu_register(), "must be");
-      assert(res->is_fpu_register(), "must be");
-      assert(left->is_last_use(), "old value gets destroyed");
-
-      insert_free_if_dead(res, left);
-      insert_exchange(left);
-      do_rename(left, res);
-
-      new_left = to_fpu_stack_top(res);
-      new_res = new_left;
-
-      op2->set_fpu_stack_size(sim()->stack_size());
       break;
     }
 

--- a/src/hotspot/cpu/x86/c1_LinearScan_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_LinearScan_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/c1_LinearScan_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_LinearScan_x86.hpp
@@ -66,35 +66,7 @@ inline bool LinearScan::is_caller_save(int assigned_reg) {
 
 
 inline void LinearScan::pd_add_temps(LIR_Op* op) {
-  switch (op->code()) {
-    case lir_tan: {
-      // The slow path for these functions may need to save and
-      // restore all live registers but we don't want to save and
-      // restore everything all the time, so mark the xmms as being
-      // killed.  If the slow path were explicit or we could propagate
-      // live register masks down to the assembly we could do better
-      // but we don't have any easy way to do that right now.  We
-      // could also consider not killing all xmm registers if we
-      // assume that slow paths are uncommon but it's not clear that
-      // would be a good idea.
-      if (UseSSE > 0) {
-#ifdef ASSERT
-        if (TraceLinearScanLevel >= 2) {
-          tty->print_cr("killing XMMs for trig");
-        }
-#endif
-        int num_caller_save_xmm_regs = FrameMap::get_num_caller_save_xmms();
-        int op_id = op->id();
-        for (int xmm = 0; xmm < num_caller_save_xmm_regs; xmm++) {
-          LIR_Opr opr = FrameMap::caller_save_xmm_reg_at(xmm);
-          add_temp(reg_num(opr), op_id, noUse, T_ILLEGAL);
-        }
-      }
-      break;
-    }
-    default:
-      break;
-  }
+  // No special case behaviours yet
 }
 
 

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -452,12 +452,18 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_monaddr:        // input and result always valid, info always invalid
     case lir_null_check:     // input and info always valid, result always invalid
     case lir_move:           // input and result always valid, may have info
+    case lir_sqrt:           // FP Ops have no info, but input and result
+    case lir_abs:
+    case lir_neg:
+    case lir_f2hf:
+    case lir_hf2f:
     {
       assert(op->as_Op1() != nullptr, "must be");
       LIR_Op1* op1 = (LIR_Op1*)op;
 
       if (op1->_info)                  do_info(op1->_info);
       if (op1->_opr->is_valid())       do_input(op1->_opr);
+      if (op1->_tmp->is_valid())       do_temp(op1->_tmp);
       if (op1->_result->is_valid())    do_output(op1->_result);
 
       break;
@@ -483,6 +489,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
       assert(op1->_info != nullptr, "");  do_info(op1->_info);
       if (op1->_opr->is_valid())       do_temp(op1->_opr); // safepoints on SPARC need temporary register
+      assert(op1->_tmp->is_illegal(), "not used");
       assert(op1->_result->is_illegal(), "safepoint does not produce value");
 
       break;
@@ -566,11 +573,6 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_add:
     case lir_sub:
     case lir_rem:
-    case lir_sqrt:
-    case lir_abs:
-    case lir_neg:
-    case lir_f2hf:
-    case lir_hf2f:
     case lir_logic_and:
     case lir_logic_or:
     case lir_logic_xor:
@@ -667,6 +669,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
       assert(op1->_info == nullptr, "no info");
       assert(op1->_opr->is_valid(), "exception oop");         do_input(op1->_opr);
+      assert(op1->_tmp->is_illegal(), "not used");
       assert(op1->_result->is_illegal(), "no result");
 
       break;
@@ -1730,6 +1733,11 @@ const char * LIR_Op::name() const {
      case lir_cond_float_branch:     s = "flt_cond_br";   break;
      case lir_move:                  s = "move";          break;
      case lir_roundfp:               s = "roundfp";       break;
+     case lir_abs:                   s = "abs";           break;
+     case lir_neg:                   s = "neg";           break;
+     case lir_sqrt:                  s = "sqrt";          break;
+     case lir_f2hf:                  s = "f2hf";          break;
+     case lir_hf2f:                  s = "hf2f";          break;
      case lir_rtcall:                s = "rtcall";        break;
      case lir_throw:                 s = "throw";         break;
      case lir_unwind:                s = "unwind";        break;
@@ -1746,11 +1754,6 @@ const char * LIR_Op::name() const {
      case lir_mul:                   s = "mul";           break;
      case lir_div:                   s = "div";           break;
      case lir_rem:                   s = "rem";           break;
-     case lir_abs:                   s = "abs";           break;
-     case lir_neg:                   s = "neg";           break;
-     case lir_sqrt:                  s = "sqrt";          break;
-     case lir_f2hf:                  s = "f2hf";          break;
-     case lir_hf2f:                  s = "hf2f";          break;
      case lir_logic_and:             s = "logic_and";     break;
      case lir_logic_or:              s = "logic_or";      break;
      case lir_logic_xor:             s = "logic_xor";     break;

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -527,6 +527,17 @@ void LIR_Assembler::emit_op1(LIR_Op1* op) {
       break;
     }
 
+    case lir_abs:
+    case lir_sqrt:
+    case lir_f2hf:
+    case lir_hf2f:
+      intrinsic_op(op->code(), op->in_opr(), op->tmp_opr(), op->result_opr(), op);
+      break;
+
+    case lir_neg:
+      negate(op->in_opr(), op->result_opr(), op->tmp_opr());
+      break;
+
     case lir_return: {
       assert(op->as_OpReturn() != nullptr, "sanity");
       LIR_OpReturn *ret_op = (LIR_OpReturn*)op;
@@ -722,19 +733,6 @@ void LIR_Assembler::emit_op2(LIR_Op2* op) {
         op->result_opr(),
         op->info(),
         op->fpu_pop_count() == 1);
-      break;
-
-    case lir_abs:
-    case lir_sqrt:
-    case lir_tan:
-    case lir_log10:
-    case lir_f2hf:
-    case lir_hf2f:
-      intrinsic_op(op->code(), op->in_opr1(), op->in_opr2(), op->result_opr(), op);
-      break;
-
-    case lir_neg:
-      negate(op->in_opr1(), op->result_opr(), op->in_opr2());
       break;
 
     case lir_logic_and:

--- a/src/hotspot/share/c1/c1_LIRAssembler.hpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_LIRAssembler.hpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.hpp
@@ -208,7 +208,7 @@ class LIR_Assembler: public CompilationResourceObj {
 
   void arith_op(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Opr dest, CodeEmitInfo* info, bool pop_fpu_stack);
   void arithmetic_idiv(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Opr temp, LIR_Opr result, CodeEmitInfo* info);
-  void intrinsic_op(LIR_Code code, LIR_Opr value, LIR_Opr unused, LIR_Opr dest, LIR_Op* op);
+  void intrinsic_op(LIR_Code code, LIR_Opr value, LIR_Opr temp, LIR_Opr dest, LIR_Op* op);
 #ifdef ASSERT
   void emit_assert(LIR_OpAssert* op);
 #endif

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -6739,7 +6739,6 @@ void LinearScanStatistic::collect(LinearScan* allocator) {
         case lir_abs:
         case lir_f2hf:
         case lir_hf2f:
-        case lir_log10:
         case lir_logic_and:
         case lir_logic_or:
         case lir_logic_xor:


### PR DESCRIPTION
Change `lir_sqrt`, `lir_abs`, `lir_neg`, `lir_f2hf`, `lir_hf2f` to use `LIR_Op1`. Extend `LIR_Op1` to support one temp register operand. Also see JBS issue.

Remove `lir_tan` and `lir_log10` which are unused (dead and incomplete code). They should have been removed with or after https://github.com/openjdk/jdk/commit/ad79a5ae65d24861ead3ae96cf148c8bc0f02736 and the corresponding changes on other platforms.

The removal of the unnecessary float constant loads improves performance:
make run-test TEST="micro:Fp16ConversionBenchmark" MICRO="VM_OPTIONS=-XX:TieredStopAtLevel=1"

Power 10 without patch:
```
Benchmark                                     (size)   Mode  Cnt      Score    Error   Units
Fp16ConversionBenchmark.floatToFloat16          2048  thrpt   15    247.064 ±  0.189  ops/ms
```

Power 10 with patch:
```
Benchmark                                     (size)   Mode  Cnt      Score    Error   Units
Fp16ConversionBenchmark.floatToFloat16          2048  thrpt   15    308.372 ±  0.432  ops/ms
```

x64 machine without patch:
```
Benchmark                                     (size)   Mode  Cnt      Score    Error   Units
Fp16ConversionBenchmark.floatToFloat16          2048  thrpt   15     384.565 ±    3.758  ops/ms
```

x64 machine with patch:
```
Benchmark                                     (size)   Mode  Cnt      Score    Error   Units
Fp16ConversionBenchmark.floatToFloat16          2048  thrpt   15     406.121 ±    3.228  ops/ms
```

Testing: tier1-4 on x64 (Windows, linux, MacOS), aarch64 (linux, MacOS), ppc64 (linux, AIX)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345609](https://bugs.openjdk.org/browse/JDK-8345609): [C1] LIR Operations with one input should be implemented as LIR_Op1 (**Enhancement** - P4)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22582/head:pull/22582` \
`$ git checkout pull/22582`

Update a local copy of the PR: \
`$ git checkout pull/22582` \
`$ git pull https://git.openjdk.org/jdk.git pull/22582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22582`

View PR using the GUI difftool: \
`$ git pr show -t 22582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22582.diff">https://git.openjdk.org/jdk/pull/22582.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22582#issuecomment-2520929787)
</details>
