### PR TITLE
Expose accept() with socket param.

### DIFF
--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -101,7 +101,7 @@ public abstract class InputStream implements Closeable {
             }
 
             @Override
-            public int read() throws IOException {
+            public byte read() throws IOException {
                 ensureOpen();
                 return -1;
             }
@@ -169,7 +169,7 @@ public abstract class InputStream implements Closeable {
 
     /**
      * Reads the next byte of data from the input stream. The value byte is
-     * returned as an {@code int} in the range {@code 0} to
+     * returned as an {@code byte} in the range {@code 0} to
      * {@code 255}. If no byte is available because the end of the stream
      * has been reached, the value {@code -1} is returned. This method
      * blocks until input data is available, the end of the stream is detected,
@@ -179,7 +179,7 @@ public abstract class InputStream implements Closeable {
      *             stream is reached.
      * @throws     IOException  if an I/O error occurs.
      */
-    public abstract int read() throws IOException;
+    public abstract byte read() throws IOException;
 
     /**
      * Reads some number of bytes from the input stream and stores them into
@@ -286,11 +286,11 @@ public abstract class InputStream implements Closeable {
             return 0;
         }
 
-        int c = read();
+        byte c = read();
         if (c == -1) {
             return -1;
         }
-        b[off] = (byte)c;
+        b[off] = c;
 
         int i = 1;
         try {
@@ -299,7 +299,7 @@ public abstract class InputStream implements Closeable {
                 if (c == -1) {
                     break;
                 }
-                b[off + i] = (byte)c;
+                b[off + i] = c;
             }
         } catch (IOException ee) {
         }


### PR DESCRIPTION
It looks like this was the original intent of the API author, not sure why it got left out.

Theoretical workaround developers can employ currently (without this PR):
* Manually overriding socket settings after connection accepts - can be wasteful, e.g. if resizing to a smaller send/recv buffer.
* Creating subclass of ServerSocket with user-defined `implAccept()` and/or providing custom socket factory - overly complicated for this simple task. Lots of boilerplate / clunky code, esp. for functions the user does not want to modify or override.
* Reflection to edit jdk functions/access!?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22859/head:pull/22859` \
`$ git checkout pull/22859`

Update a local copy of the PR: \
`$ git checkout pull/22859` \
`$ git pull https://git.openjdk.org/jdk.git pull/22859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22859`

View PR using the GUI difftool: \
`$ git pr show -t 22859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22859.diff">https://git.openjdk.org/jdk/pull/22859.diff</a>

</details>
