### PR TITLE
8346737: GenShen: Generational memory pools should not report zero for maximum capacity

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
@@ -93,11 +93,6 @@ size_t ShenandoahGenerationalMemoryPool::used_in_bytes() {
   return _generation->used();
 }
 
-size_t ShenandoahGenerationalMemoryPool::max_size() const {
-  return _generation->max_capacity();
-}
-
-
 ShenandoahYoungGenMemoryPool::ShenandoahYoungGenMemoryPool(ShenandoahHeap* heap) :
         ShenandoahGenerationalMemoryPool(heap,
                              "Shenandoah Young Gen",

--- a/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.hpp
@@ -55,7 +55,6 @@ public:
   explicit ShenandoahGenerationalMemoryPool(ShenandoahHeap* heap, const char* name, ShenandoahGeneration* generation);
   MemoryUsage get_memory_usage() override;
   size_t used_in_bytes() override;
-  size_t max_size() const override;
 };
 
 class ShenandoahYoungGenMemoryPool : public ShenandoahGenerationalMemoryPool {


### PR DESCRIPTION
The following tests fail in generational mode because the old generation reports a _maximum_ capacity of zero when it is empty. It makes sense to treat maximum capacity as a _theoretical_ maximum and let it equal the total size of the heap.

- vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded001/TestDescription.java 
- vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 
- vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded003/TestDescription.java 
- vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded004/TestDescription.java 
- vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded005/TestDescription.java 
- vmTestbase/nsk/monitoring/MemoryPoolMBean/setCollectionUsageThreshold/setthreshold001/TestDescription.java 
- vmTestbase/nsk/monitoring/MemoryPoolMBean/setCollectionUsageThreshold/setthreshold002/TestDescription.java 
- vmTestbase/nsk/monitoring/MemoryPoolMBean/setCollectionUsageThreshold/setthreshold003/TestDescription.java 
- vmTestbase/nsk/monitoring/MemoryPoolMBean/setCollectionUsageThreshold/setthreshold004/TestDescription.java 
- vmTestbase/nsk/monitoring/MemoryPoolMBean/setCollectionUsageThreshold/setthreshold005/TestDescription.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346737](https://bugs.openjdk.org/browse/JDK-8346737): GenShen: Generational memory pools should not report zero for maximum capacity (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Author)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22851/head:pull/22851` \
`$ git checkout pull/22851`

Update a local copy of the PR: \
`$ git checkout pull/22851` \
`$ git pull https://git.openjdk.org/jdk.git pull/22851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22851`

View PR using the GUI difftool: \
`$ git pr show -t 22851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22851.diff">https://git.openjdk.org/jdk/pull/22851.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22851#issuecomment-2557495398)
</details>
