### PR TITLE
8346235: RISC-V: Optimize bitwise AND with mask values

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_arith_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_arith_riscv.cpp
@@ -64,7 +64,7 @@ void LIR_Assembler::arithmetic_idiv(LIR_Code code, LIR_Opr left, LIR_Opr right, 
         if (Assembler::is_simm12(c - 1)) {
           __ andi(t1, t1, c - 1);
         } else {
-          __ zero_extend(t1, t1, shift);
+          __ zext(t1, t1, shift);
         }
         __ subw(dreg, t1, t0);
       }
@@ -78,7 +78,7 @@ void LIR_Assembler::arithmetic_idiv(LIR_Code code, LIR_Opr left, LIR_Opr right, 
         if (Assembler::is_simm12(c - 1)) {
           __ andi(t0, t0, c - 1);
         } else {
-          __ zero_extend(t0, t0, shift);
+          __ zext(t0, t0, shift);
         }
         __ addw(dreg, t0, lreg);
         __ sraiw(dreg, dreg, shift);
@@ -205,7 +205,7 @@ void LIR_Assembler::arith_op_double_cpu(LIR_Code code, LIR_Opr left, LIR_Opr rig
           if (Assembler::is_simm12(c - 1)) {
             __ andi(t0, t0, c - 1);
           } else {
-            __ zero_extend(t0, t0, shift);
+            __ zext(t0, t0, shift);
           }
           __ add(dreg, t0, lreg_lo);
           __ srai(dreg, dreg, shift);
@@ -224,7 +224,7 @@ void LIR_Assembler::arith_op_double_cpu(LIR_Code code, LIR_Opr left, LIR_Opr rig
           if (Assembler::is_simm12(c - 1)) {
             __ andi(t1, t1, c - 1);
           } else {
-            __ zero_extend(t1, t1, shift);
+            __ zext(t1, t1, shift);
           }
           __ sub(dreg, t1, t0);
         }

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -952,15 +952,15 @@ void LIR_Assembler::emit_opConvert(LIR_OpConvert* op) {
     case Bytecodes::_d2f:
       __ fcvt_s_d(dest->as_float_reg(), src->as_double_reg()); break;
     case Bytecodes::_i2c:
-      __ zero_extend(dest->as_register(), src->as_register(), 16); break;
+      __ zext(dest->as_register(), src->as_register(), 16); break;
     case Bytecodes::_i2l:
-      __ sign_extend(dest->as_register_lo(), src->as_register(), 32); break;
+      __ sext(dest->as_register_lo(), src->as_register(), 32); break;
     case Bytecodes::_i2s:
-      __ sign_extend(dest->as_register(), src->as_register(), 16); break;
+      __ sext(dest->as_register(), src->as_register(), 16); break;
     case Bytecodes::_i2b:
-      __ sign_extend(dest->as_register(), src->as_register(), 8); break;
+      __ sext(dest->as_register(), src->as_register(), 8); break;
     case Bytecodes::_l2i:
-      __ sign_extend(dest->as_register(), src->as_register_lo(), 32); break;
+      __ sext(dest->as_register(), src->as_register_lo(), 32); break;
     case Bytecodes::_d2l:
       __ fcvt_l_d_safe(dest->as_register_lo(), src->as_double_reg()); break;
     case Bytecodes::_f2i:
@@ -1288,7 +1288,7 @@ void LIR_Assembler::logic_op(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Opr
       int right_const = right->as_jint();
       if (Assembler::is_simm12(right_const)) {
         logic_op_imm(Rdst, Rleft, right_const, code);
-        __ sign_extend(Rdst, Rdst, 32);
+        __ sext(Rdst, Rdst, 32);
      } else {
         __ mv(t0, right_const);
         logic_op_reg32(Rdst, Rleft, t0, code);
@@ -1609,7 +1609,7 @@ void LIR_Assembler::emit_updatecrc32(LIR_OpUpdateCRC32* op) {
   __ la(res, ExternalAddress(StubRoutines::crc_table_addr()));
 
   __ notr(crc, crc); // ~crc
-  __ zero_extend(crc, crc, 32);
+  __ zext(crc, crc, 32);
   __ update_byte_crc32(crc, val, res);
   __ notr(res, crc); // ~crc
 }

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1027,7 +1027,7 @@ void C2_MacroAssembler::string_indexof(Register haystack, Register needle,
     srli(ch2, ch2, XLEN - 8); // pattern[m-2], 0x0000000b
     slli(ch1, tmp6, XLEN - 16);
     srli(ch1, ch1, XLEN - 8); // pattern[m-3], 0x0000000c
-    andi(tmp6, tmp6, 0xff); // pattern[m-4], 0x0000000d
+    zext(tmp6, tmp6, 8); // pattern[m-4], 0x0000000d
     slli(ch2, ch2, 16);
     orr(ch2, ch2, ch1); // 0x00000b0c
     slli(result, tmp3, 48); // use result as temp register
@@ -1540,11 +1540,11 @@ void C2_MacroAssembler::string_compare(Register str1, Register str2,
     srl(tmp1, tmp1, result);
     srl(tmp2, tmp2, result);
     if (isLL) {
-      andi(tmp1, tmp1, 0xFF);
-      andi(tmp2, tmp2, 0xFF);
+      zext(tmp1, tmp1, 8);
+      zext(tmp2, tmp2, 8);
     } else {
-      andi(tmp1, tmp1, 0xFFFF);
-      andi(tmp2, tmp2, 0xFFFF);
+      zext(tmp1, tmp1, 16);
+      zext(tmp2, tmp2, 16);
     }
     sub(result, tmp1, tmp2);
     j(DONE);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -70,20 +70,20 @@ void InterpreterMacroAssembler::narrow(Register result) {
   bind(notBool);
   mv(t1, T_BYTE);
   bne(t0, t1, notByte);
-  sign_extend(result, result, 8);
+  sext(result, result, 8);
   j(done);
 
   bind(notByte);
   mv(t1, T_CHAR);
   bne(t0, t1, notChar);
-  zero_extend(result, result, 16);
+  zext(result, result, 16);
   j(done);
 
   bind(notChar);
-  sign_extend(result, result, 16);
+  sext(result, result, 16);
 
   bind(done);
-  sign_extend(result, result, 32);
+  sext(result, result, 32);
 }
 
 void InterpreterMacroAssembler::jump_to_entry(address entry) {
@@ -276,7 +276,7 @@ void InterpreterMacroAssembler::push_ptr(Register r) {
 
 void InterpreterMacroAssembler::push_i(Register r) {
   addi(esp, esp, -wordSize);
-  sign_extend(r, r, 32);
+  sext(r, r, 32);
   sd(r, Address(esp, 0));
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -5854,21 +5854,15 @@ void MacroAssembler::zext(Register dst, Register src, int bits) {
       }
       break;
     case 8:
-      if (UseZbb) {
-        zext_b(dst, src);
-        return;
-      }
+      zext_b(dst, src);
+      return;
       break;
     default:
       break;
   }
 
-  if (bits == 8) {
-    andi(dst, src, 0xFF);
-  } else {
-    slli(dst, src, XLEN - bits);
-    srli(dst, dst, XLEN - bits);
-  }
+  slli(dst, src, XLEN - bits);
+  srli(dst, dst, XLEN - bits);
 }
 
 void MacroAssembler::sext(Register dst, Register src, int bits) {
@@ -5891,6 +5885,7 @@ void MacroAssembler::sext(Register dst, Register src, int bits) {
     default:
       break;
   }
+
   slli(dst, src, XLEN - bits);
   srai(dst, dst, XLEN - bits);
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1536,9 +1536,6 @@ int MacroAssembler::pop_fp(unsigned int bitset, Register stack) {
   return count;
 }
 
-static const int64_t right_32_bits = right_n_bits(32);
-static const int64_t right_8_bits = right_n_bits(8);
-
 /**
  * Emits code to update CRC-32 with a byte value according to constants in table
  *
@@ -1555,7 +1552,7 @@ void MacroAssembler::update_byte_crc32(Register crc, Register val, Register tabl
   assert_different_registers(crc, val, table);
 
   xorr(val, val, crc);
-  andi(val, val, right_8_bits);
+  zext(val, val, 8);
   shadd(val, val, table, val, 2);
   lwu(val, Address(val));
   srli(crc, crc, 8);
@@ -1585,7 +1582,7 @@ void MacroAssembler::update_word_crc32(Register crc, Register v, Register tmp1, 
     srli(v, v, 32);
   xorr(v, v, crc);
 
-  andi(tmp1, v, right_8_bits);
+  zext(tmp1, v, 8);
   shadd(tmp1, tmp1, table3, tmp2, 2);
   lwu(crc, Address(tmp1));
 
@@ -2086,7 +2083,11 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
   const int64_t single_table_size = 256;
   const int64_t unroll = 16;
   const int64_t unroll_words = unroll*wordSize;
-  mv(tmp5, right_32_bits);
+
+  // tmp5 = 0xffffffff
+  notr(tmp5, zr);
+  srli(tmp5, tmp5, 32);
+
   andn(crc, tmp5, crc);
 
   const ExternalAddress table_addr = StubRoutines::crc_table_addr();
@@ -2110,7 +2111,7 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
     subw(len, len, 2);
     lhu(tmp1, Address(buf));
     add(buf, buf, 2);
-    andi(tmp2, tmp1, right_8_bits);
+    zext(tmp2, tmp1, 8);
     update_byte_crc32(crc, tmp2, table0);
     srli(tmp2, tmp1, 8);
     update_byte_crc32(crc, tmp2, table0);
@@ -2634,17 +2635,17 @@ void MacroAssembler::subw(Register Rd, Register Rn, int32_t decrement, Register 
 
 void MacroAssembler::andrw(Register Rd, Register Rs1, Register Rs2) {
   andr(Rd, Rs1, Rs2);
-  sign_extend(Rd, Rd, 32);
+  sext(Rd, Rd, 32);
 }
 
 void MacroAssembler::orrw(Register Rd, Register Rs1, Register Rs2) {
   orr(Rd, Rs1, Rs2);
-  sign_extend(Rd, Rd, 32);
+  sext(Rd, Rd, 32);
 }
 
 void MacroAssembler::xorrw(Register Rd, Register Rs1, Register Rs2) {
   xorr(Rd, Rs1, Rs2);
-  sign_extend(Rd, Rd, 32);
+  sext(Rd, Rd, 32);
 }
 
 // Rd = Rs1 & (~Rd2)
@@ -2832,18 +2833,18 @@ void MacroAssembler::revbw(Register Rd, Register Rs, Register tmp1, Register tmp
   }
   assert_different_registers(Rs, tmp1, tmp2);
   assert_different_registers(Rd, tmp1, tmp2);
-  andi(tmp1, Rs, 0xFF);
+  zext(tmp1, Rs, 8);
   slli(tmp1, tmp1, 8);
   for (int step = 8; step < 24; step += 8) {
     srli(tmp2, Rs, step);
-    andi(tmp2, tmp2, 0xFF);
+    zext(tmp2, tmp2, 8);
     orr(tmp1, tmp1, tmp2);
     slli(tmp1, tmp1, 8);
   }
   srli(Rd, Rs, 24);
-  andi(Rd, Rd, 0xFF);
+  zext(Rd, Rd, 8);
   orr(Rd, tmp1, Rd);
-  sign_extend(Rd, Rd, 32);
+  sext(Rd, Rd, 32);
 }
 
 // reverse bytes in doubleword
@@ -2855,16 +2856,16 @@ void MacroAssembler::revb(Register Rd, Register Rs, Register tmp1, Register tmp2
   }
   assert_different_registers(Rs, tmp1, tmp2);
   assert_different_registers(Rd, tmp1, tmp2);
-  andi(tmp1, Rs, 0xFF);
+  zext(tmp1, Rs, 8);
   slli(tmp1, tmp1, 8);
   for (int step = 8; step < 56; step += 8) {
     srli(tmp2, Rs, step);
-    andi(tmp2, tmp2, 0xFF);
+    zext(tmp2, tmp2, 8);
     orr(tmp1, tmp1, tmp2);
     slli(tmp1, tmp1, 8);
   }
   srli(Rd, Rs, 56);
-  andi(Rd, Rd, 0xFF);
+  zext(Rd, Rd, 8);
   orr(Rd, tmp1, Rd);
 }
 
@@ -3237,7 +3238,7 @@ void MacroAssembler::encode_klass_not_null(Register dst, Register src, Register 
 
   if (((uint64_t)CompressedKlassPointers::base() & 0xffffffff) == 0 &&
       CompressedKlassPointers::shift() == 0) {
-    zero_extend(dst, src, 32);
+    zext(dst, src, 32);
     return;
   }
 
@@ -3690,7 +3691,7 @@ void MacroAssembler::load_reserved(Register dst,
       break;
     case uint32:
       lr_w(dst, addr, acquire);
-      zero_extend(dst, dst, 32);
+      zext(dst, dst, 32);
       break;
     default:
       ShouldNotReachHere();
@@ -3731,7 +3732,7 @@ void MacroAssembler::cmpxchg_narrow_value_helper(Register addr, Register expecte
   } else {
     // size == int16 case
     mv(mask, -1);
-    zero_extend(mask, mask, 16);
+    zext(mask, mask, 16);
   }
   sll(mask, mask, shift);
 
@@ -3808,10 +3809,10 @@ void MacroAssembler::cmpxchg_narrow_value(Register addr, Register expected,
     srl(result, scratch0, shift);
 
     if (size == int8) {
-      sign_extend(result, result, 8);
+      sext(result, result, 8);
     } else {
       // size == int16 case
-      sign_extend(result, result, 16);
+      sext(result, result, 16);
     }
   }
 }
@@ -4005,7 +4006,7 @@ ATOMIC_XCHG(xchgalw, amoswap_w, Assembler::aq, Assembler::rl)
 #define ATOMIC_XCHGU(OP1, OP2)                                                       \
 void MacroAssembler::atomic_##OP1(Register prev, Register newv, Register addr) {     \
   atomic_##OP2(prev, newv, addr);                                                    \
-  zero_extend(prev, prev, 32);                                                       \
+  zext(prev, prev, 32);                                                       \
   return;                                                                            \
 }
 
@@ -4025,7 +4026,7 @@ void MacroAssembler::atomic_cas(Register prev, Register newv, Register addr,
       break;
     case uint32:
       amocas_w(prev, addr, newv, (Assembler::Aqrl)(acquire | release));
-      zero_extend(prev, prev, 32);
+      zext(prev, prev, 32);
       break;
     default:
       ShouldNotReachHere();
@@ -4614,7 +4615,7 @@ void MacroAssembler::set_narrow_oop(Register dst, jobject obj) {
   relocate(oop_Relocation::spec(oop_index), [&] {
     li32(dst, 0xDEADBEEF);
   });
-  zero_extend(dst, dst, 32);
+  zext(dst, dst, 32);
 }
 
 void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
@@ -4627,7 +4628,7 @@ void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
   relocate(metadata_Relocation::spec(index), [&] {
     li32(dst, nk);
   });
-  zero_extend(dst, dst, 32);
+  zext(dst, dst, 32);
 }
 
 address MacroAssembler::reloc_call(Address entry, Register tmp) {
@@ -4902,7 +4903,7 @@ void MacroAssembler::mul_add(Register out, Register in, Register offset,
   mv(tmp, out);
   mv(out, zr);
   blez(len, L_end);
-  zero_extend(k, k, 32);
+  zext(k, k, 32);
   slliw(t0, offset, LogBytesPerInt);
   add(offset, tmp, t0);
   slliw(t0, len, LogBytesPerInt);
@@ -5436,7 +5437,7 @@ void MacroAssembler::inflate_lo32(Register Rd, Register Rs, Register tmp1, Regis
     orr(Rd, Rd, tmp2);
   }
   slli(Rd, Rd, wordSize);
-  andi(tmp2, Rs, 0xFF); // last byte mask at lower word
+  zext(tmp2, Rs, 8); // last byte mask at lower word
   orr(Rd, Rd, tmp2);
 }
 
@@ -5838,7 +5839,7 @@ void MacroAssembler::shadd(Register Rd, Register Rs1, Register Rs2, Register tmp
   }
 }
 
-void MacroAssembler::zero_extend(Register dst, Register src, int bits) {
+void MacroAssembler::zext(Register dst, Register src, int bits) {
   switch (bits) {
     case 32:
       if (UseZba) {
@@ -5861,11 +5862,16 @@ void MacroAssembler::zero_extend(Register dst, Register src, int bits) {
     default:
       break;
   }
-  slli(dst, src, XLEN - bits);
-  srli(dst, dst, XLEN - bits);
+
+  if (bits == 8) {
+    andi(dst, src, 0xFF);
+  } else {
+    slli(dst, src, XLEN - bits);
+    srli(dst, dst, XLEN - bits);
+  }
 }
 
-void MacroAssembler::sign_extend(Register dst, Register src, int bits) {
+void MacroAssembler::sext(Register dst, Register src, int bits) {
   switch (bits) {
     case 32:
       sext_w(dst, src);
@@ -5977,7 +5983,7 @@ void MacroAssembler::move32_64(VMRegPair src, VMRegPair dst, Register tmp) {
     sd(src.first()->as_Register(), Address(sp, reg2offset_out(dst.first())));
   } else {
     if (dst.first() != src.first()) {
-      sign_extend(dst.first()->as_Register(), src.first()->as_Register(), 32);
+      sext(dst.first()->as_Register(), src.first()->as_Register(), 32);
     }
   }
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -5856,7 +5856,6 @@ void MacroAssembler::zext(Register dst, Register src, int bits) {
     case 8:
       zext_b(dst, src);
       return;
-      break;
     default:
       break;
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1518,16 +1518,16 @@ public:
         sltu(Rt, zr, Rt);
         break;
       case T_CHAR   :
-        zero_extend(Rt, Rt, 16);
+        zext(Rt, Rt, 16);
         break;
       case T_BYTE   :
-        sign_extend(Rt, Rt, 8);
+        sext(Rt, Rt, 8);
         break;
       case T_SHORT  :
-        sign_extend(Rt, Rt, 16);
+        sext(Rt, Rt, 16);
         break;
       case T_INT    :
-        sign_extend(Rt, Rt, 32);
+        sext(Rt, Rt, 32);
         break;
       case T_LONG   : /* nothing to do */        break;
       case T_VOID   : /* nothing to do */        break;
@@ -1542,8 +1542,8 @@ public:
   void double_compare(Register result, FloatRegister Rs1, FloatRegister Rs2, int unordered_result);
 
   // Zero/Sign-extend
-  void zero_extend(Register dst, Register src, int bits);
-  void sign_extend(Register dst, Register src, int bits);
+  void zext(Register dst, Register src, int bits);
+  void sext(Register dst, Register src, int bits);
 
 private:
   void cmp_x2i(Register dst, Register src1, Register src2, Register tmp, bool is_signed = true);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1626,7 +1626,7 @@ uint MachSpillCopyNode::implementation(C2_MacroAssembler *masm, PhaseRegAlloc *r
       case rc_int:
         if (dst_lo_rc == rc_int) {  // gpr --> gpr copy
           if (!is64 && this->ideal_reg() != Op_RegI) { // zero extended for narrow oop or klass
-            __ zero_extend(as_Register(Matcher::_regEncode[dst_lo]), as_Register(Matcher::_regEncode[src_lo]), 32);
+            __ zext(as_Register(Matcher::_regEncode[dst_lo]), as_Register(Matcher::_regEncode[src_lo]), 32);
           } else {
             __ mv(as_Register(Matcher::_regEncode[dst_lo]), as_Register(Matcher::_regEncode[src_lo]));
           }
@@ -8079,7 +8079,7 @@ instruct convI2L_reg_reg(iRegLNoSp dst, iRegIorL2I src)
   ins_cost(ALU_COST);
   format %{ "addw  $dst, $src, zr\t#@convI2L_reg_reg" %}
   ins_encode %{
-    __ sign_extend(as_Register($dst$$reg), as_Register($src$$reg), 32);
+    __ sext(as_Register($dst$$reg), as_Register($src$$reg), 32);
   %}
   ins_pipe(ialu_reg);
 %}
@@ -8091,7 +8091,7 @@ instruct convL2I_reg(iRegINoSp dst, iRegL src) %{
   format %{ "addw  $dst, $src, zr\t#@convL2I_reg" %}
 
   ins_encode %{
-    __ sign_extend(as_Register($dst$$reg), as_Register($src$$reg), 32);
+    __ sext(as_Register($dst$$reg), as_Register($src$$reg), 32);
   %}
 
   ins_pipe(ialu_reg);
@@ -8103,10 +8103,10 @@ instruct convI2UL_reg_reg(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask)
   match(Set dst (AndL (ConvI2L src) mask));
 
   ins_cost(ALU_COST * 2);
-  format %{ "zero_extend $dst, $src, 32\t# i2ul, #@convI2UL_reg_reg" %}
+  format %{ "zext $dst, $src, 32\t# i2ul, #@convI2UL_reg_reg" %}
 
   ins_encode %{
-    __ zero_extend(as_Register($dst$$reg), as_Register($src$$reg), 32);
+    __ zext(as_Register($dst$$reg), as_Register($src$$reg), 32);
   %}
 
   ins_pipe(ialu_reg_shift);
@@ -8283,10 +8283,10 @@ instruct convP2I(iRegINoSp dst, iRegP src) %{
   match(Set dst (ConvL2I (CastP2X src)));
 
   ins_cost(ALU_COST * 2);
-  format %{ "zero_extend $dst, $src, 32\t# ptr -> int, #@convP2I" %}
+  format %{ "zext $dst, $src, 32\t# ptr -> int, #@convP2I" %}
 
   ins_encode %{
-    __ zero_extend($dst$$Register, $src$$Register, 32);
+    __ zext($dst$$Register, $src$$Register, 32);
   %}
 
   ins_pipe(ialu_reg);

--- a/src/hotspot/cpu/riscv/runtime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/runtime_riscv.cpp
@@ -82,7 +82,7 @@ void OptoRuntime::generate_uncommon_trap_blob() {
 #endif
   // compiler left unloaded_class_index in j_rarg0 move to where the
   // runtime expects it.
-  __ sign_extend(c_rarg1, j_rarg0, 32);
+  __ sext(c_rarg1, j_rarg0, 32);
 
   // we need to set the past SP to the stack pointer of the stub frame
   // and the pc to the address where this runtime call will return

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -2553,17 +2553,18 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
     // Verify the correct encoding of the poll we're about to skip.
     // See NativeInstruction::is_lwu_to_zr()
     __ lwu(t0, Address(x18));
-    __ andi(t1, t0, 0b0000011);
+    __ andi(t1, t0, 0b1111111);
     __ mv(t2, 0b0000011);
     __ bne(t1, t2, bail); // 0-6:0b0000011
     __ srli(t1, t0, 7);
-    __ andi(t1, t1, 0b00000);
+    __ andi(t1, t1, 0b11111);
     __ bnez(t1, bail);    // 7-11:0b00000
     __ srli(t1, t0, 12);
-    __ andi(t1, t1, 0b110);
+    __ andi(t1, t1, 0b111);
     __ mv(t2, 0b110);
     __ bne(t1, t2, bail); // 12-14:0b110
 #endif
+
     // Adjust return pc forward to step over the safepoint poll instruction
     __ add(x18, x18, NativeInstruction::instruction_size);
     __ sd(x18, Address(fp, frame::return_addr_offset * wordSize));

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -2553,18 +2553,17 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
     // Verify the correct encoding of the poll we're about to skip.
     // See NativeInstruction::is_lwu_to_zr()
     __ lwu(t0, Address(x18));
-    __ andi(t1, t0, 0b1111111);
+    __ andi(t1, t0, 0b0000011);
     __ mv(t2, 0b0000011);
     __ bne(t1, t2, bail); // 0-6:0b0000011
     __ srli(t1, t0, 7);
-    __ andi(t1, t1, 0b11111);
+    __ andi(t1, t1, 0b00000);
     __ bnez(t1, bail);    // 7-11:0b00000
     __ srli(t1, t0, 12);
-    __ andi(t1, t1, 0b111);
+    __ andi(t1, t1, 0b110);
     __ mv(t2, 0b110);
     __ bne(t1, t2, bail); // 12-14:0b110
 #endif
-
     // Adjust return pc forward to step over the safepoint poll instruction
     __ add(x18, x18, NativeInstruction::instruction_size);
     __ sd(x18, Address(fp, frame::return_addr_offset * wordSize));

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -1643,8 +1643,8 @@ class StubGenerator: public StubCodeGenerator {
     __ bgtu(temp, t0, L_failed);
 
     // Have to clean up high 32 bits of 'src_pos' and 'dst_pos'.
-    __ zero_extend(src_pos, src_pos, 32);
-    __ zero_extend(dst_pos, dst_pos, 32);
+    __ zext(src_pos, src_pos, 32);
+    __ zext(dst_pos, dst_pos, 32);
 
     BLOCK_COMMENT("arraycopy_range_checks done");
   }
@@ -1767,14 +1767,14 @@ class StubGenerator: public StubCodeGenerator {
     __ beqz(src, L_failed);
 
     // if [src_pos < 0] then return -1
-    __ sign_extend(t0, src_pos, 32);
+    __ sext(t0, src_pos, 32);
     __ bltz(t0, L_failed);
 
     // if dst is null then return -1
     __ beqz(dst, L_failed);
 
     // if [dst_pos < 0] then return -1
-    __ sign_extend(t0, dst_pos, 32);
+    __ sext(t0, dst_pos, 32);
     __ bltz(t0, L_failed);
 
     // registers used as temp
@@ -1783,7 +1783,7 @@ class StubGenerator: public StubCodeGenerator {
     const Register lh                = x30; // layout helper
 
     // if [length < 0] then return -1
-    __ sign_extend(scratch_length, length, 32);    // length (elements count, 32-bits value)
+    __ sext(scratch_length, length, 32); // length (elements count, 32-bits value)
     __ bltz(scratch_length, L_failed);
 
     __ load_klass(scratch_src_klass, src);
@@ -1879,13 +1879,13 @@ class StubGenerator: public StubCodeGenerator {
     __ bnez(t0, L_copy_shorts);
     __ add(from, src, src_pos); // src_addr
     __ add(to, dst, dst_pos); // dst_addr
-    __ sign_extend(count, scratch_length, 32); // length
+    __ sext(count, scratch_length, 32); // length
     __ j(RuntimeAddress(byte_copy_entry));
 
   __ BIND(L_copy_shorts);
     __ shadd(from, src_pos, src, t0, 1); // src_addr
     __ shadd(to, dst_pos, dst, t0, 1); // dst_addr
-    __ sign_extend(count, scratch_length, 32); // length
+    __ sext(count, scratch_length, 32); // length
     __ j(RuntimeAddress(short_copy_entry));
 
   __ BIND(L_copy_ints);
@@ -1893,7 +1893,7 @@ class StubGenerator: public StubCodeGenerator {
     __ bnez(t0, L_copy_longs);
     __ shadd(from, src_pos, src, t0, 2); // src_addr
     __ shadd(to, dst_pos, dst, t0, 2); // dst_addr
-    __ sign_extend(count, scratch_length, 32); // length
+    __ sext(count, scratch_length, 32); // length
     __ j(RuntimeAddress(int_copy_entry));
 
   __ BIND(L_copy_longs);
@@ -1902,7 +1902,7 @@ class StubGenerator: public StubCodeGenerator {
       BLOCK_COMMENT("assert long copy {");
       Label L;
       __ andi(lh, lh, Klass::_lh_log2_element_size_mask); // lh -> x30_elsize
-      __ sign_extend(lh, lh, 32);
+      __ sext(lh, lh, 32);
       __ mv(t0, LogBytesPerLong);
       __ beq(x30_elsize, t0, L);
       __ stop("must be long copy, but elsize is wrong");
@@ -1912,7 +1912,7 @@ class StubGenerator: public StubCodeGenerator {
 #endif
     __ shadd(from, src_pos, src, t0, 3); // src_addr
     __ shadd(to, dst_pos, dst, t0, 3); // dst_addr
-    __ sign_extend(count, scratch_length, 32); // length
+    __ sext(count, scratch_length, 32); // length
     __ j(RuntimeAddress(long_copy_entry));
 
     // ObjArrayKlass
@@ -1932,7 +1932,7 @@ class StubGenerator: public StubCodeGenerator {
     __ add(from, from, arrayOopDesc::base_offset_in_bytes(T_OBJECT));
     __ shadd(to, dst_pos, dst, t0, LogBytesPerHeapOop);
     __ add(to, to, arrayOopDesc::base_offset_in_bytes(T_OBJECT));
-    __ sign_extend(count, scratch_length, 32); // length
+    __ sext(count, scratch_length, 32); // length
   __ BIND(L_plain_copy);
     __ j(RuntimeAddress(oop_copy_entry));
 
@@ -1955,8 +1955,8 @@ class StubGenerator: public StubCodeGenerator {
       __ add(from, from, arrayOopDesc::base_offset_in_bytes(T_OBJECT));
       __ shadd(to, dst_pos, dst, t0, LogBytesPerHeapOop);
       __ add(to, to, arrayOopDesc::base_offset_in_bytes(T_OBJECT));
-      __ sign_extend(count, length, 32);      // length (reloaded)
-      const Register sco_temp = c_rarg3;      // this register is free now
+      __ sext(count, length, 32); // length (reloaded)
+      const Register sco_temp = c_rarg3; // this register is free now
       assert_different_registers(from, to, count, sco_temp,
                                  dst_klass, scratch_src_klass);
 
@@ -2022,7 +2022,7 @@ class StubGenerator: public StubCodeGenerator {
 
         // Zero extend value
         // 8 bit -> 16 bit
-        __ andi(value, value, 0xff);
+        __ zext(value, value, 8);
         __ mv(tmp_reg, value);
         __ slli(tmp_reg, tmp_reg, 8);
         __ orr(value, value, tmp_reg);
@@ -2039,7 +2039,7 @@ class StubGenerator: public StubCodeGenerator {
         shift = 1;
         // Zero extend value
         // 16 bit -> 32 bit
-        __ andi(value, value, 0xffff);
+        __ zext(value, value, 16);
         __ mv(tmp_reg, value);
         __ slli(tmp_reg, tmp_reg, 16);
         __ orr(value, value, tmp_reg);
@@ -2099,9 +2099,8 @@ class StubGenerator: public StubCodeGenerator {
     __ srliw(cnt_words, count, 3 - shift); // number of words
 
     // 32 bit -> 64 bit
-    __ andi(value, value, 0xffffffff);
-    __ mv(tmp_reg, value);
-    __ slli(tmp_reg, tmp_reg, 32);
+    __ zext(value, value, 32);
+    __ slli(tmp_reg, value, 32);
     __ orr(value, value, tmp_reg);
 
     __ slli(tmp_reg, cnt_words, 3 - shift);
@@ -2572,8 +2571,8 @@ class StubGenerator: public StubCodeGenerator {
       __ ctzc_bit(tmp4, tmp3);
       __ srl(tmp1, tmp1, tmp4);
       __ srl(tmp2, tmp2, tmp4);
-      __ andi(tmp1, tmp1, 0xFFFF);
-      __ andi(tmp2, tmp2, 0xFFFF);
+      __ zext(tmp1, tmp1, 16);
+      __ zext(tmp2, tmp2, 16);
       __ sub(result, tmp1, tmp2);
     __ bind(DONE);
       __ ret();
@@ -2708,11 +2707,11 @@ class StubGenerator: public StubCodeGenerator {
       __ srl(tmp5, tmp5, tmp3);
       __ srl(cnt1, cnt1, tmp3);
       if (isLL) {
-        __ andi(tmp5, tmp5, 0xFF);
-        __ andi(cnt1, cnt1, 0xFF);
+        __ zext(tmp5, tmp5, 8);
+        __ zext(cnt1, cnt1, 8);
       } else {
-        __ andi(tmp5, tmp5, 0xFFFF);
-        __ andi(cnt1, cnt1, 0xFFFF);
+        __ zext(tmp5, tmp5, 16);
+        __ zext(cnt1, cnt1, 16);
       }
       __ sub(result, tmp5, cnt1);
       __ j(LENGTH_DIFF);
@@ -2721,11 +2720,11 @@ class StubGenerator: public StubCodeGenerator {
       __ srl(tmp1, tmp1, tmp3);
       __ srl(tmp2, tmp2, tmp3);
       if (isLL) {
-        __ andi(tmp1, tmp1, 0xFF);
-        __ andi(tmp2, tmp2, 0xFF);
+        __ zext(tmp1, tmp1, 8);
+        __ zext(tmp2, tmp2, 8);
       } else {
-        __ andi(tmp1, tmp1, 0xFFFF);
-        __ andi(tmp2, tmp2, 0xFFFF);
+        __ zext(tmp1, tmp1, 16);
+        __ zext(tmp2, tmp2, 16);
       }
       __ sub(result, tmp1, tmp2);
       __ j(LENGTH_DIFF);
@@ -2787,7 +2786,8 @@ class StubGenerator: public StubCodeGenerator {
     __ sub(haystack_len, haystack_len, needle_len);
 
     // first is needle[0]
-    __ andi(first, ch1, needle_isL ? 0xFF : 0xFFFF, first);
+    __ zext(first, ch1, needle_isL ? 8 : 16);
+
     uint64_t mask0101 = UCONST64(0x0101010101010101);
     uint64_t mask0001 = UCONST64(0x0001000100010001);
     __ mv(mask1, haystack_isL ? mask0101 : mask0001);
@@ -2963,7 +2963,7 @@ class StubGenerator: public StubCodeGenerator {
     __ andi(result, result, haystack_isL ? -8 : -4);
     __ slli(tmp, match_mask, haystack_chr_shift);
     __ sub(haystack, haystack, tmp);
-    __ sign_extend(haystack_len, haystack_len, 32);
+    __ sext(haystack_len, haystack_len, 32);
     __ j(L_LOOP_PROCEED);
 
     __ align(OptoLoopAlignment);
@@ -5044,7 +5044,7 @@ class StubGenerator: public StubCodeGenerator {
     __ rolw_imm(cur_w, cur_w, 1, t0);
 
     // copy the cur_w value to ws[8]
-    __ zero_extend(cur_w, cur_w, 32);
+    __ zext(cur_w, cur_w, 32);
     __ orr(ws[idx/2], ws[idx/2], cur_w);
 
     // shift the w't registers, so they start from ws[0] again.
@@ -5151,11 +5151,11 @@ class StubGenerator: public StubCodeGenerator {
     assert_different_registers(a, b, c, d, e, prev_ab, prev_cd, prev_e, t0);
 
     __ slli(t0, b, 32);
-    __ zero_extend(prev_ab, a, 32);
+    __ zext(prev_ab, a, 32);
     __ orr(prev_ab, prev_ab, t0);
 
     __ slli(t0, d, 32);
-    __ zero_extend(prev_cd, c, 32);
+    __ zext(prev_cd, c, 32);
     __ orr(prev_cd, prev_cd, t0);
 
     __ mv(prev_e, e);
@@ -5285,11 +5285,11 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     // store back the state.
-    __ zero_extend(a, a, 32);
+    __ zext(a, a, 32);
     __ slli(b, b, 32);
     __ orr(a, a, b);
     __ sd(a, Address(state, 0));
-    __ zero_extend(c, c, 32);
+    __ zext(c, c, 32);
     __ slli(d, d, 32);
     __ orr(c, c, d);
     __ sd(c, Address(state, 8));
@@ -5963,7 +5963,7 @@ class StubGenerator: public StubCodeGenerator {
     // s1 is initialized to the lower 16 bits of adler
     // s2 is initialized to the upper 16 bits of adler
     __ srliw(s2, adler, 16); // s2 = ((adler >> 16) & 0xffff)
-    __ zero_extend(s1, adler, 16); // s1 = (adler & 0xffff)
+    __ zext(s1, adler, 16); // s1 = (adler & 0xffff)
 
     // The pipelined loop needs at least 16 elements for 1 iteration
     // It does check this, but it is more effective to skip to the cleanup loop

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -361,7 +361,7 @@ address TemplateInterpreterGenerator::generate_ArrayIndexOutOfBounds_handler() {
   // setup parameters
 
   // convention: expect aberrant index in register x11
-  __ zero_extend(c_rarg2, x11, 32);
+  __ zext(c_rarg2, x11, 32);
   // convention: expect array in register x13
   __ mv(c_rarg1, x13);
   __ call_VM(noreg,

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -722,7 +722,7 @@ void TemplateTable::index_check(Register array, Register index) {
     __ mv(x11, index);
   }
   Label ok;
-  __ sign_extend(index, index, 32);
+  __ sext(index, index, 32);
   __ bltu(index, length, ok);
   __ mv(x13, array);
   __ mv(t1, Interpreter::_throw_ArrayIndexOutOfBoundsException_entry);
@@ -740,7 +740,7 @@ void TemplateTable::iaload() {
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_INT) >> 2);
   __ shadd(x10, x11, x10, t0, 2);
   __ access_load_at(T_INT, IN_HEAP | IS_ARRAY, x10, Address(x10), noreg, noreg);
-  __ sign_extend(x10, x10, 32);
+  __ sext(x10, x10, 32);
 }
 
 void TemplateTable::laload() {
@@ -1545,7 +1545,7 @@ void TemplateTable::convert() {
   // Conversion
   switch (bytecode()) {
     case Bytecodes::_i2l:
-      __ sign_extend(x10, x10, 32);
+      __ sext(x10, x10, 32);
       break;
     case Bytecodes::_i2f:
       __ fcvt_s_w(f10, x10);
@@ -1554,16 +1554,16 @@ void TemplateTable::convert() {
       __ fcvt_d_w(f10, x10);
       break;
     case Bytecodes::_i2b:
-      __ sign_extend(x10, x10, 8);
+      __ sext(x10, x10, 8);
       break;
     case Bytecodes::_i2c:
-      __ zero_extend(x10, x10, 16);
+      __ zext(x10, x10, 16);
       break;
     case Bytecodes::_i2s:
-      __ sign_extend(x10, x10, 16);
+      __ sext(x10, x10, 16);
       break;
     case Bytecodes::_l2i:
-      __ sign_extend(x10, x10, 32);
+      __ sext(x10, x10, 32);
       break;
     case Bytecodes::_l2f:
       __ fcvt_s_l(f10, x10);
@@ -1783,7 +1783,7 @@ void TemplateTable::if_0cmp(Condition cc) {
   // assume branch is more often taken than not (loops use backward branches)
   Label not_taken;
 
-  __ sign_extend(x10, x10, 32);
+  __ sext(x10, x10, 32);
   switch (cc) {
     case equal:
       __ bnez(x10, not_taken);
@@ -1817,7 +1817,7 @@ void TemplateTable::if_icmp(Condition cc) {
   // assume branch is more often taken than not (loops use backward branches)
   Label not_taken;
   __ pop_i(x11);
-  __ sign_extend(x10, x10, 32);
+  __ sext(x10, x10, 32);
   switch (cc) {
     case equal:
       __ bne(x11, x10, not_taken);
@@ -2573,7 +2573,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   __ bnez(t0, notInt);
   // itos
   __ access_load_at(T_INT, IN_HEAP, x10, field, noreg, noreg);
-  __ sign_extend(x10, x10, 32);
+  __ sext(x10, x10, 32);
   __ push(itos);
   // Rewrite bytecode to be faster
   if (rc == may_rewrite) {
@@ -3137,7 +3137,7 @@ void TemplateTable::fast_accessfield(TosState state) {
       break;
     case Bytecodes::_fast_igetfield:
       __ access_load_at(T_INT, IN_HEAP, x10, field, noreg, noreg);
-      __ sign_extend(x10, x10, 32);
+      __ sext(x10, x10, 32);
       break;
     case Bytecodes::_fast_bgetfield:
       __ access_load_at(T_BYTE, IN_HEAP, x10, field, noreg, noreg);
@@ -3183,7 +3183,7 @@ void TemplateTable::fast_xaccess(TosState state) {
     case itos:
       __ add(x10, x10, x11);
       __ access_load_at(T_INT, IN_HEAP, x10, Address(x10, 0), noreg, noreg);
-      __ sign_extend(x10, x10, 32);
+      __ sext(x10, x10, 32);
       break;
     case atos:
       __ add(x10, x10, x11);


### PR DESCRIPTION
Hi, please review this small optimization and cleanup change.

This optimizes bitwise AND with immediate mask values like 0xFFFF and 0xFFFFFFFF. Currently, we do `andi` for these cases emitting 3 or 4 instructions repectively. These are effectively zero extensions and could be reduced to 1 or 2 instructions repectively depending on whether Zba and Zbb extensions are available.

This also renames existing assembler routines `zero_extend`/`sign_extend` to `zext`/`sext`. This will be more consistent with mnemonic names like `sext.h` and `zext.h` for zero/sign extension as specified by the RISC-V bit-manipulation spec. The various callsites look better to me after the renaming as the old names are much longer than other basic instructions.

Testing: tier1-3 and gtest:all are clean on Premier-P550 SBC running Ubuntu-24.04.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346235](https://bugs.openjdk.org/browse/JDK-8346235): RISC-V: Optimize bitwise AND with mask values (**Enhancement** - P4)


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer) Review applies to [6a874bfb](https://git.openjdk.org/jdk/pull/22752/files/6a874bfb248fad7858cb71333f5cbec2a69c3d89)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Author)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @Abu2rkii (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22752/head:pull/22752` \
`$ git checkout pull/22752`

Update a local copy of the PR: \
`$ git checkout pull/22752` \
`$ git pull https://git.openjdk.org/jdk.git pull/22752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22752`

View PR using the GUI difftool: \
`$ git pr show -t 22752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22752.diff">https://git.openjdk.org/jdk/pull/22752.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22752#issuecomment-2543513971)
</details>
