### PR TITLE
8345647: Fix recent NULL usage backsliding in Shenandoah

### DIFF
--- a/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
@@ -624,7 +624,7 @@ void ShenandoahBarrierSetAssembler::store_at(MacroAssembler *masm, DecoratorSet 
                                 tmp1, tmp2, tmp3,
                                 preservation_level);
 
-  // No need for post barrier if storing NULL
+  // No need for post barrier if storing null
   if (ShenandoahCardBarrier && is_reference_type(type) && val != noreg) {
     store_check(masm, base, ind_or_offs, tmp1);
   }

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -458,7 +458,7 @@ void ShenandoahBarrierSetC2::post_barrier(GraphKit* kit,
 
   // No store check needed if we're storing a null.
   if (val != nullptr && val->is_Con()) {
-    // must be either an oop or NULL
+    // must be either an oop or null
     const Type* t = val->bottom_type();
     if (t == TypePtr::NULL_PTR || t == Type::TOP)
       return;


### PR DESCRIPTION
Hi all, 

This PR addresses [8345647](https://bugs.openjdk.org/browse/JDK-8345647) addressing uses of `NULL` in Shenandoah. These should be replaced to `null`. 

I verified where those uses are with: 
`git show <commit-id> --name-only | while read file; do echo "File: $file"; git diff <commit-id> -- "$file" | grep -n -F 'NULL'; done`

The relevant output: 
```
File: src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
9:-  // No need for post barrier if storing NULL
File: src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
9:-    // must be either an oop or NULL
12:     if (t == TypePtr::NULL_PTR || t == Type::TOP)
```

Changes affect comments only. 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345647](https://bugs.openjdk.org/browse/JDK-8345647): Fix recent NULL usage backsliding in Shenandoah (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22647/head:pull/22647` \
`$ git checkout pull/22647`

Update a local copy of the PR: \
`$ git checkout pull/22647` \
`$ git pull https://git.openjdk.org/jdk.git pull/22647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22647`

View PR using the GUI difftool: \
`$ git pr show -t 22647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22647.diff">https://git.openjdk.org/jdk/pull/22647.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22647#issuecomment-2531923921)
</details>
