### PR TITLE
8345629: Remove expired flags in JDK 25

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -522,7 +522,6 @@ static SpecialFlag const special_jvm_flags[] = {
   { "DynamicDumpSharedSpaces",      JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "RequireSharedSpaces",          JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "UseSharedSpaces",              JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
-  { "DontYieldALot",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
 #ifdef LINUX
   { "UseLinuxPosixThreadCPUClocks", JDK_Version::jdk(24), JDK_Version::jdk(25), JDK_Version::jdk(26) },
 #endif
@@ -534,20 +533,7 @@ static SpecialFlag const special_jvm_flags[] = {
 
   { "MetaspaceReclaimPolicy",       JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
   { "ZGenerational",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::undefined() },
-  { "UseNotificationThread",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "PreserveAllAnnotations",       JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "UseEmptySlotsInSupers",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "OldSize",                      JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-#if defined(X86)
-  { "UseRTMLocking",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "UseRTMDeopt",                  JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "RTMRetryCount",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-#endif // X86
 
-
-  { "BaseFootPrintEstimate",           JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "HeapFirstMaximumCompactionCount", JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "UseVtableBasedCHA",               JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(25) },
 #ifdef ASSERT
   { "DummyObsoleteTestFlag",        JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::undefined() },
 #endif

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -2895,6 +2895,12 @@ when they're used.
     396](https://openjdk.org/jeps/396) and made obsolete in JDK 17
     by [JEP 403](https://openjdk.org/jeps/403).
 
+## Removed Java Options
+
+These `java` options have been removed in JDK @@VERSION_SPECIFICATION@@ and using them results in an error of:
+
+>   `Unrecognized VM option` *option-name*
+
 `-XX:RTMAbortRatio=`*abort\_ratio*
 :   Specifies the RTM abort ratio is specified as a percentage (%) of all
     executed RTM transactions. If a number of aborted transactions becomes
@@ -2954,57 +2960,9 @@ when they're used.
     processors, which forces them to read from main memory instead of their
     cache.
 
-## Removed Java Options
-
-These `java` options have been removed in JDK @@VERSION_SPECIFICATION@@ and using them results in an error of:
-
->   `Unrecognized VM option` *option-name*
-
-`-XX:InitialRAMFraction=`*ratio*
-:   Sets the initial amount of memory that the JVM may use for the Java heap
-    before applying ergonomics heuristics as a ratio of the maximum amount
-    determined as described in the `-XX:MaxRAM` option. The default value is
-    64.
-
-    Use the option `-XX:InitialRAMPercentage` instead.
-
-`-XX:MaxRAMFraction=`*ratio*
-:   Sets the maximum amount of memory that the JVM may use for the Java heap
-    before applying ergonomics heuristics as a fraction of the maximum amount
-    determined as described in the `-XX:MaxRAM` option. The default value is 4.
-
-    Specifying this option disables automatic use of compressed oops if
-    the combined result of this and other options influencing the maximum amount
-    of memory is larger than the range of memory addressable by compressed oops.
-    See `-XX:UseCompressedOops` for further information about compressed oops.
-
-    Use the option `-XX:MaxRAMPercentage` instead.
-
-`-XX:MinRAMFraction=`*ratio*
-:   Sets the maximum amount of memory that the JVM may use for the Java heap
-    before applying ergonomics heuristics as a fraction of the maximum amount
-    determined as described in the `-XX:MaxRAM` option for small heaps. A small
-    heap is a heap of approximately 125 MB. The default value is 2.
-
-    Use the option `-XX:MinRAMPercentage` instead.
-
-`-XX:+ScavengeBeforeFullGC`
-:   Enables GC of the young generation before each full GC. This option is
-    enabled by default. It is recommended that you *don't* disable it, because
-    scavenging the young generation before a full GC can reduce the number of
-    objects reachable from the old generation space into the young generation
-    space. To disable GC of the young generation before each full GC, specify
-    the option `-XX:-ScavengeBeforeFullGC`.
-
-`-Xfuture`
-:   Enables strict class-file format checks that enforce close conformance to
-    the class-file format specification. Developers should use this flag when
-    developing new code. Stricter checks may become the default in future
-    releases.
-
-    Use the option `-Xverify:all` instead.
-
 For the lists and descriptions of options removed in previous releases see the *Removed Java Options* section in:
+
+-   [The `java` Command, Release 24](https://docs.oracle.com/en/java/javase/24/docs/specs/man/java.html)
 
 -   [The `java` Command, Release 23](https://docs.oracle.com/en/java/javase/23/docs/specs/man/java.html)
 


### PR DESCRIPTION
All flags that expire in JDK 25 are removed from the special_jvm_flags table.

The Java command manpage is updated so that flags removed in the previous release are deleted from the "Removed flags" section and a link added to the previous release manpage. Any documented obsolete flags are moved to the "Removed section" from the "Obsoleted" section.

Testing: tiers 1-3 sanity

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345629](https://bugs.openjdk.org/browse/JDK-8345629): Remove expired flags in JDK 25 (**Enhancement** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22593/head:pull/22593` \
`$ git checkout pull/22593`

Update a local copy of the PR: \
`$ git checkout pull/22593` \
`$ git pull https://git.openjdk.org/jdk.git pull/22593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22593`

View PR using the GUI difftool: \
`$ git pr show -t 22593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22593.diff">https://git.openjdk.org/jdk/pull/22593.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22593#issuecomment-2521903538)
</details>
