### PR TITLE
8345580: Remove const from Node::_idx which is modified

### DIFF
--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -586,8 +586,7 @@ public:
 
   // Set this node's index, used by cisc_version to replace current node
   void set_idx(uint new_idx) {
-    const node_idx_t* ref = &_idx;
-    *(node_idx_t*)ref = new_idx;
+    _idx = new_idx;
   }
   // Swap input edge order.  (Edge indexes i1 and i2 are usually 1 and 2.)
   void swap_edges(uint i1, uint i2) {

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -345,7 +345,7 @@ protected:
   // The PhaseRenumberLive phase renumbers nodes based on liveness information.
   // Therefore, it updates the value of the _idx field. The parse-time _idx is
   // preserved in _parse_idx.
-  const node_idx_t _idx;
+  node_idx_t _idx;
   DEBUG_ONLY(const node_idx_t _parse_idx;)
   // IGV node identifier. Two nodes, possibly in different compilation phases,
   // have the same IGV identifier if (and only if) they are the very same node


### PR DESCRIPTION
`Node::_idx` is declared as `const`, however, it is modified by `Node::set_idx`. Please see: https://github.com/openjdk/jdk/blob/166c12771d9d8c466e73a9490c4eb1fc9a5f6c24/src/hotspot/share/opto/node.hpp#L588

As already stated in [JDK-8345580](https://bugs.openjdk.org/browse/JDK-8345580) issue, this behavior is counterintuitive because a const variable is expected to remain unmodified throughout its lifetime. Additionally, C++ International Standard states that "_...any attempt to modify a `const` object during its lifetime results in undefined behavior._ ". 
To address this, `const` should be removed from the declaration of `Node::_idx` to align with its intended use and avoid violating the C++ standard. Tested with tier1,2,3,4,5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345580](https://bugs.openjdk.org/browse/JDK-8345580): Remove const from Node::_idx which is modified (**Enhancement** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22646/head:pull/22646` \
`$ git checkout pull/22646`

Update a local copy of the PR: \
`$ git checkout pull/22646` \
`$ git pull https://git.openjdk.org/jdk.git pull/22646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22646`

View PR using the GUI difftool: \
`$ git pr show -t 22646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22646.diff">https://git.openjdk.org/jdk/pull/22646.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22646#issuecomment-2535274443)
</details>
