### PR TITLE
8345934: Suspicious use of Boolean::getBoolean in WPathGraphics

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,7 @@ final class WPathGraphics extends PathGraphics {
                      "sun.java2d.print.enableGDITextLayout");
 
         if (textLayoutStr != null) {
-            useGDITextLayout = Boolean.getBoolean(textLayoutStr);
+            useGDITextLayout = Boolean.parseBoolean(textLayoutStr);
             if (!useGDITextLayout) {
                 if (textLayoutStr.equalsIgnoreCase("prefer")) {
                     useGDITextLayout = true;


### PR DESCRIPTION
Please consider this PR which replaces `Boolean::getBoolean` with `Boolean::parseBoolean` when `sun.awt.WPathGraphics` evaluates the value already read from the "sun.java2d.print.enableGDITextLayout" system property.

The current use of `Boolean::getBoolean` seems suspicious here, since that method itself reads the system property with the name of the passed argument (it does not evaluate the passed value directly).

Verification:
Since I don't have a Windows client to test this on, would be nice if a reviewer can help verify this change by setting:

`-Dsun.java2d.print.enableGDITextLayout=false` (to verify that it is still enabled)
`-Dsun.java2d.print.enableGDITextLayout=prefer` (to also set `preferGDITextLayout` to true)
`-Dsun.java2d.print.enableGDITextLayout=false` (to disable it)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345934](https://bugs.openjdk.org/browse/JDK-8345934): Suspicious use of Boolean::getBoolean in WPathGraphics (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22668/head:pull/22668` \
`$ git checkout pull/22668`

Update a local copy of the PR: \
`$ git checkout pull/22668` \
`$ git pull https://git.openjdk.org/jdk.git pull/22668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22668`

View PR using the GUI difftool: \
`$ git pr show -t 22668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22668.diff">https://git.openjdk.org/jdk/pull/22668.diff</a>

</details>
