### PR TITLE
8346261: Cleanup in JDP tests

### DIFF
--- a/test/jdk/sun/management/jdp/ClientConnection.java
+++ b/test/jdk/sun/management/jdp/ClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,10 +53,10 @@ public class ClientConnection {
 
     }
 
-    public MulticastSocket connectWithTimeout(int msTimeOut) throws IOException {
+    public MulticastSocket connectWithTimeout(int msTimeout) throws IOException {
         MulticastSocket socket = new MulticastSocket(port);
         socket.joinGroup(address);
-        socket.setSoTimeout(msTimeOut);
+        socket.setSoTimeout(msTimeout);
         return socket;
     }
 }

--- a/test/jdk/sun/management/jdp/DynamicLauncher.java
+++ b/test/jdk/sun/management/jdp/DynamicLauncher.java
@@ -37,7 +37,7 @@ import java.util.UUID;
  */
 public abstract class DynamicLauncher {
 
-    private static final int MAX_RETRY_ATTEMPTS = 10;
+    private static final int MAX_PORT_RETRY_ATTEMPTS = 10;
 
     final String jdpName = UUID.randomUUID().toString();
     OutputAnalyzer output;
@@ -54,7 +54,7 @@ public abstract class DynamicLauncher {
             try {
                 output.shouldNotContain("Port already in use");
             } catch (RuntimeException e) {
-                if (retries < MAX_RETRY_ATTEMPTS) {
+                if (retries < MAX_PORT_RETRY_ATTEMPTS) {
                     retries++;
                     tryAgain = true;
                 }
@@ -77,8 +77,4 @@ public abstract class DynamicLauncher {
     }
 
     protected abstract String[] options();
-
-    protected OutputAnalyzer getProcessOutpoutAnalyzer() {
-        return output;
-    }
 }

--- a/test/jdk/sun/management/jdp/JdpDefaultsTest.java
+++ b/test/jdk/sun/management/jdp/JdpDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public class JdpDefaultsTest extends DynamicLauncher {
                 "-Dcom.sun.management.jmxremote.autodiscovery=true",
                 "-Dcom.sun.management.jdp.pause=1",
                 "-Dcom.sun.management.jdp.name=" + jdpName,
-                "-Djava.util.logging.SimpleFormatter.format='%1$tF %1$tT %4$-7s %5$s %n'",
+                "-Djava.util.logging.SimpleFormatter.format=%1$tF %1$tT %4$-7s %5$s %n",
                 testName
         };
         return options;

--- a/test/jdk/sun/management/jdp/JdpJmxRemoteDynamicPortTest.java
+++ b/test/jdk/sun/management/jdp/JdpJmxRemoteDynamicPortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public class JdpJmxRemoteDynamicPortTest  extends DynamicLauncher {
                 "-Dcom.sun.management.jmxremote.autodiscovery=true",
                 "-Dcom.sun.management.jdp.pause=1",
                 "-Dcom.sun.management.jdp.name=" + jdpName,
-                "-Djava.util.logging.SimpleFormatter.format='%1$tF %1$tT %4$-7s %5$s %n'",
+                "-Djava.util.logging.SimpleFormatter.format=%1$tF %1$tT %4$-7s %5$s %n",
                 testName
         };
         return options;

--- a/test/jdk/sun/management/jdp/JdpJmxRemoteDynamicPortTestCase.java
+++ b/test/jdk/sun/management/jdp/JdpJmxRemoteDynamicPortTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class JdpJmxRemoteDynamicPortTestCase extends JdpTestCase {
      * It is set to wait for 10 times the defined pause between Jdp packet. See JdpOnTestCase.TIME_OUT_FACTOR.
      */
     @Override
-    protected void onSocketTimeOut(SocketTimeoutException e) throws Exception {
+    protected void onSocketTimeout(SocketTimeoutException e) throws Exception {
         String message = "Timed out waiting for JDP packet. Should arrive within " +
                 connection.pauseInSeconds + " seconds, but waited for " +
                 timeOut + " seconds.";

--- a/test/jdk/sun/management/jdp/JdpOffTest.java
+++ b/test/jdk/sun/management/jdp/JdpOffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class JdpOffTest extends DynamicLauncher {
                 "-Dcom.sun.management.jmxremote.autodiscovery=false",
                 "-Dcom.sun.management.jdp.pause=1",
                 "-Dcom.sun.management.jdp.name=" + jdpName,
-                "-Djava.util.logging.SimpleFormatter.format='%1$tF %1$tT %4$-7s %5$s %n'",
+                "-Djava.util.logging.SimpleFormatter.format=%1$tF %1$tT %4$-7s %5$s %n",
                 testName
         };
         return options;

--- a/test/jdk/sun/management/jdp/JdpOffTestCase.java
+++ b/test/jdk/sun/management/jdp/JdpOffTestCase.java
@@ -49,8 +49,8 @@ public class JdpOffTestCase extends JdpTestCase {
      * The socket has not received anything, and this is the expected behavior.
      */
     @Override
-    protected void onSocketTimeOut(SocketTimeoutException e) throws Exception {
-        log.fine("No packages received. Test passed!");
+    protected void onSocketTimeout(SocketTimeoutException e) throws Exception {
+        log.fine("No packets received. Test passed!");
         testPassed = true;
     }
 
@@ -77,7 +77,7 @@ public class JdpOffTestCase extends JdpTestCase {
 
 
     /**
-     * The test should stop after the socket has timed out. See onSocketTimeOut {@link}.
+     * The test should stop after the socket has timed out. See onSocketTimeout {@link}.
      */
     @Override
     protected boolean shouldContinue() {

--- a/test/jdk/sun/management/jdp/JdpOnTestCase.java
+++ b/test/jdk/sun/management/jdp/JdpOnTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,10 +64,10 @@ public class JdpOnTestCase extends JdpTestCase {
 
     /**
      * The socket should not timeout.
-     * It is set to wait for 10 times the defined pause between Jdp packet. See JdpOnTestCase.TIME_OUT_FACTOR.
+     * It is set to wait for a multiple of the defined pause between Jdp packets. See JdpTestCase.TIME_OUT_FACTOR.
      */
     @Override
-    protected void onSocketTimeOut(SocketTimeoutException e) throws Exception {
+    protected void onSocketTimeout(SocketTimeoutException e) throws Exception {
         String message = "Timed out waiting for JDP packet. Should arrive within " +
                 connection.pauseInSeconds + " seconds, but waited for " +
                 timeOut + " seconds.";

--- a/test/jdk/sun/management/jdp/JdpSpecificAddressTest.java
+++ b/test/jdk/sun/management/jdp/JdpSpecificAddressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class JdpSpecificAddressTest extends DynamicLauncher {
                 "-Dcom.sun.management.jdp.name=" + jdpName,
                 "-Dcom.sun.management.jdp.address=224.0.1.2",
                 "-Dcom.sun.management.jdp.port=1234",
-                "-Djava.util.logging.SimpleFormatter.format='%1$tF %1$tT %4$-7s %5$s %n'",
+                "-Djava.util.logging.SimpleFormatter.format=%1$tF %1$tT %4$-7s %5$s %n",
                 testName
         };
         return options;

--- a/test/jdk/sun/management/jdp/JdpTestCase.java
+++ b/test/jdk/sun/management/jdp/JdpTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public abstract class JdpTestCase {
+
+    private static final int MAGIC = 0xC0FFEE42;              // Jdp magic number.
+    private static final int BUFFER_LENGTH = 64 * 1024;       // max UDP size, except for IPv6 jumbograms.
+    private static final int TIME_OUT_FACTOR = 10;            // Socket times out after a multiple of the jdp pause.
+
     final Logger log = Logger.getLogger("sun.management.jdp");
-    final int MAGIC = 0xC0FFEE42;                       // Jdp magic number.
-    private static final int BUFFER_LENGTH = 64 * 1024;   // max UDP size, except for IPv6 jumbograms.
-    private final int TIME_OUT_FACTOR = 10;             // Socket times out after 10 times the jdp pause.
     protected int timeOut;
     private long startTime;
     protected ClientConnection connection;
@@ -74,7 +76,7 @@ public abstract class JdpTestCase {
                 socket.receive(datagram);
                 onReceived(extractUDPpayload(datagram));
             } catch (SocketTimeoutException e) {
-                onSocketTimeOut(e);
+                onSocketTimeout(e);
             }
 
             if (!shouldContinue()) {
@@ -117,7 +119,7 @@ public abstract class JdpTestCase {
     /**
      * This method is executed when the socket has not received any packet for timeOut seconds.
      */
-    abstract protected void onSocketTimeOut(SocketTimeoutException e) throws Exception;
+    abstract protected void onSocketTimeout(SocketTimeoutException e) throws Exception;
 
     /**
      * This method is executed after a correct Jdp packet has been received.
@@ -156,7 +158,7 @@ public abstract class JdpTestCase {
      * The test should stop if it has been 12 times the jdp.pause.
      * jdp.pause is how many seconds in between packets.
      * <p/>
-     * This timeout (12 times)is slightly longer than the socket timeout (10 times) on purpose.
+     * This timeout (12 times) is slightly longer than the socket timeout (10 times) on purpose.
      * In the off test case, the socket should time out first.
      *
      * @return


### PR DESCRIPTION
Simple test update to fix some typos and formatting changes, seen while investigating and testing for JDK-8241865.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346261](https://bugs.openjdk.org/browse/JDK-8346261): Cleanup in JDP tests (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22761/head:pull/22761` \
`$ git checkout pull/22761`

Update a local copy of the PR: \
`$ git checkout pull/22761` \
`$ git pull https://git.openjdk.org/jdk.git pull/22761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22761`

View PR using the GUI difftool: \
`$ git pr show -t 22761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22761.diff">https://git.openjdk.org/jdk/pull/22761.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22761#issuecomment-2545435506)
</details>
