### PR TITLE
8344951: Stabilize write barrier micro-benchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -24,6 +24,7 @@ package org.openjdk.bench.vm.compiler;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
@@ -119,7 +120,13 @@ public abstract class WriteBarrier {
         return Math.abs((m_z << 16) + m_w);  /* 32-bit result */
     }
 
+    // This and the other testArrayWriteBarrierFast benchmarks below should not
+    // be inlined into the JMH-generated harness method. If the methods were
+    // inlined, we might spill in the main loop (on x64) depending on very
+    // subtle conditions (such as whether LinuxPerfAsmProfiler is enabled!),
+    // which could distort the results.
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathRealSmall() {
         for (int i = 0; i < NUM_REFERENCES_SMALL; i++) {
             theArraySmall[indicesSmall[NUM_REFERENCES_SMALL - i - 1]] = realRef;
@@ -127,6 +134,7 @@ public abstract class WriteBarrier {
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathNullSmall() {
         for (int i = 0; i < NUM_REFERENCES_SMALL; i++) {
             theArraySmall[indicesSmall[NUM_REFERENCES_SMALL - i - 1]] = nullRef;
@@ -134,6 +142,7 @@ public abstract class WriteBarrier {
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathRealLarge() {
         for (int i = 0; i < NUM_REFERENCES_LARGE; i++) {
             theArrayLarge[indicesLarge[NUM_REFERENCES_LARGE - i - 1]] = realRef;
@@ -141,6 +150,7 @@ public abstract class WriteBarrier {
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathNullLarge() {
         for (int i = 0; i < NUM_REFERENCES_LARGE; i++) {
             theArrayLarge[indicesLarge[NUM_REFERENCES_LARGE - i - 1]] = nullRef;

--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -59,6 +59,7 @@ public class WriteBarrier {
     private int[] indicesLarge;
 
     private Object nullRef;
+    private Object realRef;
 
     // For field update tests
     public Referencer head = null;
@@ -106,6 +107,8 @@ public class WriteBarrier {
             realReferencesLarge[i] = new Object();
         }
 
+        realRef = realReferencesLarge[42];
+
         // Build a small linked structure
         this.head = new Referencer();
         this.tail = new Referencer();
@@ -144,6 +147,14 @@ public class WriteBarrier {
     public void testArrayWriteBarrierFastPathRealLarge() {
         for (int i = 0; i < NUM_REFERENCES_LARGE; i++) {
             theArrayLarge[indicesLarge[NUM_REFERENCES_LARGE - i - 1]] = realReferencesLarge[indicesLarge[i]];
+        }
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void testArrayWriteBarrierFastPathRealLargeFixed() {
+        for (int i = 0; i < NUM_REFERENCES_LARGE; i++) {
+            theArrayLarge[indicesLarge[NUM_REFERENCES_LARGE - i - 1]] = realRef;
         }
     }
 

--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3)
+@Fork(value = 3, jvmArgs = {"-XX:LoopUnrollLimit=1"})
 public class WriteBarrier {
 
     // For array references

--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -41,8 +41,8 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3, jvmArgs = {"-XX:LoopUnrollLimit=1"})
-public class WriteBarrier {
+@Fork(value = 3)
+public abstract class WriteBarrier {
 
     // For array references
     public static final int NUM_REFERENCES_SMALL = 32;
@@ -155,4 +155,15 @@ public class WriteBarrier {
         this.head.append(this.tail);
         this.tail.clear();
     }
+
+    // This run is useful to compare different GC barrier models without being
+    // affected by C2 unrolling the main loop differently for each model.
+    @Fork(value = 3, jvmArgs = {"-XX:LoopUnrollLimit=1"})
+    public static class WithoutUnrolling extends WriteBarrier {}
+
+    // This run is useful to study the interaction of GC barriers and loop
+    // unrolling. Check that the main loop in the testArray benchmarks is
+    // unrolled (or not) as expected for the studied GC barrier model.
+    @Fork(value = 3)
+    public static class WithDefaultUnrolling extends WriteBarrier {}
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -24,6 +24,7 @@ package org.openjdk.bench.vm.compiler;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
@@ -125,6 +126,7 @@ public class WriteBarrier {
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathRealSmall() {
         for (int i = 0; i < NUM_REFERENCES_SMALL; i++) {
             theArraySmall[indicesSmall[NUM_REFERENCES_SMALL - i - 1]] = realReferencesSmall[indicesSmall[i]];
@@ -132,6 +134,7 @@ public class WriteBarrier {
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathNullSmall() {
         for (int i = 0; i < NUM_REFERENCES_SMALL; i++) {
             theArraySmall[indicesSmall[NUM_REFERENCES_SMALL - i - 1]] = nullReferencesSmall[indicesSmall[i]];
@@ -139,6 +142,7 @@ public class WriteBarrier {
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathRealLarge() {
         for (int i = 0; i < NUM_REFERENCES_LARGE; i++) {
             theArrayLarge[indicesLarge[NUM_REFERENCES_LARGE - i - 1]] = realReferencesLarge[indicesLarge[i]];
@@ -146,6 +150,7 @@ public class WriteBarrier {
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathNullLarge() {
         for (int i = 0; i < NUM_REFERENCES_LARGE; i++) {
             theArrayLarge[indicesLarge[NUM_REFERENCES_LARGE - i - 1]] = nullReferencesLarge[indicesLarge[i]];

--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -24,7 +24,6 @@ package org.openjdk.bench.vm.compiler;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
@@ -51,11 +50,9 @@ public class WriteBarrier {
 
     // For array update tests
     private Object[] theArraySmall;
-    private Object[] realReferencesSmall;
     private int[] indicesSmall;
 
     private Object[] theArrayLarge;
-    private Object[] realReferencesLarge;
     private int[] indicesLarge;
 
     private Object nullRef;
@@ -86,11 +83,9 @@ public class WriteBarrier {
     @Setup
     public void setup() {
         theArraySmall = new Object[NUM_REFERENCES_SMALL];
-        realReferencesSmall = new Object[NUM_REFERENCES_SMALL];
         indicesSmall = new int[NUM_REFERENCES_SMALL];
 
         theArrayLarge = new Object[NUM_REFERENCES_LARGE];
-        realReferencesLarge = new Object[NUM_REFERENCES_LARGE];
         indicesLarge = new int[NUM_REFERENCES_LARGE];
 
         m_w = (int) System.currentTimeMillis();
@@ -99,15 +94,13 @@ public class WriteBarrier {
 
         for (int i = 0; i < NUM_REFERENCES_SMALL; i++) {
             indicesSmall[i] = get_random() % (NUM_REFERENCES_SMALL - 1);
-            realReferencesSmall[i] = new Object();
         }
 
         for (int i = 0; i < NUM_REFERENCES_LARGE; i++) {
             indicesLarge[i] = get_random() % (NUM_REFERENCES_LARGE - 1);
-            realReferencesLarge[i] = new Object();
         }
 
-        realRef = realReferencesLarge[42];
+        realRef = new Object();
 
         // Build a small linked structure
         this.head = new Referencer();
@@ -127,15 +120,13 @@ public class WriteBarrier {
     }
 
     @Benchmark
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathRealSmall() {
         for (int i = 0; i < NUM_REFERENCES_SMALL; i++) {
-            theArraySmall[indicesSmall[NUM_REFERENCES_SMALL - i - 1]] = realReferencesSmall[indicesSmall[i]];
+            theArraySmall[indicesSmall[NUM_REFERENCES_SMALL - i - 1]] = realRef;
         }
     }
 
     @Benchmark
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathNullSmall() {
         for (int i = 0; i < NUM_REFERENCES_SMALL; i++) {
             theArraySmall[indicesSmall[NUM_REFERENCES_SMALL - i - 1]] = nullRef;
@@ -143,23 +134,13 @@ public class WriteBarrier {
     }
 
     @Benchmark
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathRealLarge() {
-        for (int i = 0; i < NUM_REFERENCES_LARGE; i++) {
-            theArrayLarge[indicesLarge[NUM_REFERENCES_LARGE - i - 1]] = realReferencesLarge[indicesLarge[i]];
-        }
-    }
-
-    @Benchmark
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void testArrayWriteBarrierFastPathRealLargeFixed() {
         for (int i = 0; i < NUM_REFERENCES_LARGE; i++) {
             theArrayLarge[indicesLarge[NUM_REFERENCES_LARGE - i - 1]] = realRef;
         }
     }
 
     @Benchmark
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathNullLarge() {
         for (int i = 0; i < NUM_REFERENCES_LARGE; i++) {
             theArrayLarge[indicesLarge[NUM_REFERENCES_LARGE - i - 1]] = nullRef;

--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -52,13 +52,13 @@ public class WriteBarrier {
     // For array update tests
     private Object[] theArraySmall;
     private Object[] realReferencesSmall;
-    private Object[] nullReferencesSmall;
     private int[] indicesSmall;
 
     private Object[] theArrayLarge;
     private Object[] realReferencesLarge;
-    private Object[] nullReferencesLarge;
     private int[] indicesLarge;
+
+    private Object nullRef;
 
     // For field update tests
     public Referencer head = null;
@@ -86,12 +86,10 @@ public class WriteBarrier {
     public void setup() {
         theArraySmall = new Object[NUM_REFERENCES_SMALL];
         realReferencesSmall = new Object[NUM_REFERENCES_SMALL];
-        nullReferencesSmall = new Object[NUM_REFERENCES_SMALL];
         indicesSmall = new int[NUM_REFERENCES_SMALL];
 
         theArrayLarge = new Object[NUM_REFERENCES_LARGE];
         realReferencesLarge = new Object[NUM_REFERENCES_LARGE];
-        nullReferencesLarge = new Object[NUM_REFERENCES_LARGE];
         indicesLarge = new int[NUM_REFERENCES_LARGE];
 
         m_w = (int) System.currentTimeMillis();
@@ -137,7 +135,7 @@ public class WriteBarrier {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathNullSmall() {
         for (int i = 0; i < NUM_REFERENCES_SMALL; i++) {
-            theArraySmall[indicesSmall[NUM_REFERENCES_SMALL - i - 1]] = nullReferencesSmall[indicesSmall[i]];
+            theArraySmall[indicesSmall[NUM_REFERENCES_SMALL - i - 1]] = nullRef;
         }
     }
 
@@ -153,7 +151,7 @@ public class WriteBarrier {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathNullLarge() {
         for (int i = 0; i < NUM_REFERENCES_LARGE; i++) {
-            theArrayLarge[indicesLarge[NUM_REFERENCES_LARGE - i - 1]] = nullReferencesLarge[indicesLarge[i]];
+            theArrayLarge[indicesLarge[NUM_REFERENCES_LARGE - i - 1]] = nullRef;
         }
     }
 


### PR DESCRIPTION
This changeset makes the `testArrayWriteBarrierFastPath*` micro-benchmarks in `WriteBarrier.java` more robust w.r.t. a few external factors, so that different GC barrier models can be compared more reliably. More specifically, it ensures that:

  - the main loop is never unrolled regardless of the selected GC algorithm,
  - no spilling occurs within the main loop for the final C2 compilation, and
  - the majority of the execution time is spent in the write operation and its associated barrier.

The changes preserve the original G1 barrier test profile, i.e. practically no write crosses heap regions under the default G1 configuration. More sophisticated benchmarks may be added in the future that exercise different G1 barrier levels.

Thanks to Thomas Schatzl for reporting and discussing issues in the micro-benchmarks.

**Testing:** build and run the micro-benchmarks (linux-x64, linux-aarch64, windows-x64, macosx-x64, macosx-aarch64).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344951](https://bugs.openjdk.org/browse/JDK-8344951): Stabilize write barrier micro-benchmarks (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22763/head:pull/22763` \
`$ git checkout pull/22763`

Update a local copy of the PR: \
`$ git checkout pull/22763` \
`$ git pull https://git.openjdk.org/jdk.git pull/22763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22763`

View PR using the GUI difftool: \
`$ git pr show -t 22763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22763.diff">https://git.openjdk.org/jdk/pull/22763.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22763#issuecomment-2545554504)
</details>
