### PR TITLE
8346787: Fix two C2 IR matching tests for RISC-V

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/ModINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModINodeIdealizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModINodeIdealizationTests.java
@@ -35,6 +35,7 @@ import compiler.lib.ir_framework.*;
  * @summary Test that Ideal transformations of ModINode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.ModINodeIdealizationTests
+ * @requires os.arch != "riscv64"
  */
 public class ModINodeIdealizationTests {
     public static final int RANDOM_POWER_OF_2 = 1 << (1 + Utils.getRandomInstance().nextInt(30));

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModINodeIdealizationTests.java
@@ -35,7 +35,6 @@ import compiler.lib.ir_framework.*;
  * @summary Test that Ideal transformations of ModINode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.ModINodeIdealizationTests
- * @requires os.arch != "riscv64"
  */
 public class ModINodeIdealizationTests {
     public static final int RANDOM_POWER_OF_2 = 1 << (1 + Utils.getRandomInstance().nextInt(30));
@@ -122,8 +121,10 @@ public class ModINodeIdealizationTests {
     }
 
     @Test
-    @IR(failOn = {IRNode.MOD_I})
-    @IR(counts = {IRNode.AND_I, ">=1", IRNode.RSHIFT, ">=1", IRNode.CMP_I, "2"})
+    @IR(applyIfPlatform = {"riscv64", "false"},
+        failOn = {IRNode.MOD_I})
+    @IR(applyIfPlatform = {"riscv64", "false"},
+        counts = {IRNode.AND_I, ">=1", IRNode.RSHIFT, ">=1", IRNode.CMP_I, "2"})
     // Special optimization for the case 2^k-1 for bigger k
     public int powerOf2Minus1(int x) {
         return x % 127;

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModLNodeIdealizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModLNodeIdealizationTests.java
@@ -35,6 +35,7 @@ import compiler.lib.ir_framework.*;
  * @summary Test that Ideal transformations of ModLNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.ModLNodeIdealizationTests
+ * @requires os.arch != "riscv64"
  */
 public class ModLNodeIdealizationTests {
     public static final long RANDOM_POWER_OF_2 = 1L << (1 + Utils.getRandomInstance().nextInt(62));

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModLNodeIdealizationTests.java
@@ -35,7 +35,6 @@ import compiler.lib.ir_framework.*;
  * @summary Test that Ideal transformations of ModLNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.ModLNodeIdealizationTests
- * @requires os.arch != "riscv64"
  */
 public class ModLNodeIdealizationTests {
     public static final long RANDOM_POWER_OF_2 = 1L << (1 + Utils.getRandomInstance().nextInt(62));
@@ -106,8 +105,10 @@ public class ModLNodeIdealizationTests {
     }
 
     @Test
-    @IR(failOn = {IRNode.MOD_L})
-    @IR(counts = {IRNode.AND_L, ">=1", IRNode.RSHIFT, ">=1", IRNode.CMP_L, "2"})
+    @IR(applyIfPlatform = {"riscv64", "false"},
+        failOn = {IRNode.MOD_L})
+    @IR(applyIfPlatform = {"riscv64", "false"},
+        counts = {IRNode.AND_L, ">=1", IRNode.RSHIFT, ">=1", IRNode.CMP_L, "2"})
     // Special optimization for the case 2^k-1 for bigger k
     public long powerOf2Minus1(long x) {
         return x % ((1L << 33) - 1);


### PR DESCRIPTION
Two IR matching tests added by [JDK-8332268](https://bugs.openjdk.org/browse/JDK-8332268) are failing on RISC-V:
  TEST: compiler/c2/irTests/ModINodeIdealizationTests.java
  TEST: compiler/c2/irTests/ModLNodeIdealizationTests.java

These two tests require conditional move support. See ModLNode::Ideal & ModLNode::Ideal [1][2]. But RISC-V base ISA (RV64GCV) does not support conditional move, so we set `ConditionalMoveLimit` to 0 for this CPU platform. This change simply skips these two tests for now.

Some further information:
An initial version of conditional move based on RISC-V `Zicond` extension has been added by: [JDK-8344306](https://bugs.openjdk.org/browse/JDK-8344306). But that still lacks performance tunning and we will reconsider and adjust this `ConditionalMoveLimit` parameter as we go. New issue: [JDK-8346786](https://bugs.openjdk.org/browse/JDK-8346786).

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/divnode.cpp#L993
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/divnode.cpp#L1253

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346787](https://bugs.openjdk.org/browse/JDK-8346787): Fix two C2 IR matching tests for RISC-V (**Bug** - P4)


### Reviewers
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer) Review applies to [27884e81](https://git.openjdk.org/jdk/pull/22874/files/27884e818fa7f5ddb3f3370b89da20645f16d17b)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22874/head:pull/22874` \
`$ git checkout pull/22874`

Update a local copy of the PR: \
`$ git checkout pull/22874` \
`$ git pull https://git.openjdk.org/jdk.git pull/22874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22874`

View PR using the GUI difftool: \
`$ git pr show -t 22874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22874.diff">https://git.openjdk.org/jdk/pull/22874.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22874#issuecomment-2561609567)
</details>
