### PR TITLE
8345773: Class-File API debug printing capability

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
@@ -97,7 +97,7 @@ public sealed interface CompoundElement<E extends ClassFileElement>
     /**
      * {@return a text representation of the compound element and its contents for debugging purposes}
      *
-     * The format, structure and exact content are not specified and may change at any time in the future.
+     * The format, structure and exact contents of the returned string are not specified and may change at any time in the future.
      */
     default String toDebugString() {
         StringBuilder text = new StringBuilder();

--- a/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
@@ -95,7 +95,9 @@ public sealed interface CompoundElement<E extends ClassFileElement>
     }
 
     /**
-     * {@return a debug printout of the compound element}
+     * {@return a text representation of the compound element and its contents for debugging purposes}
+     *
+     * The format, structure and exact content are not specified and may change at any time in the future.
      */
     default String toDebugString() {
         StringBuilder text = new StringBuilder();

--- a/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
@@ -34,6 +34,8 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import jdk.internal.classfile.components.ClassPrinter;
+
 /**
  * A {@link ClassFileElement} that has complex structure defined in terms of
  * other classfile elements, such as a method, field, method body, or entire
@@ -92,4 +94,12 @@ public sealed interface CompoundElement<E extends ClassFileElement>
         return Collections.unmodifiableList(list);
     }
 
+    /**
+     * {@return a debug printout of the compound element}
+     */
+    default String toDebugString() {
+        StringBuilder text = new StringBuilder();
+        ClassPrinter.toYaml(this, ClassPrinter.Verbosity.TRACE_ALL, text::append);
+        return text.toString();
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassPrinterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassPrinterImpl.java
@@ -44,6 +44,7 @@ import java.lang.reflect.AccessFlag;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.ToIntFunction;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -219,6 +220,10 @@ public final class ClassPrinterImpl {
             }
             return this;
         }
+    }
+
+    private interface LabelResolver {
+        int labelToBci(Label l);
     }
 
     private static Node leaf(ConstantDesc name, ConstantDesc value) {
@@ -542,7 +547,7 @@ public final class ClassPrinterImpl {
                 new MapNodeImpl(FLOW, "value").with(elementValueToTree(evp.value())))));
     }
 
-    private static Stream<ConstantDesc> convertVTIs(CodeAttribute lr, List<VerificationTypeInfo> vtis) {
+    private static Stream<ConstantDesc> convertVTIs(LabelResolver lr, List<VerificationTypeInfo> vtis) {
         return vtis.stream().mapMulti((vti, ret) -> {
             switch (vti) {
                 case SimpleVerificationTypeInfo s -> {
@@ -580,7 +585,7 @@ public final class ClassPrinterImpl {
             case ClassModel cm -> classToTree(cm, verbosity);
             case FieldModel fm -> fieldToTree(fm, verbosity);
             case MethodModel mm -> methodToTree(mm, verbosity);
-            case CodeModel com -> codeToTree((CodeAttribute)com, verbosity);
+            case CodeModel com -> codeToTree(com, verbosity);
         };
     }
 
@@ -676,7 +681,7 @@ public final class ClassPrinterImpl {
         }
     }
 
-    private static Node frameToTree(ConstantDesc name, CodeAttribute lr, StackMapFrameInfo f) {
+    private static Node frameToTree(ConstantDesc name, LabelResolver lr, StackMapFrameInfo f) {
         return new MapNodeImpl(FLOW, name).with(
                 list("locals", "item", convertVTIs(lr, f.locals())),
                 list("stack", "item", convertVTIs(lr, f.stack())));
@@ -705,11 +710,26 @@ public final class ClassPrinterImpl {
                 .with(codeToTree((CodeAttribute)m.code().orElse(null), verbosity));
     }
 
-    private static MapNode codeToTree(CodeAttribute com, Verbosity verbosity) {
+    private static MapNode codeToTree(CodeModel com, Verbosity verbosity) {
         if (verbosity != Verbosity.MEMBERS_ONLY && com != null) {
             var codeNode = new MapNodeImpl(BLOCK, "code");
-            codeNode.with(leaf("max stack", com.maxStack()));
-            codeNode.with(leaf("max locals", com.maxLocals()));
+            LabelResolver lr;
+            if (com instanceof CodeAttribute ca) {
+                codeNode.with(leaf("max stack", ca.maxStack()));
+                codeNode.with(leaf("max locals", ca.maxLocals()));
+                lr = ca::labelToBci;
+            } else {
+                var bciMap = new HashMap<Label, Integer>();
+                int bci = 0;
+                for (var e : com) {
+                    switch (e) {
+                        case Label l -> bciMap.put(l, bci);
+                        case Instruction i -> bci += i.sizeInBytes();
+                        default -> {}
+                    }
+                }
+                lr = l -> bciMap.getOrDefault(l, -1);
+            }
             codeNode.with(list("attributes",
                     "attribute", com.attributes().stream().map(Attribute::attributeName).map(Utf8Entry::stringValue)));
             var stackMap = new MapNodeImpl(BLOCK, "stack map frames");
@@ -720,7 +740,7 @@ public final class ClassPrinterImpl {
                 if (attr instanceof StackMapTableAttribute smta) {
                     codeNode.with(stackMap);
                     for (var smf : smta.entries()) {
-                        stackMap.with(frameToTree(com.labelToBci(smf.target()), com, smf));
+                        stackMap.with(frameToTree(lr.labelToBci(smf.target()), lr, smf));
                     }
                 } else if (verbosity == Verbosity.TRACE_ALL && attr != null) switch (attr) {
                     case LocalVariableTableAttribute lvta -> {
@@ -770,10 +790,10 @@ public final class ClassPrinterImpl {
                                 })));
                     }
                     case RuntimeVisibleTypeAnnotationsAttribute rvtaa ->
-                        rvtaa.annotations().forEach(a -> forEachOffset(a, com, (off, an) ->
+                        rvtaa.annotations().forEach(a -> forEachOffset(a, lr, (off, an) ->
                                 visibleTypeAnnos.computeIfAbsent(off, o -> new LinkedList<>()).add(an)));
                     case RuntimeInvisibleTypeAnnotationsAttribute ritaa ->
-                        ritaa.annotations().forEach(a -> forEachOffset(a, com, (off, an) ->
+                        ritaa.annotations().forEach(a -> forEachOffset(a, lr, (off, an) ->
                                 invisibleTypeAnnos.computeIfAbsent(off, o -> new LinkedList<>()).add(an)));
                     case Object o -> {}
                 }
@@ -781,13 +801,13 @@ public final class ClassPrinterImpl {
             codeNode.with(attributesToTree(com.attributes(), verbosity));
             if (!stackMap.containsKey(0)) {
                 codeNode.with(new MapNodeImpl(FLOW, "//stack map frame @0").with(
-                    list("locals", "item", convertVTIs(com, StackMapDecoder.initFrameLocals(com.parent().get()))),
+                    list("locals", "item", convertVTIs(lr, StackMapDecoder.initFrameLocals(com.parent().get()))),
                     list("stack", "item", Stream.of())));
             }
             var excHandlers = com.exceptionHandlers().stream().map(exc -> new ExceptionHandler(
-                    com.labelToBci(exc.tryStart()),
-                    com.labelToBci(exc.tryEnd()),
-                    com.labelToBci(exc.handler()),
+                    lr.labelToBci(exc.tryStart()),
+                    lr.labelToBci(exc.tryEnd()),
+                    lr.labelToBci(exc.handler()),
                     exc.catchType().map(ct -> ct.name().stringValue()).orElse(null))).toList();
             int bci = 0;
             for (var coe : com) {
@@ -875,17 +895,17 @@ public final class ClassPrinterImpl {
                         case ConstantInstruction cons -> in.with(leaf(
                                 "constant value", cons.constantValue()));
                         case BranchInstruction br -> in.with(leaf(
-                                "target", com.labelToBci(br.target())));
+                                "target", lr.labelToBci(br.target())));
                         case LookupSwitchInstruction si -> in.with(list(
                                 "targets", "target", Stream.concat(Stream.of(si.defaultTarget())
-                                        .map(com::labelToBci), si.cases().stream()
-                                                .map(sc -> com.labelToBci(sc.target())))));
+                                        .map(lr::labelToBci), si.cases().stream()
+                                                .map(sc -> lr.labelToBci(sc.target())))));
                         case TableSwitchInstruction si -> in.with(list(
                                 "targets", "target", Stream.concat(Stream.of(si.defaultTarget())
-                                        .map(com::labelToBci), si.cases().stream()
-                                                .map(sc -> com.labelToBci(sc.target())))));
+                                        .map(lr::labelToBci), si.cases().stream()
+                                                .map(sc -> lr.labelToBci(sc.target())))));
                         case DiscontinuedInstruction.JsrInstruction jsr -> in.with(leaf(
-                                "target", com.labelToBci(jsr.target())));
+                                "target", lr.labelToBci(jsr.target())));
                         case DiscontinuedInstruction.RetInstruction ret ->  in.with(leaf(
                                 "slot", ret.slot()));
                         default -> {}
@@ -1082,7 +1102,7 @@ public final class ClassPrinterImpl {
         return new Node[0];
     }
 
-    private static void forEachOffset(TypeAnnotation ta, CodeAttribute lr, BiConsumer<Integer, TypeAnnotation> consumer) {
+    private static void forEachOffset(TypeAnnotation ta, LabelResolver lr, BiConsumer<Integer, TypeAnnotation> consumer) {
         switch (ta.targetInfo()) {
             case TypeAnnotation.OffsetTarget ot ->
                 consumer.accept(lr.labelToBci(ot.target()), ta);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassPrinterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassPrinterImpl.java
@@ -44,7 +44,6 @@ import java.lang.reflect.AccessFlag;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.ToIntFunction;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 

--- a/test/jdk/jdk/classfile/ClassPrinterTest.java
+++ b/test/jdk/jdk/classfile/ClassPrinterTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8335927
+ * @bug 8335927 8345773
  * @summary Testing ClassFile ClassPrinter.
  * @run junit ClassPrinterTest
  */
@@ -122,8 +122,7 @@ class ClassPrinterTest {
 
     @Test
     void testPrintYamlTraceAll() throws IOException {
-        var out = new StringBuilder();
-        ClassPrinter.toYaml(getClassModel(), ClassPrinter.Verbosity.TRACE_ALL, out::append);
+        var out = getClassModel().toDebugString();
         assertOut(out,
                 """
                   - class name: Foo
@@ -904,7 +903,7 @@ class ClassPrinterTest {
         assertEquals(node.walk().count(), 42);
     }
 
-    private static void assertOut(StringBuilder out, String expected) {
+    private static void assertOut(CharSequence out, String expected) {
 //        System.out.println("-----------------");
 //        System.out.println(out.toString());
 //        System.out.println("-----------------");


### PR DESCRIPTION
Class-File API lost debug printing capability with removal of the `j.l.classfile.components.ClassPrinter` in JDK-8345343.
This PR adds `j.l.classfile.CompoundElement::toDebugString` method to restore the capability.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8345774](https://bugs.openjdk.org/browse/JDK-8345774) to be approved

### Issues
 * [JDK-8345773](https://bugs.openjdk.org/browse/JDK-8345773): Class-File API debug printing capability (**Enhancement** - P3)
 * [JDK-8345774](https://bugs.openjdk.org/browse/JDK-8345774): Class-File API debug printing capability (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22634/head:pull/22634` \
`$ git checkout pull/22634`

Update a local copy of the PR: \
`$ git checkout pull/22634` \
`$ git pull https://git.openjdk.org/jdk.git pull/22634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22634`

View PR using the GUI difftool: \
`$ git pr show -t 22634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22634.diff">https://git.openjdk.org/jdk/pull/22634.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22634#issuecomment-2527527721)
</details>
