### PR TITLE
8345876: Update nativeAddAtIndex comment to match the code

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -438,7 +438,7 @@ Java_sun_lwawt_macosx_CMenuBar_nativeAddAtIndex
      jlong menuBarObject, jlong menuObject, jint index)
 {
     JNI_COCOA_ENTER(env);
-    // Remove the specified item.
+    // Add the specified item.
     [((CMenuBar *) jlong_to_ptr(menuBarObject)) javaAddMenu:(CMenu *) jlong_to_ptr(menuObject) atIndex:index];
     JNI_COCOA_EXIT(env);
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345876](https://bugs.openjdk.org/browse/JDK-8345876): Update nativeAddAtIndex comment to match the code (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) Review applies to [62da15c0](https://git.openjdk.org/jdk/pull/22627/files/62da15c050e4b2b7ed783e121bdd58efb40176a2)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) Review applies to [62da15c0](https://git.openjdk.org/jdk/pull/22627/files/62da15c050e4b2b7ed783e121bdd58efb40176a2)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22627/head:pull/22627` \
`$ git checkout pull/22627`

Update a local copy of the PR: \
`$ git checkout pull/22627` \
`$ git pull https://git.openjdk.org/jdk.git pull/22627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22627`

View PR using the GUI difftool: \
`$ git pr show -t 22627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22627.diff">https://git.openjdk.org/jdk/pull/22627.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22627#issuecomment-2531491042)
</details>
