### PR TITLE
8345626: Build fails with fatal error: DEBUG_CFLAGS_JDK: No such file or directory

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -482,7 +482,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     DEBUG_CFLAGS_JDK="-DDEBUG"
 
     if test "x$TOOLCHAIN_TYPE" = xgcc; then
-      DEBUG_CFLAGS_JDK="DEBUG_CFLAGS_JDK -ftrivial-auto-var-init=pattern"
+      DEBUG_CFLAGS_JDK="$DEBUG_CFLAGS_JDK -ftrivial-auto-var-init=pattern"
       DEBUG_CFLAGS_JVM="-ftrivial-auto-var-init=pattern"
     fi
 


### PR DESCRIPTION
Added missing $ to variable expansion.

Local build worked.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345626](https://bugs.openjdk.org/browse/JDK-8345626): Build fails with fatal error: DEBUG_CFLAGS_JDK: No such file or directory (**Bug** - P2)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22589/head:pull/22589` \
`$ git checkout pull/22589`

Update a local copy of the PR: \
`$ git checkout pull/22589` \
`$ git pull https://git.openjdk.org/jdk.git pull/22589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22589`

View PR using the GUI difftool: \
`$ git pr show -t 22589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22589.diff">https://git.openjdk.org/jdk/pull/22589.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22589#issuecomment-2521794446)
</details>
