### PR TITLE
8346055: javax/swing/text/StyledEditorKit/4506788/bug4506788.java fails in ubuntu22.04

### DIFF
--- a/test/jdk/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
+++ b/test/jdk/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
@@ -66,7 +66,7 @@ public class bug4506788 {
             dim = jep.getSize();
         });
 
-        robot.mouseMove(p.x + dim.width / 2, p.y + dim.height / 2); 
+        robot.mouseMove(p.x + dim.width / 2, p.y + dim.height / 2);
         robot.waitForIdle();
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);

--- a/test/jdk/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
+++ b/test/jdk/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,68 +29,59 @@
  * @run main bug4506788
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import java.lang.reflect.InvocationTargetException;
-import javax.swing.*;
-import javax.swing.event.*;
-import javax.swing.text.*;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.event.InputEvent;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.event.CaretEvent;
+import javax.swing.event.CaretListener;
+import javax.swing.text.DefaultStyledDocument;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledEditorKit;
 
 public class bug4506788 {
 
-    private volatile boolean passed = false;
-    private JEditorPane jep;
+    private static volatile boolean passed;
+    private static volatile Point p;
+    private static volatile Dimension dim;
+    private static JEditorPane jep;
 
-    public static void main(final String[] args) {
-        bug4506788 app = new bug4506788();
-        app.init();
-        app.start();
-    }
+    public static void main(final String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
 
-    public void init() {
-        try {
-            SwingUtilities.invokeAndWait(new Runnable() {
-                @Override
-                public void run() {
-                    createAndShowGUI();
-                }
-            });
-        } catch (InterruptedException | InvocationTargetException ex) {
-            ex.printStackTrace();
-            throw new RuntimeException("FAILED: SwingUtilities.invokeAndWait method failed then creating and showing GUI");
-        }
-    }
-
-    public void start() {
-        Robot robot;
-        try {
-            robot = new Robot();
-            robot.setAutoDelay(100);
-        } catch (AWTException e) {
-            throw new RuntimeException("Robot could not be created");
-        }
+        SwingUtilities.invokeAndWait(() -> createAndShowGUI());
 
         robot.waitForIdle();
+        robot.delay(1000);
 
-        Point p;
-        try {
-            p = getJEPLocOnScreen();
-        } catch (Exception e) {
-            throw new RuntimeException("Could not get JEditorPane location on screen");
-        }
+        SwingUtilities.invokeAndWait(() -> {
+            p = jep.getLocationOnScreen();
+            dim = jep.getSize();
+        });
 
-        robot.mouseMove(p.x, p.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseMove(p.x + dim.width / 2, p.y + dim.height / 2); 
+        robot.waitForIdle();
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
         robot.keyPress(KeyEvent.VK_HOME);
         robot.keyRelease(KeyEvent.VK_HOME);
+        robot.waitForIdle();
         robot.keyPress(KeyEvent.VK_RIGHT);
         robot.keyRelease(KeyEvent.VK_RIGHT);
+        robot.waitForIdle();
         robot.keyPress(KeyEvent.VK_X);
         robot.keyRelease(KeyEvent.VK_X);
+        robot.waitForIdle();
         robot.keyPress(KeyEvent.VK_RIGHT);
         robot.keyRelease(KeyEvent.VK_RIGHT);
-
         robot.waitForIdle();
 
         if (!passed) {
@@ -98,29 +89,16 @@ public class bug4506788 {
         }
     }
 
-    private Point getJEPLocOnScreen() throws Exception {
-
-        final Point[] result = new Point[1];
-
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
-                result[0] = jep.getLocationOnScreen();
-            }
-        });
-
-        return result[0];
-    }
-
-    private void createAndShowGUI() {
+    private static void createAndShowGUI() {
         jep = new JEditorPane();
         String text = "abc";
-        JFrame f = new JFrame();
+        JFrame f = new JFrame("bug4506788");
         jep.setEditorKit(new StyledEditorKit());
         jep.setText(text);
         jep.addCaretListener(new CaretListener() {
             @Override
             public void caretUpdate(CaretEvent e) {
+                System.out.println("getDot " + e.getDot());
                 passed = (e.getDot() == 3);
             }
         });

--- a/test/jdk/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
+++ b/test/jdk/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
@@ -51,48 +51,57 @@ public class bug4506788 {
     private static volatile Point p;
     private static volatile Dimension dim;
     private static JEditorPane jep;
+    private static JFrame f;
 
     public static void main(final String[] args) throws Exception {
-        Robot robot = new Robot();
-        robot.setAutoDelay(100);
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
 
-        SwingUtilities.invokeAndWait(() -> createAndShowGUI());
+            SwingUtilities.invokeAndWait(() -> createAndShowGUI());
 
-        robot.waitForIdle();
-        robot.delay(1000);
+            robot.waitForIdle();
+            robot.delay(1000);
 
-        SwingUtilities.invokeAndWait(() -> {
-            p = jep.getLocationOnScreen();
-            dim = jep.getSize();
-        });
+            SwingUtilities.invokeAndWait(() -> {
+                p = jep.getLocationOnScreen();
+                dim = jep.getSize();
+            });
 
-        robot.mouseMove(p.x + dim.width / 2, p.y + dim.height / 2);
-        robot.waitForIdle();
-        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-        robot.waitForIdle();
-        robot.keyPress(KeyEvent.VK_HOME);
-        robot.keyRelease(KeyEvent.VK_HOME);
-        robot.waitForIdle();
-        robot.keyPress(KeyEvent.VK_RIGHT);
-        robot.keyRelease(KeyEvent.VK_RIGHT);
-        robot.waitForIdle();
-        robot.keyPress(KeyEvent.VK_X);
-        robot.keyRelease(KeyEvent.VK_X);
-        robot.waitForIdle();
-        robot.keyPress(KeyEvent.VK_RIGHT);
-        robot.keyRelease(KeyEvent.VK_RIGHT);
-        robot.waitForIdle();
+            robot.mouseMove(p.x + dim.width / 2, p.y + dim.height / 2);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_HOME);
+            robot.keyRelease(KeyEvent.VK_HOME);
+            robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_RIGHT);
+            robot.keyRelease(KeyEvent.VK_RIGHT);
+            robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_X);
+            robot.keyRelease(KeyEvent.VK_X);
+            robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_RIGHT);
+            robot.keyRelease(KeyEvent.VK_RIGHT);
+            robot.waitForIdle();
 
-        if (!passed) {
-            throw new RuntimeException("Test failed.");
+            if (!passed) {
+                throw new RuntimeException("Test failed.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
         }
     }
 
     private static void createAndShowGUI() {
         jep = new JEditorPane();
         String text = "abc";
-        JFrame f = new JFrame("bug4506788");
+        f = new JFrame("bug4506788");
         jep.setEditorKit(new StyledEditorKit());
         jep.setText(text);
         jep.addCaretListener(new CaretListener() {


### PR DESCRIPTION
javax/swing/text/StyledEditorKit/4506788/bug4506788.java fails in ubuntu22.04 seems to fail in OCI system citing "Test failed"
suggesting caret is not at expected place after text is typed, but I could not find any CI jobs having it failed.
Anyway simplified the test and added stability fixes which made it pass now in several OCI systems..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346055](https://bugs.openjdk.org/browse/JDK-8346055): javax/swing/text/StyledEditorKit/4506788/bug4506788.java fails in ubuntu22.04 (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22698/head:pull/22698` \
`$ git checkout pull/22698`

Update a local copy of the PR: \
`$ git checkout pull/22698` \
`$ git pull https://git.openjdk.org/jdk.git pull/22698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22698`

View PR using the GUI difftool: \
`$ git pr show -t 22698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22698.diff">https://git.openjdk.org/jdk/pull/22698.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22698#issuecomment-2537673368)
</details>
