### PR TITLE
8345664: Use simple parameter type names in @link and @see tags

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/LinkTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/LinkTaglet.java
@@ -271,7 +271,7 @@ public class LinkTaglet extends BaseTaglet {
             }
             if (utils.isExecutableElement(refMem)) {
                 if (refMemName.indexOf('(') < 0) {
-                    refMemName += utils.makeSignature((ExecutableElement) refMem, null, true);
+                    refMemName += utils.makeSignature((ExecutableElement) refMem, null, false, true);
                 }
                 if (overriddenMethod != null) {
                     // The method to actually link.

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      4732864 6280605 7064544 8014636 8016328 8025633 8071982 8182765
- *           8274781
+ *           8274781 8345664
  * @summary  Make sure that you can link from one member to another using
  *           non-qualified name, furthermore, ensure the right one is linked.
  * @library  ../../lib
@@ -50,6 +50,17 @@ public class TestLinkTaglet extends JavadocTester {
                 "pkg", testSrc("checkPkg/B.java"));
         checkExit(Exit.OK);
 
+        checkOutput("pkg/package-summary.html", true,
+                """
+                    Qualified Link: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
+                     Unqualified Link1: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
+                     Unqualified Link2: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
+                     Qualified Link: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(pkg.\
+                    C.InnerC, pkg.C.InnerC2)</code></a>.<br/>
+                     Unqualified Link: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(C.InnerC, C.InnerC2)</code></a>.<br/>
+                     Unqualified Link: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(InnerC, InnerC2)</code></a>.<br/>
+                     Link w/o Signature: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(C.InnerC, C.InnerC2)</code></a>.<br/>
+                     Package Link: <a href="package-summary.html"><code>pkg</code></a>.<br/>""");
         checkOutput("pkg/C.html", true,
                 """
                     Qualified Link: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
@@ -59,6 +70,7 @@ public class TestLinkTaglet extends JavadocTester {
                     C.InnerC, pkg.C.InnerC2)</code></a>.<br/>
                      Unqualified Link: <a href="#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>method(C.InnerC, C.InnerC2)</code></a>.<br/>
                      Unqualified Link: <a href="#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>method(InnerC, InnerC2)</code></a>.<br/>
+                     Link w/o Signature: <a href="#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>method(C.InnerC, C.InnerC2)</code></a>.<br/>
                      Package Link: <a href="package-summary.html"><code>pkg</code></a>.<br/>""");
 
         checkOutput("pkg/C.InnerC.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletWithModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletWithModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ public class TestLinkTagletWithModule extends JavadocTester {
                      <a href="../../../../m1/module-summary.html"><code>m1</code></a>
                      <a href="../../../../m1/com/m1/lib/package-summary.html"><code>package link</code></a>
                      <a href="../../../../m1/com/m1/lib/Lib.html" title="class in com.m1.lib"><code>Lib</code></a>
-                     <a href="../../../../m1/com/m1/lib/Lib.html#method(java.lang.String)"><code>Lib.method(java.lang.String)</code></a>
+                     <a href="../../../../m1/com/m1/lib/Lib.html#method(java.lang.String)"><code>Lib.method(String)</code></a>
                      <a href="../../../../m1/com/m1/lib/Lib.html#method(java.lang.String)"><code>Lib.method(String)</code></a>
                      <a href="../../../../m2/module-summary.html">m2</a>
                      <a href="../../../../m2/module-summary.html">m2</a>
@@ -110,7 +110,7 @@ public class TestLinkTagletWithModule extends JavadocTester {
                      <a href="../../../../../out1/m1/com/m1/lib/Lib.html" title="class or interface in com.m1.lib"\
                      class="external-link"><code>Lib</code></a>
                      <a href="../../../../../out1/m1/com/m1/lib/Lib.html#method(java.lang.String)" title="class or\
-                     interface in com.m1.lib" class="external-link"><code>Lib.method(java.lang.String)</code></a>
+                     interface in com.m1.lib" class="external-link"><code>Lib.method(String)</code></a>
                      <a href="../../../../../out1/m1/com/m1/lib/Lib.html#method(java.lang.String)" title="class or\
                      interface in com.m1.lib" class="external-link"><code>Lib.method(String)</code></a>
                      <a href="../../../../../out1/m2/module-summary.html" class="external-link">m2</a>

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/pkg/C.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/pkg/C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ package pkg;
  * Qualified Link: {@link #method(pkg.C.InnerC, pkg.C.InnerC2)}.<br/>
  * Unqualified Link: {@link #method(C.InnerC, C.InnerC2)}.<br/>
  * Unqualified Link: {@link #method(InnerC, InnerC2)}.<br/>
+ * Link w/o Signature: {@link #method}.<br/>
  * Package Link: {@link pkg}.<br/>
  *
  *

--- a/test/langtools/jdk/javadoc/doclet/testNestedGenerics/TestNestedGenerics.java
+++ b/test/langtools/jdk/javadoc/doclet/testNestedGenerics/TestNestedGenerics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      6758050 8025633 8182765
+ * @bug      6758050 8025633 8182765 8345664
  * @summary  Test HTML output for nested generic types.
  * @library  ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -49,7 +49,6 @@ public class TestNestedGenerics extends JavadocTester {
 
         checkOutput("pkg/NestedGenerics.html", true,
             """
-                <div class="block">Contains <a href="#foo(java.util.Map)"><code>foo(java.util.Ma\
-                p&lt;A, java.util.Map&lt;A, A&gt;&gt;)</code></a></div>""");
+                    <div class="block">Contains <a href="#foo(java.util.Map)"><code>foo(Map)</code></a></div>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTagWithModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTagWithModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,13 +79,13 @@ public class TestSeeTagWithModule extends JavadocTester {
                     <li><a href="../../../../m1/module-summary.html"><code>m1</code></a></li>
                     <li><a href="../../../../m1/com/m1/lib/package-summary.html"><code>com.m1.lib</code></a></li>
                     <li><a href="../../../../m1/com/m1/lib/Lib.html" title="class in com.m1.lib"><code>Lib</code></a></li>
-                    <li><a href="../../../../m1/com/m1/lib/Lib.html#method(java.lang.String)"><code>Lib.method(java.lang.String)</code></a></li>
+                    <li><a href="../../../../m1/com/m1/lib/Lib.html#method(java.lang.String)"><code>Lib.method(String)</code></a></li>
                     <li><a href="../../../../m1/com/m1/lib/Lib.html#method(java.lang.String)"><code>Lib.method(String)</code></a></li>
                     <li><a href="../../../../m2/module-summary.html"><code>m2</code></a></li>
                     <li><a href="../../../../m2/module-summary.html"><code>m2</code></a></li>
                     <li><a href="../../../../m2/com/m2/lib/package-summary.html"><code>com.m2.lib</code></a></li>
                     <li><a href="../../../../m2/com/m2/lib/Lib.html" title="class in com.m2.lib"><code>Lib</code></a></li>
-                    <li><a href="../../../../m2/com/m2/lib/Lib.html#method(java.lang.String)"><code>Lib.method(java.lang.String)</code></a></li>
+                    <li><a href="../../../../m2/com/m2/lib/Lib.html#method(java.lang.String)"><code>Lib.method(String)</code></a></li>
                     <li><a href="../../../../m2/com/m2/lib/Lib.html#method(java.lang.String)"><code>Lib.method(String)</code></a></li>
                     """);
     }
@@ -115,7 +115,7 @@ public class TestSeeTagWithModule extends JavadocTester {
                     <li><a href="../../../../../out1/m1/com/m1/lib/package-summary.html" class="external-link"><code>m1/com.m1.lib</code></a></li>
                     <li><a href="../../../../../out1/m1/com/m1/lib/Lib.html" title="class or interface in com.m1.lib" class="external-link"><code>Lib</code></a></li>
                     <li><a href="../../../../../out1/m1/com/m1/lib/Lib.html#method(java.lang.String)" title="class or \
-                    interface in com.m1.lib" class="external-link"><code>Lib.method(java.lang.String)</code></a></li>
+                    interface in com.m1.lib" class="external-link"><code>Lib.method(String)</code></a></li>
                     <li><a href="../../../../../out1/m1/com/m1/lib/Lib.html#method(java.lang.String)" title="class or \
                     interface in com.m1.lib" class="external-link"><code>Lib.method(String)</code></a></li>
                     <li><a href="../../../../../out1/m2/module-summary.html" class="external-link"><code>m2</code></a></li>
@@ -123,7 +123,7 @@ public class TestSeeTagWithModule extends JavadocTester {
                     <li><a href="../../../../../out1/m2/com/m2/lib/package-summary.html" class="external-link"><code>m2/com.m2.lib</code></a></li>
                     <li><a href="../../../../../out1/m2/com/m2/lib/Lib.html" title="class or interface in com.m2.lib" class="external-link"><code>Lib</code></a></li>
                     <li><a href="../../../../../out1/m2/com/m2/lib/Lib.html#method(java.lang.String)" title="class or \
-                    interface in com.m2.lib" class="external-link"><code>Lib.method(java.lang.String)</code></a></li>
+                    interface in com.m2.lib" class="external-link"><code>Lib.method(String)</code></a></li>
                     <li><a href="../../../../../out1/m2/com/m2/lib/Lib.html#method(java.lang.String)" title="class or \
                     interface in com.m2.lib" class="external-link"><code>Lib.method(String)</code></a></li>
                     """);


### PR DESCRIPTION
Please review a change to use simple raw parameter type names in method signatures generated by `@link` and `@see` tags. This is the same signature format we use for methods in the table of contents sidebar. 

The change only applies if the method reference doesn't contain a signature (i.e. method name only as in `{@link #set}`). If the reference in the tag includes a signature, that signature continues to be used in the link label (i.e. `{@link #set(Object)}` or `{@link #set(java.lang.Object)}`).

The argument for using simple and raw type names is:

 - The purpose of a method link label is to make the user understand which method we're talking about, and that requires recognizing the number and type names of parameters. Using fully qualified type names and possibly type parameters with bounded wildcards makes both much harder and is not useful at this stage.
 - If information about package names or type parameters of parameter types is required, that's what the link to the method details is for (possibly clicking through to the parameter type). 

Here is a before/after comparison of a rather typical case in `MethodHandles.collectArguments`:

<img width="763" alt="methodhandles-full" src="https://github.com/user-attachments/assets/c4ada44b-7c2e-4e54-9535-c5e7a576ca35">

<img width="482" alt="methodhandles-simple" src="https://github.com/user-attachments/assets/8a5e04f1-8be2-4b8a-8b98-d1888f386702">

Here's a before/after comparison that shows the effect on fully qualified type names with bounded wildcards in `CompletionStage.exceptionallyAsync`:

<img width="718" alt="completionhandler-full" src="https://github.com/user-attachments/assets/021b717e-a493-4110-9fda-848ed314ba51">

<img width="710" alt="completionhandler-simple" src="https://github.com/user-attachments/assets/e1f0b97b-92c0-49e2-93a1-eced52b46434">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345664](https://bugs.openjdk.org/browse/JDK-8345664): Use simple parameter type names in @<!---->link and @<!---->see tags (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22608/head:pull/22608` \
`$ git checkout pull/22608`

Update a local copy of the PR: \
`$ git checkout pull/22608` \
`$ git pull https://git.openjdk.org/jdk.git pull/22608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22608`

View PR using the GUI difftool: \
`$ git pr show -t 22608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22608.diff">https://git.openjdk.org/jdk/pull/22608.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22608#issuecomment-2523504319)
</details>
