### PR TITLE
8346052: JFR: Incorrect average value in 'jfr view'

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Function.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Function.java
@@ -175,9 +175,9 @@ abstract class Function {
         @Override
         public Object result() {
             if (count != 0) {
-                long s = seconds / count;
-                long n = nanos / count;
-                return Duration.ofSeconds(s, n);
+                double total = 1_000_000_000.0 * seconds + nanos;
+                double average = total / count;
+                return Duration.ofNanos(Math.round(average));
             } else {
                 return null;
             }


### PR DESCRIPTION
Could I have a review of PR that fixes an issue with 'jfr view' when calculating the average for a timespan.

Testing: jdk/jdk/rf

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346052](https://bugs.openjdk.org/browse/JDK-8346052): JFR: Incorrect average value in 'jfr view' (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22699/head:pull/22699` \
`$ git checkout pull/22699`

Update a local copy of the PR: \
`$ git checkout pull/22699` \
`$ git pull https://git.openjdk.org/jdk.git pull/22699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22699`

View PR using the GUI difftool: \
`$ git pr show -t 22699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22699.diff">https://git.openjdk.org/jdk/pull/22699.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22699#issuecomment-2537754454)
</details>
