### PR TITLE
8332189: Enable -Wzero-as-null-pointer-constant for gcc

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -262,6 +262,7 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
       WARNINGS_ENABLE_ADDITIONAL="-Wpointer-arith -Wsign-compare -Wreorder \
           -Wunused-function -Wundef -Wunused-value -Woverloaded-virtual"
       WARNINGS_ENABLE_ALL="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
+      WARNINGS_ENABLE_JVM="-Wzero-as-null-pointer-constant"
 
       # These warnings will never be turned on, since they generate too many
       # false positives.
@@ -609,6 +610,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
 
   elif test "x$TOOLCHAIN_TYPE" = xclang; then
     WARNING_CFLAGS="$WARNINGS_ENABLE_ALL"
+    WARNING_CFLAGS_JVM="$WARNINGS_ENABLE_JVM"
 
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     WARNING_CFLAGS="$WARNINGS_ENABLE_ALL"

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -239,7 +239,8 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
           -Wsign-compare -Wtrampolines -Wtype-limits -Wundef -Wuninitialized \
           -Wunused-const-variable=1 -Wunused-function -Wunused-result \
           -Wunused-value"
-      WARNINGS_ENABLE_ADDITIONAL_CXX="-Woverloaded-virtual -Wreorder"
+      WARNINGS_ENABLE_ADDITIONAL_CXX="-Woverloaded-virtual -Wreorder \
+          -Wzero-as-null-pointer-constant"
       WARNINGS_ENABLE_ALL_CFLAGS="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
       WARNINGS_ENABLE_ALL_CXXFLAGS="$WARNINGS_ENABLE_ALL_CFLAGS $WARNINGS_ENABLE_ADDITIONAL_CXX"
 

--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -112,6 +112,7 @@ define SetupTestFilesCompilationBody
         DISABLED_WARNINGS_gcc := format undef unused-but-set-variable \
             unused-const-variable unused-function unused-value \
             unused-variable, \
+        DISABLED_WARNINGS_CXX_gcc := zero-as-null-pointer-constant, \
         DISABLED_WARNINGS_clang := format-nonliteral \
             missing-field-initializers sometimes-uninitialized undef \
             unused-but-set-variable unused-function unused-variable, \

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -61,7 +61,7 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
     INCLUDE_FILES := gtest-all.cc gmock-all.cc, \
     DISABLED_WARNINGS_gcc := format-nonliteral maybe-uninitialized undef \
         unused-result zero-as-null-pointer-constant, \
-    DISABLED_WARNINGS_clang := format-nonliteral undef unused-result, \
+    DISABLED_WARNINGS_clang := format-nonliteral undef unused-result zero-as-null-pointer-constant, \
     DEFAULT_CFLAGS := false, \
     CFLAGS := $(JVM_CFLAGS) \
         -I$(GTEST_FRAMEWORK_SRC)/googletest \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -120,7 +120,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJIMAGE, \
     DISABLED_WARNINGS_gcc_imageDecompressor.cpp := unused-variable, \
     DISABLED_WARNINGS_gcc_imageFile.cpp := unused-const-variable \
         unused-variable, \
-    DISABLED_WARNINGS_gcc_NativeImageBuffer.cpp := zero-as-null-pointer-constant, \
     DISABLED_WARNINGS_clang_imageDecompressor.cpp := unused-variable, \
     DISABLED_WARNINGS_clang_imageFile.cpp := unused-private-field \
         unused-variable, \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -120,6 +120,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJIMAGE, \
     DISABLED_WARNINGS_gcc_imageDecompressor.cpp := unused-variable, \
     DISABLED_WARNINGS_gcc_imageFile.cpp := unused-const-variable \
         unused-variable, \
+    DISABLED_WARNINGS_gcc_NativeImageBuffer.cpp := zero-as-null-pointer-constant, \
     DISABLED_WARNINGS_clang_imageDecompressor.cpp := unused-variable, \
     DISABLED_WARNINGS_clang_imageFile.cpp := unused-private-field \
         unused-variable, \

--- a/make/modules/jdk.hotspot.agent/Lib.gmk
+++ b/make/modules/jdk.hotspot.agent/Lib.gmk
@@ -61,6 +61,8 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBSAPROC, \
     OPTIMIZATION := HIGH, \
     EXTRA_HEADER_DIRS := java.base:libjvm, \
     DISABLED_WARNINGS_gcc := sign-compare, \
+    DISABLED_WARNINGS_gcc_DwarfParser.cpp := zero-as-null-pointer-constant, \
+    DISABLED_WARNINGS_gcc_LinuxDebuggerLocal.cpp := zero-as-null-pointer-constant, \
     DISABLED_WARNINGS_gcc_ps_core.c := pointer-arith, \
     DISABLED_WARNINGS_clang := sign-compare, \
     DISABLED_WARNINGS_clang_libproc_impl.c := format-nonliteral, \

--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -94,6 +94,7 @@ ifeq ($(call isTargetOs, linux), true)
       EXCLUDE_FILES := LinuxLauncher.c LinuxPackage.c, \
       LINK_TYPE := C++, \
       OPTIMIZATION := LOW, \
+      DISABLED_WARNINGS_gcc := zero-as-null-pointer-constant, \
       DISABLED_WARNINGS_gcc_Log.cpp := unused-const-variable, \
       DISABLED_WARNINGS_clang_JvmLauncherLib.c := format-nonliteral, \
       DISABLED_WARNINGS_clang_tstrings.cpp := format-nonliteral, \

--- a/src/hotspot/os/bsd/memMapPrinter_macosx.cpp
+++ b/src/hotspot/os/bsd/memMapPrinter_macosx.cpp
@@ -131,7 +131,7 @@ public:
   static const char* tagToStr(uint32_t user_tag) {
     switch (user_tag) {
       case 0:
-        return 0;
+        return nullptr;
       X1(MALLOC, malloc);
       X1(MALLOC_SMALL, malloc_small);
       X1(MALLOC_LARGE, malloc_large);

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -607,7 +607,7 @@ static void *thread_native_entry(Thread *thread) {
   log_info(os, thread)("Thread finished (tid: %zu, pthread id: %zu).",
     os::current_thread_id(), (uintx) pthread_self());
 
-  return 0;
+  return nullptr;
 }
 
 bool os::create_thread(Thread* thread, ThreadType thr_type,
@@ -1311,7 +1311,7 @@ int os::get_loaded_modules_info(os::LoadedModulesCallbackFunc callback, void *pa
 #elif defined(__APPLE__)
   for (uint32_t i = 1; i < _dyld_image_count(); i++) {
     // Value for top_address is returned as 0 since we don't have any information about module size
-    if (callback(_dyld_get_image_name(i), (address)_dyld_get_image_header(i), (address)0, param)) {
+    if (callback(_dyld_get_image_name(i), (address)_dyld_get_image_header(i), (address)nullptr, param)) {
       return 1;
     }
   }

--- a/src/hotspot/os/posix/threadCritical_posix.cpp
+++ b/src/hotspot/os/posix/threadCritical_posix.cpp
@@ -34,7 +34,7 @@
 // See threadCritical.hpp for details of this class.
 //
 
-static pthread_t             tc_owner = 0;
+static pthread_t             tc_owner = nullptr;
 
 PRAGMA_DIAG_PUSH
 PRAGMA_ZERO_AS_NULL_POINTER_CONSTANT_IGNORED
@@ -60,7 +60,7 @@ ThreadCritical::~ThreadCritical() {
 
   tc_count--;
   if (tc_count == 0) {
-    tc_owner = 0;
+    tc_owner = nullptr;
     int ret = pthread_mutex_unlock(&tc_mutex);
     guarantee(ret == 0, "fatal error with pthread_mutex_unlock()");
   }

--- a/src/java.base/share/native/libjimage/NativeImageBuffer.cpp
+++ b/src/java.base/share/native/libjimage/NativeImageBuffer.cpp
@@ -55,5 +55,5 @@ Java_jdk_internal_jimage_NativeImageBuffer_getNativeMap(JNIEnv *env,
         return env->NewDirectByteBuffer(reader->get_index_address(), (jlong)reader->map_size());
     }
 
-    return 0;
+    return NULL;
 }

--- a/src/jdk.jpackage/macosx/native/applauncher/MacLauncher.cpp
+++ b/src/jdk.jpackage/macosx/native/applauncher/MacLauncher.cpp
@@ -35,7 +35,7 @@
 
 namespace {
 
-Jvm* jvmLauncher = 0;
+Jvm* jvmLauncher = NULL;
 
 void launchJvm() {
     // On Mac JLI_Launch() spawns a new thread that actually starts the JVM.

--- a/src/jdk.jpackage/share/native/applauncher/CfgFile.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/CfgFile.cpp
@@ -271,7 +271,7 @@ namespace {
 #define JP_SECTION(name) while (str == _T(#name)) { return &SectionName::name; }
         JP_ALL_SECTIONS
 #undef JP_SECTION
-            return 0;
+            return NULL;
     }
 }
 
@@ -303,7 +303,7 @@ namespace {
 #define JP_PROPERTY(varName, name) while (str == _T(name)) { return &PropertyName::varName; }
         JP_ALL_PROPERTIES
 #undef JP_PROPERTY
-            return 0;
+            return NULL;
     }
 } // namespace
 

--- a/src/jdk.jpackage/share/native/applauncher/JvmLauncher.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/JvmLauncher.cpp
@@ -196,7 +196,7 @@ void Jvm::launch() {
     JvmlLauncherAPI* api = jvmLauncherGetAPI();
 
     AutoJvmlLauncherData jld(jvmLauncherCreateJvmlLauncherData(api,
-                                                        jlh.release(), 0));
+                                                        jlh.release(), NULL));
 
     LOG_TRACE(tstrings::any() << "JVM library: \"" << jvmPath << "\"");
 
@@ -226,7 +226,7 @@ struct JliLaunchData {
     tstring_array envVarValues;
 
     int initJvmlLauncherData(JvmlLauncherData* ptr, int bufferSize) const {
-        int minimalBufferSize = initJvmlLauncherData(0);
+        int minimalBufferSize = initJvmlLauncherData(NULL);
         if (minimalBufferSize <= bufferSize) {
             initJvmlLauncherData(ptr);
         }
@@ -237,7 +237,7 @@ private:
     template <class T>
     static char* copyStrings(const std::vector<T>& src,
                 JvmlLauncherData* ptr, const size_t offset, char* curPtr) {
-        char** strArray = 0;
+        char** strArray = NULL;
         if (ptr) {
             strArray = *reinterpret_cast<char***>(
                                     reinterpret_cast<char*>(ptr) + offset);
@@ -276,7 +276,7 @@ private:
             ptr->jliLaunchArgv = reinterpret_cast<char**>(curPtr);
             ptr->jliLaunchArgc = (int)args.size();
             // Add terminal '0' arg.
-            ptr->jliLaunchArgv[ptr->jliLaunchArgc] = 0;
+            ptr->jliLaunchArgv[ptr->jliLaunchArgc] = NULL;
         }
         // Skip memory occupied by JvmlLauncherData::jliLaunchArgv array.
         curPtr += sizeof(char*) * (args.size() + 1 /* terminal '0' arg */);
@@ -362,7 +362,7 @@ int getJvmlLauncherDataSize(JvmlLauncherHandle h) {
     JP_TRY;
 
     const JliLaunchData* data = static_cast<const JliLaunchData*>(h);
-    return data->initJvmlLauncherData(0, 0);
+    return data->initJvmlLauncherData(NULL, 0);
 
     JP_CATCH_ALL;
 
@@ -383,7 +383,7 @@ JvmlLauncherData* initJvmlLauncherData(JvmlLauncherHandle h,
 
     JP_CATCH_ALL;
 
-    return 0;
+    return NULL;
 }
 
 class Impl : public JvmlLauncherAPI {

--- a/src/jdk.jpackage/share/native/common/ErrorHandling.h
+++ b/src/jdk.jpackage/share/native/common/ErrorHandling.h
@@ -90,7 +90,7 @@ public:
 private:
     // Assert Base is derived from std::runtime_error
     enum { isDerivedFromStdException =
-                        sizeof(static_cast<std::runtime_error*>((Base*)0)) };
+                        sizeof(static_cast<std::runtime_error*>((Base*)NULL)) };
 
     std::string msg;
 };

--- a/src/jdk.jpackage/share/native/common/app.cpp
+++ b/src/jdk.jpackage/share/native/common/app.cpp
@@ -33,7 +33,7 @@
 
 
 namespace {
-const std::string* theLastErrorMsg = 0;
+const std::string* theLastErrorMsg = NULL;
 
 char nopLogAppenderMemory[sizeof(NopLogAppender)] = {};
 
@@ -63,7 +63,7 @@ public:
     ResetLastErrorMsgAtEndOfScope() {
     }
     ~ResetLastErrorMsgAtEndOfScope() {
-        JP_NO_THROW(theLastErrorMsg = 0);
+        JP_NO_THROW(theLastErrorMsg = NULL);
     }
 };
 

--- a/src/jdk.jpackage/share/native/common/app.h
+++ b/src/jdk.jpackage/share/native/common/app.h
@@ -40,7 +40,7 @@ bool isWithLogging();
 typedef void (*LauncherFunc) ();
 
 int launch(const std::nothrow_t&, LauncherFunc func,
-        LogAppender* lastErrorLogAppender = 0);
+        LogAppender* lastErrorLogAppender = NULL);
 
 std::string lastErrorMsg();
 

--- a/src/jdk.jpackage/unix/native/common/UnixSysInfo.cpp
+++ b/src/jdk.jpackage/unix/native/common/UnixSysInfo.cpp
@@ -52,7 +52,7 @@ tstring getEnvVariable(const std::nothrow_t&, const tstring& name,
 
 
 bool isEnvVariableSet(const tstring& name) {
-    return ::getenv(name.c_str()) != 0;
+    return ::getenv(name.c_str()) != NULL;
 }
 
 void setEnvVariable(const tstring& name, const tstring& value) {
@@ -64,6 +64,6 @@ void setEnvVariable(const tstring& name, const tstring& value) {
 
 
 int argc = 0;
-char** argv = 0;
+char** argv = NULL;
 
 } // end of namespace SysInfo

--- a/test/hotspot/gtest/oops/test_compressedKlass.cpp
+++ b/test/hotspot/gtest/oops/test_compressedKlass.cpp
@@ -31,7 +31,7 @@ TEST_VM(CompressedKlass, basics) {
   if (!UseCompressedClassPointers) {
     return;
   }
-  ASSERT_LE((address)0, CompressedKlassPointers::base());
+  ASSERT_LE((address)nullptr, CompressedKlassPointers::base());
   ASSERT_LE(CompressedKlassPointers::base(), CompressedKlassPointers::klass_range_start());
   ASSERT_LT(CompressedKlassPointers::klass_range_start(), CompressedKlassPointers::klass_range_end());
   ASSERT_LE(CompressedKlassPointers::klass_range_end(), CompressedKlassPointers::encoding_range_end());


### PR DESCRIPTION
Enable -Wzero-as-null-pointer-constant for gcc. This only affects C++ code, and it will warn on code that uses a literal `0`, as opposed to `nullptr` or `NULL`.

Hotspot has recently decided to use `nullptr` and `nullptr` only, and have spent a lot of effort to fix this in their entire code base.  In JDK-8343802, they introduced a test that will verify the absence of `NULL` in the Hotspot code base; but to be complete, they also need this warning, to be able to check for the literal `0`.

However, I believe this warning would be useful not only to Hotspot, but to all C++ code in the JDK. In the JDK native libs, `NULL` is used the overwhelmingly dominant use case: I found roughly 5000 instances across 140 C++ files. In contrast, only one file in libjimage, two in libsaproc, and a handful in libjpackageapplauncheraux use the literal `0`. I think it is fair to say that this goes against an expected norm in the JDK C++ code, and should be replaced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332189](https://bugs.openjdk.org/browse/JDK-8332189): Enable -Wzero-as-null-pointer-constant for gcc (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22764/head:pull/22764` \
`$ git checkout pull/22764`

Update a local copy of the PR: \
`$ git checkout pull/22764` \
`$ git pull https://git.openjdk.org/jdk.git pull/22764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22764`

View PR using the GUI difftool: \
`$ git pr show -t 22764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22764.diff">https://git.openjdk.org/jdk/pull/22764.diff</a>

</details>
