### PR TITLE
8345888: Broken links in the JDK 24 JavaDoc API documentation, build 27

### DIFF
--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PresentationDirection.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PresentationDirection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import javax.print.attribute.PrintRequestAttribute;
  * <p>
  * <b>IPP Compatibility:</b> This attribute is not an IPP 1.1 attribute; it is
  * an attribute in the Production Printing Extension
- * (<a href="ftp://ftp.pwg.org/pub/pwg/standards/temp_archive/pwg5100.3.pdf">
+ * (<a href="https://ftp.pwg.org/pub/pwg/standards/temp_archive/pwg5100.3.pdf">
  * PDF</a>) of IPP 1.1. The category name returned by {@code getName()} is the
  * IPP attribute name. The enumeration's integer value is the IPP enum value.
  * The {@code toString()} method returns the IPP string representation of the


### PR DESCRIPTION
Please review this trivial change fixing a broken link in `PresentationDirection.java`

The contents of the links are identical, I used the [wayback machine](https://web.archive.org/web/20210511075617/https://ftp.pwg.org/pub/pwg/standards/temp_archive/pwg5100.3.pdf) to view the old content.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345888](https://bugs.openjdk.org/browse/JDK-8345888): Broken links in the JDK 24 JavaDoc API documentation, build 27 (**Sub-task** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22660/head:pull/22660` \
`$ git checkout pull/22660`

Update a local copy of the PR: \
`$ git checkout pull/22660` \
`$ git pull https://git.openjdk.org/jdk.git pull/22660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22660`

View PR using the GUI difftool: \
`$ git pr show -t 22660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22660.diff">https://git.openjdk.org/jdk/pull/22660.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22660#issuecomment-2531350981)
</details>
