### PR TITLE
8345259: Disallow ALL-MODULE-PATH without explicit --module-path

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
@@ -127,7 +127,9 @@ err.runtime.link.packaged.mods=This JDK has no packaged modules.\
 err.runtime.link.modified.file={0} has been modified
 err.runtime.link.patched.module=jlink does not support linking from the run-time image\
 \ when running on a patched runtime with --patch-module
-err.empty.module.path=empty module path
+err.no.module.path=--module-path option must be specified with --add-modules ALL-MODULE-PATH
+err.empty.module.path=No module found in module path ''{0}'' with --add-modules ALL-MODULE-PATH
+err.limit.modules=--limit-modules not allowed with --add-modules ALL-MODULE-PATH
 err.jlink.version.mismatch=jlink version {0}.{1} does not match target java.base version {2}.{3}
 err.automatic.module:automatic module cannot be used with jlink: {0} from {1}
 err.unknown.byte.order:unknown byte order {0}

--- a/test/jdk/tools/jlink/IntegrationTest.java
+++ b/test/jdk/tools/jlink/IntegrationTest.java
@@ -157,7 +157,7 @@ public class IntegrationTest {
         boolean linkFromRuntime = false;
         JlinkConfiguration config = new Jlink.JlinkConfiguration(output,
                 mods,
-                JlinkTask.newLimitedFinder(JlinkTask.newModuleFinder(modulePaths), limits, mods),
+                JlinkTask.limitFinder(JlinkTask.newModuleFinder(modulePaths), limits, mods),
                 linkFromRuntime,
                 false /* ignore modified runtime */,
                 false /* generate run-time image */);

--- a/test/jdk/tools/jlink/JLinkTest.java
+++ b/test/jdk/tools/jlink/JLinkTest.java
@@ -27,17 +27,15 @@ import java.io.StringWriter;
 import java.lang.module.ModuleDescriptor;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.spi.ToolProvider;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import jdk.tools.jlink.plugin.Plugin;
 import jdk.tools.jlink.internal.PluginRepository;
+import jdk.tools.jlink.plugin.Plugin;
 import tests.Helper;
 import tests.JImageGenerator;
 
@@ -135,11 +133,11 @@ public class JLinkTest {
 
         {
             // No --module-path specified. --add-modules ALL-MODULE-PATH specified.
-            String imageDir = "bug8189777-all-module-path";
+            String imageDir = "bug8345259-all-module-path";
             JImageGenerator.getJLinkTask()
                     .output(helper.createNewImageDir(imageDir))
                     .addMods("ALL-MODULE-PATH")
-                    .call().assertSuccess();
+                    .call().assertFailure();
         }
 
         {


### PR DESCRIPTION
Clean backport of [JDK-8345259](https://bugs.openjdk.org/browse/JDK-8345259) to JDK 24 which has JEP 493.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8345894](https://bugs.openjdk.org/browse/JDK-8345894) to be approved

### Issues
 * [JDK-8345259](https://bugs.openjdk.org/browse/JDK-8345259): Disallow ALL-MODULE-PATH without explicit --module-path (**Bug** - P3)
 * [JDK-8345894](https://bugs.openjdk.org/browse/JDK-8345894): Disallow ALL-MODULE-PATH without explicit --module-path (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22849/head:pull/22849` \
`$ git checkout pull/22849`

Update a local copy of the PR: \
`$ git checkout pull/22849` \
`$ git pull https://git.openjdk.org/jdk.git pull/22849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22849`

View PR using the GUI difftool: \
`$ git pr show -t 22849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22849.diff">https://git.openjdk.org/jdk/pull/22849.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22849#issuecomment-2557024152)
</details>
