### PR TITLE
8345622: test/langtools/tools/javac/annotations/parameter/ParameterAnnotations.java should set processorpath to work correctly in the agentvm mode

### DIFF
--- a/test/langtools/tools/javac/annotations/parameter/ParameterAnnotations.java
+++ b/test/langtools/tools/javac/annotations/parameter/ParameterAnnotations.java
@@ -640,8 +640,9 @@ public class ParameterAnnotations extends TestRunner {
         }
 
         Task.Result result = new JavacTask(tb)
-                .processors(new TestAP())
                 .options("-classpath", classes.toString(),
+                        "-processorpath", System.getProperty("test.classes"),
+                        "-processor", TestAP.class.getName(),
                         "-XDrawDiagnostics",
                         "-Xlint:classfile")
                 .outdir(classes)


### PR DESCRIPTION
There is a small difference in the `run main` action when the tests are run using the jtreg's `othervm` mode and `agentvm` mode: in the `othervm`, the test class(es) are load using the application `ClassLoader`, in the `agentvm` mode, the test class(es) are load using an additional jtreg's `ClassLoader`.

In most cases, this does not make much difference, but there's a difference when javac looks up annotation processors (or `Plugin`s): the `othervm` mode, javac can lookup the APs without any help, but in the `agentvm` mode, the `-processorpath` needs to be specified, so that the AP can be load from the correct place.

This patch undoes this (temporary) change:
https://github.com/openjdk/jdk/commit/496641955041c5e48359e6256a4a61812653d900#diff-4a737e56ccac351e29c3b2c2313d854284ec489aa56c78f09d374d9e20bbb4ecR643

and sets the `-processorpath`, so that the AP can be load. This is consistent with how other similar javac's tests work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345622](https://bugs.openjdk.org/browse/JDK-8345622): test/langtools/tools/javac/annotations/parameter/ParameterAnnotations.java should set processorpath to work correctly in the agentvm mode (**Bug** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22676/head:pull/22676` \
`$ git checkout pull/22676`

Update a local copy of the PR: \
`$ git checkout pull/22676` \
`$ git pull https://git.openjdk.org/jdk.git pull/22676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22676`

View PR using the GUI difftool: \
`$ git pr show -t 22676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22676.diff">https://git.openjdk.org/jdk/pull/22676.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22676#issuecomment-2535220621)
</details>
