### PR TITLE
8345628: [BACKOUT] JDK-8287122 Use gcc12 -ftrivial-auto-var-init=pattern in debug builds

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -481,11 +481,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   else
     DEBUG_CFLAGS_JDK="-DDEBUG"
 
-    if test "x$TOOLCHAIN_TYPE" = xgcc; then
-      DEBUG_CFLAGS_JDK="DEBUG_CFLAGS_JDK -ftrivial-auto-var-init=pattern"
-      DEBUG_CFLAGS_JVM="-ftrivial-auto-var-init=pattern"
-    fi
-
     if test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then
       DEBUG_CFLAGS_JVM="-fpic -mcmodel=large"
     fi


### PR DESCRIPTION
Revert "8287122: Use gcc12 -ftrivial-auto-var-init=pattern in debug builds"

This reverts commit 41c8971cbcc1d281ffae907c952637ebff945ebb.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345628](https://bugs.openjdk.org/browse/JDK-8345628): [BACKOUT] JDK-8287122 Use gcc12 -ftrivial-auto-var-init=pattern in debug builds (**Sub-task** - P2)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22590/head:pull/22590` \
`$ git checkout pull/22590`

Update a local copy of the PR: \
`$ git checkout pull/22590` \
`$ git pull https://git.openjdk.org/jdk.git pull/22590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22590`

View PR using the GUI difftool: \
`$ git pr show -t 22590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22590.diff">https://git.openjdk.org/jdk/pull/22590.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22590#issuecomment-2521832201)
</details>
