### PR TITLE
8346289: Confusing phrasing in IR Framework README / User-defined Regexes

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -103,7 +103,7 @@ More examples can be found in [IRExample](../../../testlibrary_tests/ir_framewor
 
 #### User-defined Regexes
 
-The user can also directly specify user-defined regexes in combination with a required compile phase (there is no default compile phase known by the framework for custom regexes). If such a user-defined regex represents a not yet supported C2 IR node, it is highly encouraged to directly add a new IR node placeholder string definition to [IRNode](./IRNode.java) for it instead together with a static regex mapping block.
+The user can also directly specify user-defined regexes in combination with a required compile phase (there is no default compile phase known by the framework for custom regexes). If a user-defined regex corresponds to a C2 IR node that is not yet supported, it is recommended to add a new placeholder string definition for the IR node to [IRNode](./IRNode.java), along with a corresponding static regex mapping block.
 
 #### Default Compile Phase
 When not specifying any compile phase with `phase` in [@IR](./IR.java) (or explicitly setting `CompilePhase.DEFAULT`), the framework will perform IR matching on a default compile phase which for most IR nodes is `CompilePhase.PRINT_IDEAL` (output of flag `-XX:+PrintIdeal`, the state of the machine independent ideal graph after applying optimizations). The default phase for each IR node is defined in the static regex mapping block below each IR node placeholder string in [IRNode](./IRNode.java).


### PR DESCRIPTION
> If such a user-defined regex represents a not yet supported C2 IR node, it is highly encouraged to directly add a new IR node placeholder string definition to IRNode for it instead together with a static regex mapping block.

The combination of "instead together" makes this sentence hard to read. I had to re-read it several times to grasp it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346289](https://bugs.openjdk.org/browse/JDK-8346289): Confusing phrasing in IR Framework README / User-defined Regexes (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22766/head:pull/22766` \
`$ git checkout pull/22766`

Update a local copy of the PR: \
`$ git checkout pull/22766` \
`$ git pull https://git.openjdk.org/jdk.git pull/22766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22766`

View PR using the GUI difftool: \
`$ git pr show -t 22766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22766.diff">https://git.openjdk.org/jdk/pull/22766.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22766#issuecomment-2545980068)
</details>
