### PR TITLE
JDK-8346609: Improve MemorySegment.toString

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -487,10 +487,13 @@ public abstract sealed class AbstractMemorySegmentImpl
     @Override
     public String toString() {
         return "MemorySegment{ " +
-                heapBase().map(hb -> "heapBase: " + hb + ", ").orElse("") +
-                "address: " + Utils.toHexString(address()) +
+                heapBase().map(hb -> "heapBase: " + hb).orElse("native") +
+                ", address: " + Utils.toHexString(address()) +
                 ", byteSize: " + length +
-                ", r" + (isReadOnly() ? "-" : "w") + (isMapped() ? "m" : "-") + 
+                (sessionImpl() instanceof ConfinedSession ? ", confined" : "") +
+                (!sessionImpl().isAlive() ? ", not alive" : "") +
+                (isReadOnly() ? ", read-only" : "") +
+                (isMapped() ? ", mapped" : "") +
                 " }";
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -490,6 +490,7 @@ public abstract sealed class AbstractMemorySegmentImpl
                 heapBase().map(hb -> "heapBase: " + hb + ", ").orElse("") +
                 "address: " + Utils.toHexString(address()) +
                 ", byteSize: " + length +
+                ", r" + (isReadOnly() ? "-" : "w") + (isMapped() ? "m" : "-") + 
                 " }";
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -260,6 +260,8 @@ public class TestByteBuffer {
         try (FileChannel fileChannel = FileChannel.open(f.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE)) {
             MemorySegment segment = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 8L, arena);
             assertTrue(segment.isMapped());
+            assertTrue(segment.toString().contains(", rwm"));
+            assertTrue(segment.asReadOnly().toString().contains(", r-m"));
             arena.close();
             mappedBufferOp.apply(segment);
         }

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -260,8 +260,7 @@ public class TestByteBuffer {
         try (FileChannel fileChannel = FileChannel.open(f.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE)) {
             MemorySegment segment = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 8L, arena);
             assertTrue(segment.isMapped());
-            assertTrue(segment.toString().contains(", rwm"));
-            assertTrue(segment.asReadOnly().toString().contains(", r-m"));
+            assertTrue(segment.toString().contains(", mapped"));
             arena.close();
             mappedBufferOp.apply(segment);
         }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -234,14 +234,33 @@ public class TestSegments {
         assertTrue(s.contains("byteSize: "));
         if (segment.heapBase().isPresent()) {
             assertTrue(s.contains("heapBase: ["));
+            assertFalse(s.contains("native"));
         } else {
             assertFalse(s.contains("heapBase: "));
+            assertTrue(s.contains("native"));
         }
         assertFalse(s.contains("Optional"));
 
-        assertTrue(s.contains(", rw-"));
+        assertFalse(s.contains(", mapped"));
+        assertFalse(s.contains(", not alive"));
         var readOnlySegment = segment.asReadOnly();
-        assertTrue(readOnlySegment.toString().contains(", r--"));
+        assertTrue(readOnlySegment.toString().contains(", read-only"));
+    }
+
+    @Test
+    public void testToString2() {
+        MemorySegment segment;
+        try (var arena = Arena.ofConfined()) {
+            segment = arena.allocate(8);
+            assertTrue(segment.toString().contains(", confined"));
+            assertFalse(segment.toString().contains(", not alive"));
+        }
+        assertTrue(segment.toString().contains(", not alive"));
+        try (var arena = Arena.ofShared()) {
+            segment = arena.allocate(8);
+            assertFalse(segment.toString().contains(", confined"));
+            assertFalse(segment.toString().contains(", not alive"));
+        }
     }
 
     @DataProvider(name = "segmentFactories")

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -238,6 +238,10 @@ public class TestSegments {
             assertFalse(s.contains("heapBase: "));
         }
         assertFalse(s.contains("Optional"));
+
+        assertTrue(s.contains(", rw-"));
+        var readOnlySegment = segment.asReadOnly();
+        assertTrue(readOnlySegment.toString().contains(", r--"));
     }
 
     @DataProvider(name = "segmentFactories")


### PR DESCRIPTION
This PR proposes to improve the current `MemorySegment.toString()` method from:

MemorySegment{ address: 0x60000264c540, byteSize: 8 }

to

MemorySegment{ native, address: 0x60000264c540, byteSize: 8, confined, not alive, read-only, mapped }