### PR TITLE
Provide Socket arg to ServerSocket.accept()

### DIFF
--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -421,6 +421,50 @@ public class ServerSocket implements java.io.Closeable {
      * of the {@linkplain Socket#setSocketImplFactory(SocketImplFactory)
      * client socket implementation factory}, if one has been set.
      *
+     * @param      s the Socket
+     * @throws     IOException  if an I/O error occurs when waiting for a
+     *               connection, the socket is not bound or the socket is closed.
+     * @throws     SocketTimeoutException if a timeout was previously set with setSoTimeout and
+     *             the timeout has been reached.
+     * @throws     java.nio.channels.IllegalBlockingModeException
+     *             if this socket has an associated channel, the channel is in
+     *             non-blocking mode, and there is no connection ready to be
+     *             accepted
+     */
+    public Socket accept(Socket s) throws IOException {
+        if (isClosed())
+            throw new SocketException("Socket is closed");
+        if (!isBound())
+            throw new SocketException("Socket is not bound yet");
+        implAccept(s);
+    }
+
+    /**
+     * Listens for a connection to be made to this socket and accepts
+     * it. The method blocks until a connection is made.
+     *
+     * <p> This method is {@linkplain Thread#interrupt() interruptible} in the
+     * following circumstances:
+     * <ol>
+     *   <li> The socket is {@linkplain ServerSocketChannel#socket() associated}
+     *        with a {@link ServerSocketChannel ServerSocketChannel}. In that
+     *        case, interrupting a thread accepting a connection will close the
+     *        underlying channel and cause this method to throw {@link
+     *        java.nio.channels.ClosedByInterruptException} with the interrupt
+     *        status set.
+     *   <li> The socket uses the system-default socket implementation and a
+     *        {@linkplain Thread#isVirtual() virtual thread} is accepting a
+     *        connection. In that case, interrupting the virtual thread will
+     *        cause it to wakeup and close the socket. This method will then throw
+     *        {@code SocketException} with the interrupt status set.
+     * </ol>
+     *
+     * @implNote
+     * An instance of this class using a system-default {@code SocketImpl}
+     * accepts sockets with a {@code SocketImpl} of the same type, regardless
+     * of the {@linkplain Socket#setSocketImplFactory(SocketImplFactory)
+     * client socket implementation factory}, if one has been set.
+     *
      * @throws     IOException  if an I/O error occurs when waiting for a
      *               connection, the socket is not bound or the socket is closed.
      * @throws     SocketTimeoutException if a timeout was previously set with setSoTimeout and
@@ -433,12 +477,8 @@ public class ServerSocket implements java.io.Closeable {
      * @return the new Socket
      */
     public Socket accept() throws IOException {
-        if (isClosed())
-            throw new SocketException("Socket is closed");
-        if (!isBound())
-            throw new SocketException("Socket is not bound yet");
         Socket s = new Socket((SocketImpl) null);
-        implAccept(s);
+        accept(s);
         return s;
     }
 


### PR DESCRIPTION
Looks like this was intent of the original API author, not sure why it got left out.

Theoretical workarounds developers can employ currently (without this PR):
* Manually overriding socket settings after connection accepts - can be wasteful, e.g. if resizing to a smaller send/recv buffer.
* Creating subclass of ServerSocket with user-defined `implAccept()` and/or providing custom socket factory - overly complicated for this simple task. Lots of boilerplate / clunky code, esp. for functions the user does not want to modify or override.
* Reflection to edit jdk functions/access!?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22860/head:pull/22860` \
`$ git checkout pull/22860`

Update a local copy of the PR: \
`$ git checkout pull/22860` \
`$ git pull https://git.openjdk.org/jdk.git pull/22860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22860`

View PR using the GUI difftool: \
`$ git pr show -t 22860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22860.diff">https://git.openjdk.org/jdk/pull/22860.diff</a>

</details>
