### PR TITLE
8346059: [ASAN] awt_LoadLibrary.c reported compile warning ignoring return value of function by clang17

### DIFF
--- a/src/java.desktop/unix/native/libawt/awt/awt_LoadLibrary.c
+++ b/src/java.desktop/unix/native/libawt/awt/awt_LoadLibrary.c
@@ -137,7 +137,9 @@ AWT_OnLoad(JavaVM *vm, void *reserved)
     } else {
         /* Get address of this library and the directory containing it. */
         dladdr((void *)AWT_OnLoad, &dlinfo);
-        realpath((char *)dlinfo.dli_fname, buf);
+        if (realpath((char *)dlinfo.dli_fname, buf) == NULL) {
+            perror((char *)dlinfo.dli_fname);
+        }
         len = strlen(buf);
         p = strrchr(buf, '/');
 


### PR DESCRIPTION
Hi all,
This PR fix file src/java.desktop/unix/native/libawt/awt/awt_LoadLibrary.c reported compile warning "ignoring return value of function" by clang17, which add check the return value of `realpath` function. Risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346059](https://bugs.openjdk.org/browse/JDK-8346059): [ASAN] awt_LoadLibrary.c reported compile warning ignoring return value of function by clang17 (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22701/head:pull/22701` \
`$ git checkout pull/22701`

Update a local copy of the PR: \
`$ git checkout pull/22701` \
`$ git pull https://git.openjdk.org/jdk.git pull/22701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22701`

View PR using the GUI difftool: \
`$ git pr show -t 22701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22701.diff">https://git.openjdk.org/jdk/pull/22701.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22701#issuecomment-2537798078)
</details>
