### PR TITLE
8346048: test/lib/containers/docker/DockerRunOptions.java uses addJavaOpts() from ctor

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerRunOptions.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerRunOptions.java
@@ -59,10 +59,10 @@ public class DockerRunOptions {
         this.imageNameAndTag = imageNameAndTag;
         this.command = javaCmd;
         this.classToRun = classToRun;
-        this.addJavaOpts(javaOpts);
+        Collections.addAll(this.javaOpts, javaOpts);
         // always print hserr to stderr in the docker tests to avoid
         // trouble accessing it after a crash in the container
-        this.addJavaOpts("-XX:+ErrorFileToStderr");
+        this.javaOpts.add("-XX:+ErrorFileToStderr");
     }
 
     public DockerRunOptions addDockerOpts(String... opts) {

--- a/test/lib/jdk/test/lib/containers/docker/DockerRunOptions.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerRunOptions.java
@@ -59,28 +59,28 @@ public class DockerRunOptions {
         this.imageNameAndTag = imageNameAndTag;
         this.command = javaCmd;
         this.classToRun = classToRun;
-        Collections.addAll(this.javaOpts, javaOpts);
+        this.addJavaOpts(javaOpts);
         // always print hserr to stderr in the docker tests to avoid
         // trouble accessing it after a crash in the container
-        this.javaOpts.add("-XX:+ErrorFileToStderr");
+        this.addJavaOpts("-XX:+ErrorFileToStderr");
     }
 
-    public DockerRunOptions addDockerOpts(String... opts) {
+    public final DockerRunOptions addDockerOpts(String... opts) {
         Collections.addAll(dockerOpts, opts);
         return this;
     }
 
-    public DockerRunOptions addJavaOpts(String... opts) {
+    public final DockerRunOptions addJavaOpts(String... opts) {
         Collections.addAll(javaOpts, opts);
         return this;
     }
 
-    public DockerRunOptions addJavaOptsAppended(String... opts) {
+    public final DockerRunOptions addJavaOptsAppended(String... opts) {
         Collections.addAll(javaOptsAppended, opts);
         return this;
     }
 
-    public DockerRunOptions addClassOptions(String... opts) {
+    public final DockerRunOptions addClassOptions(String... opts) {
         Collections.addAll(classParams,opts);
         return this;
     }


### PR DESCRIPTION
Trivial fix to avoid using methods from DockerRunOptions().

Don't methods final, just  for using them in ctor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346048](https://bugs.openjdk.org/browse/JDK-8346048): test/lib/containers/docker/DockerRunOptions.java uses addJavaOpts() from ctor (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22748/head:pull/22748` \
`$ git checkout pull/22748`

Update a local copy of the PR: \
`$ git checkout pull/22748` \
`$ git pull https://git.openjdk.org/jdk.git pull/22748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22748`

View PR using the GUI difftool: \
`$ git pr show -t 22748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22748.diff">https://git.openjdk.org/jdk/pull/22748.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22748#issuecomment-2542585349)
</details>
