### PR TITLE
8346017: Socket.connect specified to throw UHE for unresolved address is problematic for SOCKS V5 proxy

### DIFF
--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -569,9 +569,8 @@ public class Socket implements java.io.Closeable {
     /**
      * Connects this socket to the server.
      *
-     * <p> If the endpoint is an unresolved {@link InetSocketAddress}, or the
-     * connection cannot be established, then the socket is closed, and an
-     * {@link IOException} is thrown.
+     * <p> If the connection cannot be established, then the socket is closed,
+     * and an {@link IOException} is thrown.
      *
      * <p> This method is {@linkplain Thread#interrupt() interruptible} in the
      * following circumstances:
@@ -591,8 +590,8 @@ public class Socket implements java.io.Closeable {
      * @param   endpoint the {@code SocketAddress}
      * @throws  IOException if an error occurs during the connection, the socket
      *          is already connected or the socket is closed
-     * @throws  UnknownHostException if the endpoint is an unresolved
-     *          {@link InetSocketAddress}
+     * @throws  UnknownHostException if the connection could not be established
+     *          because the endpoint is an unresolved {@link InetSocketAddress}
      * @throws  java.nio.channels.IllegalBlockingModeException
      *          if this socket has an associated channel,
      *          and the channel is in non-blocking mode
@@ -609,9 +608,8 @@ public class Socket implements java.io.Closeable {
      * A timeout of zero is interpreted as an infinite timeout. The connection
      * will then block until established or an error occurs.
      *
-     * <p> If the endpoint is an unresolved {@link InetSocketAddress}, the
-     * connection cannot be established, or the timeout expires before the
-     * connection is established, then the socket is closed, and an
+     * <p> If the connection cannot be established, or the timeout expires
+     * before the connection is established, then the socket is closed, and an
      * {@link IOException} is thrown.
      *
      * <p> This method is {@linkplain Thread#interrupt() interruptible} in the
@@ -634,8 +632,8 @@ public class Socket implements java.io.Closeable {
      * @throws  IOException if an error occurs during the connection, the socket
      *          is already connected or the socket is closed
      * @throws  SocketTimeoutException if timeout expires before connecting
-     * @throws  UnknownHostException if the endpoint is an unresolved
-     *          {@link InetSocketAddress}
+     * @throws  UnknownHostException if the connection could not be established
+     *          because the endpoint is an unresolved {@link InetSocketAddress}
      * @throws  java.nio.channels.IllegalBlockingModeException
      *          if this socket has an associated channel,
      *          and the channel is in non-blocking mode
@@ -659,12 +657,6 @@ public class Socket implements java.io.Closeable {
 
         if (!(endpoint instanceof InetSocketAddress epoint))
             throw new IllegalArgumentException("Unsupported address type");
-
-        if (epoint.isUnresolved()) {
-            var uhe = new UnknownHostException(epoint.getHostName());
-            closeSuppressingExceptions(uhe);
-            throw uhe;
-        }
 
         InetAddress addr = epoint.getAddress();
         checkAddress(addr, "connect");

--- a/test/jdk/java/net/Socket/ConnectSocksProxyTest.java
+++ b/test/jdk/java/net/Socket/ConnectSocksProxyTest.java
@@ -22,20 +22,18 @@
  */
 
 import jdk.test.lib.Utils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.net.InetAddress;
+import java.net.Authenticator;
 import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
-import java.net.UnknownHostException;
-import java.nio.channels.SocketChannel;
-import java.util.List;
 
 import static java.net.InetAddress.getLoopbackAddress;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,12 +43,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * @test
- * @bug 8343791
- * @summary verifies that `connect()` failures throw the expected exception and leave socket in the expected state
- * @library /test/lib
- * @run junit ConnectFailTest
+ * @bug 8346017
+ * @summary Verifies the `connect()` behaviour of a SOCKS proxy socket. In particular, that passing a resolvable
+ *          unresolved address doesn't throw an exception.
+ * @library /test/lib /java/net/Socks
+ * @build SocksServer
+ * @run junit ConnectSocksProxyTest
  */
-class ConnectFailTest {
+class ConnectSocksProxyTest {
 
     // Implementation Note: Explicitly binding on the loopback address to avoid potential unstabilities.
 
@@ -61,6 +61,38 @@ class ConnectFailTest {
     private static final InetSocketAddress UNRESOLVED_ADDRESS =
             InetSocketAddress.createUnresolved("no.such.host", DEAD_SERVER_PORT);
 
+    private static final String PROXY_AUTH_USERNAME = "foo";
+
+    private static final String PROXY_AUTH_PASSWORD = "bar";
+
+    private static SocksServer PROXY_SERVER;
+
+    private static Proxy PROXY;
+
+    @BeforeAll
+    static void initAuthenticator() {
+        Authenticator.setDefault(new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(PROXY_AUTH_USERNAME, PROXY_AUTH_PASSWORD.toCharArray());
+            }
+        });
+    }
+
+    @BeforeAll
+    static void initProxyServer() throws IOException {
+        PROXY_SERVER = new SocksServer(getLoopbackAddress(), 0, false);
+        PROXY_SERVER.addUser(PROXY_AUTH_USERNAME, PROXY_AUTH_PASSWORD);
+        PROXY_SERVER.start();
+        InetSocketAddress proxyAddress = new InetSocketAddress(getLoopbackAddress(), PROXY_SERVER.getPort());
+        PROXY = new Proxy(Proxy.Type.SOCKS, proxyAddress);
+    }
+
+    @AfterAll
+    static void stopProxyServer() {
+        PROXY_SERVER.close();
+    }
+
     @Test
     void testUnresolvedAddress() {
         assertTrue(UNRESOLVED_ADDRESS.isUnresolved());
@@ -69,10 +101,9 @@ class ConnectFailTest {
     /**
      * Verifies that an unbound socket is closed when {@code connect()} fails.
      */
-    @ParameterizedTest
-    @MethodSource("sockets")
-    void testUnboundSocket(Socket socket) throws IOException {
-        try (socket) {
+    @Test
+    void testUnboundSocket() throws IOException {
+        try (Socket socket = createProxiedSocket()) {
             assertFalse(socket.isBound());
             assertFalse(socket.isConnected());
             assertThrows(IOException.class, () -> socket.connect(REFUSING_SOCKET_ADDRESS));
@@ -83,10 +114,9 @@ class ConnectFailTest {
     /**
      * Verifies that a bound socket is closed when {@code connect()} fails.
      */
-    @ParameterizedTest
-    @MethodSource("sockets")
-    void testBoundSocket(Socket socket) throws IOException {
-        try (socket) {
+    @Test
+    void testBoundSocket() throws IOException {
+        try (Socket socket = createProxiedSocket()) {
             socket.bind(new InetSocketAddress(getLoopbackAddress(), 0));
             assertTrue(socket.isBound());
             assertFalse(socket.isConnected());
@@ -98,10 +128,10 @@ class ConnectFailTest {
     /**
      * Verifies that a connected socket is not closed when {@code connect()} fails.
      */
-    @ParameterizedTest
-    @MethodSource("sockets")
-    void testConnectedSocket(Socket socket) throws Throwable {
-        try (socket; ServerSocket serverSocket = createEphemeralServerSocket()) {
+    @Test
+    void testConnectedSocket() throws Throwable {
+        try (Socket socket = createProxiedSocket();
+             ServerSocket serverSocket = createEphemeralServerSocket()) {
             socket.connect(serverSocket.getLocalSocketAddress());
             try (Socket _ = serverSocket.accept()) {
                 assertTrue(socket.isBound());
@@ -116,61 +146,73 @@ class ConnectFailTest {
     }
 
     /**
-     * Verifies that an unbound socket is closed when {@code connect()} is invoked using an unresolved address.
+     * Delegates to {@link #testUnconnectedSocketWithUnresolvedAddress(boolean, Socket)} using an unbound socket.
      */
-    @ParameterizedTest
-    @MethodSource("sockets")
-    void testUnboundSocketWithUnresolvedAddress(Socket socket) throws IOException {
-        try (socket) {
+    @Test
+    void testUnboundSocketWithUnresolvedAddress() throws IOException {
+        try (Socket socket = createProxiedSocket()) {
             assertFalse(socket.isBound());
             assertFalse(socket.isConnected());
-            assertThrows(UnknownHostException.class, () -> socket.connect(UNRESOLVED_ADDRESS));
-            assertTrue(socket.isClosed());
+            testUnconnectedSocketWithUnresolvedAddress(false, socket);
         }
     }
 
     /**
-     * Verifies that a bound socket is closed when {@code connect()} is invoked using an unresolved address.
+     * Delegates to {@link #testUnconnectedSocketWithUnresolvedAddress(boolean, Socket)} using a bound socket.
      */
-    @ParameterizedTest
-    @MethodSource("sockets")
-    void testBoundSocketWithUnresolvedAddress(Socket socket) throws IOException {
-        try (socket) {
+    @Test
+    void testBoundSocketWithUnresolvedAddress() throws IOException {
+        try (Socket socket = createProxiedSocket()) {
             socket.bind(new InetSocketAddress(getLoopbackAddress(), 0));
-            assertTrue(socket.isBound());
-            assertFalse(socket.isConnected());
-            assertThrows(UnknownHostException.class, () -> socket.connect(UNRESOLVED_ADDRESS));
-            assertTrue(socket.isClosed());
+            testUnconnectedSocketWithUnresolvedAddress(true, socket);
+        }
+    }
+
+    /**
+     * Verifies the behaviour of an unconnected socket when {@code connect()} is invoked using an unresolved address.
+     */
+    private static void testUnconnectedSocketWithUnresolvedAddress(boolean bound, Socket socket) throws IOException {
+        assertEquals(bound, socket.isBound());
+        assertFalse(socket.isConnected());
+        try (ServerSocket serverSocket = createEphemeralServerSocket()) {
+            InetSocketAddress unresolvedAddress = InetSocketAddress.createUnresolved(
+                    getLoopbackAddress().getHostAddress(),
+                    serverSocket.getLocalPort());
+            socket.connect(unresolvedAddress);
+            try (Socket _ = serverSocket.accept()) {
+                assertTrue(socket.isBound());
+                assertTrue(socket.isConnected());
+                assertFalse(socket.isClosed());
+            }
         }
     }
 
     /**
      * Verifies that a connected socket is not closed when {@code connect()} is invoked using an unresolved address.
      */
-    @ParameterizedTest
-    @MethodSource("sockets")
-    void testConnectedSocketWithUnresolvedAddress(Socket socket) throws Throwable {
-        try (socket; ServerSocket serverSocket = createEphemeralServerSocket()) {
+    @Test
+    void testConnectedSocketWithUnresolvedAddress() throws Throwable {
+        try (Socket socket = createProxiedSocket();
+             ServerSocket serverSocket = createEphemeralServerSocket()) {
             socket.connect(serverSocket.getLocalSocketAddress());
             try (Socket _ = serverSocket.accept()) {
                 assertTrue(socket.isBound());
                 assertTrue(socket.isConnected());
-                assertThrows(IOException.class, () -> socket.connect(UNRESOLVED_ADDRESS));
+                SocketException exception = assertThrows(
+                        SocketException.class,
+                        () -> socket.connect(UNRESOLVED_ADDRESS));
+                assertEquals("Already connected", exception.getMessage());
                 assertFalse(socket.isClosed());
             }
         }
     }
 
-    static List<Socket> sockets() throws Exception {
-        Socket socket = new Socket();
-        @SuppressWarnings("resource")
-        Socket channelSocket = SocketChannel.open().socket();
-        Socket noProxySocket = new Socket(Proxy.NO_PROXY);
-        return List.of(socket, channelSocket, noProxySocket);
+    private static Socket createProxiedSocket() {
+        return new Socket(PROXY);
     }
 
     private static ServerSocket createEphemeralServerSocket() throws IOException {
-        return new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
+        return new ServerSocket(0, 0, getLoopbackAddress());
     }
 
 }


### PR DESCRIPTION
This is a clean backport of [JDK-8346518](https://bugs.openjdk.org/browse/JDK-8346518).
CSR already approved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8346204](https://bugs.openjdk.org/browse/JDK-8346204) to be approved

### Issues
 * [JDK-8346017](https://bugs.openjdk.org/browse/JDK-8346017): Socket.connect specified to throw UHE for unresolved address is problematic for SOCKS V5 proxy (**Bug** - P2)
 * [JDK-8346204](https://bugs.openjdk.org/browse/JDK-8346204): Socket.connect specified to throw UHE for unresolved address is problematic for SOCKS V5 proxy (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22809/head:pull/22809` \
`$ git checkout pull/22809`

Update a local copy of the PR: \
`$ git checkout pull/22809` \
`$ git pull https://git.openjdk.org/jdk.git pull/22809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22809`

View PR using the GUI difftool: \
`$ git pr show -t 22809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22809.diff">https://git.openjdk.org/jdk/pull/22809.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22809#issuecomment-2551366533)
</details>
