### PR TITLE
8344802: Crash in StubRoutines::verify_mxcsr with -XX:+EnableX86ECoreOpts and -Xcheck:jni

### DIFF
--- a/Hello.java
+++ b/Hello.java
@@ -1,0 +1,5 @@
+class Hello {
+    public static void main(String[] args) {
+        System.out.println("Hello");
+    }
+}

--- a/Hello.java
+++ b/Hello.java
@@ -1,5 +1,0 @@
-class Hello {
-    public static void main(String[] args) {
-        System.out.println("Hello");
-    }
-}

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2376,6 +2376,20 @@ void MacroAssembler::jump_cc(Condition cc, AddressLiteral dst, Register rscratch
   }
 }
 
+void MacroAssembler::cmp_mxcsr(Address mxcsr_save, Register tmp, Register rscratch) {
+  ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
+  assert(rscratch != noreg || always_reachable(mxcsr_std), "missing");
+  
+  stmxcsr(mxcsr_save);
+  movl(tmp, mxcsr_save);
+  if (EnableX86ECoreOpts) {
+    orl(tmp, 0x003f); // Mask out any pending exceptions (only check control and mask bits)
+  } else {
+    andl(tmp, 0xFFC0); // Mask out any pending exceptions (only check control and mask bits)
+  }
+  cmp32(tmp, mxcsr_std, rscratch);
+}
+
 void MacroAssembler::ldmxcsr(AddressLiteral src, Register rscratch) {
   assert(rscratch != noreg || always_reachable(src), "missing");
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2379,11 +2379,11 @@ void MacroAssembler::jump_cc(Condition cc, AddressLiteral dst, Register rscratch
 void MacroAssembler::cmp_mxcsr(Address mxcsr_save, Register tmp, Register rscratch) {
   ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
   assert(rscratch != noreg || always_reachable(mxcsr_std), "missing");
-  
+
   stmxcsr(mxcsr_save);
   movl(tmp, mxcsr_save);
   if (EnableX86ECoreOpts) {
-    orl(tmp, 0x003f); // Mask out any pending exceptions (only check control and mask bits)
+    orl(tmp, 0x003f);  // Set exceptions bits, addr_mxcsr_std has them set for ECore
   } else {
     andl(tmp, 0xFFC0); // Mask out any pending exceptions (only check control and mask bits)
   }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -780,7 +780,7 @@ void MacroAssembler::warn(const char* msg) {
   push_CPU_state();   // keeps alignment at 16 bytes
 
 #ifdef _WIN64
-  // Windows always allocates space for it's register args
+  // Windows always allocates space for its register args
   subq(rsp,  frame::arg_reg_save_area_bytes);
 #endif
   lea(c_rarg0, ExternalAddress((address) msg));

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2376,16 +2376,17 @@ void MacroAssembler::jump_cc(Condition cc, AddressLiteral dst, Register rscratch
   }
 }
 
-void MacroAssembler::cmp_mxcsr(Address mxcsr_save, Register tmp, Register rscratch) {
+void MacroAssembler::cmp32_mxcsr_std(Address mxcsr_save, Register tmp, Register rscratch) {
   ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
   assert(rscratch != noreg || always_reachable(mxcsr_std), "missing");
 
   stmxcsr(mxcsr_save);
   movl(tmp, mxcsr_save);
+  // Mask out any pending exceptions (only check control and mask bits)
   if (EnableX86ECoreOpts) {
-    orl(tmp, 0x003f);  // Set exceptions bits, addr_mxcsr_std has them set for ECore
+    orl(tmp, 0x003f);  // On Ecore, exception bits are set by default
   } else {
-    andl(tmp, 0xFFC0); // Mask out any pending exceptions (only check control and mask bits)
+    andl(tmp, 0xFFC0);
   }
   cmp32(tmp, mxcsr_std, rscratch);
 }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2390,11 +2390,11 @@ void MacroAssembler::cmp32_mxcsr_std(Address mxcsr_save, Register tmp, Register 
 
   stmxcsr(mxcsr_save);
   movl(tmp, mxcsr_save);
-  // Mask out any pending exceptions (only check control and mask bits)
   if (EnableX86ECoreOpts) {
-    // On Ecore, status bits are set by default (for performance)
-    orl(tmp, 0x003f);  // On Ecore, exception bits are set by default
+    // The mxcsr_std has status bits set for performance on ECore
+    orl(tmp, 0x003f);
   } else {
+    // Mask out status bits (only check control and mask bits)
     andl(tmp, 0xFFC0);
   }
   cmp32(tmp, mxcsr_std, rscratch);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2391,7 +2391,7 @@ void MacroAssembler::cmp32_mxcsr_std(Address mxcsr_save, Register tmp, Register 
   stmxcsr(mxcsr_save);
   movl(tmp, mxcsr_save);
   // Mask out any pending exceptions (only check control and mask bits)
-  if (!EnableX86ECoreOpts) {
+  if (EnableX86ECoreOpts) {
     // On Ecore, status bits are set by default (for performance)
     orl(tmp, 0x003f);  // On Ecore, exception bits are set by default
   } else {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1135,6 +1135,7 @@ public:
   void fmul_s(AddressLiteral src) { Assembler::fmul_s(as_Address(src)); }
 #endif // !_LP64
 
+  void cmp_mxcsr(Address mxcsr_save, Register tmp, Register rscratch = noreg);
   void ldmxcsr(Address src) { Assembler::ldmxcsr(src); }
   void ldmxcsr(AddressLiteral src, Register rscratch = noreg);
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1135,7 +1135,7 @@ public:
   void fmul_s(AddressLiteral src) { Assembler::fmul_s(as_Address(src)); }
 #endif // !_LP64
 
-  void cmp_mxcsr(Address mxcsr_save, Register tmp, Register rscratch = noreg);
+  void cmp32_mxcsr_std(Address mxcsr_save, Register tmp, Register rscratch = noreg);
   void ldmxcsr(Address src) { Assembler::ldmxcsr(src); }
   void ldmxcsr(AddressLiteral src, Register rscratch = noreg);
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -62,7 +62,6 @@
 
 #define BIND(label) bind(label); BLOCK_COMMENT(#label ":")
 
-const int MXCSR_MASK  = 0xFFC0;  // Mask out any pending exceptions
 const int FPU_CNTRL_WRD_MASK = 0xFFFF;
 
 ATTRIBUTE_ALIGNED(16) static const uint32_t KEY_SHUFFLE_MASK[] = {
@@ -175,11 +174,7 @@ class StubGenerator: public StubCodeGenerator {
     // save and initialize %mxcsr
     if (sse_save) {
       Label skip_ldmx;
-      __ stmxcsr(mxcsr_save);
-      __ movl(rax, mxcsr_save);
-      __ andl(rax, MXCSR_MASK);    // Only check control and mask bits
-      ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
-      __ cmp32(rax, mxcsr_std);
+      __ cmp_mxcsr(mxcsr_save, rax, noreg);
       __ jcc(Assembler::equal, skip_ldmx);
       __ ldmxcsr(mxcsr_std);
       __ bind(skip_ldmx);
@@ -465,10 +460,7 @@ class StubGenerator: public StubCodeGenerator {
       ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
       __ push(rax);
       __ subptr(rsp, wordSize);      // allocate a temp location
-      __ stmxcsr(mxcsr_save);
-      __ movl(rax, mxcsr_save);
-      __ andl(rax, MXCSR_MASK);
-      __ cmp32(rax, mxcsr_std);
+      __ cmp_mxcsr(mxcsr_save, rax);
       __ jcc(Assembler::equal, ok_ret);
 
       __ warn("MXCSR changed by native JNI code.");

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -174,7 +174,7 @@ class StubGenerator: public StubCodeGenerator {
     // save and initialize %mxcsr
     if (sse_save) {
       Label skip_ldmx;
-      __ cmp_mxcsr(mxcsr_save, rax, noreg);
+      __ cmp32_mxcsr_std(mxcsr_save, rax);
       __ jcc(Assembler::equal, skip_ldmx);
       __ ldmxcsr(mxcsr_std);
       __ bind(skip_ldmx);
@@ -457,14 +457,14 @@ class StubGenerator: public StubCodeGenerator {
 
     if (CheckJNICalls && UseSSE > 0 ) {
       Label ok_ret;
-      ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
       __ push(rax);
       __ subptr(rsp, wordSize);      // allocate a temp location
-      __ cmp_mxcsr(mxcsr_save, rax);
+      __ cmp32_mxcsr_std(mxcsr_save, rax);
       __ jcc(Assembler::equal, ok_ret);
 
       __ warn("MXCSR changed by native JNI code.");
 
+      ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
       __ ldmxcsr(mxcsr_std);
 
       __ bind(ok_ret);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -248,11 +248,8 @@ address StubGenerator::generate_call_stub(address& return_address) {
   const Address mxcsr_save(rbp, mxcsr_off * wordSize);
   {
     Label skip_ldmx;
-    __ stmxcsr(mxcsr_save);
-    __ movl(rax, mxcsr_save);
-    __ andl(rax, 0xFFC0); // Mask out any pending exceptions (only check control and mask bits)
     ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
-    __ cmp32(rax, mxcsr_std, rscratch1);
+    __ cmp_mxcsr(mxcsr_save, rax, rscratch1);
     __ jcc(Assembler::equal, skip_ldmx);
     __ ldmxcsr(mxcsr_std, rscratch1);
     __ bind(skip_ldmx);
@@ -574,10 +571,7 @@ address StubGenerator::generate_verify_mxcsr() {
     ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
     __ push(rax);
     __ subptr(rsp, wordSize);      // allocate a temp location
-    __ stmxcsr(mxcsr_save);
-    __ movl(rax, mxcsr_save);
-    __ andl(rax, 0xFFC0); // Mask out any pending exceptions (only check control and mask bits)
-    __ cmp32(rax, mxcsr_std, rscratch1);
+    __ cmp_mxcsr(mxcsr_save, rax, rscratch1);
     __ jcc(Assembler::equal, ok_ret);
 
     __ warn("MXCSR changed by native JNI code, use -XX:+RestoreMXCSROnJNICall");

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -248,9 +248,9 @@ address StubGenerator::generate_call_stub(address& return_address) {
   const Address mxcsr_save(rbp, mxcsr_off * wordSize);
   {
     Label skip_ldmx;
-    ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
-    __ cmp_mxcsr(mxcsr_save, rax, rscratch1);
+    __ cmp32_mxcsr_std(mxcsr_save, rax, rscratch1);
     __ jcc(Assembler::equal, skip_ldmx);
+    ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
     __ ldmxcsr(mxcsr_std, rscratch1);
     __ bind(skip_ldmx);
   }
@@ -571,7 +571,7 @@ address StubGenerator::generate_verify_mxcsr() {
     ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
     __ push(rax);
     __ subptr(rsp, wordSize);      // allocate a temp location
-    __ cmp_mxcsr(mxcsr_save, rax, rscratch1);
+    __ cmp32_mxcsr_std(mxcsr_save, rax, rscratch1);
     __ jcc(Assembler::equal, ok_ret);
 
     __ warn("MXCSR changed by native JNI code, use -XX:+RestoreMXCSROnJNICall");

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -77,8 +77,6 @@ static int compute_reg_save_area_size(const ABIDescriptor& abi) {
   return size;
 }
 
-constexpr int MXCSR_MASK = 0xFFC0;  // Mask out any pending exceptions
-
 static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDescriptor& abi, int reg_save_area_offset) {
   // 1. iterate all registers in the architecture
   //     - check if they are volatile or not for the given abi
@@ -115,11 +113,8 @@ static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDesc
   {
     const Address mxcsr_save(rsp, offset);
     Label skip_ldmx;
-    __ stmxcsr(mxcsr_save);
-    __ movl(rax, mxcsr_save);
-    __ andl(rax, MXCSR_MASK);    // Only check control and mask bits
     ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
-    __ cmp32(rax, mxcsr_std, rscratch1);
+    __ cmp_mxcsr(mxcsr_save, rax, rscratch1);
     __ jcc(Assembler::equal, skip_ldmx);
     __ ldmxcsr(mxcsr_std, rscratch1);
     __ bind(skip_ldmx);

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -113,9 +113,9 @@ static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDesc
   {
     const Address mxcsr_save(rsp, offset);
     Label skip_ldmx;
-    ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
-    __ cmp_mxcsr(mxcsr_save, rax, rscratch1);
+    __ cmp32_mxcsr_std(mxcsr_save, rax, rscratch1);
     __ jcc(Assembler::equal, skip_ldmx);
+    ExternalAddress mxcsr_std(StubRoutines::x86::addr_mxcsr_std());
     __ ldmxcsr(mxcsr_std, rscratch1);
     __ bind(skip_ldmx);
   }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2588,7 +2588,7 @@ static bool handle_FLT_exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
     // On Windows, the mxcsr control bits are non-volatile across calls
     // See also CR 6192333
     //
-    jint MxCsr = INITIAL_MXCSR;
+    jint MxCsr = INITIAL_MXCSR; // FIXME? this is `define INITIAL_MXCSR 0x1f80` in windows sdk
     // we can't use StubRoutines::x86::addr_mxcsr_std()
     // because in Win64 mxcsr is not saved there
     if (MxCsr != ctx->MxCsr) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2570,38 +2570,6 @@ LONG Handle_IDiv_Exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
   return EXCEPTION_CONTINUE_EXECUTION;
 }
 
-#if defined(_M_AMD64)
-//-----------------------------------------------------------------------------
-static bool handle_FLT_exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
-  // handle exception caused by native method modifying control word
-  DWORD exception_code = exceptionInfo->ExceptionRecord->ExceptionCode;
-
-  switch (exception_code) {
-  case EXCEPTION_FLT_DENORMAL_OPERAND:
-  case EXCEPTION_FLT_DIVIDE_BY_ZERO:
-  case EXCEPTION_FLT_INEXACT_RESULT:
-  case EXCEPTION_FLT_INVALID_OPERATION:
-  case EXCEPTION_FLT_OVERFLOW:
-  case EXCEPTION_FLT_STACK_CHECK:
-  case EXCEPTION_FLT_UNDERFLOW: {
-    PCONTEXT ctx = exceptionInfo->ContextRecord;
-    // On Windows, the mxcsr control bits are non-volatile across calls
-    // See also CR 6192333
-    //
-    jint MxCsr = INITIAL_MXCSR; // FIXME? this is `define INITIAL_MXCSR 0x1f80` in windows sdk
-    // we can't use StubRoutines::x86::addr_mxcsr_std()
-    // because in Win64 mxcsr is not saved there
-    if (MxCsr != ctx->MxCsr) {
-      ctx->MxCsr = MxCsr;
-      return true;
-    }
-  }
-  }
-
-  return false;
-}
-#endif
-
 static inline void report_error(Thread* t, DWORD exception_code,
                                 address addr, void* siginfo, void* context) {
   VMError::report_and_die(t, exception_code, addr, siginfo, context);
@@ -2786,6 +2754,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
     }
 
 #if defined(_M_AMD64)
+    extern bool handle_FLT_exception(struct _EXCEPTION_POINTERS* exceptionInfo);
     if ((in_java || in_native) && handle_FLT_exception(exceptionInfo)) {
       return EXCEPTION_CONTINUE_EXECUTION;
     }

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -180,7 +180,7 @@ bool handle_FLT_exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
     //
     jint MxCsr = INITIAL_MXCSR; // set to 0x1f80` in winnt.h
     if (EnableX86ECoreOpts) {
-      // On ECore, restore with signaling flags enabled
+      // On ECore restore with status bits enabled
       MxCsr |= 0x3F;
     }
 

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -183,7 +183,7 @@ bool handle_FLT_exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
       // On ECore, restore with signaling flags enabled
       MxCsr |= 0x3F;
     }
-    
+
     // we can't use StubRoutines::x86::addr_mxcsr_std()
     // because in Win64 mxcsr is not saved there
     if (MxCsr != ctx->MxCsr) {

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -160,6 +160,43 @@ bool os::win32::register_code_area(char *low, char *high) {
   return true;
 }
 
+#if defined(_M_AMD64)
+//-----------------------------------------------------------------------------
+bool handle_FLT_exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
+  // handle exception caused by native method modifying control word
+  DWORD exception_code = exceptionInfo->ExceptionRecord->ExceptionCode;
+
+  switch (exception_code) {
+  case EXCEPTION_FLT_DENORMAL_OPERAND:
+  case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+  case EXCEPTION_FLT_INEXACT_RESULT:
+  case EXCEPTION_FLT_INVALID_OPERATION:
+  case EXCEPTION_FLT_OVERFLOW:
+  case EXCEPTION_FLT_STACK_CHECK:
+  case EXCEPTION_FLT_UNDERFLOW: {
+    PCONTEXT ctx = exceptionInfo->ContextRecord;
+    // On Windows, the mxcsr control bits are non-volatile across calls
+    // See also CR 6192333
+    //
+    jint MxCsr = INITIAL_MXCSR; // set to 0x1f80` in winnt.h
+    if (EnableX86ECoreOpts) {
+      // On ECore, restore with signaling flags enabled
+      MxCsr |= 0x3F;
+    }
+    
+    // we can't use StubRoutines::x86::addr_mxcsr_std()
+    // because in Win64 mxcsr is not saved there
+    if (MxCsr != ctx->MxCsr) {
+      ctx->MxCsr = MxCsr;
+      return true;
+    }
+  }
+  }
+
+  return false;
+}
+#endif
+
 #ifdef HAVE_PLATFORM_PRINT_NATIVE_STACK
 /*
  * Windows/x64 does not use stack frames the way expected by Java:

--- a/test/jdk/java/lang/String/IndexOf.java
+++ b/test/jdk/java/lang/String/IndexOf.java
@@ -34,7 +34,7 @@
  * @summary test String indexOf() intrinsic
  * @requires vm.cpu.features ~= ".*avx2.*"
  * @requires vm.compiler2.enabled
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xcomp -XX:-TieredCompilation -XX:UseAVX=2 -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts -XX:-CheckJNICalls IndexOf
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xcomp -XX:-TieredCompilation -XX:UseAVX=2 -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts IndexOf
  */
 
  public class IndexOf {

--- a/test/jdk/java/lang/StringBuffer/ECoreIndexOf.java
+++ b/test/jdk/java/lang/StringBuffer/ECoreIndexOf.java
@@ -34,7 +34,7 @@
  * @summary Test indexOf and lastIndexOf
  * @requires vm.cpu.features ~= ".*avx2.*"
  * @requires vm.compiler2.enabled
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts -XX:-CheckJNICalls -XX:UseAVX=2 -Xbatch -XX:-TieredCompilation -XX:CompileCommand=dontinline,ECoreIndexOf.indexOfKernel ECoreIndexOf
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts -XX:UseAVX=2 -Xbatch -XX:-TieredCompilation -XX:CompileCommand=dontinline,ECoreIndexOf.indexOfKernel ECoreIndexOf
  * @key randomness
  */
 


### PR DESCRIPTION
(Also see `8319429: Resetting MXCSR flags degrades ecore`)

This PR fixes two issues:
- the original issue is a crash caused by `__ warn` corrupting the stack on Windows only
- This issue also uncovered that -Xcheck:jni test cases were getting 65k lines of warning on HelloWorld (on both Linux _and_ windows):
```
OpenJDK 64-Bit Server VM warning: MXCSR changed by native JNI code, use -XX:+RestoreMXCSROnJNICall
```

First, the crash. Caused when FXRSTOR is attempting to write reserved bits into MXCSR. If those bits happen to be set, crash. (Hence the crash isn't deterministic. But frequent enough if `__ warn` is used). It is caused by the binding not reserving stack space for register parameters ()
![image](https://github.com/user-attachments/assets/4ad63908-088b-4e9d-9e7d-a3509bee046a)
Prolog of the warn function then proceeds to store the for arg registers onto the stack, overriding the fxstore save area. (See https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#calling-convention-defaults)

Fix uses `frame::arg_reg_save_area_bytes` to bump the stack pointer.

---

I also kept the fix to `verify_mxcsr` since without it, `-Xcheck:jni` is practically unusable when `-XX:+EnableX86ECoreOpts` are set (65k+ lines of warnings)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344802](https://bugs.openjdk.org/browse/JDK-8344802): Crash in StubRoutines::verify_mxcsr with -XX:+EnableX86ECoreOpts and -Xcheck:jni (**Bug** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**) Review applies to [b23764ab](https://git.openjdk.org/jdk/pull/22673/files/b23764ab56c3729598b52bdb660e43e342f9286b)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22673/head:pull/22673` \
`$ git checkout pull/22673`

Update a local copy of the PR: \
`$ git checkout pull/22673` \
`$ git pull https://git.openjdk.org/jdk.git pull/22673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22673`

View PR using the GUI difftool: \
`$ git pr show -t 22673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22673.diff">https://git.openjdk.org/jdk/pull/22673.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22673#issuecomment-2533406495)
</details>
