### PR TITLE
8345908: Class links should be properly spaced

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
@@ -740,16 +740,14 @@ public class ClassWriter extends SubWriterHolderWriter {
             }
             // TODO: should we simply split this method up to avoid instanceof ?
             if (type instanceof TypeElement te) {
-                Content link = getLink(
-                        new HtmlLinkInfo(configuration, context, te));
-                content.add(HtmlTree.CODE(link));
+                content.add(getLink(
+                        new HtmlLinkInfo(configuration, context, te)));
             } else {
-                Content link = getLink(
-                        new HtmlLinkInfo(configuration, context, ((TypeMirror)type)));
-                content.add(HtmlTree.CODE(link));
+                content.add(getLink(
+                        new HtmlLinkInfo(configuration, context, ((TypeMirror)type))));
             }
         }
-        return content;
+        return HtmlTree.CODE(content);
     }
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testClassLinks/TestClassLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testClassLinks/TestClassLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8163800 8175200 8186332 8182765
+ * @bug 8163800 8175200 8186332 8182765 8345908
  * @summary The fix for JDK-8072052 shows up other minor incorrect use of styles
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -66,10 +66,10 @@ public class TestClassLinks extends JavadocTester {
 
         checkOutput("p/C3.html", true,
                 """
-                    <code><a href="I1.html" title="interface in p">I1</a></code>, <code><a href="I12\
-                    .html" title="interface in p">I12</a></code>, <code><a href="I2.html" title="int\
-                    erface in p">I2</a></code>, <code><a href="IT1.html" title="interface in p">IT1<\
-                    /a>&lt;T&gt;</code>, <code><a href="IT2.html" title="interface in p">IT2</a>&lt;\
+                    <code><a href="I1.html" title="interface in p">I1</a>, <a href="I12\
+                    .html" title="interface in p">I12</a>, <a href="I2.html" title="int\
+                    erface in p">I2</a>, <a href="IT1.html" title="interface in p">IT1<\
+                    /a>&lt;T&gt;, <a href="IT2.html" title="interface in p">IT2</a>&lt;\
                     java.lang.String&gt;</code>""",
                 """
                     <code><a href="#%3Cinit%3E()" class="member-name-link">C3</a>()</code>""");
@@ -90,7 +90,7 @@ public class TestClassLinks extends JavadocTester {
                 """
                     <code><a href="C3.html" title="class in p">C3</a></code>""",
                 """
-                    <code><a href="I1.html" title="interface in p">I1</a></code>, <code><a href="I2.\
+                    <code><a href="I1.html" title="interface in p">I1</a>, <a href="I2.\
                     html" title="interface in p">I2</a></code>""");
 
         checkOutput("p/IT1.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testHiddenTag/TestHiddenTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHiddenTag/TestHiddenTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,8 +59,8 @@ public class TestHiddenTag extends JavadocTester {
                 """
                     <dt>Direct Known Subclasses:</dt>
                     <dd><code><a href="A.VisibleInner.html" title="class in pkg1">A.VisibleInner</a>\
-                    </code>, <code><a href="A.VisibleInnerExtendsInvisibleInner.html" title="class i\
-                    n pkg1">A.VisibleInnerExtendsInvisibleInner</a></code></dd>""");
+                    , <a href="A.VisibleInnerExtendsInvisibleInner.html" title="class in pkg1">A.Vis\
+                    ibleInnerExtendsInvisibleInner</a></code></dd>""");
 
         checkOutput("pkg1/A.html", false,
                 "invisibleField",

--- a/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
+++ b/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
@@ -76,8 +76,8 @@ public class TestInterface extends JavadocTester {
                 """
                     <dl class="notes">
                     <dt>All Known Implementing Classes:</dt>
-                    <dd><code><a href="Child.html" title="class in pkg">Child</a></code>, <code><a h\
-                    ref="Parent.html" title="class in pkg">Parent</a></code></dd>
+                    <dd><code><a href="Child.html" title="class in pkg">Child</a>, <a href="Parent.h\
+                    tml" title="class in pkg">Parent</a></code></dd>
                     </dl>""");
 
         checkOutput("pkg/Child.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
@@ -218,8 +218,8 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <dl class="notes">
                     <dt>All Implemented Interfaces:</dt>
                     <dd><code><a href="SubInterface.html" title="interface in pkg">SubInterface</a>&\
-                    lt;E&gt;</code>, <code><a href="SuperInterface.html" title="interface in pkg">Su\
-                    perInterface</a>&lt;E&gt;</code></dd>
+                    lt;E&gt;, <a href="SuperInterface.html" title="interface in pkg">SuperInterface<\
+                    /a>&lt;E&gt;</code></dd>
                     </dl>""");
 
         checkOutput("pkg/SuperInterface.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,8 +187,8 @@ public class TestPrivateClasses extends JavadocTester {
                     <dl class="notes">
                     <dt>All Implemented Interfaces:</dt>
                     <dd><code><a href="PrivateInterface.html" title="interface in pkg">PrivateInterf\
-                    ace</a></code>, <code><a href="PublicInterface.html" title="interface in pkg">Pu\
-                    blicInterface</a></code></dd>
+                    ace</a>, <a href="PublicInterface.html" title="interface in pkg">PublicInterface\
+                    </a></code></dd>
                     </dl>""",
                 """
                     <div class="type-signature"><span class="modifiers">public class </span><span cl\
@@ -210,9 +210,8 @@ public class TestPrivateClasses extends JavadocTester {
                 """
                     <dl class="notes">
                     <dt>All Known Implementing Classes:</dt>
-                    <dd><code><a href="PrivateParent.html" title="class in pkg">PrivateParent</a></c\
-                    ode>, <code><a href="PublicChild.html" title="class in pkg">PublicChild</a></cod\
-                    e></dd>
+                    <dd><code><a href="PrivateParent.html" title="class in pkg">PrivateParent</a>, <\
+                    a href="PublicChild.html" title="class in pkg">PublicChild</a></code></dd>
                     </dl>""");
 
         checkOutput("pkg/PrivateInterface.html", true,


### PR DESCRIPTION
Please review a trivial change to apply monospace font not just to the class links at the top of class and interface pages, but also to the comma and space characters between them. The comma-space separators currently use proportional font, which results in very narrow spacing that does not match the class name font.

Using the same monospace font for everything makes individual class names more discernible, and makes it easier to pick out individual class names. This is especially true for multiline class lists such as the subinterfaces of `java.lang.Autoclosable` below.

Before:

<img width="862" alt="class-links-old" src="https://github.com/user-attachments/assets/ea9679fa-8b41-46ea-9ad1-1f31bdfc6bce">

After:

<img width="869" alt="class-links-new" src="https://github.com/user-attachments/assets/9d712d1a-5f83-4b49-971e-b06f2f4d1a0c">
