### PR TITLE
8345698: Remove tier1_compiler_not_xcomp from github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,6 @@ jobs:
           - 'hs/tier1 compiler part 1'
           - 'hs/tier1 compiler part 2'
           - 'hs/tier1 compiler part 3'
-          - 'hs/tier1 compiler not-xcomp'
           - 'hs/tier1 gc'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
@@ -99,10 +98,6 @@ jobs:
 
           - test-name: 'hs/tier1 compiler part 3'
             test-suite: 'test/hotspot/jtreg/:tier1_compiler_3'
-            debug-suffix: -debug
-
-          - test-name: 'hs/tier1 compiler not-xcomp'
-            test-suite: 'test/hotspot/jtreg/:tier1_compiler_not_xcomp'
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 gc'


### PR DESCRIPTION
The fix for
https://bugs.openjdk.org/browse/JDK-8345435
delete tier1_compiler_not_xcomp group
but don't remove corresponding testing from github actions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345698](https://bugs.openjdk.org/browse/JDK-8345698): Remove tier1_compiler_not_xcomp from github actions (**Bug** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22612/head:pull/22612` \
`$ git checkout pull/22612`

Update a local copy of the PR: \
`$ git checkout pull/22612` \
`$ git pull https://git.openjdk.org/jdk.git pull/22612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22612`

View PR using the GUI difftool: \
`$ git pr show -t 22612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22612.diff">https://git.openjdk.org/jdk/pull/22612.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22612#issuecomment-2523824374)
</details>
