### PR TITLE
8344130: C2: Avoid excessive hoisting in scheduler due to minuscule differences in block frequency

### DIFF
--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -1252,13 +1252,15 @@ bool PhaseCFG::is_cheaper_block(Block* LCA, Node* self, uint target_latency,
     return C->randomized_select(cand_cnt);
   }
 
-  // Better Frequency
-  if (LCA->_freq < least_freq) {
+  const double delta = 1 + PROB_UNLIKELY_MAG(4);
+
+  // Better Frequency. Add a small delta to the comparison to not needlessly
+  // hoist because of, e.g., small numerical inaccuracies.
+  if (LCA->_freq * delta < least_freq) {
     return true;
   }
 
   // Otherwise, choose with latency
-  const double delta = 1 + PROB_UNLIKELY_MAG(4);
   if (!in_latency                     &&  // No block containing latency
       LCA->_freq < least_freq * delta &&  // No worse frequency
       target_latency >= end_latency   &&  // within latency range


### PR DESCRIPTION
### Issue Summary

`PhaseCFG::is_cheaper_block` can sometimes excessively hoist instructions through blocks due to minuscule differences in block frequency, even when the differences are likely caused by numerical imprecision in the block frequency computations. We saw an example of where such excessive hoisting stressed the register allocator in [JDK-8331295](https://bugs.openjdk.org/browse/JDK-8331295), but that issue was in fact two issues: one in the matcher (solved in [JDK-8331295](https://bugs.openjdk.org/browse/JDK-8331295)) and one in the scheduler (this issue).

### Changeset

Add a small delta to the frequency comparison in `PhaseCFG::is_cheaper_block`. Note that a frequency comparison using the delta is already available in the function when making sure a hoist due to latency does not result in a higher (worse) frequency. I cannot see any reason for why we should not use the same delta in the first block frequency comparison.

I do not include a regression test since I have not found a good one specific to this issue. I have verified that this fix is an alternative solution to solve the failure in [JDK-8331295](https://bugs.openjdk.org/browse/JDK-8331295) (for which tests are already present). I also documented the verification steps in the issue description in JBS.

### Testing

- [GitHub Actions](https://github.com/dlunde/jdk/actions/runs/12181425502)
- `tier1` to `tier4` (and additional Oracle-internal testing) on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64.
- Performance testing using DaCapo, SPECjbb, and SPECjvm on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64. No significant improvements nor regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344130](https://bugs.openjdk.org/browse/JDK-8344130): C2: Avoid excessive hoisting in scheduler due to minuscule differences in block frequency (**Bug** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22810/head:pull/22810` \
`$ git checkout pull/22810`

Update a local copy of the PR: \
`$ git checkout pull/22810` \
`$ git pull https://git.openjdk.org/jdk.git pull/22810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22810`

View PR using the GUI difftool: \
`$ git pr show -t 22810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22810.diff">https://git.openjdk.org/jdk/pull/22810.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22810#issuecomment-2551371405)
</details>
