### PR TITLE
8345955: Deprecate the UseOprofile flag with a view to removing the legacy oprofile support in the VM

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -36,7 +36,7 @@
                          constraint)                                    \
                                                                         \
   product(bool, UseOprofile, false,                                     \
-        "enable support for Oprofile profiler")                         \
+        "(Deprecated) enable support for Oprofile profiler")            \
                                                                         \
   product(bool, UseTransparentHugePages, false,                         \
           "Use MADV_HUGEPAGE for large pages")                          \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -524,6 +524,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "UseSharedSpaces",              JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
 #ifdef LINUX
   { "UseLinuxPosixThreadCPUClocks", JDK_Version::jdk(24), JDK_Version::jdk(25), JDK_Version::jdk(26) },
+  { "UseOprofile",                  JDK_Version::jdk(25), JDK_Version::jdk(26), JDK_Version::jdk(27) },
 #endif
   { "LockingMode",                  JDK_Version::jdk(24), JDK_Version::jdk(26), JDK_Version::jdk(27) },
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -63,6 +63,13 @@ public class VMDeprecatedOptions {
             {"CreateMinidumpOnCrash", "false"}
           }
         ));
+        if (Platform.isLinux()) {
+          deprecated.addAll(
+            Arrays.asList(new String[][] {
+              {"UseOprofile", "false"}
+            })
+          );
+        }
         if (Platform.isX86() || Platform.isX64()) {
           deprecated.addAll(
             Arrays.asList(new String[][] {


### PR DESCRIPTION
Please review this simple change to deprecate the `UseOprofile` flag in JDK 25, with a view to obsoleting it in JDK 26.

The VM has supported the Linux OProfile profiler since 2005, however to work properly with OProfile's Linux kernel module (ref lookup_dcookie()), the VM has to change the way compiled code memory is mapped. That is done under the control of the UseOprofile flag (default false). Since 2012 OProfile has not needed the kernel module, and it was removed from the kernel in 2021. Consequently this special code and the UseOprofile flag are not needed.

Could I also get a Reviewer for the CSR request please.

Testing: tiers 1-3 (sanity)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8345956](https://bugs.openjdk.org/browse/JDK-8345956) to be approved

### Issues
 * [JDK-8345955](https://bugs.openjdk.org/browse/JDK-8345955): Deprecate the UseOprofile flag with a view to removing the legacy oprofile support in the VM (**Enhancement** - P4)
 * [JDK-8345956](https://bugs.openjdk.org/browse/JDK-8345956): Deprecate the UseOprofile flag with a view to removing the legacy oprofile support in the VM (**CSR**)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22674/head:pull/22674` \
`$ git checkout pull/22674`

Update a local copy of the PR: \
`$ git checkout pull/22674` \
`$ git pull https://git.openjdk.org/jdk.git pull/22674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22674`

View PR using the GUI difftool: \
`$ git pr show -t 22674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22674.diff">https://git.openjdk.org/jdk/pull/22674.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22674#issuecomment-2533356633)
</details>
