### PR TITLE
8346573: Can't use custom default file system provider with custom system class loader

### DIFF
--- a/src/java.base/share/classes/java/nio/file/FileSystems.java
+++ b/src/java.base/share/classes/java/nio/file/FileSystems.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
+import jdk.internal.loader.ClassLoaders;
 import jdk.internal.misc.VM;
 import sun.nio.fs.DefaultFileSystemProvider;
 
@@ -112,11 +113,9 @@ public final class FileSystems {
             if (propValue != null) {
                 for (String cn: propValue.split(",")) {
                     try {
-                        Class<?> c = Class
-                            .forName(cn, true, ClassLoader.getSystemClassLoader());
-                        Constructor<?> ctor = c
-                            .getDeclaredConstructor(FileSystemProvider.class);
-                        provider = (FileSystemProvider)ctor.newInstance(provider);
+                        Class<?> c = Class.forName(cn, true, ClassLoaders.appClassLoader());
+                        Constructor<?> ctor = c.getDeclaredConstructor(FileSystemProvider.class);
+                        provider = (FileSystemProvider) ctor.newInstance(provider);
 
                         // must be "file"
                         if (!provider.getScheme().equals("file"))
@@ -146,13 +145,17 @@ public final class FileSystems {
      * is invoked to create the default file system.
      *
      * <p> If the system property {@code java.nio.file.spi.DefaultFileSystemProvider}
-     * is defined then it is taken to be a list of one or more fully-qualified
-     * names of concrete provider classes identified by the URI scheme
-     * {@code "file"}. Where the property is a list of more than one name then
-     * the names are separated by a comma. Each class is loaded, using the system
-     * class loader, and instantiated by invoking a one argument constructor
-     * whose formal parameter type is {@code FileSystemProvider}. The providers
-     * are loaded and instantiated in the order they are listed in the property.
+     * is defined then it is taken to be a list of one or more fully-qualified names
+     * of concrete provider classes identified by the URI scheme {@code "file"}.
+     * If the property is a list of more than one name then the names are separated
+     * by a comma character. Each provider class is a {@code public} class with a
+     * {@code public} constructor that has one formal parameter of type {@code
+     * FileSystemProvider}. If the provider class is in a named module then the module
+     * exports the package containing the provider class to at least {@code java.base}.
+     * Each provider class is loaded, using the
+     * {@linkplain ClassLoader#getSystemClassLoader() default system class loader},
+     * and instantiated by invoking the constructor. The providers are loaded and
+     * instantiated in the order they are listed in the property.
      * If this process fails or a provider's scheme is not equal to {@code "file"}
      * then an unspecified error is thrown. URI schemes are normally compared
      * without regard to case but for the default provider, the scheme is

--- a/test/jdk/java/nio/file/spi/CustomSystemClassLoader.java
+++ b/test/jdk/java/nio/file/spi/CustomSystemClassLoader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+
+/**
+ * Use by tests in SetDefaultProvider to test startup with a custom default file system
+ * provider and a custom system class loader.
+ */
+
+public class CustomSystemClassLoader extends ClassLoader {
+    public CustomSystemClassLoader(ClassLoader parent) {
+        super(parent);
+
+        // use default file system
+        FileSystem fs = FileSystems.getDefault();
+        var path = fs.getPath("foo");
+    }
+}

--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -23,10 +23,10 @@
 
 /*
  * @test
- * @bug 4313887 7006126 8142968 8178380 8183320 8210112 8266345 8263940 8331467
+ * @bug 4313887 7006126 8142968 8178380 8183320 8210112 8266345 8263940 8331467 8346573
  * @modules jdk.jartool jdk.jlink
  * @library /test/lib
- * @build testfsp/* testapp/*
+ * @build testfsp/* testapp/* CustomSystemClassLoader
  * @run junit SetDefaultProvider
  * @summary Runs tests with -Djava.nio.file.spi.DefaultFileSystemProvider set on
  *          the command line to override the default file system provider
@@ -202,6 +202,19 @@ class SetDefaultProvider {
                 "-p", TESTAPP_CLASSES,
                 "-cp", TESTFSP_CLASSES,
                 "-m", TESTAPP + "/" + TESTAPP_MAIN);
+    }
+
+    /**
+     * Test file system provider on class path in conjunction with a custom system
+     * class loader that uses the file system API during its initialization.
+     */
+    @Test
+    void testCustomSystemClassLoader() throws Exception {
+        String testClasses = System.getProperty("test.classes");
+        exec(SET_DEFAULT_FSP,
+                "-Djava.system.class.loader=CustomSystemClassLoader",
+                "-cp", ofClasspath(testClasses, TESTFSP_CLASSES, TESTAPP_CLASSES),
+                TESTAPP_MAIN);
     }
 
     /**


### PR DESCRIPTION
If an application is deployed to use a custom default file system provider, and a custom system class loader, and initialisation of the custom system class loader uses the file system APIs, then it leads to a recursive initialisation issue. This issue has always existed but has only recently been reported. Using both configuration knobs at the same time is probably very rare but it does require attention in advance of any proposals that re-implement the java.io file classes on java.nio.file.

The proposed change here is to re-specify FileSystems.getDefault to use the default system class loader when locating the custom default file system provider. In spec terms, this is changing "system class loader" to "default system class loader" with a link to its meaning in ClassLoader.getSystemClassLoader. As part of the change I've expanded the wording to specify that the custom default file system provider must be public in a package exported to at least java.base, and that the one-arg constructor also be public. This additional clarification specifies long standing behavior and does not change any implementation.

The SetDefaultProvider.java test is expanded to add a new test the runs with both a custom default file system provider and custom system class loader, and where where the custom system class loader uses the file APIs in its initialisation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8346709](https://bugs.openjdk.org/browse/JDK-8346709) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8346573](https://bugs.openjdk.org/browse/JDK-8346573): Can't use custom default file system provider with custom system class loader (**Bug** - P3)
 * [JDK-8346709](https://bugs.openjdk.org/browse/JDK-8346709): Can't use custom default file system provider with custom system class loader (**CSR**)


### Reviewers
 * [Maxim Kartashev](https://openjdk.org/census#mkartashev) (@mkartashev - no project role)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22842/head:pull/22842` \
`$ git checkout pull/22842`

Update a local copy of the PR: \
`$ git checkout pull/22842` \
`$ git pull https://git.openjdk.org/jdk.git pull/22842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22842`

View PR using the GUI difftool: \
`$ git pr show -t 22842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22842.diff">https://git.openjdk.org/jdk/pull/22842.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22842#issuecomment-2556744478)
</details>
