### PR TITLE
8345970: pthread_getcpuclockid related crashes in shenandoah tests

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -180,8 +180,8 @@ void ShenandoahGenerationalHeap::gc_threads_do(ThreadClosure* tcl) const {
 }
 
 void ShenandoahGenerationalHeap::stop() {
-  regulator_thread()->stop();
   ShenandoahHeap::stop();
+  regulator_thread()->stop();
 }
 
 void ShenandoahGenerationalHeap::evacuate_collection_set(bool concurrent) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1467,19 +1467,15 @@ void ShenandoahHeap::gc_threads_do(ThreadClosure* tcl) const {
   }
 
   if (_control_thread != nullptr) {
-    log_info(gc)("Do control thread");
     tcl->do_thread(_control_thread);
   }
 
   if (_uncommit_thread != nullptr) {
-    log_info(gc)("Do uncommit thread");
     tcl->do_thread(_uncommit_thread);
   }
 
-  log_info(gc)("Do workers");
   workers()->threads_do(tcl);
   if (_safepoint_workers != nullptr) {
-    log_info(gc)("Do safepoint workers");
     _safepoint_workers->threads_do(tcl);
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -639,6 +639,9 @@ public:
 void ShenandoahHeap::post_initialize() {
   CollectedHeap::post_initialize();
 
+  // Schedule periodic task to report on gc thread CPU utilization
+  _mmu_tracker.initialize();
+
   MutexLocker ml(Threads_lock);
 
   ShenandoahInitWorkerGCLABClosure init_gclabs;
@@ -652,8 +655,6 @@ void ShenandoahHeap::post_initialize() {
     _safepoint_workers->set_initialize_gclab();
   }
 
-  // Schedule periodic task to report on gc thread CPU utilization
-  _mmu_tracker.initialize();
   JFR_ONLY(ShenandoahJFRSupport::register_jfr_type_serializers();)
 }
 
@@ -1466,15 +1467,19 @@ void ShenandoahHeap::gc_threads_do(ThreadClosure* tcl) const {
   }
 
   if (_control_thread != nullptr) {
+    log_info(gc)("Do control thread");
     tcl->do_thread(_control_thread);
   }
 
   if (_uncommit_thread != nullptr) {
+    log_info(gc)("Do uncommit thread");
     tcl->do_thread(_uncommit_thread);
   }
 
+  log_info(gc)("Do workers");
   workers()->threads_do(tcl);
   if (_safepoint_workers != nullptr) {
+    log_info(gc)("Do safepoint workers");
     _safepoint_workers->threads_do(tcl);
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
@@ -67,7 +67,6 @@ ShenandoahMmuTracker::ShenandoahMmuTracker() :
 }
 
 ShenandoahMmuTracker::~ShenandoahMmuTracker() {
-  _mmu_periodic_task->disenroll();
   delete _mmu_periodic_task;
 }
 
@@ -175,6 +174,10 @@ void ShenandoahMmuTracker::report() {
   double mu = mutator_delta / (_active_processors * time_delta);
   double gcu = gc_delta / (_active_processors * time_delta);
   log_debug(gc)("Periodic Sample: GCU = %.3f%%, MU = %.3f%% during most recent %.1fs", gcu * 100, mu * 100, time_delta);
+}
+
+void ShenandoahMmuTracker::stop() const {
+  _mmu_periodic_task->disenroll();
 }
 
 void ShenandoahMmuTracker::initialize() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
@@ -48,7 +48,9 @@ class ThreadTimeAccumulator : public ThreadClosure {
   size_t total_time;
   ThreadTimeAccumulator() : total_time(0) {}
   void do_thread(Thread* thread) override {
-    total_time += os::thread_cpu_time(thread);
+    if (!thread->has_terminated()) {
+      total_time += os::thread_cpu_time(thread);
+    }
   }
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
@@ -48,9 +48,8 @@ class ThreadTimeAccumulator : public ThreadClosure {
   size_t total_time;
   ThreadTimeAccumulator() : total_time(0) {}
   void do_thread(Thread* thread) override {
-    if (!thread->has_terminated()) {
-      total_time += os::thread_cpu_time(thread);
-    }
+    assert(!thread->has_terminated(), "Cannot get cpu time for terminated thread: " UINTX_FORMAT, thread->osthread()->thread_id_for_printing());
+    total_time += os::thread_cpu_time(thread);
   }
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
@@ -101,6 +101,10 @@ public:
   // GCPauseIntervalMillis and defaults to 5 seconds. This method computes
   // the MMU over the elapsed interval and records it in a running average.
   void report();
+
+  // Unenrolls the periodic task that collects CPU utilization for GC threads. This must happen _before_ the
+  // gc threads are stopped and terminated.
+  void stop() const;
 };
 
 #endif //SHARE_GC_SHENANDOAH_SHENANDOAHMMUTRACKER_HPP


### PR DESCRIPTION
I haven't seen this failure mode in our Alpine Linux test pipelines, but the suggestion to avoid getting cpu time for terminated threads sounds sensible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345970](https://bugs.openjdk.org/browse/JDK-8345970): pthread_getcpuclockid related crashes in shenandoah tests (**Bug** - P2)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22693/head:pull/22693` \
`$ git checkout pull/22693`

Update a local copy of the PR: \
`$ git checkout pull/22693` \
`$ git pull https://git.openjdk.org/jdk.git pull/22693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22693`

View PR using the GUI difftool: \
`$ git pr show -t 22693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22693.diff">https://git.openjdk.org/jdk/pull/22693.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22693#issuecomment-2537342895)
</details>
