### PR TITLE
8344232: [PPC64] secondary_super_cache does not scale well: C1 and interpreter

### DIFF
--- a/src/hotspot/cpu/ppc/assembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.hpp
@@ -294,6 +294,8 @@ class Assembler : public AbstractAssembler {
     CLRRWI_OPCODE = RLWINM_OPCODE,
     CLRLWI_OPCODE = RLWINM_OPCODE,
 
+    RLWNM_OPCODE  = (23u << OPCODE_SHIFT),
+
     RLWIMI_OPCODE = (20u << OPCODE_SHIFT),
 
     SLW_OPCODE    = (31u << OPCODE_SHIFT |  24u << 1),
@@ -423,6 +425,9 @@ class Assembler : public AbstractAssembler {
     RLDICL_OPCODE = (30u << OPCODE_SHIFT |   0u << XO_27_29_SHIFT), // MD-FORM
     RLDIC_OPCODE  = (30u << OPCODE_SHIFT |   2u << XO_27_29_SHIFT), // MD-FORM
     RLDIMI_OPCODE = (30u << OPCODE_SHIFT |   3u << XO_27_29_SHIFT), // MD-FORM
+
+    RLDCL_OPCODE  = (30u << OPCODE_SHIFT |   8u << 1),
+    RLDCR_OPCODE  = (30u << OPCODE_SHIFT |   9u << 1),
 
     SRADI_OPCODE  = (31u << OPCODE_SHIFT | 413u << XO_21_29_SHIFT), // XS-FORM
 
@@ -1695,6 +1700,14 @@ class Assembler : public AbstractAssembler {
   inline void rlwimi(  Register a, Register s, int sh5, int mb5, int me5);
   inline void insrdi(  Register a, Register s, int n,   int b);
   inline void insrwi(  Register a, Register s, int n,   int b);
+
+  // Rotate variable
+  inline void rlwnm( Register a, Register s, Register b, int mb, int me);
+  inline void rlwnm_(Register a, Register s, Register b, int mb, int me);
+  inline void rldcl( Register a, Register s, Register b, int mb);
+  inline void rldcl_(Register a, Register s, Register b, int mb);
+  inline void rldcr( Register a, Register s, Register b, int me);
+  inline void rldcr_(Register a, Register s, Register b, int me);
 
   // PPC 1, section 3.3.2 Fixed-Point Load Instructions
   // 4 bytes

--- a/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
@@ -336,6 +336,13 @@ inline void Assembler::rldimi_( Register a, Register s, int sh6, int mb6)       
 inline void Assembler::insrdi(  Register a, Register s, int n,   int b)           { Assembler::rldimi(a, s, 64-(b+n), b); }
 inline void Assembler::insrwi(  Register a, Register s, int n,   int b)           { Assembler::rlwimi(a, s, 32-(b+n), b, b+n-1); }
 
+inline void Assembler::rlwnm( Register a, Register s, Register b, int mb, int me) { emit_int32(RLWNM_OPCODE | rta(a) | rs(s) | rb(b) | mb2125(mb) | me2630(me) | rc(0)); }
+inline void Assembler::rlwnm_(Register a, Register s, Register b, int mb, int me) { emit_int32(RLWNM_OPCODE | rta(a) | rs(s) | rb(b) | mb2125(mb) | me2630(me) | rc(1)); }
+inline void Assembler::rldcl(  Register a, Register s, Register b, int mb)        { emit_int32(RLDCL_OPCODE | rta(a) | rs(s) | rb(b) | mb2126(mb) | rc(0)); }
+inline void Assembler::rldcl_( Register a, Register s, Register b, int mb)        { emit_int32(RLDCL_OPCODE | rta(a) | rs(s) | rb(b) | mb2126(mb) | rc(1)); }
+inline void Assembler::rldcr(  Register a, Register s, Register b, int me)        { emit_int32(RLDCR_OPCODE | rta(a) | rs(s) | rb(b) | me2126(me) | rc(0)); }
+inline void Assembler::rldcr_( Register a, Register s, Register b, int me)        { emit_int32(RLDCR_OPCODE | rta(a) | rs(s) | rb(b) | me2126(me) | rc(1)); }
+
 // PPC 1, section 3.3.2 Fixed-Point Load Instructions
 inline void Assembler::lwzx( Register d, Register s1, Register s2) { emit_int32(LWZX_OPCODE | rt(d) | ra0mem(s1) | rb(s2));}
 inline void Assembler::lwz(  Register d, Address &a) {

--- a/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
@@ -603,10 +603,9 @@ OopMapSet* Runtime1::generate_code_for(C1StubId id, StubAssembler* sasm) {
       { // Support for uint StubRoutine::partial_subtype_check( Klass sub, Klass super );
         const Register sub_klass = R5,
                        super_klass = R4,
-                       temp1_reg = R6,
-                       temp2_reg = R0;
-        __ check_klass_subtype_slow_path(sub_klass, super_klass, temp1_reg, temp2_reg); // returns with CR0.eq if successful
-        __ crandc(CCR0, Assembler::equal, CCR0, Assembler::equal); // failed: CR0.ne
+                       temp1_reg = R6;
+        __ check_klass_subtype_slow_path(sub_klass, super_klass, temp1_reg, noreg); // may return with CR0.eq if successful
+        // Otherwise, result is in CR0.
         __ blr();
       }
       break;

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -612,6 +612,20 @@ class MacroAssembler: public Assembler {
   // The temp_reg can be noreg, if no temps are available.
   // It can also be sub_klass or super_klass, meaning it's OK to kill that one.
   // Updates the sub's secondary super cache as necessary.
+  void check_klass_subtype_slow_path_linear(Register sub_klass,
+                                            Register super_klass,
+                                            Register temp1_reg,
+                                            Register temp2_reg,
+                                            Label* L_success = nullptr,
+                                            Register result_reg = noreg);
+
+  void check_klass_subtype_slow_path_table(Register sub_klass,
+                                           Register super_klass,
+                                           Register temp1_reg,
+                                           Register temp2_reg,
+                                           Label* L_success = nullptr,
+                                           Register result_reg = noreg);
+
   void check_klass_subtype_slow_path(Register sub_klass,
                                      Register super_klass,
                                      Register temp1_reg,
@@ -626,6 +640,17 @@ class MacroAssembler: public Assembler {
                                          Register temp3,
                                          Register temp4,
                                          Register result);
+
+  // If r is valid, return r.
+  // If r is invalid, remove a register r2 from available_regs, add r2
+  // to regs_to_push, then return r2.
+  Register allocate_if_noreg(const Register r,
+                             RegSetIterator<Register> &available_regs,
+                             RegSet &regs_to_push);
+
+  // Frameless register spills (negative offset from SP)
+  void push_set(RegSet set);
+  void pop_set(RegSet set);
 
   // Simplified, combined version, good for typical uses.
   // Falls through on failure.

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -619,6 +619,14 @@ class MacroAssembler: public Assembler {
                                      Label* L_success = nullptr,
                                      Register result_reg = noreg);
 
+  void lookup_secondary_supers_table_var(Register sub_klass,
+                                         Register r_super_klass,
+                                         Register temp1,
+                                         Register temp2,
+                                         Register temp3,
+                                         Register temp4,
+                                         Register result);
+
   // Simplified, combined version, good for typical uses.
   // Falls through on failure.
   void check_klass_subtype(Register sub_klass,
@@ -631,14 +639,14 @@ class MacroAssembler: public Assembler {
 
   // As above, but with a constant super_klass.
   // The result is in Register result, not the condition codes.
-  void lookup_secondary_supers_table(Register r_sub_klass,
-                                     Register r_super_klass,
-                                     Register temp1,
-                                     Register temp2,
-                                     Register temp3,
-                                     Register temp4,
-                                     Register result,
-                                     u1 super_klass_slot);
+  void lookup_secondary_supers_table_const(Register r_sub_klass,
+                                           Register r_super_klass,
+                                           Register temp1,
+                                           Register temp2,
+                                           Register temp3,
+                                           Register temp4,
+                                           Register result,
+                                           u1 super_klass_slot);
 
   void verify_secondary_supers_table(Register r_sub_klass,
                                      Register r_super_klass,

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -12087,13 +12087,13 @@ instruct partialSubtypeCheck(iRegPdst result, iRegP_N2P subklass, iRegP_N2P supe
 // for. The second, far more common, is used when we do know: this is
 // used for instanceof, checkcast, and any case where C2 can determine
 // it by constant propagation.
-instruct partialSubtypeCheckVarSuper(rarg3RegP sub, rarg2RegP super, rarg6RegP result,
-                                     rarg1RegP tempR1, rarg5RegP tempR2, rarg4RegP tempR3, rscratch1RegP tempR4,
+instruct partialSubtypeCheckVarSuper(iRegPsrc sub, iRegPsrc super, iRegPdst result,
+                                     iRegPdst tempR1, iRegPdst tempR2, iRegPdst tempR3, iRegPdst tempR4,
                                      flagsRegCR0 cr0, regCTR ctr)
 %{
   match(Set result (PartialSubtypeCheck sub super));
   predicate(UseSecondarySupersTable);
-  effect(KILL cr0, KILL ctr, TEMP tempR1, TEMP tempR2, TEMP tempR3, TEMP tempR4);
+  effect(KILL cr0, KILL ctr, TEMP_DEF result, TEMP tempR1, TEMP tempR2, TEMP tempR3, TEMP tempR4);
 
   ins_cost(DEFAULT_COST * 10);  // slightly larger than the next version
   format %{ "partialSubtypeCheck $result, $sub, $super" %}

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -12069,6 +12069,7 @@ instruct branchLoopEndFar(cmpOp cmp, flagsRegSrc crx, label labl) %{
 instruct partialSubtypeCheck(iRegPdst result, iRegP_N2P subklass, iRegP_N2P superklass,
                              iRegPdst tmp_klass, iRegPdst tmp_arrayptr) %{
   match(Set result (PartialSubtypeCheck subklass superklass));
+  predicate(!UseSecondarySupersTable);
   effect(TEMP_DEF result, TEMP tmp_klass, TEMP tmp_arrayptr);
   ins_cost(DEFAULT_COST*10);
 
@@ -12078,6 +12079,30 @@ instruct partialSubtypeCheck(iRegPdst result, iRegP_N2P subklass, iRegP_N2P supe
                                      $tmp_klass$$Register, nullptr, $result$$Register);
   %}
   ins_pipe(pipe_class_default);
+%}
+
+// Two versions of partialSubtypeCheck, both used when we need to
+// search for a super class in the secondary supers array. The first
+// is used when we don't know _a priori_ the class being searched
+// for. The second, far more common, is used when we do know: this is
+// used for instanceof, checkcast, and any case where C2 can determine
+// it by constant propagation.
+instruct partialSubtypeCheckVarSuper(rarg3RegP sub, rarg2RegP super, rarg6RegP result,
+                                     rarg1RegP tempR1, rarg5RegP tempR2, rarg4RegP tempR3, rscratch1RegP tempR4,
+                                     flagsRegCR0 cr0, regCTR ctr)
+%{
+  match(Set result (PartialSubtypeCheck sub super));
+  predicate(UseSecondarySupersTable);
+  effect(KILL cr0, KILL ctr, TEMP tempR1, TEMP tempR2, TEMP tempR3, TEMP tempR4);
+
+  ins_cost(DEFAULT_COST * 10);  // slightly larger than the next version
+  format %{ "partialSubtypeCheck $result, $sub, $super" %}
+  ins_encode %{
+    __ lookup_secondary_supers_table_var($sub$$Register, $super$$Register,
+                                         $tempR1$$Register, $tempR2$$Register, $tempR3$$Register, $tempR4$$Register,
+                                         $result$$Register);
+  %}
+  ins_pipe(pipe_class_memory);
 %}
 
 instruct partialSubtypeCheckConstSuper(rarg3RegP sub, rarg2RegP super_reg, immP super_con, rarg6RegP result,
@@ -12094,9 +12119,9 @@ instruct partialSubtypeCheckConstSuper(rarg3RegP sub, rarg2RegP super_reg, immP 
   ins_encode %{
     u1 super_klass_slot = ((Klass*)$super_con$$constant)->hash_slot();
     if (InlineSecondarySupersTest) {
-      __ lookup_secondary_supers_table($sub$$Register, $super_reg$$Register,
-                                       $tempR1$$Register, $tempR2$$Register, $tempR3$$Register, $tempR4$$Register,
-                                       $result$$Register, super_klass_slot);
+      __ lookup_secondary_supers_table_const($sub$$Register, $super_reg$$Register,
+                                             $tempR1$$Register, $tempR2$$Register, $tempR3$$Register, $tempR4$$Register,
+                                             $result$$Register, super_klass_slot);
     } else {
       address stub = StubRoutines::lookup_secondary_supers_table_stub(super_klass_slot);
       Register r_stub_addr = $tempR1$$Register;

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -4458,9 +4458,9 @@ address generate_lookup_secondary_supers_table_stub(u1 super_klass_index) {
       r_bitmap       = R11_scratch1,
       result         = R8_ARG6;
 
-    __ lookup_secondary_supers_table(r_sub_klass, r_super_klass,
-                                     r_array_base, r_array_length, r_array_index,
-                                     r_bitmap, result, super_klass_index);
+    __ lookup_secondary_supers_table_const(r_sub_klass, r_super_klass,
+                                           r_array_base, r_array_length, r_array_index,
+                                           r_bitmap, result, super_klass_index);
     __ blr();
 
     return start;

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -2039,7 +2039,8 @@ class StubGenerator: public StubCodeGenerator {
   void generate_type_check(Register sub_klass,
                            Register super_check_offset,
                            Register super_klass,
-                           Register temp,
+                           Register temp1,
+                           Register temp2,
                            Label& L_success) {
     assert_different_registers(sub_klass, super_check_offset, super_klass);
 
@@ -2047,9 +2048,9 @@ class StubGenerator: public StubCodeGenerator {
 
     Label L_miss;
 
-    __ check_klass_subtype_fast_path(sub_klass, super_klass, temp, R0, &L_success, &L_miss, nullptr,
+    __ check_klass_subtype_fast_path(sub_klass, super_klass, temp1, temp2, &L_success, &L_miss, nullptr,
                                      super_check_offset);
-    __ check_klass_subtype_slow_path(sub_klass, super_klass, temp, R0, &L_success);
+    __ check_klass_subtype_slow_path(sub_klass, super_klass, temp1, temp2, &L_success);
 
     // Fall through on failure!
     __ bind(L_miss);
@@ -2079,8 +2080,7 @@ class StubGenerator: public StubCodeGenerator {
     const Register R10_oop   = R10_ARG8;     // actual oop copied
     const Register R11_klass = R11_scratch1; // oop._klass
     const Register R12_tmp   = R12_scratch2;
-
-    const Register R2_minus1 = R2;
+    const Register R2_tmp    = R2;
 
     //__ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", name);
@@ -2118,7 +2118,6 @@ class StubGenerator: public StubCodeGenerator {
     Label load_element, store_element, store_null, success, do_epilogue;
     __ or_(R9_remain, R5_count, R5_count); // Initialize loop index, and test it.
     __ li(R8_offset, 0);                   // Offset from start of arrays.
-    __ li(R2_minus1, -1);
     __ bne(CCR0, load_element);
 
     // Empty array: Nothing to do.
@@ -2146,7 +2145,7 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     __ addi(R8_offset, R8_offset, heapOopSize);   // Step to next offset.
-    __ add_(R9_remain, R2_minus1, R9_remain);     // Decrement the count.
+    __ addic_(R9_remain, R9_remain, -1);          // Decrement the count.
     __ beq(CCR0, success);
 
     // ======== loop entry is here ========
@@ -2166,7 +2165,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ load_klass(R11_klass, R10_oop); // Query the object klass.
 
-    generate_type_check(R11_klass, R6_ckoff, R7_ckval, R12_tmp,
+    generate_type_check(R11_klass, R6_ckoff, R7_ckval, R12_tmp, R2_tmp,
                         // Branch to this on success:
                         store_element);
     // ======== end loop ========
@@ -2500,7 +2499,7 @@ class StubGenerator: public StubCodeGenerator {
       int sco_offset = in_bytes(Klass::super_check_offset_offset());
       __ lwz(sco_temp, sco_offset, dst_klass);
       generate_type_check(src_klass, sco_temp, dst_klass,
-                          temp, L_disjoint_plain_copy);
+                          temp, /* temp */ R10_ARG8, L_disjoint_plain_copy);
 
       // Fetch destination element klass from the ObjArrayKlass header.
       int ek_offset = in_bytes(ObjArrayKlass::element_klass_offset());


### PR DESCRIPTION
PPC64 implementation of https://github.com/openjdk/jdk/commit/ead0116f2624e0e34529e47e4f509142d588b994#diff-0f4150a9c607ccd590bf256daa800c0276144682a92bc6bdced5e8bc1bb81f3aR1595. I have implemented a couple of rotate instructions.
C1 part is refactored such that the same code as before this patch is generated when `UseSecondarySupersTable` is disabled.
The first commit only implements `lookup_secondary_supers_table_var` and uses it in C2. The second commit makes the changes to use it in the interpreter, runtime and C1.

Performance difference can be observed when C2 is disabled:

```
-XX:TieredStopAtLevel=1 -XX:-UseSecondarySupersTable:
SecondarySuperCacheHits.test  avgt   15  13.028 ± 0.005  ns/op
SecondarySuperCacheInterContention.test     avgt   15  417.746 ± 19.046  ns/op
SecondarySuperCacheInterContention.test:t1  avgt   15  417.852 ± 17.814  ns/op
SecondarySuperCacheInterContention.test:t2  avgt   15  417.641 ± 23.431  ns/op
SecondarySuperCacheIntraContention.test  avgt   15  340.995 ± 5.620  ns/op
```

```
-XX:TieredStopAtLevel=1 -XX:+UseSecondarySupersTable:
SecondarySuperCacheHits.test  avgt   15  14.539 ± 0.002  ns/op
SecondarySuperCacheInterContention.test     avgt   15  25.667 ± 0.576  ns/op
SecondarySuperCacheInterContention.test:t1  avgt   15  25.709 ± 0.655  ns/op
SecondarySuperCacheInterContention.test:t2  avgt   15  25.626 ± 0.820  ns/op
SecondarySuperCacheIntraContention.test  avgt   15  22.466 ± 1.554  ns/op
```

`SecondarySuperCacheHits` seems to be slightly slower, but `SecondarySuperCacheInterContention` and `SecondarySuperCacheIntraContention` are much faster.