### PR TITLE
8334581: Remove no-arg constructor BasicSliderUI()

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
@@ -147,7 +147,7 @@ public class BasicSliderUI extends SliderUI{
      * baseline.
      */
     private boolean sameLabelBaselines;
-    
+
     /**
      * Returns the shadow color.
      * @return the shadow color

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
@@ -147,17 +147,7 @@ public class BasicSliderUI extends SliderUI{
      * baseline.
      */
     private boolean sameLabelBaselines;
-
-    /**
-     * Constructs a {@code BasicSliderUI}.
-     *
-     * @since 16
-     * @deprecated This constructor was exposed erroneously and will be removed in a future release.
-     *             Use {@link #BasicSliderUI(JSlider)} instead.
-     */
-    @Deprecated(since = "23", forRemoval = true)
-    public BasicSliderUI() {}
-
+    
     /**
      * Returns the shadow color.
      * @return the shadow color


### PR DESCRIPTION
The no-arg constructor BasicSliderUI() was added accidentally. It should be removed.

[JDK-8334580](https://bugs.openjdk.org/browse/JDK-8334580) deprecates the BasicSliderUI() constructor, and this follow-up is to remove the constructor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8345648](https://bugs.openjdk.org/browse/JDK-8345648) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8334581](https://bugs.openjdk.org/browse/JDK-8334581): Remove no-arg constructor BasicSliderUI() (**Bug** - P3)
 * [JDK-8345648](https://bugs.openjdk.org/browse/JDK-8345648): Remove no-arg constructor BasicSliderUI() (**CSR**)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22598/head:pull/22598` \
`$ git checkout pull/22598`

Update a local copy of the PR: \
`$ git checkout pull/22598` \
`$ git pull https://git.openjdk.org/jdk.git pull/22598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22598`

View PR using the GUI difftool: \
`$ git pr show -t 22598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22598.diff">https://git.openjdk.org/jdk/pull/22598.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22598#issuecomment-2522266003)
</details>
