### PR TITLE
8346160: Fix -Wzero-as-null-pointer-constant warnings from explicit casts

### DIFF
--- a/src/hotspot/os/aix/attachListener_aix.cpp
+++ b/src/hotspot/os/aix/attachListener_aix.cpp
@@ -39,7 +39,7 @@
 #include <unistd.h>
 
 #ifndef UNIX_PATH_MAX
-#define UNIX_PATH_MAX   sizeof(((struct sockaddr_un *)0)->sun_path)
+#define UNIX_PATH_MAX   sizeof(sockaddr_un::sun_path)
 #endif
 
 // The attach mechanism on AIX  uses a UNIX domain socket. An attach listener

--- a/src/hotspot/os/posix/attachListener_posix.cpp
+++ b/src/hotspot/os/posix/attachListener_posix.cpp
@@ -43,7 +43,7 @@
 #ifndef AIX
 
 #ifndef UNIX_PATH_MAX
-#define UNIX_PATH_MAX   sizeof(((struct sockaddr_un *)0)->sun_path)
+#define UNIX_PATH_MAX   sizeof(sockaddr_un::sun_path)
 #endif
 
 // The attach mechanism on Linux and BSD uses a UNIX domain socket. An attach

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1053,7 +1053,7 @@ static char* mmap_create_shared(size_t size) {
     return nullptr;
   }
 
-  mapAddress = (char*)::mmap((char*)0, size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+  mapAddress = (char*)::mmap(nullptr, size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
 
   result = ::close(fd);
   assert(result != OS_ERR, "could not close file");
@@ -1208,7 +1208,7 @@ static void mmap_attach_shared(int vmid, char** addr, size_t* sizep, TRAPS) {
 
   assert(size > 0, "unexpected size <= 0");
 
-  char* mapAddress = (char*)::mmap((char*)0, size, mmap_prot, MAP_SHARED, fd, 0);
+  char* mapAddress = (char*)::mmap(nullptr, size, mmap_prot, MAP_SHARED, fd, 0);
 
   int result = ::close(fd);
   assert(result != OS_ERR, "could not close file");

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -278,7 +278,7 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
   if (!set_klass_decode_mode()) {
 
     // Give fatal error if this is a specified address
-    if ((address)CompressedClassSpaceBaseAddress == _base) {
+    if (CompressedClassSpaceBaseAddress == (size_t)_base) {
       vm_exit_during_initialization(
             err_msg("CompressedClassSpaceBaseAddress=" PTR_FORMAT " given with shift %d, cannot be used to encode class pointers",
                     CompressedClassSpaceBaseAddress, _shift));

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -133,7 +133,7 @@ static const char* env_list[] = {
   // defined on Windows
   "OS", "PROCESSOR_IDENTIFIER", "_ALT_JAVA_HOME_DIR", "TMP", "TEMP",
 
-  (const char *)0
+  nullptr                       // End marker.
 };
 
 // A simple parser for -XX:OnError, usage:


### PR DESCRIPTION
Please review this change that removes -Wzero-as-null-pointer-constant
warnings from explicit casts of a literal 0 to a pointer type.  Different
versions of gcc seem to warn about different cases changed here, but all of
these showed up as a warning in some testing, whether Oracle CI, GHA sanity
tests, or local cross-builds using Oracle's devkits for that.

Some of the changes simply replace a cast of 0 with nullptr.

The UNIX_PATH_MAX macro definitions in attachListener_{aix,posix}.cpp is
changed to use a C++11 feature for obtaining the size of a non-static data
member without requiring an instance.
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2253.html
I guess I need to propose an update to the style guide to mention this feature.

In CompressedKlassPointers::initialize, casting
CompressedClassSpaceBaseAddress to a pointer type was triggering the warning
in release builds for some reason. That's not a literal 0, even though it *is*
a constant 0 in a release build. Changed to avoid that cast rather than trying
to argue with some versions of the compiler.

Although different gcc versions on different platforms seemed to vary whether
warning about each of these, this actually seems to be all of the explict
casts of a literal 0 to a pointer in HotSpot.  Though because of the varied
behaviors, new ones might slip in later.

Testing: mach5 tier1, GHA sanity tests, both with and without the warning enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346160](https://bugs.openjdk.org/browse/JDK-8346160): Fix -Wzero-as-null-pointer-constant warnings from explicit casts (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22740/head:pull/22740` \
`$ git checkout pull/22740`

Update a local copy of the PR: \
`$ git checkout pull/22740` \
`$ git pull https://git.openjdk.org/jdk.git pull/22740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22740`

View PR using the GUI difftool: \
`$ git pr show -t 22740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22740.diff">https://git.openjdk.org/jdk/pull/22740.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22740#issuecomment-2541919414)
</details>
