### PR TITLE
8345185: Some tests in test/jdk/tools/jpackage fail with a JDK without JMODs

### DIFF
--- a/src/jdk.jlink/share/classes/module-info.java
+++ b/src/jdk.jlink/share/classes/module-info.java
@@ -85,4 +85,6 @@ module jdk.jlink {
         jdk.tools.jlink.internal.plugins.VendorVersionPlugin,
         jdk.tools.jlink.internal.plugins.CDSPlugin,
         jdk.tools.jlink.internal.plugins.SaveJlinkArgfilesPlugin;
+
+    exports jdk.tools.jlink.internal to jdk.jpackage;
 }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JLinkBundlerHelper.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JLinkBundlerHelper.java
@@ -31,9 +31,11 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.module.Configuration;
 import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleDescriptor.Requires;
 import java.lang.module.ModuleFinder;
 import java.lang.module.ModuleReference;
 import java.lang.module.ResolvedModule;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,16 +43,21 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.spi.ToolProvider;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import jdk.internal.module.ModulePath;
+import jdk.tools.jlink.internal.LinkableRuntimeImage;
 
 
 final class JLinkBundlerHelper {
+
+    private static final boolean LINKABLE_RUNTIME = LinkableRuntimeImage.isLinkableRuntime();
 
     static void execute(Map<String, ? super Object> params, Path outputDir)
             throws IOException, PackagerException {
@@ -98,13 +105,48 @@ final class JLinkBundlerHelper {
                  addModules.stream()).collect(Collectors.toSet());
 
         ModuleFinder finder = createModuleFinder(paths);
+        Predicate<ModuleDescriptor> moduleFilter = defaultModulePredicate();
 
         return Configuration.empty()
                 .resolveAndBind(finder, ModuleFinder.of(), roots)
                 .modules()
                 .stream()
-                .map(ResolvedModule::name)
+                .map(ResolvedModule::reference)
+                .map(ModuleReference::descriptor)
+                .filter(moduleFilter)
+                .map(ModuleDescriptor::name)
                 .collect(Collectors.toSet());
+    }
+
+    /*
+     * Returns a predicate suitable for filtering JDK modules. It returns an
+     * allways-include predicate when the default module path, "jmods" folder in
+     * JAVA_HOME exists. Otherwise, it returns a filter that checks for a build
+     * which allows for linking from the run-time image. If so, modules 'jdk.jlink'
+     * and 'jdk.jpackage' - which depends on jdk.jlink - will be filtered by the
+     * predicate.
+     */
+    private static Predicate<ModuleDescriptor> defaultModulePredicate() {
+        Predicate<ModuleDescriptor> defaultModFilter = a -> true;
+        Path defaultJmodsPath = Path.of(System.getProperty("java.home"),
+                                        "jmods");
+        if (Files.notExists(defaultJmodsPath)) {
+            return JLinkBundlerHelper::linkableRuntimeFilter;
+        }
+        return defaultModFilter;
+    }
+
+    /*
+     * Since the jdk.jlink module is not allowed, filter it and modules that
+     * require it when we have a runtime that allows for linking from the run-time
+     * image.
+     */
+    private static boolean linkableRuntimeFilter(ModuleDescriptor desc) {
+        Set<Requires> r = desc.requires();
+        boolean requiresJlink = r.stream()
+                                 .map(Requires::name)
+                                 .anyMatch(a -> "jdk.jlink".equals(a));
+        return !(LINKABLE_RUNTIME && ("jdk.jlink".equals(desc.name()) || requiresJlink));
     }
 
     /*
@@ -121,6 +163,10 @@ final class JLinkBundlerHelper {
                 ModulePath.of(JarFile.runtimeVersion(), true,
                         modulePath.toArray(Path[]::new)),
                 ModuleFinder.ofSystem());
+    }
+
+    static boolean isLinkableRuntime() {
+        return LINKABLE_RUNTIME;
     }
 
     private static Set<String> createModuleList(List<Path> paths,
@@ -150,7 +196,6 @@ final class JLinkBundlerHelper {
         if (phonyModule != null) {
             modules.addAll(phonyModule.get());
         }
-
         return modules;
     }
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/StandardBundlerParam.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/StandardBundlerParam.java
@@ -25,8 +25,6 @@
 
 package jdk.jpackage.internal;
 
-import jdk.internal.util.OperatingSystem;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -44,6 +42,8 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import jdk.internal.util.OperatingSystem;
 import jdk.jpackage.internal.util.FileUtils;
 
 /**
@@ -469,8 +469,11 @@ class StandardBundlerParam<T> extends BundlerParamInfo<T> {
                             }
                         }
 
-                        if (javaBasePath == null ||
-                                !Files.exists(javaBasePath)) {
+                        // JEP 493 allows for a JDK build without JMODs, thus
+                        // check for a linkable runtime before issuing the warning
+                        boolean linkableRuntime = JLinkBundlerHelper.isLinkableRuntime();
+                        if (!linkableRuntime && (javaBasePath == null ||
+                                                 !Files.exists(javaBasePath))) {
                             Log.error(String.format(I18N.getString(
                                     "warning.no.jdk.modules.found")));
                         }

--- a/test/jdk/tools/jpackage/TEST.properties
+++ b/test/jdk/tools/jpackage/TEST.properties
@@ -14,4 +14,5 @@ exclusiveAccess.dirs=share windows
 modules=jdk.jpackage/jdk.jpackage.internal:+open \
         jdk.jpackage/jdk.jpackage.internal.util \
         jdk.jpackage/jdk.jpackage.internal.util.function \
-        java.base/jdk.internal.util
+        java.base/jdk.internal.util \
+        jdk.jlink/jdk.tools.jlink.internal

--- a/test/jdk/tools/jpackage/share/BasicTest.java
+++ b/test/jdk/tools/jpackage/share/BasicTest.java
@@ -42,6 +42,7 @@ import jdk.jpackage.test.JavaTool;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Annotations.Parameter;
 import jdk.jpackage.internal.util.function.ThrowingConsumer;
+import jdk.tools.jlink.internal.LinkableRuntimeImage;
 import static jdk.jpackage.test.RunnablePackageTest.Action.CREATE_AND_UNPACK;
 
 /*
@@ -312,6 +313,14 @@ public final class BasicTest {
     @Parameter("java.desktop,jdk.jartool")
     @Parameter({ "java.desktop", "jdk.jartool" })
     public void testAddModules(String... addModulesArg) {
+        if (addModulesArg.length == 1 && addModulesArg[0].equals("ALL-MODULE-PATH")) {
+            Path jmods = Path.of(System.getProperty("java.home"), "jmods");
+            boolean noJmods = Files.notExists(jmods);
+            if (LinkableRuntimeImage.isLinkableRuntime() && noJmods) {
+               System.out.println("ALL-MODULE-PATH test skipped for linkable run-time image");
+               return;
+            }
+        }
         JPackageCommand cmd = JPackageCommand
                 .helloAppImage("goodbye.jar:com.other/com.other.Hello")
                 .ignoreDefaultRuntime(true); // because of --add-modules

--- a/test/jdk/tools/jpackage/share/JLinkOptionsTest.java
+++ b/test/jdk/tools/jpackage/share/JLinkOptionsTest.java
@@ -58,24 +58,26 @@ public final class JLinkOptionsTest {
                     "--jlink-options",
                     "--strip-debug --no-man-pages --no-header-files",
                     "--jlink-options",
-                    "--bind-services",
+                    "--verbose --bind-services --limit-modules java.smartcardio,jdk.crypto.cryptoki,java.desktop",
                     },
-                    // with bind-services should have some services
+                    // with limit-modules and bind-services should have them in the result
                     new String[]{"java.smartcardio", "jdk.crypto.cryptoki"},
                     null,
                     },
             // bind-services
             {"Hello", new String[]{
-                    "--jlink-options", "--bind-services",
+                    "--jlink-options",
+                    "--bind-services --limit-modules jdk.jartool,jdk.unsupported,java.desktop",
                     },
-                    // non modular should have everything
+                    // non modular should have at least the module limits
                     new String[]{"jdk.jartool", "jdk.unsupported"},
                     null,
                     },
 
             // jlink-options --bind-services
             {"com.other/com.other.Hello", new String[]{
-                    "--jlink-options", "--bind-services",
+                    "--jlink-options",
+                    "--bind-services --limit-modules java.smartcardio,jdk.crypto.cryptoki,java.desktop",
                     },
                     // with bind-services should have some services
                     new String[]{"java.smartcardio", "jdk.crypto.cryptoki"},

--- a/test/jdk/tools/jpackage/share/RuntimeImageSymbolicLinksTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimeImageSymbolicLinksTest.java
@@ -60,7 +60,7 @@ public class RuntimeImageSymbolicLinksTest {
         .dumpOutput()
         .addArguments(
                 "--output", jlinkOutputDir.toString(),
-                "--add-modules", "ALL-MODULE-PATH",
+                "--add-modules", "java.desktop",
                 "--strip-debug",
                 "--no-header-files",
                 "--no-man-pages",

--- a/test/jdk/tools/jpackage/share/RuntimeImageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimeImageTest.java
@@ -53,7 +53,7 @@ public class RuntimeImageTest {
         .dumpOutput()
         .addArguments(
                 "--output", jlinkOutputDir.toString(),
-                "--add-modules", "ALL-MODULE-PATH",
+                "--add-modules", "java.desktop",
                 "--strip-debug",
                 "--no-header-files",
                 "--no-man-pages",

--- a/test/jdk/tools/jpackage/share/RuntimePackageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimePackageTest.java
@@ -111,7 +111,7 @@ public class RuntimePackageTest {
                 .dumpOutput()
                 .addArguments(
                         "--output", runtimeImageDir.toString(),
-                        "--add-modules", "ALL-MODULE-PATH",
+                        "--add-modules", "java.desktop",
                         "--strip-debug",
                         "--no-header-files",
                         "--no-man-pages")


### PR DESCRIPTION
Please review these changes to jpackage in light of [JEP 493](https://openjdk.org/jeps/493). When this feature is enabled, then some of the `jpackage` tests fail. The failures fall into the following categories:

- `ALL-DEFAULT` notion from `jpackage` which includes all modules that export an API, which includes `jdk.jlink`, which is prevented from being included when linking from the run-time image (see the [JEP 493](https://openjdk.org/jeps/493) restrictions). The proposal is to not include `jdk.jlink` and `jdk.jpackage` by default on a JDK build with JEP 493 enabled. A regular JDK build doesn't have this filtering. We could make this consistent across JDK builds by unconditionally filtering them, but I wasn't sure, so I've opted for the proposed solution for now.
- Don't issue a warning when there is no `jmods` folder in the JDK install and we have a JEP 493 enabled build. In that case issuing the warning isn't appropriate as it's the expected behaviour.
- `ALL-MODULE-PATH` changes: `BasicTest.java` verifies the `--add-modules` argument to `jpackage`. Using `ALL-MODULE-PATH` for JDK modules won't be supported for JEP 493-enabled builds. So I've changed this test to skip the test using `ALL-MODULE-PATH` when we have such an enabled build. Other tests, such as `RuntimeImageTest.java` and `RuntimeImageSymbolicLinksTest.java` tests verify something else not related to `ALL-MODULE-PATH` or `--add-modules`. It seems more appropriate to use the smaller set of modules to use for the runtime JDK image.
- `JLinkOptionsTest.java`: That test verifies options passed to `jlink` via the `ToolProvider` API. For some reason, it uses `--bind-services` extensively and that - in turn - and, when not limited with the `--limit-modules` option as well, will include `jdk.jlink` in the resulting image, again running afoul the JEP 493 restriction of not allowing `jdk.jlink` for now. I propose to use suitable options including `--limit-modules` which would then no longer include `jdk.jlink` in the runtime image and the link from a run-time image works as well. These changes depend on [JDK-8345573](https://bugs.openjdk.org/browse/JDK-8345573) for it to work fully.

Testing:
- [ ] GHA
- [x] running tests in `test/jdk/tools/jpackage` on a JEP 493 enabled JDK. As far as I could see the failures that I was seeing weren't any more related to JEP 493 (some RPM requirements showing up that it didn't expect to). 

Thoughts? Opinions?