### PR TITLE
8287122: Use gcc12 -ftrivial-auto-var-init=pattern in debug builds

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -489,6 +489,11 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   else
     DEBUG_CFLAGS_JDK="-DDEBUG"
 
+    if test "x$TOOLCHAIN_TYPE" = xgcc; then
+      DEBUG_CFLAGS_JDK="DEBUG_CFLAGS_JDK -ftrivial-auto-var-init=pattern"
+      DEBUG_CFLAGS_JVM="-ftrivial-auto-var-init=pattern"
+    fi
+
     if test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then
       DEBUG_CFLAGS_JVM="-fpic -mcmodel=large"
     fi


### PR DESCRIPTION
gcc12 has added -ftrivial-auto-var-init=<choice>, which specifies how automatic variables without an initializer should be initialized. The default choice is "uninitialized", which is the default C/C++ behavior. Alternatives are "pattern" and "zero". For improved debugging, helping to detect uninitialized uses, the "pattern" choice should be used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287122](https://bugs.openjdk.org/browse/JDK-8287122): Use gcc12 -ftrivial-auto-var-init=pattern in debug builds (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22587/head:pull/22587` \
`$ git checkout pull/22587`

Update a local copy of the PR: \
`$ git checkout pull/22587` \
`$ git pull https://git.openjdk.org/jdk.git pull/22587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22587`

View PR using the GUI difftool: \
`$ git pr show -t 22587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22587.diff">https://git.openjdk.org/jdk/pull/22587.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22587#issuecomment-2521612026)
</details>
