### PR TITLE
8334756: javac crashed on call to non-existent generic method with explicit annotated type arg

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -1018,7 +1018,11 @@ public class TypeAnnotations {
                     if (!invocation.typeargs.contains(tree)) {
                         return TypeAnnotationPosition.unknown;
                     }
-                    MethodSymbol exsym = (MethodSymbol) TreeInfo.symbol(invocation.getMethodSelect());
+                    Symbol exsym = TreeInfo.symbol(invocation.getMethodSelect());
+                    if (exsym.type.isErroneous()) {
+                        // bail out, don't deal with erroneous types which would be reported anyways
+                        return TypeAnnotationPosition.unknown;
+                    }
                     final int type_index = invocation.typeargs.indexOf(tree);
                     if (exsym == null) {
                         throw new AssertionError("could not determine symbol for {" + invocation + "}");

--- a/test/langtools/tools/javac/annotations/typeAnnotations/CrashOnNonExistingMethodTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/CrashOnNonExistingMethodTest.java
@@ -1,0 +1,22 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8334756
+ * @summary javac crashes on call to non-existent generic method with explicit annotated type arg
+ * @compile/fail/ref=CrashOnNonExistingMethodTest.out -XDrawDiagnostics -XDdev CrashOnNonExistingMethodTest.java
+ */
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+import java.lang.annotation.Target;
+
+class CrashOnNonExistingMethodTest {
+    @Target(TYPE_USE)
+    @interface Nullable {}
+
+    static <T extends @Nullable Object> T identity(T t) {
+        return t;
+    }
+
+    static void test() {
+        CrashOnNonExistingMethodTest.<@Nullable Object>nonNullIdentity(null);
+    }
+}

--- a/test/langtools/tools/javac/annotations/typeAnnotations/CrashOnNonExistingMethodTest.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/CrashOnNonExistingMethodTest.out
@@ -1,0 +1,2 @@
+CrashOnNonExistingMethodTest.java:20:37: compiler.err.cant.resolve.location.args.params: kindname.method, nonNullIdentity, java.lang.Object, compiler.misc.type.null, (compiler.misc.location: kindname.class, CrashOnNonExistingMethodTest, null)
+1 error


### PR DESCRIPTION
Please review this simple fix that is avoiding a CCE in javac while compiling a non-existent method annotated with type annotations,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8334756: javac crashed on call to non-existent generic method with explicit annotated type arg`

### Issue
 * [JDK-8334756](https://bugs.openjdk.org/browse/JDK-8334756): javac crashed on call to non-existent generic method with explicit annotated type arg (**Bug** - P4)


### Reviewers
 * [Aggelos Biboudis](https://openjdk.org/census#abimpoudis) (@biboudis - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22654/head:pull/22654` \
`$ git checkout pull/22654`

Update a local copy of the PR: \
`$ git checkout pull/22654` \
`$ git pull https://git.openjdk.org/jdk.git pull/22654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22654`

View PR using the GUI difftool: \
`$ git pr show -t 22654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22654.diff">https://git.openjdk.org/jdk/pull/22654.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22654#issuecomment-2529636315)
</details>
