### PR TITLE
Jdk 8345770

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
@@ -106,7 +106,6 @@ public class ClassUseWriter extends SubWriterHolderWriter {
             pkgToPackageAnnotations = new TreeSet<>(comparators.classUseComparator());
             pkgToPackageAnnotations.addAll(mapper.classToPackageAnnotations.get(typeElement));
         }
-        configuration.currentTypeElement = typeElement;
         this.pkgSet = new TreeSet<>(comparators.packageComparator());
         this.pkgToClassTypeParameter = pkgDivide(mapper.classToClassTypeParam);
         this.pkgToSubclassTypeParameter = pkgDivide(mapper.classToSubclassTypeParam);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
@@ -94,7 +94,6 @@ public class ClassWriter extends SubWriterHolderWriter {
                        ClassTree classTree) {
         super(configuration, configuration.docPaths.forClass(typeElement));
         this.typeElement = typeElement;
-        configuration.currentTypeElement = typeElement;
         this.classTree = classTree;
 
         pHelper = new PropertyUtils.PropertyHelper(configuration, typeElement);
@@ -506,7 +505,7 @@ public class ClassWriter extends SubWriterHolderWriter {
     }
 
     @Override
-    public TypeElement getCurrentPageElement() {
+    public TypeElement getCurrentTypeElement() {
         return typeElement;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
@@ -105,11 +105,6 @@ public class HtmlConfiguration extends BaseConfiguration {
     public DocPath topFile = DocPath.empty;
 
     /**
-     * The TypeElement for the class file getting generated.
-     */
-    public TypeElement currentTypeElement = null;  // Set this TypeElement in the ClassWriter.
-
-    /**
      * The collections of items for the main index.
      * This field is only initialized if {@code options.createIndex()}
      * is {@code true}.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1024,11 +1024,10 @@ public abstract class HtmlDocletWriter {
     }
 
     /**
-     * Return the main type element of the current page or null for pages that don't have one.
-     *
-     * @return the type element of the current page.
+     * {@return the type element documented by this writer if it is a {@code ClassWriter},
+     * or null for any other kind of writer}
      */
-    public TypeElement getCurrentPageElement() {
+    public TypeElement getCurrentTypeElement() {
         return null;
     }
 
@@ -1912,7 +1911,7 @@ public abstract class HtmlDocletWriter {
         // Retrieve the element of this writer if it is a "primary" writer for an element.
         // Note: It would be nice to have getCurrentPageElement() return package and module elements
         // in their respective writers, but other uses of the method are only interested in TypeElements.
-        Element currentPageElement = getCurrentPageElement();
+        Element currentPageElement = getCurrentTypeElement();
         if (currentPageElement == null) {
             if (this instanceof PackageWriter packageWriter) {
                 currentPageElement = packageWriter.packageElement;
@@ -1951,7 +1950,7 @@ public abstract class HtmlDocletWriter {
      */
     private boolean inSamePackage(Element element) {
         Element currentPageElement = (this instanceof PackageWriter packageWriter)
-                ? packageWriter.packageElement : getCurrentPageElement();
+                ? packageWriter.packageElement : getCurrentTypeElement();
         return currentPageElement != null && !utils.isModule(element)
                 && Objects.equals(utils.containingPackage(currentPageElement),
                 utils.containingPackage(element));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
@@ -270,7 +270,7 @@ public class HtmlLinkFactory {
             TypeElement enclosing = utils.getEnclosingTypeElement(linkInfo.getTargetMember());
             Set<ElementFlag> enclosingFlags = utils.elementFlags(enclosing);
             if (flags.contains(ElementFlag.PREVIEW) && enclosingFlags.contains(ElementFlag.PREVIEW)) {
-                if (enclosing.equals(m_writer.getCurrentPageElement())) {
+                if (enclosing.equals(m_writer.getCurrentTypeElement())) {
                     //skip the PREVIEW tag:
                     flags = EnumSet.copyOf(flags);
                     flags.remove(ElementFlag.PREVIEW);
@@ -294,7 +294,7 @@ public class HtmlLinkFactory {
         if (utils.isIncluded(typeElement)) {
             if (configuration.isGeneratedDoc(typeElement) && !utils.hasHiddenTag(typeElement)) {
                 DocPath fileName = getPath(linkInfo);
-                if (linkInfo.linkToSelf() || typeElement != m_writer.getCurrentPageElement()) {
+                if (linkInfo.linkToSelf() || typeElement != m_writer.getCurrentTypeElement()) {
                         link.add(m_writer.links.createLink(
                                 fileName.fragment(linkInfo.getFragment()),
                                 label, linkInfo.getStyle(), linkInfo.getTitle()));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/InheritDocTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/InheritDocTaglet.java
@@ -133,7 +133,7 @@ public class InheritDocTaglet extends BaseTaglet {
                 }
             } catch (DocFinder.NoOverriddenMethodFound e) {
                 String signature = utils.getSimpleName(method)
-                        + utils.flatSignature(method, writer.getCurrentPageElement());
+                        + utils.flatSignature(method, writer.getCurrentTypeElement());
                 messages.warning(method, "doclet.noInheritedDoc", signature);
             }
             return replacement;
@@ -157,7 +157,7 @@ public class InheritDocTaglet extends BaseTaglet {
             }
         } else {
             String signature = utils.getSimpleName(method)
-                    + utils.flatSignature(method, writer.getCurrentPageElement());
+                    + utils.flatSignature(method, writer.getCurrentTypeElement());
             messages.warning(method, "doclet.noInheritedDoc", signature);
         }
         return replacement;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/LinkTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/LinkTaglet.java
@@ -264,7 +264,7 @@ public class LinkTaglet extends BaseTaglet {
                 }
             }
             String refMemName = refFragment;
-            if (config.currentTypeElement != containing) {
+            if (htmlWriter.getCurrentTypeElement() != containing) {
                 refMemName = (utils.isConstructor(refMem))
                         ? refMemName
                         : utils.getSimpleName(containing) + "." + refMemName;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ReturnTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ReturnTaglet.java
@@ -94,7 +94,7 @@ public class ReturnTaglet extends BaseTaglet implements InheritableTaglet {
         List<? extends ReturnTree> tags = utils.getReturnTrees(holder);
 
         // make sure we are not using @return on a method with the void return type
-        TypeMirror returnType = utils.getReturnType(tagletWriter.getCurrentPageElement(), method);
+        TypeMirror returnType = utils.getReturnType(tagletWriter.getCurrentTypeElement(), method);
         if (returnType != null && utils.isVoid(returnType)) {
             if (!tags.isEmpty() && !config.isDocLintReferenceGroupEnabled()) {
                 messages.warning(holder, "doclet.Return_tag_on_void_method");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
@@ -201,12 +201,10 @@ public class TagletWriter {
     }
 
     /**
-     * Returns the main type element of the current page or null for pages that don't have one.
-     *
-     * @return the type element of the current page or null.
+     * {@return the type element documented by the current {@code HtmlDocletWriter} (may be null)}
      */
-    public TypeElement getCurrentPageElement() {
-        return htmlWriter.getCurrentPageElement();
+    public TypeElement getCurrentTypeElement() {
+        return htmlWriter.getCurrentTypeElement();
     }
 
     /**
@@ -411,7 +409,7 @@ public class TagletWriter {
             public String visitExecutable(ExecutableElement e, Void p) {
                 return utils.getFullyQualifiedName(utils.getEnclosingTypeElement(e))
                         + "." + utils.getSimpleName(e)
-                        + utils.flatSignature(e, htmlWriter.getCurrentPageElement());
+                        + utils.flatSignature(e, htmlWriter.getCurrentTypeElement());
             }
 
             @Override
@@ -476,11 +474,11 @@ public class TagletWriter {
     // Test if element is the same as or belongs to the current page element
     private boolean isDifferentTypeElement(Element element) {
         if (element.getKind().isDeclaredType()) {
-            return element != getCurrentPageElement();
+            return element != getCurrentTypeElement();
         } else if (element.getKind() == ElementKind.OTHER) {
             return false;
         } else {
-            return utils.getEnclosingTypeElement(element) != getCurrentPageElement();
+            return utils.getEnclosingTypeElement(element) != getCurrentTypeElement();
         }
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/ThrowsTaglet.java
@@ -211,7 +211,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
             // since {@inheritDoc} in @throws is processed by ThrowsTaglet (this taglet) rather than
             // InheritDocTaglet, we have to duplicate some of the behavior of the latter taglet
             String signature = utils.getSimpleName(holder)
-                    + utils.flatSignature((ExecutableElement) holder, tagletWriter.getCurrentPageElement());
+                    + utils.flatSignature((ExecutableElement) holder, tagletWriter.getCurrentTypeElement());
             messages.warning(holder, "doclet.noInheritedDoc", signature);
         }
         return tagletWriter.getOutputInstance(); // TODO: consider invalid rather than empty output
@@ -235,7 +235,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         }
         var executable = (ExecutableElement) holder;
         ExecutableType instantiatedType = utils.asInstantiatedMethodType(
-                tagletWriter.getCurrentPageElement(), executable);
+                tagletWriter.getCurrentTypeElement(), executable);
         List<? extends TypeMirror> substitutedExceptionTypes = instantiatedType.getThrownTypes();
         List<? extends TypeMirror> originalExceptionTypes = executable.getThrownTypes();
         Map<TypeMirror, TypeMirror> typeSubstitutions = getSubstitutedThrownTypes(

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -621,7 +621,7 @@ public class TestModules extends JavadocTester {
                     estpkgmdltags"><code>TestClassInModuleTags</code></a>.""",
                 """
                     Member Link: <a href="testpkgmdltags/TestClassInModuleTags.html#testMethod(java.\
-                    lang.String)"><code>testMethod(String)</code></a>.""",
+                    lang.String)"><code>TestClassInModuleTags.testMethod(String)</code></a>.""",
                 """
                     Package Link: <a href="testpkgmdltags/package-summary.html"><code>testpkgmdltags</code></a>.""",
                 """
@@ -892,7 +892,7 @@ public class TestModules extends JavadocTester {
                      Type Link: <a href="moduletags/testpkgmdltags/TestClassInModuleTags.html" title\
                     ="class in testpkgmdltags"><code>TestClassInModuleTags</code></a>.<br>
                      Member Link: <a href="moduletags/testpkgmdltags/TestClassInModuleTags.html#test\
-                    Method(java.lang.String)"><code>testMethod(String)</code></a>.<br>
+                    Method(java.lang.String)"><code>TestClassInModuleTags.testMethod(String)</code></a>.<br>
                      Package Link: <a href="moduletags/testpkgmdltags/package-summary.html"><code>testpkgmdltags</code></a>.<br></div>
                     </div>""");
         checkOutput("moduleA/module-summary.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testUseOption/TestUseOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testUseOption/TestUseOption.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 4496290 4985072 7006178 7068595 8016328 8050031 8048351 8081854 8071982 8162363 8175200 8186332
- *      8182765 8196202 8202626 8261976 8323698
+ *      8182765 8196202 8202626 8261976 8323698 8345770
  * @summary A simple test to ensure class-use files are correct.
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -107,7 +107,10 @@ public class TestUseOption extends JavadocTester {
         );
         checkOutput("pkg1/class-use/UsedInterface.html", true,
            """
-               <a href="../AnAbstract.html" class="type-name-link" title="class in pkg1">AnAbstract</a>"""
+               <a href="../AnAbstract.html" class="type-name-link" title="class in pkg1">AnAbstract</a>""",
+           """
+               Link to interface method: <a href="../UsedInterface.html#doNothing()"><code>Use\
+               dInterface.doNothing()</code></a>."""
         );
         checkOutput("pkg1/class-use/UsedInterface.html", true,
             "../C10.html#withReturningTypeParameters()"

--- a/test/langtools/jdk/javadoc/doclet/testUseOption/pkg1/AnAbstract.java
+++ b/test/langtools/jdk/javadoc/doclet/testUseOption/pkg1/AnAbstract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,4 +22,8 @@
  */
 
 package pkg1;
+
+/**
+ * Link to interface method: {@link #doNothing}.
+ */
 public abstract class AnAbstract implements UsedInterface {}


### PR DESCRIPTION
Please review a fix for a bug that could cause non-reproducible documentation builds and the wrong link label being used in summary pages. 

We used to rely on field `HtmlConfiguration.currentTypeElement` to decide whether to include the type name in member links generated from `{@link}` or `@see` tags. However, that field was only set by the `ClassWriter` and `ClassUseWriter` classes, but never unset by any other writer class, so effectively it contained the *last* instead of the *current* type element. This resulted in summary pages using non-qualified member links, depending on the last previously executing class writer.

The fix is to use `HtmlDocletWriter.getCurrentTypeElement()` (previously called `getCurrentPageElement()`) instead. Note that this method returns `null` for `ClassUseWriter`, so it changes the generated documentation for class-use pages. The new behavior is preferable, because class-use pages are primarily about other classes using the class, so links to members of the used class should be qualified by the class name. A good example for this are the links to the `FALSE` and `TRUE` fields in the [class use page for java.lang.Boolean][1] which should include the class name.

[1]: https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/class-use/Boolean.html#java.lang.constant

As mentioned above I also renamed `getCurrentPageElement()` method to `getCurrentTypeElement()` and made the doc comments a bit more precise.