### PR TITLE
8346739: jpackage tests failed after JDK-8345259

### DIFF
--- a/test/jdk/tools/jpackage/share/RuntimeImageSymbolicLinksTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimeImageSymbolicLinksTest.java
@@ -51,6 +51,7 @@ public class RuntimeImageSymbolicLinksTest {
 
     @Test
     public static void test() throws Exception {
+        final Path jmods = Path.of(System.getProperty("java.home"), "jmods");
         final Path workDir = TKit.createTempDirectory("runtime").resolve("data");
         final Path jlinkOutputDir = workDir.resolve("temp.runtime");
         Files.createDirectories(jlinkOutputDir.getParent());
@@ -61,6 +62,7 @@ public class RuntimeImageSymbolicLinksTest {
         .addArguments(
                 "--output", jlinkOutputDir.toString(),
                 "--add-modules", "ALL-MODULE-PATH",
+                "--module-path", jmods.toString(),
                 "--strip-debug",
                 "--no-header-files",
                 "--no-man-pages",

--- a/test/jdk/tools/jpackage/share/RuntimeImageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimeImageTest.java
@@ -44,6 +44,7 @@ public class RuntimeImageTest {
 
     @Test
     public static void test() throws Exception {
+        final Path jmods = Path.of(System.getProperty("java.home"), "jmods");
         final Path workDir = TKit.createTempDirectory("runtime").resolve("data");
         final Path jlinkOutputDir = workDir.resolve("temp.runtime");
         Files.createDirectories(jlinkOutputDir.getParent());
@@ -54,6 +55,7 @@ public class RuntimeImageTest {
         .addArguments(
                 "--output", jlinkOutputDir.toString(),
                 "--add-modules", "ALL-MODULE-PATH",
+                "--module-path", jmods.toString(),
                 "--strip-debug",
                 "--no-header-files",
                 "--no-man-pages",

--- a/test/jdk/tools/jpackage/share/RuntimePackageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimePackageTest.java
@@ -101,6 +101,8 @@ public class RuntimePackageTest {
         .forTypes(types)
         .addInitializer(cmd -> {
             final Path runtimeImageDir;
+            final Path jmods = Path.of(System.getProperty("java.home"), "jmods");
+
             if (JPackageCommand.DEFAULT_RUNTIME_IMAGE != null) {
                 runtimeImageDir = JPackageCommand.DEFAULT_RUNTIME_IMAGE;
             } else {
@@ -112,6 +114,7 @@ public class RuntimePackageTest {
                 .addArguments(
                         "--output", runtimeImageDir.toString(),
                         "--add-modules", "ALL-MODULE-PATH",
+                        "--module-path", jmods.toString(),
                         "--strip-debug",
                         "--no-header-files",
                         "--no-man-pages")


### PR DESCRIPTION
A few jpackage tests invoke `jlink --add-modules ALL-MODULE-PATH` without `--module-path` and they now fail because of JDK-8345259 which requires `--module-path` to be set when `ALL-MODULE-PATH` is used.  The fix is to add `--add-modules $JAVA_HOME/jmods` which was the default before JDK-8345259.  A separate issue is needed to skip these tests when running on a linkable runtime image without the packaged modules.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8346739: jpackage tests failed after JDK-8345259`

### Issue
 * [JDK-8346739](https://bugs.openjdk.org/browse/JDK-8346739): jpackage tests failed after JDK-8345259 (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22853/head:pull/22853` \
`$ git checkout pull/22853`

Update a local copy of the PR: \
`$ git checkout pull/22853` \
`$ git pull https://git.openjdk.org/jdk.git pull/22853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22853`

View PR using the GUI difftool: \
`$ git pr show -t 22853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22853.diff">https://git.openjdk.org/jdk/pull/22853.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22853#issuecomment-2557573177)
</details>
