### PR TITLE
8346667: Doccheck: warning about missing </span> before <h2>

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,8 +108,6 @@ import java.util.Objects;
  * }</pre>
  *
  * </ul>
- * @param <E> the boxed version of {@code ETYPE},
- *           the element type of a vector
  *
  * <h2>Value-based classes and identity operations</h2>
  *
@@ -128,6 +126,9 @@ import java.util.Objects;
  * {@code static final} constants, but storing them in other Java
  * fields or in array elements, while semantically valid, may incur
  * performance penalties.
+ *
+ * @param <E> the boxed version of {@code ETYPE},
+ *           the element type of a vector
  */
 @SuppressWarnings("exports")
 public abstract class VectorMask<E> extends jdk.internal.vm.vector.VectorSupport.VectorMask<E> {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [054c644e](https://github.com/openjdk/jdk/commit/054c644ea6ea38e54abc81e231977106d04bb69e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Nizar Benalla on 20 Dec 2024 and was reviewed by Paul Sandoz.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346667](https://bugs.openjdk.org/browse/JDK-8346667): Doccheck: warning about missing &lt;/span&gt; before &lt;h2&gt; (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22844/head:pull/22844` \
`$ git checkout pull/22844`

Update a local copy of the PR: \
`$ git checkout pull/22844` \
`$ git pull https://git.openjdk.org/jdk.git pull/22844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22844`

View PR using the GUI difftool: \
`$ git pr show -t 22844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22844.diff">https://git.openjdk.org/jdk/pull/22844.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22844#issuecomment-2559765503)
</details>
