### PR TITLE
8346304: SA doesn't need a copy of getModifierFlags

### DIFF
--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -2029,8 +2029,6 @@
   /* HotSpot specific JVM_ACC constants from global anon enum */          \
   /************************************************************/          \
                                                                           \
-  declare_constant(JVM_ACC_WRITTEN_FLAGS)                                 \
-                                                                          \
   declare_constant(JVM_CONSTANT_Utf8)                                     \
   declare_constant(JVM_CONSTANT_Unicode)                                  \
   declare_constant(JVM_CONSTANT_Integer)                                  \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ArrayKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ArrayKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,10 +101,6 @@ public class ArrayKlass extends Klass {
 
   public int getClassStatus() {
      return JVMDIClassStatus.VERIFIED | JVMDIClassStatus.PREPARED | JVMDIClassStatus.INITIALIZED;
-  }
-
-  public long computeModifierFlags() {
-     return JVM_ACC_ABSTRACT | JVM_ACC_FINAL | JVM_ACC_PUBLIC;
   }
 
   public long getArrayHeaderInBytes() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
@@ -434,46 +434,6 @@ public class InstanceKlass extends Klass {
     }
   }
 
-  // refer to compute_modifier_flags in VM code.
-  public long computeModifierFlags() {
-    long access = getAccessFlags();
-    // But check if it happens to be member class.
-    U2Array innerClassList = getInnerClasses();
-    int length = (innerClassList == null)? 0 : innerClassList.length();
-    if (length > 0) {
-       if (Assert.ASSERTS_ENABLED) {
-          Assert.that(length % InnerClassAttributeOffset.innerClassNextOffset == 0 ||
-                      length % InnerClassAttributeOffset.innerClassNextOffset == EnclosingMethodAttributeOffset.enclosingMethodAttributeSize,
-                      "just checking");
-       }
-       for (int i = 0; i < length; i += InnerClassAttributeOffset.innerClassNextOffset) {
-          if (i == length - EnclosingMethodAttributeOffset.enclosingMethodAttributeSize) {
-              break;
-          }
-          int ioff = innerClassList.at(i +
-                         InnerClassAttributeOffset.innerClassInnerClassInfoOffset);
-          // 'ioff' can be zero.
-          // refer to JVM spec. section 4.7.5.
-          if (ioff != 0) {
-             // only look at classes that are already loaded
-             // since we are looking for the flags for our self.
-             Symbol name = getConstants().getKlassNameAt(ioff);
-
-             if (name.equals(getName())) {
-                // This is really a member class
-                access = innerClassList.at(i +
-                        InnerClassAttributeOffset.innerClassAccessFlagsOffset);
-                break;
-             }
-          }
-       } // for inner classes
-    }
-
-    // Remember to strip ACC_SUPER bit
-    return (access & (~JVM_ACC_SUPER)) & JVM_ACC_WRITTEN_FLAGS;
-  }
-
-
   // whether given Symbol is name of an inner/nested Klass of this Klass?
   // anonymous and local classes are excluded.
   public boolean isInnerClassName(Symbol sym) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Klass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Klass.java
@@ -133,23 +133,6 @@ public class Klass extends Metadata implements ClassConstants {
     return traceIDField.getJLong(addr);
   }
 
-  // computed access flags - takes care of inner classes etc.
-  // This is closer to actual source level than getAccessFlags() etc.
-  public long computeModifierFlags() {
-    return 0L; // Unless overridden, modifier_flags is 0.
-  }
-
-  // same as JVM_GetClassModifiers
-  public final long getClassModifiers() {
-    // unlike the VM counterpart we never have to deal with primitive type,
-    // because we operator on Klass and not an instance of java.lang.Class.
-    long flags = computeModifierFlags();
-    if (isSuper()) {
-       flags |= JVM_ACC_SUPER;
-    }
-    return flags;
-  }
-
   // subclass check
   public boolean isSubclassOf(Klass k) {
     if (k != null) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjArrayKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjArrayKlass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,19 +59,6 @@ public class ObjArrayKlass extends ArrayKlass {
 
   public Klass getElementKlass() { return (Klass) elementKlass.getValue(this); }
   public Klass getBottomKlass()  { return (Klass) bottomKlass.getValue(this); }
-
-  public long computeModifierFlags() {
-    long elementFlags = getElementKlass().computeModifierFlags();
-    long arrayFlags = 0L;
-    if ((elementFlags & (JVM_ACC_PUBLIC | JVM_ACC_PROTECTED)) != 0) {
-       // The array type is public if the component type is public or protected
-       arrayFlags = JVM_ACC_ABSTRACT | JVM_ACC_FINAL | JVM_ACC_PUBLIC;
-    } else {
-       // The array type is private if the component type is private
-       arrayFlags = JVM_ACC_ABSTRACT | JVM_ACC_FINAL;
-    }
-    return arrayFlags;
-  }
 
   public void iterateFields(MetadataVisitor visitor) {
     super.iterateFields(visitor);


### PR DESCRIPTION
Please review this trivial change to remove unused SA code.  Ran serviceability/sa tests, tier1 testing in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346304](https://bugs.openjdk.org/browse/JDK-8346304): SA doesn't need a copy of getModifierFlags (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22772/head:pull/22772` \
`$ git checkout pull/22772`

Update a local copy of the PR: \
`$ git checkout pull/22772` \
`$ git pull https://git.openjdk.org/jdk.git pull/22772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22772`

View PR using the GUI difftool: \
`$ git pr show -t 22772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22772.diff">https://git.openjdk.org/jdk/pull/22772.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22772#issuecomment-2546688717)
</details>
