### PR TITLE
8346306: Unattached thread can cause crash during VM exit if it calls wait_if_vm_exited

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3319,8 +3319,9 @@ JVM_END
 // VM Raw monitors (not to be confused with JvmtiRawMonitors) are a simple mutual exclusion
 // lock (not actually monitors: no wait/notify) that is exported by the VM for use by JDK
 // library code. They may be used by JavaThreads and non-JavaThreads and do not participate
-// in the safepoint protocol, thread suspension, thread interruption, or anything of that
-// nature. JavaThreads will be "in native" when using this API from JDK code.
+// in the safepoint protocol, thread suspension, thread interruption, or most things of that
+// nature, except JavaThreads will be blocked by VM_Exit::block_if_vm_exited if the VM has
+// shutdown. JavaThreads will be "in native" when using this API from JDK code.
 
 
 JNIEXPORT void* JNICALL JVM_RawMonitorCreate(void) {

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -611,12 +611,16 @@ void VM_Exit::doit() {
 
 
 void VM_Exit::wait_if_vm_exited() {
-  if (_vm_exited &&
-      Thread::current_or_null() != _shutdown_thread) {
-    // _vm_exited is set at safepoint, and the Threads_lock is never released
-    // so we will block here until the process dies.
-    Threads_lock->lock();
-    ShouldNotReachHere();
+  if (_vm_exited) {
+    // Need to check for an unattached thread as only attached threads
+    // can acquire the lock.
+    Thread* current = Thread::current_or_null();
+    if (current != nullptr && current != _shutdown_thread) {
+      // _vm_exited is set at safepoint, and the Threads_lock is never released
+      // so we will block here until the process dies.
+      Threads_lock->lock();
+      ShouldNotReachHere();
+    }
   }
 }
 


### PR DESCRIPTION
Please review this simple fix to account for unattached threads using RawMonitors which check if the VM has exited.

Testing:
 - tiers 1-3 (sanity)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346306](https://bugs.openjdk.org/browse/JDK-8346306): Unattached thread can cause crash during VM exit if it calls wait_if_vm_exited (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22779/head:pull/22779` \
`$ git checkout pull/22779`

Update a local copy of the PR: \
`$ git checkout pull/22779` \
`$ git pull https://git.openjdk.org/jdk.git pull/22779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22779`

View PR using the GUI difftool: \
`$ git pr show -t 22779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22779.diff">https://git.openjdk.org/jdk/pull/22779.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22779#issuecomment-2547209981)
</details>
