### PR TITLE
8339331: GCC fortify error in vm_version_linux_aarch64.cpp

### DIFF
--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -185,7 +185,10 @@ static bool read_fully(const char *fname, char *buf, size_t buflen) {
   assert(buflen >= 1, "invalid argument");
   int fd = os::open(fname, O_RDONLY, 0);
   if (fd != -1) {
+    PRAGMA_DIAG_PUSH
+    PRAGMA_NONNULL_IGNORED
     ssize_t read_sz = ::read(fd, buf, buflen);
+    PRAGMA_DIAG_POP
     ::close(fd);
 
     // Skip if the contents is just "\n" because some machine only sets

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -187,9 +187,10 @@ static bool read_fully(const char *fname, char *buf, size_t buflen) {
   if (fd != -1) {
     PRAGMA_DIAG_PUSH
     PRAGMA_NONNULL_IGNORED
-    // Use pragma to suppress false positive gcc compile warning which maybe be gcc bug
-    // recorded by https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87489. The false positive warning
-    // not seen with vanilla gcc release since maybe include some distro-specific gcc patch.
+    // Suppress false positive gcc warning, which may be an example of
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87489
+    // The warning also hasn't been seen with vanilla gcc release, so may also
+    // involve some distro-specific gcc patch.
     ssize_t read_sz = ::read(fd, buf, buflen);
     PRAGMA_DIAG_POP
     ::close(fd);

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -181,7 +181,7 @@ void VM_Version::get_os_cpu_info() {
 }
 
 static bool read_fully(const char *fname, char *buf, size_t buflen) {
-  assert(buf != nullptr, "buf should not be nullptr");
+  assert(buf != nullptr, "invalid argument");
   assert(buflen >= 1, "invalid argument");
   int fd = os::open(fname, O_RDONLY, 0);
   if (fd != -1) {

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -181,14 +181,11 @@ void VM_Version::get_os_cpu_info() {
 }
 
 static bool read_fully(const char *fname, char *buf, size_t buflen) {
-  assert(buf != nullptr, "invalid argument");
+  guarantee(buf != nullptr, "buf should not be nullptr");  // Use guarantee to suppress gcc warnings
   assert(buflen >= 1, "invalid argument");
   int fd = os::open(fname, O_RDONLY, 0);
   if (fd != -1) {
-    PRAGMA_DIAG_PUSH
-    PRAGMA_NONNULL_IGNORED
     ssize_t read_sz = ::read(fd, buf, buflen);
-    PRAGMA_DIAG_POP
     ::close(fd);
 
     // Skip if the contents is just "\n" because some machine only sets

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -181,11 +181,17 @@ void VM_Version::get_os_cpu_info() {
 }
 
 static bool read_fully(const char *fname, char *buf, size_t buflen) {
-  guarantee(buf != nullptr, "buf should not be nullptr");  // Use guarantee to suppress gcc warnings
+  assert(buf != nullptr, "buf should not be nullptr");
   assert(buflen >= 1, "invalid argument");
   int fd = os::open(fname, O_RDONLY, 0);
   if (fd != -1) {
+    PRAGMA_DIAG_PUSH
+    PRAGMA_NONNULL_IGNORED
+    // Use pragma to suppress false positive gcc compile warning which maybe be gcc bug
+    // recorded by https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87489. The false positive warning
+    // not seen with vanilla gcc release since maybe include some distro-specific gcc patch.
     ssize_t read_sz = ::read(fd, buf, buflen);
+    PRAGMA_DIAG_POP
     ::close(fd);
 
     // Skip if the contents is just "\n" because some machine only sets


### PR DESCRIPTION
Hi all,
The file src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp reported nullptr compile warning by gcc14 with fastdebug configure. I think it's false positive, since the statement 'assert(buf != nullptr, "invalid argument");' has make sure the `buf` should not be nullptr before execute '::read(int, void*, int)'. The call chain is `void VM_Version::initialize_cpu_information(void)` -> `void VM_Version::get_compatible_board(char *buf, int buflen)` -> `static bool read_fully(const char *fname, char *buf, size_t buflen)`, `*buf` is defined as `char  Abstract_VM_Version::_cpu_desc[4096] = {0};` and then right shift 8 bytes, so `*buf` should not be nullptr.
This PR use `PRAGMA_NONNULL_IGNORED` suppress false positive gcc compile warning to make fastdebug configure make success on linux-aarch64 by gcc14.2.0.
Risk is low.

Additional testing:

- [x]  jtreg tests(include tier1/2/3 etc.) on linux-x64 with release build
- [x]  jtreg tests(include tier1/2/3 etc.) on linux-x64 with fastdebug build
- [x]  jtreg tests(include tier1/2/3 etc.) on linux-aarch64 with release build
- [x]  jtreg tests(include tier1/2/3 etc.) on linux-aarch64 with fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339331](https://bugs.openjdk.org/browse/JDK-8339331): GCC fortify error in vm_version_linux_aarch64.cpp (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22655/head:pull/22655` \
`$ git checkout pull/22655`

Update a local copy of the PR: \
`$ git checkout pull/22655` \
`$ git pull https://git.openjdk.org/jdk.git pull/22655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22655`

View PR using the GUI difftool: \
`$ git pr show -t 22655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22655.diff">https://git.openjdk.org/jdk/pull/22655.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22655#issuecomment-2530200431)
</details>
