### PR TITLE
8332506: SIGFPE In ObjectSynchronizer::is_async_deflation_needed()

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1278,16 +1278,16 @@ static bool monitors_used_above_threshold(MonitorList* list) {
   if (int(monitor_usage) > MonitorUsedDeflationThreshold) {
     bool status = true;
 
-    // Check if we it's time to adjust the in_use_list_ceiling up, due
+    // Check if it's time to adjust the in_use_list_ceiling up, due
     // to too many async deflation attempts without any progress.
     if (NoAsyncDeflationProgressMax != 0 &&
         _no_progress_cnt >= NoAsyncDeflationProgressMax) {
       double remainder = (100.0 - MonitorUsedDeflationThreshold) / 100.0;
-      size_t new_ceiling = ceiling + (size_t)((double)ceiling * remainder) + 1;
+      size_t delta = (size_t)((double)ceiling * remainder) + 1;
+      size_t new_ceiling = (ceiling > SIZE_MAX - delta)
+        ? SIZE_MAX         // Overflow, let's clamp new_ceiling.
+        : ceiling + delta;
 
-      if (new_ceiling < old_ceiling) {
-        new_ceiling = SIZE_MAX; // Wrap around, let's clamp new_ceiling.
-      }
       ObjectSynchronizer::set_in_use_list_ceiling(new_ceiling);
       log_info(monitorinflation)("Too many deflations without progress; "
                                  "bumping in_use_list_ceiling from " SIZE_FORMAT

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1276,7 +1276,9 @@ static bool monitors_used_above_threshold(MonitorList* list) {
   // Check if our monitor usage is above the threshold:
   size_t monitor_usage = (monitors_used * 100LL) / ceiling;
   if (int(monitor_usage) > MonitorUsedDeflationThreshold) {
-    bool status = true;
+    // Deflate monitors if over the threshold percentage, unless no
+    // progress on previous deflations.
+    bool is_above_threshold = true;
 
     // Check if it's time to adjust the in_use_list_ceiling up, due
     // to too many async deflation attempts without any progress.
@@ -1297,12 +1299,12 @@ static bool monitors_used_above_threshold(MonitorList* list) {
 
       // Check if our monitor usage is still above the threshold:
       monitor_usage = (monitors_used * 100LL) / ceiling;
-      status = int(monitor_usage) > MonitorUsedDeflationThreshold;
+      is_above_threshold = int(monitor_usage) > MonitorUsedDeflationThreshold;
     }
     log_info(monitorinflation)("monitors_used=" SIZE_FORMAT ", ceiling=" SIZE_FORMAT
                                ", monitor_usage=" SIZE_FORMAT ", threshold=%d",
                                monitors_used, ceiling, monitor_usage, MonitorUsedDeflationThreshold);
-    return status;
+    return is_above_threshold;
   }
 
   return false;


### PR DESCRIPTION
This PR solves a division by zero problem, that according to the bug report happened in `ObjectSynchronizer::is_async_deflation_needed()`. As it turns out it really happened in the inlined  `monitors_used_above_threshold()` function. The problematic line looked like this:

`size_t monitor_usage = (monitors_used * 100LL) / ceiling;`

Unfortunately the `ceiling` value was increased every time there where too many deflations without any progress. This whould eventually lead to an overflow in the `ceiling` value, and in unlucky circumstances, it would become zero. Thus causing a division by zero crash.

This PR makes sure not to increase the `ceiling` value if `monitor_usage` is below the `MonitorUsedDeflationThreshold`.
It also makes sure the ceiling value is never zero, and does not wrap around.

Tested okay in tier1-5 and `test/hotspot/jtreg/runtime/Monitor/MonitorUsedDeflationThresholdTest.java`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332506](https://bugs.openjdk.org/browse/JDK-8332506): SIGFPE In ObjectSynchronizer::is_async_deflation_needed() (**Bug** - P3)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22815/head:pull/22815` \
`$ git checkout pull/22815`

Update a local copy of the PR: \
`$ git checkout pull/22815` \
`$ git pull https://git.openjdk.org/jdk.git pull/22815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22815`

View PR using the GUI difftool: \
`$ git pr show -t 22815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22815.diff">https://git.openjdk.org/jdk/pull/22815.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22815#issuecomment-2551999501)
</details>
