### PR TITLE
8175709: DateTimeFormatterBuilder.appendZoneId() has misleading JavaDoc

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -1097,14 +1097,14 @@ public final class DateTimeFormatterBuilder {
      * During parsing, the text must match a known zone or offset.
      * There are two types of zone ID, offset-based, such as '+01:30' and
      * region-based, such as 'Europe/London'. These are parsed differently.
-     * If the parse starts with '+', '-', 'UT', 'UTC' or 'GMT', then the parser
-     * expects an offset-based zone and will not match region-based zones.
-     * The offset ID, such as '+02:30', may be at the start of the parse,
-     * or prefixed by  'UT', 'UTC' or 'GMT'. The offset ID parsing is
-     * equivalent to using {@link #appendOffset(String, String)} using the
-     * arguments 'HH:MM:ss' and the no offset string '0'.
-     * If the parse starts with 'UT', 'UTC' or 'GMT', and the parser cannot
-     * match a following offset ID, then {@link ZoneOffset#UTC} is selected.
+     * If the parse starts with '+' or '-', then the parser expects an
+     * offset-based zone and will not match region-based zones. The offset
+     * ID parsing is equivalent to using {@link #appendOffset(String, String)}
+     * using the arguments 'HH:MM:ss' and the no offset string '0'.
+     * If the parse starts with 'UT', 'UTC' or 'GMT', and the parser can
+     * match a following offset, then a region-based zone with the parsed
+     * offset will be returned, or else if the parser cannot match a following
+     * offset, then {@link ZoneOffset#UTC} is selected.
      * In all other cases, the list of known region-based zones is used to
      * find the longest available match. If no match is found, and the parse
      * starts with 'Z', then {@code ZoneOffset.UTC} is selected.
@@ -1118,9 +1118,9 @@ public final class DateTimeFormatterBuilder {
      *   "UTC"                     -- ZoneId.of("UTC")
      *   "GMT"                     -- ZoneId.of("GMT")
      *   "+01:30"                  -- ZoneOffset.of("+01:30")
-     *   "UT+01:30"                -- ZoneOffset.of("+01:30")
-     *   "UTC+01:30"               -- ZoneOffset.of("+01:30")
-     *   "GMT+01:30"               -- ZoneOffset.of("+01:30")
+     *   "UT+01:30"                -- ZoneId.of("UT+01:30")
+     *   "UTC+01:30"               -- ZoneId.of("UTC+01:30")
+     *   "GMT+01:30"               -- ZoneId.of("GMT+01:30")
      * </pre>
      *
      * @return this, for chaining, not null
@@ -1133,7 +1133,7 @@ public final class DateTimeFormatterBuilder {
 
     /**
      * Appends the time-zone region ID, such as 'Europe/Paris', to the formatter,
-     * rejecting the zone ID if it is a {@code ZoneOffset}.
+     * rejecting the zone ID if it is a {@code ZoneOffset} during formatting.
      * <p>
      * This appends an instruction to format/parse the zone ID to the builder
      * only if it is a region-based ID.
@@ -1148,14 +1148,14 @@ public final class DateTimeFormatterBuilder {
      * During parsing, the text must match a known zone or offset.
      * There are two types of zone ID, offset-based, such as '+01:30' and
      * region-based, such as 'Europe/London'. These are parsed differently.
-     * If the parse starts with '+', '-', 'UT', 'UTC' or 'GMT', then the parser
-     * expects an offset-based zone and will not match region-based zones.
-     * The offset ID, such as '+02:30', may be at the start of the parse,
-     * or prefixed by  'UT', 'UTC' or 'GMT'. The offset ID parsing is
-     * equivalent to using {@link #appendOffset(String, String)} using the
-     * arguments 'HH:MM:ss' and the no offset string '0'.
-     * If the parse starts with 'UT', 'UTC' or 'GMT', and the parser cannot
-     * match a following offset ID, then {@link ZoneOffset#UTC} is selected.
+     * If the parse starts with '+' or '-', then the parser expects an
+     * offset-based zone and will not match region-based zones. The offset
+     * ID parsing is equivalent to using {@link #appendOffset(String, String)}
+     * using the arguments 'HH:MM:ss' and the no offset string '0'.
+     * If the parse starts with 'UT', 'UTC' or 'GMT', and the parser can
+     * match a following offset, then a region-based zone with the parsed
+     * offset will be returned, or else if the parser cannot match a following
+     * offset, then {@link ZoneOffset#UTC} is selected.
      * In all other cases, the list of known region-based zones is used to
      * find the longest available match. If no match is found, and the parse
      * starts with 'Z', then {@code ZoneOffset.UTC} is selected.
@@ -1169,9 +1169,9 @@ public final class DateTimeFormatterBuilder {
      *   "UTC"                     -- ZoneId.of("UTC")
      *   "GMT"                     -- ZoneId.of("GMT")
      *   "+01:30"                  -- ZoneOffset.of("+01:30")
-     *   "UT+01:30"                -- ZoneOffset.of("+01:30")
-     *   "UTC+01:30"               -- ZoneOffset.of("+01:30")
-     *   "GMT+01:30"               -- ZoneOffset.of("+01:30")
+     *   "UT+01:30"                -- ZoneId.of("UT+01:30")
+     *   "UTC+01:30"               -- ZoneId.of("UTC+01:30")
+     *   "GMT+01:30"               -- ZoneId.of("GMT+01:30")
      * </pre>
      * <p>
      * Note that this method is identical to {@code appendZoneId()} except
@@ -1206,14 +1206,14 @@ public final class DateTimeFormatterBuilder {
      * During parsing, the text must match a known zone or offset.
      * There are two types of zone ID, offset-based, such as '+01:30' and
      * region-based, such as 'Europe/London'. These are parsed differently.
-     * If the parse starts with '+', '-', 'UT', 'UTC' or 'GMT', then the parser
-     * expects an offset-based zone and will not match region-based zones.
-     * The offset ID, such as '+02:30', may be at the start of the parse,
-     * or prefixed by  'UT', 'UTC' or 'GMT'. The offset ID parsing is
-     * equivalent to using {@link #appendOffset(String, String)} using the
-     * arguments 'HH:MM:ss' and the no offset string '0'.
-     * If the parse starts with 'UT', 'UTC' or 'GMT', and the parser cannot
-     * match a following offset ID, then {@link ZoneOffset#UTC} is selected.
+     * If the parse starts with '+' or '-', then the parser expects an
+     * offset-based zone and will not match region-based zones. The offset
+     * ID parsing is equivalent to using {@link #appendOffset(String, String)}
+     * using the arguments 'HH:MM:ss' and the no offset string '0'.
+     * If the parse starts with 'UT', 'UTC' or 'GMT', and the parser can
+     * match a following offset, then a region-based zone with the parsed
+     * offset will be returned, or else if the parser cannot match a following
+     * offset, then {@link ZoneOffset#UTC} is selected.
      * In all other cases, the list of known region-based zones is used to
      * find the longest available match. If no match is found, and the parse
      * starts with 'Z', then {@code ZoneOffset.UTC} is selected.
@@ -1227,9 +1227,9 @@ public final class DateTimeFormatterBuilder {
      *   "UTC"                     -- ZoneId.of("UTC")
      *   "GMT"                     -- ZoneId.of("GMT")
      *   "+01:30"                  -- ZoneOffset.of("+01:30")
-     *   "UT+01:30"                -- ZoneOffset.of("UT+01:30")
-     *   "UTC+01:30"               -- ZoneOffset.of("UTC+01:30")
-     *   "GMT+01:30"               -- ZoneOffset.of("GMT+01:30")
+     *   "UT+01:30"                -- ZoneId.of("UT+01:30")
+     *   "UTC+01:30"               -- ZoneId.of("UTC+01:30")
+     *   "GMT+01:30"               -- ZoneId.of("GMT+01:30")
      * </pre>
      * <p>
      * Note that this method is identical to {@code appendZoneId()} except


### PR DESCRIPTION
Clarifying the documentation of `DateTimeFormatterBuilder.appendZoneId()` and similar methods to align the description with the behavior, in which `ZoneOffset` is only parsed from the formatter for offset texts without any prefixes. Corresponding CSR has also been drafted.