### PR TITLE
8345726: Update mx in RunTestPrebuiltSpec to reflect change in JDK-8345302

### DIFF
--- a/make/RunTestsPrebuiltSpec.gmk
+++ b/make/RunTestsPrebuiltSpec.gmk
@@ -63,7 +63,7 @@ TEST_JOBS ?= 0
 
 # Use hard-coded values for java flags (one size, fits all!)
 JAVA_FLAGS := -Duser.language=en -Duser.country=US
-JAVA_FLAGS_BIG := -Xms64M -Xmx1600M
+JAVA_FLAGS_BIG := -Xms64M -Xmx2048M
 JAVA_FLAGS_SMALL := -XX:+UseSerialGC -Xms32M -Xmx512M -XX:TieredStopAtLevel=1
 BUILDJDK_JAVA_FLAGS_SMALL := -Xms32M -Xmx512M -XX:TieredStopAtLevel=1
 BUILD_JAVA_FLAGS := $(JAVA_FLAGS_BIG)


### PR DESCRIPTION
In [JDK-8345302](https://bugs.openjdk.org/browse/JDK-8345302) I updated the default JAVA_FLAGS_BIG to -Xmx2048M in configure. In RunTestPrebuiltSpec.gmk, there is a copy of this value that also needs to be updated as it should mimic a typical configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345726](https://bugs.openjdk.org/browse/JDK-8345726): Update mx in RunTestPrebuiltSpec to reflect change in JDK-8345302 (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22615/head:pull/22615` \
`$ git checkout pull/22615`

Update a local copy of the PR: \
`$ git checkout pull/22615` \
`$ git pull https://git.openjdk.org/jdk.git pull/22615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22615`

View PR using the GUI difftool: \
`$ git pr show -t 22615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22615.diff">https://git.openjdk.org/jdk/pull/22615.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22615#issuecomment-2524158040)
</details>
