### PR TITLE
8345818: Fix SM cleanup of parsing of System property resource.bundle.debug

### DIFF
--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -3654,8 +3654,7 @@ public abstract class ResourceBundle {
 
     }
 
-    private static final boolean TRACE_ON = Boolean.getBoolean(
-        System.getProperty("resource.bundle.debug", "false"));
+    private static final boolean TRACE_ON = Boolean.getBoolean("resource.bundle.debug");
 
     private static void trace(String format, Object... params) {
         if (TRACE_ON)


### PR DESCRIPTION
Backport this trivial fix to parsing of the system property "resource.bundle.debug" to jdk24.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345818](https://bugs.openjdk.org/browse/JDK-8345818): Fix SM cleanup of parsing of System property resource.bundle.debug (**Bug** - P3)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22664/head:pull/22664` \
`$ git checkout pull/22664`

Update a local copy of the PR: \
`$ git checkout pull/22664` \
`$ git pull https://git.openjdk.org/jdk.git pull/22664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22664`

View PR using the GUI difftool: \
`$ git pr show -t 22664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22664.diff">https://git.openjdk.org/jdk/pull/22664.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22664#issuecomment-2532086062)
</details>
