### PR TITLE
8346101: [JVMCI] Export jdk.internal.misc to jdk.graal.compiler

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -227,7 +227,8 @@ module java.base {
         jdk.jshell,
         jdk.nio.mapmode,
         jdk.unsupported,
-        jdk.internal.vm.ci;
+        jdk.internal.vm.ci,
+        jdk.graal.compiler;
     exports jdk.internal.module to
         java.instrument,
         java.management.rmi,

--- a/src/jdk.graal.compiler/share/classes/module-info.java
+++ b/src/jdk.graal.compiler/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
   * external implementation of a JVMCI compiler. It must be upgradeable so
   * that it can be replaced when jlinking a new JDK image without failing
   * the hash check for the qualified exports in jdk.internal.vm.ci's
-  * module descriptor.
+  * and java.base's module descriptors.
   *
   * @moduleGraph
   * @since 22

--- a/test/jdk/jdk/modules/etc/JdkQualifiedExportTest.java
+++ b/test/jdk/jdk/modules/etc/JdkQualifiedExportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,8 @@ public class JdkQualifiedExportTest {
                "jdk.internal.vm.ci/jdk.vm.ci.hotspot",
                "jdk.internal.vm.ci/jdk.vm.ci.meta",
                "jdk.internal.vm.ci/jdk.vm.ci.code",
-               "java.base/jdk.internal.javac");
+               "java.base/jdk.internal.javac",
+               "java.base/jdk.internal.misc");
 
     static void checkExports(ModuleDescriptor md) {
         // build a map of upgradeable module to Exports that are qualified to it


### PR DESCRIPTION
In the past, the Graal Compiler used `sun.misc.Unsafe` but these usages were recently changed to `jdk.internal.misc.Unsafe` [1]. We should therefor export `jdk.internal.misc` to `jdk.graal.compiler` which is an upgradeable module in the JDK.

[1] Remove sun.misc.Unsafe plugins (https://github.com/oracle/graal/commit/5c67d1a6eb8ecf717)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346101](https://bugs.openjdk.org/browse/JDK-8346101): [JVMCI] Export jdk.internal.misc to jdk.graal.compiler (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22714/head:pull/22714` \
`$ git checkout pull/22714`

Update a local copy of the PR: \
`$ git checkout pull/22714` \
`$ git pull https://git.openjdk.org/jdk.git pull/22714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22714`

View PR using the GUI difftool: \
`$ git pr show -t 22714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22714.diff">https://git.openjdk.org/jdk/pull/22714.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22714#issuecomment-2539157076)
</details>
