### PR TITLE
8345888: Broken links in the JDK 24 JavaDoc API documentation, build 27

### DIFF
--- a/src/java.desktop/share/classes/javax/print/attribute/standard/PresentationDirection.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/PresentationDirection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import javax.print.attribute.PrintRequestAttribute;
  * <p>
  * <b>IPP Compatibility:</b> This attribute is not an IPP 1.1 attribute; it is
  * an attribute in the Production Printing Extension
- * (<a href="ftp://ftp.pwg.org/pub/pwg/standards/temp_archive/pwg5100.3.pdf">
+ * (<a href="https://ftp.pwg.org/pub/pwg/standards/temp_archive/pwg5100.3.pdf">
  * PDF</a>) of IPP 1.1. The category name returned by {@code getName()} is the
  * IPP attribute name. The enumeration's integer value is the IPP enum value.
  * The {@code toString()} method returns the IPP string representation of the


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 9bd70ec806ac0134926f32e222f4075e3d407422 from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Nizar Benalla on 10 Dec 2024 and was reviewed by [Prasanta Sadhukhan](https://github.com/prsadhuk).

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345888](https://bugs.openjdk.org/browse/JDK-8345888): Broken links in the JDK 24 JavaDoc API documentation, build 27 (**Sub-task** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22669/head:pull/22669` \
`$ git checkout pull/22669`

Update a local copy of the PR: \
`$ git checkout pull/22669` \
`$ git pull https://git.openjdk.org/jdk.git pull/22669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22669`

View PR using the GUI difftool: \
`$ git pr show -t 22669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22669.diff">https://git.openjdk.org/jdk/pull/22669.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22669#issuecomment-2532588328)
</details>
