### PR TITLE
8346278: Clean up some flag handing in flags-cflags.m4

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -237,7 +237,7 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
       # Additional warnings that are not activated by -Wall and -Wextra
       WARNINGS_ENABLE_ADDITIONAL="-Wpointer-arith -Wreturn-type -Wsign-compare \
           -Wtrampolines -Wundef -Wunused-const-variable=1 -Wunused-function \
-          -Wunused-result -Wunused-value"
+          -Wunused-result -Wunused-value -Wtype-limits -Wuninitialized"
       WARNINGS_ENABLE_ADDITIONAL_CXX="-Woverloaded-virtual -Wreorder"
       WARNINGS_ENABLE_ALL_CFLAGS="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
       WARNINGS_ENABLE_ALL_CXXFLAGS="$WARNINGS_ENABLE_ALL_CFLAGS $WARNINGS_ENABLE_ADDITIONAL_CXX"
@@ -754,10 +754,9 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
   fi
 
   if test "x$TOOLCHAIN_TYPE" = xgcc; then
-    FLAGS_SETUP_GCC6_COMPILER_FLAGS($1, $3)
-    $1_TOOLCHAIN_CFLAGS="${$1_GCC6_CFLAGS}"
-
-    $1_WARNING_CFLAGS_JVM="-Wno-format-zero-length -Wtype-limits -Wuninitialized"
+    # This flag is required since GCC 6 as undefined behavior in OpenJDK code
+    # runs afoul of the more aggressive versions of this optimization.
+    $1_TOOLCHAIN_CFLAGS="-fno-lifetime-dse"
   fi
 
   if test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
@@ -917,20 +916,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
     fi
   fi
   AC_SUBST($2SVE_CFLAGS)
-])
-
-# FLAGS_SETUP_GCC6_COMPILER_FLAGS([PREFIX])
-# Arguments:
-# $1 - Prefix for each variable defined.
-# $2 - Prefix for compiler variables (either BUILD_ or nothing).
-AC_DEFUN([FLAGS_SETUP_GCC6_COMPILER_FLAGS],
-[
-  # This flag is required for GCC 6 builds as undefined behavior in OpenJDK code
-  # runs afoul of the more aggressive versions of this optimization.
-  NO_LIFETIME_DSE_CFLAG="-fno-lifetime-dse"
-  FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [$NO_LIFETIME_DSE_CFLAG],
-      PREFIX: $2, IF_FALSE: [NO_LIFETIME_DSE_CFLAG=""])
-  $1_GCC6_CFLAGS="${NO_LIFETIME_DSE_CFLAG}"
 ])
 
 AC_DEFUN_ONCE([FLAGS_SETUP_BRANCH_PROTECTION],

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -90,7 +90,7 @@ CFLAGS_VM_VERSION := \
 # Disabled warnings
 
 DISABLED_WARNINGS_gcc := array-bounds comment delete-non-virtual-dtor \
-    empty-body implicit-fallthrough int-in-bool-context \
+    empty-body format-zero-length implicit-fallthrough int-in-bool-context \
     maybe-uninitialized missing-field-initializers \
     shift-negative-value unknown-pragmas unused-but-set-variable \
     unused-local-typedefs unused-variable


### PR DESCRIPTION
WARNING_CFLAGS_JVM should not be used to set arbitrary warning flags for Hotspot.

We do not need to check for gcc 6+ anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346278](https://bugs.openjdk.org/browse/JDK-8346278): Clean up some flag handing in flags-cflags.m4 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22762/head:pull/22762` \
`$ git checkout pull/22762`

Update a local copy of the PR: \
`$ git checkout pull/22762` \
`$ git pull https://git.openjdk.org/jdk.git pull/22762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22762`

View PR using the GUI difftool: \
`$ git pr show -t 22762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22762.diff">https://git.openjdk.org/jdk/pull/22762.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22762#issuecomment-2545891186)
</details>
