### PR TITLE
8346324: javax/swing/JScrollBar/4865918/bug4865918.java fails in CI

### DIFF
--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -56,7 +56,9 @@ public class bug4865918 {
             robot.delay(1000);
 
             SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
-            mousePressLatch.await(2, TimeUnit.SECONDS);
+            if (!mousePressLatch.await(2, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Timed out waiting for mouse press");
+            }
 
             robot.waitForIdle();
             robot.delay(200);

--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -31,11 +31,11 @@
 
 import java.awt.Dimension;
 import java.awt.Robot;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import javax.swing.JFrame;
 import javax.swing.JScrollBar;
 import javax.swing.SwingUtilities;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 

--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -34,7 +34,9 @@ import java.awt.Robot;
 import javax.swing.JFrame;
 import javax.swing.JScrollBar;
 import javax.swing.SwingUtilities;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.concurrent.CountDownLatch;
 
 import java.util.Date;
 
@@ -42,8 +44,10 @@ public class bug4865918 {
 
     private static TestScrollBar sbar;
     private static JFrame frame;
+    private static volatile CountDownLatch latch;
 
     public static void main(String[] argv) throws Exception {
+        latch = new CountDownLatch(1);
         try {
             Robot robot = new Robot();
             SwingUtilities.invokeAndWait(() -> createAndShowGUI());
@@ -52,6 +56,7 @@ public class bug4865918 {
             robot.delay(1000);
 
             SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
+            latch.await();
 
             robot.waitForIdle();
             robot.delay(200);
@@ -81,6 +86,11 @@ public class bug4865918 {
         sbar = new TestScrollBar(JScrollBar.HORIZONTAL, -1, 10, -100, 100);
         sbar.setPreferredSize(new Dimension(200, 20));
         sbar.setBlockIncrement(10);
+        sbar.addMouseListener(new MouseAdapter() {
+            public void mousePressed(MouseEvent e) {
+                latch.countDown();
+            }
+        });
 
         frame.getContentPane().add(sbar);
         frame.pack();

--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -37,6 +37,7 @@ import javax.swing.SwingUtilities;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import java.util.Date;
 
@@ -44,10 +45,9 @@ public class bug4865918 {
 
     private static TestScrollBar sbar;
     private static JFrame frame;
-    private static volatile CountDownLatch latch;
+    private static final CountDownLatch mousePressLatch = new CountDownLatch(1);
 
     public static void main(String[] argv) throws Exception {
-        latch = new CountDownLatch(1);
         try {
             Robot robot = new Robot();
             SwingUtilities.invokeAndWait(() -> createAndShowGUI());
@@ -56,7 +56,7 @@ public class bug4865918 {
             robot.delay(1000);
 
             SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
-            latch.await();
+            mousePressLatch.await(2, TimeUnit.SECONDS);
 
             robot.waitForIdle();
             robot.delay(200);
@@ -88,7 +88,7 @@ public class bug4865918 {
         sbar.setBlockIncrement(10);
         sbar.addMouseListener(new MouseAdapter() {
             public void mousePressed(MouseEvent e) {
-                latch.countDown();
+                mousePressLatch.countDown();
             }
         });
 


### PR DESCRIPTION
javax/swing/JScrollBar/4865918/bug4865918.java fails in CI citing

java.lang.RuntimeException: The scrollbar block increment is incorrect
at bug4865918.main(bug4865918.java:60) 

Seems like scrollbar is not in focus when mouse is pressed..Used CountDownLatch to mage focus gain more determinisitic.
Fix is passing in CI in several CI systems

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346324](https://bugs.openjdk.org/browse/JDK-8346324): javax/swing/JScrollBar/4865918/bug4865918.java fails in CI (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**) Review applies to [2eb13c95](https://git.openjdk.org/jdk/pull/22783/files/2eb13c950fdf9f7683bb02ac371a0bf79d7bf68d)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22783/head:pull/22783` \
`$ git checkout pull/22783`

Update a local copy of the PR: \
`$ git checkout pull/22783` \
`$ git pull https://git.openjdk.org/jdk.git pull/22783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22783`

View PR using the GUI difftool: \
`$ git pr show -t 22783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22783.diff">https://git.openjdk.org/jdk/pull/22783.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22783#issuecomment-2547720794)
</details>
