### PR TITLE
8346239: Improve memory efficiency of JimageDiffGenerator

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/runtimelink/JimageDiffGenerator.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/runtimelink/JimageDiffGenerator.java
@@ -24,6 +24,9 @@
  */
 package jdk.tools.jlink.internal.runtimelink;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -49,6 +52,7 @@ public class JimageDiffGenerator {
     public interface ImageResource extends AutoCloseable {
         public List<String> getEntries();
         public byte[] getResourceBytes(String name);
+        public InputStream getResource(String name);
     }
 
     /**
@@ -71,7 +75,6 @@ public class JimageDiffGenerator {
             resources.addAll(image.getEntries());
             baseResources = base.getEntries();
             for (String item: baseResources) {
-                byte[] baseBytes = base.getResourceBytes(item);
                 // First check that every item in the base image exist in
                 // the optimized image as well. If it does not, it's a removed
                 // item in the optimized image.
@@ -82,19 +85,18 @@ public class JimageDiffGenerator {
                     ResourceDiff.Builder builder = new ResourceDiff.Builder();
                     ResourceDiff diff = builder.setKind(ResourceDiff.Kind.REMOVED)
                            .setName(item)
-                           .setResourceBytes(baseBytes)
+                           .setResourceBytes(base.getResourceBytes(item))
                            .build();
                     diffs.add(diff);
                     continue;
                 }
                 // Verify resource bytes are equal if present in both images
-                boolean contentEquals = Arrays.equals(baseBytes, image.getResourceBytes(item));
-                if (!contentEquals) {
+                if (!compareStreams(base.getResource(item), image.getResource(item))) {
                     // keep track of original bytes (non-optimized)
                     ResourceDiff.Builder builder = new ResourceDiff.Builder();
                     ResourceDiff diff = builder.setKind(ResourceDiff.Kind.MODIFIED)
                         .setName(item)
-                        .setResourceBytes(baseBytes)
+                        .setResourceBytes(base.getResourceBytes(item))
                         .build();
                     diffs.add(diff);
                 }
@@ -110,6 +112,53 @@ public class JimageDiffGenerator {
             diffs.add(diff);
         }
         return diffs;
+    }
+
+    /**
+     * Compare the contents of the two input streams (byte-by-byte).
+     *
+     * @param is1 The first input stream
+     * @param is2 The second input stream
+     * @return {@code true} iff the two streams contain the same number of
+     *         bytes and each byte of the streams are equal. {@code false}
+     *         otherwise.
+     */
+    private boolean compareStreams(InputStream is1, InputStream is2) {
+        byte[] buf1 = new byte[1024];
+        byte[] buf2 = new byte[1024];
+        int bytesRead1, bytesRead2 = 0;
+        try {
+            try (is1; is2) {
+                while ((bytesRead1 = is1.read(buf1)) != -1 &&
+                       (bytesRead2 = is2.read(buf2)) != -1) {
+                    if (bytesRead1 != bytesRead2) {
+                        return false;
+                    }
+                    if (bytesRead1 == buf1.length) {
+                        if (!Arrays.equals(buf1, buf2)) {
+                            return false;
+                        }
+                    } else {
+                        for (int i = 0; i < bytesRead1; i++) {
+                            if (buf1[i] != buf2[i]) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                // ensure we read both to the end
+                if (bytesRead1 == -1) {
+                    bytesRead2 = is2.read(buf2);
+                    if (bytesRead2 != -1) {
+                        return false;
+                    }
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("IO exception when comparing bytes", e);
+        }
+        return true;
     }
 
 }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/runtimelink/JimageDiffGenerator.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/runtimelink/JimageDiffGenerator.java
@@ -158,7 +158,7 @@ public class JimageDiffGenerator {
         } catch (IOException e) {
             throw new UncheckedIOException("IO exception when comparing bytes", e);
         }
-        return true;
+        return false;
     }
 
 }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/runtimelink/ResourcePoolReader.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/runtimelink/ResourcePoolReader.java
@@ -25,6 +25,7 @@
 
 package jdk.tools.jlink.internal.runtimelink;
 
+import java.io.InputStream;
 import java.util.List;
 import java.util.Objects;
 
@@ -54,6 +55,11 @@ public class ResourcePoolReader implements ImageResource {
     @Override
     public byte[] getResourceBytes(String name) {
         return pool.findEntry(name).orElseThrow().contentBytes();
+    }
+
+    @Override
+    public InputStream getResource(String name) {
+        return pool.findEntry(name).orElseThrow().content();
     }
 
 }

--- a/test/jdk/tools/jlink/runtimeImage/AddOptionsTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/AddOptionsTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m AddOptionsTest
+ * @run main/othervm -Xmx1g AddOptionsTest
  */
 public class AddOptionsTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/BasicJlinkMissingJavaBase.java
+++ b/test/jdk/tools/jlink/runtimeImage/BasicJlinkMissingJavaBase.java
@@ -41,7 +41,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m BasicJlinkMissingJavaBase
+ * @run main/othervm -Xmx1g BasicJlinkMissingJavaBase
  */
 public class BasicJlinkMissingJavaBase extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/BasicJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/BasicJlinkTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m BasicJlinkTest false
+ * @run main/othervm -Xmx1g BasicJlinkTest false
  */
 public class BasicJlinkTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/CustomModuleJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/CustomModuleJlinkTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m CustomModuleJlinkTest
+ * @run main/othervm -Xmx1g CustomModuleJlinkTest
  */
 public class CustomModuleJlinkTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/GenerateJLIClassesTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/GenerateJLIClassesTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m GenerateJLIClassesTest
+ * @run main/othervm -Xmx1g GenerateJLIClassesTest
  */
 public class GenerateJLIClassesTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/JavaSEReproducibleTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/JavaSEReproducibleTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m JavaSEReproducibleTest
+ * @run main/othervm -Xmx1g JavaSEReproducibleTest
  */
 public class JavaSEReproducibleTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/KeepPackagedModulesFailTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/KeepPackagedModulesFailTest.java
@@ -41,7 +41,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m KeepPackagedModulesFailTest
+ * @run main/othervm -Xmx1g KeepPackagedModulesFailTest
  */
 public class KeepPackagedModulesFailTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesExitTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesExitTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m ModifiedFilesExitTest
+ * @run main/othervm -Xmx1g ModifiedFilesExitTest
  */
 public class ModifiedFilesExitTest extends ModifiedFilesTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWarningTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWarningTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m ModifiedFilesWarningTest
+ * @run main/othervm -Xmx1g ModifiedFilesWarningTest
  */
 public class ModifiedFilesWarningTest extends ModifiedFilesTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/MultiHopTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/MultiHopTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m MultiHopTest
+ * @run main/othervm -Xmx1g MultiHopTest
  */
 public class MultiHopTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java
@@ -49,7 +49,7 @@ import tests.JImageGenerator;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g PackagedModulesVsRuntimeImageLinkTest
+ * @run main/othervm/timeout=1200 -Xmx1g PackagedModulesVsRuntimeImageLinkTest
  */
 public class PackagedModulesVsRuntimeImageLinkTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java
@@ -49,7 +49,7 @@ import tests.JImageGenerator;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm/timeout=1200 -Xmx1400m PackagedModulesVsRuntimeImageLinkTest
+ * @run main/othervm -Xmx1g PackagedModulesVsRuntimeImageLinkTest
  */
 public class PackagedModulesVsRuntimeImageLinkTest extends AbstractLinkableRuntimeTest {
 
@@ -76,7 +76,6 @@ public class PackagedModulesVsRuntimeImageLinkTest extends AbstractLinkableRunti
                 .output(helper.createNewImageDir("java-se-jmodfull"))
                 .addMods("java.se").call().assertSuccess();
 
-        System.out.println("Now comparing jmod-less and jmod-full) images");
         compareRecursively(javaSEruntimeLink, javaSEJmodFull);
     }
 

--- a/test/jdk/tools/jlink/runtimeImage/PatchedJDKModuleJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/PatchedJDKModuleJlinkTest.java
@@ -42,7 +42,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m PatchedJDKModuleJlinkTest
+ * @run main/othervm -Xmx1g PatchedJDKModuleJlinkTest
  */
 public class PatchedJDKModuleJlinkTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/SystemModulesTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/SystemModulesTest.java
@@ -41,7 +41,7 @@ import tests.JImageValidator;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m SystemModulesTest
+ * @run main/othervm -Xmx1g SystemModulesTest
  */
 public class SystemModulesTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/SystemModulesTest2.java
+++ b/test/jdk/tools/jlink/runtimeImage/SystemModulesTest2.java
@@ -42,7 +42,7 @@ import tests.JImageValidator;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1400m SystemModulesTest2
+ * @run main/othervm -Xmx1g SystemModulesTest2
  */
 public class SystemModulesTest2 extends AbstractLinkableRuntimeTest {
 


### PR DESCRIPTION
Please review this fairly simple change to improve how the `JimageDiffGenerator` works. The original implementation is pretty naive and read all bytes into memory and then compared them. This improved version only reads bytes on a bound buffer into memory compares those bytes and if equal continues on to reading the next bytes (`2k` at most) at a time. Previously it was `2*N` (where `N` is the file size of a file in bytes) part of the JDK. Ouch.

There is still the off-chance of reading a full file into memory when the generator detects a change, but this shouldn't happen for large files since the total diff should be around `600K` as of today.

This also reverts changes from [JDK-8344036](https://bugs.openjdk.org/browse/JDK-8344036) other than the `/timeout` change to the test, which is preserved as I think this bump is no longer needed.

Testing:
- [x] GHA
- [x] jlink tests on a fastdebug build with `--with-native-debug-symbols=internal` (so as to have a large libjvm.so).
- [x] Manual reproducer from the bug which fails with OOM before the patch and passes after

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346239](https://bugs.openjdk.org/browse/JDK-8346239): Improve memory efficiency of JimageDiffGenerator (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22835/head:pull/22835` \
`$ git checkout pull/22835`

Update a local copy of the PR: \
`$ git checkout pull/22835` \
`$ git pull https://git.openjdk.org/jdk.git pull/22835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22835`

View PR using the GUI difftool: \
`$ git pr show -t 22835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22835.diff">https://git.openjdk.org/jdk/pull/22835.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22835#issuecomment-2555497411)
</details>
