### PR TITLE
8346051: MemoryTest fails when Shenandoah's generational mode is enabled

### DIFF
--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -46,15 +46,27 @@
  */
 
 /*
- * @test
+ * @test id=Shenandoah
  * @bug     4530538
- * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
- *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc == "Shenandoah"
+ * @summary Shenandoah has a gc mgr bean for cycles and another
+ *          for pauses, they both have one pool.
+ * @requires vm.gc == "Shenandoah" & vm.opt.ShenandoahGCMode != "generational"
  * @author  Mandy Chung
  *
  * @modules jdk.management
  * @run main MemoryTest 2 1
+ */
+
+/*
+ * @test id=Genshen
+ * @bug     4530538
+ * @summary Shenandoah's generational mode has a gc mgr bean for cycles.
+ *          They both reference the young and old pools.
+ * @requires vm.gc == "Shenandoah" & vm.opt.ShenandoahGCMode == "generational"
+ * @author  Mandy Chung
+ *
+ * @modules jdk.management
+ * @run main MemoryTest 2 2
  */
 
 /*
@@ -174,6 +186,7 @@ public class MemoryTest {
         // Check the number of Memory Managers
         for (ListIterator iter = mgrs.listIterator(); iter.hasNext();) {
             MemoryManagerMXBean mgr = (MemoryManagerMXBean) iter.next();
+            System.out.println(mgr.getName());
             String[] poolNames = mgr.getMemoryPoolNames();
             if (poolNames == null || poolNames.length == 0) {
                 throw new RuntimeException("TEST FAILED: " +

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -60,8 +60,8 @@
 /*
  * @test id=Genshen
  * @bug     4530538
- * @summary Shenandoah's generational mode has a gc mgr bean for cycles.
- *          They both reference the young and old pools.
+ * @summary Shenandoah's generational mode has a gc mgr bean for cycles
+ *          and another for pauses. They both reference the young and old pools.
  * @requires vm.gc == "Shenandoah" & vm.opt.ShenandoahGCMode == "generational"
  * @author  Mandy Chung
  *
@@ -186,7 +186,6 @@ public class MemoryTest {
         // Check the number of Memory Managers
         for (ListIterator iter = mgrs.listIterator(); iter.hasNext();) {
             MemoryManagerMXBean mgr = (MemoryManagerMXBean) iter.next();
-            System.out.println(mgr.getName());
             String[] poolNames = mgr.getMemoryPoolNames();
             if (poolNames == null || poolNames.length == 0) {
                 throw new RuntimeException("TEST FAILED: " +


### PR DESCRIPTION
This test makes assertions about the number of gc manager beans and the number of memory pools. The generational mode for Shenandoah adds another memory pool.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346051](https://bugs.openjdk.org/browse/JDK-8346051): MemoryTest fails when Shenandoah's generational mode is enabled (**Bug** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**) Review applies to [57526d7f](https://git.openjdk.org/jdk/pull/22695/files/57526d7fed79208d227be36336f15b1a4eab9c81)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22695/head:pull/22695` \
`$ git checkout pull/22695`

Update a local copy of the PR: \
`$ git checkout pull/22695` \
`$ git pull https://git.openjdk.org/jdk.git pull/22695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22695`

View PR using the GUI difftool: \
`$ git pr show -t 22695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22695.diff">https://git.openjdk.org/jdk/pull/22695.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22695#issuecomment-2537453013)
</details>
