### PR TITLE
8337995: ZUtils::fill uses std::fill_n

### DIFF
--- a/src/hotspot/share/gc/z/zUtils.cpp
+++ b/src/hotspot/share/gc/z/zUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 #include "gc/z/zUtils.hpp"
 #include "runtime/nonJavaThread.hpp"
 
-#include <algorithm>
-
 const char* ZUtils::thread_name() {
   const Thread* const thread = Thread::current();
   if (thread->is_Named_thread()) {
@@ -38,5 +36,7 @@ const char* ZUtils::thread_name() {
 }
 
 void ZUtils::fill(uintptr_t* addr, size_t count, uintptr_t value) {
-  std::fill_n(addr, count, value);
+  for (uintptr_t* end = addr + count; addr < end; ++addr) {
+    *addr = value;
+  }
 }

--- a/src/hotspot/share/gc/z/zUtils.cpp
+++ b/src/hotspot/share/gc/z/zUtils.cpp
@@ -36,7 +36,7 @@ const char* ZUtils::thread_name() {
 }
 
 void ZUtils::fill(uintptr_t* addr, size_t count, uintptr_t value) {
-  for (uintptr_t* end = addr + count; addr < end; ++addr) {
-    *addr = value;
+  for (size_t i = 0; i < count; ++i) {
+    addr[i] = value;
   }
 }


### PR DESCRIPTION
Please review this change to zUtils.cpp to use a for-loop to fill a block of
memory rather than using the std::fill_n algorithm. Use of <algorithm> is
currently not permitted in HotSpot.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337995](https://bugs.openjdk.org/browse/JDK-8337995): ZUtils::fill uses std::fill_n (**Enhancement** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer) Review applies to [cbfc9708](https://git.openjdk.org/jdk/pull/22667/files/cbfc9708169c12cdbe5c3ddb4a6ba0fa3a2bc662)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) Review applies to [cbfc9708](https://git.openjdk.org/jdk/pull/22667/files/cbfc9708169c12cdbe5c3ddb4a6ba0fa3a2bc662)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22667/head:pull/22667` \
`$ git checkout pull/22667`

Update a local copy of the PR: \
`$ git checkout pull/22667` \
`$ git pull https://git.openjdk.org/jdk.git pull/22667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22667`

View PR using the GUI difftool: \
`$ git pr show -t 22667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22667.diff">https://git.openjdk.org/jdk/pull/22667.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22667#issuecomment-2532252308)
</details>
