### PR TITLE
8345818: Fix SM cleanup of parsing of System property resource.bundle.debug

### DIFF
--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -3654,8 +3654,7 @@ public abstract class ResourceBundle {
 
     }
 
-    private static final boolean TRACE_ON = Boolean.getBoolean(
-        System.getProperty("resource.bundle.debug", "false"));
+    private static final boolean TRACE_ON = Boolean.getBoolean("resource.bundle.debug");
 
     private static void trace(String format, Object... params) {
         if (TRACE_ON)


### PR DESCRIPTION
Replace broken getProperty with Boolean.getBoolean.

Manual testing confirms trace messages are enabled with `-Dresource.bundle.debug=true`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345818](https://bugs.openjdk.org/browse/JDK-8345818): Fix SM cleanup of parsing of System property resource.bundle.debug (**Bug** - P3)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Eirik Bjørsnøs](https://openjdk.org/census#eirbjo) (@eirbjo - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22649/head:pull/22649` \
`$ git checkout pull/22649`

Update a local copy of the PR: \
`$ git checkout pull/22649` \
`$ git pull https://git.openjdk.org/jdk.git pull/22649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22649`

View PR using the GUI difftool: \
`$ git pr show -t 22649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22649.diff">https://git.openjdk.org/jdk/pull/22649.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22649#issuecomment-2528814079)
</details>
