### PR TITLE
8338714: vmTestbase/nsk/jdb/kill/kill001/kill001.java fails with JTREG_TEST_THREAD_FACTORY=Virtual

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -87,18 +87,9 @@ vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location002/TestDescription.java
 vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemoryException001.java 8285417 generic-all
 
 ###
-# The test first suspends a vthread and all the carriers and then it resumes the vthread expecting it
-# to run to completion. In mainline it only works because the suspension step happens while the vthread is
-# pinned to the carrier blocked on synchronized. So the carrier only actually suspends on the next unmount
-# transition which in this test happens once the vthread has finished executing the expected code.
-
+# Fails because resume of a virtual thread is not enough to allow the virtual thread
+# to make progress when all other threads are currently suspended.
 vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002/TestDescription.java 8338713 generic-all
-
-###
-# The test sends a StopThread to a vthread expecting that is currently pinned to the carrier blocked on
-# synchronized. Since the vthread is now unmounted StopThread returns JVMTI_ERROR_OPAQUE_FRAME error.
-
-vmTestbase/nsk/jdb/kill/kill001/kill001.java 8338714 generic-all
 
 ###
 # Fails on Windows because of additional memory allocation.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -27,6 +27,7 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
 import nsk.share.jdi.JDIThreadFactory;
+import jdk.test.lib.thread.VThreadPinner;
 
 import java.io.*;
 import java.util.*;
@@ -152,6 +153,17 @@ class MyThread extends Thread {
     }
 
     public void run() {
+        boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
+        if (vthreadMode) {
+            // JVMTI StopThread is only supported for mounted virtual threads. We need to
+            // pin the virtual threads so they remain mounted.
+            VThreadPinner.runPinned(() -> run1());
+        } else {
+            run1();
+        }
+    }
+
+    public void run1() {
         // Concatenate strings in advance to avoid lambda calculations later
         String ThreadFinished = "Thread finished: " + this.name;
         String CaughtExpected = "Thread " + this.name + " caught expected async exception: " + expectedException;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -157,13 +157,13 @@ class MyThread extends Thread {
         if (vthreadMode) {
             // JVMTI StopThread is only supported for mounted virtual threads. We need to
             // pin the virtual threads so they remain mounted.
-            VThreadPinner.runPinned(() -> run1());
+            VThreadPinner.runPinned(() -> test());
         } else {
-            run1();
+            test();
         }
     }
 
-    public void run1() {
+    public void test() {
         // Concatenate strings in advance to avoid lambda calculations later
         String ThreadFinished = "Thread finished: " + this.name;
         String CaughtExpected = "Thread " + this.name + " caught expected async exception: " + expectedException;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
@@ -137,6 +137,9 @@ public class Launcher extends DebugeeBinder {
                 /* Some tests need more carrier threads than the default provided. */
                 args.add("-R-Djdk.virtualThreadScheduler.parallelism=15");
             }
+            /* Some jdb tests need java.library.path setup for native libraries. */
+            String libpath = System.getProperty("java.library.path");
+            args.add("-R-Djava.library.path=" + libpath);
         }
 
         args.addAll(argumentHandler.enwrapJavaOptions(argumentHandler.getJavaOptions()));


### PR DESCRIPTION
This test fails after [JDK-8338713](https://bugs.openjdk.org/browse/JDK-8338713) when using JTREG_TEST_THREAD_FACTORY=Virtual. The test uses JVMTI StopThread on a thread expecting it to be mounted. Before [JDK-8338713](https://bugs.openjdk.org/browse/JDK-8338713) it would be mounted because it was blocked on a syncrhonized, which resulted in the thread being pinned. After [JDK-8338713](https://bugs.openjdk.org/browse/JDK-8338713) this is no longer the case and the virtual thread has unmounted. This causes JVMTI StopThread to fail with JVMTI_ERROR_OPAQUE_FRAME because it only supports mounted virtual threads.

Fixed by using the VThreadPinner class to make sure the virtual threads remains pinned, and therefore mounted.

Testing:

- [x] Ran jdb tests locally in both virtual thread mode and platform thread mode.
- [x] tier1
- [x] tier2 svc
- [x] tier5 svc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338714](https://bugs.openjdk.org/browse/JDK-8338714): vmTestbase/nsk/jdb/kill/kill001/kill001.java fails with JTREG_TEST_THREAD_FACTORY=Virtual (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22620/head:pull/22620` \
`$ git checkout pull/22620`

Update a local copy of the PR: \
`$ git checkout pull/22620` \
`$ git pull https://git.openjdk.org/jdk.git pull/22620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22620`

View PR using the GUI difftool: \
`$ git pr show -t 22620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22620.diff">https://git.openjdk.org/jdk/pull/22620.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22620#issuecomment-2524333319)
</details>
