### PR TITLE
8346570: SM cleanup of tests for Beans and Serialization

### DIFF
--- a/test/jdk/java/beans/Introspector/8132566/OverrideUserDefPropertyInfoTest.java
+++ b/test/jdk/java/beans/Introspector/8132566/OverrideUserDefPropertyInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,7 +118,7 @@ public class OverrideUserDefPropertyInfoTest {
                 m[0] = new MethodDescriptor(Base.class.getMethod("setX", new Class[] {int.class}));
                 m[0].setDisplayName("");
             }
-            catch( NoSuchMethodException | SecurityException e) {}
+            catch( NoSuchMethodException e) {}
             return m;
         }
 

--- a/test/jdk/java/beans/XMLEncoder/BeanValidator.java
+++ b/test/jdk/java/beans/XMLEncoder/BeanValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,7 +117,7 @@ final class BeanValidator {
         try {
             this.cache.put(object1, object2);
             // validate values of public fields
-            for (Field field : getFields(type)) {
+            for (Field field : type.getFields()) {
                 int mod = field.getModifiers();
                 if (!Modifier.isStatic(mod)) {
                     log("validate field", field.getName());
@@ -239,22 +239,7 @@ final class BeanValidator {
         catch (NoSuchMethodException exception) {
             log(exception);
         }
-        catch (SecurityException exception) {
-            log(exception);
-        }
         return false;
-    }
-
-    private static final Field[] FIELDS = {};
-
-    private Field[] getFields(Class type) {
-        try {
-            return type.getFields();
-        }
-        catch (SecurityException exception) {
-            log(exception);
-        }
-        return FIELDS;
     }
 
     private static final PropertyDescriptor[] DESCRIPTORS = {};

--- a/test/jdk/java/io/Serializable/subclass/AbstractObjectInputStream.java
+++ b/test/jdk/java/io/Serializable/subclass/AbstractObjectInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,13 +26,6 @@
  */
 
 import java.io.*;
-import java.util.Vector;
-import java.util.Stack;
-import java.util.Hashtable;
-import java.lang.Math;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 
 /**
  * This abstract class enables one to subclass ObjectInputStream
@@ -43,9 +36,7 @@ import java.lang.reflect.Modifier;
  * Since serialization must override java access rules in order to
  * access private, protected and package accessible Serializable fields,
  * only trusted classes are allowed to subclass AbstractObjectInputStream.
- * Subclasses of AbstractObjectInputStream must define SerializablePermission
- * "enableAbstractSubclass" within a security policy file or this
- * constructor will throw a SecurityException. Implementations of this
+ * Implementations of this
  * class should protect themselves from being subclassed in a way that will
  * provide access to object references and other sensitive info.
  * Specifically, readObjectOverride() should be made final.
@@ -149,17 +140,8 @@ public abstract class AbstractObjectInputStream extends ObjectInputStream
     /**
      * Create an ObjectInputStream that reads from the specified InputStream.<p>
      *
-     * Add the following line to the security policy file to enable
-     * subclassing.
-     *
-     * <PRE>
-     *     permission SerializablePermission "enableAbstractSubclass" ;
-     * </PRE><p>
-     *
      * @exception StreamCorruptedException The version or magic number are incorrect.
      * @exception IOException An exception occurred in the underlying stream.
-     * @exception SecurityException if subclass does not have SerializablePermiision
-     *            "enableAbstractSubclass".
      */
     public AbstractObjectInputStream(InputStream in)
         throws IOException, StreamCorruptedException
@@ -286,7 +268,7 @@ public abstract class AbstractObjectInputStream extends ObjectInputStream
     public abstract ObjectInputStream.GetField readFields()
         throws IOException, ClassNotFoundException, NotActiveException;
 
-    protected abstract boolean enableResolveObject(boolean enable) throws SecurityException;
+    protected abstract boolean enableResolveObject(boolean enable);
 
     public abstract void registerValidation(ObjectInputValidation obj,
                                             int prio)

--- a/test/jdk/java/io/Serializable/subclass/AbstractObjectOutputStream.java
+++ b/test/jdk/java/io/Serializable/subclass/AbstractObjectOutputStream.java
@@ -45,9 +45,7 @@ import java.io.ObjectOutputStream;
  * Since serialization must override java access rules in order to
  * access private, protected and package accessible Serializable fields,
  * only trusted classes are allowed to subclass AbstractObjectOutputStream.
- * Subclasses of AbstractObjectOututStream must have SerializablePermission
- * "enableAbstractSubclass" or this constructor will throw a
- * SecurityException.Implementations of this class should protect themselves
+ * Implementations of this class should protect themselves
  * from being subclassed in a way that will provide access to object
  * references and other sensitive info. Specifically, writeObjectOverride()
  * should be made final.
@@ -142,13 +140,6 @@ public abstract class AbstractObjectOutputStream extends ObjectOutputStream
     /**
      * Creates an ObjectOutputStream that writes to the specified OutputStream.
      *
-     * Add the following line to the security policy file to enable
-     * subclassing.
-     *
-     * <PRE>
-     *     permission SerializablePermission "enableAbstractSubclass" ;
-     * </PRE><p>
-     *
      * @exception IOException Any exception thrown by the underlying OutputStream.
      * @see java.io.ObjectOutputStream#writeStreamHeader()
      */
@@ -231,7 +222,7 @@ public abstract class AbstractObjectOutputStream extends ObjectOutputStream
      */
     public abstract void writeFields() throws IOException;
 
-    protected abstract boolean enableReplaceObject(boolean enable) throws SecurityException;
+    protected abstract boolean enableReplaceObject(boolean enable);
 
     /*******************************************************************/
     /* Write Primitive Data to stream.  DataOutput methods. */

--- a/test/jdk/java/io/Serializable/subclass/SubclassTest.java
+++ b/test/jdk/java/io/Serializable/subclass/SubclassTest.java
@@ -31,13 +31,6 @@
  *          An entire protocol would need to be implemented and written
  *          out before being able to test the input side of the API.
  *
- *          Also, would be appropriate that this program verify
- *          that if SerializablePermission "enableSubclassImplementation"
- *          is not in the security policy and security is enabled, that
- *          a security exception is thrown when constructing the
- *          ObjectOutputStream subclass.
- *
- *
  * @compile AbstractObjectInputStream.java AbstractObjectOutputStream.java
  * @compile XObjectInputStream.java XObjectOutputStream.java
  * @compile SubclassTest.java
@@ -129,8 +122,6 @@ public class SubclassTest {
     public static void main(String argv[])
         throws IOException, ClassNotFoundException
     {
-        boolean expectSecurityException = false;
-
         ByteArrayOutputStream baos = new ByteArrayOutputStream(20);
         XObjectOutputStream os = null;
         os = new XObjectOutputStream(baos);

--- a/test/jdk/java/io/Serializable/subclass/XObjectInputStream.java
+++ b/test/jdk/java/io/Serializable/subclass/XObjectInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,20 +72,6 @@ class XObjectInputStream extends AbstractObjectInputStream {
                 throw new InvalidClassException(currentClassDescriptor.getName(),
                                                 e.getMessage());
             }
-
-            //if currentDescriptor.isAssignable(Externalizable.class) {
-            //    Object[] argList = {this};
-            //    InvokeMethod(currentObject, readExternalMethod, argList);
-            //} else {
-            //    Does currentDescriptor have a readObject method
-            //    if it does
-            //        invokeMethod(this, readObjectMethod, {this});
-            //    else
-            //        defaultReadObject();
-            //}
-            // check for replacement on currentObject.
-            // if toplevel readobject
-            //    doObjectValidations.
 
         } finally {
             readResult = currentObject;
@@ -245,82 +231,9 @@ class XObjectInputStream extends AbstractObjectInputStream {
     private Object currentObject;
     private Class<?> currentClassDescriptor;
 
-
-
-    /****************************************************************/
-
-    /* CODE LIFTED FROM ObjectStreamClass constuctor.
-     * ObjectStreamClass.readObjectMethod is private.
-     *
-     * Look for the readObject method
-     * Set the accessible flag on it here. ObjectOutputStream
-     * will call it as necessary.
-     */
-    public static Method getReadObjectMethod(final Class<?> cl) {
-
-        Method readObjectMethod =
-            java.security.AccessController.doPrivileged
-            (new java.security.PrivilegedAction<Method>() {
-                public Method run() {
-                    Method m = null;
-                    try {
-                        Class<?>[] args = {ObjectInputStream.class};
-                        m = cl.getDeclaredMethod("readObject", args);
-                        int mods = m.getModifiers();
-                        // Method must be private and non-static
-                        if (!Modifier.isPrivate(mods) ||
-                            Modifier.isStatic(mods)) {
-                            m = null;
-                        } else {
-                            m.setAccessible(true);
-                        }
-                    } catch (NoSuchMethodException e) {
-                        m = null;
-                    }
-                    return m;
-                }
-            });
-        return readObjectMethod;
-    }
-
     /*************************************************************/
 
-    /* taken verbatim from ObjectInputStream. */
-    private static void invokeMethod(final Object obj, final Method m,
-                                        final Object[] argList)
-        throws IOException
-    {
-        try {
-            java.security.AccessController.doPrivileged
-                (new java.security.PrivilegedExceptionAction<Void>() {
-                    public Void run() throws InvocationTargetException,
-                                        java.lang.IllegalAccessException {
-                        m.invoke(obj, argList);
-                        return null;
-                    }
-                });
-        } catch (java.security.PrivilegedActionException e) {
-            Exception ex = e.getException();
-            if (ex instanceof InvocationTargetException) {
-                Throwable t =
-                        ((InvocationTargetException)ex).getTargetException();
-                if (t instanceof IOException)
-                    throw (IOException)t;
-                else if (t instanceof RuntimeException)
-                    throw (RuntimeException) t;
-                else if (t instanceof Error)
-                    throw (Error) t;
-                else
-                    throw new Error("interal error");
-            } else {
-                // IllegalAccessException cannot happen
-            }
-        }
-    }
-
-    protected boolean enableResolveObject(boolean enable)
-        throws SecurityException
-    {
+    protected boolean enableResolveObject(boolean enable) {
         throw new Error("To be implemented");
     }
 


### PR DESCRIPTION
Continuing SM removal cleanup of tests for test/jdk/java/beans and test/jdk/java/io/Serializable. 
Removing doPrivileged, Permissions, and SecurityException.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346570](https://bugs.openjdk.org/browse/JDK-8346570): SM cleanup of tests for Beans and Serialization (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22813/head:pull/22813` \
`$ git checkout pull/22813`

Update a local copy of the PR: \
`$ git checkout pull/22813` \
`$ git pull https://git.openjdk.org/jdk.git pull/22813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22813`

View PR using the GUI difftool: \
`$ git pr show -t 22813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22813.diff">https://git.openjdk.org/jdk/pull/22813.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22813#issuecomment-2551559863)
</details>
