### PR TITLE
8346008: Fix recent NULL usage backsliding in Shenandoah

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -793,7 +793,7 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
   // Free set maintains mutator and collector partitions.  Normally, each allocates only from its partition,
   // except in special cases when the collector steals regions from the mutator partition.
 
-  // Overwrite with non-zero (non-NULL) values only if necessary for allocation bookkeeping.
+  // Overwrite with non-zero (non-null) values only if necessary for allocation bookkeeping.
 
   switch (req.type()) {
     case ShenandoahAllocRequest::_alloc_tlab:

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalEvacuationTask.cpp
@@ -202,7 +202,7 @@ void ShenandoahGenerationalEvacuationTask::promote_in_place(ShenandoahHeapRegion
   while (obj_addr < tams) {
     oop obj = cast_to_oop(obj_addr);
     if (marking_context->is_marked(obj)) {
-      assert(obj->klass() != nullptr, "klass should not be NULL");
+      assert(obj->klass() != nullptr, "klass should not be null");
       // This thread is responsible for registering all objects in this region.  No need for lock.
       scanner->register_object_without_lock(obj_addr);
       obj_addr += obj->size();


### PR DESCRIPTION
Hi all, 

This PR addresses [8346008](https://bugs.openjdk.org/browse/JDK-8346008). It's a follow-up from [8345647](https://bugs.openjdk.org/browse/JDK-8345647) with some cases I missed. 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346008](https://bugs.openjdk.org/browse/JDK-8346008): Fix recent NULL usage backsliding in Shenandoah (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22684/head:pull/22684` \
`$ git checkout pull/22684`

Update a local copy of the PR: \
`$ git checkout pull/22684` \
`$ git pull https://git.openjdk.org/jdk.git pull/22684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22684`

View PR using the GUI difftool: \
`$ git pr show -t 22684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22684.diff">https://git.openjdk.org/jdk/pull/22684.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22684#issuecomment-2536437059)
</details>
