### PR TITLE
8343890: SEGV crash in RunTimeClassInfo::klass

### DIFF
--- a/src/hotspot/share/cds/runTimeClassInfo.cpp
+++ b/src/hotspot/share/cds/runTimeClassInfo.cpp
@@ -76,10 +76,13 @@ void RunTimeClassInfo::init(DumpTimeClassInfo& info) {
 }
 
 InstanceKlass* RunTimeClassInfo::klass() const {
-  if (ArchiveBuilder::is_active() && ArchiveBuilder::current()->is_in_buffer_space((address)this)) {
-    return ArchiveBuilder::current()->offset_to_buffered<InstanceKlass*>(_klass_offset);
-  } else {
+  if (MetaspaceShared::is_in_shared_metaspace(this)) {
+    // <this> is inside a mmaped CDS archive.
     return ArchiveUtils::offset_to_archived_address<InstanceKlass*>(_klass_offset);
+  } else {
+    // <this> is a temporary copy of a RunTimeClassInfo that's being initialized
+    // by the ArchiveBuilder.
+    return ArchiveBuilder::current()->offset_to_buffered<InstanceKlass*>(_klass_offset);
   }
 }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [bf0debc0](https://github.com/openjdk/jdk/commit/bf0debc023a42ccdf2f589039e4d98e11424b4dd) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Matias Saavedra Silva on 5 Dec 2024 and was reviewed by Ioi Lam and Calvin Cheung.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343890](https://bugs.openjdk.org/browse/JDK-8343890): SEGV crash in RunTimeClassInfo::klass (**Bug** - P3)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22583/head:pull/22583` \
`$ git checkout pull/22583`

Update a local copy of the PR: \
`$ git checkout pull/22583` \
`$ git pull https://git.openjdk.org/jdk.git pull/22583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22583`

View PR using the GUI difftool: \
`$ git pr show -t 22583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22583.diff">https://git.openjdk.org/jdk/pull/22583.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22583#issuecomment-2521328185)
</details>
