### PR TITLE
8339019: Obsolete the UseLinuxPosixThreadCPUClocks flag

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -38,9 +38,6 @@
   product(bool, UseOprofile, false,                                     \
         "enable support for Oprofile profiler")                         \
                                                                         \
-  product(bool, UseLinuxPosixThreadCPUClocks, true,                     \
-          "(Deprecated) enable fast Linux Posix clocks where available") \
-                                                                        \
   product(bool, UseTransparentHugePages, false,                         \
           "Use MADV_HUGEPAGE for large pages")                          \
                                                                         \

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1484,9 +1484,6 @@ double os::elapsedVTime() {
 }
 
 void os::Linux::fast_thread_clock_init() {
-  if (!UseLinuxPosixThreadCPUClocks) {
-    return;
-  }
   clockid_t clockid;
   struct timespec tp;
   int (*pthread_getcpuclockid_func)(pthread_t, clockid_t *) =


### PR DESCRIPTION
The UseLinuxPosixThreadCPUClocks flag was deprecated in 24 and should be obsoleted in 25. 

Testing: tiers 1-3 sanity

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339019](https://bugs.openjdk.org/browse/JDK-8339019): Obsolete the UseLinuxPosixThreadCPUClocks flag (**Enhancement** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22595/head:pull/22595` \
`$ git checkout pull/22595`

Update a local copy of the PR: \
`$ git checkout pull/22595` \
`$ git pull https://git.openjdk.org/jdk.git pull/22595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22595`

View PR using the GUI difftool: \
`$ git pr show -t 22595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22595.diff">https://git.openjdk.org/jdk/pull/22595.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22595#issuecomment-2522131631)
</details>
