### PR TITLE
8346378: Cannot use DllMain in libnet for static builds

### DIFF
--- a/src/java.base/share/native/libnet/net_util.c
+++ b/src/java.base/share/native/libnet/net_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,10 @@ DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
     jint preferIPv4Stack;
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
         return JNI_EVERSION; /* JNI version not supported */
+    }
+
+    if (NET_PlatformInit() != 0) {
+      return JNI_ERR;
     }
 
     iCls = (*env)->FindClass(env, "java/lang/Boolean");

--- a/src/java.base/share/native/libnet/net_util.h
+++ b/src/java.base/share/native/libnet/net_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,6 +154,8 @@ int NET_IPv4MappedToIPv4(jbyte* caddr);
 int NET_IsEqual(jbyte* caddr1, jbyte* caddr2);
 
 int NET_IsZeroAddr(jbyte* caddr);
+
+int NET_PlatformInit();
 
 /* Socket operations
  *

--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,15 @@
 #if defined(__linux__) && !defined(IPV6_FLOWINFO_SEND)
 #define IPV6_FLOWINFO_SEND      33
 #endif
+
+/* Perform platform specific initialization.
+ * Returns 0 on success, non-0 on failure */
+int
+NET_PlatformInit()
+{
+    // Not needed on unix
+    return 0;
+}
 
 void
 NET_ThrowByNameWithLastError(JNIEnv *env, const char *name,

--- a/src/java.base/windows/native/libnet/net_util_md.c
+++ b/src/java.base/windows/native/libnet/net_util_md.c
@@ -101,29 +101,21 @@ static struct {
     { WSA_OPERATION_ABORTED,    0,      "Overlapped operation aborted" },
 };
 
-/*
- * Initialize Windows Sockets API support
- */
-BOOL WINAPI
-DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved)
+static void at_exit_callback(void)
+{
+    WSACleanup();
+}
+
+/* Perform platform specific initialization.
+ * Returns 0 on success, non-0 on failure */
+int
+NET_PlatformInit()
 {
     WSADATA wsadata;
 
-    switch (reason) {
-        case DLL_PROCESS_ATTACH:
-            if (WSAStartup(MAKEWORD(2,2), &wsadata) != 0) {
-                return FALSE;
-            }
-            break;
+    atexit(at_exit_callback);
 
-        case DLL_PROCESS_DETACH:
-            WSACleanup();
-            break;
-
-        default:
-            break;
-    }
-    return TRUE;
+    return WSAStartup(MAKEWORD(2,2), &wsadata);
 }
 
 /*


### PR DESCRIPTION
To be able to properly support static builds on Windows in [JDK-8346377](https://bugs.openjdk.org/browse/JDK-8346377), we cannot use `DllMain`, for two reasons:

1) This is not called for statically linked libraries, and
2) There are multiple `DllMain` definitions throughout the JDK native libraries, causing name collisions.

While it could have been possible to keep the `DllMain` function for non-static builds and just use an alternative solution for static builds, I think it is preferable to have a single solution that works as well for both static and dynamic builds.

On top of this, the existing solution was contrary to [Microsoft recommendations](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsacleanup), which state: "The WSACleanup function typically leads to protocol-specific helper DLLs being unloaded. As a result, the WSACleanup function should not be called from the DllMain function in a application DLL. This can potentially cause deadlocks. "

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346378](https://bugs.openjdk.org/browse/JDK-8346378): Cannot use DllMain in libnet for static builds (**Bug** - P3)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22788/head:pull/22788` \
`$ git checkout pull/22788`

Update a local copy of the PR: \
`$ git checkout pull/22788` \
`$ git pull https://git.openjdk.org/jdk.git pull/22788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22788`

View PR using the GUI difftool: \
`$ git pr show -t 22788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22788.diff">https://git.openjdk.org/jdk/pull/22788.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22788#issuecomment-2548443616)
</details>
