### PR TITLE
8339313: 32-bit build broken

### DIFF
--- a/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
@@ -47,6 +47,7 @@ Java_NoClassDefFoundErrorTest_callFindClass(JNIEnv *env, jclass klass, jstring c
 
 
 static char* giant_string() {
+#ifdef _LP64
     size_t len = ((size_t)INT_MAX) + 3;
     char* c_name = malloc(len * sizeof(char));
     if (c_name != NULL) {
@@ -54,6 +55,14 @@ static char* giant_string() {
         c_name[len - 1] = '\0';
     }
     return c_name;
+#else
+    /* On 32-bit, gcc warns us against using values larger than ptrdiff_t for malloc,
+     * memset and as array subscript. Since the chance of a 2GB allocation to be
+     * successful is slim (would typically reach or exceed the user address space
+     * size), lets just not bother. Returning NULL will cause the test to be silently
+     * skipped. */
+    return NULL;
+#endif
 }
 
 JNIEXPORT jboolean JNICALL

--- a/test/hotspot/jtreg/serviceability/sa/libupcall.c
+++ b/test/hotspot/jtreg/serviceability/sa/libupcall.c
@@ -22,11 +22,12 @@
  */
 
 #include <jni.h>
+#include <stdint.h>
 
 typedef void (*upcall_func)(void);
 
 JNIEXPORT void JNICALL
 Java_LingeredAppWithFFMUpcall_callJNI(JNIEnv *env, jclass cls, jlong upcallAddr) {
-  upcall_func upcall = (upcall_func)upcallAddr;
+  upcall_func upcall = (upcall_func)(uintptr_t)upcallAddr;
   upcall();
 }


### PR DESCRIPTION
Two fixes to fix the 32-bit build.

See JBS issue and code comment for details.

I ran nNoClassDefFoundErrorTest x64 and x86 fastdebug and release. On fastdebug, the giant string test now gets silently skipped as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339313](https://bugs.openjdk.org/browse/JDK-8339313): 32-bit build broken (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Sonia Zaldana Calles](https://openjdk.org/census#szaldana) (@SoniaZaldana - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22707/head:pull/22707` \
`$ git checkout pull/22707`

Update a local copy of the PR: \
`$ git checkout pull/22707` \
`$ git pull https://git.openjdk.org/jdk.git pull/22707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22707`

View PR using the GUI difftool: \
`$ git pr show -t 22707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22707.diff">https://git.openjdk.org/jdk/pull/22707.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22707#issuecomment-2538659949)
</details>
