### PR TITLE
8346829: Problem list com/sun/jdi/ReattachStressTest.java & ProcessAttachTest.java on Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -727,6 +727,8 @@ javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
 
 # jdk_jdi
 
+com/sun/jdi/ProcessAttachTest.java         8346827 linux-all
+com/sun/jdi/ReattachStressTest.java        8346827 linux-all
 com/sun/jdi/RepStep.java                                        8043571 generic-all
 
 com/sun/jdi/InvokeHangTest.java                                 8218463 linux-all


### PR DESCRIPTION
I'd like to problem list two tests which have started failing very frequently

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346829](https://bugs.openjdk.org/browse/JDK-8346829): Problem list com/sun/jdi/ReattachStressTest.java &amp; ProcessAttachTest.java on Linux (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22877/head:pull/22877` \
`$ git checkout pull/22877`

Update a local copy of the PR: \
`$ git checkout pull/22877` \
`$ git pull https://git.openjdk.org/jdk.git pull/22877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22877`

View PR using the GUI difftool: \
`$ git pr show -t 22877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22877.diff">https://git.openjdk.org/jdk/pull/22877.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22877#issuecomment-2561491205)
</details>
