### PR TITLE
8344924: Default CA certificates loaded despite request to use custom keystore

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
@@ -50,7 +50,7 @@ import sun.security.validator.*;
  */
 final class X509TrustManagerImpl extends X509ExtendedTrustManager
         implements X509TrustManager {
-    
+
     private final String validatorType;
 
     /**

--- a/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
@@ -25,7 +25,6 @@
 
 package sun.security.ssl;
 
-import java.lang.invoke.MethodHandles;
 import java.net.Socket;
 import java.security.*;
 import java.security.cert.*;
@@ -51,16 +50,7 @@ import sun.security.validator.*;
  */
 final class X509TrustManagerImpl extends X509ExtendedTrustManager
         implements X509TrustManager {
-
-    static {
-        // eagerly initialize to avoid pinning virtual thread during TLS handshake
-        try {
-            MethodHandles.lookup().ensureInitialized(AnchorCertificates.class);
-        } catch (IllegalAccessException e) {
-            throw new ExceptionInInitializerError(e);
-        }
-    }
-
+    
     private final String validatorType;
 
     /**


### PR DESCRIPTION
A regression was introduced by [JDK-8338383](https://bugs.openjdk.org/browse/JDK-8338383). Remove the forced static eager initialization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344924](https://bugs.openjdk.org/browse/JDK-8344924): Default CA certificates loaded despite request to use custom keystore (**Bug** - P3)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22616/head:pull/22616` \
`$ git checkout pull/22616`

Update a local copy of the PR: \
`$ git checkout pull/22616` \
`$ git pull https://git.openjdk.org/jdk.git pull/22616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22616`

View PR using the GUI difftool: \
`$ git pr show -t 22616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22616.diff">https://git.openjdk.org/jdk/pull/22616.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22616#issuecomment-2524210577)
</details>
