### PR TITLE
8345659: Fix broken alignment after ReservedSpace splitting in GC code

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -70,7 +70,7 @@ jint ParallelScavengeHeap::initialize() {
 
   initialize_reserved_region(heap_rs);
   // Layout the reserved space for the generations.
-  ReservedSpace old_rs   = heap_rs.first_part(MaxOldSize);
+  ReservedSpace old_rs   = heap_rs.first_part(MaxOldSize, GenAlignment);
   ReservedSpace young_rs = heap_rs.last_part(MaxOldSize, GenAlignment);
   assert(young_rs.size() == MaxNewSize, "Didn't reserve all of the heap");
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -71,7 +71,7 @@ jint ParallelScavengeHeap::initialize() {
   initialize_reserved_region(heap_rs);
   // Layout the reserved space for the generations.
   ReservedSpace old_rs   = heap_rs.first_part(MaxOldSize);
-  ReservedSpace young_rs = heap_rs.last_part(MaxOldSize);
+  ReservedSpace young_rs = heap_rs.last_part(MaxOldSize, GenAlignment);
   assert(young_rs.size() == MaxNewSize, "Didn't reserve all of the heap");
 
   PSCardTable* card_table = new PSCardTable(heap_rs.region());

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -186,7 +186,7 @@ jint SerialHeap::initialize() {
 
   initialize_reserved_region(heap_rs);
 
-  ReservedSpace young_rs = heap_rs.first_part(MaxNewSize);
+  ReservedSpace young_rs = heap_rs.first_part(MaxNewSize, GenAlignment);
   ReservedSpace old_rs = heap_rs.last_part(MaxNewSize, GenAlignment);
 
   _rem_set = new CardTableRS(heap_rs.region());

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -187,7 +187,7 @@ jint SerialHeap::initialize() {
   initialize_reserved_region(heap_rs);
 
   ReservedSpace young_rs = heap_rs.first_part(MaxNewSize);
-  ReservedSpace old_rs = heap_rs.last_part(MaxNewSize);
+  ReservedSpace old_rs = heap_rs.last_part(MaxNewSize, GenAlignment);
 
   _rem_set = new CardTableRS(heap_rs.region());
   _rem_set->initialize(young_rs.base(), old_rs.base());


### PR DESCRIPTION
The Serial and Parallel GCs create a ReservedSpace for the total heap and then splits it into a young generation ReservedSpace and an old generation ReservedSpace. The latter operation creates an ReservedSpace with an alignment that doesn't match the base address. This bug is benign because the ReservedSpaces are short-lived and we don't look at the alignment. However, if we are to add stricter checks when creating ReservedSpaces we need to fix this. 

Tested with tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345659](https://bugs.openjdk.org/browse/JDK-8345659): Fix broken alignment after ReservedSpace splitting in GC code (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22602/head:pull/22602` \
`$ git checkout pull/22602`

Update a local copy of the PR: \
`$ git checkout pull/22602` \
`$ git pull https://git.openjdk.org/jdk.git pull/22602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22602`

View PR using the GUI difftool: \
`$ git pr show -t 22602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22602.diff">https://git.openjdk.org/jdk/pull/22602.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22602#issuecomment-2522754841)
</details>
