### PR TITLE
8344880: AArch64: Add compile time check for class offsets

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3715,7 +3715,7 @@ encode %{
       Label retaddr;
       // Make the anchor frame walkable
       __ adr(rscratch2, retaddr);
-      __ str(rscratch2, Address(rthread, JavaThread::last_Java_pc_offset()));
+      __ str(rscratch2, Address(rthread, create_imm_offset(JavaThread, last_Java_pc_offset)));
       __ lea(rscratch1, RuntimeAddress(entry));
       __ blr(rscratch1);
       __ bind(retaddr);

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -656,6 +656,9 @@ class Address {
 
   static bool offset_ok_for_immed(int64_t offset, uint shift);
 
+  template <int64_t immed_offset, uint shift>
+  static constexpr bool offset_ok_for_immed_compile_time();
+
   static bool offset_ok_for_sve_immed(int64_t offset, int shift, int vl /* sve vector length */) {
     if (offset % vl == 0) {
       // Convert address offset into sve imm offset (MUL VL).
@@ -668,6 +671,13 @@ class Address {
     }
     return false;
   }
+
+  #define create_imm_offset(klass, field_offset_func) \
+  ([]() { \
+    constexpr size_t max_possible_offset = sizeof(klass); \
+    static_assert(Address::offset_ok_for_immed_compile_time<max_possible_offset, 0>(), "must fit in instruction"); \
+    return klass::field_offset_func(); \
+  }())
 };
 
 // Convenience classes

--- a/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
@@ -42,7 +42,7 @@ void C1SafepointPollStub::emit_code(LIR_Assembler* ce) {
   __ bind(_entry);
   InternalAddress safepoint_pc(ce->masm()->pc() - ce->masm()->offset() + safepoint_offset());
   __ adr(rscratch1, safepoint_pc);
-  __ str(rscratch1, Address(rthread, JavaThread::saved_exception_pc_offset()));
+  __ str(rscratch1, Address(rthread, create_imm_offset(JavaThread, saved_exception_pc_offset)));
 
   assert(SharedRuntime::polling_page_return_handler_blob() != nullptr,
          "polling page return stub not created yet");

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -396,9 +396,9 @@ int LIR_Assembler::emit_unwind_handler() {
   int offset = code_offset();
 
   // Fetch the exception from TLS and clear out exception related thread state
-  __ ldr(r0, Address(rthread, JavaThread::exception_oop_offset()));
-  __ str(zr, Address(rthread, JavaThread::exception_oop_offset()));
-  __ str(zr, Address(rthread, JavaThread::exception_pc_offset()));
+  __ ldr(r0, Address(rthread, create_imm_offset(JavaThread, exception_oop_offset)));
+  __ str(zr, Address(rthread, create_imm_offset(JavaThread, exception_oop_offset)));
+  __ str(zr, Address(rthread, create_imm_offset(JavaThread, exception_pc_offset)));
 
   __ bind(_unwind_handler_entry);
   __ verify_not_null_oop(r0);
@@ -1438,7 +1438,7 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
     __ load_klass(klass_RInfo, value);
 
     // get instance klass (it's already uncompressed)
-    __ ldr(k_RInfo, Address(k_RInfo, ObjArrayKlass::element_klass_offset()));
+    __ ldr(k_RInfo, Address(k_RInfo, create_imm_offset(ObjArrayKlass, element_klass_offset)));
     // perform the fast part of the checking logic
     __ check_klass_subtype_fast_path(klass_RInfo, k_RInfo, Rtmp1, success_target, failure_target, nullptr);
     // call out-of-line instance of __ check_klass_subtype_slow_path(...):
@@ -2372,7 +2372,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
         assert_different_registers(c_rarg2, dst);
 
         __ load_klass(c_rarg4, dst);
-        __ ldr(c_rarg4, Address(c_rarg4, ObjArrayKlass::element_klass_offset()));
+        __ ldr(c_rarg4, Address(c_rarg4, create_imm_offset(ObjArrayKlass, element_klass_offset)));
         __ ldrw(c_rarg3, Address(c_rarg4, Klass::super_check_offset_offset()));
         __ far_call(RuntimeAddress(copyfunc_addr));
 

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -69,7 +69,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
   verify_oop(obj);
 
   // save object being locked into the BasicObjectLock
-  str(obj, Address(disp_hdr, BasicObjectLock::obj_offset()));
+  str(obj, Address(disp_hdr, create_imm_offset(BasicObjectLock, obj_offset)));
 
   null_check_offset = offset();
 
@@ -140,7 +140,7 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
   }
 
   // load object
-  ldr(obj, Address(disp_hdr, BasicObjectLock::obj_offset()));
+  ldr(obj, Address(disp_hdr, create_imm_offset(BasicObjectLock, obj_offset)));
   verify_oop(obj);
 
   if (LockingMode == LM_LIGHTWEIGHT) {
@@ -177,16 +177,16 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
   assert_different_registers(obj, klass, len);
 
   if (UseCompactObjectHeaders) {
-    ldr(t1, Address(klass, Klass::prototype_header_offset()));
-    str(t1, Address(obj, oopDesc::mark_offset_in_bytes()));
+    ldr(t1, Address(klass, create_imm_offset(Klass, prototype_header_offset)));
+    str(t1, Address(obj, create_imm_offset(oopDesc, mark_offset_in_bytes)));
   } else {
     mov(t1, checked_cast<int32_t>(markWord::prototype().value()));
-    str(t1, Address(obj, oopDesc::mark_offset_in_bytes()));
+    str(t1, Address(obj, create_imm_offset(oopDesc, mark_offset_in_bytes)));
     if (UseCompressedClassPointers) { // Take care not to kill klass
       encode_klass_not_null(t1, klass);
       strw(t1, Address(obj, oopDesc::klass_offset_in_bytes()));
     } else {
-      str(klass, Address(obj, oopDesc::klass_offset_in_bytes()));
+      str(klass, Address(obj, create_imm_offset(oopDesc, klass_offset_in_bytes)));
     }
   }
 

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -87,15 +87,15 @@ int StubAssembler::call_RT(Register oop_result1, Register metadata_result, addre
   // check for pending exceptions
   { Label L;
     // check for pending exceptions (java_thread is set upon return)
-    ldr(rscratch1, Address(rthread, in_bytes(Thread::pending_exception_offset())));
+    ldr(rscratch1, Address(rthread, create_imm_offset(Thread, pending_exception_offset)));
     cbz(rscratch1, L);
     // exception pending => remove activation and forward to exception handler
     // make sure that the vm_results are cleared
     if (oop_result1->is_valid()) {
-      str(zr, Address(rthread, JavaThread::vm_result_offset()));
+      str(zr, Address(rthread, create_imm_offset(JavaThread, vm_result_offset)));
     }
     if (metadata_result->is_valid()) {
-      str(zr, Address(rthread, JavaThread::vm_result_2_offset()));
+      str(zr, Address(rthread, create_imm_offset(JavaThread, vm_result_2_offset)));
     }
     if (frame_size() == no_frame_size) {
       leave();
@@ -396,16 +396,16 @@ OopMapSet* Runtime1::generate_handle_exception(C1StubId id, StubAssembler *sasm)
     oop_map = generate_oop_map(sasm, 1 /*thread*/);
 
     // load and clear pending exception oop into r0
-    __ ldr(exception_oop, Address(rthread, Thread::pending_exception_offset()));
-    __ str(zr, Address(rthread, Thread::pending_exception_offset()));
+    __ ldr(exception_oop, Address(rthread, create_imm_offset(Thread, pending_exception_offset)));
+    __ str(zr, Address(rthread, create_imm_offset(Thread, pending_exception_offset)));
 
     // load issuing PC (the return address for this stub) into r3
     __ ldr(exception_pc, Address(rfp, 1*BytesPerWord));
     __ authenticate_return_address(exception_pc);
 
     // make sure that the vm_results are cleared (may be unnecessary)
-    __ str(zr, Address(rthread, JavaThread::vm_result_offset()));
-    __ str(zr, Address(rthread, JavaThread::vm_result_2_offset()));
+    __ str(zr, Address(rthread, create_imm_offset(JavaThread, vm_result_offset)));
+    __ str(zr, Address(rthread, create_imm_offset(JavaThread, vm_result_2_offset)));
     break;
   case C1StubId::handle_exception_nofpu_id:
   case C1StubId::handle_exception_id:
@@ -432,13 +432,13 @@ OopMapSet* Runtime1::generate_handle_exception(C1StubId id, StubAssembler *sasm)
   // check that fields in JavaThread for exception oop and issuing pc are
   // empty before writing to them
   Label oop_empty;
-  __ ldr(rscratch1, Address(rthread, JavaThread::exception_oop_offset()));
+  __ ldr(rscratch1, Address(rthread, create_imm_offset(JavaThread, exception_oop_offset)));
   __ cbz(rscratch1, oop_empty);
   __ stop("exception oop already set");
   __ bind(oop_empty);
 
   Label pc_empty;
-  __ ldr(rscratch1, Address(rthread, JavaThread::exception_pc_offset()));
+  __ ldr(rscratch1, Address(rthread, create_imm_offset(JavaThread, exception_pc_offset)));
   __ cbz(rscratch1, pc_empty);
   __ stop("exception pc already set");
   __ bind(pc_empty);
@@ -446,8 +446,8 @@ OopMapSet* Runtime1::generate_handle_exception(C1StubId id, StubAssembler *sasm)
 
   // save exception oop and issuing pc into JavaThread
   // (exception handler will load it from here)
-  __ str(exception_oop, Address(rthread, JavaThread::exception_oop_offset()));
-  __ str(exception_pc, Address(rthread, JavaThread::exception_pc_offset()));
+  __ str(exception_oop, Address(rthread, create_imm_offset(JavaThread, exception_oop_offset)));
+  __ str(exception_pc, Address(rthread, create_imm_offset(JavaThread, exception_pc_offset)));
 
   // patch throwing pc into return address (has bci & oop map)
   __ protect_return_address(exception_pc);
@@ -509,13 +509,13 @@ void Runtime1::generate_unwind_exception(StubAssembler *sasm) {
 #ifdef ASSERT
   // check that fields in JavaThread for exception oop and issuing pc are empty
   Label oop_empty;
-  __ ldr(rscratch1, Address(rthread, JavaThread::exception_oop_offset()));
+  __ ldr(rscratch1, Address(rthread, create_imm_offset(JavaThread, exception_oop_offset)));
   __ cbz(rscratch1, oop_empty);
   __ stop("exception oop must be empty");
   __ bind(oop_empty);
 
   Label pc_empty;
-  __ ldr(rscratch1, Address(rthread, JavaThread::exception_pc_offset()));
+  __ ldr(rscratch1, Address(rthread, create_imm_offset(JavaThread, exception_pc_offset)));
   __ cbz(rscratch1, pc_empty);
   __ stop("exception pc must be empty");
   __ bind(pc_empty);
@@ -596,13 +596,13 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
 #ifdef ASSERT
   // check that fields in JavaThread for exception oop and issuing pc are empty
   Label oop_empty;
-  __ ldr(rscratch1, Address(rthread, Thread::pending_exception_offset()));
+  __ ldr(rscratch1, Address(rthread, create_imm_offset(Thread, pending_exception_offset)));
   __ cbz(rscratch1, oop_empty);
   __ stop("exception oop must be empty");
   __ bind(oop_empty);
 
   Label pc_empty;
-  __ ldr(rscratch1, Address(rthread, JavaThread::exception_pc_offset()));
+  __ ldr(rscratch1, Address(rthread, create_imm_offset(JavaThread, exception_pc_offset)));
   __ cbz(rscratch1, pc_empty);
   __ stop("exception pc must be empty");
   __ bind(pc_empty);

--- a/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
@@ -45,7 +45,7 @@ void C2SafepointPollStub::emit(C2_MacroAssembler& masm) {
   __ bind(entry());
   InternalAddress safepoint_pc(masm.pc() - masm.offset() + _safepoint_offset);
   __ adr(rscratch1, safepoint_pc);
-  __ str(rscratch1, Address(rthread, JavaThread::saved_exception_pc_offset()));
+  __ str(rscratch1, Address(rthread, create_imm_offset(JavaThread, saved_exception_pc_offset)));
   __ far_jump(callback_addr);
 }
 

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -249,18 +249,18 @@ void BarrierSetAssembler::tlab_allocate(MacroAssembler* masm, Register obj,
 
   // verify_tlab();
 
-  __ ldr(obj, Address(rthread, JavaThread::tlab_top_offset()));
+  __ ldr(obj, Address(rthread, create_imm_offset(JavaThread, tlab_top_offset)));
   if (var_size_in_bytes == noreg) {
     __ lea(end, Address(obj, con_size_in_bytes));
   } else {
     __ lea(end, Address(obj, var_size_in_bytes));
   }
-  __ ldr(rscratch1, Address(rthread, JavaThread::tlab_end_offset()));
+  __ ldr(rscratch1, Address(rthread, create_imm_offset(JavaThread, tlab_end_offset)));
   __ cmp(end, rscratch1);
   __ br(Assembler::HI, slow_case);
 
   // update the tlab top pointer
-  __ str(end, Address(rthread, JavaThread::tlab_top_offset()));
+  __ str(end, Address(rthread, create_imm_offset(JavaThread, tlab_top_offset)));
 
   // recover var_size_in_bytes if necessary
   if (var_size_in_bytes == end) {
@@ -380,7 +380,7 @@ void BarrierSetAssembler::c2i_entry_barrier(MacroAssembler* masm) {
 
   // Is it a weak but alive CLD?
   __ push(RegSet::of(r10), sp);
-  __ ldr(r10, Address(rscratch1, ClassLoaderData::holder_offset()));
+  __ ldr(r10, Address(rscratch1, create_imm_offset(ClassLoaderData, holder_offset)));
 
   __ resolve_weak_handle(r10, rscratch1, rscratch2);
   __ mov(rscratch1, r10);

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -217,7 +217,7 @@ void ShenandoahBarrierSetAssembler::resolve_forward_pointer_not_null(MacroAssemb
   assert_different_registers(tmp, dst);
 
   Label done;
-  __ ldr(tmp, Address(dst, oopDesc::mark_offset_in_bytes()));
+  __ ldr(tmp, Address(dst, create_imm_offset(oopDesc, mark_offset_in_bytes)));
   __ eon(tmp, tmp, zr);
   __ ands(zr, tmp, markWord::lock_mask_in_place);
   __ br(Assembler::NE, done);

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
@@ -122,22 +122,22 @@ class InterpreterMacroAssembler: public MacroAssembler {
 
   void get_const(Register reg) {
     get_method(reg);
-    ldr(reg, Address(reg, in_bytes(Method::const_offset())));
+    ldr(reg, Address(reg, create_imm_offset(Method, const_offset)));
   }
 
   void get_constant_pool(Register reg) {
     get_const(reg);
-    ldr(reg, Address(reg, in_bytes(ConstMethod::constants_offset())));
+    ldr(reg, Address(reg, create_imm_offset(ConstMethod, constants_offset)));
   }
 
   void get_constant_pool_cache(Register reg) {
     get_constant_pool(reg);
-    ldr(reg, Address(reg, ConstantPool::cache_offset()));
+    ldr(reg, Address(reg, create_imm_offset(ConstantPool, cache_offset)));
   }
 
   void get_cpool_and_tags(Register cpool, Register tags) {
     get_constant_pool(cpool);
-    ldr(tags, Address(cpool, ConstantPool::tags_offset()));
+    ldr(tags, Address(cpool, create_imm_offset(ConstantPool, tags_offset)));
   }
 
   void get_unsigned_2_byte_index_at_bcp(Register reg, int bcp_offset);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7035,7 +7035,7 @@ void MacroAssembler::lightweight_lock(Register basic_lock, Register obj, Registe
 
   if (UseObjectMonitorTable) {
     // Clear cache in case fast locking succeeds.
-    str(zr, Address(basic_lock, 
+    str(zr, Address(basic_lock,
       create_imm_offset(BasicObjectLock, lock_offset) + in_ByteSize((BasicLock::object_monitor_cache_offset_in_bytes()))));
   }
 

--- a/src/hotspot/cpu/aarch64/methodHandles_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/methodHandles_aarch64.cpp
@@ -51,7 +51,7 @@ void MethodHandles::load_klass_from_Class(MacroAssembler* _masm, Register klass_
   if (VerifyMethodHandles)
     verify_klass(_masm, klass_reg, VM_CLASS_ID(java_lang_Class),
                  "MH argument is a Class");
-  __ ldr(klass_reg, Address(klass_reg, java_lang_Class::klass_offset()));
+  __ ldr(klass_reg, Address(klass_reg, create_imm_offset(java_lang_Class, klass_offset)));
 }
 
 #ifdef ASSERT
@@ -111,7 +111,7 @@ void MethodHandles::jump_from_method_handle(MacroAssembler* _masm, Register meth
 
     __ ldrw(rscratch1, Address(rthread, JavaThread::interp_only_mode_offset()));
     __ cbzw(rscratch1, run_compiled_code);
-    __ ldr(rscratch1, Address(method, Method::interpreter_entry_offset()));
+    __ ldr(rscratch1, Address(method, create_imm_offset(Method, interpreter_entry_offset)));
     __ br(rscratch1);
     __ BIND(run_compiled_code);
   }
@@ -147,7 +147,7 @@ void MethodHandles::jump_to_lambda_form(MacroAssembler* _masm,
 
   if (VerifyMethodHandles && !for_compiler_entry) {
     // make sure recv is already on stack
-    __ ldr(temp2, Address(method_temp, Method::const_offset()));
+    __ ldr(temp2, Address(method_temp, create_imm_offset(Method, const_offset)));
     __ load_sized_value(temp2,
                         Address(temp2, ConstMethod::size_of_parameters_offset()),
                         sizeof(u2), /*is_signed*/ false);
@@ -222,7 +222,7 @@ address MethodHandles::generate_method_handle_interpreter_entry(MacroAssembler* 
   int ref_kind = signature_polymorphic_intrinsic_ref_kind(iid);
   assert(ref_kind != 0 || iid == vmIntrinsics::_invokeBasic, "must be _invokeBasic or a linkTo intrinsic");
   if (ref_kind == 0 || MethodHandles::ref_kind_has_receiver(ref_kind)) {
-    __ ldr(argp, Address(rmethod, Method::const_offset()));
+    __ ldr(argp, Address(rmethod, create_imm_offset(Method, const_offset)));
     __ load_sized_value(argp,
                         Address(argp, ConstMethod::size_of_parameters_offset()),
                         sizeof(u2), /*is_signed*/ false);

--- a/src/hotspot/cpu/aarch64/runtime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/runtime_aarch64.cpp
@@ -161,7 +161,7 @@ void OptoRuntime::generate_uncommon_trap_blob() {
 
   // Load address of array of frame pcs into r2 (address*)
   __ ldr(r2, Address(r4,
-                     Deoptimization::UnrollBlock::frame_pcs_offset()));
+                     create_imm_offset(Deoptimization::UnrollBlock, frame_pcs_offset)));
 
   // Load address of array of frame sizes into r5 (intptr_t*)
   __ ldr(r5, Address(r4,
@@ -304,8 +304,8 @@ void OptoRuntime::generate_exception_blob() {
   // Store exception in Thread object. We cannot pass any arguments to the
   // handle_exception call, since we do not want to make any assumption
   // about the size of the frame where the exception happened in.
-  __ str(r0, Address(rthread, JavaThread::exception_oop_offset()));
-  __ str(r3, Address(rthread, JavaThread::exception_pc_offset()));
+  __ str(r0, Address(rthread, create_imm_offset(JavaThread, exception_oop_offset)));
+  __ str(r3, Address(rthread, create_imm_offset(JavaThread, exception_pc_offset)));
 
   // This call does all the hard work.  It checks if an exception handler
   // exists in the method.
@@ -356,15 +356,15 @@ void OptoRuntime::generate_exception_blob() {
   __ mov(r8, r0);
 
   // Get the exception oop
-  __ ldr(r0, Address(rthread, JavaThread::exception_oop_offset()));
+  __ ldr(r0, Address(rthread, create_imm_offset(JavaThread, exception_oop_offset)));
   // Get the exception pc in case we are deoptimized
-  __ ldr(r4, Address(rthread, JavaThread::exception_pc_offset()));
+  __ ldr(r4, Address(rthread, create_imm_offset(JavaThread, exception_pc_offset)));
 #ifdef ASSERT
-  __ str(zr, Address(rthread, JavaThread::exception_handler_pc_offset()));
-  __ str(zr, Address(rthread, JavaThread::exception_pc_offset()));
+  __ str(zr, Address(rthread, create_imm_offset(JavaThread, exception_handler_pc_offset)));
+  __ str(zr, Address(rthread, create_imm_offset(JavaThread, exception_pc_offset)));
 #endif
   // Clear the exception oop so GC no longer processes it as a root.
-  __ str(zr, Address(rthread, JavaThread::exception_oop_offset()));
+  __ str(zr, Address(rthread, create_imm_offset(JavaThread, exception_oop_offset)));
 
   // r0: exception oop
   // r8:  exception handler

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -278,7 +278,7 @@ class StubGenerator: public StubCodeGenerator {
     // make sure we have no pending exceptions
     {
       Label L;
-      __ ldr(rscratch1, Address(rthread, in_bytes(Thread::pending_exception_offset())));
+      __ ldr(rscratch1, Address(rthread, create_imm_offset(Thread, pending_exception_offset)));
       __ cmp(rscratch1, (u1)NULL_WORD);
       __ br(Assembler::EQ, L);
       __ stop("StubRoutines::call_stub: entered with pending exception");
@@ -448,9 +448,9 @@ class StubGenerator: public StubCodeGenerator {
     // set pending exception
     __ verify_oop(r0);
 
-    __ str(r0, Address(rthread, Thread::pending_exception_offset()));
+    __ str(r0, Address(rthread, create_imm_offset(Thread, pending_exception_offset)));
     __ mov(rscratch1, (address)__FILE__);
-    __ str(rscratch1, Address(rthread, Thread::exception_file_offset()));
+    __ str(rscratch1, Address(rthread, create_imm_offset(Thread, exception_file_offset)));
     __ movw(rscratch1, (int)__LINE__);
     __ strw(rscratch1, Address(rthread, Thread::exception_line_offset()));
 
@@ -493,7 +493,7 @@ class StubGenerator: public StubCodeGenerator {
     // make sure this code is only executed if there is a pending exception
     {
       Label L;
-      __ ldr(rscratch1, Address(rthread, Thread::pending_exception_offset()));
+      __ ldr(rscratch1, Address(rthread, create_imm_offset(Thread, pending_exception_offset)));
       __ cbnz(rscratch1, L);
       __ stop("StubRoutines::forward exception: no pending exception (1)");
       __ bind(L);
@@ -529,8 +529,8 @@ class StubGenerator: public StubCodeGenerator {
     // setup r0 & r3 & clear pending exception
     __ mov(r3, r19);
     __ mov(r19, r0);
-    __ ldr(r0, Address(rthread, Thread::pending_exception_offset()));
-    __ str(zr, Address(rthread, Thread::pending_exception_offset()));
+    __ ldr(r0, Address(rthread, create_imm_offset(Thread, pending_exception_offset)));
+    __ str(zr, Address(rthread, create_imm_offset(Thread, pending_exception_offset)));
 
 #ifdef ASSERT
     // make sure exception is set
@@ -7345,10 +7345,10 @@ class StubGenerator: public StubCodeGenerator {
     address start = __ pc();
 
     if (return_barrier) {
-      __ ldr(rscratch1, Address(rthread, JavaThread::cont_entry_offset()));
+      __ ldr(rscratch1, Address(rthread, create_imm_offset(JavaThread, cont_entry_offset)));
       __ mov(sp, rscratch1);
     }
-    assert_asm(_masm, (__ ldr(rscratch1, Address(rthread, JavaThread::cont_entry_offset())), __ cmp(sp, rscratch1)), Assembler::EQ, "incorrect sp");
+    assert_asm(_masm, (__ ldr(rscratch1, Address(rthread, create_imm_offset(JavaThread, cont_entry_offset))), __ cmp(sp, rscratch1)), Assembler::EQ, "incorrect sp");
 
     if (return_barrier) {
       // preserve possible return value from a method returning to the return barrier
@@ -7365,7 +7365,7 @@ class StubGenerator: public StubCodeGenerator {
       __ ldp(rscratch1, r0, Address(__ post(sp, 2 * wordSize)));
       __ fmovd(v0, rscratch1);
     }
-    assert_asm(_masm, (__ ldr(rscratch1, Address(rthread, JavaThread::cont_entry_offset())), __ cmp(sp, rscratch1)), Assembler::EQ, "incorrect sp");
+    assert_asm(_masm, (__ ldr(rscratch1, Address(rthread, create_imm_offset(JavaThread, cont_entry_offset))), __ cmp(sp, rscratch1)), Assembler::EQ, "incorrect sp");
 
 
     Label thaw_success;
@@ -7474,7 +7474,7 @@ class StubGenerator: public StubCodeGenerator {
     __ reset_last_Java_frame(true);
 
     // Set sp to enterSpecial frame, i.e. remove all frames copied into the heap.
-    __ ldr(rscratch2, Address(rthread, JavaThread::cont_entry_offset()));
+    __ ldr(rscratch2, Address(rthread, create_imm_offset(JavaThread, cont_entry_offset)));
     __ mov(sp, rscratch2);
 
     Label preemption_cancelled;
@@ -7692,7 +7692,7 @@ class StubGenerator: public StubCodeGenerator {
     __ access_load_at(T_ADDRESS, IN_HEAP, rmethod,
                       Address(rmethod, java_lang_invoke_ResolvedMethodName::vmtarget_offset()),
                       noreg, noreg);
-    __ str(rmethod, Address(rthread, JavaThread::callee_target_offset())); // just in case callee is deoptimized
+    __ str(rmethod, Address(rthread, create_imm_offset(JavaThread, callee_target_offset))); // just in case callee is deoptimized
 
     __ ret(lr);
 

--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -245,7 +245,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Symbol* signature,
 
   __ push_cont_fastpath(rthread);
 
-  __ ldr(rscratch1, Address(rmethod, Method::from_compiled_offset()));
+  __ ldr(rscratch1, Address(rmethod, create_imm_offset(Method, from_compiled_offset)));
   __ blr(rscratch1);
 
   __ pop_cont_fastpath(rthread);

--- a/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
@@ -116,7 +116,7 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index) {
   if (DebugVtables) {
     Label L;
     __ cbz(rmethod, L);
-    __ ldr(rscratch1, Address(rmethod, Method::from_compiled_offset()));
+    __ ldr(rscratch1, Address(rmethod, create_imm_offset(Method, from_compiled_offset)));
     __ cbnz(rscratch1, L);
     __ stop("Vtable entry is null");
     __ bind(L);
@@ -127,7 +127,7 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index) {
   // rmethod: Method*
   // r2: receiver
   address ame_addr = __ pc();
-  __ ldr(rscratch1, Address(rmethod, Method::from_compiled_offset()));
+  __ ldr(rscratch1, Address(rmethod, create_imm_offset(Method, from_compiled_offset)));
   __ br(rscratch1);
 
   masm->flush();
@@ -182,8 +182,8 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
 
   Label L_no_such_interface;
 
-  __ ldr(resolved_klass_reg, Address(icdata_reg, CompiledICData::itable_refc_klass_offset()));
-  __ ldr(holder_klass_reg,   Address(icdata_reg, CompiledICData::itable_defc_klass_offset()));
+  __ ldr(resolved_klass_reg, Address(icdata_reg, create_imm_offset(CompiledICData, itable_refc_klass_offset)));
+  __ ldr(holder_klass_reg,   Address(icdata_reg, create_imm_offset(CompiledICData, itable_defc_klass_offset)));
 
   start_pc = __ pc();
 
@@ -207,7 +207,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   if (DebugVtables) {
     Label L2;
     __ cbz(rmethod, L2);
-    __ ldr(rscratch1, Address(rmethod, Method::from_compiled_offset()));
+    __ ldr(rscratch1, Address(rmethod, create_imm_offset(Method, from_compiled_offset)));
     __ cbnz(rscratch1, L2);
     __ stop("compiler entrypoint is null");
     __ bind(L2);
@@ -217,7 +217,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   // rmethod: Method*
   // j_rarg0: receiver
   address ame_addr = __ pc();
-  __ ldr(rscratch1, Address(rmethod, Method::from_compiled_offset()));
+  __ ldr(rscratch1, Address(rmethod, create_imm_offset(Method, from_compiled_offset)));
   __ br(rscratch1);
 
   __ bind(L_no_such_interface);

--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -340,27 +340,27 @@ class AbstractAssembler : public ResourceObj  {
   enum { min_simm10 = -512 };
 
   // Test if x is within signed immediate range for width.
-  static bool is_simm(int64_t x, uint w) {
+  static constexpr bool is_simm(int64_t x, uint w) {
     precond(1 < w && w < 64);
     int64_t limes = INT64_C(1) << (w - 1);
     return -limes <= x && x < limes;
   }
 
-  static bool is_simm8(int64_t x) { return is_simm(x, 8); }
-  static bool is_simm9(int64_t x) { return is_simm(x, 9); }
-  static bool is_simm10(int64_t x) { return is_simm(x, 10); }
-  static bool is_simm16(int64_t x) { return is_simm(x, 16); }
-  static bool is_simm32(int64_t x) { return is_simm(x, 32); }
+  static constexpr bool is_simm8(int64_t x) { return is_simm(x, 8); }
+  static constexpr bool is_simm9(int64_t x) { return is_simm(x, 9); }
+  static constexpr bool is_simm10(int64_t x) { return is_simm(x, 10); }
+  static constexpr bool is_simm16(int64_t x) { return is_simm(x, 16); }
+  static constexpr bool is_simm32(int64_t x) { return is_simm(x, 32); }
 
   // Test if x is within unsigned immediate range for width.
-  static bool is_uimm(uint64_t x, uint w) {
+  static constexpr bool is_uimm(uint64_t x, uint w) {
     precond(0 < w && w < 64);
     uint64_t limes = UINT64_C(1) << w;
     return x < limes;
   }
 
-  static bool is_uimm12(uint64_t x) { return is_uimm(x, 12); }
-  static bool is_uimm32(uint64_t x) { return is_uimm(x, 32); }
+  static constexpr bool is_uimm12(uint64_t x) { return is_uimm(x, 12); }
+  static constexpr bool is_uimm32(uint64_t x) { return is_uimm(x, 32); }
 
   // Accessors
   CodeSection*  code_section() const   { return _code_section; }


### PR DESCRIPTION
[JDK-8344880](https://bugs.openjdk.org/browse/JDK-8344880)

Adds compile time checks for str/ldr instructions to verify that the immediate offset will fit. This adds static_assert for constant offsets that are checked at compile time. The macro offset_of is not constexpr so instead the class size is checked. If the size of a class fits into a memory instructions then any offset in it will fit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344880](https://bugs.openjdk.org/browse/JDK-8344880): AArch64: Add compile time check for class offsets (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22623/head:pull/22623` \
`$ git checkout pull/22623`

Update a local copy of the PR: \
`$ git checkout pull/22623` \
`$ git pull https://git.openjdk.org/jdk.git pull/22623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22623`

View PR using the GUI difftool: \
`$ git pr show -t 22623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22623.diff">https://git.openjdk.org/jdk/pull/22623.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22623#issuecomment-2539776534)
</details>
