### PR TITLE
8346107: Generators: testing utility for random value generation

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/generators/AnyBitsDoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/AnyBitsDoubleGenerator.java
@@ -27,12 +27,15 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 /**
- * Provide a any-bits double distribution random generator, i.e. the bits are uniformly sampled,
+ * Provides an any-bits double distribution random generator, i.e. the bits are uniformly sampled,
  * thus creating any possible double value, including the multiple different NaN representations.
  */
 public final class AnyBitsDoubleGenerator extends DoubleGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
 
+    /**
+     * Create a new {@link AnyBitsDoubleGenerator}.
+     */
     public AnyBitsDoubleGenerator() {}
 
     @Override

--- a/test/hotspot/jtreg/compiler/lib/generators/AnyBitsDoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/AnyBitsDoubleGenerator.java
@@ -23,15 +23,11 @@
 
 package compiler.lib.generators;
 
-import java.util.Random;
-import jdk.test.lib.Utils;
-
 /**
  * Provides an any-bits double distribution random generator, i.e. the bits are uniformly sampled,
  * thus creating any possible double value, including the multiple different NaN representations.
  */
 public final class AnyBitsDoubleGenerator extends DoubleGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
 
     /**
      * Create a new {@link AnyBitsDoubleGenerator}.
@@ -40,6 +36,6 @@ public final class AnyBitsDoubleGenerator extends DoubleGenerator {
 
     @Override
     public double nextDouble() {
-        return Double.longBitsToDouble(RANDOM.nextLong());
+        return Double.longBitsToDouble(Generators.RANDOM.nextLong());
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/generators/AnyBitsDoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/AnyBitsDoubleGenerator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/**
+ * Provide a any-bits double distribution random generator, i.e. the bits are uniformly sampled,
+ * thus creating any possible double value, including the multiple different NaN representations.
+ */
+public final class AnyBitsDoubleGenerator extends DoubleGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    public AnyBitsDoubleGenerator() {}
+
+    @Override
+    public double nextDouble() {
+        return Double.longBitsToDouble(RANDOM.nextLong());
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/AnyBitsFloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/AnyBitsFloatGenerator.java
@@ -23,15 +23,11 @@
 
 package compiler.lib.generators;
 
-import java.util.Random;
-import jdk.test.lib.Utils;
-
 /**
  * Provides an any-bits float distribution random generator, i.e. the bits are uniformly sampled,
  * thus creating any possible float value, including the multiple different NaN representations.
  */
 public final class AnyBitsFloatGenerator extends FloatGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
 
     /**
      * Creates a new {@link AnyBitsFloatGenerator}.
@@ -40,6 +36,6 @@ public final class AnyBitsFloatGenerator extends FloatGenerator {
 
     @Override
     public float nextFloat() {
-        return Float.intBitsToFloat(RANDOM.nextInt());
+        return Float.intBitsToFloat(Generators.RANDOM.nextInt());
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/generators/AnyBitsFloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/AnyBitsFloatGenerator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/**
+ * Provide a any-bits float distribution random generator, i.e. the bits are uniformly sampled,
+ * thus creating any possible float value, including the multiple different NaN representations.
+ */
+public final class AnyBitsFloatGenerator extends FloatGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    public AnyBitsFloatGenerator() {}
+
+    @Override
+    public float nextFloat() {
+        return Float.intBitsToFloat(RANDOM.nextInt());
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/AnyBitsFloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/AnyBitsFloatGenerator.java
@@ -27,12 +27,15 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 /**
- * Provide a any-bits float distribution random generator, i.e. the bits are uniformly sampled,
+ * Provides an any-bits float distribution random generator, i.e. the bits are uniformly sampled,
  * thus creating any possible float value, including the multiple different NaN representations.
  */
 public final class AnyBitsFloatGenerator extends FloatGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
 
+    /**
+     * Creates a new {@link AnyBitsFloatGenerator}.
+     */
     public AnyBitsFloatGenerator() {}
 
     @Override

--- a/test/hotspot/jtreg/compiler/lib/generators/DoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/DoubleGenerator.java
@@ -28,27 +28,38 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 /**
- * Define interface of double generators.
+ * Base class of double generators.
  */
 public abstract class DoubleGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
 
     /**
+     * Creates a new {@link DoubleGenerator}.
+     */
+    public DoubleGenerator() {}
+
+    /**
      * Generate a random double, the distribution can be arbitrarily defined by the generator.
+     *
+     * @return Random double value.
      */
     public abstract double nextDouble();
 
     /**
      * Fill the memory segments with doubles using the distribution of nextDouble.
+     *
+     * @param ms Memory segment to be filled with random values.
      */
     public final void fill(MemorySegment ms) {
-        for (long i = 0; i < ms.byteSize() / 8; i++ ) {
+        for (long i = 0; i < ms.byteSize() / 8; i++) {
             ms.set(ValueLayout.JAVA_DOUBLE_UNALIGNED, 8L * i, nextDouble());
         }
     }
 
     /**
      * Fill the array with doubles using the distribution of nextDouble.
+     *
+     * @param a Array to be filled with random values.
      */
     public final void fill(double[] a) {
         fill(MemorySegment.ofArray(a));

--- a/test/hotspot/jtreg/compiler/lib/generators/DoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/DoubleGenerator.java
@@ -24,14 +24,11 @@
 package compiler.lib.generators;
 
 import java.lang.foreign.*;
-import java.util.Random;
-import jdk.test.lib.Utils;
 
 /**
  * Base class of double generators.
  */
 public abstract class DoubleGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
 
     /**
      * Creates a new {@link DoubleGenerator}.

--- a/test/hotspot/jtreg/compiler/lib/generators/DoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/DoubleGenerator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.lang.foreign.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/**
+ * Define interface of double generators.
+ */
+public abstract class DoubleGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    /**
+     * Generate a random double, the distribution can be arbitrarily defined by the generator.
+     */
+    public abstract double nextDouble();
+
+    /**
+     * Fill the memory segments with doubles using the distribution of nextDouble.
+     */
+    public final void fill(MemorySegment ms) {
+        for (long i = 0; i < ms.byteSize() / 8; i++ ) {
+            ms.set(ValueLayout.JAVA_DOUBLE_UNALIGNED, 8L * i, nextDouble());
+        }
+    }
+
+    /**
+     * Fill the array with doubles using the distribution of nextDouble.
+     */
+    public final void fill(double[] a) {
+        fill(MemorySegment.ofArray(a));
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/FloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/FloatGenerator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.lang.foreign.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/**
+ * Define interface of float generators.
+ */
+public abstract class FloatGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    /**
+     * Generate a random float, the distribution can be arbitrarily defined by the generator.
+     */
+    public abstract float nextFloat();
+
+    /**
+     * Fill the memory segments with floats using the distribution of nextFloat.
+     */
+    public final void fill(MemorySegment ms) {
+        for (long i = 0; i < ms.byteSize() / 4; i++ ) {
+            ms.set(ValueLayout.JAVA_FLOAT_UNALIGNED, 4L * i, nextFloat());
+        }
+    }
+
+    /**
+     * Fill the array with floats using the distribution of nextFloat.
+     */
+    public final void fill(float[] a) {
+        fill(MemorySegment.ofArray(a));
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/FloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/FloatGenerator.java
@@ -28,27 +28,38 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 /**
- * Define interface of float generators.
+ * Base class of float generators.
  */
 public abstract class FloatGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
 
     /**
+     * Creates a new {@link FloatGenerator}.
+     */
+    public FloatGenerator() {}
+
+    /**
      * Generate a random float, the distribution can be arbitrarily defined by the generator.
+     *
+     * @return Random float value.
      */
     public abstract float nextFloat();
 
     /**
      * Fill the memory segments with floats using the distribution of nextFloat.
+     *
+     * @param ms Memory segment to be filled with random values.
      */
     public final void fill(MemorySegment ms) {
-        for (long i = 0; i < ms.byteSize() / 4; i++ ) {
+        for (long i = 0; i < ms.byteSize() / 4; i++) {
             ms.set(ValueLayout.JAVA_FLOAT_UNALIGNED, 4L * i, nextFloat());
         }
     }
 
     /**
      * Fill the array with floats using the distribution of nextFloat.
+     *
+     * @param a Array to be filled with random values.
      */
     public final void fill(float[] a) {
         fill(MemorySegment.ofArray(a));

--- a/test/hotspot/jtreg/compiler/lib/generators/FloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/FloatGenerator.java
@@ -24,14 +24,11 @@
 package compiler.lib.generators;
 
 import java.lang.foreign.*;
-import java.util.Random;
-import jdk.test.lib.Utils;
 
 /**
  * Base class of float generators.
  */
 public abstract class FloatGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
 
     /**
      * Creates a new {@link FloatGenerator}.

--- a/test/hotspot/jtreg/compiler/lib/generators/Generators.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/Generators.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/**
+ * The generators class provides a set of generator functions for testing.
+ * The goal is to cover many special cases, such as NaNs in Floats or values
+ * close to overflow in ints. They should produce values from specific
+ * "intersting" distributions which might trigger various behaviours in
+ * optimizations.
+ */
+public final class Generators {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    /**
+     * Randomly pick an int generator.
+     */
+    public static IntGenerator ints() {
+        switch(RANDOM.nextInt(6)) {
+            case 0  -> { return new UniformIntGenerator(); }
+            case 1  -> { return new SpecialIntGenerator(0); }
+            case 2  -> { return new SpecialIntGenerator(2); }
+            case 3  -> { return new SpecialIntGenerator(16); }
+            case 4  -> { return new MixedIntGenerator(1, 1, 16); }
+            case 5  -> { return new MixedIntGenerator(1, 2, 2); }
+            default -> { throw new RuntimeException("impossible"); }
+        }
+    }
+
+    /**
+     * Randomly pick an long generator.
+     */
+    public static LongGenerator longs() {
+        switch(RANDOM.nextInt(6)) {
+            case 0  -> { return new UniformLongGenerator(); }
+            case 1  -> { return new SpecialLongGenerator(0); }
+            case 2  -> { return new SpecialLongGenerator(2); }
+            case 3  -> { return new SpecialLongGenerator(16); }
+            case 4  -> { return new MixedLongGenerator(1, 1, 16); }
+            case 5  -> { return new MixedLongGenerator(1, 2, 2); }
+            default -> { throw new RuntimeException("impossible"); }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/Generators.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/Generators.java
@@ -36,8 +36,14 @@ import jdk.test.lib.Utils;
 public final class Generators {
     private static final Random RANDOM = Utils.getRandomInstance();
 
+    private Generators() {
+        throw new AssertionError();
+    }
+
     /**
      * Randomly pick an int generator.
+     *
+     * @return Random int generator.
      */
     public static IntGenerator ints() {
         switch(RANDOM.nextInt(6)) {
@@ -53,6 +59,8 @@ public final class Generators {
 
     /**
      * Randomly pick a long generator.
+     *
+     * @return Random long generator.
      */
     public static LongGenerator longs() {
         switch(RANDOM.nextInt(6)) {
@@ -68,6 +76,8 @@ public final class Generators {
 
     /**
      * Randomly pick a float generator.
+     *
+     * @return Random float generator.
      */
     public static FloatGenerator floats() {
         switch(RANDOM.nextInt(5)) {
@@ -85,6 +95,8 @@ public final class Generators {
 
     /**
      * Randomly pick a double generator.
+     *
+     * @return Random double generator.
      */
     public static DoubleGenerator doubles() {
         switch(RANDOM.nextInt(5)) {

--- a/test/hotspot/jtreg/compiler/lib/generators/Generators.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/Generators.java
@@ -34,7 +34,7 @@ import jdk.test.lib.Utils;
  * optimizations.
  */
 public final class Generators {
-    private static final Random RANDOM = Utils.getRandomInstance();
+    static final Random RANDOM = Utils.getRandomInstance();
 
     private Generators() {
         throw new AssertionError();

--- a/test/hotspot/jtreg/compiler/lib/generators/Generators.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/Generators.java
@@ -70,11 +70,15 @@ public final class Generators {
      * Randomly pick a float generator.
      */
     public static FloatGenerator floats() {
-        switch(RANDOM.nextInt(2)) {
+        switch(RANDOM.nextInt(5)) {
             case 0  -> { return new UniformFloatGenerator(-1, 1); }
             // Well balanced, so that multiplication reduction never explodes or collapses to zero:
-            case 1  -> { return new UniformFloatGenerator(0.99f, 1.01f); }
+            case 1  -> { return new UniformFloatGenerator(0.999f, 1.001f); }
             case 2  -> { return new AnyBitsFloatGenerator(); }
+            // A tame distribution, mixed in with the occasional special float value:
+            case 3  -> { return new SpecialFloatGenerator(new UniformFloatGenerator(0.999f, 1.001f), 10, 1000); }
+            // Generating any bits, but special values are more frequent.
+            case 4  -> { return new SpecialFloatGenerator(new AnyBitsFloatGenerator(), 100, 200); }
             default -> { throw new RuntimeException("impossible"); }
         }
     }

--- a/test/hotspot/jtreg/compiler/lib/generators/Generators.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/Generators.java
@@ -52,7 +52,7 @@ public final class Generators {
     }
 
     /**
-     * Randomly pick an long generator.
+     * Randomly pick a long generator.
      */
     public static LongGenerator longs() {
         switch(RANDOM.nextInt(6)) {
@@ -65,4 +65,18 @@ public final class Generators {
             default -> { throw new RuntimeException("impossible"); }
         }
     }
+
+    /**
+     * Randomly pick a float generator.
+     */
+    public static FloatGenerator floats() {
+        switch(RANDOM.nextInt(2)) {
+            case 0  -> { return new UniformFloatGenerator(-1, 1); }
+            // Well balanced, so that multiplication reduction never explodes or collapses to zero:
+            case 1  -> { return new UniformFloatGenerator(0.99f, 1.01f); }
+            case 2  -> { return new AnyBitsFloatGenerator(); }
+            default -> { throw new RuntimeException("impossible"); }
+        }
+    }
+
 }

--- a/test/hotspot/jtreg/compiler/lib/generators/Generators.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/Generators.java
@@ -83,4 +83,20 @@ public final class Generators {
         }
     }
 
+    /**
+     * Randomly pick a double generator.
+     */
+    public static DoubleGenerator doubles() {
+        switch(RANDOM.nextInt(5)) {
+            case 0  -> { return new UniformDoubleGenerator(-1, 1); }
+            // Well balanced, so that multiplication reduction never explodes or collapses to zero:
+            case 1  -> { return new UniformDoubleGenerator(0.999f, 1.001f); }
+            case 2  -> { return new AnyBitsDoubleGenerator(); }
+            // A tame distribution, mixed in with the occasional special double value:
+            case 3  -> { return new SpecialDoubleGenerator(new UniformDoubleGenerator(0.999f, 1.001f), 10, 1000); }
+            // Generating any bits, but special values are more frequent.
+            case 4  -> { return new SpecialDoubleGenerator(new AnyBitsDoubleGenerator(), 100, 200); }
+            default -> { throw new RuntimeException("impossible"); }
+        }
+    }
 }

--- a/test/hotspot/jtreg/compiler/lib/generators/IntGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/IntGenerator.java
@@ -26,23 +26,38 @@ package compiler.lib.generators;
 import java.lang.foreign.*;
 
 /**
- * Define interface of int generators.
+ * Base class for int generators.
  */
 public abstract class IntGenerator {
+
     /**
-     * Generate a random int from [lo, hi], where the bounds are inclusive.
+     * Creates a new {@link IntGenerator}.
+     */
+    public IntGenerator() {}
+
+    /**
+     * Generates a random int from [lo, hi], where the bounds are inclusive.
+     *
+     * @param lo Lower bound of the sampling range (inclusive).
+     * @param hi Higher bound of the sampling range (inclusive).
+     * @return Value sampled between [lo, hi].
      */
     public abstract int nextInt(int lo, int hi);
 
     /**
-     * Generate a random integer from the whole int range.
+     * Generates a random integer from the whole int range.
+     *
+     * @return Value sampled from the whole long range.
      */
     public final int nextInt() {
         return nextInt(Integer.MIN_VALUE, Integer.MAX_VALUE);
     }
 
     /**
-     * Generate a random integer in the range [0, hi], where the bounds are inclusive.
+     * Generates a random integer in the range [0, hi], where the bounds are inclusive.
+     *
+     * @param hi Higher bound of the sampling range (inclusive).
+     * @return Value sampled from {0, hi}.
      */
     public final int nextInt(int hi) {
         return nextInt(0, hi);
@@ -51,9 +66,13 @@ public abstract class IntGenerator {
     /**
      * Fill the memory segments with ints in range [lo, hi], where the bounds are inclusive,
      * Fill it with ints from the generators distribution.
+     *
+     * @param ms Memory segment to be filled.
+     * @param hi Higher bound of the sampling range (inclusive).
+     * @param lo Lower bound of the sampling range (inclusive).
      */
-    public void fill(MemorySegment ms, int lo, int hi) {
-        for (long i = 0; i < ms.byteSize() / 4; i++ ) {
+    public final void fill(MemorySegment ms, int lo, int hi) {
+        for (long i = 0; i < ms.byteSize() / 4; i++) {
             ms.set(ValueLayout.JAVA_INT_UNALIGNED, 4L * i, nextInt(lo, hi));
         }
     }
@@ -61,8 +80,12 @@ public abstract class IntGenerator {
     /**
      * Fill the array with ints in range [lo, hi], where the bounds are inclusive,
      * Fill it with ints from the generators distribution.
+     *
+     * @param a Array to be filled.
+     * @param hi Higher bound of the sampling range (inclusive).
+     * @param lo Lower bound of the sampling range (inclusive).
      */
-    public void fill(int[] a, int lo, int hi) {
+    public final void fill(int[] a, int lo, int hi) {
         fill(MemorySegment.ofArray(a), lo, hi);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/generators/IntGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/IntGenerator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.lang.foreign.*;
+
+/**
+ * Define interface of int generators.
+ */
+public abstract class IntGenerator {
+    /**
+     * Generate a random int from [lo, hi], where the bounds are inclusive.
+     */
+    public abstract int nextInt(int lo, int hi);
+
+    /**
+     * Generate a random integer from the whole int range.
+     */
+    public final int nextInt() {
+        return nextInt(Integer.MIN_VALUE, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Generate a random integer in the range [0, hi], where the bounds are inclusive.
+     */
+    public final int nextInt(int hi) {
+        return nextInt(0, hi);
+    }
+
+    /**
+     * Fill the memory segments with ints in range [lo, hi], where the bounds are inclusive,
+     * Fill it with ints from the generators distribution.
+     */
+    public void fill(MemorySegment ms, int lo, int hi) {
+        for (long i = 0; i < ms.byteSize() / 4; i++ ) {
+            ms.set(ValueLayout.JAVA_INT_UNALIGNED, 4L * i, nextInt(lo, hi));
+        }
+    }
+
+    /**
+     * Fill the array with ints in range [lo, hi], where the bounds are inclusive,
+     * Fill it with ints from the generators distribution.
+     */
+    public void fill(int[] a, int lo, int hi) {
+        fill(MemorySegment.ofArray(a), lo, hi);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/LongGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/LongGenerator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.lang.foreign.*;
+
+/**
+ * Define interface of long generators.
+ */
+public abstract class LongGenerator {
+    /**
+     * Generate a random long from [lo, hi], where the bounds are inclusive.
+     */
+    public abstract long nextLong(long lo, long hi);
+
+    /**
+     * Generate a random long from the whole long range.
+     */
+    public final long nextLong() {
+        return nextLong(Long.MIN_VALUE, Long.MAX_VALUE);
+    }
+
+    /**
+     * Generate a random long in the range [0, hi], where the bounds are inclusive.
+     */
+    public final long nextLong(long hi) {
+        return nextLong(0, hi);
+    }
+
+    /**
+     * Fill the memory segments with longs in range [lo, hi], where the bounds are inclusive,
+     * Fill it with longs from the generators distribution.
+     */
+    public void fill(MemorySegment ms, long lo, long hi) {
+        for (long i = 0; i < ms.byteSize() / 8; i++ ) {
+            ms.set(ValueLayout.JAVA_LONG_UNALIGNED, 8L * i, nextLong(lo, hi));
+        }
+    }
+
+    /**
+     * Fill the array with longs in range [lo, hi], where the bounds are inclusive,
+     * Fill it with longs from the generators distribution.
+     */
+    public void fill(long[] a, long lo, long hi) {
+        fill(MemorySegment.ofArray(a), lo, hi);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/LongGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/LongGenerator.java
@@ -26,23 +26,38 @@ package compiler.lib.generators;
 import java.lang.foreign.*;
 
 /**
- * Define interface of long generators.
+ * Base class for long generators.
  */
 public abstract class LongGenerator {
+
     /**
-     * Generate a random long from [lo, hi], where the bounds are inclusive.
+     * Creates a new {@link LongGenerator}.
+     */
+    public LongGenerator() {}
+
+    /**
+     * Generates a random long from [lo, hi], where the bounds are inclusive.
+     *
+     * @param lo Lower bound of the sampling range (inclusive).
+     * @param hi Higher bound of the sampling range (inclusive).
+     * @return Value sampled between [lo, hi].
      */
     public abstract long nextLong(long lo, long hi);
 
     /**
-     * Generate a random long from the whole long range.
+     * Generates a random long from the whole long range.
+     *
+     * @return Value sampled from the whole long range.
      */
     public final long nextLong() {
         return nextLong(Long.MIN_VALUE, Long.MAX_VALUE);
     }
 
     /**
-     * Generate a random long in the range [0, hi], where the bounds are inclusive.
+     * Generates a random long in the range [0, hi], where the bounds are inclusive.
+     *
+     * @param hi Higher bound of the sampling range (inclusive).
+     * @return Value sampled from {0, hi}.
      */
     public final long nextLong(long hi) {
         return nextLong(0, hi);
@@ -51,9 +66,13 @@ public abstract class LongGenerator {
     /**
      * Fill the memory segments with longs in range [lo, hi], where the bounds are inclusive,
      * Fill it with longs from the generators distribution.
+     *
+     * @param ms Memory segment to be filled.
+     * @param hi Higher bound of the sampling range (inclusive).
+     * @param lo Lower bound of the sampling range (inclusive).
      */
-    public void fill(MemorySegment ms, long lo, long hi) {
-        for (long i = 0; i < ms.byteSize() / 8; i++ ) {
+    public final void fill(MemorySegment ms, long lo, long hi) {
+        for (long i = 0; i < ms.byteSize() / 8; i++) {
             ms.set(ValueLayout.JAVA_LONG_UNALIGNED, 8L * i, nextLong(lo, hi));
         }
     }
@@ -61,8 +80,12 @@ public abstract class LongGenerator {
     /**
      * Fill the array with longs in range [lo, hi], where the bounds are inclusive,
      * Fill it with longs from the generators distribution.
+     *
+     * @param a Array to be filled.
+     * @param hi Higher bound of the sampling range (inclusive).
+     * @param lo Lower bound of the sampling range (inclusive).
      */
-    public void fill(long[] a, long lo, long hi) {
+    public final void fill(long[] a, long lo, long hi) {
         fill(MemorySegment.ofArray(a), lo, hi);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/generators/MixedIntGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/MixedIntGenerator.java
@@ -29,7 +29,7 @@ import java.util.HashSet;
 import jdk.test.lib.Utils;
 
 /**
- * Mixed results between UniformIntGenerator and SpecialIntGenerator.
+ * Mixed results between {@link UniformIntGenerator} and {@link SpecialIntGenerator}.
  */
 public final class MixedIntGenerator extends IntGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
@@ -39,6 +39,14 @@ public final class MixedIntGenerator extends IntGenerator {
     private final int weightUniform;
     private final int weightSpecial;
 
+    /**
+     * Creates a new {@link MixedIntGenerator}, which samples from {@link UniformIntGenerator} and {@link SpecialIntGenerator},
+     * according to specified weights.
+     *
+     * @param weightUniform Weight for the uniform distribution.
+     * @param weightSpecial Weight for the special distribution.
+     * @param rangeSpecial Range for the special distribution.
+     */
     public MixedIntGenerator(int weightUniform, int weightSpecial, int rangeSpecial) {
         this.weightUniform = weightUniform;
         this.weightSpecial = weightSpecial;

--- a/test/hotspot/jtreg/compiler/lib/generators/MixedIntGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/MixedIntGenerator.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.HashSet;
+import jdk.test.lib.Utils;
+
+/**
+ * Mixed results between UniformIntGenerator and SpecialIntGenerator.
+ */
+public final class MixedIntGenerator extends IntGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    private final UniformIntGenerator uniform;
+    private final SpecialIntGenerator special;
+    private final int weightUniform;
+    private final int weightSpecial;
+
+    public MixedIntGenerator(int weightUniform, int weightSpecial, int rangeSpecial) {
+        this.weightUniform = weightUniform;
+        this.weightSpecial = weightSpecial;
+        this.uniform = new UniformIntGenerator();
+        this.special = new SpecialIntGenerator(rangeSpecial);
+    }
+
+    @Override
+    public int nextInt(int lo, int hi) {
+        int r = RANDOM.nextInt(weightUniform + weightSpecial);
+        if (r < weightUniform) {
+            return uniform.nextInt(lo, hi);
+        } else {
+            return special.nextInt(lo, hi);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/MixedIntGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/MixedIntGenerator.java
@@ -24,16 +24,12 @@
 package compiler.lib.generators;
 
 import java.util.Arrays;
-import java.util.Random;
 import java.util.HashSet;
-import jdk.test.lib.Utils;
 
 /**
  * Mixed results between {@link UniformIntGenerator} and {@link SpecialIntGenerator}.
  */
 public final class MixedIntGenerator extends IntGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
-
     private final UniformIntGenerator uniform;
     private final SpecialIntGenerator special;
     private final int weightUniform;
@@ -56,7 +52,7 @@ public final class MixedIntGenerator extends IntGenerator {
 
     @Override
     public int nextInt(int lo, int hi) {
-        int r = RANDOM.nextInt(weightUniform + weightSpecial);
+        int r = Generators.RANDOM.nextInt(weightUniform + weightSpecial);
         if (r < weightUniform) {
             return uniform.nextInt(lo, hi);
         } else {

--- a/test/hotspot/jtreg/compiler/lib/generators/MixedLongGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/MixedLongGenerator.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.HashSet;
+import jdk.test.lib.Utils;
+
+/**
+ * Mixed results between UniformLongGenerator and SpecialLongGenerator.
+ */
+public final class MixedLongGenerator extends LongGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    private final UniformLongGenerator uniform;
+    private final SpecialLongGenerator special;
+    private final int weightUniform;
+    private final int weightSpecial;
+
+    public MixedLongGenerator(int weightUniform, int weightSpecial, int rangeSpecial) {
+        this.weightUniform = weightUniform;
+        this.weightSpecial = weightSpecial;
+        this.uniform = new UniformLongGenerator();
+        this.special = new SpecialLongGenerator(rangeSpecial);
+    }
+
+    @Override
+    public long nextLong(long lo, long hi) {
+        int r = RANDOM.nextInt(weightUniform + weightSpecial);
+        if (r < weightUniform) {
+            return uniform.nextLong(lo, hi);
+        } else {
+            return special.nextLong(lo, hi);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/MixedLongGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/MixedLongGenerator.java
@@ -29,7 +29,7 @@ import java.util.HashSet;
 import jdk.test.lib.Utils;
 
 /**
- * Mixed results between UniformLongGenerator and SpecialLongGenerator.
+ * Mixed results between {@link UniformLongGenerator} and {@link SpecialLongGenerator}.
  */
 public final class MixedLongGenerator extends LongGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
@@ -39,6 +39,14 @@ public final class MixedLongGenerator extends LongGenerator {
     private final int weightUniform;
     private final int weightSpecial;
 
+    /**
+     * Creates a new {@link MixedLongGenerator}, which samples from {@link UniformLongGenerator} and {@link SpecialLongGenerator},
+     * according to specified weights.
+     *
+     * @param weightUniform Weight for the uniform distribution.
+     * @param weightSpecial Weight for the special distribution.
+     * @param rangeSpecial Range for the special distribution.
+     */
     public MixedLongGenerator(int weightUniform, int weightSpecial, int rangeSpecial) {
         this.weightUniform = weightUniform;
         this.weightSpecial = weightSpecial;

--- a/test/hotspot/jtreg/compiler/lib/generators/MixedLongGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/MixedLongGenerator.java
@@ -24,16 +24,12 @@
 package compiler.lib.generators;
 
 import java.util.Arrays;
-import java.util.Random;
 import java.util.HashSet;
-import jdk.test.lib.Utils;
 
 /**
  * Mixed results between {@link UniformLongGenerator} and {@link SpecialLongGenerator}.
  */
 public final class MixedLongGenerator extends LongGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
-
     private final UniformLongGenerator uniform;
     private final SpecialLongGenerator special;
     private final int weightUniform;
@@ -56,7 +52,7 @@ public final class MixedLongGenerator extends LongGenerator {
 
     @Override
     public long nextLong(long lo, long hi) {
-        int r = RANDOM.nextInt(weightUniform + weightSpecial);
+        int r = Generators.RANDOM.nextInt(weightUniform + weightSpecial);
         if (r < weightUniform) {
             return uniform.nextLong(lo, hi);
         } else {

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialDoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialDoubleGenerator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/**
+ * Provide a double distribution picked from a list of special values, including NaN, zero, int, etc.
+ */
+public final class SpecialDoubleGenerator extends DoubleGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    // Pre-generated values we can chose from.
+    private static final double[] VALUES = new double[] {
+        0,
+        1,
+        -1,
+        Double.POSITIVE_INFINITY,
+        Double.NEGATIVE_INFINITY,
+        Double.NaN,
+        Double.MAX_VALUE,
+        Double.MIN_NORMAL,
+        Double.MIN_VALUE,
+    };
+
+    // We also mix in other values at a certain percentage.
+    private final DoubleGenerator backgroundGenerator;
+
+    // specialCountDown detemines in how many iterations we generate the next special value.
+    private final int specialMinFrequency;
+    private final int specialMaxFrequency;
+    private int specialCountDown;
+
+    public SpecialDoubleGenerator(DoubleGenerator backgroundGenerator, int specialMinFrequency, int specialMaxFrequency) {
+        this.backgroundGenerator = backgroundGenerator;
+        this.specialMinFrequency = specialMinFrequency;
+        this.specialMaxFrequency = specialMaxFrequency;
+        this.specialCountDown = RANDOM.nextInt(specialMaxFrequency);
+    }
+
+    @Override
+    public double nextDouble() {
+        specialCountDown--;
+        if (specialCountDown <= 0) {
+            specialCountDown = RANDOM.nextInt(specialMinFrequency, specialMaxFrequency);
+            int r = RANDOM.nextInt(VALUES.length);
+            return VALUES[r];
+        } else {
+            return backgroundGenerator.nextDouble();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialDoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialDoubleGenerator.java
@@ -27,12 +27,14 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 /**
- * Provide a double distribution picked from a list of special values, including NaN, zero, int, etc.
+ * Provides a double distribution picked from a list of special values, including NaN, zero, int, etc.
  */
 public final class SpecialDoubleGenerator extends DoubleGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
 
-    // Pre-generated values we can chose from.
+    /*
+     * Pre-generated values we can chose from.
+     */
     private static final double[] VALUES = new double[] {
         0,
         1,
@@ -45,26 +47,39 @@ public final class SpecialDoubleGenerator extends DoubleGenerator {
         Double.MIN_VALUE,
     };
 
-    // We also mix in other values at a certain percentage.
+    /*
+     * We also mix in other values at a certain percentage.
+     */
     private final DoubleGenerator backgroundGenerator;
 
-    // specialCountDown detemines in how many iterations we generate the next special value.
-    private final int specialMinFrequency;
-    private final int specialMaxFrequency;
+    /*
+     * {@link specialCountDown} detemines in how many iterations we generate the next special value.
+     */
+    private final int specialMinDistance;
+    private final int specialMaxDistance;
     private int specialCountDown;
 
-    public SpecialDoubleGenerator(DoubleGenerator backgroundGenerator, int specialMinFrequency, int specialMaxFrequency) {
+    /**
+     * Creates a new {@link SpecialDoubleGenerator}. It periodically generates a special value (NaN, zero, infinity, etc).
+     * The distance between two special values is chosen randomly between {@code specialMinDistance} and
+     * {@code specialMaxDistance}. All other values in between are chosen from a {@code backgroundGenerator}.
+     *
+     * @param backgroundGenerator Provides the random values between the special values.
+     * @param specialMinDistance Minimum distance between special values.
+     * @param specialMaxDistance Maximum distance between special values.
+     */
+    public SpecialDoubleGenerator(DoubleGenerator backgroundGenerator, int specialMinDistance, int specialMaxDistance) {
         this.backgroundGenerator = backgroundGenerator;
-        this.specialMinFrequency = specialMinFrequency;
-        this.specialMaxFrequency = specialMaxFrequency;
-        this.specialCountDown = RANDOM.nextInt(specialMaxFrequency);
+        this.specialMinDistance = specialMinDistance;
+        this.specialMaxDistance = specialMaxDistance;
+        this.specialCountDown = RANDOM.nextInt(specialMaxDistance);
     }
 
     @Override
     public double nextDouble() {
         specialCountDown--;
         if (specialCountDown <= 0) {
-            specialCountDown = RANDOM.nextInt(specialMinFrequency, specialMaxFrequency);
+            specialCountDown = RANDOM.nextInt(specialMinDistance, specialMaxDistance);
             int r = RANDOM.nextInt(VALUES.length);
             return VALUES[r];
         } else {

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialDoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialDoubleGenerator.java
@@ -23,14 +23,10 @@
 
 package compiler.lib.generators;
 
-import java.util.Random;
-import jdk.test.lib.Utils;
-
 /**
  * Provides a double distribution picked from a list of special values, including NaN, zero, int, etc.
  */
 public final class SpecialDoubleGenerator extends DoubleGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
 
     /*
      * Pre-generated values we can chose from.
@@ -72,15 +68,15 @@ public final class SpecialDoubleGenerator extends DoubleGenerator {
         this.backgroundGenerator = backgroundGenerator;
         this.specialMinDistance = specialMinDistance;
         this.specialMaxDistance = specialMaxDistance;
-        this.specialCountDown = RANDOM.nextInt(specialMaxDistance);
+        this.specialCountDown = Generators.RANDOM.nextInt(specialMaxDistance);
     }
 
     @Override
     public double nextDouble() {
         specialCountDown--;
         if (specialCountDown <= 0) {
-            specialCountDown = RANDOM.nextInt(specialMinDistance, specialMaxDistance);
-            int r = RANDOM.nextInt(VALUES.length);
+            specialCountDown = Generators.RANDOM.nextInt(specialMinDistance, specialMaxDistance);
+            int r = Generators.RANDOM.nextInt(VALUES.length);
             return VALUES[r];
         } else {
             return backgroundGenerator.nextDouble();

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialFloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialFloatGenerator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/**
+ * Provide a float distribution picked from a list of special values, including NaN, zero, int, etc.
+ */
+public final class SpecialFloatGenerator extends FloatGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    // Pre-generated values we can chose from.
+    private static final float[] VALUES = new float[] {
+        0,
+        1,
+        -1,
+        Float.POSITIVE_INFINITY,
+        Float.NEGATIVE_INFINITY,
+        Float.NaN,
+        Float.MAX_VALUE,
+        Float.MIN_NORMAL,
+        Float.MIN_VALUE,
+    };
+
+    // We also mix in other values at a certain percentage.
+    private final FloatGenerator backgroundGenerator;
+
+    // specialCountDown detemines in how many iterations we generate the next special value.
+    private final int specialMinFrequency;
+    private final int specialMaxFrequency;
+    private int specialCountDown;
+
+    public SpecialFloatGenerator(FloatGenerator backgroundGenerator, int specialMinFrequency, int specialMaxFrequency) {
+        this.backgroundGenerator = backgroundGenerator;
+        this.specialMinFrequency = specialMinFrequency;
+        this.specialMaxFrequency = specialMaxFrequency;
+        this.specialCountDown = RANDOM.nextInt(specialMaxFrequency);
+    }
+
+    @Override
+    public float nextFloat() {
+        specialCountDown--;
+        if (specialCountDown <= 0) {
+            specialCountDown = RANDOM.nextInt(specialMinFrequency, specialMaxFrequency);
+            int r = RANDOM.nextInt(VALUES.length);
+            return VALUES[r];
+        } else {
+            return backgroundGenerator.nextFloat();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialFloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialFloatGenerator.java
@@ -27,12 +27,14 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 /**
- * Provide a float distribution picked from a list of special values, including NaN, zero, int, etc.
+ * Provides a float distribution picked from a list of special values, including NaN, zero, int, etc.
  */
 public final class SpecialFloatGenerator extends FloatGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
 
-    // Pre-generated values we can chose from.
+    /*
+     * Pre-generated values we can chose from.
+     */
     private static final float[] VALUES = new float[] {
         0,
         1,
@@ -45,26 +47,39 @@ public final class SpecialFloatGenerator extends FloatGenerator {
         Float.MIN_VALUE,
     };
 
-    // We also mix in other values at a certain percentage.
+    /*
+     * We also mix in other values at a certain percentage.
+     */
     private final FloatGenerator backgroundGenerator;
 
-    // specialCountDown detemines in how many iterations we generate the next special value.
-    private final int specialMinFrequency;
-    private final int specialMaxFrequency;
+    /*
+     * {@link specialCountDown} detemines in how many iterations we generate the next special value.
+     */
+    private final int specialMinDistance;
+    private final int specialMaxDistance;
     private int specialCountDown;
 
-    public SpecialFloatGenerator(FloatGenerator backgroundGenerator, int specialMinFrequency, int specialMaxFrequency) {
+    /**
+     * Creates a new {@link SpecialFloatGenerator}. It periodically generates a special value (NaN, zero, infinity, etc).
+     * The distance between two special values is chosen randomly between {@code specialMinDistance} and
+     * {@code specialMaxDistance}. All other values in between are chosen from a {@code backgroundGenerator}.
+     *
+     * @param backgroundGenerator Provides the random values between the special values.
+     * @param specialMinDistance Minimum distance between special values.
+     * @param specialMaxDistance Maximum distance between special values.
+     */
+    public SpecialFloatGenerator(FloatGenerator backgroundGenerator, int specialMinDistance, int specialMaxDistance) {
         this.backgroundGenerator = backgroundGenerator;
-        this.specialMinFrequency = specialMinFrequency;
-        this.specialMaxFrequency = specialMaxFrequency;
-        this.specialCountDown = RANDOM.nextInt(specialMaxFrequency);
+        this.specialMinDistance = specialMinDistance;
+        this.specialMaxDistance = specialMaxDistance;
+        this.specialCountDown = RANDOM.nextInt(specialMaxDistance);
     }
 
     @Override
     public float nextFloat() {
         specialCountDown--;
         if (specialCountDown <= 0) {
-            specialCountDown = RANDOM.nextInt(specialMinFrequency, specialMaxFrequency);
+            specialCountDown = RANDOM.nextInt(specialMinDistance, specialMaxDistance);
             int r = RANDOM.nextInt(VALUES.length);
             return VALUES[r];
         } else {

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialFloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialFloatGenerator.java
@@ -23,14 +23,10 @@
 
 package compiler.lib.generators;
 
-import java.util.Random;
-import jdk.test.lib.Utils;
-
 /**
  * Provides a float distribution picked from a list of special values, including NaN, zero, int, etc.
  */
 public final class SpecialFloatGenerator extends FloatGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
 
     /*
      * Pre-generated values we can chose from.
@@ -72,15 +68,15 @@ public final class SpecialFloatGenerator extends FloatGenerator {
         this.backgroundGenerator = backgroundGenerator;
         this.specialMinDistance = specialMinDistance;
         this.specialMaxDistance = specialMaxDistance;
-        this.specialCountDown = RANDOM.nextInt(specialMaxDistance);
+        this.specialCountDown = Generators.RANDOM.nextInt(specialMaxDistance);
     }
 
     @Override
     public float nextFloat() {
         specialCountDown--;
         if (specialCountDown <= 0) {
-            specialCountDown = RANDOM.nextInt(specialMinDistance, specialMaxDistance);
-            int r = RANDOM.nextInt(VALUES.length);
+            specialCountDown = Generators.RANDOM.nextInt(specialMinDistance, specialMaxDistance);
+            int r = Generators.RANDOM.nextInt(VALUES.length);
             return VALUES[r];
         } else {
             return backgroundGenerator.nextFloat();

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialIntGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialIntGenerator.java
@@ -24,21 +24,17 @@
 package compiler.lib.generators;
 
 import java.util.Arrays;
-import java.util.Random;
 import java.util.HashSet;
-import jdk.test.lib.Utils;
 
 /**
  * Provides a distribution over values close to the powers of 2.
  */
 public final class SpecialIntGenerator extends IntGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
 
     /*
      * Pre-generated values we can chose from.
      */
     private final int[] values;
-
 
     /*
      * Fall-back generator if values does not contain any value in the
@@ -83,7 +79,7 @@ public final class SpecialIntGenerator extends IntGenerator {
             hiIndex++;
         }
         if (loIndex < hiIndex) {
-            int r = RANDOM.nextInt(hiIndex - loIndex);
+            int r = Generators.RANDOM.nextInt(hiIndex - loIndex);
             return values[loIndex + r];
         }
 

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialIntGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialIntGenerator.java
@@ -29,18 +29,29 @@ import java.util.HashSet;
 import jdk.test.lib.Utils;
 
 /**
- * Provide a distribution over values close to the powers of 2.
+ * Provides a distribution over values close to the powers of 2.
  */
 public final class SpecialIntGenerator extends IntGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
 
-    // Pre-generated values we can chose from.
+    /*
+     * Pre-generated values we can chose from.
+     */
     private final int[] values;
 
-    // Fall-back generator if values does not contain any value in the
-    // expected range.
+
+    /*
+     * Fall-back generator if values does not contain any value in the
+     * expected range.
+     */
     private final UniformIntGenerator uniform = new UniformIntGenerator();
 
+    /**
+     * Creates a new {@link SpecialIntGenerator}. Generates only powers of 2, and
+     * values that are not more than {@code range} away from powers of 2.
+     *
+     * @param range How far away from the powers of 2 the values should be generated.
+     */
     public SpecialIntGenerator(int range) {
         HashSet<Integer> set = new HashSet<Integer>();
         for (int i = 0; i < 32; i++) {

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialIntGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialIntGenerator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.HashSet;
+import jdk.test.lib.Utils;
+
+/**
+ * Provide a distribution over values close to the powers of 2.
+ */
+public final class SpecialIntGenerator extends IntGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    // Pre-generated values we can chose from.
+    private final int[] values;
+
+    // Fall-back generator if values does not contain any value in the
+    // expected range.
+    private final UniformIntGenerator uniform = new UniformIntGenerator();
+
+    public SpecialIntGenerator(int range) {
+        HashSet<Integer> set = new HashSet<Integer>();
+        for (int i = 0; i < 32; i++) {
+            int pow2 = 1 << i;
+            for (int j = -range; j <= range; j++) {
+                set.add(+pow2 + j);
+                set.add(-pow2 + j);
+            }
+        }
+        this.values = set.stream().mapToInt(Number::intValue).toArray();
+        Arrays.sort(this.values);
+    }
+
+    @Override
+    public int nextInt(int lo, int hi) {
+        // Find indices in values.
+        int loIndex = Arrays.binarySearch(values, lo);
+        int hiIndex = Arrays.binarySearch(values, hi);
+        if (loIndex < 0) {
+            // Not found, but we know that any values higher than lo
+            // must be at loIndex or higher.
+            loIndex = -(loIndex + 1);
+        }
+        if (hiIndex < 0) {
+            // Not found, but we know that any values lower than hi
+            // must be at less than hiIndex.
+            hiIndex = -(hiIndex + 1);
+        } else {
+            hiIndex++;
+        }
+        if (loIndex < hiIndex) {
+            int r = RANDOM.nextInt(hiIndex - loIndex);
+            return values[loIndex + r];
+        }
+
+        // No element in values is in the required range.
+        // Fall-back to uniform.
+        return uniform.nextInt(lo, hi);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialLongGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialLongGenerator.java
@@ -29,18 +29,28 @@ import java.util.HashSet;
 import jdk.test.lib.Utils;
 
 /**
- * Provide a distribution over values close to the powers of 2.
+ * Provides a distribution over values close to the powers of 2.
  */
 public final class SpecialLongGenerator extends LongGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
 
-    // Pre-generated values we can chose from.
+    /*
+     * Pre-generated values we can chose from.
+     */
     private final long[] values;
 
-    // Fall-back generator if values does not contain any value in the
-    // expected range.
+    /*
+     * Fall-back generator if values does not contain any value in the
+     * expected range.
+     */
     private final UniformLongGenerator uniform = new UniformLongGenerator();
 
+    /**
+     * Creates a new {@link SpecialLongGenerator}. Generates only powers of 2, and
+     * values that are not more than {@code range} away from powers of 2.
+     *
+     * @param range How far away from the powers of 2 the values should be generated.
+     */
     public SpecialLongGenerator(int range) {
         HashSet<Long> set = new HashSet<Long>();
         for (int i = 0; i < 64; i++) {

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialLongGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialLongGenerator.java
@@ -24,15 +24,12 @@
 package compiler.lib.generators;
 
 import java.util.Arrays;
-import java.util.Random;
 import java.util.HashSet;
-import jdk.test.lib.Utils;
 
 /**
  * Provides a distribution over values close to the powers of 2.
  */
 public final class SpecialLongGenerator extends LongGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
 
     /*
      * Pre-generated values we can chose from.
@@ -82,7 +79,7 @@ public final class SpecialLongGenerator extends LongGenerator {
             hiIndex++;
         }
         if (loIndex < hiIndex) {
-            int r = RANDOM.nextInt(hiIndex - loIndex);
+            int r = Generators.RANDOM.nextInt(hiIndex - loIndex);
             return values[loIndex + r];
         }
 

--- a/test/hotspot/jtreg/compiler/lib/generators/SpecialLongGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/SpecialLongGenerator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.HashSet;
+import jdk.test.lib.Utils;
+
+/**
+ * Provide a distribution over values close to the powers of 2.
+ */
+public final class SpecialLongGenerator extends LongGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    // Pre-generated values we can chose from.
+    private final long[] values;
+
+    // Fall-back generator if values does not contain any value in the
+    // expected range.
+    private final UniformLongGenerator uniform = new UniformLongGenerator();
+
+    public SpecialLongGenerator(int range) {
+        HashSet<Long> set = new HashSet<Long>();
+        for (int i = 0; i < 64; i++) {
+            long pow2 = 1L << i;
+            for (int j = -range; j <= range; j++) {
+                set.add(+pow2 + j);
+                set.add(-pow2 + j);
+            }
+        }
+        this.values = set.stream().mapToLong(Number::longValue).toArray();
+        Arrays.sort(this.values);
+    }
+
+    @Override
+    public long nextLong(long lo, long hi) {
+        // Find indices in values.
+        int loIndex = Arrays.binarySearch(values, lo);
+        int hiIndex = Arrays.binarySearch(values, hi);
+        if (loIndex < 0) {
+            // Not found, but we know that any values higher than lo
+            // must be at loIndex or higher.
+            loIndex = -(loIndex + 1);
+        }
+        if (hiIndex < 0) {
+            // Not found, but we know that any values lower than hi
+            // must be at less than hiIndex.
+            hiIndex = -(hiIndex + 1);
+        } else {
+            hiIndex++;
+        }
+        if (loIndex < hiIndex) {
+            int r = RANDOM.nextInt(hiIndex - loIndex);
+            return values[loIndex + r];
+        }
+
+        // No element in values is in the required range.
+        // Fall-back to uniform.
+        return uniform.nextLong(lo, hi);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformDoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformDoubleGenerator.java
@@ -27,7 +27,7 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 /**
- * Provide a uniform double distribution random generator, in the provided range [lo, hi).
+ * Provides a uniform double distribution random generator, in the provided range [lo, hi).
  */
 public final class UniformDoubleGenerator extends DoubleGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
@@ -35,6 +35,12 @@ public final class UniformDoubleGenerator extends DoubleGenerator {
     private final double lo;
     private final double hi;
 
+    /**
+     * Creates a new {@link UniformFloatGenerator}.
+     *
+     * @param lo Lower bound of the range (inclusive).
+     * @param hi Higher bound of the range (exclusive).
+     */
     public UniformDoubleGenerator(double lo, double hi) {
         this.lo = lo;
         this.hi = hi;

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformDoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformDoubleGenerator.java
@@ -23,15 +23,10 @@
 
 package compiler.lib.generators;
 
-import java.util.Random;
-import jdk.test.lib.Utils;
-
 /**
  * Provides a uniform double distribution random generator, in the provided range [lo, hi).
  */
 public final class UniformDoubleGenerator extends DoubleGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
-
     private final double lo;
     private final double hi;
 
@@ -48,6 +43,6 @@ public final class UniformDoubleGenerator extends DoubleGenerator {
 
     @Override
     public double nextDouble() {
-        return RANDOM.nextDouble(lo, hi);
+        return Generators.RANDOM.nextDouble(lo, hi);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformDoubleGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformDoubleGenerator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/**
+ * Provide a uniform double distribution random generator, in the provided range [lo, hi).
+ */
+public final class UniformDoubleGenerator extends DoubleGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    private final double lo;
+    private final double hi;
+
+    public UniformDoubleGenerator(double lo, double hi) {
+        this.lo = lo;
+        this.hi = hi;
+    }
+
+    @Override
+    public double nextDouble() {
+        return RANDOM.nextDouble(lo, hi);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformFloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformFloatGenerator.java
@@ -27,7 +27,7 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 /**
- * Provide a uniform float distribution random generator, in the provided range [lo, hi).
+ * Provides a uniform float distribution random generator, in the provided range [lo, hi).
  */
 public final class UniformFloatGenerator extends FloatGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
@@ -35,6 +35,12 @@ public final class UniformFloatGenerator extends FloatGenerator {
     private final float lo;
     private final float hi;
 
+    /**
+     * Creates a new {@link UniformFloatGenerator}.
+     *
+     * @param lo Lower bound of the range (inclusive).
+     * @param hi Higher bound of the range (exclusive).
+     */
     public UniformFloatGenerator(float lo, float hi) {
         this.lo = lo;
         this.hi = hi;

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformFloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformFloatGenerator.java
@@ -23,15 +23,10 @@
 
 package compiler.lib.generators;
 
-import java.util.Random;
-import jdk.test.lib.Utils;
-
 /**
  * Provides a uniform float distribution random generator, in the provided range [lo, hi).
  */
 public final class UniformFloatGenerator extends FloatGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
-
     private final float lo;
     private final float hi;
 
@@ -48,6 +43,6 @@ public final class UniformFloatGenerator extends FloatGenerator {
 
     @Override
     public float nextFloat() {
-        return RANDOM.nextFloat(lo, hi);
+        return Generators.RANDOM.nextFloat(lo, hi);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformFloatGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformFloatGenerator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/**
+ * Provide a uniform float distribution random generator, in the provided range [lo, hi).
+ */
+public final class UniformFloatGenerator extends FloatGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    private final float lo;
+    private final float hi;
+
+    public UniformFloatGenerator(float lo, float hi) {
+        this.lo = lo;
+        this.hi = hi;
+    }
+
+    @Override
+    public float nextFloat() {
+        return RANDOM.nextFloat(lo, hi);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformIntGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformIntGenerator.java
@@ -27,11 +27,14 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 /**
- * Provide a uniform int distribution random generator.
+ * Provides a uniform int distribution random generator.
  */
 public final class UniformIntGenerator extends IntGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
 
+    /**
+     * Creates a new {@link UniformIntGenerator}.
+     */
     public UniformIntGenerator() {}
 
     @Override

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformIntGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformIntGenerator.java
@@ -23,14 +23,10 @@
 
 package compiler.lib.generators;
 
-import java.util.Random;
-import jdk.test.lib.Utils;
-
 /**
  * Provides a uniform int distribution random generator.
  */
 public final class UniformIntGenerator extends IntGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
 
     /**
      * Creates a new {@link UniformIntGenerator}.
@@ -41,10 +37,10 @@ public final class UniformIntGenerator extends IntGenerator {
     public int nextInt(int lo, int hi) {
         if (hi == Integer.MAX_VALUE) {
             if (lo == Integer.MIN_VALUE) {
-                return RANDOM.nextInt();
+                return Generators.RANDOM.nextInt();
             }
-            return RANDOM.nextInt(lo - 1, hi) + 1;
+            return Generators.RANDOM.nextInt(lo - 1, hi) + 1;
         }
-        return RANDOM.nextInt(lo, hi + 1);
+        return Generators.RANDOM.nextInt(lo, hi + 1);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformIntGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformIntGenerator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/**
+ * Provide a uniform int distribution random generator.
+ */
+public final class UniformIntGenerator extends IntGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    public UniformIntGenerator() {}
+
+    @Override
+    public int nextInt(int lo, int hi) {
+        if (hi == Integer.MAX_VALUE) {
+            if (lo == Integer.MIN_VALUE) {
+                return RANDOM.nextInt();
+            }
+            return RANDOM.nextInt(lo - 1, hi) + 1;
+        }
+        return RANDOM.nextInt(lo, hi + 1);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformLongGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformLongGenerator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.generators;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/**
+ * Provide a uniform long distribution random generator.
+ */
+public final class UniformLongGenerator extends LongGenerator {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    public UniformLongGenerator() {}
+
+    @Override
+    public long nextLong(long lo, long hi) {
+        if (hi == Long.MAX_VALUE) {
+            if (lo == Long.MIN_VALUE) {
+                return RANDOM.nextLong();
+            }
+            return RANDOM.nextLong(lo - 1, hi) + 1;
+        }
+        return RANDOM.nextLong(lo, hi + 1);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformLongGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformLongGenerator.java
@@ -23,14 +23,10 @@
 
 package compiler.lib.generators;
 
-import java.util.Random;
-import jdk.test.lib.Utils;
-
 /**
  * Provides a uniform long distribution random generator.
  */
 public final class UniformLongGenerator extends LongGenerator {
-    private static final Random RANDOM = Utils.getRandomInstance();
 
     /**
      * Creates a new {@link UniformLongGenerator}.
@@ -41,10 +37,10 @@ public final class UniformLongGenerator extends LongGenerator {
     public long nextLong(long lo, long hi) {
         if (hi == Long.MAX_VALUE) {
             if (lo == Long.MIN_VALUE) {
-                return RANDOM.nextLong();
+                return Generators.RANDOM.nextLong();
             }
-            return RANDOM.nextLong(lo - 1, hi) + 1;
+            return Generators.RANDOM.nextLong(lo - 1, hi) + 1;
         }
-        return RANDOM.nextLong(lo, hi + 1);
+        return Generators.RANDOM.nextLong(lo, hi + 1);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/generators/UniformLongGenerator.java
+++ b/test/hotspot/jtreg/compiler/lib/generators/UniformLongGenerator.java
@@ -27,11 +27,14 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 /**
- * Provide a uniform long distribution random generator.
+ * Provides a uniform long distribution random generator.
  */
 public final class UniformLongGenerator extends LongGenerator {
     private static final Random RANDOM = Utils.getRandomInstance();
 
+    /**
+     * Creates a new {@link UniformLongGenerator}.
+     */
     public UniformLongGenerator() {}
 
     @Override

--- a/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestDoubleGenerators.java
+++ b/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestDoubleGenerators.java
@@ -140,7 +140,7 @@ public class TestDoubleGenerators {
     }
 
     public static void checkRange(MemorySegment ms, double lo, double hi) {
-        for (long i = 0; i < ms.byteSize() / 8; i++ ) {
+        for (long i = 0; i < ms.byteSize() / 8; i++) {
             double v = ms.get(ValueLayout.JAVA_DOUBLE_UNALIGNED, 8L * i);
             checkRange(v, lo, hi);
         }

--- a/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestDoubleGenerators.java
+++ b/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestDoubleGenerators.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test functionality of DoubleGenerator implementations.
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @run driver generators.tests.TestDoubleGenerators
+ */
+
+package generators.tests;
+
+import java.lang.foreign.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
+import compiler.lib.generators.*;
+
+public class TestDoubleGenerators {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    public static void main(String[] args) {
+        // Test every specific distribution.
+        testGeneral(new UniformDoubleGenerator(-1, 1));
+        testGeneral(new UniformDoubleGenerator(0.99f, 1.01f));
+        testGeneral(new AnyBitsDoubleGenerator());
+        testGeneral(new SpecialDoubleGenerator(new UniformDoubleGenerator(0.999f, 1.001f), 10, 1000));
+        testGeneral(new SpecialDoubleGenerator(new AnyBitsDoubleGenerator(), 100, 200));
+
+        // Test randomly picked generators.
+        for (int i = 0; i < 10; i++) {
+            testGeneral(Generators.doubles());
+        }
+
+        // Test specific distributions for their qualities.
+        testUniform(-1, 1);
+        testUniform(0.99f, 1.01f);
+        testUniform(Double.MIN_VALUE, Double.MAX_VALUE);
+
+        // Test for a distribution that does not degenerate to inf or NaN.
+        testUniformReduction();
+
+        // Check that the special distribution has the expected frequency of special values.
+        testSpecial();
+    }
+
+    public static void testGeneral(DoubleGenerator g) {
+        // Generate doubles from unknown distribution - cannot test anything.
+        for (int i = 0; i < 1000; i++) {
+             g.nextDouble();
+        }
+        for (int i = 0; i < 10; i++) {
+             double[] a = new double[1000];
+             g.fill(a);
+        }
+        for (int i = 0; i < 100; i++) {
+             double[] a = new double[1000];
+             MemorySegment ms = MemorySegment.ofArray(a);
+             g.fill(ms);
+        }
+    }
+
+    public static void testUniform(double lo, double hi) {
+        DoubleGenerator g = new UniformDoubleGenerator(lo, hi);
+        for (int i = 0; i < 1000; i++) {
+             double v = g.nextDouble();
+             checkRange(v, lo, hi);
+        }
+        for (int i = 0; i < 10; i++) {
+             double[] a = new double[1000];
+             g.fill(a);
+             checkRange(a, lo, hi);
+        }
+        for (int i = 0; i < 100; i++) {
+             double[] a = new double[1000];
+             MemorySegment ms = MemorySegment.ofArray(a);
+             g.fill(ms);
+             checkRange(a, lo, hi);
+             checkRange(ms, lo, hi);
+        }
+    }
+
+    public static void testUniformReduction() {
+        DoubleGenerator g1 = new UniformDoubleGenerator(0.998f, 0.999f);
+        DoubleGenerator g2 = new UniformDoubleGenerator(1.001f, 1.002f);
+        double v1 = 1;
+        double v2 = 1;
+        for (int i = 0; i < 10_000; i++) {
+            v1 *= g1.nextDouble();
+            v2 *= g2.nextDouble();
+        }
+        checkRange(v1, 1e-10f, 1e-4f);
+        checkRange(v2, 1e4f,   1e10f);
+    }
+
+    public static void testSpecial() {
+        // Generate "safe" values that do not overlap the special values.
+        // Generate about 10% special values.
+        DoubleGenerator g1 = new UniformDoubleGenerator(100, 200);
+        DoubleGenerator g = new SpecialDoubleGenerator(g1, 10, 11);
+        int specialCount = 0;
+        for (int i = 0; i < 10_000; i++) {
+            double v = g.nextDouble();
+            if (!(100 <= v && v < 200)) { specialCount++; }
+        }
+        // Expect special count to be close to 10%
+        if (specialCount < 1000 - 10 || 1000 + 10 < specialCount) {
+            throw new RuntimeException("Special count too far away from 1000: " + specialCount);
+        }
+    }
+
+    public static void checkRange(double v, double lo, double hi) {
+        if (!(lo <= v && v < hi)) {
+            throw new RuntimeException("Out of bounds: " + v + "not in [" + lo + "," + hi + ")");
+        }
+    }
+
+    public static void checkRange(double[] a, double lo, double hi) {
+        checkRange(MemorySegment.ofArray(a), lo, hi);
+    }
+
+    public static void checkRange(MemorySegment ms, double lo, double hi) {
+        for (long i = 0; i < ms.byteSize() / 8; i++ ) {
+            double v = ms.get(ValueLayout.JAVA_DOUBLE_UNALIGNED, 8L * i);
+            checkRange(v, lo, hi);
+        }
+    }
+}

--- a/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestFloatGenerators.java
+++ b/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestFloatGenerators.java
@@ -140,7 +140,7 @@ public class TestFloatGenerators {
     }
 
     public static void checkRange(MemorySegment ms, float lo, float hi) {
-        for (long i = 0; i < ms.byteSize() / 4; i++ ) {
+        for (long i = 0; i < ms.byteSize() / 4; i++) {
             float v = ms.get(ValueLayout.JAVA_FLOAT_UNALIGNED, 4L * i);
             checkRange(v, lo, hi);
         }

--- a/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestFloatGenerators.java
+++ b/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestFloatGenerators.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test functionality of FloatGenerator implementations.
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @run driver generators.tests.TestFloatGenerators
+ */
+
+package generators.tests;
+
+import java.lang.foreign.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
+import compiler.lib.generators.*;
+
+public class TestFloatGenerators {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    public static void main(String[] args) {
+        // Test every specific distribution.
+        testGeneral(new UniformFloatGenerator(-1, 1));
+        testGeneral(new UniformFloatGenerator(0.99f, 1.01f));
+        testGeneral(new AnyBitsFloatGenerator());
+
+        // Test randomly picked generators.
+        for (int i = 0; i < 10; i++) {
+            testGeneral(Generators.floats());
+        }
+    }
+
+    public static void testGeneral(FloatGenerator g) {
+        testGeneralIndividual(g);
+        testGeneralFill(g);
+    }
+
+    public static void testGeneralIndividual(FloatGenerator g) {
+        // Generate floats from unknown distribution - cannot test anything.
+        for (int i = 0; i < 1000; i++) {
+             g.nextFloat();
+        }
+    }
+
+    public static void testGeneralFill(FloatGenerator g) {
+        // Generate floats from unknown distribution - cannot test anything.
+        for (int i = 0; i < 10; i++) {
+             float[] a = new float[1000];
+             g.fill(a);
+        }
+        for (int i = 0; i < 100; i++) {
+             float[] a = new float[1000];
+             MemorySegment ms = MemorySegment.ofArray(a);
+             g.fill(ms);
+        }
+    }
+
+    public static void checkRange(float v, float lo, float hi) {
+        if (!(lo <= v && v < hi)) {
+            throw new RuntimeException("Out of bounds: " + v + "not in [" + lo + "," + hi + ")");
+        }
+    }
+
+    public static void checkRange(float[] a, float lo, float hi) {
+        checkRange(MemorySegment.ofArray(a), lo, hi);
+    }
+
+    public static void checkRange(MemorySegment ms, float lo, float hi) {
+        for (long i = 0; i < ms.byteSize() / 4; i++ ) {
+            float v = ms.get(ValueLayout.JAVA_FLOAT_UNALIGNED, 4L * i);
+            checkRange(v, lo, hi);
+        }
+    }
+}

--- a/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestFloatGenerators.java
+++ b/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestFloatGenerators.java
@@ -44,27 +44,31 @@ public class TestFloatGenerators {
         testGeneral(new UniformFloatGenerator(-1, 1));
         testGeneral(new UniformFloatGenerator(0.99f, 1.01f));
         testGeneral(new AnyBitsFloatGenerator());
+        testGeneral(new SpecialFloatGenerator(new UniformFloatGenerator(0.999f, 1.001f), 10, 1000));
+        testGeneral(new SpecialFloatGenerator(new AnyBitsFloatGenerator(), 100, 200));
 
         // Test randomly picked generators.
         for (int i = 0; i < 10; i++) {
             testGeneral(Generators.floats());
         }
+
+        // Test specific distributions for their qualities.
+        testUniform(-1, 1);
+        testUniform(0.99f, 1.01f);
+        testUniform(Float.MIN_VALUE, Float.MAX_VALUE);
+
+        // Test for a distribution that does not degenerate to inf or NaN.
+        testUniformReduction();
+
+        // Check that the special distribution has the expected frequency of special values.
+        testSpecial();
     }
 
     public static void testGeneral(FloatGenerator g) {
-        testGeneralIndividual(g);
-        testGeneralFill(g);
-    }
-
-    public static void testGeneralIndividual(FloatGenerator g) {
         // Generate floats from unknown distribution - cannot test anything.
         for (int i = 0; i < 1000; i++) {
              g.nextFloat();
         }
-    }
-
-    public static void testGeneralFill(FloatGenerator g) {
-        // Generate floats from unknown distribution - cannot test anything.
         for (int i = 0; i < 10; i++) {
              float[] a = new float[1000];
              g.fill(a);
@@ -73,6 +77,55 @@ public class TestFloatGenerators {
              float[] a = new float[1000];
              MemorySegment ms = MemorySegment.ofArray(a);
              g.fill(ms);
+        }
+    }
+
+    public static void testUniform(float lo, float hi) {
+        FloatGenerator g = new UniformFloatGenerator(lo, hi);
+        for (int i = 0; i < 1000; i++) {
+             float v = g.nextFloat();
+             checkRange(v, lo, hi);
+        }
+        for (int i = 0; i < 10; i++) {
+             float[] a = new float[1000];
+             g.fill(a);
+             checkRange(a, lo, hi);
+        }
+        for (int i = 0; i < 100; i++) {
+             float[] a = new float[1000];
+             MemorySegment ms = MemorySegment.ofArray(a);
+             g.fill(ms);
+             checkRange(a, lo, hi);
+             checkRange(ms, lo, hi);
+        }
+    }
+
+    public static void testUniformReduction() {
+        FloatGenerator g1 = new UniformFloatGenerator(0.998f, 0.999f);
+        FloatGenerator g2 = new UniformFloatGenerator(1.001f, 1.002f);
+        float v1 = 1;
+        float v2 = 1;
+        for (int i = 0; i < 10_000; i++) {
+            v1 *= g1.nextFloat();
+            v2 *= g2.nextFloat();
+        }
+        checkRange(v1, 1e-10f, 1e-4f);
+        checkRange(v2, 1e4f,   1e10f);
+    }
+
+    public static void testSpecial() {
+        // Generate "safe" values that do not overlap the special values.
+        // Generate about 10% special values.
+        FloatGenerator g1 = new UniformFloatGenerator(100, 200);
+        FloatGenerator g = new SpecialFloatGenerator(g1, 10, 11);
+        int specialCount = 0;
+        for (int i = 0; i < 10_000; i++) {
+            float v = g.nextFloat();
+            if (!(100 <= v && v < 200)) { specialCount++; }
+        }
+        // Expect special count to be close to 10%
+        if (specialCount < 1000 - 10 || 1000 + 10 < specialCount) {
+            throw new RuntimeException("Special count too far away from 1000: " + specialCount);
         }
     }
 

--- a/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestIntGenerators.java
+++ b/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestIntGenerators.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test functionality of IntGenerator implementations.
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @run driver generators.tests.TestIntGenerators
+ */
+
+package generators.tests;
+
+import java.lang.foreign.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
+import compiler.lib.generators.*;
+
+public class TestIntGenerators {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    public static void main(String[] args) {
+        // Test every specific distribution.
+        test(new UniformIntGenerator());
+        test(new SpecialIntGenerator(0));
+        test(new SpecialIntGenerator(2));
+        test(new SpecialIntGenerator(16));
+        test(new MixedIntGenerator(1, 1, 16));
+        test(new MixedIntGenerator(1, 2, 2));
+
+        // Test randomly picked generators.
+        for (int i = 0; i < 10; i++) {
+            test(Generators.ints());
+        }
+    }
+
+    public static void test(IntGenerator g) {
+        testIndividual(g);
+        testFill(g);
+    }
+
+    public static void testIndividual(IntGenerator g) {
+        // Just generate some full range integers - cannot test anything.
+        for (int i = 0; i < 1000; i++) {
+             g.nextInt();
+        }
+
+        // Test positive values.
+        for (int i = 0; i < 1000; i++) {
+             int hi = RANDOM.nextInt(Integer.MAX_VALUE);
+             int v = g.nextInt(hi);
+             checkRange(v, 0, hi);
+        }
+        for (int i = 0; i < 1000; i++) {
+             int v = g.nextInt(Integer.MAX_VALUE);
+             checkRange(v, 0, Integer.MAX_VALUE);
+        }
+        for (int i = 0; i < 1000; i++) {
+             int v = g.nextInt(i);
+             checkRange(v, 0, i);
+        }
+
+        // Any range.
+        for (int i = 0; i < 1000; i++) {
+             int v = g.nextInt(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        }
+        for (int i = 0; i < 10_000; i++) {
+             // hi in [min_int+1, max_int]
+             // lo in [min_int, hi-1]
+             int hi = RANDOM.nextInt(Integer.MIN_VALUE, Integer.MAX_VALUE) + 1;
+             int lo = RANDOM.nextInt(Integer.MIN_VALUE, hi);
+             int v = g.nextInt(lo, hi);
+             checkRange(v, lo, hi);
+        }
+    }
+
+    public static void testFill(IntGenerator g) {
+        for (int i = 0; i < 10; i++) {
+             int[] a = new int[1000];
+             g.fill(a, Integer.MIN_VALUE, Integer.MAX_VALUE);
+        }
+        for (int i = 0; i < 100; i++) {
+             int[] a = new int[1000];
+             // hi in [min_int+1, max_int]
+             // lo in [min_int, hi-1]
+             int hi = RANDOM.nextInt(Integer.MIN_VALUE, Integer.MAX_VALUE) + 1;
+             int lo = RANDOM.nextInt(Integer.MIN_VALUE, hi);
+             g.fill(a, lo, hi);
+             checkRange(a, lo, hi);
+             MemorySegment ms = MemorySegment.ofArray(a);
+             g.fill(ms, lo, hi);
+             checkRange(ms, lo, hi);
+        }
+    }
+
+    public static void checkRange(int v, int lo, int hi) {
+        if (v < lo || v > hi) {
+            throw new RuntimeException("Out of bounds: " + v + "not in [" + lo + "," + hi + "]");
+        }
+    }
+
+    public static void checkRange(int[] a, int lo, int hi) {
+        checkRange(MemorySegment.ofArray(a), lo, hi);
+    }
+
+    public static void checkRange(MemorySegment ms, int lo, int hi) {
+        for (long i = 0; i < ms.byteSize() / 4; i++ ) {
+            int v = ms.get(ValueLayout.JAVA_INT_UNALIGNED, 4L * i);
+            checkRange(v, lo, hi);
+        }
+    }
+}

--- a/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestIntGenerators.java
+++ b/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestIntGenerators.java
@@ -124,7 +124,7 @@ public class TestIntGenerators {
     }
 
     public static void checkRange(MemorySegment ms, int lo, int hi) {
-        for (long i = 0; i < ms.byteSize() / 4; i++ ) {
+        for (long i = 0; i < ms.byteSize() / 4; i++) {
             int v = ms.get(ValueLayout.JAVA_INT_UNALIGNED, 4L * i);
             checkRange(v, lo, hi);
         }

--- a/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestLongGenerators.java
+++ b/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestLongGenerators.java
@@ -124,7 +124,7 @@ public class TestLongGenerators {
     }
 
     public static void checkRange(MemorySegment ms, long lo, long hi) {
-        for (long i = 0; i < ms.byteSize() / 8; i++ ) {
+        for (long i = 0; i < ms.byteSize() / 8; i++) {
             long v = ms.get(ValueLayout.JAVA_LONG_UNALIGNED, 8L * i);
             checkRange(v, lo, hi);
         }

--- a/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestLongGenerators.java
+++ b/test/hotspot/jtreg/testlibrary_tests/generators/tests/TestLongGenerators.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test functionality of LongGenerator implementations.
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @run driver generators.tests.TestLongGenerators
+ */
+
+package generators.tests;
+
+import java.lang.foreign.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
+import compiler.lib.generators.*;
+
+public class TestLongGenerators {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    public static void main(String[] args) {
+        // Test every specific distribution.
+        test(new UniformLongGenerator());
+        test(new SpecialLongGenerator(0));
+        test(new SpecialLongGenerator(2));
+        test(new SpecialLongGenerator(16));
+        test(new MixedLongGenerator(1, 1, 16));
+        test(new MixedLongGenerator(1, 2, 2));
+
+        // Test randomly picked generators.
+        for (int i = 0; i < 10; i++) {
+            test(Generators.longs());
+        }
+    }
+
+    public static void test(LongGenerator g) {
+        testIndividual(g);
+        testFill(g);
+    }
+
+    public static void testIndividual(LongGenerator g) {
+        // Just generate some full range longs - cannot test anything.
+        for (int i = 0; i < 1000; i++) {
+             g.nextLong();
+        }
+
+        // Test positive values.
+        for (int i = 0; i < 1000; i++) {
+             long hi = RANDOM.nextLong(Long.MAX_VALUE);
+             long v = g.nextLong(hi);
+             checkRange(v, 0, hi);
+        }
+        for (int i = 0; i < 1000; i++) {
+             long v = g.nextLong(Long.MAX_VALUE);
+             checkRange(v, 0, Long.MAX_VALUE);
+        }
+        for (int i = 0; i < 1000; i++) {
+             long v = g.nextLong(i);
+             checkRange(v, 0, i);
+        }
+
+        // Any range.
+        for (int i = 0; i < 1000; i++) {
+             long v = g.nextLong(Long.MIN_VALUE, Long.MAX_VALUE);
+        }
+        for (int i = 0; i < 10_000; i++) {
+             // hi in [min_long+1, max_long]
+             // lo in [min_long, hi-1]
+             long hi = RANDOM.nextLong(Long.MIN_VALUE, Long.MAX_VALUE) + 1;
+             long lo = RANDOM.nextLong(Long.MIN_VALUE, hi);
+             long v = g.nextLong(lo, hi);
+             checkRange(v, lo, hi);
+        }
+    }
+
+    public static void testFill(LongGenerator g) {
+        for (int i = 0; i < 10; i++) {
+             long[] a = new long[1000];
+             g.fill(a, Long.MIN_VALUE, Long.MAX_VALUE);
+        }
+        for (int i = 0; i < 100; i++) {
+             long[] a = new long[1000];
+             // hi in [min_long+1, max_long]
+             // lo in [min_long, hi-1]
+             long hi = RANDOM.nextLong(Long.MIN_VALUE, Long.MAX_VALUE) + 1;
+             long lo = RANDOM.nextLong(Long.MIN_VALUE, hi);
+             g.fill(a, lo, hi);
+             checkRange(a, lo, hi);
+             MemorySegment ms = MemorySegment.ofArray(a);
+             g.fill(ms, lo, hi);
+             checkRange(ms, lo, hi);
+        }
+    }
+
+    public static void checkRange(long v, long lo, long hi) {
+        if (v < lo || v > hi) {
+            throw new RuntimeException("Out of bounds: " + v + "not in [" + lo + "," + hi + "]");
+        }
+    }
+
+    public static void checkRange(long[] a, long lo, long hi) {
+        checkRange(MemorySegment.ofArray(a), lo, hi);
+    }
+
+    public static void checkRange(MemorySegment ms, long lo, long hi) {
+        for (long i = 0; i < ms.byteSize() / 8; i++ ) {
+            long v = ms.get(ValueLayout.JAVA_LONG_UNALIGNED, 8L * i);
+            checkRange(v, lo, hi);
+        }
+    }
+}


### PR DESCRIPTION
For verification testing, it is often critical to generate "interesting" values, to provoke overflows, NaN, etc. And to generate these values in the correct distribution to trigger certain optimizations.

I would like to start a collection of such generators, that can then be used in testing.

The goal is to grow this collection in the future, and add new types. For example `byte`, `char`, `short`, or even `Float16`.

This will be helpful for the Template framework [JDK-8344942](https://bugs.openjdk.org/browse/JDK-8344942), but also other tests.

Related PR, for value verification: https://github.com/openjdk/jdk/pull/22715

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346107](https://bugs.openjdk.org/browse/JDK-8346107): Generators: testing utility for random value generation (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22716/head:pull/22716` \
`$ git checkout pull/22716`

Update a local copy of the PR: \
`$ git checkout pull/22716` \
`$ git pull https://git.openjdk.org/jdk.git pull/22716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22716`

View PR using the GUI difftool: \
`$ git pr show -t 22716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22716.diff">https://git.openjdk.org/jdk/pull/22716.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22716#issuecomment-2540924429)
</details>
