### PR TITLE
8345635: JVMCI compiler should not be disabled by java -Xshare:dump

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -433,6 +433,11 @@ bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_fla
       // By default, -Xshare:dump runs in interpreter-only mode, which is required for
       // generating deterministic archives when building the JDK.
       //
+      // We check the JVMCI flags here to avoid running with -Xint when the JVMCI compiler is used.
+      // Ideally we should only check EnableJVMCI, but that flag can be ergonomically enabled
+      // in CompilerConfig::check_args_consistency(), which is called after the current function returns.
+      // So we have to manually check all the relevant flags here. TODO: This should be refactored.
+      //
       // If your classlist is large and you don't care about deterministic dumping, you can use
       // -Xshare:dump -Xmixed to improve dumping speed.
       Arguments::set_mode_flags(Arguments::_int);

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -429,7 +429,7 @@ bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_fla
   }
 
   if (is_dumping_static_archive()) {
-    if (!mode_flag_cmd_line JVMCI_ONLY(&& !UseJVMCICompiler && !UseGraalJIT && !EnableJVMCIProduct)) {
+    if (!mode_flag_cmd_line JVMCI_ONLY(&& !UseJVMCICompiler && !UseGraalJIT && !EnableJVMCIProduct && !EnableJVMCI)) {
       // By default, -Xshare:dump runs in interpreter-only mode, which is required for
       // generating deterministic archives when building the JDK.
       //

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -429,7 +429,7 @@ bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_fla
   }
 
   if (is_dumping_static_archive()) {
-    if (!mode_flag_cmd_line JVMCI_ONLY(&& !UseJVMCICompiler && !UseGraalJIT)) {
+    if (!mode_flag_cmd_line JVMCI_ONLY(&& !UseJVMCICompiler && !UseGraalJIT && !EnableJVMCIProduct)) {
       // By default, -Xshare:dump runs in interpreter-only mode, which is required for
       // generating deterministic archives when building the JDK.
       //

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -429,8 +429,9 @@ bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_fla
   }
 
   if (is_dumping_static_archive()) {
-    if (!mode_flag_cmd_line) {
-      // By default, -Xshare:dump runs in interpreter-only mode, which is required for deterministic archive.
+    if (!mode_flag_cmd_line JVMCI_ONLY(&& !UseJVMCICompiler && !UseGraalJIT)) {
+      // By default, -Xshare:dump runs in interpreter-only mode, which is required for
+      // generating deterministic archives when building the JDK.
       //
       // If your classlist is large and you don't care about deterministic dumping, you can use
       // -Xshare:dump -Xmixed to improve dumping speed.


### PR DESCRIPTION
This PR fixes failures when using  `-XX:+UseJVMCICompiler` with tersts like runtime/cds/appcds/resolvedConstants/AOTLinkedLambdas.java

By default, `java -Xshare:dump` runs the JVM in interpreter-only mode (as if `-Xint` was specified). This behavior is required only when generating deterministic archives during the JDK build. Since those archives are never generated using JVMCI compiler anyway, we don't need to force `-Xint` when `java -Xshare:dump -XX:+UseJVMCICompiler` is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345635](https://bugs.openjdk.org/browse/JDK-8345635): JVMCI compiler should not be disabled by java -Xshare:dump (**Bug** - P3)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**) 🔄 Re-review required (review applies to [f9c83e7c](https://git.openjdk.org/jdk/pull/22687/files/f9c83e7c147176d54ba84c8f72b80f8577b43016))
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**) 🔄 Re-review required (review applies to [f9c83e7c](https://git.openjdk.org/jdk/pull/22687/files/f9c83e7c147176d54ba84c8f72b80f8577b43016))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22687/head:pull/22687` \
`$ git checkout pull/22687`

Update a local copy of the PR: \
`$ git checkout pull/22687` \
`$ git pull https://git.openjdk.org/jdk.git pull/22687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22687`

View PR using the GUI difftool: \
`$ git pr show -t 22687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22687.diff">https://git.openjdk.org/jdk/pull/22687.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22687#issuecomment-2536968401)
</details>
