### PR TITLE
8346688: GenShen: Missing metadata trigger log message

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -64,7 +64,8 @@ void ShenandoahRegulatorThread::regulate_young_and_old_cycles() {
     if (mode == ShenandoahGenerationalControlThread::none) {
       if (should_start_metaspace_gc()) {
         if (request_concurrent_gc(GLOBAL)) {
-          log_debug(gc)("Heuristics request for global (unload classes) accepted.");
+          // Some of vmTestbase/metaspace tests depend on following line to count GC cycles
+          _global_heuristics->log_trigger("%s", GCCause::to_string(GCCause::_metadata_GC_threshold));
         }
       } else {
         if (_young_heuristics->should_start_gc()) {


### PR DESCRIPTION
The generational mode may trigger a global collection when metaspace is exhausted. When this happens, it should log this trigger as the reason for starting a cycle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346688](https://bugs.openjdk.org/browse/JDK-8346688): GenShen: Missing metadata trigger log message (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22838/head:pull/22838` \
`$ git checkout pull/22838`

Update a local copy of the PR: \
`$ git checkout pull/22838` \
`$ git pull https://git.openjdk.org/jdk.git pull/22838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22838`

View PR using the GUI difftool: \
`$ git pr show -t 22838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22838.diff">https://git.openjdk.org/jdk/pull/22838.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22838#issuecomment-2555933817)
</details>
