### PR TITLE
8346046: Enable copyright header format check

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -36,7 +36,6 @@ pattern=^([124-8][0-9]{6}): (\S.*)$
 dirs=test/jdk|test/langtools|test/lib-test|test/hotspot/jtreg|test/jaxp
 
 [checks "copyright"]
-files=^(?!LICENSE$|THIRD_PARTY_README$|COPYING.*$|license\.txt$|.*\.bin$|.*\.mdl$|.*\.gif$|.*\.jpg$|.*\.png$|.*\.msi$|.*\.patch$|.*\.swp$|.*\.wav$|.*\.gm$|.*\.class$|.*-header$|lib.*\.so$|lib.*\.dll$|.*\.jar$|.*\.mini$|reorder[-_]*$).*
+files=^(?!LICENSE|license\.txt|.*\.bin|.*\.gif|.*\.jpg|.*\.png|.*\.patch|.*\.wav|.*\.class|.*-header|.*\.jar|).*
 oracle_locator=.*Copyright \(c\)(.*)Oracle and/or its affiliates\. All rights reserved\.
 oracle_validator=.*Copyright \(c\) (\d{4})(?:, (\d{4}))?, Oracle and/or its affiliates\. All rights reserved\.
-oracle_required=true

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -4,7 +4,7 @@ jbs=JDK
 version=25
 
 [checks]
-error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists
+error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists,copyright
 warning=issuestitle,binary
 
 [repository]
@@ -34,3 +34,9 @@ pattern=^([124-8][0-9]{6}): (\S.*)$
 
 [checks "problemlists"]
 dirs=test/jdk|test/langtools|test/lib-test|test/hotspot/jtreg|test/jaxp
+
+[checks "copyright"]
+files=^(?!LICENSE$|THIRD_PARTY_README$|COPYING.*$|license\.txt$|.*\.bin$|.*\.mdl$|.*\.gif$|.*\.jpg$|.*\.png$|.*\.msi$|.*\.patch$|.*\.swp$|.*\.wav$|.*\.gm$|.*\.class$|.*-header$|lib.*\.so$|lib.*\.dll$|.*\.jar$|.*\.mini$|reorder[-_]*$).*
+oracle_locator=.*Copyright \(c\)(.*)Oracle and/or its affiliates\. All rights reserved\.
+oracle_validator=.*Copyright \(c\) (\d{4})(?:, (\d{4}))?, Oracle and/or its affiliates\. All rights reserved\.
+oracle_required=true

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -36,6 +36,6 @@ pattern=^([124-8][0-9]{6}): (\S.*)$
 dirs=test/jdk|test/langtools|test/lib-test|test/hotspot/jtreg|test/jaxp
 
 [checks "copyright"]
-files=^(?!LICENSE|license\.txt|.*\.bin|.*\.gif|.*\.jpg|.*\.png|.*\.patch|.*\.wav|.*\.class|.*-header|.*\.jar|).*
+files=^(?!LICENSE|license\.txt|.*\.bin|.*\.gif|.*\.jpg|.*\.png|.*\.icon|.*\.tiff|.*\.dat|.*\.patch|.*\.wav|.*\.class|.*-header|.*\.jar|).*
 oracle_locator=.*Copyright \(c\)(.*)Oracle and/or its affiliates\. All rights reserved\.
 oracle_validator=.*Copyright \(c\) (\d{4})(?:, (\d{4}))?, Oracle and/or its affiliates\. All rights reserved\.


### PR DESCRIPTION
As requested in [SKARA-1357](https://bugs.openjdk.org/browse/SKARA-1357), now skara bot is able to check the copyright header format.
Now I am going to update the jcheck configuration to configure copyright check as an error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8346046](https://bugs.openjdk.org/browse/JDK-8346046): Enable copyright header format check (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22721/head:pull/22721` \
`$ git checkout pull/22721`

Update a local copy of the PR: \
`$ git checkout pull/22721` \
`$ git pull https://git.openjdk.org/jdk.git pull/22721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22721`

View PR using the GUI difftool: \
`$ git pr show -t 22721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22721.diff">https://git.openjdk.org/jdk/pull/22721.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22721#issuecomment-2540230134)
</details>
