### PR TITLE
8346468: SM cleanup of common test library

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestHumongousConcurrentStartUndo.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousConcurrentStartUndo.java
@@ -34,7 +34,6 @@ package gc.g1;
  *          java.management
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- *             jdk.test.whitebox.WhiteBox$WhiteBoxPermission
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   gc.g1.TestHumongousConcurrentStartUndo
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
@@ -130,36 +130,6 @@ public class JarBuilder {
         executeProcess(args.toArray(new String[1]));
     }
 
-    // Add commonly used inner classes that are often omitted by mistake. Currently
-    // we support only jdk/test/whitebox/WhiteBox$WhiteBoxPermission.
-    // See JDK-8199290
-    private static String[] addInnerClasses(String[] classes, int startIdx) {
-        boolean seenNewWb = false;
-        boolean seenNewWbInner = false;
-        // This method is different than ClassFileInstaller.addInnerClasses which
-        // uses "." as the package delimiter :-(
-        final String newWb = "jdk/test/whitebox/WhiteBox";
-        final String newWbInner = newWb + "$WhiteBoxPermission";
-
-        ArrayList<String> list = new ArrayList<>();
-
-        for (int i = startIdx; i < classes.length; i++) {
-            String cls = classes[i];
-            list.add(cls);
-            switch (cls) {
-            case newWb:      seenNewWb      = true; break;
-            case newWbInner: seenNewWbInner = true; break;
-            }
-        }
-        if (seenNewWb && !seenNewWbInner) {
-            list.add(newWbInner);
-        }
-        String[] array = new String[list.size()];
-        list.toArray(array);
-        return array;
-    }
-
-
     private static String createSimpleJar(String jarclassDir, String jarName,
         String[] classNames) throws Exception {
 
@@ -174,8 +144,6 @@ public class JarBuilder {
 
     private static void addClassArgs(ArrayList<String> args, String jarclassDir,
         String[] classNames) {
-
-        classNames = addInnerClasses(classNames, 0);
 
         for (String name : classNames) {
             args.add("-C");

--- a/test/lib/jdk/test/lib/NetworkConfiguration.java
+++ b/test/lib/jdk/test/lib/NetworkConfiguration.java
@@ -39,8 +39,6 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import static java.net.NetworkInterface.getNetworkInterfaces;
 import static java.util.Collections.list;
@@ -111,7 +109,7 @@ public class NetworkConfiguration {
      * was looked up.
      *
      * @param ni1 A network interface, may be {@code null}
-     * @param ni2 An other network interface, may be {@code null}
+     * @param ni2 Another network interface, may be {@code null}
      * @return {@code true} if the two network interfaces have the same name
      *         and index, {@code false} otherwise.
      */
@@ -447,19 +445,15 @@ public class NetworkConfiguration {
     }
 
     /** Prints all the system interface information to the give stream. */
-    @SuppressWarnings("removal")
     public static void printSystemConfiguration(PrintStream out) {
-        PrivilegedAction<Void> pa = () -> {
         try {
             out.println("*** all system network interface configuration ***");
             for (NetworkInterface nif : list(getNetworkInterfaces())) {
                 out.print(interfaceInformation(nif));
             }
             out.println("*** end ***");
-            return null;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
-        }};
-        AccessController.doPrivileged(pa);
+        }
     }
 }

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -30,33 +30,25 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import static java.util.Locale.ROOT;
 
 public class Platform {
-    public  static final String vmName      = privilegedGetProperty("java.vm.name");
-    public  static final String vmInfo      = privilegedGetProperty("java.vm.info");
-    private static final String osVersion   = privilegedGetProperty("os.version");
+    public  static final String vmName      = System.getProperty("java.vm.name");
+    public  static final String vmInfo      = System.getProperty("java.vm.info");
+    private static final String osVersion   = System.getProperty("os.version");
     private static       int osVersionMajor = -1;
     private static       int osVersionMinor = -1;
-    private static final String osName      = privilegedGetProperty("os.name");
-    private static final String dataModel   = privilegedGetProperty("sun.arch.data.model");
-    private static final String vmVersion   = privilegedGetProperty("java.vm.version");
-    private static final String jdkDebug    = privilegedGetProperty("jdk.debug");
-    private static final String osArch      = privilegedGetProperty("os.arch");
-    private static final String userName    = privilegedGetProperty("user.name");
-    private static final String compiler    = privilegedGetProperty("sun.management.compiler");
-    private static final String testJdk     = privilegedGetProperty("test.jdk");
-
-    @SuppressWarnings("removal")
-    private static String privilegedGetProperty(String key) {
-        return AccessController.doPrivileged((
-                PrivilegedAction<String>) () -> System.getProperty(key));
-    }
+    private static final String osName      = System.getProperty("os.name");
+    private static final String dataModel   = System.getProperty("sun.arch.data.model");
+    private static final String vmVersion   = System.getProperty("java.vm.version");
+    private static final String jdkDebug    = System.getProperty("jdk.debug");
+    private static final String osArch      = System.getProperty("os.arch");
+    private static final String userName    = System.getProperty("user.name");
+    private static final String compiler    = System.getProperty("sun.management.compiler");
+    private static final String testJdk     = System.getProperty("test.jdk");
 
     public static boolean isClient() {
         return vmName.endsWith(" Client VM");

--- a/test/lib/jdk/test/lib/SA/SATestUtils.java
+++ b/test/lib/jdk/test/lib/SA/SATestUtils.java
@@ -200,7 +200,6 @@ public class SATestUtils {
      * if we are root, so return true.  Then return false for an expected denial
      * if "ptrace_scope" is 1, and true otherwise.
      */
-    @SuppressWarnings("removal")
     private static boolean canPtraceAttachLinux() throws IOException {
         // SELinux deny_ptrace:
         var deny_ptrace = Paths.get("/sys/fs/selinux/booleans/deny_ptrace");

--- a/test/lib/jdk/test/lib/SA/SATestUtils.java
+++ b/test/lib/jdk/test/lib/SA/SATestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,6 @@ import jtreg.SkippedException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -208,18 +205,12 @@ public class SATestUtils {
         // SELinux deny_ptrace:
         var deny_ptrace = Paths.get("/sys/fs/selinux/booleans/deny_ptrace");
         if (Files.exists(deny_ptrace)) {
-            try {
-                var bb = AccessController.doPrivileged(
-                    (PrivilegedExceptionAction<byte[]>) () -> Files.readAllBytes(deny_ptrace));
-                if (bb.length == 0) {
-                    throw new Error("deny_ptrace is empty");
-                }
-                if (bb[0] != '0') {
-                    return false;
-                }
-            } catch (PrivilegedActionException e) {
-                IOException t = (IOException) e.getException();
-                throw t;
+            var bb = Files.readAllBytes(deny_ptrace);
+            if (bb.length == 0) {
+                throw new Error("deny_ptrace is empty");
+            }
+            if (bb[0] != '0') {
+                return false;
             }
         }
 
@@ -230,23 +221,17 @@ public class SATestUtils {
         // 3 - no attach: no processes may use ptrace with PTRACE_ATTACH
         var ptrace_scope = Paths.get("/proc/sys/kernel/yama/ptrace_scope");
         if (Files.exists(ptrace_scope)) {
-            try {
-                var bb = AccessController.doPrivileged(
-                    (PrivilegedExceptionAction<byte[]>) () -> Files.readAllBytes(ptrace_scope));
-                if (bb.length == 0) {
-                    throw new Error("ptrace_scope is empty");
-                }
-                byte yama_scope = bb[0];
-                if (yama_scope == '3') {
-                    return false;
-                }
+            var bb = Files.readAllBytes(ptrace_scope);
+            if (bb.length == 0) {
+                throw new Error("ptrace_scope is empty");
+            }
+            byte yama_scope = bb[0];
+            if (yama_scope == '3') {
+                return false;
+            }
 
-                if (!Platform.isRoot() && yama_scope != '0') {
-                    return false;
-                }
-            } catch (PrivilegedActionException e) {
-                IOException t = (IOException) e.getException();
-                throw t;
+            if (!Platform.isRoot() && yama_scope != '0') {
+                return false;
             }
         }
         // Otherwise expect to be permitted:

--- a/test/lib/jdk/test/lib/helpers/ClassFileInstaller.java
+++ b/test/lib/jdk/test/lib/helpers/ClassFileInstaller.java
@@ -93,7 +93,7 @@ public class ClassFileInstaller {
             if (DEBUG) {
                 System.out.println("ClassFileInstaller: Writing to " + System.getProperty("user.dir"));
             }
-            String[] classes = Arrays.copyOfRange(args,0, args.length);
+            String[] classes = Arrays.copyOfRange(args, 0, args.length);
             for (String cls : classes) {
                 writeClassToDisk(cls);
             }

--- a/test/lib/jdk/test/lib/helpers/ClassFileInstaller.java
+++ b/test/lib/jdk/test/lib/helpers/ClassFileInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -86,44 +87,17 @@ public class ClassFileInstaller {
                                            "  -jar <path>             Write to the JAR file <path>");
             }
             String jarFile = args[1];
-            String[] classes = addInnerClasses(args, 2);
+            String[] classes = Arrays.copyOfRange(args, 2, args.length);
             writeJar_impl(jarFile, null, classes);
         } else {
             if (DEBUG) {
                 System.out.println("ClassFileInstaller: Writing to " + System.getProperty("user.dir"));
             }
-            String[] classes = addInnerClasses(args, 0);
+            String[] classes = Arrays.copyOfRange(args,0, args.length);
             for (String cls : classes) {
                 writeClassToDisk(cls);
             }
         }
-    }
-
-    // Add commonly used inner classes that are often omitted by mistake. Currently
-    // we support only jdk.test.whitebox.WhiteBox$WhiteBoxPermission.
-    // See JDK-8199290
-    private static String[] addInnerClasses(String[] classes, int startIdx) {
-        boolean seenNewWb = false;
-        boolean seenNewWbInner = false;
-        final String newWb = "jdk.test.whitebox.WhiteBox";
-        final String newWbInner = newWb + "$WhiteBoxPermission";
-
-        ArrayList<String> list = new ArrayList<>();
-
-        for (int i = startIdx; i < classes.length; i++) {
-            String cls = classes[i];
-            list.add(cls);
-            switch (cls) {
-            case newWb:      seenNewWb      = true; break;
-            case newWbInner: seenNewWbInner = true; break;
-            }
-        }
-        if (seenNewWb && !seenNewWbInner) {
-            list.add(newWbInner);
-        }
-        String[] array = new String[list.size()];
-        list.toArray(array);
-        return array;
     }
 
     public static class Manifest {
@@ -188,13 +162,11 @@ public class ClassFileInstaller {
      * @build jdk.test.lib.helpers.ClassFileInstaller
      */
     public static String writeJar(String jarFile, String... classes) throws Exception {
-        classes = addInnerClasses(classes, 0);
         writeJar_impl(jarFile, null, classes);
         return getJarPath(jarFile);
     }
 
     public static String writeJar(String jarFile, Manifest manifest, String... classes) throws Exception {
-        classes = addInnerClasses(classes, 0);
         writeJar_impl(jarFile, manifest, classes);
         return getJarPath(jarFile);
     }

--- a/test/lib/jdk/test/lib/net/IPSupport.java
+++ b/test/lib/jdk/test/lib/net/IPSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,13 @@ import jdk.test.lib.Platform;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.UncheckedIOException;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.ProtocolFamily;
 import java.net.StandardProtocolFamily;
 import java.nio.channels.SocketChannel;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-import java.util.concurrent.Callable;
+
 import jtreg.SkippedException;
 
 /**
@@ -55,12 +51,10 @@ public class IPSupport {
     private static final int IPV6_SNDBUF_AIX = 65487;
 
     static {
-        hasIPv4 = runPrivilegedAction(() -> isSupported(Inet4Address.class));
-        hasIPv6 = runPrivilegedAction(() -> isSupported(Inet6Address.class));
-        preferIPv4Stack = runPrivilegedAction(() -> Boolean.parseBoolean(
-            System.getProperty("java.net.preferIPv4Stack")));
-        preferIPv6Addresses = runPrivilegedAction(() -> Boolean.parseBoolean(
-            System.getProperty("java.net.preferIPv6Addresses")));
+        hasIPv4 = isSupported(Inet4Address.class);
+        hasIPv6 = isSupported(Inet6Address.class);
+        preferIPv4Stack = Boolean.parseBoolean(System.getProperty("java.net.preferIPv4Stack"));
+        preferIPv6Addresses = Boolean.parseBoolean(System.getProperty("java.net.preferIPv6Addresses"));
         if (!preferIPv4Stack && !hasIPv4 && !hasIPv6) {
             throw new AssertionError("IPv4 and IPv6 both not available and java.net.preferIPv4Stack is not true");
         }
@@ -73,16 +67,6 @@ public class IPSupport {
             return true;
         } catch (IOException | UnsupportedOperationException ex) {
             return false;
-        }
-    }
-
-    @SuppressWarnings("removal")
-    private static <T> T runPrivilegedAction(Callable<T> callable) {
-        try {
-            PrivilegedExceptionAction<T> pa = () -> callable.call();
-            return AccessController.doPrivileged(pa);
-        } catch (PrivilegedActionException pae) {
-            throw new UncheckedIOException((IOException) pae.getCause());
         }
     }
 

--- a/test/lib/jdk/test/lib/net/SimpleHttpServer.java
+++ b/test/lib/jdk/test/lib/net/SimpleHttpServer.java
@@ -102,7 +102,7 @@ public class SimpleHttpServer {
                     try {
                         uri = URI.create("file://" + rootUri.getRawPath() + path).normalize();
                         fPath = Path.of(uri);
-                    } catch (IllegalArgumentException | FileSystemNotFoundException | SecurityException ex) {
+                    } catch (IllegalArgumentException | FileSystemNotFoundException ex) {
                         ex.printStackTrace();
                         notfound(t, path);
                         return;

--- a/test/lib/jdk/test/lib/net/SimpleHttpServer.java
+++ b/test/lib/jdk/test/lib/net/SimpleHttpServer.java
@@ -1,6 +1,5 @@
-
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/net/SimpleSSLContext.java
+++ b/test/lib/jdk/test/lib/net/SimpleSSLContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/net/SimpleSSLContext.java
+++ b/test/lib/jdk/test/lib/net/SimpleSSLContext.java
@@ -34,13 +34,6 @@ import javax.net.ssl.*;
  * Creates a simple usable SSLContext for SSLSocketFactory
  * or a HttpsServer using either a given keystore or a default
  * one in the test tree.
- *
- * Using this class with a security manager requires the following
- * permissions to be granted:
- *
- * permission "java.util.PropertyPermission" "test.src.path", "read";
- * permission java.io.FilePermission "/path/to/test/lib/jdk/test/lib/testkeys", "read";
- * The exact path above depends on the location of the test.
  */
 public class SimpleSSLContext {
 
@@ -54,47 +47,19 @@ public class SimpleSSLContext {
         this(() -> "TLS");
     }
 
-    @SuppressWarnings("removal")
     private SimpleSSLContext(Supplier<String> protocols) throws IOException {
-        try {
-            final String proto = protocols.get();
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
-                @Override
-                public Void run() throws Exception {
-                    String paths = System.getProperty("test.src.path");
-                    StringTokenizer st = new StringTokenizer(paths, File.pathSeparator);
-                    boolean securityExceptions = false;
-                    while (st.hasMoreTokens()) {
-                        String path = st.nextToken();
-                        try {
-                            File f = new File(path, "jdk/test/lib/net/testkeys");
-                            if (f.exists()) {
-                                try (FileInputStream fis = new FileInputStream(f)) {
-                                    init(fis, proto);
-                                    return null;
-                                }
-                            }
-                        } catch (SecurityException e) {
-                            // catch and ignore because permission only required
-                            // for one entry on path (at most)
-                            securityExceptions = true;
-                        }
-                    }
-                    if (securityExceptions) {
-                        System.err.println("SecurityExceptions thrown on loading testkeys");
-                    }
-                    return null;
+        final String proto = protocols.get();
+
+        String paths = System.getProperty("test.src.path");
+        StringTokenizer st = new StringTokenizer(paths, File.pathSeparator);
+        while (st.hasMoreTokens()) {
+            String path = st.nextToken();
+            File f = new File(path, "jdk/test/lib/net/testkeys");
+            if (f.exists()) {
+                try (FileInputStream fis = new FileInputStream(f)) {
+                    init(fis, proto);
                 }
-            });
-        } catch (PrivilegedActionException pae) {
-            Throwable t = pae.getCause() != null ? pae.getCause() : pae;
-            if (t instanceof IOException)
-                throw (IOException)t;
-            if (t instanceof RuntimeException)
-                throw (RuntimeException)t;
-            if (t instanceof Error)
-                throw (Error)t;
-            throw new RuntimeException(t);
+            }
         }
     }
 

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -29,18 +29,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.security.BasicPermission;
 import java.util.Objects;
 
 import jdk.test.whitebox.parser.DiagnosticCommand;
 
 public class WhiteBox {
-  @SuppressWarnings("serial")
-  public static class WhiteBoxPermission extends BasicPermission {
-    public WhiteBoxPermission(String s) {
-      super(s);
-    }
-  }
 
   private WhiteBox() {}
   private static final WhiteBox instance = new WhiteBox();


### PR DESCRIPTION
SM Cleanup of common test library test/lib/...:

Remove unnecessary catches of SecurityException
Remove AccessController and doPrivileged from SimpleSSLContext and ProcessTools.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346468](https://bugs.openjdk.org/browse/JDK-8346468): SM cleanup of common test library (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) Review applies to [1bdd54d2](https://git.openjdk.org/jdk/pull/22814/files/1bdd54d28a073e92a1a8f0d780fd20bea30660d8)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22814/head:pull/22814` \
`$ git checkout pull/22814`

Update a local copy of the PR: \
`$ git checkout pull/22814` \
`$ git pull https://git.openjdk.org/jdk.git pull/22814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22814`

View PR using the GUI difftool: \
`$ git pr show -t 22814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22814.diff">https://git.openjdk.org/jdk/pull/22814.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22814#issuecomment-2551563736)
</details>
