### PR TITLE
8346151: Add transformer error logging to VerifyLocalVariableTableOnRetransformTest

### DIFF
--- a/test/jdk/java/lang/instrument/VerifyLocalVariableTableOnRetransformTest.java
+++ b/test/jdk/java/lang/instrument/VerifyLocalVariableTableOnRetransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/instrument/VerifyLocalVariableTableOnRetransformTest.java
+++ b/test/jdk/java/lang/instrument/VerifyLocalVariableTableOnRetransformTest.java
@@ -256,9 +256,9 @@ VerifyLocalVariableTableOnRetransformTest
                 System.out.println(this + ".transform() sees '" + className
                     + "' of " + classfileBuffer.length + " bytes.");
             } catch (Throwable t) {
-                // try to log, save the error for handling by main thread if the logging fails
+                // Try to log. Save the error for handling by main thread if the logging fails.
                 try {
-                    transformerException.printStackTrace();
+                    t.printStackTrace();
                 } catch (Throwable t1) {
                     transformerException = t;
                 }

--- a/test/jdk/java/lang/instrument/VerifyLocalVariableTableOnRetransformTest.java
+++ b/test/jdk/java/lang/instrument/VerifyLocalVariableTableOnRetransformTest.java
@@ -55,6 +55,7 @@ VerifyLocalVariableTableOnRetransformTest
     private String  fTargetClassName = "DummyClassWithLVT";
     private String  classFileName = fTargetClassName + ".class";
     private boolean fTargetClassSeen;
+    private Throwable transformerException;
 
     /**
      * Constructor for VerifyLocalVariableTableOnRetransformTest.
@@ -109,9 +110,11 @@ VerifyLocalVariableTableOnRetransformTest
         // make an instance to prove the class was really loaded
         Object testInstance = target.newInstance();
 
-        // With this call here, we will see the target class once:
-        // when it gets retransformed.
-        //addTransformerToManager(fInst, new MyObserver(), true);
+        // check for unexpected errors (see JDK-8311534)
+        if (transformerException != null) {
+            transformerException.printStackTrace();
+            throw new RuntimeException("Error in transformer" + transformerException);
+        }
 
         assertTrue(fTargetClassName + " was not seen by transform()",
             fTargetClassSeen);
@@ -247,8 +250,20 @@ VerifyLocalVariableTableOnRetransformTest
             ProtectionDomain    protectionDomain,
             byte[] classfileBuffer) {
 
-            System.out.println(this + ".transform() sees '" + className
-                + "' of " + classfileBuffer.length + " bytes.");
+            // String concatenation can cause LinkageError or ClassCircularityError (see JDK-8311534).
+            // Need to log it for analysis.
+            try {
+                System.out.println(this + ".transform() sees '" + className
+                    + "' of " + classfileBuffer.length + " bytes.");
+            } catch (Throwable t) {
+                // try to log, save the error for handling by main thread if the logging fails
+                try {
+                    transformerException.printStackTrace();
+                } catch (Throwable t1) {
+                    transformerException = t;
+                }
+                return null;
+            }
             if (className.equals(fTargetClassName)) {
                 fTargetClassSeen = true;
 


### PR DESCRIPTION
In some circumstances ClassFileTransformer.transform can get ClassCircularityError or LinkageError concatenating strings (see JDK-8264667, JDK-8262002).
VerifyLocalVariableTableOnRetransformTest fails sometimes on Oracle CI.
The fix adds handling of the errors to get information for analysis.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346151](https://bugs.openjdk.org/browse/JDK-8346151): Add transformer error logging to VerifyLocalVariableTableOnRetransformTest (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22727/head:pull/22727` \
`$ git checkout pull/22727`

Update a local copy of the PR: \
`$ git checkout pull/22727` \
`$ git pull https://git.openjdk.org/jdk.git pull/22727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22727`

View PR using the GUI difftool: \
`$ git pr show -t 22727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22727.diff">https://git.openjdk.org/jdk/pull/22727.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22727#issuecomment-2540397933)
</details>
