### PR TITLE
8344575: Examine usage of ReflectUtil.forName() in java.sql.rowset - XmlReaderContentHandler

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -315,8 +315,7 @@ module java.base {
         java.desktop;
     exports sun.reflect.misc to
         java.desktop,
-        java.management,
-        java.sql.rowset;
+        java.management;
     exports sun.security.internal.interfaces to
         jdk.crypto.cryptoki;
     exports sun.security.internal.spec to

--- a/src/java.base/share/classes/sun/reflect/misc/ReflectUtil.java
+++ b/src/java.base/share/classes/sun/reflect/misc/ReflectUtil.java
@@ -32,10 +32,6 @@ public final class ReflectUtil {
     private ReflectUtil() {
     }
 
-    public static Class<?> forName(String name) throws ClassNotFoundException {
-        return Class.forName(name);
-    }
-
     /**
      * Ensures that access to a method or field is granted and throws
      * IllegalAccessException if not. This method is not suitable for checking

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/XmlReaderContentHandler.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/XmlReaderContentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/XmlReaderContentHandler.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/XmlReaderContentHandler.java
@@ -659,13 +659,12 @@ public class XmlReaderContentHandler extends DefaultHandler {
                  case PropClassTag:
                      //Added the handling for Class tags to take care of maps
                      //Makes an entry into the map upon end of class tag
-                     try{
-                          typeMap.put(Key_map,sun.reflect.misc.ReflectUtil.forName(Value_map));
-
-                        }catch(ClassNotFoundException ex) {
-                          throw new SAXException(MessageFormat.format(resBundle.handleGetObject("xmlrch.errmap").toString(), ex.getMessage()));
-                        }
-                      break;
+                     try {
+                         typeMap.put(Key_map, Class.forName(Value_map, true, null));
+                     } catch (ClassNotFoundException ex) {
+                         throw new SAXException(MessageFormat.format(resBundle.handleGetObject("xmlrch.errmap").toString(), ex.getMessage()));
+                     }
+                     break;
 
                  case MapTag:
                       //Added the handling for Map to take set the typeMap


### PR DESCRIPTION
`XmlReaderContentHandler.endElement()` routes a `Class.forName()` call through `ReflectUtil.forName()`. When `sun.reflect.misc.ReflectUtil.forName()` calls the 1-arg `Class.forName()`, it is doing so from `java.base`, and so using the boot loader.

Changing `XmlReaderContentHandler` to use the 3-arg `Class.forName()` method with a null classloader should yield equivalent behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344575](https://bugs.openjdk.org/browse/JDK-8344575): Examine usage of ReflectUtil.forName() in java.sql.rowset - XmlReaderContentHandler (**Bug** - P4)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) Review applies to [8202d66b](https://git.openjdk.org/jdk/pull/22585/files/8202d66bba5c034b4fe14d792b7499ad5fddafb3)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [8202d66b](https://git.openjdk.org/jdk/pull/22585/files/8202d66bba5c034b4fe14d792b7499ad5fddafb3)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [8202d66b](https://git.openjdk.org/jdk/pull/22585/files/8202d66bba5c034b4fe14d792b7499ad5fddafb3)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22585/head:pull/22585` \
`$ git checkout pull/22585`

Update a local copy of the PR: \
`$ git checkout pull/22585` \
`$ git pull https://git.openjdk.org/jdk.git pull/22585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22585`

View PR using the GUI difftool: \
`$ git pr show -t 22585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22585.diff">https://git.openjdk.org/jdk/pull/22585.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22585#issuecomment-2521520142)
</details>
