### PR TITLE
8346282: [JVMCI] Add failure reason support to UnresolvedJava/Type/Method/Field

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
@@ -798,11 +798,10 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
             HotSpotResolvedObjectTypeImpl resolvedHolder;
             try {
                 resolvedHolder = compilerToVM().resolveFieldInPool(this, rawIndex, (HotSpotResolvedJavaMethodImpl) method, (byte) opcode, info);
-            } catch (Throwable t) {
-                resolvedHolder = null;
+            } catch (Throwable cause) {
+                return new UnresolvedJavaField(fieldHolder, lookupUtf8(getNameRefIndexAt(nameAndTypeIndex)), type, cause);
             }
             if (resolvedHolder == null) {
-                // There was an exception resolving the field or it returned null so return an unresolved field.
                 return new UnresolvedJavaField(fieldHolder, lookupUtf8(getNameRefIndexAt(nameAndTypeIndex)), type);
             }
             final int flags = info[0];

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/UnresolvedJavaField.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/UnresolvedJavaField.java
@@ -32,7 +32,7 @@ public final class UnresolvedJavaField implements JavaField {
     private final JavaType type;
 
     /**
-     * The reason method resolution failed. Can be null.
+     * The reason field resolution failed. Can be null.
      */
     private final Throwable cause;
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/UnresolvedJavaField.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/UnresolvedJavaField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,27 @@ public final class UnresolvedJavaField implements JavaField {
     private final JavaType holder;
     private final JavaType type;
 
-    public UnresolvedJavaField(JavaType holder, String name, JavaType type) {
+    /**
+     * The reason method resolution failed. Can be null.
+     */
+    private final Throwable cause;
+
+    public UnresolvedJavaField(JavaType holder, String name, JavaType type, Throwable cause) {
         this.name = name;
         this.type = type;
         this.holder = holder;
+        this.cause = cause;
+    }
+
+    public UnresolvedJavaField(JavaType holder, String name, JavaType type) {
+        this(holder, name, type, null);
+    }
+
+    /**
+     * Gets the exception, if any, representing the reason field resolution resulted in this object.
+     */
+    public Throwable getCause() {
+        return cause;
     }
 
     @Override

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/UnresolvedJavaMethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/UnresolvedJavaMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,27 @@ public final class UnresolvedJavaMethod implements JavaMethod {
     private final Signature signature;
     protected JavaType holder;
 
-    public UnresolvedJavaMethod(String name, Signature signature, JavaType holder) {
+    /**
+     * The reason method resolution failed. Can be null.
+     */
+    private final Throwable cause;
+
+    public UnresolvedJavaMethod(String name, Signature signature, JavaType holder, Throwable cause) {
         this.name = name;
         this.holder = holder;
         this.signature = signature;
+        this.cause = cause;
+    }
+
+    public UnresolvedJavaMethod(String name, Signature signature, JavaType holder) {
+        this(name, signature, holder, null);
+    }
+
+    /**
+     * Gets the exception, if any, representing the reason method resolution resulted in this object.
+     */
+    public Throwable getCause() {
+        return cause;
     }
 
     @Override

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/UnresolvedJavaType.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/UnresolvedJavaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,13 +28,19 @@ package jdk.vm.ci.meta;
 public final class UnresolvedJavaType implements JavaType {
     private final String name;
 
+    /**
+     * The reason type resolution failed. Can be null.
+     */
+    private final Throwable cause;
+
     @Override
     public String getName() {
         return name;
     }
 
-    private UnresolvedJavaType(String name) {
+    private UnresolvedJavaType(String name, Throwable cause) {
         this.name = name;
+        this.cause = cause;
         assert name.length() == 1 && JavaKind.fromPrimitiveOrVoidTypeChar(name.charAt(0)) != null || name.charAt(0) == '[' || name.charAt(name.length() - 1) == ';' : name;
     }
 
@@ -42,20 +48,34 @@ public final class UnresolvedJavaType implements JavaType {
      * Creates an unresolved type for a valid {@link JavaType#getName() type name}.
      */
     public static UnresolvedJavaType create(String name) {
-        return new UnresolvedJavaType(name);
+        return new UnresolvedJavaType(name, null);
+    }
+
+    /**
+     * Creates an unresolved type for a valid {@link JavaType#getName() type name}.
+     */
+    public static UnresolvedJavaType create(String name, Throwable cause) {
+        return new UnresolvedJavaType(name, cause);
+    }
+
+    /**
+     * Gets the exception, if any, representing the reason type resolution resulted in this object.
+     */
+    public Throwable getCause() {
+        return cause;
     }
 
     @Override
     public JavaType getComponentType() {
         if (getName().charAt(0) == '[') {
-            return new UnresolvedJavaType(getName().substring(1));
+            return new UnresolvedJavaType(getName().substring(1), null);
         }
         return null;
     }
 
     @Override
     public JavaType getArrayClass() {
-        return new UnresolvedJavaType('[' + getName());
+        return new UnresolvedJavaType('[' + getName(), null);
     }
 
     @Override


### PR DESCRIPTION
The JVMCI UnresolvedJava/Type/Method/Field types can be used to represent resolution failures. It would be useful if an exception describing the resolution failure could be attached to these objects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346282](https://bugs.openjdk.org/browse/JDK-8346282): [JVMCI] Add failure reason support to UnresolvedJava/Type/Method/Field (**Enhancement** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * [Yudi Zheng](https://openjdk.org/census#yzheng) (@mur47x111 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22767/head:pull/22767` \
`$ git checkout pull/22767`

Update a local copy of the PR: \
`$ git checkout pull/22767` \
`$ git pull https://git.openjdk.org/jdk.git pull/22767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22767`

View PR using the GUI difftool: \
`$ git pr show -t 22767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22767.diff">https://git.openjdk.org/jdk/pull/22767.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22767#issuecomment-2546141194)
</details>
