### PR TITLE
8336412: sun.net.www.MimeTable has a few unused methods

### DIFF
--- a/src/java.base/share/classes/java/net/URLConnection.java
+++ b/src/java.base/share/classes/java/net/URLConnection.java
@@ -306,7 +306,7 @@ public abstract class URLConnection {
         if (map == null) {
             fileNameMap = map = new FileNameMap() {
                 private final FileNameMap internalMap =
-                    sun.net.www.MimeTable.loadTable();
+                    sun.net.www.MimeTable.getDefaultTable();
 
                 public String getContentTypeFor(String fileName) {
                     return internalMap.getContentTypeFor(fileName);

--- a/src/java.base/share/classes/sun/net/www/MimeTable.java
+++ b/src/java.base/share/classes/sun/net/www/MimeTable.java
@@ -37,7 +37,7 @@ import java.util.Hashtable;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
-public class MimeTable implements FileNameMap {
+public final class MimeTable implements FileNameMap {
 
     /** Hash mark introducing a URI fragment */
     private static final int HASH_MARK = '#';


### PR DESCRIPTION
Cleans up `sun.net.www.MimeTable`:

* Removes unused methods & variables
* Removes commented out code
* Simplifies iterations over arrays

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336412](https://bugs.openjdk.org/browse/JDK-8336412): sun.net.www.MimeTable has a few unused methods (**Enhancement** - P5)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22831/head:pull/22831` \
`$ git checkout pull/22831`

Update a local copy of the PR: \
`$ git checkout pull/22831` \
`$ git pull https://git.openjdk.org/jdk.git pull/22831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22831`

View PR using the GUI difftool: \
`$ git pr show -t 22831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22831.diff">https://git.openjdk.org/jdk/pull/22831.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22831#issuecomment-2554967541)
</details>
