### PR TITLE
8344556: [Graal] compiler/intrinsics/bmi/* fail when AOTCache cannot be loaded

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
@@ -130,10 +130,14 @@ public class BMITestRunner {
         //setup mode-specific options
         switch (testVMMode) {
         case INT:
-            Collections.addAll(vmOpts, new String[] { "-Xint" });
+            Collections.addAll(vmOpts, new String[] {
+                    "-Xlog:cds=off",  // Work around JDK-8344556
+                    "-Xint"
+                });
             break;
         case COMP:
             Collections.addAll(vmOpts, new String[] {
+                    "-Xlog:cds=off",  // Work around JDK-8344556
                     "-Xcomp",
                     "-XX:-TieredCompilation",
                     String.format("-XX:CompileCommand=compileonly,%s::*",


### PR DESCRIPTION
See JBS issue for detailed evaluation.

In summary -- when `-XX:+UseJVMCICompiler` is used, one of `-int` or `-Xcomp` will print out the `[cds][error]` message. The work around is to disable the CDS log for both cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344556](https://bugs.openjdk.org/browse/JDK-8344556): [Graal] compiler/intrinsics/bmi/* fail when AOTCache cannot be loaded (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22596/head:pull/22596` \
`$ git checkout pull/22596`

Update a local copy of the PR: \
`$ git checkout pull/22596` \
`$ git pull https://git.openjdk.org/jdk.git pull/22596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22596`

View PR using the GUI difftool: \
`$ git pr show -t 22596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22596.diff">https://git.openjdk.org/jdk/pull/22596.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22596#issuecomment-2522408703)
</details>
