### PR TITLE
8345744: Use C++ LINK_TYPE with SetupBuildLauncher in StaticLibs.gmk

### DIFF
--- a/make/StaticLibs.gmk
+++ b/make/StaticLibs.gmk
@@ -98,7 +98,6 @@ EXTERNAL_LIBS := $(strip $(shell $(CAT) $(LIB_FLAGS_FILES) | \
 
 ifeq ($(call isTargetOs, macosx), true)
   STATIC_LIBS := $(addprefix -force_load$(SPACE), $(STATIC_LIB_FILES))
-  STANDARD_LIBS += -lstdc++
 else ifeq ($(call isTargetOs, linux), true)
   STATIC_LIBS := -Wl,--export-dynamic -Wl,--whole-archive $(STATIC_LIB_FILES) -Wl,--no-whole-archive
 else ifeq ($(call isTargetOs, windows), true)
@@ -114,7 +113,7 @@ $(eval $(call SetupBuildLauncher, java, \
     OPTIMIZATION := HIGH, \
     STATIC_LAUNCHER := true, \
     LDFLAGS := $(LDFLAGS_STATIC_JDK), \
-    LIBS := $(STATIC_LIBS) $(EXTERNAL_LIBS) $(STANDARD_LIBS), \
+    LIBS := $(STATIC_LIBS) $(EXTERNAL_LIBS), \
     LINK_TYPE := C++, \
     OUTPUT_DIR := $(STATIC_LAUNCHER_OUTPUT_DIR), \
     OBJECT_DIR := $(STATIC_LAUNCHER_OUTPUT_DIR), \

--- a/make/StaticLibs.gmk
+++ b/make/StaticLibs.gmk
@@ -101,7 +101,6 @@ ifeq ($(call isTargetOs, macosx), true)
   STANDARD_LIBS += -lstdc++
 else ifeq ($(call isTargetOs, linux), true)
   STATIC_LIBS := -Wl,--export-dynamic -Wl,--whole-archive $(STATIC_LIB_FILES) -Wl,--no-whole-archive
-  STANDARD_LIBS := -l:libstdc++.a
 else ifeq ($(call isTargetOs, windows), true)
   STATIC_LIBS := $(addprefix -wholearchive:, $(STATIC_LIB_FILES))
 else
@@ -116,6 +115,7 @@ $(eval $(call SetupBuildLauncher, java, \
     STATIC_LAUNCHER := true, \
     LDFLAGS := $(LDFLAGS_STATIC_JDK), \
     LIBS := $(STATIC_LIBS) $(EXTERNAL_LIBS) $(STANDARD_LIBS), \
+    LINK_TYPE := C++, \
     OUTPUT_DIR := $(STATIC_LAUNCHER_OUTPUT_DIR), \
     OBJECT_DIR := $(STATIC_LAUNCHER_OUTPUT_DIR), \
 ))

--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -160,6 +160,7 @@ define SetupBuildLauncherBody
           -framework ApplicationServices \
           -framework Cocoa \
           -framework Security, \
+      LINK_TYPE := $$($1_LINK_TYPE), \
       OUTPUT_DIR := $$($1_OUTPUT_DIR), \
       OBJECT_DIR := $$($1_OBJECT_DIR), \
       VERSIONINFO_RESOURCE := $$($1_VERSION_INFO_RESOURCE), \


### PR DESCRIPTION
Please review following fix for linking static JDK launcher, thanks.

- Set LINK_TYPE to C++ when building the static launcher to make sure LDCXX instead of LD is used for linking.

- Remove -l:libstdc++. For linux, -static-libstdc++ is already set in STATIC_STDCXX_FLAGS. See https://github.com/openjdk/jdk/blob/e0d639878346946d0627a57b0eeb0cac8ca533fc/make/autoconf/lib-std.m4#L50.

See more details in https://bugs.openjdk.org/browse/JDK-8345744.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345744](https://bugs.openjdk.org/browse/JDK-8345744): Use C++ LINK_TYPE with SetupBuildLauncher in StaticLibs.gmk (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22624/head:pull/22624` \
`$ git checkout pull/22624`

Update a local copy of the PR: \
`$ git checkout pull/22624` \
`$ git pull https://git.openjdk.org/jdk.git pull/22624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22624`

View PR using the GUI difftool: \
`$ git pr show -t 22624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22624.diff">https://git.openjdk.org/jdk/pull/22624.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22624#issuecomment-2524800545)
</details>
