### PR TITLE
8345323: Parallel GC does not handle UseLargePages and UseNUMA gracefully

### DIFF
--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -37,7 +37,11 @@ size_t MinNewSize = 0;
 size_t MinOldSize = 0;
 size_t MaxOldSize = 0;
 
-size_t OldSize = 0;
+// If InitialHeapSize or MinHeapSize is not set on cmdline, this variable,
+// together with NewSize, is used to derive them.
+// Using the same value when it was a configurable flag to avoid breakage.
+// See more in JDK-8346005
+size_t OldSize = ScaleForWordSize(4*M);
 
 size_t GenAlignment = 0;
 


### PR DESCRIPTION
This is a clean backport to JDK 24.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345323](https://bugs.openjdk.org/browse/JDK-8345323): Parallel GC does not handle UseLargePages and UseNUMA gracefully (**Bug** - P3)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22733/head:pull/22733` \
`$ git checkout pull/22733`

Update a local copy of the PR: \
`$ git checkout pull/22733` \
`$ git pull https://git.openjdk.org/jdk.git pull/22733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22733`

View PR using the GUI difftool: \
`$ git pr show -t 22733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22733.diff">https://git.openjdk.org/jdk/pull/22733.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22733#issuecomment-2541309334)
</details>
