### PR TITLE
8345658: WB_NMTCommitMemory redundantly records an NMT tag

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -58,7 +58,6 @@
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "nmt/mallocSiteTable.hpp"
-#include "nmt/memTracker.hpp"
 #include "oops/array.hpp"
 #include "oops/compressedOops.hpp"
 #include "oops/constantPool.inline.hpp"
@@ -720,7 +719,6 @@ WB_END
 
 WB_ENTRY(void, WB_NMTCommitMemory(JNIEnv* env, jobject o, jlong addr, jlong size))
   os::commit_memory((char *)(uintptr_t)addr, size, !ExecMem);
-  MemTracker::record_virtual_memory_tag((address)(uintptr_t)addr, mtTest);
 WB_END
 
 WB_ENTRY(void, WB_NMTUncommitMemory(JNIEnv* env, jobject o, jlong addr, jlong size))


### PR DESCRIPTION
This functions is called after an previous calls to WB_NMTReserveMemory and WB_NMTAttemptReserveMemoryAt, which both already registered an NMT tag. So, explicitly recording an NMT tag for this memory is redundant and slightly confusing.

The HotSpot JVM code does not record NMT tags when committing memory (except in a special case on Windows when mapping file memory).

Tested with tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345658](https://bugs.openjdk.org/browse/JDK-8345658): WB_NMTCommitMemory redundantly records an NMT tag (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22601/head:pull/22601` \
`$ git checkout pull/22601`

Update a local copy of the PR: \
`$ git checkout pull/22601` \
`$ git pull https://git.openjdk.org/jdk.git pull/22601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22601`

View PR using the GUI difftool: \
`$ git pr show -t 22601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22601.diff">https://git.openjdk.org/jdk/pull/22601.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22601#issuecomment-2522735771)
</details>
