### PR TITLE
8346202: Correct typo in SQLPermission

### DIFF
--- a/src/java.sql/share/classes/java/sql/SQLPermission.java
+++ b/src/java.sql/share/classes/java/sql/SQLPermission.java
@@ -32,7 +32,7 @@ import java.security.*;
  * A {@code SQLPermission} object contains
  * a name (also referred to as a "target name") but no actions
  * list; there is either a named permission or there is not.
- * The target name is the name of the permission (see below). The
+ * The target name is the name of the permission. The
  * naming convention follows the  hierarchical property naming convention.
  * In addition, an asterisk
  * may appear at the end of the name, following a ".", or by itself, to


### PR DESCRIPTION
Please review this trivial PR which  removes `(See below)`  which was missed during the SQLPermission update as part of the updates for [JEP 486: Permanently Disable the Security Manager](https://openjdk.org/jeps/486)

I have confirmed there are no issues with the build via a macht tier1 run

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346202](https://bugs.openjdk.org/browse/JDK-8346202): Correct typo in SQLPermission (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22739/head:pull/22739` \
`$ git checkout pull/22739`

Update a local copy of the PR: \
`$ git checkout pull/22739` \
`$ git pull https://git.openjdk.org/jdk.git pull/22739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22739`

View PR using the GUI difftool: \
`$ git pr show -t 22739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22739.diff">https://git.openjdk.org/jdk/pull/22739.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22739#issuecomment-2542217080)
</details>
