### PR TITLE
8345800: Update copyright year to 2024 for serviceability in files where it was missed

### DIFF
--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/DefaultMXBeanMappingFactory.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/DefaultMXBeanMappingFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/MBeanServerDelegateImpl.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/MBeanServerDelegateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.management/share/classes/javax/management/MBeanServerDelegate.java
+++ b/src/java.management/share/classes/javax/management/MBeanServerDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.attach/aix/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/aix/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/jdk.attach/macosx/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/macosx/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.attach/windows/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/windows/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/resources/aliasmap
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/resources/aliasmap
@@ -1,6 +1,6 @@
 /*
 *
-* Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jcmd/share/man/jinfo.md
+++ b/src/jdk.jcmd/share/man/jinfo.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jcmd/share/man/jmap.md
+++ b/src/jdk.jcmd/share/man/jmap.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jcmd/share/man/jps.md
+++ b/src/jdk.jcmd/share/man/jps.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jcmd/share/man/jstack.md
+++ b/src/jdk.jcmd/share/man/jstack.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jcmd/share/man/jstat.md
+++ b/src/jdk.jcmd/share/man/jstat.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/resources/messages_de.properties
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/resources/messages_de.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jconsole/share/man/jconsole.md
+++ b/src/jdk.jconsole/share/man/jconsole.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ThreadReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ThreadReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources_de.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources_de.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/SunCommandLineLauncher.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/SunCommandLineLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/man/jdb.md
+++ b/src/jdk.jdi/share/man/jdb.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/windows/classes/com/sun/tools/jdi/SharedMemoryTransportService.java
+++ b/src/jdk.jdi/windows/classes/com/sun/tools/jdi/SharedMemoryTransportService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent.properties
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2012, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_de.properties
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_de.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2012, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_es.properties
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_es.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_fr.properties
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_fr.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_it.properties
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_it.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_ja.properties
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_ja.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2012, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_ko.properties
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_ko.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_pt_BR.properties
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_pt_BR.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_sv.properties
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_sv.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_zh_CN.properties
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_zh_CN.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2012, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_zh_TW.properties
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/resources/agent_zh_TW.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/jdi/BadAgentPath.java
+++ b/test/jdk/com/sun/jdi/BadAgentPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/jdi/DoubleAgentTest.java
+++ b/test/jdk/com/sun/jdi/DoubleAgentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/jdi/SuspendNoFlagTest.java
+++ b/test/jdk/com/sun/jdi/SuspendNoFlagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/management/remote/mandatory/loading/MissingClassTest.java
+++ b/test/jdk/javax/management/remote/mandatory/loading/MissingClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Some files have been modified in 2024, but the copyright year has not been properly updated. This should be fixed. 

I have located these modified files using:
```
git log --since="Jan 1" --name-only --pretty=format: | sort -u > file.list
```
and then run a script to update the copyright year to 2024 on these files.

I have made a manual sampling of files in the list to verify that they have indeed been modified in 2024.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345800](https://bugs.openjdk.org/browse/JDK-8345800): Update copyright year to 2024 for serviceability in files where it was missed (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22641/head:pull/22641` \
`$ git checkout pull/22641`

Update a local copy of the PR: \
`$ git checkout pull/22641` \
`$ git pull https://git.openjdk.org/jdk.git pull/22641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22641`

View PR using the GUI difftool: \
`$ git pr show -t 22641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22641.diff">https://git.openjdk.org/jdk/pull/22641.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22641#issuecomment-2527845185)
</details>
