### PR TITLE
8322983: Virtual Threads: exclude 2 tests

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -103,7 +103,9 @@ gc/g1/TestMixedGCLiveThreshold.java#25percent 8334759 windows-x64
 
 gc/arguments/TestNewSizeThreadIncrease.java 0000000 generic-all
 gc/g1/TestSkipRebuildRemsetPhase.java 0000000 generic-all
+runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java JDK-8346442 generic-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 0000000 generic-all
+runtime/logging/LoaderConstraintsTest.java JDK-8346442 generic-all
 runtime/Thread/AsyncExceptionOnMonitorEnter.java 0000000 generic-all
 runtime/Thread/StopAtExit.java 0000000 generic-all
 runtime/handshake/HandshakeWalkStackTest.java 0000000 generic-all


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [cf28fd4c](https://github.com/openjdk/jdk/commit/cf28fd4cbc6507eb69fcfeb33622316eb5b6b0c5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Evgeny Nikitin on 20 Dec 2024 and was reviewed by Jaikiran Pai, Leonid Mesnik and SendaoYan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322983](https://bugs.openjdk.org/browse/JDK-8322983): Virtual Threads: exclude 2 tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22872/head:pull/22872` \
`$ git checkout pull/22872`

Update a local copy of the PR: \
`$ git checkout pull/22872` \
`$ git pull https://git.openjdk.org/jdk.git pull/22872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22872`

View PR using the GUI difftool: \
`$ git pr show -t 22872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22872.diff">https://git.openjdk.org/jdk/pull/22872.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22872#issuecomment-2560536102)
</details>
