### PR TITLE
8346832: runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java fails on RISC-V

### DIFF
--- a/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
+++ b/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
@@ -58,7 +58,8 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
 
   // Failing that, optimize for case (3) - a base with only bits set between [32-44)
   if (result == nullptr) {
-    const uintptr_t from = nth_bit(32);
+    const uintptr_t from = nth_bit(32 +
+                    (optimize_for_zero_base ? CompressedKlassPointers::max_shift() : 0));
     constexpr uintptr_t to = nth_bit(44);
     constexpr size_t alignment = nth_bit(32);
     result = reserve_address_space_X(from, to, size, alignment, aslr);

--- a/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
+++ b/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
@@ -31,7 +31,7 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
 
   char* result = nullptr;
 
-  // RiscV loads a 64-bit immediate in up to four separate steps, splitting it into four different sections
+  // RISC-V loads a 64-bit immediate in up to four separate steps, splitting it into four different sections
   // (two 32-bit sections, each split into two subsections of 20/12 bits).
   //
   // 63 ....... 44 43 ... 32 31 ....... 12 11 ... 0
@@ -51,15 +51,9 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
   //   with one instruction (2)
   result = reserve_address_space_for_unscaled_encoding(size, aslr);
 
-  // Failing that, attempt to reserve for base=zero shift>0
-  if (result == nullptr && optimize_for_zero_base) {
-    result = reserve_address_space_for_zerobased_encoding(size, aslr);
-  }
-
   // Failing that, optimize for case (3) - a base with only bits set between [32-44)
   if (result == nullptr) {
-    const uintptr_t from = nth_bit(32 +
-                    (optimize_for_zero_base ? CompressedKlassPointers::max_shift() : 0));
+    const uintptr_t from = nth_bit(32)
     constexpr uintptr_t to = nth_bit(44);
     constexpr size_t alignment = nth_bit(32);
     result = reserve_address_space_X(from, to, size, alignment, aslr);

--- a/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
+++ b/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
@@ -53,7 +53,7 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
 
   // Failing that, optimize for case (3) - a base with only bits set between [32-44)
   if (result == nullptr) {
-    const uintptr_t from = nth_bit(32)
+    const uintptr_t from = nth_bit(32);
     constexpr uintptr_t to = nth_bit(44);
     constexpr size_t alignment = nth_bit(32);
     result = reserve_address_space_X(from, to, size, alignment, aslr);

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
@@ -85,15 +85,8 @@ public class CompressedCPUSpecificClassSpaceReservation {
             output.shouldContain(tryReserveFor16bitMoveIntoQ3);
         } else if (Platform.isRISCV64()) {
             output.shouldContain(tryReserveForUnscaled); // unconditionally
-            if (CDS) {
-                output.shouldNotContain(tryReserveForZeroBased);
-                // bits 32..44
-                output.shouldContain("reserve_between (range [0x0000000100000000-0x0000100000000000)");
-            } else {
-                output.shouldContain(tryReserveForZeroBased);
-                // bits 32..44, but not lower than zero-based limit
-                output.shouldContain("reserve_between (range [0x0000000800000000-0x0000100000000000)");
-            }
+            // bits 32..44
+            output.shouldContain("reserve_between (range [0x0000000100000000-0x0000100000000000)");
             // bits 44..64
             output.shouldContain("reserve_between (range [0x0000100000000000-0xffffffffffffffff)");
         } else if (Platform.isS390x()) {


### PR DESCRIPTION
Hi, please review this small change fixing a test failure.

This test first expects `tryReserveForUnscaled` and `tryReserveForZeroBased` from the process output. In addition, when test without CDS, it also expects `reserve_between (range [0x0000000800000000-0x0000100000000000)` which is not lower than zero-based limit. But the process output gives `reserve_between (range [0x0000000100000000-0x0000100000000000)`, which is not expected.

Previously, we have the code handling this case in `CompressedKlassPointers::reserve_address_space_for_compressed_classes`.
But I find that the code is gone after [JDK-8305895](https://bugs.openjdk.org/browse/JDK-8305895): Implement JEP 450: Compact Object Headers. This is the related change:

```
diff --git a/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp b/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
index cffadb4189b..7c8d6b8f5bb 100644
--- a/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
+++ b/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
@@ -56,9 +56,9 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
     result = reserve_address_space_for_zerobased_encoding(size, aslr);
   }

-  // Failing that, optimize for case (3) - a base with only bits set between [33-44)
+  // Failing that, optimize for case (3) - a base with only bits set between [32-44)
   if (result == nullptr) {
-    const uintptr_t from = nth_bit(32 + (optimize_for_zero_base ? LogKlassAlignmentInBytes : 0));
+    const uintptr_t from = nth_bit(32);
     constexpr uintptr_t to = nth_bit(44);
     constexpr size_t alignment = nth_bit(32);
     result = reserve_address_space_X(from, to, size, alignment, aslr);
```

It seems to me more reasonable to add the `optimize_for_zero_base check` back and replace the `LogKlassAlignmentInBytes` with
`CompressedKlassPointers::max_shift()`. max_shift() is used in `CompressedKlassPointers::reserve_address_space_for_zerobased_encoding` to calculate `zerobased_max` as well [1].

Testing: same test passes with fastdebug build on linux-riscv64 platform. Tagging @tstuefe 

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/oops/compressedKlass.cpp#L201

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346832](https://bugs.openjdk.org/browse/JDK-8346832): runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java fails on RISC-V (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22879/head:pull/22879` \
`$ git checkout pull/22879`

Update a local copy of the PR: \
`$ git checkout pull/22879` \
`$ git pull https://git.openjdk.org/jdk.git pull/22879/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22879`

View PR using the GUI difftool: \
`$ git pr show -t 22879`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22879.diff">https://git.openjdk.org/jdk/pull/22879.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22879#issuecomment-2561610206)
</details>
