### PR TITLE
8345589: Simplify Windows definition of strtok_r

### DIFF
--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -28,8 +28,9 @@
 #include "jvm_md.h"
 #include "runtime/osInfo.hpp"
 #include "utilities/exceptions.hpp"
-#include "utilities/ostream.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
+#include "utilities/ostream.hpp"
 #ifdef __APPLE__
 # include <mach/mach_time.h>
 #endif
@@ -1025,14 +1026,6 @@ class os: AllStatic {
   // Ditto - Posix-specific API. Ideally should be moved to something like ::PosixUtils.
 #ifndef _WINDOWS
   class Posix;
-#endif
-
-  // FIXME - some random stuff that was in os_windows.hpp
-#ifdef _WINDOWS
-  // strtok_s is the Windows thread-safe equivalent of POSIX strtok_r
-# define strtok_r strtok_s
-# define S_ISCHR(mode)   (((mode) & _S_IFCHR) == _S_IFCHR)
-# define S_ISFIFO(mode)  (((mode) & _S_IFIFO) == _S_IFIFO)
 #endif
 
 #ifndef OS_NATIVE_THREAD_CREATION_FAILED_MSG

--- a/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
@@ -37,6 +37,7 @@
 # include <stdlib.h>
 # include <stdint.h>
 # include <stddef.h>// for offsetof
+# include <sys/stat.h>
 # include <io.h>    // for stream.cpp
 # include <float.h> // for _isnan
 # include <stdio.h> // for va_list
@@ -79,6 +80,18 @@ inline int strcasecmp(const char *s1, const char *s2) { return _stricmp(s1,s2); 
 inline int strncasecmp(const char *s1, const char *s2, size_t n) {
   return _strnicmp(s1,s2,n);
 }
+
+// VS doesn't provide strtok_r, which is a POSIX function.  Instead, it
+// provides the same function under the name strtok_s.  Note that this is
+// *not* the same as the C99 Annex K strtok_s.  VS provides that function
+// under the name strtok_s_l.  Make strtok_r a synonym so we can use that name
+// in shared code.
+const auto strtok_r = strtok_s;
+
+// VS doesn't provide POSIX macros S_ISFIFO or S_IFIFO.  It doesn't even
+// provide _S_ISFIFO, per its usual naming convention for POSIX stuff.  But it
+// does provide _S_IFIFO, so we can roll our own S_ISFIFO.
+#define S_ISFIFO(mode) (((mode) & _S_IFIFO) == _S_IFIFO)
 
 // Checking for nanness
 


### PR DESCRIPTION
Please review this change to move the Windows-specific definition of strtok_r
to globalDefinitions_visCPP.hpp.  In addition, the unused S_ISCHR macro is
removed and the S_ISFIFO macro is also moved.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345589](https://bugs.openjdk.org/browse/JDK-8345589): Simplify Windows definition of strtok_r (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22597/head:pull/22597` \
`$ git checkout pull/22597`

Update a local copy of the PR: \
`$ git checkout pull/22597` \
`$ git pull https://git.openjdk.org/jdk.git pull/22597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22597`

View PR using the GUI difftool: \
`$ git pr show -t 22597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22597.diff">https://git.openjdk.org/jdk/pull/22597.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22597#issuecomment-2522243047)
</details>
