### PR TITLE
8345942: Separate source output from class output when building microbenchmarks

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -47,6 +47,7 @@ MICROBENCHMARK_JAR := $(MICROBENCHMARK_IMAGE_DIR)/benchmarks.jar
 
 MICROBENCHMARK_OUTPUT := $(SUPPORT_OUTPUTDIR)/test/micro
 MICROBENCHMARK_CLASSES := $(MICROBENCHMARK_OUTPUT)/classes
+MICROBENCHMARK_GENSRC := $(MICROBENCHMARK_OUTPUT)/gensrc
 MICROBENCHMARK_JAR_BIN := $(MICROBENCHMARK_OUTPUT)/jar
 
 MICROBENCHMARK_TOOLS_CLASSES := $(MICROBENCHMARK_OUTPUT)/tools-classes
@@ -104,7 +105,8 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
         --add-exports java.base/sun.security.util.math.intpoly=ALL-UNNAMED \
         --enable-preview \
         -XDsuppressNotes \
-        -processor org.openjdk.jmh.generators.BenchmarkProcessor, \
+        -processor org.openjdk.jmh.generators.BenchmarkProcessor \
+        -s $(MICROBENCHMARK_GENSRC), \
     JAVA_FLAGS := \
         --add-exports java.base/jdk.internal.vm=ALL-UNNAMED \
         --add-modules jdk.unsupported \


### PR DESCRIPTION
The microbenchmarks build generates a considerable amount of (generated) sources using an annotation processor. This, by itself, is not a problem. But, it generates them into the class output, and after the microbenchmarks build has been updated to be (somewhat) incremental, the class output has been added to the classpath(*):
https://github.com/openjdk/jdk/commit/b704bfa205bbd8c56f128ce5d727d40c8a3ec613

Then when the AP attempts to generate a new file (for a class name), javac will look for same-named classes on the classpath, and may load the source code generated by a previous rounds of builds, in case of an incremental build. And since the AP generates the considerable amount of these files, this leads to loading a considerable amounts of source code, eventually leading to memory problems ([JDK-8345302](https://bugs.openjdk.org/browse/JDK-8345302)).

The proposal herein is to split the (generated) source output from the class output. This considerably reduces the amount of memory javac uses, and generally seems like a good approach for the build.

(*) adding the class output to the classpath is usually needed when incrementally compiling code in the unnamed module, to ensure that if e.g. only one source file is being compiled, it can refer to other, already produced, classes. As a side note, this does not need to be done in named-module compilation modes, as javac automatically reads the class output when compiling the named modules. But it is not easily possible to enhance javac to do that for unnamed module, due to compatibility concerns.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345942](https://bugs.openjdk.org/browse/JDK-8345942): Separate source output from class output when building microbenchmarks (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22731/head:pull/22731` \
`$ git checkout pull/22731`

Update a local copy of the PR: \
`$ git checkout pull/22731` \
`$ git pull https://git.openjdk.org/jdk.git pull/22731/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22731`

View PR using the GUI difftool: \
`$ git pr show -t 22731`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22731.diff">https://git.openjdk.org/jdk/pull/22731.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22731#issuecomment-2540605732)
</details>
