### PR TITLE
8344647: Make java.se participate in the preview language feature `requires transitive java.base`

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -155,7 +155,6 @@ module java.base {
     exports jdk.internal.javac to
         java.compiler,
         java.desktop, // for ScopedValue
-        java.se, // for ParticipatesInPreview
         jdk.compiler,
         jdk.incubator.vector, // participates in preview features
         jdk.jartool, // participates in preview features

--- a/src/java.se/share/classes/module-info.java
+++ b/src/java.se/share/classes/module-info.java
@@ -23,8 +23,6 @@
  * questions.
  */
 
-import jdk.internal.javac.ParticipatesInPreview;
-
 /**
  * Defines the API of the Java SE Platform.
  *
@@ -40,7 +38,6 @@ import jdk.internal.javac.ParticipatesInPreview;
  * @moduleGraph
  * @since 9
  */
-@ParticipatesInPreview
 module java.se {
     requires transitive java.base;
     requires transitive java.compiler;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Directive.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Directive.java
@@ -76,7 +76,7 @@ public abstract class Directive implements ModuleElement.Directive {
 
         @Override
         public String toString() {
-            return String.format("ACC_%s (0x%04x", name(), value);
+            return String.format("ACC_%s (0x%04x)", name(), value);
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
@@ -150,7 +150,9 @@ public class Preview {
         // s participates in the preview API
         return syms.java_base.exports.stream()
                 .filter(ed -> ed.packge.fullname == names.jdk_internal_javac)
-                .anyMatch(ed -> ed.modules.contains(m));
+                .anyMatch(ed -> ed.modules.contains(m)) ||
+               //the specification lists the java.se module as participating in preview:
+               m.name == names.java_se;
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3770,7 +3770,7 @@ compiler.misc.cant.resolve.modules=\
     cannot resolve modules
 
 compiler.misc.bad.requires.flag=\
-    bad requires flag: {0}
+    invalid flag for "requires java.base": {0}
 
 # 0: string
 compiler.err.invalid.module.specifier=\

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -127,6 +127,7 @@ public class Names {
 
     // module names
     public final Name java_base;
+    public final Name java_se;
     public final Name jdk_unsupported;
 
     // attribute names
@@ -315,6 +316,7 @@ public class Names {
 
         // module names
         java_base = fromString("java.base");
+        java_se = fromString("java.se");
         jdk_unsupported = fromString("jdk.unsupported");
 
         // attribute names

--- a/test/langtools/tools/javac/modules/AnnotationsOnModules.java
+++ b/test/langtools/tools/javac/modules/AnnotationsOnModules.java
@@ -804,7 +804,7 @@ public class AnnotationsOnModules extends ModuleTestBase {
                 .writeAll()
                 .getOutputLines(OutputKind.DIRECT);
         List<String> expectedErrors = List.of(
-            "- compiler.err.cant.access: m.module-info, (compiler.misc.bad.class.file.header: module-info.class, (compiler.misc.bad.requires.flag: ACC_TRANSITIVE (0x0020))",
+            "- compiler.err.cant.access: m.module-info, (compiler.misc.bad.class.file.header: module-info.class, (compiler.misc.bad.requires.flag: ACC_TRANSITIVE (0x0020)))",
             "1 error"
         );
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d50b725a](https://github.com/openjdk/jdk/commit/d50b725ac0f228f5b04dd68c123c7f6b263c0d02) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 18 Dec 2024 and was reviewed by Adam Sotona and Joe Darcy.

Thanks!

Description from the original PR:
There is a new preview language feature, `requires transitive java.base;`. And the `java.se` module is permitted to use the feature, without being marked as preview (i.e. the `java.se` module participates in preview). This is currently implemented by the common "participates in preview" way, by checking that `java.base` is exporting `jdk.internal.javac` package to `java.se`.

This common way works OK for internal preview feature and API usage, but turns out it may not be appropriate for this feature: the qualified export of the `jdk.internal.javac` package is not a specified API, it is an implementation detail; and the JLS itself specifies that the `java.se` module is participating in preview.

So this PR proposes to change the way javac handles the `java.se` module: it permits the use of the preview feature based on the module name, instead relying on the internal qualified export.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344647](https://bugs.openjdk.org/browse/JDK-8344647): Make java.se participate in the preview language feature `requires transitive java.base` (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22808/head:pull/22808` \
`$ git checkout pull/22808`

Update a local copy of the PR: \
`$ git checkout pull/22808` \
`$ git pull https://git.openjdk.org/jdk.git pull/22808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22808`

View PR using the GUI difftool: \
`$ git pr show -t 22808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22808.diff">https://git.openjdk.org/jdk/pull/22808.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22808#issuecomment-2550904280)
</details>
