### PR TITLE
8345700: tier{1,2,3}_compiler don't cover all compiler tests

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -250,18 +250,7 @@ tier2_compiler = \
   -:hotspot_slow_compiler
 
 tier3_compiler = \
-  applications/ctw/modules \
-  compiler/c2/ \
-  compiler/ciReplay/ \
-  compiler/compilercontrol/ \
-  compiler/debug/ \
-  compiler/oracle/ \
-  compiler/print/ \
-  compiler/relocations/ \
-  compiler/tiered/ \
-  compiler/vectorapi/ \
-  compiler/whitebox/ \
-  :hotspot_slow_compiler \
+  :hotspot_compiler \
   -:tier1_compiler \
   -:tier2_compiler
 
@@ -281,6 +270,9 @@ ctw_3 = \
   applications/ctw/modules/jdk_compiler.java \
   applications/ctw/modules/jdk_localedata.java \
   applications/ctw/modules/jdk_localedata_2.java
+
+tier2_ctw = \
+  :ctw_1
 
 tier1_gc = \
   :tier1_gc_1 \
@@ -634,6 +626,7 @@ tier2 = \
   :hotspot_tier2_runtime_platform_agnostic \
   :hotspot_tier2_serviceability \
   :tier2_compiler \
+  :tier2_ctw \
   :tier2_gc_epsilon \
   :tier2_gc_shenandoah
 


### PR DESCRIPTION
Hi, 
could you please review following fix that update
tier3_compiler test group
so :hotspot_compiler is always a sum of
tier1_compiler, tier2_compiler, tier3_compiler
This is natural splitting of tests into 3 layers. 
The fix is done to execution :hotspot_compiler into 3 tiers with corresponding group names.

New tests in tier3:
9 tests in compiler/ccp/
22 test in ompiler/predicates/
8 tests in compiler/splitif/
So the number is not increased significantly.

The new group
` tier2_ctw`
was introduced for ctw testing. 
It is different from tests in hotspot_compiler, and usually executed separately, So I added it as separate sub-test of tier2.

I moved ctw from tier3 to tier2 to correspond current tiers of Hotspot CI in our system. 
If anyone thinks it should be part of tier3 - we can discuss in PR comments how do deal with it.

@shipilev, could you please take a look and check if these changes are ok to you since you the author of tier2/tier3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345700](https://bugs.openjdk.org/browse/JDK-8345700): tier{1,2,3}_compiler don't cover all compiler tests (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22614/head:pull/22614` \
`$ git checkout pull/22614`

Update a local copy of the PR: \
`$ git checkout pull/22614` \
`$ git pull https://git.openjdk.org/jdk.git pull/22614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22614`

View PR using the GUI difftool: \
`$ git pr show -t 22614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22614.diff">https://git.openjdk.org/jdk/pull/22614.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22614#issuecomment-2524085508)
</details>
