### PR TITLE
8338714: vmTestbase/nsk/jdb/kill/kill001/kill001.java fails with JTREG_TEST_THREAD_FACTORY=Virtual

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -87,18 +87,9 @@ vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location002/TestDescription.java
 vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemoryException001.java 8285417 generic-all
 
 ###
-# The test first suspends a vthread and all the carriers and then it resumes the vthread expecting it
-# to run to completion. In mainline it only works because the suspension step happens while the vthread is
-# pinned to the carrier blocked on synchronized. So the carrier only actually suspends on the next unmount
-# transition which in this test happens once the vthread has finished executing the expected code.
-
+# Fails because resume of a virtual thread is not enough to allow the virtual thread
+# to make progress when all other threads are currently suspended.
 vmTestbase/nsk/jdi/ThreadReference/isSuspended/issuspended002/TestDescription.java 8338713 generic-all
-
-###
-# The test sends a StopThread to a vthread expecting that is currently pinned to the carrier blocked on
-# synchronized. Since the vthread is now unmounted StopThread returns JVMTI_ERROR_OPAQUE_FRAME error.
-
-vmTestbase/nsk/jdb/kill/kill001/kill001.java 8338714 generic-all
 
 ###
 # Fails on Windows because of additional memory allocation.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -27,6 +27,7 @@ import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
 import nsk.share.jdi.JDIThreadFactory;
+import jdk.test.lib.thread.VThreadPinner;
 
 import java.io.*;
 import java.util.*;
@@ -152,6 +153,17 @@ class MyThread extends Thread {
     }
 
     public void run() {
+        boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
+        if (vthreadMode) {
+            // JVMTI StopThread is only supported for mounted virtual threads. We need to
+            // pin the virtual threads so they remain mounted.
+            VThreadPinner.runPinned(() -> test());
+        } else {
+            test();
+        }
+    }
+
+    public void test() {
         // Concatenate strings in advance to avoid lambda calculations later
         String ThreadFinished = "Thread finished: " + this.name;
         String CaughtExpected = "Thread " + this.name + " caught expected async exception: " + expectedException;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
@@ -137,6 +137,9 @@ public class Launcher extends DebugeeBinder {
                 /* Some tests need more carrier threads than the default provided. */
                 args.add("-R-Djdk.virtualThreadScheduler.parallelism=15");
             }
+            /* Some jdb tests need java.library.path setup for native libraries. */
+            String libpath = System.getProperty("java.library.path");
+            args.add("-R-Djava.library.path=" + libpath);
         }
 
         args.addAll(argumentHandler.enwrapJavaOptions(argumentHandler.getJavaOptions()));


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [414eb6bb](https://github.com/openjdk/jdk/commit/414eb6bb83d092fbcd87d5ab72519b6eb109837f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Chris Plummer on 17 Dec 2024 and was reviewed by Serguei Spitsyn and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338714](https://bugs.openjdk.org/browse/JDK-8338714): vmTestbase/nsk/jdb/kill/kill001/kill001.java fails with JTREG_TEST_THREAD_FACTORY=Virtual (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22805/head:pull/22805` \
`$ git checkout pull/22805`

Update a local copy of the PR: \
`$ git checkout pull/22805` \
`$ git pull https://git.openjdk.org/jdk.git pull/22805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22805`

View PR using the GUI difftool: \
`$ git pr show -t 22805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22805.diff">https://git.openjdk.org/jdk/pull/22805.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22805#issuecomment-2550529010)
</details>
