### PR TITLE
8285150: Improve tab completion for annotations

### DIFF
--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -821,4 +821,22 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("ints.le|", "length");
         assertCompletion("String[].|", "class");
     }
+
+    public void testAnnotation() {
+        assertCompletion("@Deprec|", "Deprecated");
+        assertCompletion("@Deprecated(|", "forRemoval = ", "since = ");
+        assertCompletion("@Deprecated(forRemoval = |", true, "false", "true");
+        assertCompletion("@Deprecated(forRemoval = true, |", "since = ");
+        assertEval("import java.lang.constant.ConstantDescs;");
+        assertEval("import static java.lang.constant.ConstantDescs.*;");
+        assertEval("@interface Ann1 { public String test(); }");
+        assertCompletionIncludesExcludes("@Ann1(test = |", Set.of("java.", "ConstantDescs", "INIT_NAME"), Set.of("CD_char", "byte"));
+        assertEval("@interface Ann2 { public String[] test(); }");
+        assertCompletionIncludesExcludes("@Ann2(test = {|", Set.of("java.", "ConstantDescs", "INIT_NAME"), Set.of("CD_char", "byte"));
+        assertCompletionIncludesExcludes("@Ann2(test = {|", true, Set.of("INIT_NAME"), Set.of("java.", "ConstantDescs", "CD_char", "byte"));
+        assertEval("@interface Ann3 { public String value(); }");
+        assertCompletionIncludesExcludes("@Ann3(|", Set.of("java.", "ConstantDescs", "INIT_NAME", "value = "), Set.of("CD_char", "byte"));
+        assertCompletionIncludesExcludes("@Ann3(|", true, Set.of("INIT_NAME", "value = "), Set.of("java.", "ConstantDescs", "CD_char", "byte"));
+        assertSignature("@Deprecated(|", "boolean Deprecated.forRemoval()", "String Deprecated.since()");
+    }
 }


### PR DESCRIPTION
When using types code like:
```
@Deprecated(
```

and presses `<tab>`, there should be a sensible completion, but currently there is nothing. This PR proposes to add code completion for annotation attributes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/BorderLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/FlowLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridBagLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridBagLayout-2.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridLayout-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/java/awt/doc-files/GridLayout-2.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletColor32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono16.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/beaninfo/images/JAppletMono32.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/doc-files/JRootPane-1.gif)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/glass.png)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/x.png)
&nbsp;⚠️ Patch contains a binary file (test/hotspot/jtreg/runtime/ClassFile/JsrRewritingTestCase.jar)
&nbsp;⚠️ Patch contains a binary file (test/hotspot/jtreg/runtime/ClassFile/testcase.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/rmi/ssl/truststore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/jdk/internal/loader/URLClassPath/testclasses.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/dnsstore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/net/www/protocol/https/HttpsClient/ipstore)

### Issue
 * [JDK-8285150](https://bugs.openjdk.org/browse/JDK-8285150): Improve tab completion for annotations (**Enhancement** - P4)(⚠️ The fixVersion in this issue is [26] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22840/head:pull/22840` \
`$ git checkout pull/22840`

Update a local copy of the PR: \
`$ git checkout pull/22840` \
`$ git pull https://git.openjdk.org/jdk.git pull/22840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22840`

View PR using the GUI difftool: \
`$ git pr show -t 22840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22840.diff">https://git.openjdk.org/jdk/pull/22840.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22840#issuecomment-2556374009)
</details>
