### PR TITLE
8345684: OperatingSystemMXBean.getSystemCpuLoad() throws NPE

### DIFF
--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -275,6 +275,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
 
     private boolean isCpuSetSameAsHostCpuSet() {
         if (containerMetrics != null) {
+            // The return value may change (including from non-null to null) and
+            // the call may involve I/O, so keep the result in a local variable.
             int[] cpuSetCpus = containerMetrics.getCpuSetCpus();
             if (cpuSetCpus != null) {
                 return cpuSetCpus.length == getHostOnlineCpuCount0();

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -274,8 +274,11 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     }
 
     private boolean isCpuSetSameAsHostCpuSet() {
-        if (containerMetrics != null && containerMetrics.getCpuSetCpus() != null) {
-            return containerMetrics.getCpuSetCpus().length == getHostOnlineCpuCount0();
+        if (containerMetrics != null) {
+            int[] cpuSetCpus = containerMetrics.getCpuSetCpus();
+            if (cpuSetCpus != null) {
+                return cpuSetCpus.length == getHostOnlineCpuCount0();
+            }
         }
         return false;
     }


### PR DESCRIPTION
The return value of Metrics#getCpuSetCpus may change over time, including from non-null to null across the two calls in this method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345684](https://bugs.openjdk.org/browse/JDK-8345684): OperatingSystemMXBean.getSystemCpuLoad() throws NPE (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22611/head:pull/22611` \
`$ git checkout pull/22611`

Update a local copy of the PR: \
`$ git checkout pull/22611` \
`$ git pull https://git.openjdk.org/jdk.git pull/22611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22611`

View PR using the GUI difftool: \
`$ git pr show -t 22611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22611.diff">https://git.openjdk.org/jdk/pull/22611.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22611#issuecomment-2523778134)
</details>
