### PR TITLE
8345569: [ubsan] adjustments to filemap.cpp and virtualspace.cpp for macOS aarch64

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2245,7 +2245,7 @@ address FileMapInfo::heap_region_requested_address() {
     // Runtime base = 0x4000 and shift is also 0. If we map this region at 0x5000, then
     // the value P can remain 0x1200. The decoded address = (0x4000 + (0x1200 << 0)) = 0x5200,
     // which is the runtime location of the referenced object.
-    return /*runtime*/ CompressedOops::base() + r->mapping_offset();
+    return /*runtime*/ (address)((uintptr_t)CompressedOops::base() + r->mapping_offset());
   } else {
     // This was the hard-coded requested base address used at dump time. With uncompressed oops,
     // the heap range is assigned by the OS so we will most likely have to relocate anyway, no matter

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2219,7 +2219,7 @@ address FileMapInfo::heap_region_dumptime_address() {
   assert(CDSConfig::is_using_archive(), "runtime only");
   assert(is_aligned(r->mapping_offset(), sizeof(HeapWord)), "must be");
   if (UseCompressedOops) {
-    return /*dumptime*/ narrow_oop_base() + r->mapping_offset();
+    return /*dumptime*/ (address)((uintptr_t)narrow_oop_base() + r->mapping_offset());
   } else {
     return heap_region_requested_address();
   }

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -34,7 +34,6 @@
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
-#include "sanitizers/ub.hpp"
 #include "utilities/align.hpp"
 #include "utilities/formatBuffer.hpp"
 #include "utilities/powerOfTwo.hpp"

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -436,7 +436,6 @@ void ReservedHeapSpace::try_reserve_heap(size_t size,
   }
 }
 
-ATTRIBUTE_NO_UBSAN
 void ReservedHeapSpace::try_reserve_range(char *highest_start,
                                           char *lowest_start,
                                           size_t attach_point_alignment,
@@ -459,7 +458,7 @@ void ReservedHeapSpace::try_reserve_range(char *highest_start,
   while (attach_point >= lowest_start  &&
          attach_point <= highest_start &&  // Avoid wrap around.
          ((_base == nullptr) ||
-          (_base < aligned_heap_base_min_address || _base + size > upper_bound))) {
+          (_base < aligned_heap_base_min_address || size > (uintptr_t)(upper_bound - _base)))) {
     try_reserve_heap(size, alignment, page_size, attach_point);
     attach_point -= stepsize;
   }

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -34,6 +34,7 @@
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
+#include "sanitizers/ub.hpp"
 #include "utilities/align.hpp"
 #include "utilities/formatBuffer.hpp"
 #include "utilities/powerOfTwo.hpp"
@@ -435,6 +436,7 @@ void ReservedHeapSpace::try_reserve_heap(size_t size,
   }
 }
 
+ATTRIBUTE_NO_UBSAN
 void ReservedHeapSpace::try_reserve_range(char *highest_start,
                                           char *lowest_start,
                                           size_t attach_point_alignment,


### PR DESCRIPTION
This fixes the build when building on macOS aarch64 with ubsan enabled.

Seems there is an undefined addition to a nullptr in filemap.cpp :

jdk/src/hotspot/share/cds/filemap.cpp:2215:47: runtime error: applying non-zero offset 34358689792 to null pointer
    #0 0x107b70c78 in FileMapInfo::heap_region_requested_address() filemap.cpp:2215
    #1 0x107b71960 in FileMapInfo::map_heap_region_impl() filemap.cpp:2260
    #2 0x107b70e04 in FileMapInfo::map_or_load_heap_region() filemap.cpp:2081
    #3 0x1082976ec in MetaspaceShared::map_archives(FileMapInfo*, FileMapInfo*, bool) metaspaceShared.cpp:1344
    #4 0x10829699c in MetaspaceShared::initialize_runtime_shared_and_meta_spaces() metaspaceShared.cpp:1098
    #5 0x108289530 in Metaspace::global_initialize() metaspace.cpp:736
    #6 0x108819da8 in universe_init() universe.cpp:887
    #7 0x107d8b4ec in init_globals() init.cpp:133
    #8 0x1087e43d8 in Threads::create_vm(JavaVMInitArgs*, bool*) threads.cpp:574
    #9 0x107eca96c in JNI_CreateJavaVM jni.cpp:3681
    #10 0x102e6e770 in JavaMain java.c:494
    #11 0x102e7579c in ThreadJavaMain java_md_macosx.m:679
    #12 0x19d38ef90 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6f90)
    #13 0x19d389d30 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1d30)


coding in filemap.cpp is (and CompressedOops::base() seems to return nullptr on this macoS aarch64 machine)

`return /*runtime*/ CompressedOops::base() + r->mapping_offset();
`
This was seen in the OpenJDK build on macOS aarch64 when building with ubsan enabled.

There is also another very recent issue showing up in the ubsan enabled build on macOS aarch64 since today.
jdk/src/hotspot/share/memory/virtualspace.cpp:462:18: runtime error: applying non-zero offset to non-null pointer 0x000080000000 produced null pointer
    #0 0x10a6a2df0 in ReservedHeapSpace::try_reserve_range(char*, char*, unsigned long, char*, char*, unsigned long, unsigned long, unsigned long) virtualspace.cpp:462
    #1 0x10a6a3684 in ReservedHeapSpace::initialize_compressed_heap(unsigned long, unsigned long, unsigned long) virtualspace.cpp:569
    #2 0x10a6a39cc in ReservedHeapSpace::ReservedHeapSpace(unsigned long, unsigned long, unsigned long, char const*) virtualspace.cpp:647
    #3 0x10a6a3bd0 in ReservedHeapSpace::ReservedHeapSpace(unsigned long, unsigned long, unsigned long, char const*) virtualspace.cpp:622
    #4 0x10a625d5c in Universe::reserve_heap(unsigned long, unsigned long) universe.cpp:959
    #5 0x1099d4580 in G1CollectedHeap::initialize() g1CollectedHeap.cpp:1286
    #6 0x10a6255e8 in universe_init() universe.cpp:880
    #7 0x109b95dec in init_globals() init.cpp:133
    #8 0x10a5efd98 in Threads::create_vm(JavaVMInitArgs*, bool*) threads.cpp:574
    #9 0x109cd53b4 in JNI_CreateJavaVM jni.cpp:3680
    #10 0x104d26770 in JavaMain java.c:494
    #11 0x104d2d79c in ThreadJavaMain java_md_macosx.m:679
    #12 0x19d38ef90 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6f90)
    #13 0x19d389d30 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1d30)
   ... (rest of output omitted)

For now I exclude this method from ubsan checking. 
After these changes,  the build on macOS aarch64 with ubsan enabled works .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345569](https://bugs.openjdk.org/browse/JDK-8345569): [ubsan] adjustments to filemap.cpp and virtualspace.cpp for macOS aarch64 (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [5ac17045](https://git.openjdk.org/jdk/pull/22603/files/5ac170453383b73a78a2c57b8d1fa82d7ae879cc)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22603/head:pull/22603` \
`$ git checkout pull/22603`

Update a local copy of the PR: \
`$ git checkout pull/22603` \
`$ git pull https://git.openjdk.org/jdk.git pull/22603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22603`

View PR using the GUI difftool: \
`$ git pr show -t 22603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22603.diff">https://git.openjdk.org/jdk/pull/22603.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22603#issuecomment-2522763671)
</details>
