### PR TITLE
8345590: AIX 'make all' fails after JDK-8339480

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1310,7 +1310,11 @@ endif
 ################################################################################
 
 # all-images builds all our deliverables as images.
+ifeq ($(call isTargetOs, aix), true)
+all-images: product-images test-image all-docs-images
+else
 all-images: product-images static-jdk-image test-image all-docs-images
+endif
 
 # all-bundles packages all our deliverables as tar.gz bundles.
 all-bundles: product-bundles test-bundles docs-bundles static-libs-bundles

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1310,10 +1310,9 @@ endif
 ################################################################################
 
 # all-images builds all our deliverables as images.
-ifeq ($(call isTargetOs, aix), true)
 all-images: product-images test-image all-docs-images
-else
-all-images: product-images static-jdk-image test-image all-docs-images
+ifeq ($(call isTargetOs, linux macosx windows), true)
+  all-images: static-jdk-image
 endif
 
 # all-bundles packages all our deliverables as tar.gz bundles.


### PR DESCRIPTION
On AIX we after [JDK-8339480](https://bugs.openjdk.org/browse/JDK-8339480) into this error

```
make all
Building target 'all' in configuration '/open_jdk/jdk/build_aix'
Creating 1 test executable file(s) for BUILD_LIBTEST_JTREG_EXECUTABLES
StaticLibs.gmk:107: *** Unsupported platform. Stop.
make/Main.gmk:457: recipe for target 'static-launcher' failed
gmake[2]: *** [static-launcher] Error 1
```

For now, do not build the  static-jdk-image  part on AIX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345590](https://bugs.openjdk.org/browse/JDK-8345590): AIX 'make all' fails after JDK-8339480 (**Bug** - P4)


### Reviewers
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer) Review applies to [5f8bb400](https://git.openjdk.org/jdk/pull/22713/files/5f8bb400f3ccf8e48b448ad3498be0265e28ed34)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) Review applies to [5f8bb400](https://git.openjdk.org/jdk/pull/22713/files/5f8bb400f3ccf8e48b448ad3498be0265e28ed34)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) Review applies to [5f8bb400](https://git.openjdk.org/jdk/pull/22713/files/5f8bb400f3ccf8e48b448ad3498be0265e28ed34)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22713/head:pull/22713` \
`$ git checkout pull/22713`

Update a local copy of the PR: \
`$ git checkout pull/22713` \
`$ git pull https://git.openjdk.org/jdk.git pull/22713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22713`

View PR using the GUI difftool: \
`$ git pr show -t 22713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22713.diff">https://git.openjdk.org/jdk/pull/22713.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22713#issuecomment-2539091698)
</details>
