### PR TITLE
8346007: Incorrect copyright header in UModLNodeIdealizationTests.java

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/UModLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/UModLNodeIdealizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Fixes a missing comma in the copyright notice.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346007](https://bugs.openjdk.org/browse/JDK-8346007): Incorrect copyright header in UModLNodeIdealizationTests.java (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22683/head:pull/22683` \
`$ git checkout pull/22683`

Update a local copy of the PR: \
`$ git checkout pull/22683` \
`$ git pull https://git.openjdk.org/jdk.git pull/22683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22683`

View PR using the GUI difftool: \
`$ git pr show -t 22683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22683.diff">https://git.openjdk.org/jdk/pull/22683.diff</a>

</details>
