### PR TITLE
8345959: Make JVM_IsStaticallyLinked JVM_LEAF

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3299,7 +3299,7 @@ JVM_LEAF(jboolean, JVM_IsForeignLinkerSupported(void))
   return ForeignGlobals::is_foreign_linker_supported() ? JNI_TRUE : JNI_FALSE;
 JVM_END
 
-JVM_ENTRY_NO_ENV(jboolean, JVM_IsStaticallyLinked(void))
+JVM_LEAF(jboolean, JVM_IsStaticallyLinked(void))
   return is_vm_statically_linked() ? JNI_TRUE : JNI_FALSE;
 JVM_END
 


### PR DESCRIPTION
Please review this simple fix that changes JVM_IsStaticallyLinked from JVM_ENTRY_NO_ENV to JVM_LEAF. Please see context in https://bugs.openjdk.org/browse/JDK-8345959, thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345959](https://bugs.openjdk.org/browse/JDK-8345959): Make JVM_IsStaticallyLinked JVM_LEAF (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22685/head:pull/22685` \
`$ git checkout pull/22685`

Update a local copy of the PR: \
`$ git checkout pull/22685` \
`$ git pull https://git.openjdk.org/jdk.git pull/22685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22685`

View PR using the GUI difftool: \
`$ git pr show -t 22685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22685.diff">https://git.openjdk.org/jdk/pull/22685.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22685#issuecomment-2536495283)
</details>
