### PR TITLE
8346432: java.lang.foreign.Linker comment typo

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -797,7 +797,7 @@ public sealed interface Linker permits AbstractLinker {
          *     arguments</li>
          * <li>{@code N}, none of the arguments passed to the function are passed as
          *     variadic arguments</li>
-         * <li>{@code n}, where {@code 0 < m < N}, the arguments {@code m..N} are passed
+         * <li>{@code m}, where {@code 0 < m < N}, the arguments {@code m..N-1} are passed
          *     as variadic arguments</li>
          * </ul>
          * It is important to always use this linker option when linking a


### PR DESCRIPTION
There are 2 typos and I find the API a bit complex so it does not help a new perplexed user of the API to be additionally confused by typos.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346432](https://bugs.openjdk.org/browse/JDK-8346432): java.lang.foreign.Linker comment typo (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22792/head:pull/22792` \
`$ git checkout pull/22792`

Update a local copy of the PR: \
`$ git checkout pull/22792` \
`$ git pull https://git.openjdk.org/jdk.git pull/22792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22792`

View PR using the GUI difftool: \
`$ git pr show -t 22792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22792.diff">https://git.openjdk.org/jdk/pull/22792.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22792#issuecomment-2548513713)
</details>
