### PR TITLE
8346383: Cannot use DllMain in libdt_socket for static builds

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -1345,6 +1345,10 @@ jdwpTransport_OnLoad(JavaVM *vm, jdwpTransportCallback* cbTablePtr,
     jvm = vm;
     callback = cbTablePtr;
 
+    if (dbgsysPlatformInit() != 0) {
+      return JNI_ERR;
+    }
+
     /* initialize interface table */
     interface.GetCapabilities = &socketTransport_getCapabilities;
     interface.Attach = &socketTransport_attach;

--- a/src/jdk.jdwp.agent/share/native/libdt_socket/sysSocket.h
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/sysSocket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdwp.agent/share/native/libdt_socket/sysSocket.h
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/sysSocket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@
 typedef int socklen_t;
 #endif
 
+int dbgsysPlatformInit();
 int dbgsysSocketClose(int fd);
 int dbgsysConnect(int fd, struct sockaddr *him, socklen_t len);
 int dbgsysFinishConnect(int fd, int timeout);

--- a/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,15 @@
 
 #include "socket_md.h"
 #include "sysSocket.h"
+
+/* Perform platform specific initialization.
+ * Returns 0 on success, non-0 on failure */
+int
+dbgsysPlatformInit()
+{
+    // Not needed on unix
+    return 0;
+}
 
 int
 dbgsysListen(int fd, int backlog) {

--- a/src/jdk.jdwp.agent/windows/native/libdt_socket/socket_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libdt_socket/socket_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdwp.agent/windows/native/libdt_socket/socket_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libdt_socket/socket_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+#include <stdlib.h>
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -88,30 +89,21 @@ static struct {
     { WSA_OPERATION_ABORTED,    "Overlapped operation aborted" },
 };
 
+static void dbgsysAtExitCallback(void)
+{
+    WSACleanup();
+}
 
-/*
- * Initialize Windows Sockets API support
- */
-BOOL WINAPI
-DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved)
+/* Perform platform specific initialization.
+ * Returns 0 on success, non-0 on failure */
+int
+dbgsysPlatformInit()
 {
     WSADATA wsadata;
 
-    switch (reason) {
-        case DLL_PROCESS_ATTACH:
-            if (WSAStartup(MAKEWORD(2,2), &wsadata) != 0) {
-                return FALSE;
-            }
-            break;
+    atexit(dbgsysAtExitCallback);
 
-        case DLL_PROCESS_DETACH:
-            WSACleanup();
-            break;
-
-        default:
-            break;
-    }
-    return TRUE;
+    return WSAStartup(MAKEWORD(2,2), &wsadata);
 }
 
 /*


### PR DESCRIPTION
To be able to properly support static builds on Windows in [JDK-8346377](https://bugs.openjdk.org/browse/JDK-8346377), we cannot use `DllMain`, for two reasons:

1) This is not called for statically linked libraries, and
2) There are multiple `DllMain` definitions throughout the JDK native libraries, causing name collisions.

While it could have been possible to keep the `DllMain` function for non-static builds and just use an alternative solution for static builds, I think it is preferable to have a single solution that works as well for both static and dynamic builds.

On top of this, the existing solution was contrary to [Microsoft recommendations](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsacleanup), which state: "The WSACleanup function typically leads to protocol-specific helper DLLs being unloaded. As a result, the WSACleanup function should not be called from the DllMain function in a application DLL. This can potentially cause deadlocks. "

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346383](https://bugs.openjdk.org/browse/JDK-8346383): Cannot use DllMain in libdt_socket for static builds (**Bug** - P3)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) Review applies to [ea53ff03](https://git.openjdk.org/jdk/pull/22789/files/ea53ff03f793c13e51d0b3f9b70e3c52f2e5acbd)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22789/head:pull/22789` \
`$ git checkout pull/22789`

Update a local copy of the PR: \
`$ git checkout pull/22789` \
`$ git pull https://git.openjdk.org/jdk.git pull/22789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22789`

View PR using the GUI difftool: \
`$ git pr show -t 22789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22789.diff">https://git.openjdk.org/jdk/pull/22789.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22789#issuecomment-2548444546)
</details>
