### PR TITLE
8346669: Increase abstraction in SetupBuildLauncher and remove extra args

### DIFF
--- a/make/StaticLibs.gmk
+++ b/make/StaticLibs.gmk
@@ -107,7 +107,8 @@ else
 endif
 
 $(eval $(call SetupBuildLauncher, java, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS -DENABLE_ARG_FILES, \
+    ENABLE_ARG_FILES := true, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
     EXTRA_RCFLAGS := $(JAVA_RCFLAGS), \
     VERSION_INFO_RESOURCE := $(JAVA_VERSION_INFO_RESOURCE), \
     OPTIMIZATION := HIGH, \

--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -48,15 +48,11 @@ JAVA_MANIFEST := $(TOPDIR)/src/java.base/windows/native/launcher/java.manifest
 # used as the name of the executable.
 #
 # Remaining parameters are named arguments. These include:
-# MAIN_MODULE  The module of the main class to launch if different from the
-#     current module
 # MAIN_CLASS   The Java main class to launch
-# JAVA_ARGS   Processed into a -DJAVA_ARGS and added to CFLAGS
-# EXTRA_JAVA_ARGS Processed into a -DEXTRA_JAVA_ARGS and is prepended
-#     before JAVA_ARGS to CFLAGS, primarily to allow long string literal
-#     compile time defines exceeding Visual Studio 2013 limitations.
-# CFLAGS   Additional CFLAGS
-# CFLAGS_windows   Additional CFLAGS_windows
+# JAVA_ARGS   Additional arguments to pass to Java when launching the main class
+# EXPAND_CLASSPATH_WILDCARDS   Set to true to pass EXPAND_CLASSPATH_WILDCARDS
+# ENABLE_ARG_FILES   Set to true to pass ENABLE_ARG_FILES
+# WINDOWS_JAVAW   Set to true to pass JAVAW on Windows
 # EXTRA_RCFLAGS   Additional EXTRA_RCFLAGS
 # MACOSX_PRIVILEGED   On macosx, allow to access other processes
 # OPTIMIZATION   Override default optimization level (LOW)
@@ -70,19 +66,25 @@ define SetupBuildLauncherBody
     $1_OPTIMIZATION := LOW
   endif
 
-  ifeq ($$($1_MAIN_MODULE), )
-    $1_MAIN_MODULE := $(MODULE)
-  endif
+  $1_MAIN_MODULE := $(MODULE)
 
   ifneq ($$($1_MAIN_CLASS), )
     $1_JAVA_ARGS += -Xms8m
     $1_LAUNCHER_CLASS := -m $$($1_MAIN_MODULE)/$$($1_MAIN_CLASS)
   endif
 
-  ifneq ($$($1_EXTRA_JAVA_ARGS), )
-    $1_EXTRA_JAVA_ARGS_STR := '{ $$(strip $$(foreach a, \
-      $$(addprefix -J, $$($1_EXTRA_JAVA_ARGS)), "$$a"$(COMMA) )) }'
-    $1_CFLAGS += -DEXTRA_JAVA_ARGS=$$($1_EXTRA_JAVA_ARGS_STR)
+  ifeq ($$($1_EXPAND_CLASSPATH_WILDCARDS), true)
+    $1_CFLAGS += -DEXPAND_CLASSPATH_WILDCARDS
+  endif
+
+  ifeq ($$($1_ENABLE_ARG_FILES), true)
+    $1_CFLAGS += -DENABLE_ARG_FILES
+  endif
+
+  ifeq ($(call isTargetOs, windows), true)
+    ifeq ($$($1_WINDOWS_JAVAW), true)
+      $1_CFLAGS += -DJAVAW
+    endif
   endif
 
   ifneq ($$($1_JAVA_ARGS), )
@@ -143,7 +145,6 @@ define SetupBuildLauncherBody
           -DLAUNCHER_NAME='"$$(LAUNCHER_NAME)"' \
           -DPROGNAME='"$1"' \
           $$($1_CFLAGS), \
-      CFLAGS_windows := $$($1_CFLAGS_windows), \
       EXTRA_HEADER_DIRS := java.base:libjvm, \
       DISABLED_WARNINGS_gcc := unused-function unused-variable, \
       DISABLED_WARNINGS_clang := unused-function, \
@@ -153,13 +154,6 @@ define SetupBuildLauncherBody
       LDFLAGS_FILTER_OUT := $$($1_LDFLAGS_FILTER_OUT), \
       JDK_LIBS := $$($1_JDK_LIBS), \
       JDK_LIBS_windows := $$($1_JDK_LIBS_windows), \
-      LIBS := $$($1_LIBS), \
-      LIBS_unix := $(LIBZ_LIBS), \
-      LIBS_linux := $(LIBDL) -lpthread, \
-      LIBS_macosx := \
-          -framework ApplicationServices \
-          -framework Cocoa \
-          -framework Security, \
       LINK_TYPE := $$($1_LINK_TYPE), \
       OUTPUT_DIR := $$($1_OUTPUT_DIR), \
       OBJECT_DIR := $$($1_OBJECT_DIR), \

--- a/make/modules/java.base/Launcher.gmk
+++ b/make/modules/java.base/Launcher.gmk
@@ -38,7 +38,8 @@ JAVA_RCFLAGS ?= -I$(TOPDIR)/src/java.base/windows/native/launcher/icons
 ################################################################################
 
 $(eval $(call SetupBuildLauncher, java, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS -DENABLE_ARG_FILES, \
+    ENABLE_ARG_FILES := true, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
     EXTRA_RCFLAGS := $(JAVA_RCFLAGS), \
     VERSION_INFO_RESOURCE := $(JAVA_VERSION_INFO_RESOURCE), \
     OPTIMIZATION := HIGH, \
@@ -50,7 +51,9 @@ $(eval $(call SetupBuildLauncher, java, \
 
 ifeq ($(call isTargetOs, windows), true)
   $(eval $(call SetupBuildLauncher, javaw, \
-      CFLAGS := -DJAVAW -DEXPAND_CLASSPATH_WILDCARDS -DENABLE_ARG_FILES, \
+      ENABLE_ARG_FILES := true, \
+      EXPAND_CLASSPATH_WILDCARDS := true, \
+      WINDOWS_JAVAW := true, \
       EXTRA_RCFLAGS := $(JAVA_RCFLAGS), \
       VERSION_INFO_RESOURCE := $(JAVA_VERSION_INFO_RESOURCE), \
   ))

--- a/make/modules/jdk.compiler/Launcher.gmk
+++ b/make/modules/jdk.compiler/Launcher.gmk
@@ -32,7 +32,7 @@ include LauncherCommon.gmk
 $(eval $(call SetupBuildLauncher, javac, \
     MAIN_CLASS := com.sun.tools.javac.Main, \
     JAVA_ARGS := --add-modules ALL-DEFAULT, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
 ))
 
 ################################################################################
@@ -41,5 +41,5 @@ $(eval $(call SetupBuildLauncher, javac, \
 
 $(eval $(call SetupBuildLauncher, serialver, \
     MAIN_CLASS := sun.tools.serialver.SerialVer, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
 ))

--- a/make/modules/jdk.javadoc/Launcher.gmk
+++ b/make/modules/jdk.javadoc/Launcher.gmk
@@ -32,5 +32,5 @@ include LauncherCommon.gmk
 $(eval $(call SetupBuildLauncher, javadoc, \
     MAIN_CLASS := jdk.javadoc.internal.tool.Main, \
     JAVA_ARGS := --add-modules ALL-DEFAULT, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
 ))

--- a/make/modules/jdk.jconsole/Launcher.gmk
+++ b/make/modules/jdk.jconsole/Launcher.gmk
@@ -36,5 +36,5 @@ $(eval $(call SetupBuildLauncher, jconsole, \
         --add-modules ALL-DEFAULT \
         -Djconsole.showOutputViewer \
         -Djdk.attach.allowAttachSelf=true, \
-    CFLAGS_windows := -DJAVAW, \
+    WINDOWS_JAVAW := true, \
 ))

--- a/make/modules/jdk.jdeps/Launcher.gmk
+++ b/make/modules/jdk.jdeps/Launcher.gmk
@@ -31,7 +31,7 @@ include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, javap, \
     MAIN_CLASS := com.sun.tools.javap.Main, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
 ))
 
 ################################################################################
@@ -40,7 +40,7 @@ $(eval $(call SetupBuildLauncher, javap, \
 
 $(eval $(call SetupBuildLauncher, jdeps, \
     MAIN_CLASS := com.sun.tools.jdeps.Main, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
 ))
 
 ################################################################################
@@ -49,7 +49,7 @@ $(eval $(call SetupBuildLauncher, jdeps, \
 
 $(eval $(call SetupBuildLauncher, jdeprscan, \
     MAIN_CLASS := com.sun.tools.jdeprscan.Main, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
 ))
 
 ################################################################################
@@ -58,5 +58,5 @@ $(eval $(call SetupBuildLauncher, jdeprscan, \
 
 $(eval $(call SetupBuildLauncher, jnativescan, \
     MAIN_CLASS := com.sun.tools.jnativescan.Main, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
 ))

--- a/make/modules/jdk.jfr/Launcher.gmk
+++ b/make/modules/jdk.jfr/Launcher.gmk
@@ -31,5 +31,5 @@ include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, jfr, \
     MAIN_CLASS := jdk.jfr.internal.tool.Main, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
 ))

--- a/make/modules/jdk.jlink/Launcher.gmk
+++ b/make/modules/jdk.jlink/Launcher.gmk
@@ -31,7 +31,7 @@ include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, jimage, \
     MAIN_CLASS := jdk.tools.jimage.Main, \
-    CFLAGS := -DENABLE_ARG_FILES, \
+    ENABLE_ARG_FILES := true, \
 ))
 
 ################################################################################
@@ -41,7 +41,8 @@ $(eval $(call SetupBuildLauncher, jimage, \
 $(eval $(call SetupBuildLauncher, jlink, \
     MAIN_CLASS := jdk.tools.jlink.internal.Main, \
     JAVA_ARGS := --add-modules ALL-DEFAULT, \
-    CFLAGS := -DENABLE_ARG_FILES -DEXPAND_CLASSPATH_WILDCARDS, \
+    ENABLE_ARG_FILES := true, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
 ))
 
 ################################################################################
@@ -50,5 +51,6 @@ $(eval $(call SetupBuildLauncher, jlink, \
 
 $(eval $(call SetupBuildLauncher, jmod, \
     MAIN_CLASS := jdk.tools.jmod.Main, \
-    CFLAGS := -DENABLE_ARG_FILES -DEXPAND_CLASSPATH_WILDCARDS, \
+    ENABLE_ARG_FILES := true, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
 ))

--- a/make/modules/jdk.jshell/Launcher.gmk
+++ b/make/modules/jdk.jshell/Launcher.gmk
@@ -31,5 +31,5 @@ include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, jshell, \
     MAIN_CLASS := jdk.internal.jshell.tool.JShellToolProvider, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+    EXPAND_CLASSPATH_WILDCARDS := true, \
 ))

--- a/src/java.base/share/native/launcher/defines.h
+++ b/src/java.base/share/native/launcher/defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,18 +50,9 @@ static const char* const_progname = PROGNAME;
 static char* const_progname = NULL;
 #endif
 static const char* const_jargs[] = JAVA_ARGS;
-#ifdef EXTRA_JAVA_ARGS
-static const char* const_extra_jargs[] = EXTRA_JAVA_ARGS;
-#else
-static const char** const_extra_jargs = NULL;
-#endif
 #else  /* !JAVA_ARGS */
-#ifdef EXTRA_JAVA_ARGS
-#error "EXTRA_JAVA_ARGS defined without JAVA_ARGS"
-#endif
 static const char* const_progname = "java";
 static const char** const_jargs = NULL;
-static const char** const_extra_jargs = NULL;
 #endif /* JAVA_ARGS */
 
 #ifdef LAUNCHER_NAME

--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -44,10 +44,6 @@ char **__initenv;
 int WINAPI
 WinMain(HINSTANCE inst, HINSTANCE previnst, LPSTR cmdline, int cmdshow)
 {
-    int margc;
-    char** margv;
-    int jargc;
-    char** jargv;
     const jboolean const_javaw = JNI_TRUE;
 
     __initenv = _environ;
@@ -56,47 +52,17 @@ WinMain(HINSTANCE inst, HINSTANCE previnst, LPSTR cmdline, int cmdshow)
 JNIEXPORT int
 main(int argc, char **argv)
 {
+    const jboolean const_javaw = JNI_FALSE;
+#endif /* JAVAW */
+
     int margc;
     char** margv;
     int jargc;
-    char** jargv;
-    const jboolean const_javaw = JNI_FALSE;
-#endif /* JAVAW */
-    {
-        int i, main_jargc, extra_jargc;
-        JLI_List list;
+    const char** jargv = const_jargs;
 
-        main_jargc = (sizeof(const_jargs) / sizeof(char *)) > 1
-            ? sizeof(const_jargs) / sizeof(char *)
-            : 0; // ignore the null terminator index
-
-        extra_jargc = (sizeof(const_extra_jargs) / sizeof(char *)) > 1
-            ? sizeof(const_extra_jargs) / sizeof(char *)
-            : 0; // ignore the null terminator index
-
-        if (main_jargc > 0 && extra_jargc > 0) { // combine extra java args
-            jargc = main_jargc + extra_jargc;
-            list = JLI_List_new(jargc + 1);
-
-            for (i = 0 ; i < extra_jargc; i++) {
-                JLI_List_add(list, JLI_StringDup(const_extra_jargs[i]));
-            }
-
-            for (i = 0 ; i < main_jargc ; i++) {
-                JLI_List_add(list, JLI_StringDup(const_jargs[i]));
-            }
-
-            // terminate the list
-            JLI_List_add(list, NULL);
-            jargv = list->elements;
-         } else if (extra_jargc > 0) { // should never happen
-            fprintf(stderr, "EXTRA_JAVA_ARGS defined without JAVA_ARGS");
-            abort();
-         } else { // no extra args, business as usual
-            jargc = main_jargc;
-            jargv = (char **) const_jargs;
-         }
-    }
+    jargc = (sizeof(const_jargs) / sizeof(char *)) > 1
+        ? sizeof(const_jargs) / sizeof(char *)
+        : 0; // ignore the null terminator index
 
     JLI_InitArgProcessing(jargc > 0, const_disable_argfile);
 
@@ -182,7 +148,7 @@ main(int argc, char **argv)
     }
 #endif /* WIN32 */
     return JLI_Launch(margc, margv,
-                   jargc, (const char**) jargv,
+                   jargc, jargv,
                    0, NULL,
                    VERSION_STRING,
                    DOT_VERSION,


### PR DESCRIPTION
We need to raise the abstraction of the SetupBuildLauncher API, to prepare for static launchers. We should specify the desired outcome, not what flags we should add. This can be seen as the last part of [JDK-8141444](https://bugs.openjdk.org/browse/JDK-8141444) (9 years later).

In the process, I am removing EXTRA_JAVA_ARGS which has not been used for a long time. I also removed this part from the launcher itself.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346669](https://bugs.openjdk.org/browse/JDK-8346669): Increase abstraction in SetupBuildLauncher and remove extra args (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22832/head:pull/22832` \
`$ git checkout pull/22832`

Update a local copy of the PR: \
`$ git checkout pull/22832` \
`$ git pull https://git.openjdk.org/jdk.git pull/22832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22832`

View PR using the GUI difftool: \
`$ git pr show -t 22832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22832.diff">https://git.openjdk.org/jdk/pull/22832.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22832#issuecomment-2555790746)
</details>
