### PR TITLE
8345794: Backout doc change introduced by JDK-8235786

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,29 +233,22 @@ public abstract class HttpExchange implements AutoCloseable, Request {
     public abstract String getProtocol();
 
     /**
-     * Returns the attribute's value from this exchange's
-     * {@linkplain HttpContext#getAttributes() context attributes}.
-     *
-     * @apiNote {@link Filter} modules may store arbitrary objects as attributes through
-     * {@code HttpExchange} instances as an out-of-band communication mechanism. Other filters
+     * {@link Filter} modules may store arbitrary objects with {@code HttpExchange}
+     * instances as an out-of-band communication mechanism. Other filters
      * or the exchange handler may then access these objects.
      *
      * <p> Each {@code Filter} class will document the attributes which they make
      * available.
      *
      * @param name the name of the attribute to retrieve
-     * @return the attribute's value or {@code null} if either the attribute isn't set
-     *         or the attribute value is {@code null}
+     * @return the attribute object, or {@code null} if it does not exist
      * @throws NullPointerException if name is {@code null}
      */
     public abstract Object getAttribute(String name);
 
     /**
-     * Sets an attribute with the given {@code name} and {@code value} in this exchange's
-     * {@linkplain HttpContext#getAttributes() context attributes}.
-     *
-     * @apiNote {@link Filter} modules may store arbitrary objects as attributes through
-     * {@code HttpExchange} instances as an out-of-band communication mechanism. Other filters
+     * {@link Filter} modules may store arbitrary objects with {@code HttpExchange}
+     * instances as an out-of-band communication mechanism. Other filters
      * or the exchange handler may then access these objects.
      *
      * <p> Each {@code Filter} class will document the attributes which they make


### PR DESCRIPTION
This change backs out the API doc change in com.sun.net.httpserver.HttpExchange introduced by JDK-8235786.

It is a straight git revert of that commit. We will address the original issue in a different way in 25

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8345796](https://bugs.openjdk.org/browse/JDK-8345796) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8345794](https://bugs.openjdk.org/browse/JDK-8345794): Backout doc change introduced by JDK-8235786 (**Bug** - P4)
 * [JDK-8345796](https://bugs.openjdk.org/browse/JDK-8345796): Backout doc change introduced by JDK-8235786 (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22639/head:pull/22639` \
`$ git checkout pull/22639`

Update a local copy of the PR: \
`$ git checkout pull/22639` \
`$ git pull https://git.openjdk.org/jdk.git pull/22639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22639`

View PR using the GUI difftool: \
`$ git pr show -t 22639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22639.diff">https://git.openjdk.org/jdk/pull/22639.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22639#issuecomment-2527791154)
</details>
