### PR TITLE
JDK-8344907 : NullPointerException in Win32ShellFolder2.getSystemIcon when "icon" is null

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1200,15 +1200,15 @@ final class Win32ShellFolder2 extends ShellFolder {
      * Gets an icon from the Windows system icon list as an {@code Image}
      */
     static Image getSystemIcon(SystemIcon iconType) {
-        Image icon = null;
         long hIcon = getSystemIcon(iconType.getIconID());
-        if (hIcon != 0) {
-            icon = makeIcon(hIcon);
-            if (icon != null && LARGE_ICON_SIZE != icon.getWidth(null)) {
-                icon = new MultiResolutionIconImage(LARGE_ICON_SIZE, icon);
-            }
-            disposeIcon(hIcon);
+        if (hIcon == 0) {
+            return null;
         }
+        Image icon = makeIcon(hIcon);
+        if (icon != null && LARGE_ICON_SIZE != icon.getWidth(null)) {
+            icon = new MultiResolutionIconImage(LARGE_ICON_SIZE, icon);
+        }
+        disposeIcon(hIcon);
         return icon;
     }
 
@@ -1217,15 +1217,15 @@ final class Win32ShellFolder2 extends ShellFolder {
      */
     static Image getShell32Icon(int iconID, int size) {
         long hIcon = getIconResource("shell32.dll", iconID, size, size);
-        if (hIcon != 0) {
-            Image icon = makeIcon(hIcon);
-            if (icon != null && size != icon.getWidth(null)) {
-                icon = new MultiResolutionIconImage(size, icon);
-            }
-            disposeIcon(hIcon);
-            return icon;
+        if (hIcon == 0) {
+            return null;
         }
-        return null;
+        Image icon = makeIcon(hIcon);
+        if (icon != null && size != icon.getWidth(null)) {
+            icon = new MultiResolutionIconImage(size, icon);
+        }
+        disposeIcon(hIcon);
+        return icon;
     }
 
     /**

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1204,6 +1204,7 @@ final class Win32ShellFolder2 extends ShellFolder {
         if (hIcon == 0) {
             return null;
         }
+
         Image icon = makeIcon(hIcon);
         if (icon != null && LARGE_ICON_SIZE != icon.getWidth(null)) {
             icon = new MultiResolutionIconImage(LARGE_ICON_SIZE, icon);
@@ -1220,6 +1221,7 @@ final class Win32ShellFolder2 extends ShellFolder {
         if (hIcon == 0) {
             return null;
         }
+
         Image icon = makeIcon(hIcon);
         if (icon != null && size != icon.getWidth(null)) {
             icon = new MultiResolutionIconImage(size, icon);

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1202,7 +1202,7 @@ final class Win32ShellFolder2 extends ShellFolder {
     static Image getSystemIcon(SystemIcon iconType) {
         long hIcon = getSystemIcon(iconType.getIconID());
         Image icon = makeIcon(hIcon);
-        if (LARGE_ICON_SIZE != icon.getWidth(null)) {
+        if (icon != null && LARGE_ICON_SIZE != icon.getWidth(null)) {
             icon = new MultiResolutionIconImage(LARGE_ICON_SIZE, icon);
         }
         disposeIcon(hIcon);
@@ -1216,7 +1216,7 @@ final class Win32ShellFolder2 extends ShellFolder {
         long hIcon = getIconResource("shell32.dll", iconID, size, size);
         if (hIcon != 0) {
             Image icon = makeIcon(hIcon);
-            if (size != icon.getWidth(null)) {
+            if (icon != null && size != icon.getWidth(null)) {
                 icon = new MultiResolutionIconImage(size, icon);
             }
             disposeIcon(hIcon);

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1200,12 +1200,15 @@ final class Win32ShellFolder2 extends ShellFolder {
      * Gets an icon from the Windows system icon list as an {@code Image}
      */
     static Image getSystemIcon(SystemIcon iconType) {
+        Image icon = null;
         long hIcon = getSystemIcon(iconType.getIconID());
-        Image icon = makeIcon(hIcon);
-        if (icon != null && LARGE_ICON_SIZE != icon.getWidth(null)) {
-            icon = new MultiResolutionIconImage(LARGE_ICON_SIZE, icon);
+        if (hIcon != 0) {
+            icon = makeIcon(hIcon);
+            if (icon != null && LARGE_ICON_SIZE != icon.getWidth(null)) {
+                icon = new MultiResolutionIconImage(LARGE_ICON_SIZE, icon);
+            }
+            disposeIcon(hIcon);
         }
-        disposeIcon(hIcon);
         return icon;
     }
 


### PR DESCRIPTION
Win32ShellFolder2.getSystemIcon() can result in NPE if icon is null. Sanity null checks have been added.

```
long hIcon = getSystemIcon(iconType.getIconID()); //Can return null
Image icon = makeIcon(hIcon); // returns null if the condition (hIcon != 0L && hIcon != -1L) is false
if (LARGE_ICON_SIZE != icon.getWidth(null)) { // NullPointerException -- icon is null
```

Occurs when Windows is unable to provide a system icon and the code assumes an icon will **always** be returned, but the Windows API makes no such guarantee.

getSystemIcon calls LoadIcon (User32.dll). This can return null.
https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadicona

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344907](https://bugs.openjdk.org/browse/JDK-8344907): NullPointerException in Win32ShellFolder2.getSystemIcon when "icon" is null (**Bug** - P3)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22776/head:pull/22776` \
`$ git checkout pull/22776`

Update a local copy of the PR: \
`$ git checkout pull/22776` \
`$ git pull https://git.openjdk.org/jdk.git pull/22776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22776`

View PR using the GUI difftool: \
`$ git pr show -t 22776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22776.diff">https://git.openjdk.org/jdk/pull/22776.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22776#issuecomment-2547169654)
</details>
