### PR TITLE
8346477: Clarify the Java manpage in relation to the JVM's OnOutOfMemoryError flags

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1297,6 +1297,11 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
     contains spaces, then it must be enclosed in quotation marks. For an
     example of a command string, see the description of the `-XX:OnError`
     option.
+    This applies only to `OutOfMemoryError` exceptions caused by Java Heap
+    exhaustion; it does not apply to `OutOfMemoryError` exceptions thrown
+    directly from Java code, nor by the JVM for other types of resource
+    exhaustion (such as native thread creation errors).
+
     This does not apply to any `OutOfMemoryError` thrown by Java, or native,
     code in the JDK libraries.
 
@@ -2196,8 +2201,10 @@ perform extensive debugging.
     name using the `-XX:HeapDumpPath` option. By default, this option is
     disabled and the heap isn't dumped when an `OutOfMemoryError` exception is
     thrown.
-    This does not apply to any `OutOfMemoryError` thrown by Java, or native,
-    code in the JDK libraries.
+    This applies only to `OutOfMemoryError` exceptions caused by Java Heap
+    exhaustion; it does not apply to `OutOfMemoryError` exceptions thrown
+    directly from Java code, nor by the JVM for other types of resource
+    exhaustion (such as native thread creation errors).
 
 `-XX:HeapDumpPath=`*path*
 :   Sets the path and file name for writing the heap dump provided by the heap

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1302,9 +1302,6 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
     directly from Java code, nor by the JVM for other types of resource
     exhaustion (such as native thread creation errors).
 
-    This does not apply to any `OutOfMemoryError` thrown by Java, or native,
-    code in the JDK libraries.
-
 `-XX:+PrintCommandLineFlags`
 :   Enables printing of ergonomically selected JVM flags that appeared on the
     command line. It can be useful to know the ergonomic values set by the JVM,

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1292,10 +1292,13 @@ These `java` options control the runtime behavior of the Java HotSpot VM.
 
 `-XX:OnOutOfMemoryError=`*string*
 :   Sets a custom command or a series of semicolon-separated commands to run
-    when an `OutOfMemoryError` exception is first thrown. If the string
+    when an `OutOfMemoryError` exception is first thrown by the JVM.
+    If the string
     contains spaces, then it must be enclosed in quotation marks. For an
     example of a command string, see the description of the `-XX:OnError`
     option.
+    This does not apply to any `OutOfMemoryError` thrown by Java, or native,
+    code in the JDK libraries.
 
 `-XX:+PrintCommandLineFlags`
 :   Enables printing of ergonomically selected JVM flags that appeared on the
@@ -2189,10 +2192,12 @@ perform extensive debugging.
 `-XX:+HeapDumpOnOutOfMemoryError`
 :   Enables the dumping of the Java heap to a file in the current directory by
     using the heap profiler (HPROF) when a `java.lang.OutOfMemoryError`
-    exception is thrown. You can explicitly set the heap dump file path and
+    exception is thrown by the JVM. You can explicitly set the heap dump file path and
     name using the `-XX:HeapDumpPath` option. By default, this option is
     disabled and the heap isn't dumped when an `OutOfMemoryError` exception is
     thrown.
+    This does not apply to any `OutOfMemoryError` thrown by Java, or native,
+    code in the JDK libraries.
 
 `-XX:HeapDumpPath=`*path*
 :   Sets the path and file name for writing the heap dump provided by the heap


### PR DESCRIPTION
Please review this simple clarification to the Java command reference / manpage.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346477](https://bugs.openjdk.org/browse/JDK-8346477): Clarify the Java manpage in relation to the JVM's OnOutOfMemoryError flags (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Contributors
 * Thomas Stuefe `<stuefe@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22802/head:pull/22802` \
`$ git checkout pull/22802`

Update a local copy of the PR: \
`$ git checkout pull/22802` \
`$ git pull https://git.openjdk.org/jdk.git pull/22802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22802`

View PR using the GUI difftool: \
`$ git pr show -t 22802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22802.diff">https://git.openjdk.org/jdk/pull/22802.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22802#issuecomment-2550157789)
</details>
