### PR TITLE
8345432: (ch, fs) Replace anonymous Thread with InnocuousThread

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
+++ b/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
@@ -38,8 +38,6 @@ public final class InnocuousThread extends Thread {
     private static final ThreadGroup INNOCUOUSTHREADGROUP;
     private static final long CONTEXTCLASSLOADER;
 
-    private final boolean isUninterruptible;
-
     private static final AtomicInteger threadNumber = new AtomicInteger(1);
     private static String newName() {
         return "InnocuousThread-" + threadNumber.getAndIncrement();
@@ -51,16 +49,6 @@ public final class InnocuousThread extends Thread {
      */
     public static Thread newThread(Runnable target) {
         return newThread(newName(), target);
-    }
-
-    /**
-     * Returns a new InnocuousThread with an auto-generated thread name,
-     * and its context class loader is set to the system class loader, and
-     * it is uninterruptible.
-     */
-    public static Thread newUninterruptibleThread(Runnable target) {
-        return createThread(newName(), target, 0L,
-                ClassLoader.getSystemClassLoader(), -1, true);
     }
 
     /**
@@ -77,7 +65,7 @@ public final class InnocuousThread extends Thread {
      */
     public static Thread newThread(String name, Runnable target, int priority) {
         return createThread(name, target, 0L,
-                ClassLoader.getSystemClassLoader(), priority, false);
+                ClassLoader.getSystemClassLoader(), priority);
     }
 
     /**
@@ -100,7 +88,7 @@ public final class InnocuousThread extends Thread {
      * Thread priority is set to the given priority.
      */
     public static Thread newSystemThread(String name, Runnable target, int priority) {
-        return createThread(name, target, 0L, null, priority, false);
+        return createThread(name, target, 0L, null, priority);
     }
 
     /**
@@ -109,14 +97,13 @@ public final class InnocuousThread extends Thread {
      */
     public static Thread newSystemThread(String name, Runnable target,
                                          long stackSize, int priority) {
-        return createThread(name, target, stackSize, null, priority, false);
+        return createThread(name, target, stackSize, null, priority);
     }
 
     private static Thread createThread(String name, Runnable target, long stackSize,
-                                       ClassLoader loader, int priority,
-                                       boolean isUninterruptible) {
+                                       ClassLoader loader, int priority) {
         Thread t = new InnocuousThread(INNOCUOUSTHREADGROUP,
-                target, name, stackSize, loader, isUninterruptible);
+                target, name, stackSize, loader);
         if (priority >= 0) {
             t.setPriority(priority);
         }
@@ -124,17 +111,9 @@ public final class InnocuousThread extends Thread {
     }
 
     private InnocuousThread(ThreadGroup group, Runnable target, String name,
-                            long stackSize, ClassLoader tccl,
-                            boolean isUninterruptible) {
+                            long stackSize, ClassLoader tccl) {
         super(group, target, name, stackSize, false);
-        this.isUninterruptible = isUninterruptible;
         UNSAFE.putReferenceRelease(this, CONTEXTCLASSLOADER, tccl);
-    }
-
-    @Override
-    public void interrupt() {
-        if (!isUninterruptible)
-            super.interrupt();
     }
 
     @Override

--- a/src/java.base/share/classes/sun/nio/ch/ThreadPool.java
+++ b/src/java.base/share/classes/sun/nio/ch/ThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ public class ThreadPool {
 
     static ThreadFactory defaultThreadFactory() {
         return (Runnable r) -> {
-            Thread t = new Thread(r);
+            Thread t = InnocuousThread.newThread(r);
             t.setDaemon(true);
             return t;
         };

--- a/src/java.base/share/classes/sun/nio/fs/AbstractPoller.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractPoller.java
@@ -25,9 +25,10 @@
 
 package sun.nio.fs;
 
-import java.nio.file.*;
 import java.io.IOException;
+import java.nio.file.*;
 import java.util.*;
+import jdk.internal.misc.InnocuousThread;
 
 /**
  * Base implementation of background poller thread used in watch service
@@ -53,11 +54,7 @@ abstract class AbstractPoller implements Runnable {
      * Starts the poller thread
      */
     public void start() {
-        Thread thr = new Thread(null,
-                                this,
-                                "FileSystemWatchService",
-                                0,
-                                false);
+        Thread thr = InnocuousThread.newThread("FileSystemWatchService", this);
         thr.setDaemon(true);
         thr.start();
     }

--- a/src/java.base/share/classes/sun/nio/fs/Cancellable.java
+++ b/src/java.base/share/classes/sun/nio/fs/Cancellable.java
@@ -32,8 +32,8 @@ import jdk.internal.misc.Unsafe;
 /**
  * Base implementation of a task (typically native) that polls a memory location
  * during execution so that it may be aborted/cancelled before completion. The
- * task is executed by invoking the {@link runInterruptibly} method defined
- * here and cancelled by invoking Thread.interrupt.
+ * task is executed by invoking the {@linkplain #runInterruptibly} method
+ * defined here and cancelled by invoking Thread.interrupt.
  */
 
 abstract class Cancellable implements Runnable {
@@ -118,7 +118,7 @@ abstract class Cancellable implements Runnable {
      * thread by writing into the memory location that it polls cooperatively.
      */
     static void runInterruptibly(Cancellable task) throws ExecutionException {
-        Thread t = InnocuousThread.newThread("NIO-Task", task);
+        Thread t = InnocuousThread.newThread("CancellableOp", task);
         t.start();
         boolean cancelledByInterrupt = false;
         while (t.isAlive()) {

--- a/src/java.base/share/classes/sun/nio/fs/Cancellable.java
+++ b/src/java.base/share/classes/sun/nio/fs/Cancellable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,9 @@
 
 package sun.nio.fs;
 
-import jdk.internal.misc.Unsafe;
 import java.util.concurrent.ExecutionException;
+import jdk.internal.misc.InnocuousThread;
+import jdk.internal.misc.Unsafe;
 
 /**
  * Base implementation of a task (typically native) that polls a memory location
@@ -117,7 +118,7 @@ abstract class Cancellable implements Runnable {
      * thread by writing into the memory location that it polls cooperatively.
      */
     static void runInterruptibly(Cancellable task) throws ExecutionException {
-        Thread t = new Thread(null, task, "NIO-Task", 0, false);
+        Thread t = InnocuousThread.newThread("NIO-Task", task);
         t.start();
         boolean cancelledByInterrupt = false;
         while (t.isAlive()) {

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import jdk.internal.misc.InnocuousThread;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 
 /**
@@ -73,7 +74,7 @@ class PollingWatchService
             .newSingleThreadScheduledExecutor(new ThreadFactory() {
                  @Override
                  public Thread newThread(Runnable r) {
-                     Thread t = new Thread(null, r, "FileSystemWatcher", 0, false);
+                     Thread t = InnocuousThread.newThread("FileSystemWatcher", r);
                      t.setDaemon(true);
                      return t;
                  }});

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -41,7 +41,6 @@ import java.nio.file.Path;
 import java.nio.channels.spi.*;
 import java.security.SecureRandom;
 import java.util.Random;
-import jdk.internal.misc.InnocuousThread;
 
 import static java.net.StandardProtocolFamily.UNIX;
 
@@ -79,7 +78,10 @@ class PipeImpl
             connector.run();
             if (ioe instanceof ClosedByInterruptException) {
                 ioe = null;
-                Thread connThread = InnocuousThread.newUninterruptibleThread(connector);
+                Thread connThread = new Thread(connector, "LoopbackConnector") {
+                    @Override
+                    public void interrupt() {}
+                };
                 connThread.start();
                 for (;;) {
                     try {

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -41,6 +41,7 @@ import java.nio.file.Path;
 import java.nio.channels.spi.*;
 import java.security.SecureRandom;
 import java.util.Random;
+import jdk.internal.misc.InnocuousThread;
 
 import static java.net.StandardProtocolFamily.UNIX;
 
@@ -78,10 +79,7 @@ class PipeImpl
             connector.run();
             if (ioe instanceof ClosedByInterruptException) {
                 ioe = null;
-                Thread connThread = new Thread(connector) {
-                    @Override
-                    public void interrupt() {}
-                };
+                Thread connThread = InnocuousThread.newUninterruptibleThread(connector);
                 connThread.start();
                 for (;;) {
                     try {


### PR DESCRIPTION
Change internal instances of anonymous `Thread`s to instances of `InnocuousThread`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8346124](https://bugs.openjdk.org/browse/JDK-8346124) to be approved

### Issues
 * [JDK-8345432](https://bugs.openjdk.org/browse/JDK-8345432): (ch, fs) Replace anonymous Thread with InnocuousThread (**Enhancement** - P4)
 * [JDK-8346124](https://bugs.openjdk.org/browse/JDK-8346124): (ch, fs) Replace anonymous Thread with InnocuousThread (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22697/head:pull/22697` \
`$ git checkout pull/22697`

Update a local copy of the PR: \
`$ git checkout pull/22697` \
`$ git pull https://git.openjdk.org/jdk.git pull/22697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22697`

View PR using the GUI difftool: \
`$ git pr show -t 22697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22697.diff">https://git.openjdk.org/jdk/pull/22697.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22697#issuecomment-2537665472)
</details>
