### PR TITLE
8345266: java/util/concurrent/locks/StampedLock/OOMEInStampedLock.java JTREG_TEST_THREAD_FACTORY=Virtual fails with OOME

### DIFF
--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -162,9 +162,10 @@ freeze_result Continuation::try_preempt(JavaThread* current, oop continuation) {
   JVMTI_ONLY(jubm.set_result(res);)
 
   if (current->has_pending_exception()) {
-    assert(res == freeze_exception, "");
+    assert(res == freeze_exception, "expecting an exception result from freeze");
     // We don't want to throw exceptions, especially when returning
-    // from monitorenter since the compiler does not expect one.
+    // from monitorenter since the compiler does not expect one. We
+    // just ignore the exception and pin the vthread to the carrier.
     current->clear_pending_exception();
   }
   return res;

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -160,6 +160,13 @@ freeze_result Continuation::try_preempt(JavaThread* target, oop continuation) {
   freeze_result res = CAST_TO_FN_PTR(FreezeContFnT, freeze_preempt_entry())(target, target->last_Java_sp());
   log_trace(continuations, preempt)("try_preempt: %d", res);
   JVMTI_ONLY(jubm.set_result(res);)
+
+  if (target->has_pending_exception()) {
+    assert(res == freeze_exception, "");
+    // We don't want to throw exceptions, especially when returning
+    // from monitorenter since the compiler does not expect one.
+    target->clear_pending_exception();
+  }
   return res;
 }
 

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -60,14 +60,14 @@ JVM_END
 #if INCLUDE_JVMTI
 class JvmtiUnmountBeginMark : public StackObj {
   Handle _vthread;
-  JavaThread* _target;
+  JavaThread* _current;
   freeze_result _result;
   bool _failed;
 
  public:
   JvmtiUnmountBeginMark(JavaThread* t) :
-    _vthread(t, t->vthread()), _target(t), _result(freeze_pinned_native), _failed(false) {
-    assert(!_target->is_in_VTMS_transition(), "must be");
+    _vthread(t, t->vthread()), _current(t), _result(freeze_pinned_native), _failed(false) {
+    assert(!_current->is_in_VTMS_transition(), "must be");
 
     if (JvmtiVTMSTransitionDisabler::VTMS_notify_jvmti_events()) {
       JvmtiVTMSTransitionDisabler::VTMS_vthread_unmount((jthread)_vthread.raw_value(), true);
@@ -75,26 +75,26 @@ class JvmtiUnmountBeginMark : public StackObj {
       // Don't preempt if there is a pending popframe or earlyret operation. This can
       // be installed in start_VTMS_transition() so we need to check it here.
       if (JvmtiExport::can_pop_frame() || JvmtiExport::can_force_early_return()) {
-        JvmtiThreadState* state = _target->jvmti_thread_state();
-        if (_target->has_pending_popframe() || (state != nullptr && state->is_earlyret_pending())) {
+        JvmtiThreadState* state = _current->jvmti_thread_state();
+        if (_current->has_pending_popframe() || (state != nullptr && state->is_earlyret_pending())) {
           _failed = true;
         }
       }
 
       // Don't preempt in case there is an async exception installed since
       // we would incorrectly throw it during the unmount logic in the carrier.
-      if (_target->has_async_exception_condition()) {
+      if (_current->has_async_exception_condition()) {
         _failed = true;
       }
     } else {
-      _target->set_is_in_VTMS_transition(true);
+      _current->set_is_in_VTMS_transition(true);
       java_lang_Thread::set_is_in_VTMS_transition(_vthread(), true);
     }
   }
   ~JvmtiUnmountBeginMark() {
-    assert(!_target->is_suspended(), "must be");
+    assert(!_current->is_suspended(), "must be");
 
-    assert(_target->is_in_VTMS_transition(), "must be");
+    assert(_current->is_in_VTMS_transition(), "must be");
     assert(java_lang_Thread::is_in_VTMS_transition(_vthread()), "must be");
 
     // Read it again since for late binding agents the flag could have
@@ -106,7 +106,7 @@ class JvmtiUnmountBeginMark : public StackObj {
       if (jvmti_present) {
         JvmtiVTMSTransitionDisabler::VTMS_vthread_mount((jthread)_vthread.raw_value(), false);
       } else {
-        _target->set_is_in_VTMS_transition(false);
+        _current->set_is_in_VTMS_transition(false);
         java_lang_Thread::set_is_in_VTMS_transition(_vthread(), false);
       }
     }
@@ -115,57 +115,57 @@ class JvmtiUnmountBeginMark : public StackObj {
   bool failed() { return _failed; }
 };
 
-static bool is_vthread_safe_to_preempt_for_jvmti(JavaThread* target) {
-  if (target->is_in_VTMS_transition()) {
-    // We caught target at the end of a mount transition.
+static bool is_vthread_safe_to_preempt_for_jvmti(JavaThread* current) {
+  if (current->is_in_VTMS_transition()) {
+    // We are at the end of a mount transition.
     return false;
   }
   return true;
 }
 #endif // INCLUDE_JVMTI
 
-static bool is_vthread_safe_to_preempt(JavaThread* target, oop vthread) {
+static bool is_vthread_safe_to_preempt(JavaThread* current, oop vthread) {
   assert(java_lang_VirtualThread::is_instance(vthread), "");
   if (java_lang_VirtualThread::state(vthread) != java_lang_VirtualThread::RUNNING) {  // inside transition
     return false;
   }
-  return JVMTI_ONLY(is_vthread_safe_to_preempt_for_jvmti(target)) NOT_JVMTI(true);
+  return JVMTI_ONLY(is_vthread_safe_to_preempt_for_jvmti(current)) NOT_JVMTI(true);
 }
 
 typedef freeze_result (*FreezeContFnT)(JavaThread*, intptr_t*);
 
-static void verify_preempt_preconditions(JavaThread* target, oop continuation) {
-  assert(target == JavaThread::current(), "no support for external preemption");
-  assert(target->has_last_Java_frame(), "");
-  assert(!target->preempting(), "");
-  assert(target->last_continuation() != nullptr, "");
-  assert(target->last_continuation()->cont_oop(target) == continuation, "");
+static void verify_preempt_preconditions(JavaThread* current, oop continuation) {
+  assert(current == JavaThread::current(), "no support for external preemption");
+  assert(current->has_last_Java_frame(), "");
+  assert(!current->preempting(), "");
+  assert(current->last_continuation() != nullptr, "");
+  assert(current->last_continuation()->cont_oop(current) == continuation, "");
   assert(Continuation::continuation_scope(continuation) == java_lang_VirtualThread::vthread_scope(), "");
-  assert(!target->has_pending_exception(), "");
+  assert(!current->has_pending_exception(), "");
 }
 
-freeze_result Continuation::try_preempt(JavaThread* target, oop continuation) {
-  verify_preempt_preconditions(target, continuation);
+freeze_result Continuation::try_preempt(JavaThread* current, oop continuation) {
+  verify_preempt_preconditions(current, continuation);
 
   if (LockingMode == LM_LEGACY) {
     return freeze_unsupported;
   }
 
-  if (!is_vthread_safe_to_preempt(target, target->vthread())) {
+  if (!is_vthread_safe_to_preempt(current, current->vthread())) {
     return freeze_pinned_native;
   }
 
-  JVMTI_ONLY(JvmtiUnmountBeginMark jubm(target);)
+  JVMTI_ONLY(JvmtiUnmountBeginMark jubm(current);)
   JVMTI_ONLY(if (jubm.failed()) return freeze_pinned_native;)
-  freeze_result res = CAST_TO_FN_PTR(FreezeContFnT, freeze_preempt_entry())(target, target->last_Java_sp());
+  freeze_result res = CAST_TO_FN_PTR(FreezeContFnT, freeze_preempt_entry())(current, current->last_Java_sp());
   log_trace(continuations, preempt)("try_preempt: %d", res);
   JVMTI_ONLY(jubm.set_result(res);)
 
-  if (target->has_pending_exception()) {
+  if (current->has_pending_exception()) {
     assert(res == freeze_exception, "");
     // We don't want to throw exceptions, especially when returning
     // from monitorenter since the compiler does not expect one.
-    target->clear_pending_exception();
+    current->clear_pending_exception();
   }
   return res;
 }

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -44,8 +44,6 @@ javax/management/remote/mandatory/connection/DeadLockTest.java 8309069 windows-x
 
 javax/management/remote/mandatory/connection/ConnectionTest.java 8308352 windows-x64
 
-java/util/concurrent/locks/StampedLock/OOMEInStampedLock.java 8345266 generic-all
-
 ##########
 ## Tests incompatible with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.

--- a/test/jdk/java/lang/Thread/virtual/MonitorOOM.java
+++ b/test/jdk/java/lang/Thread/virtual/MonitorOOM.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=monitorenter
+ * @bug 8345266
+ * @summary Test OOM while trying to unmount vthread on monitorenter
+ * @requires vm.continuations & vm.gc.G1 & vm.opt.DisableExplicitGC != "true"
+ * @library /test/lib
+ * @run main/othervm -XX:+UseG1GC -Xmx48M MonitorOOM false
+ */
+
+/*
+ * @test id=wait
+ * @bug 8345266
+ * @summary Test OOM while trying to unmount vthread on Object.wait
+ * @requires vm.continuations & vm.gc.G1 & vm.opt.DisableExplicitGC != "true"
+ * @library /test/lib
+ * @run main/othervm -XX:+UseG1GC -Xmx48M MonitorOOM true
+ */
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class MonitorOOM {
+    static volatile Object data;
+
+    public static void main(String[] args) throws Throwable {
+        final boolean testWait = args.length == 1 ? Boolean.parseBoolean(args[0]) : false;
+
+        Thread vthread;
+        var lock = new Object();
+        var canFillHeap = new AtomicBoolean();
+        var heapFilled = new AtomicBoolean();
+        var heapCollected = new AtomicBoolean();
+        var exRef = new AtomicReference<Throwable>();
+        synchronized (lock) {
+            vthread = Thread.ofVirtual().start(() -> {
+                try {
+                    awaitTrue(canFillHeap);
+                    data = fillHeap();
+                    heapFilled.set(true);
+                    synchronized (lock) {
+                        if (testWait) {
+                            lock.wait(5);
+                        }
+                    }
+                    data = null;
+                    System.gc();
+                    heapCollected.set(true);
+                } catch (Throwable e) {
+                    data = null;
+                    System.gc(); // avoid nested OOME
+                    exRef.set(e);
+                }
+            });
+            canFillHeap.set(true);
+            awaitTrue(heapFilled);
+            loopMillis(100); // allow vthread to reach synchronized
+        }
+        joinVThread(vthread, heapCollected, exRef);
+        assert exRef.get() == null;
+    }
+
+    private static Object[] fillHeap() {
+        Object[] first = null, last = null;
+        int size = 1 << 20;
+        while (size > 0) {
+            try {
+                Object[] array = new Object[size];
+                if (first == null) {
+                    first = array;
+                } else {
+                    last[0] = array;
+                }
+                last = array;
+            } catch (OutOfMemoryError oome) {
+                size = size >>> 1;
+            }
+        }
+        return first;
+    }
+
+    private static void awaitTrue(AtomicBoolean ready) {
+        // Don't call anything that might allocate from the Java heap.
+        while (!ready.get()) {}
+    }
+
+    private static void loopMillis(long millis) {
+        // Don't call anything that might allocate from the Java heap.
+        long start = System.currentTimeMillis();
+        while ((System.currentTimeMillis() - start) < millis) {}
+    }
+
+    private static void joinVThread(Thread vthread, AtomicBoolean ready, AtomicReference<Throwable> exRef) throws Throwable {
+        // Don't call anything that might allocate from the Java heap until ready is set.
+        while (!ready.get()) {
+            Throwable ex = exRef.get();
+            if (ex != null) {
+                throw ex;
+            }
+        }
+        vthread.join();
+    }
+}


### PR DESCRIPTION
Please review this small fix. The call to `Continuation::try_preempt()` can fail and return with a pending OOM exception due to insufficient memory while trying to allocate a new stackChunk. On this particular `OOMEInStampedLock.java` test, the OOM is thrown when returning from Object.wait, which is unexpected and causes the test to fail. But this could also happen when a virtual thread returns from monitorenter, which would cause an assert when coming from compiled code (see `SharedRuntime::monitor_enter_helper()`). Since a failing `try_preempt()` call will just prevent the vthread from being unmounted and force it to follow the normal platform thread code there is no need to throw OOM. The fix is to just clear the pending exception if set, and let future bytecodes handle the OOM condition if still present.

I verified that test `OOMEInStampedLock.java` now passes with the fix. I also added a new more specific test which fails without this fix and passes with it. I also run the change through mach5 tiers1-3.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345266](https://bugs.openjdk.org/browse/JDK-8345266): java/util/concurrent/locks/StampedLock/OOMEInStampedLock.java JTREG_TEST_THREAD_FACTORY=Virtual fails with OOME (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) Review applies to [dff693c4](https://git.openjdk.org/jdk/pull/22780/files/dff693c414acc555f04d9622e5a8c3148e8db242)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22780/head:pull/22780` \
`$ git checkout pull/22780`

Update a local copy of the PR: \
`$ git checkout pull/22780` \
`$ git pull https://git.openjdk.org/jdk.git pull/22780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22780`

View PR using the GUI difftool: \
`$ git pr show -t 22780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22780.diff">https://git.openjdk.org/jdk/pull/22780.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22780#issuecomment-2547306741)
</details>
