### PR TITLE
8346713: [testsuite] NeverActAsServerClassMachine breaks TestPLABAdaptToMinTLABSize.java TestPinnedHumongousFragmentation.java TestPinnedObjectContents.java

### DIFF
--- a/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
+++ b/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
@@ -35,6 +35,7 @@ package gc;
  */
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 
 import jdk.test.lib.process.OutputAnalyzer;
@@ -68,9 +69,11 @@ public class TestPLABAdaptToMinTLABSize {
     }
 
     public static void main(String[] args) throws Exception {
-        runTest(true, "-XX:MinTLABSize=100k");
-        // Should not succeed when explicitly specifying invalid combination.
-        runTest(false, "-XX:MinTLABSize=100k", "-XX:OldPLABSize=5k");
-        runTest(false, "-XX:MinTLABSize=100k", "-XX:YoungPLABSize=5k");
+        for (String gc : Arrays.asList("-XX:+UseG1GC", "-XX:+UseParallelGC")) {
+            runTest(true, gc, "-XX:MinTLABSize=100k");
+            // Should not succeed when explicitly specifying invalid combination.
+            runTest(false, gc, "-XX:MinTLABSize=100k", "-XX:OldPLABSize=5k");
+            runTest(false, gc, "-XX:MinTLABSize=100k", "-XX:YoungPLABSize=5k");
+        }
     }
 }

--- a/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
+++ b/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
@@ -24,14 +24,25 @@
 package gc;
 
 /*
- * @test TestPLABAdaptToMinTLABSize
+ * @test TestPLABAdaptToMinTLABSizeG1
  * @bug 8289137
  * @summary Make sure that Young/OldPLABSize adapt to MinTLABSize setting.
- * @requires vm.gc.Parallel | vm.gc.G1
+ * @requires vm.gc.G1
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver gc.TestPLABAdaptToMinTLABSize
+ * @run driver gc.TestPLABAdaptToMinTLABSize -XX:+UseG1GC
+ */
+
+/*
+ * @test TestPLABAdaptToMinTLABSizeParallel
+ * @bug 8289137
+ * @summary Make sure that Young/OldPLABSize adapt to MinTLABSize setting.
+ * @requires vm.gc.Parallel
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver gc.TestPLABAdaptToMinTLABSize -XX:+UseParallelGC
  */
 
 import java.util.ArrayList;
@@ -69,11 +80,10 @@ public class TestPLABAdaptToMinTLABSize {
     }
 
     public static void main(String[] args) throws Exception {
-        for (String gc : Arrays.asList("-XX:+UseG1GC", "-XX:+UseParallelGC")) {
-            runTest(true, gc, "-XX:MinTLABSize=100k");
-            // Should not succeed when explicitly specifying invalid combination.
-            runTest(false, gc, "-XX:MinTLABSize=100k", "-XX:OldPLABSize=5k");
-            runTest(false, gc, "-XX:MinTLABSize=100k", "-XX:YoungPLABSize=5k");
-        }
+        String gc = args[0];
+        runTest(true, gc, "-XX:MinTLABSize=100k");
+        // Should not succeed when explicitly specifying invalid combination.
+        runTest(false, gc, "-XX:MinTLABSize=100k", "-XX:OldPLABSize=5k");
+        runTest(false, gc, "-XX:MinTLABSize=100k", "-XX:YoungPLABSize=5k");
     }
 }

--- a/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedHumongousFragmentation.java
+++ b/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedHumongousFragmentation.java
@@ -36,7 +36,7 @@
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xlog:gc+region=trace -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
- *      -XX:VerifyGCType=full -XX:+VerifyDuringGC -XX:+VerifyAfterGC -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *      -XX:VerifyGCType=full -XX:+VerifyDuringGC -XX:+VerifyAfterGC -XX:+WhiteBoxAPI -XX:+UseG1GC -Xbootclasspath/a:.
  *      gc.g1.pinnedobjs.TestPinnedHumongousFragmentation
  */
 

--- a/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedObjectContents.java
+++ b/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedObjectContents.java
@@ -33,7 +33,8 @@
  *          java.management
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. -XX:+ZapUnusedHeapArea -Xlog:gc,gc+ergo+cset=trace gc.g1.pinnedobjs.TestPinnedObjectContents
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseG1GC
+ *      -Xbootclasspath/a:. -XX:+ZapUnusedHeapArea -Xlog:gc,gc+ergo+cset=trace gc.g1.pinnedobjs.TestPinnedObjectContents
  */
 
 package gc.g1.pinnedobjs;


### PR DESCRIPTION
JTREG=JAVA_OPTIONS=-XX:+NeverActAsServerClassMachine

test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
java.lang.RuntimeException: Unexpected to get exit value of [0]

test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedHumongousFragmentation.java
# Internal Error (/home/azul/azul/openjdk-git/src/hotspot/share/prims/whitebox.cpp:2647), pid=1672170, tid=1672189
# Error: ShouldNotReachHere()

test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedObjectContents.java
# Internal Error (/home/azul/azul/openjdk-git/src/hotspot/share/prims/whitebox.cpp:2647), pid=1672170, tid=1672189
# Error: ShouldNotReachHere()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346713](https://bugs.openjdk.org/browse/JDK-8346713): [testsuite] NeverActAsServerClassMachine breaks TestPLABAdaptToMinTLABSize.java TestPinnedHumongousFragmentation.java TestPinnedObjectContents.java (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22847/head:pull/22847` \
`$ git checkout pull/22847`

Update a local copy of the PR: \
`$ git checkout pull/22847` \
`$ git pull https://git.openjdk.org/jdk.git pull/22847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22847`

View PR using the GUI difftool: \
`$ git pr show -t 22847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22847.diff">https://git.openjdk.org/jdk/pull/22847.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22847#issuecomment-2556832496)
</details>
