### PR TITLE
8337016: serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java gets Metaspace OOM

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -35,7 +35,7 @@
  * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=25m -XX:MaxMetaspaceSize=25m RedefineLeakThrowable
  */
 
-// MaxMetaspaceSize=23m allows InMemoryJavaCompiler to load even if CDS is off.
+// MaxMetaspaceSize=25m allows InMemoryJavaCompiler to load even if CDS is off.
 class Tester {
     void test() {
         try {

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -35,6 +35,7 @@
  * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=25m -XX:MaxMetaspaceSize=25m RedefineLeakThrowable
  */
 
+// MaxMetaspaceSize=23m allows InMemoryJavaCompiler to load even if CDS is off.
 class Tester {
     void test() {
         try {

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -26,7 +26,6 @@
  * @bug 8308762
  * @library /test/lib
  * @summary Test that redefinition of class containing Throwable refs does not leak constant pool
- * @requires os.family == "aix"
  * @requires vm.jvmti
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
@@ -34,21 +33,6 @@
  *          java.compiler
  * @run main RedefineClassHelper
  * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=25m -XX:MaxMetaspaceSize=25m RedefineLeakThrowable
- */
-
-/*
- * @test
- * @bug 8308762
- * @library /test/lib
- * @summary Test that redefinition of class containing Throwable refs does not leak constant pool
- * @requires os.family != "aix"
- * @requires vm.jvmti
- * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- * @modules java.instrument
- *          java.compiler
- * @run main RedefineClassHelper
- * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=17m -XX:MaxMetaspaceSize=17m RedefineLeakThrowable
  */
 
 class Tester {


### PR DESCRIPTION
This increases MaxMetaspaceSize for this test so that it can be run with CDS turned off.  This change is upstreamed from the valhalla repo from when it didn't have CDS on.  The test still finds a metaspace leak with this larger MaxMetaspaceSize.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337016](https://bugs.openjdk.org/browse/JDK-8337016): serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java gets Metaspace OOM (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22746/head:pull/22746` \
`$ git checkout pull/22746`

Update a local copy of the PR: \
`$ git checkout pull/22746` \
`$ git pull https://git.openjdk.org/jdk.git pull/22746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22746`

View PR using the GUI difftool: \
`$ git pr show -t 22746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22746.diff">https://git.openjdk.org/jdk/pull/22746.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22746#issuecomment-2542484921)
</details>
