### PR TITLE
8346039: [BACKOUT] - [C1] LIR Operations with one input should be implemented as LIR_Op1

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -777,11 +777,13 @@ void LIRGenerator::do_MathIntrinsic(Intrinsic* x) {
         }
         case vmIntrinsics::_floatToFloat16: {
           LIR_Opr tmp = new_register(T_FLOAT);
+          __ move(LIR_OprFact::floatConst(-0.0), tmp);
           __ f2hf(src, dst, tmp);
           break;
         }
         case vmIntrinsics::_float16ToFloat: {
           LIR_Opr tmp = new_register(T_FLOAT);
+          __ move(LIR_OprFact::floatConst(-0.0), tmp);
           __ hf2f(src, dst, tmp);
           break;
         }

--- a/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
@@ -696,6 +696,8 @@ void LIRGenerator::do_MathIntrinsic(Intrinsic* x) {
       value.load_item();
       LIR_Opr dst = rlock_result(x);
       LIR_Opr tmp = new_register(T_FLOAT);
+      // f2hf treats tmp as live_in. Workaround: initialize to some value.
+      __ move(LIR_OprFact::floatConst(-0.0), tmp); // just to satisfy LinearScan
       __ f2hf(value.result(), dst, tmp);
       break;
     }

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -349,9 +349,11 @@ void LIRGenerator::do_NegateOp(NegateOp* x) {
   if (UseAVX > 2 && !VM_Version::supports_avx512vl()) {
     if (x->type()->tag() == doubleTag) {
       tmp = new_register(T_DOUBLE);
+      __ move(LIR_OprFact::doubleConst(-0.0), tmp);
     }
     else if (x->type()->tag() == floatTag) {
       tmp = new_register(T_FLOAT);
+      __ move(LIR_OprFact::floatConst(-0.0), tmp);
     }
   }
 #endif
@@ -832,10 +834,12 @@ void LIRGenerator::do_MathIntrinsic(Intrinsic* x) {
   if (UseAVX > 2 && (!VM_Version::supports_avx512vl()) &&
       (x->id() == vmIntrinsics::_dabs)) {
     tmp = new_register(T_DOUBLE);
+    __ move(LIR_OprFact::doubleConst(-0.0), tmp);
   }
 #endif
   if (x->id() == vmIntrinsics::_floatToFloat16) {
     tmp = new_register(T_FLOAT);
+    __ move(LIR_OprFact::floatConst(-0.0), tmp);
   }
 
   switch(x->id()) {

--- a/src/hotspot/cpu/x86/c1_LinearScan_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LinearScan_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -635,24 +635,6 @@ void FpuStackAllocator::handle_op1(LIR_Op1* op1) {
       break;
     }
 
-    case lir_abs:
-    case lir_sqrt:
-    case lir_neg: {
-      assert(in->is_fpu_register(), "must be");
-      assert(res->is_fpu_register(), "must be");
-      assert(in->is_last_use(), "old value gets destroyed");
-
-      insert_free_if_dead(res, in);
-      insert_exchange(in);
-      do_rename(in, res);
-
-      new_in = to_fpu_stack_top(res);
-      new_res = new_in;
-
-      op1->set_fpu_stack_size(sim()->stack_size());
-      break;
-    }
-
     default: {
       assert(!in->is_float_kind() && !res->is_float_kind(), "missed a fpu-operation");
     }
@@ -771,6 +753,26 @@ void FpuStackAllocator::handle_op2(LIR_Op2* op2) {
       do_rename(right, res);
 
       new_res = to_fpu_stack_top(res);
+      break;
+    }
+
+    case lir_abs:
+    case lir_sqrt:
+    case lir_neg: {
+      // Right argument appears to be unused
+      assert(right->is_illegal(), "must be");
+      assert(left->is_fpu_register(), "must be");
+      assert(res->is_fpu_register(), "must be");
+      assert(left->is_last_use(), "old value gets destroyed");
+
+      insert_free_if_dead(res, left);
+      insert_exchange(left);
+      do_rename(left, res);
+
+      new_left = to_fpu_stack_top(res);
+      new_res = new_left;
+
+      op2->set_fpu_stack_size(sim()->stack_size());
       break;
     }
 

--- a/src/hotspot/cpu/x86/c1_LinearScan_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_LinearScan_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,35 @@ inline bool LinearScan::is_caller_save(int assigned_reg) {
 
 
 inline void LinearScan::pd_add_temps(LIR_Op* op) {
-  // No special case behaviours yet
+  switch (op->code()) {
+    case lir_tan: {
+      // The slow path for these functions may need to save and
+      // restore all live registers but we don't want to save and
+      // restore everything all the time, so mark the xmms as being
+      // killed.  If the slow path were explicit or we could propagate
+      // live register masks down to the assembly we could do better
+      // but we don't have any easy way to do that right now.  We
+      // could also consider not killing all xmm registers if we
+      // assume that slow paths are uncommon but it's not clear that
+      // would be a good idea.
+      if (UseSSE > 0) {
+#ifdef ASSERT
+        if (TraceLinearScanLevel >= 2) {
+          tty->print_cr("killing XMMs for trig");
+        }
+#endif
+        int num_caller_save_xmm_regs = FrameMap::get_num_caller_save_xmms();
+        int op_id = op->id();
+        for (int xmm = 0; xmm < num_caller_save_xmm_regs; xmm++) {
+          LIR_Opr opr = FrameMap::caller_save_xmm_reg_at(xmm);
+          add_temp(reg_num(opr), op_id, noUse, T_ILLEGAL);
+        }
+      }
+      break;
+    }
+    default:
+      break;
+  }
 }
 
 

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -452,18 +452,12 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_monaddr:        // input and result always valid, info always invalid
     case lir_null_check:     // input and info always valid, result always invalid
     case lir_move:           // input and result always valid, may have info
-    case lir_sqrt:           // FP Ops have no info, but input and result
-    case lir_abs:
-    case lir_neg:
-    case lir_f2hf:
-    case lir_hf2f:
     {
       assert(op->as_Op1() != nullptr, "must be");
       LIR_Op1* op1 = (LIR_Op1*)op;
 
       if (op1->_info)                  do_info(op1->_info);
       if (op1->_opr->is_valid())       do_input(op1->_opr);
-      if (op1->_tmp->is_valid())       do_temp(op1->_tmp);
       if (op1->_result->is_valid())    do_output(op1->_result);
 
       break;
@@ -489,7 +483,6 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
       assert(op1->_info != nullptr, "");  do_info(op1->_info);
       if (op1->_opr->is_valid())       do_temp(op1->_opr); // safepoints on SPARC need temporary register
-      assert(op1->_tmp->is_illegal(), "not used");
       assert(op1->_result->is_illegal(), "safepoint does not produce value");
 
       break;
@@ -573,6 +566,11 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
     case lir_add:
     case lir_sub:
     case lir_rem:
+    case lir_sqrt:
+    case lir_abs:
+    case lir_neg:
+    case lir_f2hf:
+    case lir_hf2f:
     case lir_logic_and:
     case lir_logic_or:
     case lir_logic_xor:
@@ -669,7 +667,6 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
 
       assert(op1->_info == nullptr, "no info");
       assert(op1->_opr->is_valid(), "exception oop");         do_input(op1->_opr);
-      assert(op1->_tmp->is_illegal(), "not used");
       assert(op1->_result->is_illegal(), "no result");
 
       break;
@@ -1733,11 +1730,6 @@ const char * LIR_Op::name() const {
      case lir_cond_float_branch:     s = "flt_cond_br";   break;
      case lir_move:                  s = "move";          break;
      case lir_roundfp:               s = "roundfp";       break;
-     case lir_abs:                   s = "abs";           break;
-     case lir_neg:                   s = "neg";           break;
-     case lir_sqrt:                  s = "sqrt";          break;
-     case lir_f2hf:                  s = "f2hf";          break;
-     case lir_hf2f:                  s = "hf2f";          break;
      case lir_rtcall:                s = "rtcall";        break;
      case lir_throw:                 s = "throw";         break;
      case lir_unwind:                s = "unwind";        break;
@@ -1754,6 +1746,11 @@ const char * LIR_Op::name() const {
      case lir_mul:                   s = "mul";           break;
      case lir_div:                   s = "div";           break;
      case lir_rem:                   s = "rem";           break;
+     case lir_abs:                   s = "abs";           break;
+     case lir_neg:                   s = "neg";           break;
+     case lir_sqrt:                  s = "sqrt";          break;
+     case lir_f2hf:                  s = "f2hf";          break;
+     case lir_hf2f:                  s = "hf2f";          break;
      case lir_logic_and:             s = "logic_and";     break;
      case lir_logic_or:              s = "logic_or";      break;
      case lir_logic_xor:             s = "logic_xor";     break;

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -939,11 +939,6 @@ enum LIR_Code {
       , lir_alloc_object
       , lir_monaddr
       , lir_roundfp
-      , lir_sqrt
-      , lir_abs
-      , lir_neg
-      , lir_f2hf
-      , lir_hf2f
       , lir_safepoint
       , lir_unwind
       , lir_load_klass
@@ -960,6 +955,13 @@ enum LIR_Code {
       , lir_mul
       , lir_div
       , lir_rem
+      , lir_sqrt
+      , lir_abs
+      , lir_neg
+      , lir_tan
+      , lir_f2hf
+      , lir_hf2f
+      , lir_log10
       , lir_logic_and
       , lir_logic_or
       , lir_logic_xor
@@ -1355,7 +1357,6 @@ class LIR_Op1: public LIR_Op {
 
  protected:
   LIR_Opr         _opr;   // input operand
-  LIR_Opr         _tmp;
   BasicType       _type;  // Operand types
   LIR_PatchCode   _patch; // only required with patchin (NEEDS_CLEANUP: do we want a special instruction for patching?)
 
@@ -1370,21 +1371,12 @@ class LIR_Op1: public LIR_Op {
   LIR_Op1(LIR_Code code, LIR_Opr opr, LIR_Opr result = LIR_OprFact::illegalOpr, BasicType type = T_ILLEGAL, LIR_PatchCode patch = lir_patch_none, CodeEmitInfo* info = nullptr)
     : LIR_Op(code, result, info)
     , _opr(opr)
-    , _tmp(LIR_OprFact::illegalOpr)
-    , _type(type)
-    , _patch(patch)                    { assert(is_in_range(code, begin_op1, end_op1), "code check"); }
-
-  LIR_Op1(LIR_Code code, LIR_Opr opr, LIR_Opr result, LIR_Opr tmp, BasicType type = T_ILLEGAL, LIR_PatchCode patch = lir_patch_none, CodeEmitInfo* info = nullptr)
-    : LIR_Op(code, result, info)
-    , _opr(opr)
-    , _tmp(tmp)
     , _type(type)
     , _patch(patch)                    { assert(is_in_range(code, begin_op1, end_op1), "code check"); }
 
   LIR_Op1(LIR_Code code, LIR_Opr opr, LIR_Opr result, BasicType type, LIR_PatchCode patch, CodeEmitInfo* info, LIR_MoveKind kind)
     : LIR_Op(code, result, info)
     , _opr(opr)
-    , _tmp(LIR_OprFact::illegalOpr)
     , _type(type)
     , _patch(patch)                    {
     assert(code == lir_move, "must be");
@@ -1394,12 +1386,10 @@ class LIR_Op1: public LIR_Op {
   LIR_Op1(LIR_Code code, LIR_Opr opr, CodeEmitInfo* info)
     : LIR_Op(code, LIR_OprFact::illegalOpr, info)
     , _opr(opr)
-    , _tmp(LIR_OprFact::illegalOpr)
     , _type(T_ILLEGAL)
     , _patch(lir_patch_none)           { assert(is_in_range(code, begin_op1, end_op1), "code check"); }
 
   LIR_Opr in_opr()           const               { return _opr;   }
-  LIR_Opr tmp_opr()          const               { return _tmp;   }
   LIR_PatchCode patch_code() const               { return _patch; }
   BasicType type()           const               { return _type;  }
 
@@ -2282,13 +2272,15 @@ class LIR_List: public CompilationResourceObj {
   void cas_int(LIR_Opr addr, LIR_Opr cmp_value, LIR_Opr new_value,
                LIR_Opr t1, LIR_Opr t2, LIR_Opr result = LIR_OprFact::illegalOpr);
 
-  void abs (LIR_Opr from, LIR_Opr to, LIR_Opr tmp)                { append(new LIR_Op1(lir_abs , from, to, tmp)); }
-  void negate(LIR_Opr from, LIR_Opr to, LIR_Opr tmp = LIR_OprFact::illegalOpr) { append(new LIR_Op1(lir_neg, from, to, tmp)); }
-  void sqrt(LIR_Opr from, LIR_Opr to, LIR_Opr tmp)                { append(new LIR_Op1(lir_sqrt, from, to, tmp)); }
+  void abs (LIR_Opr from, LIR_Opr to, LIR_Opr tmp)                { append(new LIR_Op2(lir_abs , from, tmp, to)); }
+  void negate(LIR_Opr from, LIR_Opr to, LIR_Opr tmp = LIR_OprFact::illegalOpr)              { append(new LIR_Op2(lir_neg, from, tmp, to)); }
+  void sqrt(LIR_Opr from, LIR_Opr to, LIR_Opr tmp)                { append(new LIR_Op2(lir_sqrt, from, tmp, to)); }
   void fmad(LIR_Opr from, LIR_Opr from1, LIR_Opr from2, LIR_Opr to) { append(new LIR_Op3(lir_fmad, from, from1, from2, to)); }
   void fmaf(LIR_Opr from, LIR_Opr from1, LIR_Opr from2, LIR_Opr to) { append(new LIR_Op3(lir_fmaf, from, from1, from2, to)); }
-  void f2hf(LIR_Opr from, LIR_Opr to, LIR_Opr tmp)                { append(new LIR_Op1(lir_f2hf, from, to, tmp)); }
-  void hf2f(LIR_Opr from, LIR_Opr to, LIR_Opr tmp)                { append(new LIR_Op1(lir_hf2f, from, to, tmp)); }
+  void log10 (LIR_Opr from, LIR_Opr to, LIR_Opr tmp)              { append(new LIR_Op2(lir_log10, from, LIR_OprFact::illegalOpr, to, tmp)); }
+  void tan (LIR_Opr from, LIR_Opr to, LIR_Opr tmp1, LIR_Opr tmp2) { append(new LIR_Op2(lir_tan , from, tmp1, to, tmp2)); }
+  void f2hf(LIR_Opr from, LIR_Opr to, LIR_Opr tmp)                { append(new LIR_Op2(lir_f2hf, from, tmp, to)); }
+  void hf2f(LIR_Opr from, LIR_Opr to, LIR_Opr tmp)                { append(new LIR_Op2(lir_hf2f, from, tmp, to)); }
 
   void add (LIR_Opr left, LIR_Opr right, LIR_Opr res)      { append(new LIR_Op2(lir_add, left, right, res)); }
   void sub (LIR_Opr left, LIR_Opr right, LIR_Opr res, CodeEmitInfo* info = nullptr) { append(new LIR_Op2(lir_sub, left, right, res, info)); }

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -527,17 +527,6 @@ void LIR_Assembler::emit_op1(LIR_Op1* op) {
       break;
     }
 
-    case lir_abs:
-    case lir_sqrt:
-    case lir_f2hf:
-    case lir_hf2f:
-      intrinsic_op(op->code(), op->in_opr(), op->tmp_opr(), op->result_opr(), op);
-      break;
-
-    case lir_neg:
-      negate(op->in_opr(), op->result_opr(), op->tmp_opr());
-      break;
-
     case lir_return: {
       assert(op->as_OpReturn() != nullptr, "sanity");
       LIR_OpReturn *ret_op = (LIR_OpReturn*)op;
@@ -733,6 +722,19 @@ void LIR_Assembler::emit_op2(LIR_Op2* op) {
         op->result_opr(),
         op->info(),
         op->fpu_pop_count() == 1);
+      break;
+
+    case lir_abs:
+    case lir_sqrt:
+    case lir_tan:
+    case lir_log10:
+    case lir_f2hf:
+    case lir_hf2f:
+      intrinsic_op(op->code(), op->in_opr1(), op->in_opr2(), op->result_opr(), op);
+      break;
+
+    case lir_neg:
+      negate(op->in_opr1(), op->result_opr(), op->in_opr2());
       break;
 
     case lir_logic_and:

--- a/src/hotspot/share/c1/c1_LIRAssembler.hpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,7 +208,7 @@ class LIR_Assembler: public CompilationResourceObj {
 
   void arith_op(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Opr dest, CodeEmitInfo* info, bool pop_fpu_stack);
   void arithmetic_idiv(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Opr temp, LIR_Opr result, CodeEmitInfo* info);
-  void intrinsic_op(LIR_Code code, LIR_Opr value, LIR_Opr temp, LIR_Opr dest, LIR_Op* op);
+  void intrinsic_op(LIR_Code code, LIR_Opr value, LIR_Opr unused, LIR_Opr dest, LIR_Op* op);
 #ifdef ASSERT
   void emit_assert(LIR_OpAssert* op);
 #endif

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -6739,6 +6739,7 @@ void LinearScanStatistic::collect(LinearScan* allocator) {
         case lir_abs:
         case lir_f2hf:
         case lir_hf2f:
+        case lir_log10:
         case lir_logic_and:
         case lir_logic_or:
         case lir_logic_xor:


### PR DESCRIPTION
Revert "8345609: [C1] LIR Operations with one input should be implemented as LIR_Op1"

This reverts commit a21d21f4d7b74e21f68b6bf9c5dc9ba7d3f9963c.

Testing tiers 1-3 in progress

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346039](https://bugs.openjdk.org/browse/JDK-8346039): [BACKOUT] - [C1] LIR Operations with one input should be implemented as LIR_Op1 (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22690/head:pull/22690` \
`$ git checkout pull/22690`

Update a local copy of the PR: \
`$ git checkout pull/22690` \
`$ git pull https://git.openjdk.org/jdk.git pull/22690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22690`

View PR using the GUI difftool: \
`$ git pr show -t 22690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22690.diff">https://git.openjdk.org/jdk/pull/22690.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22690#issuecomment-2537125881)
</details>
