### PR TITLE
8346082: Output JVMTI agent information in hserr files

### DIFF
--- a/src/hotspot/share/prims/jvmtiAgentList.hpp
+++ b/src/hotspot/share/prims/jvmtiAgentList.hpp
@@ -61,7 +61,6 @@ class JvmtiAgentList : AllStatic {
  private:
   static JvmtiAgent* _list;
 
-  static Iterator all();
   static void initialize();
   static void convert_xrun_agents();
 
@@ -82,6 +81,7 @@ class JvmtiAgentList : AllStatic {
 
   static JvmtiAgent* lookup(JvmtiEnv* env, void* f_ptr);
 
+  static Iterator all();
   static Iterator agents() NOT_JVMTI({ Iterator it; return it; });
   static Iterator java_agents();
   static Iterator native_agents();

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1124,14 +1124,15 @@ void os::print_environment_variables(outputStream* st, const char** env_list) {
 
 void os::print_jvmti_agent_info(outputStream* st) {
 #if INCLUDE_JVMTI
-  // should return all kinds of JVMTI agents, but no xrun agents
-  const JvmtiAgentList::Iterator it = JvmtiAgentList::agents();
-  bool first_agent = true;
+  const JvmtiAgentList::Iterator it = JvmtiAgentList::all();
+  if (it.has_next()) {
+    st->print_cr("JVMTI agents:");
+  } else {
+    st->print_cr("JVMTI agents: none");
+  }
   while (it.has_next()) {
     const JvmtiAgent* agent = it.next();
     if (agent != nullptr) {
-      if (first_agent) st->print_cr("JVMTI agents:");
-      first_agent = false;
       const char* dyninfo = agent->is_dynamic() ? "dynamic" : "";
       const char* instrumentinfo = agent->is_instrument_lib() ? "instrumentlib" : "";
       const char* loadinfo = agent->is_loaded() ? "loaded" : "not loaded";
@@ -1140,7 +1141,6 @@ void os::print_jvmti_agent_info(outputStream* st) {
       const char* pathinfo = agent->os_lib_path();
       if (optionsinfo == nullptr) optionsinfo = "none";
       if (pathinfo == nullptr) pathinfo = "none";
-      // jplis output too?
       st->print_cr("%s path:%s, %s, %s %s %s options:%s", agent->name(), pathinfo, loadinfo, initinfo, dyninfo, instrumentinfo, optionsinfo);
     }
   }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1125,26 +1125,22 @@ void os::print_environment_variables(outputStream* st, const char** env_list) {
 void os::print_jvmti_agent_info(outputStream* st) {
 #if INCLUDE_JVMTI
   // should return all kinds of JVMTI agents, but no xrun agents
-  const JvmtiAgentList::Iterator it =JvmtiAgentList::agents();
+  const JvmtiAgentList::Iterator it = JvmtiAgentList::agents();
   bool first_agent = true;
   while (it.has_next()) {
     const JvmtiAgent* agent = it.next();
     if (agent != nullptr) {
       if (first_agent) st->print_cr("JVMTI agents:");
       first_agent = false;
-      const char* dyninfo = "";
-      const char* instrumentinfo = "";
-      const char* loadinfo = "not loaded";
-      const char* initinfo = "not initialized";
+      const char* dyninfo = agent->is_dynamic() ? "dynamic" : "";
+      const char* instrumentinfo = agent->is_instrument_lib() ? "instrumentlib" : "";
+      const char* loadinfo = agent->is_loaded() ? "loaded" : "not loaded";
+      const char* initinfo = agent->is_initialized() ? "initialized" : "not initialized";
       const char* optionsinfo = agent->options();
       const char* pathinfo = agent->os_lib_path();
-      if (agent->is_dynamic()) dyninfo = "dynamic";
-      if (agent->is_instrument_lib()) instrumentinfo = "instrumentlib";
-      if (agent->is_loaded()) loadinfo = "loaded";
       if (optionsinfo == nullptr) optionsinfo = "none";
       if (pathinfo == nullptr) pathinfo = "none";
       // jplis output too?
-      if (agent->is_initialized()) initinfo = "initialized";
       st->print_cr("%s path:%s, %s, %s %s %s options:%s", agent->name(), pathinfo, loadinfo, initinfo, dyninfo, instrumentinfo, optionsinfo);
     }
   }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1148,8 +1148,6 @@ void os::print_jvmti_agent_info(outputStream* st) {
       st->print_cr("%s path:%s, %s, %s %s %s options:%s", agent->name(), pathinfo, loadinfo, initinfo, dyninfo, instrumentinfo, optionsinfo);
     }
   }
-#else
-  st->print_cr("JVMTI support not included in this JVM.");
 #endif
 }
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1133,15 +1133,15 @@ void os::print_jvmti_agent_info(outputStream* st) {
   while (it.has_next()) {
     const JvmtiAgent* agent = it.next();
     if (agent != nullptr) {
-      const char* dyninfo = agent->is_dynamic() ? "dynamic" : "";
-      const char* instrumentinfo = agent->is_instrument_lib() ? "instrumentlib" : "";
+      const char* dyninfo = agent->is_dynamic() ? "dynamic " : "";
+      const char* instrumentinfo = agent->is_instrument_lib() ? "instrumentlib " : "";
       const char* loadinfo = agent->is_loaded() ? "loaded" : "not loaded";
       const char* initinfo = agent->is_initialized() ? "initialized" : "not initialized";
       const char* optionsinfo = agent->options();
       const char* pathinfo = agent->os_lib_path();
       if (optionsinfo == nullptr) optionsinfo = "none";
       if (pathinfo == nullptr) pathinfo = "none";
-      st->print_cr("%s path:%s, %s, %s %s %s options:%s", agent->name(), pathinfo, loadinfo, initinfo, dyninfo, instrumentinfo, optionsinfo);
+      st->print_cr("%s path:%s, %s, %s, %s%soptions:%s", agent->name(), pathinfo, loadinfo, initinfo, dyninfo, instrumentinfo, optionsinfo);
     }
   }
 #endif

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -813,6 +813,7 @@ class os: AllStatic {
   static void print_summary_info(outputStream* st, char* buf, size_t buflen);
   static void print_memory_info(outputStream* st);
   static void print_dll_info(outputStream* st);
+  static void print_jvmti_agent_info(outputStream* st);
   static void print_environment_variables(outputStream* st, const char** env_list);
   static void print_context(outputStream* st, const void* context);
   static void print_tos_pc(outputStream* st, const void* context);

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1275,6 +1275,12 @@ void VMError::report(outputStream* st, bool _verbose) {
     os::print_dll_info(st);
     st->cr();
 
+#if INCLUDE_JVMTI
+  STEP_IF("printing jvmti agent infos", _verbose)
+    os::print_jvmti_agent_info(st);
+    st->cr();
+#endif
+
   STEP_IF("printing native decoder state", _verbose)
     Decoder::print_state_on(st);
     st->cr();
@@ -1452,6 +1458,11 @@ void VMError::print_vm_info(outputStream* st) {
   // dynamic libraries, or memory map
   os::print_dll_info(st);
   st->cr();
+
+#if INCLUDE_JVMTI
+  os::print_jvmti_agent_info(st);
+  st->cr();
+#endif
 
   // STEP("printing VM options")
 

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1276,7 +1276,7 @@ void VMError::report(outputStream* st, bool _verbose) {
     st->cr();
 
 #if INCLUDE_JVMTI
-  STEP_IF("printing jvmti agent infos", _verbose)
+  STEP_IF("printing jvmti agent info", _verbose)
     os::print_jvmti_agent_info(st);
     st->cr();
 #endif


### PR DESCRIPTION
We should output more information about the JVMTI agents in the hserr file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346082](https://bugs.openjdk.org/browse/JDK-8346082): Output JVMTI agent information in hserr files (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [fa422ce3](https://git.openjdk.org/jdk/pull/22706/files/fa422ce304fba1f7244d7c13aa4bb0f8861c55ad)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [fa960c86](https://git.openjdk.org/jdk/pull/22706/files/fa960c86de21e02da5e3d571e13ee75002229ec9)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22706/head:pull/22706` \
`$ git checkout pull/22706`

Update a local copy of the PR: \
`$ git checkout pull/22706` \
`$ git pull https://git.openjdk.org/jdk.git pull/22706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22706`

View PR using the GUI difftool: \
`$ git pr show -t 22706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22706.diff">https://git.openjdk.org/jdk/pull/22706.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22706#issuecomment-2538391506)
</details>
