### PR TITLE
8302293: jar --create fails with IllegalArgumentException if archive name is shorter than 3 characters

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
@@ -315,11 +315,13 @@ public class Main {
                     // error("Warning: -v option ignored");
                     vflag = false;
                 }
-                final String tmpbase = (fname == null)
+                String tmpFilePrefix = (fname == null)
                         ? "tmpjar"
                         : fname.substring(fname.indexOf(File.separatorChar) + 1);
-
-                tmpFile = createTemporaryFile(tmpbase, ".jar");
+                if (tmpFilePrefix.length() < 3) {
+                    tmpFilePrefix = "tmpjar" + tmpFilePrefix;
+                }
+                tmpFile = createTemporaryFile(tmpFilePrefix, ".jar");
                 try (OutputStream out = new FileOutputStream(tmpFile)) {
                     create(new BufferedOutputStream(out, 4096), manifest);
                 }
@@ -1775,11 +1777,12 @@ public class Main {
             // Unable to create file due to permission violation or security exception
         }
         if (tmpfile == null) {
-            // Were unable to create temporary file, fall back to temporary file in the same folder
+            // We were unable to create temporary file, fall back to temporary file in the
+            // same folder as the JAR file
             if (fname != null) {
                 try {
                     File tmpfolder = new File(fname).getAbsoluteFile().getParentFile();
-                    tmpfile = File.createTempFile(fname, ".tmp" + suffix, tmpfolder);
+                    tmpfile = File.createTempFile(tmpbase, ".tmp" + suffix, tmpfolder);
                 } catch (IOException ioe) {
                     // Last option failed - fall gracefully
                     fatalError(ioe);

--- a/test/jdk/tools/jar/JarCreateFileNameTest.java
+++ b/test/jdk/tools/jar/JarCreateFileNameTest.java
@@ -31,6 +31,7 @@ import java.util.zip.ZipEntry;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /*
  * @test
@@ -61,12 +62,8 @@ public class JarCreateFileNameTest {
         assertEquals(0, exitCode, "jar command failed");
         // verify the JAR file is created and contains the expected entry
         try (final JarFile jarFile = new JarFile(new File(targetJarFileName))) {
-            jarFile.stream()
-                    .map(ZipEntry::getName)
-                    .filter(fileName::equals)
-                    .findFirst()
-                    .orElseThrow(() -> new AssertionError("missing " + fileName
-                            + " entry in JAR file " + targetJarFileName));
+            final ZipEntry entry = jarFile.getEntry(fileName);
+            assertNotNull(entry, "missing " + fileName + " entry in JAR file " + targetJarFileName);
         }
     }
 }

--- a/test/jdk/tools/jar/JarCreateFileNameTest.java
+++ b/test/jdk/tools/jar/JarCreateFileNameTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarFile;
+import java.util.spi.ToolProvider;
+import java.util.zip.ZipEntry;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/*
+ * @test
+ * @bug 8302293
+ * @summary verify that a JAR file creation through "jar --create" operation
+ *          works fine if the JAR file name is less than 3 characters in length
+ * @run junit JarCreateFileNameTest
+ */
+public class JarCreateFileNameTest {
+
+    private static final ToolProvider JAR_TOOL = ToolProvider.findFirst("jar")
+            .orElseThrow(() ->
+                    new RuntimeException("jar tool not found")
+            );
+
+    @ParameterizedTest
+    @ValueSource(strings = {"abcd", "abc", "ab", "a", "d.jar", "ef.jar"})
+    void testCreate(final String targetJarFileName) throws Exception {
+        final Path cwd = Path.of(".");
+        final Path tmpFile = Files.createTempFile(cwd, "8302293", ".txt");
+        final String fileName = tmpFile.getFileName().toString();
+        final int exitCode = JAR_TOOL.run(System.out, System.err,
+                "--create", "--file", targetJarFileName, fileName);
+        assertEquals(0, exitCode, "jar command failed");
+        // verify the JAR file is created and contains the expected entry
+        try (final JarFile jarFile = new JarFile(new File(targetJarFileName))) {
+            jarFile.stream()
+                    .map(ZipEntry::getName)
+                    .filter(fileName::equals)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("missing " + fileName
+                            + " entry in JAR file " + targetJarFileName));
+        }
+    }
+}
+

--- a/test/jdk/tools/jar/JarCreateFileNameTest.java
+++ b/test/jdk/tools/jar/JarCreateFileNameTest.java
@@ -46,6 +46,10 @@ public class JarCreateFileNameTest {
                     new RuntimeException("jar tool not found")
             );
 
+    /*
+     * Launches "jar --create --file" with file names of varying lengths and verifies
+     * that the JAR file was successfully created.
+     */
     @ParameterizedTest
     @ValueSource(strings = {"abcd", "abc", "ab", "a", "d.jar", "ef.jar"})
     void testCreate(final String targetJarFileName) throws Exception {


### PR DESCRIPTION
Can I please get a review for this change which proposes to fix the issue noted in https://bugs.openjdk.org/browse/JDK-8302293?

As noted in the issue, when creating a temporary file during the "jar --create" operation, if the original file name is lesser than 3 characters, the temporary file creation which uses the original file's name as the temporary file name prefix, runs into an exception. The commit in this PR addresses that issue by ensuring that the temporary file name prefix is atleast 3 characters in length. Within the same file, an additional place was spotted where the code could potentially run into the same exception, so that too has been addressed in this change.

A new jtreg test has been introduced which reproduces the issue and verifies the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8302293: jar --create fails with IllegalArgumentException if archive name is shorter than 3 characters`

### Issue
 * [JDK-8302293](https://bugs.openjdk.org/browse/JDK-8302293): jar --create fails with IllegalArgumentException if archive name is shorter than 3 characters (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22841/head:pull/22841` \
`$ git checkout pull/22841`

Update a local copy of the PR: \
`$ git checkout pull/22841` \
`$ git pull https://git.openjdk.org/jdk.git pull/22841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22841`

View PR using the GUI difftool: \
`$ git pr show -t 22841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22841.diff">https://git.openjdk.org/jdk/pull/22841.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22841#issuecomment-2556388839)
</details>
