### PR TITLE
8345746: Remove :resourcehogs/compiler from :hotspot_slow_compiler

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -38,6 +38,9 @@ hotspot_all_no_apps = \
 hotspot_compiler = \
   compiler
 
+hotspot_compiler_resourcehogs = \
+  resourcehogs/compiler
+
 hotspot_gc = \
   gc
 

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -160,7 +160,6 @@ hotspot_slow_compiler = \
   compiler/gcbarriers/PreserveFPRegistersTest.java \
   compiler/memoryinitialization/ZeroTLABTest.java \
   compiler/classUnloading/methodUnloading/TestOverloadCompileQueues.java \
-  resourcehogs/compiler \
   :hotspot_compiler_arraycopy
 
 tier1_compiler_1 = \


### PR DESCRIPTION
The test group
:resourcehogs/compiler
contains tests that should not be executed concurrently with *any* tests.

They might use a lot of resources and cause unexplained sporadic failures of other tests.

So it should be removed from :hotspot_slow_compiler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345746](https://bugs.openjdk.org/browse/JDK-8345746): Remove :resourcehogs/compiler from :hotspot_slow_compiler (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22626/head:pull/22626` \
`$ git checkout pull/22626`

Update a local copy of the PR: \
`$ git checkout pull/22626` \
`$ git pull https://git.openjdk.org/jdk.git pull/22626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22626`

View PR using the GUI difftool: \
`$ git pr show -t 22626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22626.diff">https://git.openjdk.org/jdk/pull/22626.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22626#issuecomment-2524846664)
</details>
