### PR TITLE
8346099: JFR: Query for 'jfr view' can't handle wildcard with multiple event types

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
@@ -369,7 +369,6 @@ final class FieldBuilder {
             FieldBuilder fb = new FieldBuilder(eventTypes, type, we.name());
             Field field = fb.build().getFirst();
             field.label = we.label;
-            field.index = result.size();
             field.visible = true;
             field.sourceFields.add(field);
             result.add(field);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/QueryResolver.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/QueryResolver.java
@@ -98,9 +98,17 @@ final class QueryResolver {
         resolveGroupBy();
         resolveOrderBy();
         resolveWhere();
+        applyIndex();
         applyColumn();
         applyFormat();
         return resultFields;
+    }
+
+    private void applyIndex() {
+        int index = 0;
+        for (Field field : resultFields) {
+            field.index = index++;
+        }
     }
 
     private void resolveWhere() throws QuerySyntaxException {
@@ -238,7 +246,6 @@ final class QueryResolver {
             }
         }
         for (Field field: fields) {
-            field.index = resultFields.size();
             primary.sourceFields.add(field);
             // Convert to String if field data types mismatch
             if (mixedTypes) {


### PR DESCRIPTION
Could I have a review of PR that improves the query language for 'jfr view' so it can handle a wildcard with multiple event types, e.g. "SELECT * FROM E1, E2".

Every field has an index which corresponds to where it is located in resultFields array. Today, the same index can appear multiple times. See FieldBuilder::createWildcardField how this can happen when there are multiple event/filter types. The fix is to set the index after all fields have been added. 

Testing: jdk/jdk/jfr + manual check

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346099](https://bugs.openjdk.org/browse/JDK-8346099): JFR: Query for 'jfr view' can't handle wildcard with multiple event types (**Enhancement** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22711/head:pull/22711` \
`$ git checkout pull/22711`

Update a local copy of the PR: \
`$ git checkout pull/22711` \
`$ git pull https://git.openjdk.org/jdk.git pull/22711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22711`

View PR using the GUI difftool: \
`$ git pr show -t 22711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22711.diff">https://git.openjdk.org/jdk/pull/22711.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22711#issuecomment-2538959312)
</details>
