### PR TITLE
8346248: serviceability/dcmd/vm/{SystemMapTest.java,SystemMapTest.java} failing on macos-aarch64

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
@@ -157,7 +157,7 @@ public class SystemMapTestBase {
 
         static final String macow = "cow";
         static final String macprivate = "pvt";
-        static final String macprivate_or_shared = "(pvt|tsh-shared)";
+        static final String macprivate_or_shared = "(pvt|tsh)";
         static final String macprivatealiased = "p/a";
 
         static final String macOSbase = range + space + someSize + space + macprot + space;


### PR DESCRIPTION
[JDK-8319875](https://bugs.openjdk.org/browse/JDK-8319875) updated jcmd System.map to support macOS but the tests are now failing on macosx-aarch64 with ZGC.

serviceability/dcmd/vm/SystemDumpMapTest.java
serviceability/dcmd/vm/SystemMapTest.java

test SystemMapTest.jmx(): failure
java.lang.RuntimeException: '0x\\p{XDigit}+-0x\\p{XDigit}+ +\\d+ +[\\-rwx]*/[\\-rwx]* +(pvt|tsh-shared) +(0x\\p{XDigit}+|\\d+) +JAVAHEAP.*' missing from stdout/stderr
at jdk.test.lib.process.OutputAnalyzer.shouldMatch(OutputAnalyzer.java:372)
at SystemMapTest.run(SystemMapTest.java:50)
at SystemMapTest.jmx(SystemMapTest.java:57)

The output from my runs says `tsh` and not `tsh-shared`. The following change seems to work on my machine and on macosx-aarch64 and macosx-x64 in our CI pipeline.

@stooke @tstuefe Do you think this looks reasonable or was there some systems that reported this as pvt-shared?