### PR TITLE
8345661: Simplify page size alignment in code heap reservation

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -433,7 +433,7 @@ void CodeCache::add_heap(ReservedSpace rs, const char* name, CodeBlobType code_b
 
   // Reserve Space
   size_t size_initial = MIN2((size_t)InitialCodeCacheSize, rs.size());
-  size_initial = align_up(size_initial, os::vm_page_size());
+  size_initial = align_up(size_initial, rs.page_size());
   if (!heap->reserve(rs, size_initial, CodeCacheSegmentSize)) {
     vm_exit_during_initialization(err_msg("Could not reserve enough space in %s (" SIZE_FORMAT "K)",
                                           heap->name(), size_initial/K));

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -200,6 +200,7 @@ void CodeHeap::on_code_mapping(char* base, size_t size) {
 
 bool CodeHeap::reserve(ReservedSpace rs, size_t committed_size, size_t segment_size) {
   assert(rs.size() >= committed_size, "reserved < committed");
+  assert(is_aligned(committed_size, rs.page_size()), "must be page aligned");
   assert(segment_size >= sizeof(FreeBlock), "segment size is too small");
   assert(is_power_of_2(segment_size), "segment_size must be a power of 2");
   assert_locked_or_safepoint(CodeCache_lock);
@@ -208,13 +209,8 @@ bool CodeHeap::reserve(ReservedSpace rs, size_t committed_size, size_t segment_s
   _log2_segment_size = exact_log2(segment_size);
 
   // Reserve and initialize space for _memory.
-  const size_t page_size = rs.page_size();
-  const size_t granularity = os::vm_allocation_granularity();
-  const size_t c_size = align_up(committed_size, page_size);
-  assert(c_size <= rs.size(), "alignment made committed size to large");
-
-  os::trace_page_sizes(_name, c_size, rs.size(), rs.base(), rs.size(), page_size);
-  if (!_memory.initialize(rs, c_size)) {
+  os::trace_page_sizes(_name, committed_size, rs.size(), rs.base(), rs.size(), rs.page_size());
+  if (!_memory.initialize(rs, committed_size)) {
     return false;
   }
 
@@ -222,7 +218,7 @@ bool CodeHeap::reserve(ReservedSpace rs, size_t committed_size, size_t segment_s
   _number_of_committed_segments = size_to_segments(_memory.committed_size());
   _number_of_reserved_segments  = size_to_segments(_memory.reserved_size());
   assert(_number_of_reserved_segments >= _number_of_committed_segments, "just checking");
-  const size_t reserved_segments_alignment = MAX2(os::vm_page_size(), granularity);
+  const size_t reserved_segments_alignment = MAX2(os::vm_page_size(), os::vm_allocation_granularity());
   const size_t reserved_segments_size = align_up(_number_of_reserved_segments, reserved_segments_alignment);
   const size_t committed_segments_size = align_to_page_size(_number_of_committed_segments);
 


### PR DESCRIPTION
While working on a prototype to clean up ReservedSpace ([JDK-8345655](https://bugs.openjdk.org/browse/JDK-8345655)) I noticed that the code that reserves the code heap first aligns the committed memory size towards small pages and then aligns it against the page size that was set up for the ReservedSpace. I suggest that just align to the latter immediately.

I also inlined the one usage of `os::vm_allocation_granularity`.

Testing tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345661](https://bugs.openjdk.org/browse/JDK-8345661): Simplify page size alignment in code heap reservation (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22604/head:pull/22604` \
`$ git checkout pull/22604`

Update a local copy of the PR: \
`$ git checkout pull/22604` \
`$ git pull https://git.openjdk.org/jdk.git pull/22604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22604`

View PR using the GUI difftool: \
`$ git pr show -t 22604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22604.diff">https://git.openjdk.org/jdk/pull/22604.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22604#issuecomment-2522899407)
</details>
