### PR TITLE
8346602: Remove unused macro parameters in `jni.cpp`

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -2413,7 +2413,7 @@ static char* get_bad_address() {
 
 
 
-#define DEFINE_GETSCALARARRAYELEMENTS(ElementTag,ElementType,Result, Tag \
+#define DEFINE_GETSCALARARRAYELEMENTS(ElementType,Result \
                                       , EntryProbe, ReturnProbe) \
 \
 JNI_ENTRY_NO_PRESERVE(ElementType*, \
@@ -2447,35 +2447,35 @@ JNI_ENTRY_NO_PRESERVE(ElementType*, \
   return result; \
 JNI_END
 
-DEFINE_GETSCALARARRAYELEMENTS(T_BOOLEAN, jboolean, Boolean, bool
+DEFINE_GETSCALARARRAYELEMENTS(jboolean, Boolean
                               , HOTSPOT_JNI_GETBOOLEANARRAYELEMENTS_ENTRY(env, array, (uintptr_t *) isCopy),
                               HOTSPOT_JNI_GETBOOLEANARRAYELEMENTS_RETURN((uintptr_t*)result))
-DEFINE_GETSCALARARRAYELEMENTS(T_BYTE,    jbyte,    Byte,    byte
+DEFINE_GETSCALARARRAYELEMENTS(jbyte,    Byte
                               , HOTSPOT_JNI_GETBYTEARRAYELEMENTS_ENTRY(env, array, (uintptr_t *) isCopy),
                               HOTSPOT_JNI_GETBYTEARRAYELEMENTS_RETURN((char*)result))
-DEFINE_GETSCALARARRAYELEMENTS(T_SHORT,   jshort,   Short,   short
+DEFINE_GETSCALARARRAYELEMENTS(jshort,   Short
                               , HOTSPOT_JNI_GETSHORTARRAYELEMENTS_ENTRY(env, (uint16_t*) array, (uintptr_t *) isCopy),
                               HOTSPOT_JNI_GETSHORTARRAYELEMENTS_RETURN((uint16_t*)result))
-DEFINE_GETSCALARARRAYELEMENTS(T_CHAR,    jchar,    Char,    char
+DEFINE_GETSCALARARRAYELEMENTS(jchar,    Char
                               , HOTSPOT_JNI_GETCHARARRAYELEMENTS_ENTRY(env, (uint16_t*) array, (uintptr_t *) isCopy),
                               HOTSPOT_JNI_GETCHARARRAYELEMENTS_RETURN(result))
-DEFINE_GETSCALARARRAYELEMENTS(T_INT,     jint,     Int,     int
+DEFINE_GETSCALARARRAYELEMENTS(jint,     Int
                               , HOTSPOT_JNI_GETINTARRAYELEMENTS_ENTRY(env, array, (uintptr_t *) isCopy),
                               HOTSPOT_JNI_GETINTARRAYELEMENTS_RETURN((uint32_t*)result))
-DEFINE_GETSCALARARRAYELEMENTS(T_LONG,    jlong,    Long,    long
+DEFINE_GETSCALARARRAYELEMENTS(jlong,    Long
                               , HOTSPOT_JNI_GETLONGARRAYELEMENTS_ENTRY(env, array, (uintptr_t *) isCopy),
                               HOTSPOT_JNI_GETLONGARRAYELEMENTS_RETURN(((uintptr_t*)result)))
 // Float and double probes don't return value because dtrace doesn't currently support it
-DEFINE_GETSCALARARRAYELEMENTS(T_FLOAT,   jfloat,   Float,   float
+DEFINE_GETSCALARARRAYELEMENTS(jfloat,   Float
                               , HOTSPOT_JNI_GETFLOATARRAYELEMENTS_ENTRY(env, array, (uintptr_t *) isCopy),
                               HOTSPOT_JNI_GETFLOATARRAYELEMENTS_RETURN(result))
-DEFINE_GETSCALARARRAYELEMENTS(T_DOUBLE,  jdouble,  Double,  double
+DEFINE_GETSCALARARRAYELEMENTS(jdouble,  Double
                               , HOTSPOT_JNI_GETDOUBLEARRAYELEMENTS_ENTRY(env, array, (uintptr_t *) isCopy),
                               HOTSPOT_JNI_GETDOUBLEARRAYELEMENTS_RETURN(result))
 
 
-#define DEFINE_RELEASESCALARARRAYELEMENTS(ElementTag,ElementType,Result,Tag \
-                                          , EntryProbe, ReturnProbe);\
+#define DEFINE_RELEASESCALARARRAYELEMENTS(ElementType,Result \
+                                          , EntryProbe, ReturnProbe) \
 \
 JNI_ENTRY_NO_PRESERVE(void, \
           jni_Release##Result##ArrayElements(JNIEnv *env, ElementType##Array array, \
@@ -2494,28 +2494,28 @@ JNI_ENTRY_NO_PRESERVE(void, \
   ReturnProbe; \
 JNI_END
 
-DEFINE_RELEASESCALARARRAYELEMENTS(T_BOOLEAN, jboolean, Boolean, bool
+DEFINE_RELEASESCALARARRAYELEMENTS(jboolean, Boolean
                                   , HOTSPOT_JNI_RELEASEBOOLEANARRAYELEMENTS_ENTRY(env, array, (uintptr_t *) buf, mode),
                                   HOTSPOT_JNI_RELEASEBOOLEANARRAYELEMENTS_RETURN())
-DEFINE_RELEASESCALARARRAYELEMENTS(T_BYTE,    jbyte,    Byte,    byte
+DEFINE_RELEASESCALARARRAYELEMENTS(jbyte,    Byte
                                   , HOTSPOT_JNI_RELEASEBYTEARRAYELEMENTS_ENTRY(env, array, (char *) buf, mode),
                                   HOTSPOT_JNI_RELEASEBYTEARRAYELEMENTS_RETURN())
-DEFINE_RELEASESCALARARRAYELEMENTS(T_SHORT,   jshort,   Short,   short
+DEFINE_RELEASESCALARARRAYELEMENTS(jshort,   Short
                                   ,  HOTSPOT_JNI_RELEASESHORTARRAYELEMENTS_ENTRY(env, array, (uint16_t *) buf, mode),
                                   HOTSPOT_JNI_RELEASESHORTARRAYELEMENTS_RETURN())
-DEFINE_RELEASESCALARARRAYELEMENTS(T_CHAR,    jchar,    Char,    char
+DEFINE_RELEASESCALARARRAYELEMENTS(jchar,    Char
                                   ,  HOTSPOT_JNI_RELEASECHARARRAYELEMENTS_ENTRY(env, array, (uint16_t *) buf, mode),
                                   HOTSPOT_JNI_RELEASECHARARRAYELEMENTS_RETURN())
-DEFINE_RELEASESCALARARRAYELEMENTS(T_INT,     jint,     Int,     int
+DEFINE_RELEASESCALARARRAYELEMENTS(jint,     Int
                                   , HOTSPOT_JNI_RELEASEINTARRAYELEMENTS_ENTRY(env, array, (uint32_t *) buf, mode),
                                   HOTSPOT_JNI_RELEASEINTARRAYELEMENTS_RETURN())
-DEFINE_RELEASESCALARARRAYELEMENTS(T_LONG,    jlong,    Long,    long
+DEFINE_RELEASESCALARARRAYELEMENTS(jlong,    Long
                                   , HOTSPOT_JNI_RELEASELONGARRAYELEMENTS_ENTRY(env, array, (uintptr_t *) buf, mode),
                                   HOTSPOT_JNI_RELEASELONGARRAYELEMENTS_RETURN())
-DEFINE_RELEASESCALARARRAYELEMENTS(T_FLOAT,   jfloat,   Float,   float
+DEFINE_RELEASESCALARARRAYELEMENTS(jfloat,   Float
                                   , HOTSPOT_JNI_RELEASEFLOATARRAYELEMENTS_ENTRY(env, array, (float *) buf, mode),
                                   HOTSPOT_JNI_RELEASEFLOATARRAYELEMENTS_RETURN())
-DEFINE_RELEASESCALARARRAYELEMENTS(T_DOUBLE,  jdouble,  Double,  double
+DEFINE_RELEASESCALARARRAYELEMENTS(jdouble,  Double
                                   , HOTSPOT_JNI_RELEASEDOUBLEARRAYELEMENTS_ENTRY(env, array, (double *) buf, mode),
                                   HOTSPOT_JNI_RELEASEDOUBLEARRAYELEMENTS_RETURN())
 
@@ -2533,8 +2533,8 @@ static void check_bounds(jsize start, jsize copy_len, jsize array_len, TRAPS) {
   }
 }
 
-#define DEFINE_GETSCALARARRAYREGION(ElementTag,ElementType,Result, Tag \
-                                    , EntryProbe, ReturnProbe); \
+#define DEFINE_GETSCALARARRAYREGION(ElementType,Result \
+                                    , EntryProbe, ReturnProbe) \
   DT_VOID_RETURN_MARK_DECL(Get##Result##ArrayRegion \
                            , ReturnProbe); \
 \
@@ -2550,34 +2550,34 @@ jni_Get##Result##ArrayRegion(JNIEnv *env, ElementType##Array array, jsize start,
   } \
 JNI_END
 
-DEFINE_GETSCALARARRAYREGION(T_BOOLEAN, jboolean,Boolean, bool
+DEFINE_GETSCALARARRAYREGION(jboolean,Boolean
                             , HOTSPOT_JNI_GETBOOLEANARRAYREGION_ENTRY(env, array, start, len, (uintptr_t *) buf),
                             HOTSPOT_JNI_GETBOOLEANARRAYREGION_RETURN());
-DEFINE_GETSCALARARRAYREGION(T_BYTE,    jbyte,   Byte,    byte
+DEFINE_GETSCALARARRAYREGION(jbyte,   Byte
                             ,  HOTSPOT_JNI_GETBYTEARRAYREGION_ENTRY(env, array, start, len, (char *) buf),
                             HOTSPOT_JNI_GETBYTEARRAYREGION_RETURN());
-DEFINE_GETSCALARARRAYREGION(T_SHORT,   jshort,  Short,   short
+DEFINE_GETSCALARARRAYREGION(jshort,  Short
                             , HOTSPOT_JNI_GETSHORTARRAYREGION_ENTRY(env, array, start, len, (uint16_t *) buf),
                             HOTSPOT_JNI_GETSHORTARRAYREGION_RETURN());
-DEFINE_GETSCALARARRAYREGION(T_CHAR,    jchar,   Char,    char
+DEFINE_GETSCALARARRAYREGION(jchar,   Char
                             ,  HOTSPOT_JNI_GETCHARARRAYREGION_ENTRY(env, array, start, len, (uint16_t*) buf),
                             HOTSPOT_JNI_GETCHARARRAYREGION_RETURN());
-DEFINE_GETSCALARARRAYREGION(T_INT,     jint,    Int,     int
+DEFINE_GETSCALARARRAYREGION(jint,    Int
                             , HOTSPOT_JNI_GETINTARRAYREGION_ENTRY(env, array, start, len, (uint32_t*) buf),
                             HOTSPOT_JNI_GETINTARRAYREGION_RETURN());
-DEFINE_GETSCALARARRAYREGION(T_LONG,    jlong,   Long,    long
+DEFINE_GETSCALARARRAYREGION(jlong,   Long
                             ,  HOTSPOT_JNI_GETLONGARRAYREGION_ENTRY(env, array, start, len, (uintptr_t *) buf),
                             HOTSPOT_JNI_GETLONGARRAYREGION_RETURN());
-DEFINE_GETSCALARARRAYREGION(T_FLOAT,   jfloat,  Float,   float
+DEFINE_GETSCALARARRAYREGION(jfloat,  Float
                             , HOTSPOT_JNI_GETFLOATARRAYREGION_ENTRY(env, array, start, len, (float *) buf),
                             HOTSPOT_JNI_GETFLOATARRAYREGION_RETURN());
-DEFINE_GETSCALARARRAYREGION(T_DOUBLE,  jdouble, Double,  double
+DEFINE_GETSCALARARRAYREGION(jdouble, Double
                             , HOTSPOT_JNI_GETDOUBLEARRAYREGION_ENTRY(env, array, start, len, (double *) buf),
                             HOTSPOT_JNI_GETDOUBLEARRAYREGION_RETURN());
 
 
-#define DEFINE_SETSCALARARRAYREGION(ElementTag,ElementType,Result, Tag \
-                                    , EntryProbe, ReturnProbe); \
+#define DEFINE_SETSCALARARRAYREGION(ElementType,Result \
+                                    , EntryProbe, ReturnProbe) \
   DT_VOID_RETURN_MARK_DECL(Set##Result##ArrayRegion \
                            ,ReturnProbe);           \
 \
@@ -2593,28 +2593,28 @@ jni_Set##Result##ArrayRegion(JNIEnv *env, ElementType##Array array, jsize start,
   } \
 JNI_END
 
-DEFINE_SETSCALARARRAYREGION(T_BOOLEAN, jboolean, Boolean, bool
+DEFINE_SETSCALARARRAYREGION(jboolean, Boolean
                             , HOTSPOT_JNI_SETBOOLEANARRAYREGION_ENTRY(env, array, start, len, (uintptr_t *)buf),
                             HOTSPOT_JNI_SETBOOLEANARRAYREGION_RETURN())
-DEFINE_SETSCALARARRAYREGION(T_BYTE,    jbyte,    Byte,    byte
+DEFINE_SETSCALARARRAYREGION(jbyte,    Byte
                             , HOTSPOT_JNI_SETBYTEARRAYREGION_ENTRY(env, array, start, len, (char *) buf),
                             HOTSPOT_JNI_SETBYTEARRAYREGION_RETURN())
-DEFINE_SETSCALARARRAYREGION(T_SHORT,   jshort,   Short,   short
+DEFINE_SETSCALARARRAYREGION(jshort,   Short
                             , HOTSPOT_JNI_SETSHORTARRAYREGION_ENTRY(env, array, start, len, (uint16_t *) buf),
                             HOTSPOT_JNI_SETSHORTARRAYREGION_RETURN())
-DEFINE_SETSCALARARRAYREGION(T_CHAR,    jchar,    Char,    char
+DEFINE_SETSCALARARRAYREGION(jchar,    Char
                             , HOTSPOT_JNI_SETCHARARRAYREGION_ENTRY(env, array, start, len, (uint16_t *) buf),
                             HOTSPOT_JNI_SETCHARARRAYREGION_RETURN())
-DEFINE_SETSCALARARRAYREGION(T_INT,     jint,     Int,     int
+DEFINE_SETSCALARARRAYREGION(jint,     Int
                             , HOTSPOT_JNI_SETINTARRAYREGION_ENTRY(env, array, start, len, (uint32_t *) buf),
                             HOTSPOT_JNI_SETINTARRAYREGION_RETURN())
-DEFINE_SETSCALARARRAYREGION(T_LONG,    jlong,    Long,    long
+DEFINE_SETSCALARARRAYREGION(jlong,    Long
                             , HOTSPOT_JNI_SETLONGARRAYREGION_ENTRY(env, array, start, len, (uintptr_t *) buf),
                             HOTSPOT_JNI_SETLONGARRAYREGION_RETURN())
-DEFINE_SETSCALARARRAYREGION(T_FLOAT,   jfloat,   Float,   float
+DEFINE_SETSCALARARRAYREGION(jfloat,   Float
                             , HOTSPOT_JNI_SETFLOATARRAYREGION_ENTRY(env, array, start, len, (float *) buf),
                             HOTSPOT_JNI_SETFLOATARRAYREGION_RETURN())
-DEFINE_SETSCALARARRAYREGION(T_DOUBLE,  jdouble,  Double,  double
+DEFINE_SETSCALARARRAYREGION(jdouble,  Double
                             , HOTSPOT_JNI_SETDOUBLEARRAYREGION_ENTRY(env, array, start, len, (double *) buf),
                             HOTSPOT_JNI_SETDOUBLEARRAYREGION_RETURN())
 


### PR DESCRIPTION
Some of the macros in `jni.cpp`, including `DEFINE_GETSCALARARRAYELEMENTS`, `DEFINE_RELEASESCALARARRAYELEMENTS`, `DEFINE_GETSCALARARRAYREGION` and `DEFINE_SETSCALARARRAYREGION`, have unused parameters.

This patch removes them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346602](https://bugs.openjdk.org/browse/JDK-8346602): Remove unused macro parameters in `jni.cpp` (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22824/head:pull/22824` \
`$ git checkout pull/22824`

Update a local copy of the PR: \
`$ git checkout pull/22824` \
`$ git pull https://git.openjdk.org/jdk.git pull/22824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22824`

View PR using the GUI difftool: \
`$ git pr show -t 22824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22824.diff">https://git.openjdk.org/jdk/pull/22824.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22824#issuecomment-2553050714)
</details>
