### PR TITLE
8346257: Problemlist jdp tests for macosx-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -547,6 +547,9 @@ java/lang/management/MemoryMXBean/Pending.java                  8158837 generic-
 java/lang/management/MemoryMXBean/PendingAllGC.sh               8158837 generic-all
 java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java    8247426 generic-all
 
+sun/management/jdp/JdpDefaultsTest.java                         8241865 macosx-aarc64
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8241865 macosx-aarc64
+sun/management/jdp/JdpSpecificAddressTest.java                  8241865 macosx-aarc64
 sun/management/jdp/JdpDefaultsTest.java                         8308807 aix-ppc64
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8308807 aix-ppc64
 sun/management/jdp/JdpSpecificAddressTest.java                  8308807 aix-ppc64

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -547,12 +547,9 @@ java/lang/management/MemoryMXBean/Pending.java                  8158837 generic-
 java/lang/management/MemoryMXBean/PendingAllGC.sh               8158837 generic-all
 java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java    8247426 generic-all
 
-sun/management/jdp/JdpDefaultsTest.java                         8241865 macosx-aarc64
-sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8241865 macosx-aarc64
-sun/management/jdp/JdpSpecificAddressTest.java                  8241865 macosx-aarc64
-sun/management/jdp/JdpDefaultsTest.java                         8308807 aix-ppc64
-sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8308807 aix-ppc64
-sun/management/jdp/JdpSpecificAddressTest.java                  8308807 aix-ppc64
+sun/management/jdp/JdpDefaultsTest.java                         8308807,8241865 aix-ppc64,macosx-aarch64
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8308807,8241865 aix-ppc64,macosx-aarch64
+sun/management/jdp/JdpSpecificAddressTest.java                  8308807,8241865 aix-ppc64,macosx-aarch64
 sun/management/jdp/JdpOffTest.java                              8308807 aix-ppc64
 
 ############################################################################


### PR DESCRIPTION
Fairly frequent failures on macosx-aarch64.  For a while it was always on 15.0.1, but now also seen on "Mac OS X 12.7.1 (aarch64)", so this should be problemlisted for macosx-aarch64.

There are existing entries for aix, and the ProblemList file says it only wants one line per test. 

Trivial change tested in CI which shows that sun/management/jdp/JdpOffTest.java still runs on macosx-aarch64.

Tests failing:
sun/management/jdp/JdpSpecificAddressTest.java
sun/management/jdp/JdpDefaultsTest.java
sun/management/jdp/JdpJmxRemoteDynamicPortTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346257](https://bugs.openjdk.org/browse/JDK-8346257): Problemlist jdp tests for macosx-aarch64 (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22758/head:pull/22758` \
`$ git checkout pull/22758`

Update a local copy of the PR: \
`$ git checkout pull/22758` \
`$ git pull https://git.openjdk.org/jdk.git pull/22758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22758`

View PR using the GUI difftool: \
`$ git pr show -t 22758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22758.diff">https://git.openjdk.org/jdk/pull/22758.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22758#issuecomment-2545205451)
</details>
