### PR TITLE
8346128: Comparison build fails due to difference in LabelTarget.html

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/instruction/LabelTarget.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LabelTarget.java
@@ -55,7 +55,7 @@ import jdk.internal.classfile.impl.LabelImpl;
  * {@snippet lang=java :
  * cob.with(lt); // @link substring="with" target="CodeBuilder#with"
  * // @link substring="labelBinding" target="CodeBuilder#labelBinding" :
- * cob.labelBinding(lt.label()); // @link substring="label" target="#label"
+ * cob.labelBinding(lt.label()); // @link regex="label(?=\()" target="#label"
  * }
  *
  * @see Label


### PR DESCRIPTION
Please review this doc-only patch to fix an issue that causes the cmp-baseline build to fail.

The snippet in `LabelTrget.java` showed a highly rare non deterministism in javadoc snippet generation, which will be fixed in [JDK-8346659](https://bugs.openjdk.org/browse/JDK-8346659), but we can fix the snippet now to stop the failures.

Previously, "label" in "labelBinding" would be matched to either `CodeBuilder#labelBinding` or `LabelTarget#label` (about 50:50 chance of either happening). I repaced the substring with a regex which seems to fix the issue.

This will need to be backported to JDK 24.

TIA!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346128](https://bugs.openjdk.org/browse/JDK-8346128): Comparison build fails due to difference in LabelTarget.html (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22834/head:pull/22834` \
`$ git checkout pull/22834`

Update a local copy of the PR: \
`$ git checkout pull/22834` \
`$ git pull https://git.openjdk.org/jdk.git pull/22834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22834`

View PR using the GUI difftool: \
`$ git pr show -t 22834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22834.diff">https://git.openjdk.org/jdk/pull/22834.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22834#issuecomment-2555076668)
</details>
