### PR TITLE
8345505: Fix -Wzero-as-null-pointer-constant warnings in zero code

### DIFF
--- a/src/hotspot/cpu/zero/frame_zero.cpp
+++ b/src/hotspot/cpu/zero/frame_zero.cpp
@@ -125,10 +125,10 @@ bool frame::safe_for_sender(JavaThread *thread) {
 bool frame::is_interpreted_frame_valid(JavaThread *thread) const {
   assert(is_interpreted_frame(), "Not an interpreted frame");
   // These are reasonable sanity checks
-  if (fp() == 0 || (intptr_t(fp()) & (wordSize-1)) != 0) {
+  if (fp() == nullptr || (intptr_t(fp()) & (wordSize-1)) != 0) {
     return false;
   }
-  if (sp() == 0 || (intptr_t(sp()) & (wordSize-1)) != 0) {
+  if (sp() == nullptr || (intptr_t(sp()) & (wordSize-1)) != 0) {
     return false;
   }
   // These are hacks to keep us out of trouble.


### PR DESCRIPTION
Please review this trivial change to remove some -Wzero-as-null-pointer-constant
warnings in zero code.  Just replaced two literal 0's with nullptr.

Testing: mach5 tier1, GHA sanity tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345505](https://bugs.openjdk.org/browse/JDK-8345505): Fix -Wzero-as-null-pointer-constant warnings in zero code (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22728/head:pull/22728` \
`$ git checkout pull/22728`

Update a local copy of the PR: \
`$ git checkout pull/22728` \
`$ git pull https://git.openjdk.org/jdk.git pull/22728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22728`

View PR using the GUI difftool: \
`$ git pr show -t 22728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22728.diff">https://git.openjdk.org/jdk/pull/22728.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22728#issuecomment-2540470739)
</details>
