### PR TITLE
8346195: Fix static initialization problem in GDIHashtable

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/GDIHashtable.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/GDIHashtable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 #include "GDIHashtable.h"
 #include "awt_GDIObject.h"
 
-GDIHashtable::BatchDestructionManager GDIHashtable::manager;
-
 /*
  * The order of monitor entrance is BatchDestructionManager->List->Hashtable.
  * GDIHashtable::put() and GDIHashtable::release() are designed to be called
@@ -35,12 +33,12 @@ GDIHashtable::BatchDestructionManager GDIHashtable::manager;
  */
 
 void* GDIHashtable::put(void* key, void* value) {
-    manager.decrementCounter();
+    manager().decrementCounter();
     return Hashtable::put(key, value);
 }
 
 void GDIHashtable::release(void* key) {
-    if (!manager.isBatchingEnabled()) {
+    if (!manager().isBatchingEnabled()) {
         void* value = remove(key);
         DASSERT(value != NULL);
         m_deleteProc(value);

--- a/src/java.desktop/windows/native/libawt/windows/GDIHashtable.h
+++ b/src/java.desktop/windows/native/libawt/windows/GDIHashtable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,11 +162,11 @@ class GDIHashtable : public Hashtable {
     GDIHashtable(const char* name, void (*deleteProc)(void*) = NULL,
                    int initialCapacity = 29, float loadFactor = 0.75) :
         Hashtable(name, deleteProc, initialCapacity, loadFactor) {
-        manager.add(this);
+        manager().add(this);
     }
 
     ~GDIHashtable() {
-        manager.remove(this);
+        manager().remove(this);
     }
 
     /**
@@ -192,14 +192,17 @@ class GDIHashtable : public Hashtable {
     /**
      * Flushes all existing GDIHashtable instances.
      */
-    INLINE static void flushAll() { manager.flushAll(); }
+    INLINE static void flushAll() { manager().flushAll(); }
 
-    INLINE CriticalSection& getManagerLock() { return manager.getLock(); }
+    INLINE CriticalSection& getManagerLock() { return manager().getLock(); }
 
  private:
 
-    static BatchDestructionManager manager;
+    static BatchDestructionManager& manager() {
+        static BatchDestructionManager manager;
 
+        return manager;
+    }
 };
 
 #endif // GDIHASHTABLE_H


### PR DESCRIPTION
There has been a latent problem in `GDIHashtable` since time immemorial, but due to sheer luck it has not caused any issues for us. However, I managed to provoke it when I was doing some build changes.

This is the problem:
In `GDIHashtable`, there is a static field `GDIHashtable::BatchDestructionManager manager`, which is initialized in `GDIHashtable.cpp`.

In `AwtPen`, there is a static field `GDIHashtable cache`, which is initialized in `awt_Pen.cpp`.

The `GDIHashtable` constructor calls `manager.add(this)`.

For this to work, the manager must have been initialized prior to the AwtPen. However, the order of which static initializers are run between different compilation units are not well-defined, and we've just been lucky so far that it works.

This problem is known as the "Static Initialization Order Fiasco", see e.g. https://en.cppreference.com/w/cpp/language/siof

I have solved this by encapsulating the static manager instance in a method, which guarantees that it has been initialized before use. This seemed to me to be the cleanest solution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346195](https://bugs.openjdk.org/browse/JDK-8346195): Fix static initialization problem in GDIHashtable (**Bug** - P2)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22736/head:pull/22736` \
`$ git checkout pull/22736`

Update a local copy of the PR: \
`$ git checkout pull/22736` \
`$ git pull https://git.openjdk.org/jdk.git pull/22736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22736`

View PR using the GUI difftool: \
`$ git pr show -t 22736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22736.diff">https://git.openjdk.org/jdk/pull/22736.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22736#issuecomment-2541597247)
</details>
