### PR TITLE
8345646: aotClassLinking/BulkLoaderTest.java fails if VM options are incompatible

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -180,6 +180,7 @@ ArchiveBuilder::ArchiveBuilder() :
   _entropy_seed = 0x12345678;
   assert(_current == nullptr, "must be");
   _current = this;
+  CDSConfig::print_dumping_config();
 }
 
 ArchiveBuilder::~ArchiveBuilder() {

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -611,4 +611,16 @@ bool CDSConfig::is_loading_invokedynamic() {
   return UseSharedSpaces && is_using_full_module_graph() && _has_archived_invokedynamic;
 }
 
+void CDSConfig::print_dumping_config() {
+#define _PRINT_CONFIG(x) log_info(cds)("%-35s = %s", #x, x() ? "true" : "false");
+  _PRINT_CONFIG(is_dumping_static_archive);
+  _PRINT_CONFIG(is_dumping_dynamic_archive);
+  _PRINT_CONFIG(is_dumping_aot_linked_classes);
+  _PRINT_CONFIG(is_dumping_heap);
+  _PRINT_CONFIG(is_dumping_invokedynamic);
+  _PRINT_CONFIG(is_dumping_full_module_graph);
+  _PRINT_CONFIG(is_initing_classes_at_dump_time);
+#undef _PRINT_CONFIG
+}
+
 #endif // INCLUDE_CDS_JAVA_HEAP

--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -144,6 +144,8 @@ public:
   };
 
   static bool current_thread_is_vm_or_dumper() NOT_CDS_RETURN_(false);
+
+  static void print_dumping_config();
 };
 
 #endif // SHARE_CDS_CDSCONFIG_HPP

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
@@ -57,6 +57,7 @@ import java.util.Set;
 import jdk.test.lib.cds.CDSAppTester;
 import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
 
 public class BulkLoaderTest {
     static final String appJar = ClassFileInstaller.getJarPath("BulkLoaderTestApp.jar");
@@ -115,6 +116,13 @@ public class BulkLoaderTest {
             return new String[] {
                 mainClass,
             };
+        }
+
+        @Override
+        public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {
+            if (runMode.isDumping() && out.firstMatch("is_dumping_aot_linked_classes * = false") != null) {
+                throw new SkippedException("VM options are not compatible with -XX:+AOTClassLinking");
+            }
         }
     }
 }

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -88,6 +88,9 @@ abstract public class CDSAppTester {
         public boolean isProductionRun() {
             return this == PRODUCTION;
         }
+        public boolean isDumping() {
+          return this == DUMP_STATIC || this == DUMP_DYNAMIC;
+        }
     }
 
     public final String name() {


### PR DESCRIPTION
I added logs that look like this to describe what optimizations are enabled in the CDS archive.

```
[0.305s][info][cds] is_dumping_static_archive           = false
[0.305s][info][cds] is_dumping_dynamic_archive          = true
[0.305s][info][cds] is_dumping_aot_linked_classes       = false
[0.305s][info][cds] is_dumping_heap                     = false
[0.305s][info][cds] is_dumping_invokedynamic            = false
[0.305s][info][cds] is_dumping_full_module_graph        = false
[0.305s][info][cds] is_initing_classes_at_dump_time     = false
```

If BulkLoaderTest.java finds "is_dumping_aot_linked_classes = false" in the log, that means the current set of VM options are not compatible with `-XX:+AOTClassLinking`. There's no point of continuing with the tests, so we throw a `SkippedException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345646](https://bugs.openjdk.org/browse/JDK-8345646): aotClassLinking/BulkLoaderTest.java fails if VM options are incompatible (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22599/head:pull/22599` \
`$ git checkout pull/22599`

Update a local copy of the PR: \
`$ git checkout pull/22599` \
`$ git pull https://git.openjdk.org/jdk.git pull/22599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22599`

View PR using the GUI difftool: \
`$ git pr show -t 22599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22599.diff">https://git.openjdk.org/jdk/pull/22599.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22599#issuecomment-2522267818)
</details>
