### PR TITLE
8346063: java/lang/Thread/virtual/Starvation.java missing @requires vm.continuations

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/Starvation.java
+++ b/test/jdk/java/lang/Thread/virtual/Starvation.java
@@ -22,6 +22,7 @@
  */
 
 /* @test
+ * @requires vm.continuations
  * @library /test/lib
  * @bug 8345294
  * @run main/othervm --enable-native-access=ALL-UNNAMED Starvation 100000


### PR DESCRIPTION
java/lang/Thread/virtual/Starvation.java is failing on s390x with Timeout error as continuations support is not there for s390x.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346063](https://bugs.openjdk.org/browse/JDK-8346063): java/lang/Thread/virtual/Starvation.java missing @<!---->requires vm.continuations (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Viktor Klang](https://openjdk.org/census#vklang) (@viktorklang-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22702/head:pull/22702` \
`$ git checkout pull/22702`

Update a local copy of the PR: \
`$ git checkout pull/22702` \
`$ git pull https://git.openjdk.org/jdk.git pull/22702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22702`

View PR using the GUI difftool: \
`$ git pr show -t 22702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22702.diff">https://git.openjdk.org/jdk/pull/22702.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22702#issuecomment-2537799909)
</details>
