### PR TITLE
8346040: Zero interpreter build on Linux Aarch64 is broken

### DIFF
--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -258,9 +258,15 @@ public:
         is_aligned(addr, klass_alignment_in_bytes());
   }
 
-  // Check that with the given base, shift and range, aarch64 an encode and decode the klass pointer.
-  static bool check_klass_decode_mode(address base, int shift, const size_t range) NOT_AARCH64({ return true;});
-  static bool set_klass_decode_mode() NOT_AARCH64({ return true;});  // can be called after initialization
+#if defined(AARCH64) && !defined(ZERO)
+  // Check that with the given base, shift and range, aarch64 code can encode and decode the klass pointer.
+  static bool check_klass_decode_mode(address base, int shift, const size_t range);
+  // Called after initialization.
+  static bool set_klass_decode_mode();
+#else
+  static bool check_klass_decode_mode(address base, int shift, const size_t range) { return true; }
+  static bool set_klass_decode_mode() { return true; }
+#endif
 };
 
 #endif // SHARE_OOPS_COMPRESSEDKLASS_HPP


### PR DESCRIPTION
This is a clean backport to JDK 24.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346040](https://bugs.openjdk.org/browse/JDK-8346040): Zero interpreter build on Linux Aarch64 is broken (**Bug** - P3)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22722/head:pull/22722` \
`$ git checkout pull/22722`

Update a local copy of the PR: \
`$ git checkout pull/22722` \
`$ git pull https://git.openjdk.org/jdk.git pull/22722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22722`

View PR using the GUI difftool: \
`$ git pr show -t 22722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22722.diff">https://git.openjdk.org/jdk/pull/22722.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22722#issuecomment-2540108284)
</details>
