### PR TITLE
8345632: [ASAN] memory leak in get_numbered_property_as_sorted_string function

### DIFF
--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -724,7 +724,12 @@ const char* Modules::get_numbered_property_as_sorted_string(const char* property
   }
 
   const char* result = (const char*)os::strdup(st.as_string()); // Example: "java.base,java.compiler"
-  return strcmp(result, "") != 0 ? result : nullptr;
+  if (strcmp(result, "") != 0) {
+    return result;
+  } else {
+    os::free((void*)result);
+    return nullptr;
+  }
 }
 
 void Modules::define_archived_modules(Handle h_platform_loader, Handle h_system_loader, TRAPS) {

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -723,13 +723,7 @@ const char* Modules::get_numbered_property_as_sorted_string(const char* property
     }
   }
 
-  const char* result = (const char*)os::strdup(st.as_string()); // Example: "java.base,java.compiler"
-  if (strcmp(result, "") != 0) {
-    return result;
-  } else {
-    os::free((void*)result);
-    return nullptr;
-  }
+  return (st.size() > 0) ? os::strdup(st.as_string()) : nullptr;  // Example: "java.base,java.compiler"
 }
 
 void Modules::define_archived_modules(Handle h_platform_loader, Handle h_system_loader, TRAPS) {


### PR DESCRIPTION
Hi all,
This PR fix memory leak problem in get_numbered_property_as_sorted_string function which introduced by [JDK-8342089](https://bugs.openjdk.org/browse/JDK-8342089) when the function get_numbered_property_as_sorted_string `return nullptr`. Avoid strdup in the empty string case, risk is low.

Additional testing:

- [x] jtreg tests (include tier1/2/3 etc.) on linux-x64
- [x] jtreg tests (include tier1/2/3 etc.) on linux-aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345632](https://bugs.openjdk.org/browse/JDK-8345632): [ASAN] memory leak in get_numbered_property_as_sorted_string function (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22594/head:pull/22594` \
`$ git checkout pull/22594`

Update a local copy of the PR: \
`$ git checkout pull/22594` \
`$ git pull https://git.openjdk.org/jdk.git pull/22594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22594`

View PR using the GUI difftool: \
`$ git pr show -t 22594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22594.diff">https://git.openjdk.org/jdk/pull/22594.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22594#issuecomment-2522116682)
</details>
