### PR TITLE
8345266: java/util/concurrent/locks/StampedLock/OOMEInStampedLock.java JTREG_TEST_THREAD_FACTORY=Virtual fails with OOME

### DIFF
--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -60,14 +60,14 @@ JVM_END
 #if INCLUDE_JVMTI
 class JvmtiUnmountBeginMark : public StackObj {
   Handle _vthread;
-  JavaThread* _target;
+  JavaThread* _current;
   freeze_result _result;
   bool _failed;
 
  public:
   JvmtiUnmountBeginMark(JavaThread* t) :
-    _vthread(t, t->vthread()), _target(t), _result(freeze_pinned_native), _failed(false) {
-    assert(!_target->is_in_VTMS_transition(), "must be");
+    _vthread(t, t->vthread()), _current(t), _result(freeze_pinned_native), _failed(false) {
+    assert(!_current->is_in_VTMS_transition(), "must be");
 
     if (JvmtiVTMSTransitionDisabler::VTMS_notify_jvmti_events()) {
       JvmtiVTMSTransitionDisabler::VTMS_vthread_unmount((jthread)_vthread.raw_value(), true);
@@ -75,26 +75,26 @@ class JvmtiUnmountBeginMark : public StackObj {
       // Don't preempt if there is a pending popframe or earlyret operation. This can
       // be installed in start_VTMS_transition() so we need to check it here.
       if (JvmtiExport::can_pop_frame() || JvmtiExport::can_force_early_return()) {
-        JvmtiThreadState* state = _target->jvmti_thread_state();
-        if (_target->has_pending_popframe() || (state != nullptr && state->is_earlyret_pending())) {
+        JvmtiThreadState* state = _current->jvmti_thread_state();
+        if (_current->has_pending_popframe() || (state != nullptr && state->is_earlyret_pending())) {
           _failed = true;
         }
       }
 
       // Don't preempt in case there is an async exception installed since
       // we would incorrectly throw it during the unmount logic in the carrier.
-      if (_target->has_async_exception_condition()) {
+      if (_current->has_async_exception_condition()) {
         _failed = true;
       }
     } else {
-      _target->set_is_in_VTMS_transition(true);
+      _current->set_is_in_VTMS_transition(true);
       java_lang_Thread::set_is_in_VTMS_transition(_vthread(), true);
     }
   }
   ~JvmtiUnmountBeginMark() {
-    assert(!_target->is_suspended(), "must be");
+    assert(!_current->is_suspended(), "must be");
 
-    assert(_target->is_in_VTMS_transition(), "must be");
+    assert(_current->is_in_VTMS_transition(), "must be");
     assert(java_lang_Thread::is_in_VTMS_transition(_vthread()), "must be");
 
     // Read it again since for late binding agents the flag could have
@@ -106,7 +106,7 @@ class JvmtiUnmountBeginMark : public StackObj {
       if (jvmti_present) {
         JvmtiVTMSTransitionDisabler::VTMS_vthread_mount((jthread)_vthread.raw_value(), false);
       } else {
-        _target->set_is_in_VTMS_transition(false);
+        _current->set_is_in_VTMS_transition(false);
         java_lang_Thread::set_is_in_VTMS_transition(_vthread(), false);
       }
     }
@@ -115,51 +115,59 @@ class JvmtiUnmountBeginMark : public StackObj {
   bool failed() { return _failed; }
 };
 
-static bool is_vthread_safe_to_preempt_for_jvmti(JavaThread* target) {
-  if (target->is_in_VTMS_transition()) {
-    // We caught target at the end of a mount transition.
+static bool is_vthread_safe_to_preempt_for_jvmti(JavaThread* current) {
+  if (current->is_in_VTMS_transition()) {
+    // We are at the end of a mount transition.
     return false;
   }
   return true;
 }
 #endif // INCLUDE_JVMTI
 
-static bool is_vthread_safe_to_preempt(JavaThread* target, oop vthread) {
+static bool is_vthread_safe_to_preempt(JavaThread* current, oop vthread) {
   assert(java_lang_VirtualThread::is_instance(vthread), "");
   if (java_lang_VirtualThread::state(vthread) != java_lang_VirtualThread::RUNNING) {  // inside transition
     return false;
   }
-  return JVMTI_ONLY(is_vthread_safe_to_preempt_for_jvmti(target)) NOT_JVMTI(true);
+  return JVMTI_ONLY(is_vthread_safe_to_preempt_for_jvmti(current)) NOT_JVMTI(true);
 }
 
 typedef freeze_result (*FreezeContFnT)(JavaThread*, intptr_t*);
 
-static void verify_preempt_preconditions(JavaThread* target, oop continuation) {
-  assert(target == JavaThread::current(), "no support for external preemption");
-  assert(target->has_last_Java_frame(), "");
-  assert(!target->preempting(), "");
-  assert(target->last_continuation() != nullptr, "");
-  assert(target->last_continuation()->cont_oop(target) == continuation, "");
+static void verify_preempt_preconditions(JavaThread* current, oop continuation) {
+  assert(current == JavaThread::current(), "no support for external preemption");
+  assert(current->has_last_Java_frame(), "");
+  assert(!current->preempting(), "");
+  assert(current->last_continuation() != nullptr, "");
+  assert(current->last_continuation()->cont_oop(current) == continuation, "");
   assert(Continuation::continuation_scope(continuation) == java_lang_VirtualThread::vthread_scope(), "");
-  assert(!target->has_pending_exception(), "");
+  assert(!current->has_pending_exception(), "");
 }
 
-freeze_result Continuation::try_preempt(JavaThread* target, oop continuation) {
-  verify_preempt_preconditions(target, continuation);
+freeze_result Continuation::try_preempt(JavaThread* current, oop continuation) {
+  verify_preempt_preconditions(current, continuation);
 
   if (LockingMode == LM_LEGACY) {
     return freeze_unsupported;
   }
 
-  if (!is_vthread_safe_to_preempt(target, target->vthread())) {
+  if (!is_vthread_safe_to_preempt(current, current->vthread())) {
     return freeze_pinned_native;
   }
 
-  JVMTI_ONLY(JvmtiUnmountBeginMark jubm(target);)
+  JVMTI_ONLY(JvmtiUnmountBeginMark jubm(current);)
   JVMTI_ONLY(if (jubm.failed()) return freeze_pinned_native;)
-  freeze_result res = CAST_TO_FN_PTR(FreezeContFnT, freeze_preempt_entry())(target, target->last_Java_sp());
+  freeze_result res = CAST_TO_FN_PTR(FreezeContFnT, freeze_preempt_entry())(current, current->last_Java_sp());
   log_trace(continuations, preempt)("try_preempt: %d", res);
   JVMTI_ONLY(jubm.set_result(res);)
+
+  if (current->has_pending_exception()) {
+    assert(res == freeze_exception, "expecting an exception result from freeze");
+    // We don't want to throw exceptions, especially when returning
+    // from monitorenter since the compiler does not expect one. We
+    // just ignore the exception and pin the vthread to the carrier.
+    current->clear_pending_exception();
+  }
   return res;
 }
 

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -44,8 +44,6 @@ javax/management/remote/mandatory/connection/DeadLockTest.java 8309069 windows-x
 
 javax/management/remote/mandatory/connection/ConnectionTest.java 8308352 windows-x64
 
-java/util/concurrent/locks/StampedLock/OOMEInStampedLock.java 8345266 generic-all
-
 ##########
 ## Tests incompatible with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.

--- a/test/jdk/java/lang/Thread/virtual/MonitorEnterWaitOOME.java
+++ b/test/jdk/java/lang/Thread/virtual/MonitorEnterWaitOOME.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=monitorenter
+ * @bug 8345266
+ * @summary Test OOM while trying to unmount vthread on monitorenter
+ * @requires vm.continuations & vm.gc.G1 & vm.opt.DisableExplicitGC != "true"
+ * @library /test/lib
+ * @run main/othervm -XX:+UseG1GC -Xmx48M MonitorEnterWaitOOME false
+ */
+
+/*
+ * @test id=timedwait
+ * @summary Test OOM while trying to unmount vthread on Object.wait
+ * @requires vm.continuations & vm.gc.G1 & vm.opt.DisableExplicitGC != "true"
+ * @library /test/lib
+ * @run main/othervm -XX:+UseG1GC -Xmx48M MonitorEnterWaitOOME true 5
+ */
+
+/*
+ * @test id=untimedwait
+ * @summary Test OOM while trying to unmount vthread on Object.wait
+ * @requires vm.continuations & vm.gc.G1 & vm.opt.DisableExplicitGC != "true"
+ * @library /test/lib
+ * @run main/othervm -XX:+UseG1GC -Xmx48M MonitorEnterWaitOOME true 0
+ */
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jdk.test.lib.thread.VThreadRunner;
+
+public class MonitorEnterWaitOOME {
+    static volatile Object data;
+    static Thread.State dummyState = Thread.State.RUNNABLE; // load java.lang.Thread$State
+
+    public static void main(String[] args) throws Throwable {
+        final boolean testWait = args.length >= 1 ? Boolean.parseBoolean(args[0]) : false;
+        final long timeout = testWait && args.length == 2 ? Long.parseLong(args[1]) : 0L;
+
+        VThreadRunner.ensureParallelism(2);
+
+        Thread vthread;
+        var lock = new Object();
+        var canFillHeap = new AtomicBoolean();
+        var heapFilled = new AtomicBoolean();
+        var heapCollected = new AtomicBoolean();
+        var exRef = new AtomicReference<Throwable>();
+        synchronized (lock) {
+            vthread = Thread.ofVirtual().start(() -> {
+                try {
+                    awaitTrue(canFillHeap);
+                    data = fillHeap();
+                    heapFilled.set(true);
+                    synchronized (lock) {
+                        if (testWait) {
+                            lock.wait(timeout);
+                        }
+                    }
+                    data = null;
+                    System.gc();
+                    heapCollected.set(true);
+                } catch (Throwable e) {
+                    data = null;
+                    System.gc(); // avoid nested OOME
+                    exRef.set(e);
+                }
+            });
+            canFillHeap.set(true);
+            awaitTrue(heapFilled);
+            awaitState(vthread, Thread.State.BLOCKED);
+        }
+        if (testWait && timeout == 0) {
+            awaitState(vthread, Thread.State.WAITING);
+            synchronized (lock) {
+                lock.notify();
+            }
+        }
+        joinVThread(vthread, heapCollected, exRef);
+        assert exRef.get() == null;
+    }
+
+    private static Object[] fillHeap() {
+        Object[] first = null, last = null;
+        int size = 1 << 20;
+        while (size > 0) {
+            try {
+                Object[] array = new Object[size];
+                if (first == null) {
+                    first = array;
+                } else {
+                    last[0] = array;
+                }
+                last = array;
+            } catch (OutOfMemoryError oome) {
+                size = size >>> 1;
+            }
+        }
+        return first;
+    }
+
+    private static void awaitTrue(AtomicBoolean ready) {
+        // Don't call anything that might allocate from the Java heap.
+        while (!ready.get()) {
+            Thread.onSpinWait();
+        }
+    }
+
+    private static void awaitState(Thread thread, Thread.State expectedState) {
+        // Don't call anything that might allocate from the Java heap.
+        while (thread.getState() != expectedState) {
+            Thread.onSpinWait();
+        }
+    }
+
+    private static void joinVThread(Thread vthread, AtomicBoolean ready, AtomicReference<Throwable> exRef) throws Throwable {
+        // Don't call anything that might allocate from the Java heap until ready is set.
+        while (!ready.get()) {
+            Throwable ex = exRef.get();
+            if (ex != null) {
+                throw ex;
+            }
+            Thread.onSpinWait();
+        }
+        vthread.join();
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [572ce269](https://github.com/openjdk/jdk/commit/572ce269d0cf7974ad5299edbff596a36d0692a9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Patricio Chilano Mateo on 19 Dec 2024 and was reviewed by David Holmes, Alan Bateman and Coleen Phillimore.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345266](https://bugs.openjdk.org/browse/JDK-8345266): java/util/concurrent/locks/StampedLock/OOMEInStampedLock.java JTREG_TEST_THREAD_FACTORY=Virtual fails with OOME (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22836/head:pull/22836` \
`$ git checkout pull/22836`

Update a local copy of the PR: \
`$ git checkout pull/22836` \
`$ git pull https://git.openjdk.org/jdk.git pull/22836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22836`

View PR using the GUI difftool: \
`$ git pr show -t 22836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22836.diff">https://git.openjdk.org/jdk/pull/22836.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22836#issuecomment-2556076614)
</details>
