### PR TITLE
8345813: Replace $LDCXX with proper libraries to $LD instead

### DIFF
--- a/make/autoconf/buildjdk-spec.gmk.template
+++ b/make/autoconf/buildjdk-spec.gmk.template
@@ -36,7 +36,6 @@ CXX := @BUILD_CXX@
 # and this should work in most cases.
 CPP := @BUILD_CC@ -E
 LD := @BUILD_LD@
-LDCXX := @BUILD_LDCXX@
 AS := @BUILD_AS@
 NM := @BUILD_NM@
 AR := @BUILD_AR@

--- a/make/autoconf/lib-std.m4
+++ b/make/autoconf/lib-std.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -68,17 +68,17 @@ AC_DEFUN_ONCE([LIB_SETUP_STD_LIBS],
     if test "x$with_stdc__lib" = xdynamic || test "x$has_static_libstdcxx" = xno ; then
       AC_MSG_RESULT([dynamic])
     else
-      LIBCXX="$LIBCXX $STATIC_STDCXX_FLAGS"
-      JVM_LDFLAGS="$JVM_LDFLAGS $STATIC_STDCXX_FLAGS"
-      ADLC_LDFLAGS="$ADLC_LDFLAGS $STATIC_STDCXX_FLAGS"
-      # Ideally, we should test stdc++ for the BUILD toolchain separately. For now
-      # just use the same setting as for the TARGET toolchain.
-      OPENJDK_BUILD_JVM_LDFLAGS="$OPENJDK_BUILD_JVM_LDFLAGS $STATIC_STDCXX_FLAGS"
+      STATIC_STDCXX_LDFLAGS="$STATIC_STDCXX_FLAGS"
       AC_MSG_RESULT([static])
     fi
   fi
 
-  AC_SUBST(LIBCXX)
+  AC_SUBST(STATIC_STDCXX_LDFLAGS)
+
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
+    STDCXX_LIBS="-lstdc++"
+  fi
+  AC_SUBST(STDCXX_LIBS)
 
   # Setup Windows runtime dlls
   if test "x$OPENJDK_TARGET_OS" = "xwindows"; then

--- a/make/autoconf/spec.gmk.template
+++ b/make/autoconf/spec.gmk.template
@@ -568,17 +568,15 @@ LDFLAGS_CXX_JDK := @LDFLAGS_CXX_JDK@
 # LDFLAGS specific to partial linking.
 LDFLAGS_CXX_PARTIAL_LINKING := @LDFLAGS_CXX_PARTIAL_LINKING@
 
-# Sometimes a different linker is needed for c++ libs
-LDCXX := @LDCXX@
-# The flags for linking libstdc++ linker.
-LIBCXX := @LIBCXX@
+# Linker flags needed to statically link std C++ libs, if requested
+STATIC_STDCXX_LDFLAGS := @STATIC_STDCXX_LDFLAGS@
+STDCXX_LIBS := @STDCXX_LIBS@
 
 # BUILD_CC/BUILD_LD is a compiler/linker that generates code that is runnable on the
 # build platform.
 BUILD_CC := @BUILD_ICECC@ @BUILD_CC@
 BUILD_CXX := @BUILD_ICECC@ @BUILD_CXX@
 BUILD_LD := @BUILD_LD@
-BUILD_LDCXX := @BUILD_LDCXX@
 BUILD_AS := @BUILD_AS@
 BUILD_AR := @BUILD_AR@
 BUILD_NM := @BUILD_NM@

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -615,15 +615,11 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_CORE],
     # In the Microsoft toolchain we have a separate LD command "link".
     UTIL_LOOKUP_TOOLCHAIN_PROGS(LD, link)
     TOOLCHAIN_VERIFY_LINK_BINARY(LD)
-    LDCXX="$LD"
   else
     # All other toolchains use the compiler to link.
     LD="$CC"
-    LDCXX="$CXX"
   fi
   AC_SUBST(LD)
-  # FIXME: it should be CXXLD, according to standard (cf CXXCPP)
-  AC_SUBST(LDCXX)
 
   TOOLCHAIN_EXTRACT_LD_VERSION([LD], [linker])
   TOOLCHAIN_PREPARE_FOR_LD_VERSION_COMPARISONS
@@ -850,7 +846,6 @@ AC_DEFUN_ONCE([TOOLCHAIN_SETUP_BUILD_COMPILERS],
       # In the Microsoft toolchain we have a separate LD command "link".
       UTIL_REQUIRE_PROGS(BUILD_LD, link, [$VS_PATH])
       TOOLCHAIN_VERIFY_LINK_BINARY(BUILD_LD)
-      BUILD_LDCXX="$BUILD_LD"
     else
       if test "x$OPENJDK_BUILD_OS" = xmacosx; then
         UTIL_REQUIRE_PROGS(BUILD_CC, clang)
@@ -867,7 +862,6 @@ AC_DEFUN_ONCE([TOOLCHAIN_SETUP_BUILD_COMPILERS],
       BUILD_AS="$BUILD_CC -c"
       # Just like for the target compiler, use the compiler as linker
       BUILD_LD="$BUILD_CC"
-      BUILD_LDCXX="$BUILD_CXX"
     fi
 
     PATH="$OLDPATH"
@@ -883,7 +877,6 @@ AC_DEFUN_ONCE([TOOLCHAIN_SETUP_BUILD_COMPILERS],
     BUILD_CC="$CC"
     BUILD_CXX="$CXX"
     BUILD_LD="$LD"
-    BUILD_LDCXX="$LDCXX"
     BUILD_NM="$NM"
     BUILD_AS="$AS"
     BUILD_OBJCOPY="$OBJCOPY"
@@ -897,7 +890,6 @@ AC_DEFUN_ONCE([TOOLCHAIN_SETUP_BUILD_COMPILERS],
   AC_SUBST(BUILD_CC)
   AC_SUBST(BUILD_CXX)
   AC_SUBST(BUILD_LD)
-  AC_SUBST(BUILD_LDCXX)
   AC_SUBST(BUILD_NM)
   AC_SUBST(BUILD_AS)
   AC_SUBST(BUILD_AR)

--- a/make/common/JdkNativeCompilation.gmk
+++ b/make/common/JdkNativeCompilation.gmk
@@ -279,7 +279,7 @@ JDK_RCFLAGS=$(RCFLAGS) \
 #     to be included for this module when building static libs
 #   EXTRA_RCFLAGS -- additional RCFLAGS to append.
 #   RC_FILEDESC -- override the default FILEDESC for Windows version.rc
-#   DEFAULT_LIBCXX -- if false, do not add LIBCXX to LIBS for C++ compilations
+#   NO_STATIC_LIBCXX -- if true, do not add flags to statically link std C++ libs
 #   DEFAULT_CFLAGS -- if false, do not add default CFLAGS and CXXFLAGS
 #   DEFAULT_LDFLAGS -- if false, do not add default LDFLAGS
 #   CFLAGS_FILTER_OUT -- flags to filter out from default CFLAGS
@@ -331,12 +331,6 @@ define SetupJdkNativeCompilationBody
       $1_OBJECT_DIR := $$(SUPPORT_OUTPUTDIR)/native/$$(MODULE)/$$($1_NATIVE_DIR_PREFIX)$$($1_NAME)
     else
       $$(error Must specify OBJECT_DIR in a MODULE free context)
-    endif
-  endif
-
-  ifneq ($$($1_DEFAULT_LIBCXX), false)
-    ifeq ($$($1_LINK_TYPE), C++)
-      $1_LIBS += $(LIBCXX)
     endif
   endif
 
@@ -437,6 +431,14 @@ define SetupJdkNativeCompilationBody
     else
       # Set the default flags first to be able to override
       $1_LDFLAGS := $$(filter-out $$($1_LDFLAGS_FILTER_OUT), $$(LDFLAGS_JDKLIB) $$($1_LDFLAGS))
+    endif
+  endif
+
+  ifeq ($$($1_LINK_TYPE), C++)
+    $1_LIBS += $$(STDCXX_LIBS)
+
+    ifneq ($$($1_NO_STATIC_LIBCXX), true)
+      $1_LDFLAGS += $$(STATIC_STDCXX_LDFLAGS)
     endif
   endif
 

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -308,11 +308,7 @@ define SetupToolchain
     $$(call SetIfEmpty, $1_STRIP, $$(BUILD_STRIP))
     $$(call SetIfEmpty, $1_SYSROOT_CFLAGS, $$(BUILD_SYSROOT_CFLAGS))
     $$(call SetIfEmpty, $1_SYSROOT_LDFLAGS, $$(BUILD_SYSROOT_LDFLAGS))
-    ifeq ($$($1_LINK_TYPE), C++)
-      $$(call SetIfEmpty, $1_LD, $$(BUILD_LDCXX))
-    else
-      $$(call SetIfEmpty, $1_LD, $$(BUILD_LD))
-    endif
+    $$(call SetIfEmpty, $1_LD, $$(BUILD_LD))
   else
     $$(call SetIfEmpty, $1_CC, $$(CC))
     $$(call SetIfEmpty, $1_CXX, $$(CXX))
@@ -325,11 +321,7 @@ define SetupToolchain
     $$(call SetIfEmpty, $1_STRIP, $$(STRIP))
     $$(call SetIfEmpty, $1_SYSROOT_CFLAGS, $$(SYSROOT_CFLAGS))
     $$(call SetIfEmpty, $1_SYSROOT_LDFLAGS, $$(SYSROOT_LDFLAGS))
-    ifeq ($$($1_LINK_TYPE), C++)
-      $$(call SetIfEmpty, $1_LD, $$(LDCXX))
-    else
-      $$(call SetIfEmpty, $1_LD, $$(LD))
-    endif
+    $$(call SetIfEmpty, $1_LD, $$(LD))
   endif
 endef
 

--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -118,7 +118,7 @@ define SetupTestFilesCompilationBody
         DISABLED_WARNINGS_clang := format-nonliteral \
             missing-field-initializers sometimes-uninitialized undef \
             unused-but-set-variable unused-function unused-variable, \
-        DEFAULT_LIBCXX := false, \
+        NO_STATIC_LIBCXX := true, \
         JDK_LIBS := $$($1_JDK_LIBS_$$(name)), \
         LIBS := $$($1_LIBS_$$(name)), \
         DEFAULT_VERSIONINFO_RESOURCE := false, \

--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -137,6 +137,11 @@ $(eval $(call SetupJarArchive, BUILD_JDK_JAR, \
     JAR := $(MICROBENCHMARK_JAR), \
 ))
 
+ifeq ($(TOOLCHAIN_TYPE), gcc)
+  BUILD_MICROBENCHMARK_LIBRARIES_LIBS_libPoint := -lm
+  BUILD_MICROBENCHMARK_LIBRARIES_LIBS_libJNIPoint := -lm
+endif
+
 # Setup compilation of native library dependencies
 $(eval $(call SetupTestFilesCompilation, BUILD_MICROBENCHMARK_LIBRARIES, \
     TYPE := LIBRARY, \

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -71,7 +71,6 @@ ifeq ($(call isTargetOs, windows), true)
       libExplicitAttach.c libImplicitAttach.c \
       exelauncher.c
 
-  BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := $(LIBCXX)
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exerevokeall := advapi32.lib
   BUILD_JDK_JTREG_EXECUTABLES_CFLAGS_exeNullCallerTest := /EHsc
 else
@@ -93,7 +92,7 @@ else
     BUILD_JDK_JTREG_LIBRARIES_JDK_LIBS_libInheritedChannel := java.base:libjava
     BUILD_JDK_JTREG_EXECUTABLES_LIBS_exelauncher := -ldl
   endif
-  BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := $(LIBCXX)
+  BUILD_JDK_JTREG_EXECUTABLES_LDFLAGS_exeNullCallerTest := $(STATIC_STDCXX_LDFLAGS)
 endif
 
 ifeq ($(call isTargetOs, macosx), true)


### PR DESCRIPTION
As suggested by @djelinski in https://github.com/openjdk/jdk/pull/17986#issuecomment-1965991536, we can (and should) remove the special `$LDCXX` linker, and instead just pass the C++ standard libraries to gcc. 