### PR TITLE
8346605: AIX fastdebug build fails in memoryReserver.cpp after JDK-8345655

### DIFF
--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -30,7 +30,7 @@
 #include "oops/markWord.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
-#include "runtime/os.hpp"
+#include "runtime/os.inline.hpp"
 #include "utilities/formatBuffer.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/powerOfTwo.hpp"


### PR DESCRIPTION
After "8345655: Move reservation code out of ReservedSpace" the AIX fastdebug build fails with

```
/priv/jenkins/client-home/workspace/openjdk-jdk-dev-aix_ppc64-dbg/jdk/src/hotspot/share/memory/memoryReserver.cpp:513:26: error: incomplete type 'os::Aix' named in nested name specifier
        AIX_ONLY(&& (os::Aix::supports_64K_mmap_pages() || os::vm_page_size() == 4*K))) {
                     ~~~~^~~~~
/priv/jenkins/client-home/workspace/openjdk-jdk-dev-aix_ppc64-dbg/jdk/src/hotspot/share/utilities/macros.hpp:399:24: note: expanded from macro 'AIX_ONLY'
#define AIX_ONLY(code) code
                       ^~~~
/priv/jenkins/client-home/workspace/openjdk-jdk-dev-aix_ppc64-dbg/jdk/src/hotspot/share/runtime/os.hpp:1024:9: note: forward declaration of 'os::Aix'
  class Aix;
```


This is seen when configure is called with '--disable-precompiled-headers' .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346605](https://bugs.openjdk.org/browse/JDK-8346605): AIX fastdebug build fails in memoryReserver.cpp after JDK-8345655 (**Bug** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22830/head:pull/22830` \
`$ git checkout pull/22830`

Update a local copy of the PR: \
`$ git checkout pull/22830` \
`$ git pull https://git.openjdk.org/jdk.git pull/22830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22830`

View PR using the GUI difftool: \
`$ git pr show -t 22830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22830.diff">https://git.openjdk.org/jdk/pull/22830.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22830#issuecomment-2554433717)
</details>
