### PR TITLE
8285692: Enable _FORTIFY_SOURCE=2 when building with Clang

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -302,7 +302,7 @@ AC_DEFUN([FLAGS_SETUP_QUALITY_CHECKS],
 
 AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
 [
-  if test "x$TOOLCHAIN_TYPE" = xgcc; then
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     C_O_FLAG_HIGHEST_JVM="-O3"
     C_O_FLAG_HIGHEST="-O3"
     C_O_FLAG_HI="-O3"
@@ -311,6 +311,13 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
     C_O_FLAG_DEBUG="-O0"
     C_O_FLAG_DEBUG_JVM="-O0"
     C_O_FLAG_NONE="-O0"
+
+    if test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then
+      C_O_FLAG_HIGHEST_JVM="${C_O_FLAG_HIGHEST_JVM} -finline-functions"
+      C_O_FLAG_HIGHEST="${C_O_FLAG_HIGHEST} -finline-functions"
+      C_O_FLAG_HI="${C_O_FLAG_HI} -finline-functions"
+    fi
+
     # -D_FORTIFY_SOURCE=2 hardening option needs optimization (at least -O1) enabled
     # set for lower O-levels -U_FORTIFY_SOURCE to overwrite previous settings
     if test "x$OPENJDK_TARGET_OS" = xlinux -a "x$DEBUG_LEVEL" = "xfastdebug"; then
@@ -331,21 +338,6 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
       C_O_FLAG_DEBUG_JVM="${C_O_FLAG_DEBUG_JVM} ${DISABLE_FORTIFY_CFLAGS}"
       C_O_FLAG_NONE="${C_O_FLAG_NONE} ${DISABLE_FORTIFY_CFLAGS}"
     fi
-  elif test "x$TOOLCHAIN_TYPE" = xclang; then
-    if test "x$OPENJDK_TARGET_OS" = xaix; then
-      C_O_FLAG_HIGHEST_JVM="-O3 -finline-functions"
-      C_O_FLAG_HIGHEST="-O3 -finline-functions"
-      C_O_FLAG_HI="-O3 -finline-functions"
-    else
-      C_O_FLAG_HIGHEST_JVM="-O3"
-      C_O_FLAG_HIGHEST="-O3"
-      C_O_FLAG_HI="-O3"
-    fi
-    C_O_FLAG_NORM="-O2"
-    C_O_FLAG_DEBUG_JVM="-O0"
-    C_O_FLAG_SIZE="-Os"
-    C_O_FLAG_DEBUG="-O0"
-    C_O_FLAG_NONE="-O0"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     C_O_FLAG_HIGHEST_JVM="-O2 -Oy-"
     C_O_FLAG_HIGHEST="-O2"


### PR DESCRIPTION
Clang has supported _FORTIFY_SOURCE since version 10. We already use it when building with gcc ([JDK-8130017](https://bugs.openjdk.org/browse/JDK-8130017)) in fastdebug builds. We should add it to fastdebug builds with Clang.

I solved this by unifying the clang/gcc flag setup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285692](https://bugs.openjdk.org/browse/JDK-8285692): Enable _FORTIFY_SOURCE=2 when building with Clang (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22586/head:pull/22586` \
`$ git checkout pull/22586`

Update a local copy of the PR: \
`$ git checkout pull/22586` \
`$ git pull https://git.openjdk.org/jdk.git pull/22586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22586`

View PR using the GUI difftool: \
`$ git pr show -t 22586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22586.diff">https://git.openjdk.org/jdk/pull/22586.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22586#issuecomment-2521595083)
</details>
