### PR TITLE
8346232: Remove leftovers of the jar --normalize feature

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
@@ -152,7 +152,6 @@ public class Main {
      * flag0: no zip compression (store only)
      * Mflag: DO NOT generate a manifest file (just ZIP)
      * iflag: generate jar index
-     * nflag: Perform jar normalization at the end
      * pflag: preserve/don't strip leading slash and .. component from file name
      * dflag: print module descriptor
      * kflag: keep existing file

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -282,10 +282,6 @@ main.help.opt.any.verbose=\
 \  -v, --verbose              Generate verbose output on standard output
 main.help.opt.create=\
 \ Operation modifiers valid only in create mode:\n
-main.help.opt.create.normalize=\
-\  -n, --normalize            Normalize information in the new jar archive\n\
-\                             after creation. This option is deprecated, and is\n\
-\                             planned for removal in a future JDK release
 main.help.opt.create.update=\
 \ Operation modifiers valid only in create and update mode:\n
 main.help.opt.create.update.main-class=\

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_de.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_de.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,6 @@ main.help.opt.any=\ In jedem Modus gültige Vorgangsmodifikatoren:\n\n  -C DIR  
 main.help.opt.any.file=\  -f, --file=FILE            Der Name der Archivdatei. Wenn Sie dies auslassen, wird entweder stdin oder\n                             stdout verwendet, je nach Vorgang\n      --release VERSION      Speichert alle der folgenden Dateien in einem versionierten Verzeichnis\n                             der JAR-Datei (d.h. META-INF/versions/VERSION/)
 main.help.opt.any.verbose=\  -v, --verbose              Verbose-Ausgabe bei Standardausgabe generieren
 main.help.opt.create=\ Vorgangsmodifikatoren, die nur im Erstellungsmodus gültig sind:\n
-main.help.opt.create.normalize=\  -n, --normalize            Normalisiert Informationen im neuen JAR-Archiv\n                             nach der Erstellung. Diese Option ist veraltet, und ihre\n                             Entfernung in einem künftigen JDK-Release ist geplant
 main.help.opt.create.update=\ Vorgangsmodifikatoren, die nur im Erstellungs- und Aktualisierungsmodus gültig sind:\n
 main.help.opt.create.update.main-class=\  -e, --main-class=CLASSNAME Der Anwendungseinstiegspunkt für Standalone-\n                             Anwendungen, die in einem modularen oder ausführbaren\n                             JAR-Archiv gebündelt sind
 main.help.opt.create.update.manifest=\  -m, --manifest=FILE        Die Manifestinformationen aus der angegebenen\n                             Manifestdatei aufnehmen

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_es.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_es.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,6 @@ main.help.opt.any=\ Modificadores de operación válidos en cualquier modo:\n\n 
 main.help.opt.any.file=\  -f, --file=FILE            El nombre del archivo. Si se omite, se usa stdin o\n                             stdout en función de la operación\n      --release VERSION      Se colocan todos los archivos siguientes en un directorio con versión\n                             del archivo jar (es decir, META-INF/versions/VERSION/)
 main.help.opt.any.verbose=\  -v, --verbose              Generar salida verbose en salida estándar
 main.help.opt.create=\ Modificadores de operación válidos solo en el modo de creación:\n
-main.help.opt.create.normalize=\  -n, --normalize            Normalizar información en el nuevo archivo jar\n                             después de la creación
 main.help.opt.create.update=\ Modificadores de operación válidos solo en el modo de creación y de actualización:\n
 main.help.opt.create.update.main-class=\  -e, --main-class=CLASSNAME Punto de entrada de la aplicación para aplicaciones\n                             autónomas agrupadas en un archivo jar modular o\n                             ejecutable
 main.help.opt.create.update.manifest=\  -m, --manifest=FILE        Incluir la información de manifiesto del archivo\n                             de manifiesto proporcionado

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_fr.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_fr.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,6 @@ main.help.opt.any=\ Modificateurs d'opération valides pour tous les modes :\n\n
 main.help.opt.any.file=\  -f, --file=FILE            Nom du fichier d'archive. Lorsqu'il est omis, stdin ou\n                             stdout est utilisé en fonction de l'opération\n      --release VERSION      Place tous les fichiers suivants dans un répertoire avec numéro de version\n                             du fichier JAR (à savoir META-INF/versions/VERSION/)
 main.help.opt.any.verbose=\  -v, --verbose              Génère une sortie en mode verbose d'une sortie standard
 main.help.opt.create=\ Modificateurs d'opération valides uniquement en mode create :\n
-main.help.opt.create.normalize=\  -n, --normalize            Normaliser des informations dans la nouvelle archive JAR\n                             après la création
 main.help.opt.create.update=\ Modificateurs d'opération valides uniquement en modes create et update :\n
 main.help.opt.create.update.main-class=\  -e, --main-class=CLASSNAME Point d'entrée d'une application en mode autonome\n                             intégrée à une archive JAR modulaire\n                             ou exécutable
 main.help.opt.create.update.manifest=\  -m, --manifest=FILE        Inclut les informations de manifeste du fichier\n                             manifeste donné

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_it.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_it.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,6 @@ main.help.opt.any=\ Modificatori di funzionamento validi in qualsiasi modalità:
 main.help.opt.any.file=\  -f, --file=FILE            Il nome file dell'archivio. Se omesso, viene usato stdin o\n                             stdout in base all'operazione\n      --release VERSION      Posiziona tutti i file successivi in una directory con controllo delle versioni\n                             del file jar (ad esempio, META-INF/versions/VERSION/)
 main.help.opt.any.verbose=\  -v, --verbose              Genera l'output descrittivo nell'output standard
 main.help.opt.create=\ Modificatori di funzionamento validi solo nella modalità di creazione:\n
-main.help.opt.create.normalize=\  -n, --normalize            Normalizza le informazioni nel nuovo archivio jar\n                             dopo la creazione
 main.help.opt.create.update=\ Modificatori di funzionamento validi solo nella modalità di creazione e aggiornamento:\n
 main.help.opt.create.update.main-class=\  -e, --main-class=CLASSNAME Punto di ingresso per le applicazioni\n                             stand-alone incluse nell'archivio jar modulare o\n                             eseguibile
 main.help.opt.create.update.manifest=\  -m, --manifest=FILE        Include le informazioni sul file manifest dal file\n                             manifest specificato

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_ja.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_ja.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,6 @@ main.help.opt.any=\ どのモードでも有効な操作修飾子:\n\n  -C DIR  
 main.help.opt.any.file=\  -f、--file=FILE            アーカイブ・ファイル名。省略した場合、stdinまたは\n                             stdoutのいずれかが操作に基づいて使用されます\n      --release VERSION      次のすべてのファイルをjarのバージョニングされたディレクトリ\n                             (つまり、META-INF/versions/VERSION/)に配置します
 main.help.opt.any.verbose=\  -v、--verbose              標準出力に詳細な出力を生成します
 main.help.opt.create=\ 作成モードでのみ有効な操作修飾子:\n
-main.help.opt.create.normalize=\  -n, --normalize            新しいjarアーカイブの作成後、含まれる情報を\n                             正規化します。このオプションは非推奨であり、\n                             今後のJDKリリースで削除される予定です
 main.help.opt.create.update=\ 作成または更新モードでのみ有効な操作修飾子:\n
 main.help.opt.create.update.main-class=\  -e、--main-class=CLASSNAME モジュラまたは実行可能なjarアーカイブに\n                             バンドルされたスタンドアロン・アプリケーションの\n                             アプリケーション・エントリ・ポイント
 main.help.opt.create.update.manifest=\  -m、--manifest=FILE        指定のマニフェスト・ファイルからマニフェスト情報を\n                             取り込みます

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_ko.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_ko.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,6 @@ main.help.opt.any=\ 모든 모드에서 적합한 작업 수정자:\n\n  -C DIR 
 main.help.opt.any.file=\  -f, --file=FILE            아카이브 파일 이름입니다. 생략할 경우 작업에 따라 \n                             stdin 또는 stdout이 사용됩니다.\n      --release VERSION      다음 모든 파일을 버전 지정된 jar 디렉토리\n                             (예: META-INF/versions/VERSION/)에 배치합니다.
 main.help.opt.any.verbose=\  -v, --verbose              표준 출력에 상세 정보 출력을 생성합니다.
 main.help.opt.create=\ 생성 모드에서만 적합한 작업 수정자:\n
-main.help.opt.create.normalize=\  -n, --normalize            생성 후 새 jar 아카이브에서 정보를\n                             정규화합니다.
 main.help.opt.create.update=\ 생성 및 업데이트 모드에서만 적합한 작업 수정자:\n
 main.help.opt.create.update.main-class=\  -e, --main-class=CLASSNAME 모듈형 또는 실행형 jar 아카이브에 번들로\n                             제공된 독립형 애플리케이션의 애플리케이션\n                             시작 지점입니다.
 main.help.opt.create.update.manifest=\  -m, --manifest=FILE        지정된 Manifest 파일의 Manifest 정보를\n                             포함합니다.

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_pt_BR.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_pt_BR.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,6 @@ main.help.opt.any=\ Modificadores de operação válidos em qualquer modo:\n\n  
 main.help.opt.any.file=\  -f, --file=FILE            O nome do arquivo compactado. Quando omitido, stdin ou\n                             stdout será usado com base na operação\n      --release VERSION      Coloca todos os arquivos a seguir em um diretório com controle de versão\n                             do arquivo jar (i.e. META-INF/versions/VERSION/)
 main.help.opt.any.verbose=\  -v, --verbose              Gera saída detalhada na saída padrão
 main.help.opt.create=\ Modificadores de operação válidos somente no modo de criação:\n
-main.help.opt.create.normalize=\  -n, --normalize            Normaliza as informações no novo arquivo compactado jar\n                             após a criação
 main.help.opt.create.update=\ Modificadores de operação válidos somente no modo de criação e atualização:\n
 main.help.opt.create.update.main-class=\  -e, --main-class=CLASSNAME O ponto de entrada do aplicativo para aplicativos\n                             stand-alone empacotados em um arquivo compactado jar modular\n                             ou executável
 main.help.opt.create.update.manifest=\  -m, --manifest=FILE        Inclui as informações de manifesto provenientes do arquivo de\n                             manifesto em questão

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_sv.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_sv.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,6 @@ main.help.opt.any=\ Åtgärdsmodifierare som är giltiga i alla lägen:\n\n  -C 
 main.help.opt.any.file=\  -f, --file=FILE            Namnet på arkivfilen. När det utelämnas används stdin eller\n                             stdout beroende på åtgärden\n      --release VERSION      Placerar alla följande filer i en versionshanterad katalog\n                             i jar-filen (t.ex. META-INF/versions/VERSION/)
 main.help.opt.any.verbose=\  -v, --verbose              Generera utförliga utdata till standardutdata
 main.help.opt.create=\ Åtgärdsmodifierare som endast är giltiga i läget create:\n
-main.help.opt.create.normalize=\  -n, --normalize            Normalisera informationen i det nya jar-arkivet\n                             när det har skapats
 main.help.opt.create.update=\ Åtgärdsmodifierare som endast är giltiga i lägena create och update:\n
 main.help.opt.create.update.main-class=\  -e, --main-class=CLASSNAME Applikationsingångspunkten för fristående\n                             applikationer paketerad i ett modulärt, eller körbart,\n                             jar-arkiv
 main.help.opt.create.update.manifest=\  -m, --manifest=FILE        Inkludera manifestinformationen från den angivna\n                             manifestfilen

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_zh_CN.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_zh_CN.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,6 @@ main.help.opt.any=\ 在任意模式下有效的操作修饰符:\n\n  -C DIR     
 main.help.opt.any.file=\  -f, --file=FILE            档案文件名。省略时, 基于操作\n                             使用 stdin 或 stdout\n      --release VERSION      将下面的所有文件都放在\n                             jar 的版本化目录中 (即 META-INF/versions/VERSION/)
 main.help.opt.any.verbose=\  -v, --verbose              在标准输出中生成详细输出
 main.help.opt.create=\ 仅在创建模式下有效的操作修饰符:\n
-main.help.opt.create.normalize=\  -n, --normalize            创建后在新的 jar 档案中\n                             规范化信息。此选项已过时，\n                             计划在未来的 JDK 发行版中删除
 main.help.opt.create.update=\ 在创建和更新模式下有效的操作修饰符:\n
 main.help.opt.create.update.main-class=\  -e, --main-class=CLASSNAME 捆绑到模块化或可执行 \n                             jar 档案的独立应用程序\n                             的应用程序入口点
 main.help.opt.create.update.manifest=\  -m, --manifest=FILE        包含指定清单文件中的\n                             清单信息

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_zh_TW.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar_zh_TW.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,6 @@ main.help.opt.any=\ 可在任何模式下使用的作業修飾條件:\n\n  -C DI
 main.help.opt.any.file=\  -f, --file=FILE            存檔檔案名稱。如果省略，會根據作業使用\n                             stdin 或 stdout\n      --release VERSION      將所有下列檔案放置在 jar 的啟動多版本\n                             功能目錄中 (例如 META-INF/versions/VERSION/)
 main.help.opt.any.verbose=\  -v, --verbose              在標準輸出中產生詳細輸出
 main.help.opt.create=\ 只能在建立模式使用的作業修飾條件:\n
-main.help.opt.create.normalize=\  -n, --normalize            建立新的 jar 存檔之後，將其中的資訊\n                             標準化
 main.help.opt.create.update=\ 只能在建立和更新模式下使用的作業修飾條件:\n
 main.help.opt.create.update.main-class=\  -e, --main-class=CLASSNAME 隨附於模組化或可執行\n                             jar 存檔中獨立應用程式的\n                             應用程式進入點
 main.help.opt.create.update.manifest=\  -m, --manifest=FILE        包含指定資訊清單檔案中的資訊清單\n                             資訊


### PR DESCRIPTION
Please review this cleanup PR which removes a property and a code comment left behind after the `jar --normalize` feature  was removed in JDK 14.

The feature was deprecated in JDK-8199871 and removed in JDK-8234542, along with removal of Pack200 tools and APIs.

This PR removes the now unused `main.help.opt.create.normalize` property and a code comment in `Main.java` referencing normalization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346232](https://bugs.openjdk.org/browse/JDK-8346232): Remove leftovers of the jar --normalize feature (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22751/head:pull/22751` \
`$ git checkout pull/22751`

Update a local copy of the PR: \
`$ git checkout pull/22751` \
`$ git pull https://git.openjdk.org/jdk.git pull/22751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22751`

View PR using the GUI difftool: \
`$ git pr show -t 22751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22751.diff">https://git.openjdk.org/jdk/pull/22751.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22751#issuecomment-2543099104)
</details>
