### PR TITLE
8346288: WB_IsIntrinsicAvailable fails if called with wrong compilation level

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -929,14 +929,19 @@ WB_ENTRY(jboolean, WB_IsIntrinsicAvailable(JNIEnv* env, jobject o, jobject metho
   if (compLevel < CompLevel_none || compLevel > CompilationPolicy::highest_compile_level()) {
     return false; // Intrinsic is not available on a non-existent compilation level.
   }
+  AbstractCompiler* comp = CompileBroker::compiler((int)compLevel);
+  if (comp == nullptr) {
+    // Could have compLevel == 0, or !TieredCompilation and incompatible values of TieredStopAtLevel and compLevel.
+    tty->print_cr("WB error: no compiler for requested compilation level %d", compLevel);
+    return false;
+  }
+
   jmethodID method_id, compilation_context_id;
   method_id = reflected_method_to_jmid(thread, env, method);
   CHECK_JNI_EXCEPTION_(env, JNI_FALSE);
   methodHandle mh(THREAD, Method::checked_resolve_jmethod_id(method_id));
 
   DirectiveSet* directive;
-  AbstractCompiler* comp = CompileBroker::compiler((int)compLevel);
-  assert(comp != nullptr, "compiler not available");
   if (compilation_context != nullptr) {
     compilation_context_id = reflected_method_to_jmid(thread, env, compilation_context);
     CHECK_JNI_EXCEPTION_(env, JNI_FALSE);


### PR DESCRIPTION
Fixes crashes when calling isIntrinsicAvailable with an incorrect compilation level or incompatible VM flag values.

Testing: T1-3.
Extra testing: called isIntrinsicAvailable with compLevel={-2, -1, ..., 5) without extra flags, and with -XX:-TieredCompilation -XX:TieredStopAtLevel={0, 1, ..., 4} and observed no crashes after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346288](https://bugs.openjdk.org/browse/JDK-8346288): WB_IsIntrinsicAvailable fails if called with wrong compilation level (**Bug** - P5)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22823/head:pull/22823` \
`$ git checkout pull/22823`

Update a local copy of the PR: \
`$ git checkout pull/22823` \
`$ git pull https://git.openjdk.org/jdk.git pull/22823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22823`

View PR using the GUI difftool: \
`$ git pr show -t 22823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22823.diff">https://git.openjdk.org/jdk/pull/22823.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22823#issuecomment-2552967384)
</details>
