### PR TITLE
8345506: jar --validate may lead to java.nio.file.FileAlreadyExistsException

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
@@ -431,8 +431,9 @@ public class Main {
                     file = new File(fname);
                 } else {
                     file = createTemporaryFile("tmpJar", ".jar");
-                    try (InputStream in = new FileInputStream(FileDescriptor.in)) {
-                        Files.copy(in, file.toPath());
+                    try (InputStream in = new FileInputStream(FileDescriptor.in);
+                         OutputStream os = Files.newOutputStream(file.toPath())) {
+                        in.transferTo(os);
                     }
                 }
                 ok = validateJar(file);

--- a/test/jdk/tools/jar/JarNoFileArgOperations.java
+++ b/test/jdk/tools/jar/JarNoFileArgOperations.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+
+import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * @test
+ * @bug 8345506
+ * @summary verifies that the "jar" operations that are expected to work
+ *          without the "--file" option work as expected
+ * @library /test/lib
+ * @run junit JarNoFileArgOperations
+ */
+public class JarNoFileArgOperations {
+
+    private static final Path SCRATCH_DIR = Path.of(".");
+    private static final Path JAR_TOOL = Path.of(JDKToolFinder.getJDKTool("jar")).toAbsolutePath();
+    private static final String JAR_ENTRY_NAME = "foobarhello.txt";
+
+    private static Path SIMPLE_JAR;
+
+    private static void makeSimpleJar(final Path path) throws IOException {
+        final Manifest manifest = new Manifest();
+        manifest.getMainAttributes().putValue("Manifest-Version", "1.0");
+        try (OutputStream fos = Files.newOutputStream(path);
+             JarOutputStream jaros = new JarOutputStream(fos, manifest)) {
+            jaros.putNextEntry(new ZipEntry(JAR_ENTRY_NAME));
+            jaros.write("foobar-8345506".getBytes(US_ASCII));
+            jaros.closeEntry();
+        }
+    }
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        final Path jarFile = Files.createTempFile(SCRATCH_DIR, "8345506", ".jar");
+        makeSimpleJar(jarFile);
+        SIMPLE_JAR = jarFile;
+        System.out.println("created JAR file " + jarFile);
+    }
+
+    /*
+     * Launches "jar --validate" by streaming the JAR file content through the "jar" tool
+     * process' STDIN and expects that the command completes normally.
+     */
+    @Test
+    public void testValidate() throws Exception {
+        System.out.println("launching jar --validate");
+        final ProcessBuilder pb = new ProcessBuilder()
+                .command(JAR_TOOL.toString(), "--validate")
+                // stream the JAR file content to the jar command through the process' STDIN
+                .redirectInput(SIMPLE_JAR.toFile());
+        final OutputAnalyzer oa = ProcessTools.executeCommand(pb);
+        oa.shouldHaveExitValue(0);
+    }
+
+    /*
+     * Launches "jar --list" and "jar -t" by streaming the JAR file content through the "jar" tool
+     * process' STDIN and expects that the command completes normally.
+     */
+    @Test
+    public void testListing() throws Exception {
+        for (String opt : new String[]{"-t", "--list"}) {
+            final ProcessBuilder pb = new ProcessBuilder()
+                    .command(JAR_TOOL.toString(), opt)
+                    // stream the JAR file content to the jar command through the process' STDIN
+                    .redirectInput(SIMPLE_JAR.toFile());
+            final OutputAnalyzer oa = ProcessTools.executeCommand(pb);
+            oa.shouldHaveExitValue(0);
+            // verify the listing contained the JAR entry name
+            oa.contains(JAR_ENTRY_NAME);
+        }
+    }
+
+    /*
+     * Launches "jar --extract" and "jar -x" by streaming the JAR file content through
+     * the "jar" tool process' STDIN and expects that the command completes normally.
+     */
+    @Test
+    public void testExtract() throws Exception {
+        for (String opt : new String[]{"-x", "--extract"}) {
+            final Path tmpDestDir = Files.createTempDirectory(SCRATCH_DIR, "8345506");
+            final ProcessBuilder pb = new ProcessBuilder()
+                    .command(JAR_TOOL.toString(), opt, "--dir", tmpDestDir.toString())
+                    // stream the JAR file content to the jar command through the process' STDIN
+                    .redirectInput(SIMPLE_JAR.toFile());
+            final OutputAnalyzer oa = ProcessTools.executeCommand(pb);
+            oa.shouldHaveExitValue(0);
+            // verify the file content was extracted
+            assertTrue(Files.exists(tmpDestDir.resolve(JAR_ENTRY_NAME)),
+                    JAR_ENTRY_NAME + " wasn't extracted to " + tmpDestDir);
+        }
+    }
+}


### PR DESCRIPTION
Can I please get a review of this change which proposes to address the issue reported in https://bugs.openjdk.org/browse/JDK-8345506?

The `jar` tool has several operations which take `--file` as a parameter. The value for that option is a JAR file path. The `jar` operation is then run against that JAR file. The `--file` parameter is optional and when it isn't provided, the `jar` tool expects the JAR file content to be streamed through STDIN of the `jar` process.

The issue here is that the `--validate` option has a bug in the implementation where when the `--file` option is absent, it tries to read from the STDIN into a temporary file that the implementation just created. To do so it uses `Files.copy(...)` which throws an exception if the destination file exists (which it does in this case because that temporary destination file was created just a few lines above).

The fix in this commit address this issue by using an alternate way to transfer the JAR content into the temporary file. 

A new jtreg test has been introduced to reproduce the issue and verify the fix. I couldn't locate any other existing test which was exercising the code path which deals with `jar` operations against the STDIN of the `jar` process. So the new jtreg test has test for other operations and not just `--validate` operation.

The new test and existing tests in tier1, tier2 and tier3 continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8345506: jar --validate may lead to java.nio.file.FileAlreadyExistsException`

### Issue
 * [JDK-8345506](https://bugs.openjdk.org/browse/JDK-8345506): jar --validate may lead to java.nio.file.FileAlreadyExistsException (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22734/head:pull/22734` \
`$ git checkout pull/22734`

Update a local copy of the PR: \
`$ git checkout pull/22734` \
`$ git pull https://git.openjdk.org/jdk.git pull/22734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22734`

View PR using the GUI difftool: \
`$ git pr show -t 22734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22734.diff">https://git.openjdk.org/jdk/pull/22734.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22734#issuecomment-2541459757)
</details>
