### PR TITLE
8345883: Relax system property "stackwalk.debug" in StackStreamFactory to be case insensitive

### DIFF
--- a/src/java.base/share/classes/java/lang/StackStreamFactory.java
+++ b/src/java.base/share/classes/java/lang/StackStreamFactory.java
@@ -81,8 +81,7 @@ final class StackStreamFactory {
     @Native private static final int SHOW_HIDDEN_FRAMES        = 0x20;  // LambdaForms are hidden by the VM
     @Native private static final int FILL_LIVE_STACK_FRAMES    = 0x100;
 
-    static final boolean isDebug =
-            "true".equals(System.getProperty("stackwalk.debug"));
+    static final boolean isDebug = Boolean.getBoolean("stackwalk.debug");
 
     static <T> StackFrameTraverser<T>
         makeStackTraverser(StackWalker walker, Function<? super Stream<StackFrame>, ? extends T> function)


### PR DESCRIPTION
Please review this PR which relaxes the interpretation of the system property `stackwalk.debug` in `java.lang.StackStreamFactory` to be case insensitive.

Motivation:
Only 5 of 83 boolean system properties in `java.base` have a case sensitive interpretation. Relaxing these to be case insensitive will improve consistency across the code base and simplifies our reasoning about such system properties.

The `stackwalk.debug` property was introduced when JEP-259 was integrated in JDK-8143911. The property was not mentioned in the CCC for this change, neither in the JEP. Seems like an undocumented, internal debug facility for development and maintenance purposes.

Risk:
This should be a low risk change. The property is used for debugging, and the change will shift the interpretation of "TRUE" from false to true. Any user specifying `-Dstackwalk.debug=TRUE` probably meant to enable it.

Verification:
Manually verified that `-Dstackwalk.debug=TRUE` and `-Dstackwalk.debug=true` enables debugging and that `-Dstackwalk.debug=false`, `-Dstackwalk.debug` and `-Dstackwalk.debug=abc` does not enable it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345883](https://bugs.openjdk.org/browse/JDK-8345883): Relax system property "stackwalk.debug" in StackStreamFactory to be case insensitive (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22659/head:pull/22659` \
`$ git checkout pull/22659`

Update a local copy of the PR: \
`$ git checkout pull/22659` \
`$ git pull https://git.openjdk.org/jdk.git pull/22659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22659`

View PR using the GUI difftool: \
`$ git pr show -t 22659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22659.diff">https://git.openjdk.org/jdk/pull/22659.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22659#issuecomment-2532093958)
</details>
