### PR TITLE
8339356: Test javax/net/ssl/SSLSocket/Tls13PacketSize.java failed with java.net.SocketException: An established connection was aborted by the software in your host machine

### DIFF
--- a/test/jdk/javax/net/ssl/SSLSocket/Tls13PacketSize.java
+++ b/test/jdk/javax/net/ssl/SSLSocket/Tls13PacketSize.java
@@ -72,6 +72,7 @@ public class Tls13PacketSize extends SSLSocketTemplate {
 
         sslOS.write(appData);
         sslOS.flush();
+        sslIS.read();
     }
 
     /*

--- a/test/jdk/javax/net/ssl/SSLSocket/Tls13PacketSize.java
+++ b/test/jdk/javax/net/ssl/SSLSocket/Tls13PacketSize.java
@@ -72,7 +72,7 @@ public class Tls13PacketSize extends SSLSocketTemplate {
 
         sslOS.write(appData);
         sslOS.flush();
-        sslIS.read();
+        sslIS.read(appData, 1, appData.length-1);
     }
 
     /*

--- a/test/jdk/javax/net/ssl/SSLSocket/Tls13PacketSize.java
+++ b/test/jdk/javax/net/ssl/SSLSocket/Tls13PacketSize.java
@@ -72,7 +72,10 @@ public class Tls13PacketSize extends SSLSocketTemplate {
 
         sslOS.write(appData);
         sslOS.flush();
-        sslIS.read(appData, 1, appData.length-1);
+        int drained = 1;
+        while (drained < appData.length) {
+            drained += sslIS.read(appData, drained, appData.length - drained);
+        }
     }
 
     /*


### PR DESCRIPTION
I was unable to reproduce the error but I suspect the error is caused by the server-side closing the socket as soon as the write operation is done. I added a read() call on the server to ensure the client initiates connection close

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339356](https://bugs.openjdk.org/browse/JDK-8339356): Test javax/net/ssl/SSLSocket/Tls13PacketSize.java failed with java.net.SocketException: An established connection was aborted by the software in your host machine (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Contributors
 * Daniel Jeliński `<djelinski@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22591/head:pull/22591` \
`$ git checkout pull/22591`

Update a local copy of the PR: \
`$ git checkout pull/22591` \
`$ git pull https://git.openjdk.org/jdk.git pull/22591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22591`

View PR using the GUI difftool: \
`$ git pr show -t 22591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22591.diff">https://git.openjdk.org/jdk/pull/22591.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22591#issuecomment-2521890462)
</details>
