### PR TITLE
8345911: Enhance error message when IncompatibleClassChangeError is thrown for sealed class loading failures

### DIFF
--- a/src/hotspot/share/classfile/classFileError.cpp
+++ b/src/hotspot/share/classfile/classFileError.cpp
@@ -92,6 +92,12 @@ void ClassFileParser::classfile_icce_error(const char* msg,
                      msg, _class_name->as_klass_external_name(), k->external_name());
 }
 
+void ClassFileParser::classfile_icce_error(const char* msg,
+                                           TRAPS) const {
+  ResourceMark rm(THREAD);
+  Exceptions::fthrow(THREAD_AND_LOCATION, vmSymbols::java_lang_IncompatibleClassChangeError(), msg);
+}
+
 void ClassFileParser::classfile_ucve_error(const char* msg,
                                            const Symbol* class_name,
                                            u2 major,

--- a/src/hotspot/share/classfile/classFileError.cpp
+++ b/src/hotspot/share/classfile/classFileError.cpp
@@ -45,11 +45,11 @@ void ClassFileParser::classfile_parse_error(const char* msg, TRAPS) const {
                      msg, _class_name->as_C_string());
 }
 
+// The caller is required/expected to have a ResourceMark in this case.
 void ClassFileParser::classfile_parse_error(const char* msg,
                                             int index,
                                             TRAPS) const {
   assert(_class_name != nullptr, "invariant");
-  ResourceMark rm(THREAD);
   Exceptions::fthrow(THREAD_AND_LOCATION, vmSymbols::java_lang_ClassFormatError(),
                      msg, index, _class_name->as_C_string());
 }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4066,6 +4066,7 @@ void ClassFileParser::check_super_class_access(const InstanceKlass* this_klass, 
 
     if (super_ik->is_sealed()) {
       stringStream ss;
+      ResourceMark rm(THREAD);
       if (!super_ik->has_as_permitted_subclass(this_klass, ss)) {
         classfile_icce_error(ss.as_string(), THREAD);
         return;
@@ -4116,6 +4117,7 @@ void ClassFileParser::check_super_interface_access(const InstanceKlass* this_kla
 
     if (k->is_sealed()) {
       stringStream ss;
+      ResourceMark rm(THREAD);
       if (!k->has_as_permitted_subclass(this_klass, ss)) {
         classfile_icce_error(ss.as_string(), THREAD);
         return;

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4064,9 +4064,12 @@ void ClassFileParser::check_super_class_access(const InstanceKlass* this_klass, 
       return;
     }
 
-    if (super_ik->is_sealed() && !super_ik->has_as_permitted_subclass(this_klass)) {
-      classfile_icce_error("class %s cannot inherit from sealed class %s", super_ik, THREAD);
-      return;
+    if (super_ik->is_sealed()) {
+      stringStream ss;
+      if (!super_ik->has_as_permitted_subclass(this_klass, ss)) {
+        classfile_icce_error(ss.as_string(), THREAD);
+        return;
+      }
     }
 
     Reflection::VerifyClassAccessResults vca_result =
@@ -4111,12 +4114,12 @@ void ClassFileParser::check_super_interface_access(const InstanceKlass* this_kla
     InstanceKlass* const k = local_interfaces->at(i);
     assert (k != nullptr && k->is_interface(), "invalid interface");
 
-    if (k->is_sealed() && !k->has_as_permitted_subclass(this_klass)) {
-      classfile_icce_error(this_klass->is_interface() ?
-                             "class %s cannot extend sealed interface %s" :
-                             "class %s cannot implement sealed interface %s",
-                           k, THREAD);
-      return;
+    if (k->is_sealed()) {
+      stringStream ss;
+      if (!k->has_as_permitted_subclass(this_klass, ss)) {
+        classfile_icce_error(ss.as_string(), THREAD);
+        return;
+      }
     }
 
     Reflection::VerifyClassAccessResults vca_result =

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -367,6 +367,10 @@ class ClassFileParser {
                             const Klass* k,
                             TRAPS) const;
 
+  // Uses msg directly in the ICCE, with no additional content
+  void classfile_icce_error(const char* msg,
+                            TRAPS) const;
+
   void classfile_ucve_error(const char* msg,
                             const Symbol* class_name,
                             u2 major,

--- a/src/hotspot/share/classfile/moduleEntry.cpp
+++ b/src/hotspot/share/classfile/moduleEntry.cpp
@@ -742,7 +742,7 @@ void ModuleEntryTable::modules_do(ModuleClosure* closure) {
 void ModuleEntry::print(outputStream* st) {
   st->print_cr("entry " PTR_FORMAT " name %s module " PTR_FORMAT " loader %s version %s location %s strict %s",
                p2i(this),
-               name() == nullptr ? UNNAMED_MODULE : name()->as_C_string(),
+               name_as_C_string(),
                p2i(module()),
                loader_data()->loader_name_and_id(),
                version() != nullptr ? version()->as_C_string() : "nullptr",

--- a/src/hotspot/share/classfile/moduleEntry.hpp
+++ b/src/hotspot/share/classfile/moduleEntry.hpp
@@ -185,6 +185,10 @@ public:
   static ModuleEntry* create_boot_unnamed_module(ClassLoaderData* cld);
   static ModuleEntry* new_unnamed_module_entry(Handle module_handle, ClassLoaderData* cld);
 
+  // Note caller requires ResourceMark
+  const char* name_as_C_string() {
+    return is_named() ? name()->as_C_string() : UNNAMED_MODULE;
+  }
   void print(outputStream* st = tty);
   void verify();
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -230,8 +230,12 @@ bool InstanceKlass::has_as_permitted_subclass(const InstanceKlass* k, stringStre
   if (k->module() != this->module()) {
     ss.print("Failed same module check: subclass %s is in module '%s' with loader %s, "
              "and sealed class %s is in module '%s' with loader %s",
-             k->external_name(), k->module()->name_as_C_string(), k->module()->loader_data()->loader_name_and_id(),
-             this->external_name(), this->module()->name_as_C_string(), this->module()->loader_data()->loader_name_and_id());
+             k->external_name(),
+             k->module()->name_as_C_string(),
+             k->module()->loader_data()->loader_name_and_id(),
+             this->external_name(),
+             this->module()->name_as_C_string(),
+             this->module()->loader_data()->loader_name_and_id());
     log_trace(class, sealed)(" - %s", ss.as_string());
     return false;
   }
@@ -239,9 +243,11 @@ bool InstanceKlass::has_as_permitted_subclass(const InstanceKlass* k, stringStre
   if (!k->is_public() && !is_same_class_package(k)) {
     ss.print("Failed same package check: non-public subclass %s is in package '%s' with classloader %s, "
              "and sealed class %s is in package '%s' with classloader %s",
-             k->external_name(), k->package() != nullptr ? k->package()->name()->as_C_string() : "unnamed",
+             k->external_name(),
+             k->package() != nullptr ? k->package()->name()->as_C_string() : "unnamed",
              k->module()->loader_data()->loader_name_and_id(),
-             this->external_name(), this->package() != nullptr ? this->package()->name()->as_C_string() : "unnamed",
+             this->external_name(),
+             this->package() != nullptr ? this->package()->name()->as_C_string() : "unnamed",
              this->module()->loader_data()->loader_name_and_id());
     log_trace(class, sealed)(" - %s", ss.as_string());
     return false;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -228,8 +228,8 @@ bool InstanceKlass::has_as_permitted_subclass(const InstanceKlass* k, stringStre
 
   // Check that the class and its super are in the same module.
   if (k->module() != this->module()) {
-    ss.print("Failed same module check: subclass %s is in module \"%s\" for loader %s "
-             "and sealed class %s is in module \"%s\" for loader %s",
+    ss.print("Failed same module check: subclass %s is in module '%s' with loader %s, "
+             "and sealed class %s is in module '%s' with loader %s",
              k->external_name(), k->module()->name_as_C_string(), k->module()->loader_data()->loader_name_and_id(),
              this->external_name(), this->module()->name_as_C_string(), this->module()->loader_data()->loader_name_and_id());
     log_trace(class, sealed)(" - %s", ss.as_string());
@@ -237,11 +237,11 @@ bool InstanceKlass::has_as_permitted_subclass(const InstanceKlass* k, stringStre
   }
 
   if (!k->is_public() && !is_same_class_package(k)) {
-    ss.print("Failed same run-time package check: non-public subclass %s is in package \"%s\" with classloader %s,"
-             "and sealed class %s is in package \"%s\" with classloader %s",
-             k->external_name(), k->package() != nullptr ? k->package()->name()->as_C_string() : "un-named",
+    ss.print("Failed same package check: non-public subclass %s is in package '%s' with classloader %s, "
+             "and sealed class %s is in package '%s' with classloader %s",
+             k->external_name(), k->package() != nullptr ? k->package()->name()->as_C_string() : "unnamed",
              k->module()->loader_data()->loader_name_and_id(),
-             this->external_name(), this->package() != nullptr ? this->package()->name()->as_C_string() : "un-named",
+             this->external_name(), this->package() != nullptr ? this->package()->name()->as_C_string() : "unnamed",
              this->module()->loader_data()->loader_name_and_id());
     log_trace(class, sealed)(" - %s", ss.as_string());
     return false;

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -456,8 +456,10 @@ public:
   // Check if this klass is a nestmate of k - resolves this nest-host and k's
   bool has_nestmate_access_to(InstanceKlass* k, TRAPS);
 
-  // Called to verify that k is a permitted subclass of this class
-  bool has_as_permitted_subclass(const InstanceKlass* k) const;
+  // Called to verify that k is a permitted subclass of this class.
+  // The incoming stringStream is used for logging, and for the caller to create
+  // a detailed exception message on failure.
+  bool has_as_permitted_subclass(const InstanceKlass* k, stringStream& ss) const;
 
   enum InnerClassAttributeOffset {
     // From http://mirror.eng/products/jdk/1.1/docs/guide/innerclasses/spec/innerclasses.doc10.html#18814

--- a/test/hotspot/jtreg/runtime/modules/SealedInterfaceModuleTest.java
+++ b/test/hotspot/jtreg/runtime/modules/SealedInterfaceModuleTest.java
@@ -74,9 +74,9 @@ public class SealedInterfaceModuleTest {
             Class p2_C2_class = Class.forName("sealedP2.C2");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().equals("Failed same run-time package check: non-public subclass sealedP2.C2 " +
-                                       "is in package \"sealedP2\" with classloader 'app',and sealed class " +
-                                       "sealedP1.SuperInterface is in package \"sealedP1\" with classloader 'app'")) {
+            if (!e.getMessage().equals("Failed same package check: non-public subclass sealedP2.C2 " +
+                                       "is in package 'sealedP2' with classloader 'app', and sealed class " +
+                                       "sealedP1.SuperInterface is in package 'sealedP1' with classloader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }
@@ -88,9 +88,9 @@ public class SealedInterfaceModuleTest {
             Class p3_C3_class = Class.forName("sealedP3.C3");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().equals("Failed same module check: subclass sealedP3.C3 is in module \"module_two\" " +
-                                       "for loader 'app' and sealed class sealedP1.SuperInterface is in module " +
-                                       "\"module_one\" for loader 'app'")) {
+            if (!e.getMessage().equals("Failed same module check: subclass sealedP3.C3 is in module 'module_two' " +
+                                       "with loader 'app', and sealed class sealedP1.SuperInterface is in module " +
+                                       "'module_one' with loader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }

--- a/test/hotspot/jtreg/runtime/modules/SealedInterfaceModuleTest.java
+++ b/test/hotspot/jtreg/runtime/modules/SealedInterfaceModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,9 @@ public class SealedInterfaceModuleTest {
             Class p2_C2_class = Class.forName("sealedP2.C2");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().contains("cannot implement sealed interface")) {
+            if (!e.getMessage().equals("Failed same run-time package check: non-public subclass sealedP2.C2 " +
+                                       "is in package \"sealedP2\" with classloader 'app',and sealed class " +
+                                       "sealedP1.SuperInterface is in package \"sealedP1\" with classloader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }
@@ -86,7 +88,9 @@ public class SealedInterfaceModuleTest {
             Class p3_C3_class = Class.forName("sealedP3.C3");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().contains("cannot implement sealed interface")) {
+            if (!e.getMessage().equals("Failed same module check: subclass sealedP3.C3 is in module \"module_two\" " +
+                                       "for loader 'app' and sealed class sealedP1.SuperInterface is in module " +
+                                       "\"module_one\" for loader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }

--- a/test/hotspot/jtreg/runtime/modules/SealedModuleTest.java
+++ b/test/hotspot/jtreg/runtime/modules/SealedModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,9 @@ public class SealedModuleTest {
             Class p2_C2_class = Class.forName("sealedP2.C2");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().contains("cannot inherit from sealed class")) {
+            if (!e.getMessage().equals("Failed same run-time package check: non-public subclass sealedP2.C2 " +
+                                       "is in package \"sealedP2\" with classloader 'app',and sealed class " +
+                                       "sealedP1.SuperClass is in package \"sealedP1\" with classloader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }
@@ -86,7 +88,9 @@ public class SealedModuleTest {
             Class p3_C3_class = Class.forName("sealedP3.C3");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().contains("cannot inherit from sealed class")) {
+            if (!e.getMessage().equals("Failed same module check: subclass sealedP3.C3 is in module \"module_two\" " +
+                                       "for loader 'app' and sealed class sealedP1.SuperClass is in module " +
+                                       "\"module_one\" for loader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }

--- a/test/hotspot/jtreg/runtime/modules/SealedModuleTest.java
+++ b/test/hotspot/jtreg/runtime/modules/SealedModuleTest.java
@@ -74,9 +74,9 @@ public class SealedModuleTest {
             Class p2_C2_class = Class.forName("sealedP2.C2");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().equals("Failed same run-time package check: non-public subclass sealedP2.C2 " +
-                                       "is in package \"sealedP2\" with classloader 'app',and sealed class " +
-                                       "sealedP1.SuperClass is in package \"sealedP1\" with classloader 'app'")) {
+            if (!e.getMessage().equals("Failed same package check: non-public subclass sealedP2.C2 " +
+                                       "is in package 'sealedP2' with classloader 'app', and sealed class " +
+                                       "sealedP1.SuperClass is in package 'sealedP1' with classloader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }
@@ -88,9 +88,9 @@ public class SealedModuleTest {
             Class p3_C3_class = Class.forName("sealedP3.C3");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().equals("Failed same module check: subclass sealedP3.C3 is in module \"module_two\" " +
-                                       "for loader 'app' and sealed class sealedP1.SuperClass is in module " +
-                                       "\"module_one\" for loader 'app'")) {
+            if (!e.getMessage().equals("Failed same module check: subclass sealedP3.C3 is in module 'module_two' " +
+                                       "with loader 'app', and sealed class sealedP1.SuperClass is in module " +
+                                       "'module_one' with loader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }

--- a/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclassesTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclassesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclassesTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclassesTest.java
@@ -27,7 +27,7 @@
  * @compile GetPermittedSubclasses.jcod
  * @compile noSubclass/BaseC.java noSubclass/BaseI.java noSubclass/Impl1.java
  * @compile noSubclass/Impl2.java
- * @run main GetPermittedSubclassesTest
+ * @run main/othervm -Xlog:class+sealed=trace GetPermittedSubclassesTest
  */
 
 import java.util.ArrayList;
@@ -49,6 +49,7 @@ public class GetPermittedSubclassesTest {
 
     final class Final4 {}
 
+    // Check if the given class has the expected permitted subclasses
     public static void testSealedInfo(Class<?> c, String[] expected, boolean isSealed) {
         var permitted = c.getPermittedSubclasses();
 
@@ -92,16 +93,16 @@ public class GetPermittedSubclassesTest {
 
     public static void testBadSealedClass(String className,
                                           Class<?> expectedException,
-                                          String expectedCFEMessage) throws Throwable {
+                                          String expectedMessage) throws Throwable {
         try {
             Class.forName(className);
-            throw new RuntimeException("Expected ClassFormatError exception not thrown for " + className);
+            throw new RuntimeException("Expected exception " + expectedException.getName() + " not thrown for " + className);
         } catch (ClassFormatError cfe) {
             if (ClassFormatError.class != expectedException) {
                 throw new RuntimeException(
                     "Class " + className + " got unexpected exception: " + cfe.getMessage());
             }
-            if (!cfe.getMessage().contains(expectedCFEMessage)) {
+            if (!cfe.getMessage().contains(expectedMessage)) {
                 throw new RuntimeException(
                     "Class " + className + " got unexpected ClassFormatError exception: " + cfe.getMessage());
             }
@@ -110,7 +111,7 @@ public class GetPermittedSubclassesTest {
                 throw new RuntimeException(
                     "Class " + className + " got unexpected exception: " + icce.getMessage());
             }
-            if (!icce.getMessage().contains(expectedCFEMessage)) {
+            if (!icce.getMessage().contains(expectedMessage)) {
                 throw new RuntimeException(
                     "Class " + className + " got unexpected IncompatibleClassChangeError exception: " + icce.getMessage());
             }
@@ -135,7 +136,7 @@ public class GetPermittedSubclassesTest {
 
         // Test that a class with an empty PermittedSubclasses attribute cannot be subclass-ed.
         testBadSealedClass("SubClass", IncompatibleClassChangeError.class,
-                           "SubClass cannot inherit from sealed class NoSubclasses");
+                           "Failed listed permitted subclass check: class SubClass is not a permitted subclass of NoSubclasses");
 
         // Test returning only names of existing classes.
         testSealedInfo(NoLoadSubclasses.class, new String[]{"ExistingClassFile" }, true);

--- a/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclassesTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/GetPermittedSubclassesTest.java
@@ -27,7 +27,7 @@
  * @compile GetPermittedSubclasses.jcod
  * @compile noSubclass/BaseC.java noSubclass/BaseI.java noSubclass/Impl1.java
  * @compile noSubclass/Impl2.java
- * @run main/othervm -Xlog:class+sealed=trace GetPermittedSubclassesTest
+ * @run main GetPermittedSubclassesTest
  */
 
 import java.util.ArrayList;

--- a/test/hotspot/jtreg/runtime/sealedClasses/SealedDifferentUnnamedModuleTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/SealedDifferentUnnamedModuleTest.java
@@ -46,9 +46,9 @@ public class SealedDifferentUnnamedModuleTest {
             Class<?> c2 = Class.forName("SealedSub");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().equals("Failed same module check: subclass SealedSub is in module \"unnamed module\" " +
-                                       "for loader 'app' and sealed class SealedSuper is in module \"unnamed module\" " +
-                                       "for loader 'bootstrap'")) {
+            if (!e.getMessage().equals("Failed same module check: subclass SealedSub is in module 'unnamed module' " +
+                                       "with loader 'app', and sealed class SealedSuper is in module 'unnamed module' " +
+                                       "with loader 'bootstrap'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }

--- a/test/hotspot/jtreg/runtime/sealedClasses/SealedDifferentUnnamedModuleTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/SealedDifferentUnnamedModuleTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8345911
+ * @library /test/lib
+ * @compile SealedSuper.java SealedSub.java
+ * @comment Copy SealedSuper.class to the currnet directory so it will be on the bootclasspath
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller SealedSuper
+ * @run main/othervm -Xbootclasspath/a:. -Xlog:class+sealed=trace SealedDifferentUnnamedModuleTest
+ */
+
+public class SealedDifferentUnnamedModuleTest {
+
+    public static void main(String args[]) throws Throwable {
+
+        // Load the sealed superclass. It will be loaded by the boot loader and
+        // so reside in the boot loaders un-named module.
+        Class<?> c1 = Class.forName("SealedSuper");
+
+        // Test loading a "permitted" subclass in the app classloader, which then resides
+        // in the app loader's un-named module.
+        // This should fail.
+        try {
+            Class<?> c2 = Class.forName("SealedSub");
+            throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
+        } catch (IncompatibleClassChangeError e) {
+            if (!e.getMessage().equals("Failed same module check: subclass SealedSub is in module \"unnamed module\" " +
+                                       "for loader 'app' and sealed class SealedSuper is in module \"unnamed module\" " +
+                                       "for loader 'bootstrap'")) {
+                throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/sealedClasses/SealedSub.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/SealedSub.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+public final class SealedSub extends SealedSuper {
+}

--- a/test/hotspot/jtreg/runtime/sealedClasses/SealedSuper.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/SealedSuper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public sealed class SealedSuper permits SealedSub {
+}

--- a/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleIntfTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleIntfTest.java
@@ -26,7 +26,7 @@
  * @bug 8225056
  * @compile Pkg/SealedInterface.jcod Pkg/NotPermitted.jcod
  * @compile Pkg/Permitted.java otherPkg/WrongPackage.java otherPkg/WrongPackageNotPublic.java
- * @run main SealedUnnamedModuleIntfTest
+ * @run main/othervm SealedUnnamedModuleIntfTest
  */
 
 public class SealedUnnamedModuleIntfTest {

--- a/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleIntfTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleIntfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,8 @@ public class SealedUnnamedModuleIntfTest {
             Class notPermitted = Class.forName("Pkg.NotPermitted");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().contains("cannot implement sealed interface")) {
+            if (!e.getMessage().equals("Failed listed permitted subclass check: class Pkg.NotPermitted " +
+                                       "is not a permitted subclass of Pkg.SealedInterface")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }
@@ -62,7 +63,9 @@ public class SealedUnnamedModuleIntfTest {
             Class notPermitted = Class.forName("otherPkg.WrongPackageNotPublic");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().contains("cannot implement sealed interface")) {
+            if (!e.getMessage().equals("Failed same run-time package check: non-public subclass otherPkg.WrongPackageNotPublic " +
+                                       "is in package \"otherPkg\" with classloader 'app',and sealed class Pkg.SealedInterface " +
+                                       "is in package \"Pkg\" with classloader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }

--- a/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleIntfTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleIntfTest.java
@@ -63,9 +63,9 @@ public class SealedUnnamedModuleIntfTest {
             Class notPermitted = Class.forName("otherPkg.WrongPackageNotPublic");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().equals("Failed same run-time package check: non-public subclass otherPkg.WrongPackageNotPublic " +
-                                       "is in package \"otherPkg\" with classloader 'app',and sealed class Pkg.SealedInterface " +
-                                       "is in package \"Pkg\" with classloader 'app'")) {
+            if (!e.getMessage().equals("Failed same package check: non-public subclass otherPkg.WrongPackageNotPublic " +
+                                       "is in package 'otherPkg' with classloader 'app', and sealed class Pkg.SealedInterface " +
+                                       "is in package 'Pkg' with classloader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }

--- a/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleTest.java
@@ -26,7 +26,7 @@
  * @bug 8225056
  * @compile planets/OuterPlanets.jcod planets/Mars.jcod
  * @compile planets/Neptune.java asteroids/Pluto.java asteroids/Charon.java
- * @run main SealedUnnamedModuleTest
+ * @run main/othervm SealedUnnamedModuleTest
  */
 
 public class SealedUnnamedModuleTest {

--- a/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleTest.java
@@ -58,9 +58,9 @@ public class SealedUnnamedModuleTest {
             Class pluto = Class.forName("asteroids.Pluto");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().equals("Failed same run-time package check: non-public subclass asteroids.Pluto is " +
-                                       "in package \"asteroids\" with classloader 'app',and sealed class " +
-                                       "planets.OuterPlanets is in package \"planets\" with classloader 'app'")) {
+            if (!e.getMessage().equals("Failed same package check: non-public subclass asteroids.Pluto is " +
+                                       "in package 'asteroids' with classloader 'app', and sealed class " +
+                                       "planets.OuterPlanets is in package 'planets' with classloader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }

--- a/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleTest.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/SealedUnnamedModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,8 @@ public class SealedUnnamedModuleTest {
             Class mars = Class.forName("planets.Mars");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().contains("cannot inherit from sealed class")) {
+            if (!e.getMessage().equals("Failed listed permitted subclass check: class planets.Mars is " +
+                                       "not a permitted subclass of planets.OuterPlanets")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }
@@ -57,7 +58,9 @@ public class SealedUnnamedModuleTest {
             Class pluto = Class.forName("asteroids.Pluto");
             throw new RuntimeException("Expected IncompatibleClassChangeError exception not thrown");
         } catch (IncompatibleClassChangeError e) {
-            if (!e.getMessage().contains("cannot inherit from sealed class")) {
+            if (!e.getMessage().equals("Failed same run-time package check: non-public subclass asteroids.Pluto is " +
+                                       "in package \"asteroids\" with classloader 'app',and sealed class " +
+                                       "planets.OuterPlanets is in package \"planets\" with classloader 'app'")) {
                 throw new RuntimeException("Wrong IncompatibleClassChangeError exception thrown: " + e.getMessage());
             }
         }


### PR DESCRIPTION
When a sealed superclass and its permitted subclass get loaded by different classloaders they end up in different modules (the unnamed module of each loader) and cause an `IncompatibleClassChangeError` to be thrown when loading the subclass. The existing error message is not very useful in recognizing this situation:
```
java.lang.IncompatibleClassChangeError: class SealedSubClass cannot inherit from sealed class SealedClass
```
as inspection of the class sources will show the expected `permits` and `extends` clauses.

This change augments the `InstanceKlass::has_as_permitted_subclass` method to provide a means to return a meaningful error message to the `ClassFileParser` callers for use in any ICCE that is to be thrown. That same message is shared between unified logging within the method, and the throwing of the ICCE by the caller. We introduce a new helper to throw the ICCE in this case.

The changes also adds a little helper method to `ModuleEntry` to make it easier to gets its name.

The existing tests are updated to reflect the updated error messages, and a new test for the missing "different module" situation is added.

Note: as with the existing logging code the message always refers to class/subclass when in some cases it is really interface and/or subinterface. This can be changed to be more accurate but greatly complicates the formulation of the messages. It is not uncommon to use "(sub)class" when we mean "(sub)class or (sub)interface".

The presented implementation exposes the error message by having the caller pass in a `stringStream` which is then used to store the message. This has the downside of always requiring a `stringStream` in the caller, even if there is no problem to report. Alternatively, we could create the `stringStream` in the callee and then "return" its `as_string()` result to the caller via an out parameter (e.g. `char** error_msg`). However because of the lifetime of the `stringStream` we would need to `os::strdup` the `as_string()` value before returning it, and then free it in the caller. A third alternative would be to push the throwing of the ICCE down into the `InstanceKlass` method so there is no need to pass the message around - though that blurs the line of "division of responsibility" between checking the condition and deciding it should result in ICCE being thrown (the normal pattern is to have the `ClassFileParser` code make that decision, while `InstanceKlass` just provides the queries - but we could do it for convenience).

Other testing:
- tiers 1-3

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345911](https://bugs.openjdk.org/browse/JDK-8345911): Enhance error message when IncompatibleClassChangeError is thrown for sealed class loading failures (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [9f3c618d](https://git.openjdk.org/jdk/pull/22703/files/9f3c618d603d23447f8d40de0e0179f67da3ebf8)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22703/head:pull/22703` \
`$ git checkout pull/22703`

Update a local copy of the PR: \
`$ git checkout pull/22703` \
`$ git pull https://git.openjdk.org/jdk.git pull/22703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22703`

View PR using the GUI difftool: \
`$ git pr show -t 22703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22703.diff">https://git.openjdk.org/jdk/pull/22703.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22703#issuecomment-2537849540)
</details>
