### PR TITLE
8346439: Allow late binding of module services in custom layers

### DIFF
--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -48,6 +48,7 @@ import jdk.internal.javac.Restricted;
 import jdk.internal.loader.ClassLoaderValue;
 import jdk.internal.loader.Loader;
 import jdk.internal.loader.LoaderPool;
+import jdk.internal.module.Modules;
 import jdk.internal.module.ServicesCatalog;
 import jdk.internal.misc.CDS;
 import jdk.internal.reflect.CallerSensitive;
@@ -296,6 +297,52 @@ public final class ModuleLayer {
         public Controller addOpens(Module source, String pn, Module target) {
             ensureInLayer(source);
             source.implAddOpens(pn, target);
+            return this;
+        }
+
+        /**
+         * Updates module {@code source} in the layer to use a service.
+         *
+         * @param  source
+         *         The source module
+         * @param  service
+         *         The service class
+         *
+         * @return This controller
+         *
+         * @throws IllegalArgumentException
+         *         If {@code source} is not in the module layer
+         *
+         * @see Module#addUses
+         *
+         * @since 25
+         */
+        public Controller addUses(Module source, Class<?> service) {
+            ensureInLayer(source);
+            source.implAddUses(service);
+            return this;
+        }
+
+        /**
+         * Updates module {@code source} in the layer to provide a service.
+         *
+         * @param  source
+         *         The source module
+         * @param  service
+         *         The service class
+         * @param  impl
+         *         The implementation class
+         *
+         * @return This controller
+         *
+         * @throws IllegalArgumentException
+         *         If {@code source} is not in the module layer
+         *
+         * @since 25
+         */
+        public Controller addProvides(Module source, Class<?> service, Class<?> impl) {
+            ensureInLayer(source);
+            Modules.addProvides(source, service, impl);
             return this;
         }
 

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -324,10 +324,9 @@ public final class ModuleLayer {
         }
 
         /**
-         * Updates module {@code source} in the layer to provide a service.
+         * Updates the module layer to locate a service of the given type using
+         * the given implementation class.
          *
-         * @param  source
-         *         The source module
          * @param  service
          *         The service class
          * @param  impl
@@ -335,14 +334,12 @@ public final class ModuleLayer {
          *
          * @return This controller
          *
-         * @throws IllegalArgumentException
-         *         If {@code source} is not in the module layer
-         *
          * @since 25
          */
-        public Controller addProvides(Module source, Class<?> service, Class<?> impl) {
-            ensureInLayer(source);
-            Modules.addProvides(source, service, impl);
+        public Controller addProvider(Class<?> service, Class<?> impl) {
+            // the implementation module for the service may be named or unnamed
+            Module implModule = impl.getModule();
+            Modules.addProvider(layer, service, impl);
             return this;
         }
 

--- a/src/java.base/share/classes/jdk/internal/module/Modules.java
+++ b/src/java.base/share/classes/jdk/internal/module/Modules.java
@@ -180,7 +180,6 @@ public class Modules {
      * @param impl the service implementation class (must not be {@code null})
      */
     public static void addProvider(ModuleLayer layer, Class<?> service, Class<?> impl) {
-        // throws NPE if the layer is null
         JLA.getServicesCatalog(layer).addProvider(impl.getModule(), service, impl);
     }
 

--- a/src/java.base/share/classes/jdk/internal/module/Modules.java
+++ b/src/java.base/share/classes/jdk/internal/module/Modules.java
@@ -173,6 +173,18 @@ public class Modules {
     }
 
     /**
+     * Add a provider to a module layer.
+     *
+     * @param layer the layer ot add the provider to (must not be {@code null})
+     * @param service the service class (must not be {@code null})
+     * @param impl the service implementation class (must not be {@code null})
+     */
+    public static void addProvider(ModuleLayer layer, Class<?> service, Class<?> impl) {
+        // throws NPE if the layer is null
+        JLA.getServicesCatalog(layer).addProvider(impl.getModule(), service, impl);
+    }
+
+    /**
      * Resolves a collection of root modules, with service binding and the empty
      * Configuration as the parent to create a Configuration for the boot layer.
      *


### PR DESCRIPTION
Custom module layers allow for lazy loading, late binding, and full customization of module dependencies through the `Controller` API. However, it is not possible for custom layer users to late-bind services, which has prevented some popular application containers from moving to use Java modules.

Add an API to `ModuleLayer.Controller` to allow adding `uses` and `provides` relationships after a module has been defined for custom layers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 25 to be approved (needs to be created)

### Issue
 * [JDK-8346439](https://bugs.openjdk.org/browse/JDK-8346439): Allow late binding of module services in custom layers (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22796/head:pull/22796` \
`$ git checkout pull/22796`

Update a local copy of the PR: \
`$ git checkout pull/22796` \
`$ git pull https://git.openjdk.org/jdk.git pull/22796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22796`

View PR using the GUI difftool: \
`$ git pr show -t 22796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22796.diff">https://git.openjdk.org/jdk/pull/22796.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22796#issuecomment-2548971024)
</details>
