### PR TITLE
8344922: Redefinition verifies the new klass when verification is disabled

### DIFF
--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -133,6 +133,8 @@ static bool is_eligible_for_verification(InstanceKlass* klass, bool should_verif
   Symbol* name = klass->name();
 
   return (should_verify_class &&
+    // Override parameter (return false) if -Xverify:none
+    BytecodeVerificationRemote &&
     // Can not verify the bytecodes for shared classes because they have
     // already been rewritten to contain constant pool cache indices,
     // which the verifier can't understand.

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineVerifyError.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineVerifyError.java
@@ -35,8 +35,13 @@
  * @run main RedefineClassHelper
  * @run main/othervm/timeout=180
  *         -javaagent:redefineagent.jar
- *         -Xlog:class+init,exceptions
+ *         -Xlog:exceptions
  *         RedefineVerifyError
+ * @run main/othervm/timeout=180
+ *         -javaagent:redefineagent.jar
+ *         -Xlog:exceptions
+ *         -Xverify:none
+ *         RedefineVerifyError nothrow
  */
 
 import jdk.internal.org.objectweb.asm.AnnotationVisitor;
@@ -91,10 +96,14 @@ public class RedefineVerifyError implements Opcodes {
         try {
             // The Verifier is called for the redefinition, which will fail because of the broken <init> method above.
             RedefineClassHelper.redefineClass(verifyErrorMirror, dump());
-            throw new RuntimeException("This should throw VerifyError");
+            if (args.length == 0) {
+                throw new RuntimeException("This should throw VerifyError");
+            } else {
+                System.out.println("Passed: noverify");
+            }
         } catch (VerifyError e) {
             // JVMTI recreates the VerifyError so the verification message is lost.
-            System.out.println("Passed");
+            System.out.println("Passed: default verify");
         }
     }
 }


### PR DESCRIPTION
This change only verifies redefined classes if Verification is enabled.  BytecodeVerificationRemote will be false for verification turned off.  If someone turns it off but BytecodeVerificationLocal on (which is non-sensical), the argument processing code will fix that up.  So all this needs to do is check for BytecodeVerifificationRemote for -Xverify:none (which is a deprecated option).

```
  // Treat the odd case where local verification is enabled but remote
  // verification is not as if both were enabled.
  if (BytecodeVerificationLocal && !BytecodeVerificationRemote) {
    log_info(verification)("Turning on remote verification because local verification is on");
    FLAG_SET_DEFAULT(BytecodeVerificationRemote, true);
  }
```

Tested with runtime/verifier, jck vm and tier1-4 (in progress), and the new test case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344922](https://bugs.openjdk.org/browse/JDK-8344922): Redefinition verifies the new klass when verification is disabled (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22617/head:pull/22617` \
`$ git checkout pull/22617`

Update a local copy of the PR: \
`$ git checkout pull/22617` \
`$ git pull https://git.openjdk.org/jdk.git pull/22617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22617`

View PR using the GUI difftool: \
`$ git pr show -t 22617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22617.diff">https://git.openjdk.org/jdk/pull/22617.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22617#issuecomment-2524225214)
</details>
