### PR TITLE
8308105: Multi-array allocations are very slow

### DIFF
--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -553,7 +553,6 @@ class Parse : public GraphKit {
   void do_anewarray();
   void do_multianewarray();
   Node* expand_multianewarray(ciArrayKlass* array_klass, Node* *lengths, int ndimensions, int nargs);
-  Node* expand_multianewarray2(ciArrayKlass* array_klass, Node* *lengths, int ndimensions, int nargs);
 
   // implementation of jsr/ret
   void do_jsr();

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -553,6 +553,7 @@ class Parse : public GraphKit {
   void do_anewarray();
   void do_multianewarray();
   Node* expand_multianewarray(ciArrayKlass* array_klass, Node* *lengths, int ndimensions, int nargs);
+  Node* expand_multianewarray2(ciArrayKlass* array_klass, Node** lengths, int nargs);
 
   // implementation of jsr/ret
   void do_jsr();

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -553,6 +553,7 @@ class Parse : public GraphKit {
   void do_anewarray();
   void do_multianewarray();
   Node* expand_multianewarray(ciArrayKlass* array_klass, Node* *lengths, int ndimensions, int nargs);
+  Node* expand_multianewarray2(ciArrayKlass* array_klass, Node* *lengths, int ndimensions, int nargs);
 
   // implementation of jsr/ret
   void do_jsr();

--- a/src/hotspot/share/opto/parse3.cpp
+++ b/src/hotspot/share/opto/parse3.cpp
@@ -320,6 +320,40 @@ Node* Parse::expand_multianewarray(ciArrayKlass* array_klass, Node* *lengths, in
   return array;
 }
 
+// arr = new int[size1][size2]
+// -->
+// arr = new[size1][]; for (int i=0; i<size1; i++) { arr[i] = new int[size2]; }
+Node* Parse::expand_multianewarray2(ciArrayKlass* array_klass, Node* *lengths, int ndimensions, int nargs) {
+  Node* length = lengths[0];
+  assert(length != nullptr, "");
+  Node* array = new_array(makecon(TypeKlassPtr::make(array_klass, Type::trust_interfaces)), length, nargs);
+
+  // here must be a runtime cycle: for (int i = 0; i < length; i++) { array[i] = new_array[length1]; }
+  Node* idx = _gvn.transform(new SubINode(length, _gvn.intcon(1)));
+  { // _loop:
+    Node* cmp = _gvn.transform(new CmpINode(idx, _gvn.intcon(0)));
+    Node* tst = _gvn.transform(new BoolNode(cmp, BoolTest::ge));
+    IfNode* iff = create_and_map_if(control(), tst, 0.9f, 0.1f);
+    int after_loop_bci = 0; // does not work this way. next block :(
+    //jump_if_true_fork(iff, after_loop_bci, false);
+
+    ciArrayKlass* array_klass_1 = array_klass->as_obj_array_klass()->element_klass()->as_array_klass();
+    const TypePtr* adr_type = TypeAryPtr::OOPS;
+    const TypeOopPtr* elemtype = _gvn.type(array)->is_aryptr()->elem()->make_oopptr();
+    const intptr_t header = arrayOopDesc::base_offset_in_bytes(T_OBJECT);
+    Node* elem = expand_multianewarray(array_klass_1, &lengths[1], ndimensions-1, nargs);
+    jint index = 0;
+    intptr_t offset = header + ((intptr_t)index << LogBytesPerHeapOop);
+    Node*    eaddr  = basic_plus_adr(array, offset);
+    access_store_at(array, eaddr, adr_type, elem, elemtype, T_OBJECT, IN_HEAP | IS_ARRAY);
+
+    // _gvn.transform(new SubINode(idx, _gvn.intcon(1)));
+    // goto: _loop
+  }
+
+  return array;
+}
+
 void Parse::do_multianewarray() {
   int ndimensions = iter().get_dimensions();
 
@@ -373,6 +407,13 @@ void Parse::do_multianewarray() {
       // Pass 0 as nargs since uncommon trap code does not need to restore stack.
       obj = expand_multianewarray(array_klass, &length[0], ndimensions, 0);
     } //original reexecute and sp are set back here
+    push(obj);
+    return;
+  }
+
+  if (ndimensions == 2) {
+    // PreserveReexecuteState?
+    Node* obj = expand_multianewarray2(array_klass, &length[0], ndimensions, 0);
     push(obj);
     return;
   }
@@ -436,6 +477,5 @@ void Parse::do_multianewarray() {
   push(cast);
 
   // Possible improvements:
-  // - Make a fast path for small multi-arrays.  (W/ implicit init. loops.)
   // - Issue CastII against length[*] values, to TypeInt::POS.
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/ArrayAllocation.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ArrayAllocation.java
@@ -55,4 +55,21 @@ public class ArrayAllocation {
         byte z[] = new byte[size];
         return z.length;
     }
+
+    @Param({"2"})
+    int size2;
+
+    @Benchmark
+    public Object full() {
+        return new int[size2][size2];
+    }
+
+    @Benchmark
+    public Object piecemeal() {
+        int[][] ints = new int[size2][];
+        for (int c = 0; c < size2; c++) {
+            ints[c] = new int[size2];
+        }
+        return ints;
+    }
 }


### PR DESCRIPTION
The performance issue arises from transforming new int[size1][size2] into a costly hotspot runtime call that allocates the main array and then sequentially allocates subarrays.

During the C2 parse phase, expressions with constant sizes, such as new int[2][2], are optimized into a series of AllocateArray nodes. These nodes are compiled into inline TLAB allocations, avoiding runtime calls.

This change aims at optimising the case of multidimensional arrays of variable size. For such cases, a Parse::expand_multianewarray2 will generate a c2 graph equivalent to `array = new int[size1][]; for (int i=0; i<size1; i++) { array[i] = new int[size2] }` expression.

Current status: _in progress. Change produces good results, but is not yet functionally correct._ The preliminary performance result:

```
Benchmark                  (size)  (size2)  Mode  Cnt   Score    Error   Units
ArrayAllocation.full (before) 128        2  avgt    4  540.707 ± 12.154  ns/op
ArrayAllocation.full (after)  128        2  avgt    4   12.713 ±  0.435  ns/op
ArrayAllocation.piecemeal     128        2  avgt    4   12.966 ±  0.297  ns/op
```