### PR TITLE
8346132: fallbacklinker.c failed compilation due to unused variable

### DIFF
--- a/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
+++ b/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
@@ -165,7 +165,7 @@ Java_jdk_internal_foreign_abi_fallback_LibFallback_doDowncall(JNIEnv* env, jclas
 static void do_upcall(ffi_cif* cif, void* ret, void** args, void* user_data) {
   // attach thread
   JNIEnv* env;
-  jint result = (*VM)->AttachCurrentThreadAsDaemon(VM, (void**) &env, NULL);
+  (*VM)->AttachCurrentThreadAsDaemon(VM, (void**) &env, NULL);
 
   // call into doUpcall in LibFallback
   jobject upcall_data = (jobject) user_data;


### PR DESCRIPTION
A simple fix for removing an unused variable in fallbacklinker.c. This is needed for building zero jvm variant on macosx-x64.

Testing:

- [x] tier1
- [x] zero jvm variant build on macosx-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346132](https://bugs.openjdk.org/browse/JDK-8346132): fallbacklinker.c failed compilation due to unused variable (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22799/head:pull/22799` \
`$ git checkout pull/22799`

Update a local copy of the PR: \
`$ git checkout pull/22799` \
`$ git pull https://git.openjdk.org/jdk.git pull/22799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22799`

View PR using the GUI difftool: \
`$ git pr show -t 22799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22799.diff">https://git.openjdk.org/jdk/pull/22799.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22799#issuecomment-2549712198)
</details>
