### PR TITLE
8345133: Test sun/security/tools/jarsigner/TsacertOptionTest.java failed: Warning found in stdout

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/TsacertOptionTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/TsacertOptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,6 +103,7 @@ public class TsacertOptionTest extends Test {
                 "-alias", CA_KEY_ALIAS,
                 "-keystore", KEYSTORE,
                 "-storepass", PASSWORD,
+                "-startdate", "-1M",
                 "-keypass", PASSWORD,
                 "-validity", Integer.toString(VALIDITY),
                 "-infile", "certreq",


### PR DESCRIPTION
I was unable to recreate the error but it is probably the same root cause as JDK-8337951  (https://github.com/openjdk/jdk/pull/20728).

I updated the gencert command to explicitly set the start date to ensure the certificate is valid.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345133](https://bugs.openjdk.org/browse/JDK-8345133): Test sun/security/tools/jarsigner/TsacertOptionTest.java failed: Warning found in stdout (**Bug** - P4)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22592/head:pull/22592` \
`$ git checkout pull/22592`

Update a local copy of the PR: \
`$ git checkout pull/22592` \
`$ git pull https://git.openjdk.org/jdk.git pull/22592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22592`

View PR using the GUI difftool: \
`$ git pr show -t 22592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22592.diff">https://git.openjdk.org/jdk/pull/22592.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22592#issuecomment-2521897018)
</details>
