### PR TITLE
8346667: Doccheck: warning about missing </span> before <h2>

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,8 +108,6 @@ import java.util.Objects;
  * }</pre>
  *
  * </ul>
- * @param <E> the boxed version of {@code ETYPE},
- *           the element type of a vector
  *
  * <h2>Value-based classes and identity operations</h2>
  *
@@ -128,6 +126,9 @@ import java.util.Objects;
  * {@code static final} constants, but storing them in other Java
  * fields or in array elements, while semantically valid, may incur
  * performance penalties.
+ *
+ * @param <E> the boxed version of {@code ETYPE},
+ *           the element type of a vector
  */
 @SuppressWarnings("exports")
 public abstract class VectorMask<E> extends jdk.internal.vm.vector.VectorSupport.VectorMask<E> {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ import java.util.Objects;
  * @param <E> the boxed version of {@code ETYPE},
  *           the element type of a vector
  *
- * <p style="font-size: large; font-weight: bold;">Value-based classes and identity operations</p>
+ * <h2>Value-based classes and identity operations</h2>
  *
  * {@code VectorMask}, along with {@link Vector}, is a
  * <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ import java.util.Objects;
  * @param <E> the boxed version of {@code ETYPE},
  *           the element type of a vector
  *
- * <h2>Value-based classes and identity operations</h2>
+ * <p style="font-size: large; font-weight: bold;">Value-based classes and identity operations</p>
  *
  * {@code VectorMask}, along with {@link Vector}, is a
  * <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>


### PR DESCRIPTION
Please review this doc-only patch to avoid some unwanted failures in our HTML checks. 

Javadoc wraps everything under `@param` in a `<span>`, so having an `h2` tag there trips some of our tests that use html validators (html-tidy and some other tests). I believe you shouldn't have an `<h2>` inside of a span.

This patch moves the text about "Value-based classes and identity operations" above the `@param` tag, it will now be rendered at the bottom of the class documentation.

This will need to be backported to JDK 24.

TIA.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346667](https://bugs.openjdk.org/browse/JDK-8346667): Doccheck: warning about missing &lt;/span&gt; before &lt;h2&gt; (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22833/head:pull/22833` \
`$ git checkout pull/22833`

Update a local copy of the PR: \
`$ git checkout pull/22833` \
`$ git pull https://git.openjdk.org/jdk.git pull/22833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22833`

View PR using the GUI difftool: \
`$ git pr show -t 22833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22833.diff">https://git.openjdk.org/jdk/pull/22833.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22833#issuecomment-2555183726)
</details>
