### PR TITLE
8344453: Test jdk/jfr/event/oldobject/TestSanityDefault.java timed out

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestSanityDefault.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestSanityDefault.java
@@ -35,6 +35,7 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
+ * @requires vm.flagless
  * @library /test/lib /test/jdk
  * @summary Purpose of this test is to run leak profiler without command line tweaks or WhiteBox hacks until we succeed
  * @run main/othervm -Xmx1G jdk.jfr.event.oldobject.TestSanityDefault


### PR DESCRIPTION
The test Test jdk/jfr/event/oldobject/TestSanityDefault.java timed out with non G1 GC.

It is no regression, just was not executed in this configuration.

It might be not reliably trigger event for non G1 GC/ with VM flags and should not be executed this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344453](https://bugs.openjdk.org/browse/JDK-8344453): Test jdk/jfr/event/oldobject/TestSanityDefault.java timed out (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22726/head:pull/22726` \
`$ git checkout pull/22726`

Update a local copy of the PR: \
`$ git checkout pull/22726` \
`$ git pull https://git.openjdk.org/jdk.git pull/22726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22726`

View PR using the GUI difftool: \
`$ git pr show -t 22726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22726.diff">https://git.openjdk.org/jdk/pull/22726.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22726#issuecomment-2540307504)
</details>
