### PR TITLE
8346714: [ASAN] compressedKlass.cpp reported applying non-zero offset to null pointer

### DIFF
--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -96,8 +96,7 @@ void CompressedKlassPointers::sanity_check_after_initialization() {
 
   // Check that Klass range is fully engulfed in the encoding range
   const address encoding_start = _base;
-  const intptr_t encodeing_offset = nth_bit(narrow_klass_pointer_bits() + _shift);
-  const address encoding_end = (_base == nullptr) ? (address)encodeing_offset : _base + encodeing_offset;
+  const address encoding_end = (address)((intptr_t)_base + nth_bit(narrow_klass_pointer_bits() + _shift));
   ASSERT_HERE_2(_klass_range_start >= _base && _klass_range_end <= encoding_end,
                 "Resulting encoding range does not fully cover the class range");
 

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -96,7 +96,7 @@ void CompressedKlassPointers::sanity_check_after_initialization() {
 
   // Check that Klass range is fully engulfed in the encoding range
   const address encoding_start = _base;
-  const address encoding_end = (address)((uintptr_t)_base + (uintptr_t)nth_bit(narrow_klass_pointer_bits() + _shift));
+  const address encoding_end = (address)(p2u(_base) + (uintptr_t)nth_bit(narrow_klass_pointer_bits() + _shift));
   ASSERT_HERE_2(_klass_range_start >= _base && _klass_range_end <= encoding_end,
                 "Resulting encoding range does not fully cover the class range");
 

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -96,7 +96,7 @@ void CompressedKlassPointers::sanity_check_after_initialization() {
 
   // Check that Klass range is fully engulfed in the encoding range
   const address encoding_start = _base;
-  const address encoding_end = (address)((intptr_t)_base + (intptr_t)nth_bit(narrow_klass_pointer_bits() + _shift));
+  const address encoding_end = (address)((uintptr_t)_base + (uintptr_t)nth_bit(narrow_klass_pointer_bits() + _shift));
   ASSERT_HERE_2(_klass_range_start >= _base && _klass_range_end <= encoding_end,
                 "Resulting encoding range does not fully cover the class range");
 

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -96,7 +96,7 @@ void CompressedKlassPointers::sanity_check_after_initialization() {
 
   // Check that Klass range is fully engulfed in the encoding range
   const address encoding_start = _base;
-  const address encoding_end = (address)((intptr_t)_base + nth_bit(narrow_klass_pointer_bits() + _shift));
+  const address encoding_end = (address)((intptr_t)_base + (intptr_t)nth_bit(narrow_klass_pointer_bits() + _shift));
   ASSERT_HERE_2(_klass_range_start >= _base && _klass_range_end <= encoding_end,
                 "Resulting encoding range does not fully cover the class range");
 

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -96,7 +96,8 @@ void CompressedKlassPointers::sanity_check_after_initialization() {
 
   // Check that Klass range is fully engulfed in the encoding range
   const address encoding_start = _base;
-  const address encoding_end = _base + nth_bit(narrow_klass_pointer_bits() + _shift);
+  const intptr_t encodeing_offset = nth_bit(narrow_klass_pointer_bits() + _shift);
+  const address encoding_end = (_base == nullptr) ? (address)encodeing_offset : _base + encodeing_offset;
   ASSERT_HERE_2(_klass_range_start >= _base && _klass_range_end <= encoding_end,
                 "Resulting encoding range does not fully cover the class range");
 

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -185,6 +185,11 @@ inline intptr_t p2i(const volatile void* p) {
   return (intptr_t) p;
 }
 
+// Convert pointer to uintptr_t
+inline uintptr_t p2u(const volatile void* p) {
+  return (uintptr_t) p;
+}
+
 #define BOOL_TO_STR(_b_) ((_b_) ? "true" : "false")
 
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Hi all,
CompressedKlassPointers::sanity_check_after_initialization() src/hotspot/share/oops/compressedKlass.cpp:104:38 reported runtime error: applying non-zero offset 4294967296 to null pointer by clang17 UndefinedBehaviorSanitizer.

The _base initial as nullptr in function CompressedKlassPointers::initialize(address addr, size_t len) shows as below. In C/C++, offsetting a null pointer is undefined behavior. This PR do not change the original logic but eliminate the undefined behaviour in code, the risk is low.

```c++
    address const end = addr + len;
    if (end <= (address)unscaled_max) {
      _base = nullptr;
      _shift = 0;
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346714](https://bugs.openjdk.org/browse/JDK-8346714): [ASAN] compressedKlass.cpp reported applying non-zero offset to null pointer (**Bug** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) Review applies to [86f00f87](https://git.openjdk.org/jdk/pull/22848/files/86f00f87f03a7e9d207e6d031977e034f7b7acab)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22848/head:pull/22848` \
`$ git checkout pull/22848`

Update a local copy of the PR: \
`$ git checkout pull/22848` \
`$ git pull https://git.openjdk.org/jdk.git pull/22848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22848`

View PR using the GUI difftool: \
`$ git pr show -t 22848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22848.diff">https://git.openjdk.org/jdk/pull/22848.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22848#issuecomment-2556963249)
</details>
