### PR TITLE
8345757: [ASAN] clang17 report 'dprintf' macro redefined

### DIFF
--- a/src/java.smartcardio/share/native/libj2pcsc/pcsc.c
+++ b/src/java.smartcardio/share/native/libj2pcsc/pcsc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,15 +40,9 @@
 // #define J2PCSC_DEBUG
 
 #ifdef J2PCSC_DEBUG
-#define dprintf(s) printf(s)
-#define dprintf1(s, p1) printf(s, p1)
-#define dprintf2(s, p1, p2) printf(s, p1, p2)
-#define dprintf3(s, p1, p2, p3) printf(s, p1, p2, p3)
+#define debug_printf(format, ...) printf(format, ##__VA_ARGS__)
 #else
-#define dprintf(s)
-#define dprintf1(s, p1)
-#define dprintf2(s, p1, p2)
-#define dprintf3(s, p1, p2, p3)
+#define debug_printf(format, ...)
 #endif
 
 #include "sun_security_smartcardio_PCSC.h"
@@ -112,7 +106,7 @@ JNIEXPORT jlong JNICALL Java_sun_security_smartcardio_PCSC_SCardEstablishContext
 {
     SCARDCONTEXT context = 0;
     LONG rv;
-    dprintf("-establishContext\n");
+    debug_printf("-establishContext\n");
     rv = CALL_SCardEstablishContext(dwScope, NULL, NULL, &context);
     if (handleRV(env, rv)) {
         return 0;
@@ -185,12 +179,12 @@ JNIEXPORT jobjectArray JNICALL Java_sun_security_smartcardio_PCSC_SCardListReade
     DWORD size = 0;
     jobjectArray result;
 
-    dprintf1("-context: %x\n", context);
+    debug_printf("-context: %x\n", context);
     rv = CALL_SCardListReaders(context, NULL, NULL, &size);
     if (handleRV(env, rv)) {
         return NULL;
     }
-    dprintf1("-size: %d\n", size);
+    debug_printf("-size: %d\n", size);
 
     if (size != 0) {
         mszReaders = malloc(size);
@@ -204,7 +198,7 @@ JNIEXPORT jobjectArray JNICALL Java_sun_security_smartcardio_PCSC_SCardListReade
             free(mszReaders);
             return NULL;
         }
-        dprintf1("-String: %s\n", mszReaders);
+        debug_printf("-String: %s\n", mszReaders);
     } else {
       return NULL;
     }
@@ -230,8 +224,8 @@ JNIEXPORT jlong JNICALL Java_sun_security_smartcardio_PCSC_SCardConnect
     }
     rv = CALL_SCardConnect(context, readerName, jShareMode, jPreferredProtocols, &card, &proto);
     (*env)->ReleaseStringUTFChars(env, jReaderName, readerName);
-    dprintf1("-cardhandle: %x\n", card);
-    dprintf1("-protocol: %d\n", proto);
+    debug_printf("-cardhandle: %x\n", card);
+    debug_printf("-protocol: %d\n", proto);
     if (handleRV(env, rv)) {
         return 0;
     }
@@ -295,9 +289,9 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_smartcardio_PCSC_SCardStatus
     if (handleRV(env, rv)) {
         return NULL;
     }
-    dprintf1("-reader: %s\n", readerName);
-    dprintf1("-status: %d\n", state);
-    dprintf1("-protocol: %d\n", protocol);
+    debug_printf("-reader: %s\n", readerName);
+    debug_printf("-status: %d\n", state);
+    debug_printf("-protocol: %d\n", protocol);
 
     jArray = (*env)->NewByteArray(env, atrLen);
     if (jArray == NULL) {
@@ -323,7 +317,7 @@ JNIEXPORT void JNICALL Java_sun_security_smartcardio_PCSC_SCardDisconnect
     LONG rv;
 
     rv = CALL_SCardDisconnect(card, jDisposition);
-    dprintf1("-disconnect: 0x%X\n", rv);
+    debug_printf("-disconnect: 0x%X\n", rv);
     handleRV(env, rv);
     return;
 }
@@ -392,7 +386,7 @@ JNIEXPORT jintArray JNICALL Java_sun_security_smartcardio_PCSC_SCardGetStatusCha
     }
     for (i = 0; i < readers; i++) {
         jint eventStateTmp;
-        dprintf3("-reader status %s: 0x%X, 0x%X\n", readerState[i].szReader,
+        debug_printf("-reader status %s: 0x%X, 0x%X\n", readerState[i].szReader,
             readerState[i].dwCurrentState, readerState[i].dwEventState);
         eventStateTmp = (jint)readerState[i].dwEventState;
         (*env)->SetIntArrayRegion(env, jEventState, i, 1, &eventStateTmp);
@@ -417,7 +411,7 @@ JNIEXPORT void JNICALL Java_sun_security_smartcardio_PCSC_SCardBeginTransaction
     LONG rv;
 
     rv = CALL_SCardBeginTransaction(card);
-    dprintf1("-beginTransaction: 0x%X\n", rv);
+    debug_printf("-beginTransaction: 0x%X\n", rv);
     handleRV(env, rv);
     return;
 }
@@ -429,7 +423,7 @@ JNIEXPORT void JNICALL Java_sun_security_smartcardio_PCSC_SCardEndTransaction
     LONG rv;
 
     rv = CALL_SCardEndTransaction(card, jDisposition);
-    dprintf1("-endTransaction: 0x%X\n", rv);
+    debug_printf("-endTransaction: 0x%X\n", rv);
     handleRV(env, rv);
     return;
 }

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ JNIEXPORT jboolean JNICALL Java_sun_security_pkcs11_Secmod_nssVersionCheck
     }
 
     res = versionCheck(requiredVersion);
-    dprintf2("-version >=%s: %d\n", requiredVersion, res);
+    debug_printf("-version >=%s: %d\n", requiredVersion, res);
     (*env)->ReleaseStringUTFChars(env, jVersion, requiredVersion);
 
     return (res == 0) ? JNI_FALSE : JNI_TRUE;
@@ -146,11 +146,11 @@ cleanup:
     if (configDir != NULL) {
         (*env)->ReleaseStringUTFChars(env, jConfigDir, configDir);
     }
-    dprintf1("-res: %d\n", res);
+    debug_printf("-res: %d\n", res);
     #ifdef SECMOD_DEBUG
     if (res == -1) {
         if (getError != NULL) {
-            dprintf1("-NSS error: %d\n", getError());
+            debug_printf("-NSS error: %d\n", getError());
         }
     }
     #endif // SECMOD_DEBUG
@@ -173,12 +173,12 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_Secmod_nssGetModuleList
     jint i, jSlotID;
 
     if (getModuleList == NULL) {
-        dprintf("-getmodulelist function not found\n");
+        debug_printf("-getmodulelist function not found\n");
         return NULL;
     }
     list = getModuleList();
     if (list == NULL) {
-        dprintf("-module list is null\n");
+        debug_printf("-module list is null\n");
         return NULL;
     }
 
@@ -211,12 +211,12 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_Secmod_nssGetModuleList
     while (list != NULL) {
         module = list->module;
         // assert module != null
-        dprintf1("-commonname: %s\n", module->commonName);
-        dprintf1("-dllname: %s\n", (module->dllName != NULL) ? module->dllName : "NULL");
-        dprintf1("-slots: %d\n", module->slotCount);
-        dprintf1("-loaded: %d\n", module->loaded);
-        dprintf1("-internal: %d\n", module->internal);
-        dprintf1("-fips: %d\n", module->isFIPS);
+        debug_printf("-commonname: %s\n", module->commonName);
+        debug_printf("-dllname: %s\n", (module->dllName != NULL) ? module->dllName : "NULL");
+        debug_printf("-slots: %d\n", module->slotCount);
+        debug_printf("-loaded: %d\n", module->loaded);
+        debug_printf("-internal: %d\n", module->internal);
+        debug_printf("-fips: %d\n", module->isFIPS);
         jCommonName = (*env)->NewStringUTF(env, module->commonName);
         if (jCommonName == NULL) {
             return NULL;
@@ -248,7 +248,7 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_Secmod_nssGetModuleList
         }
         list = list->next;
     }
-    dprintf("-ok\n");
+    debug_printf("-ok\n");
 
     return jList;
 }

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,15 +37,9 @@
 void *p11FindFunction(JNIEnv *env, jlong jHandle, const char *functionName);
 
 #ifdef SECMOD_DEBUG
-#define dprintf(s) printf(s)
-#define dprintf1(s, p1) printf(s, p1)
-#define dprintf2(s, p1, p2) printf(s, p1, p2)
-#define dprintf3(s, p1, p2, p3) printf(s, p1, p2, p3)
+#define debug_printf(format, ...) printf(format, ##__VA_ARGS__)
 #else
-#define dprintf(s)
-#define dprintf1(s, p1)
-#define dprintf2(s, p1, p2)
-#define dprintf3(s, p1, p2, p3)
+#define debug_printf(format, ...)
 #endif
 
 // NSS types

--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/j2secmod_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/j2secmod_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ JNIEXPORT jlong JNICALL Java_sun_security_pkcs11_Secmod_nssGetLibraryHandle
 #else
     hModule = dlopen(libName, RTLD_NOLOAD);
 #endif
-    dprintf2("-handle for %s: %u\n", libName, hModule);
+    debug_printf("-handle for %s: %u\n", libName, hModule);
     (*env)->ReleaseStringUTFChars(env, jLibName, libName);
     return ptr_to_jlong(hModule);
 }
@@ -75,10 +75,10 @@ JNIEXPORT jlong JNICALL Java_sun_security_pkcs11_Secmod_nssLoadLibrary
        return 0L;
     }
 
-    dprintf1("-lib %s\n", libName);
+    debug_printf("-lib %s\n", libName);
     hModule = dlopen(libName, RTLD_LAZY);
     (*env)->ReleaseStringUTFChars(env, jLibName, libName);
-    dprintf2("-handle: %u (0X%X)\n", hModule, hModule);
+    debug_printf("-handle: %u (0X%X)\n", hModule, hModule);
 
     if (hModule == NULL) {
         p11ThrowIOException(env, dlerror());

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/j2secmod_md.c
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/j2secmod_md.c
@@ -51,7 +51,7 @@ JNIEXPORT jlong JNICALL Java_sun_security_pkcs11_Secmod_nssGetLibraryHandle
 {
     const char *libName = (*env)->GetStringUTFChars(env, jLibName, NULL);
     HMODULE hModule = GetModuleHandle(libName);
-    dprintf2("-handle for %s: %d\n", libName, hModule);
+    debug_printf("-handle for %s: %d\n", libName, hModule);
     (*env)->ReleaseStringUTFChars(env, jLibName, libName);
     return (jlong)hModule;
 }
@@ -63,7 +63,7 @@ JNIEXPORT jlong JNICALL Java_sun_security_pkcs11_Secmod_nssLoadLibrary
     LPVOID lpMsgBuf;
 
     const char *libName = (*env)->GetStringUTFChars(env, jName, NULL);
-    dprintf1("-lib %s\n", libName);
+    debug_printf("-lib %s\n", libName);
 
     hModule = LoadLibrary(libName);
     (*env)->ReleaseStringUTFChars(env, jName, libName);
@@ -80,11 +80,11 @@ JNIEXPORT jlong JNICALL Java_sun_security_pkcs11_Secmod_nssLoadLibrary
             0,
             NULL
         );
-        dprintf1("-error: %s\n", lpMsgBuf);
+        debug_printf("-error: %s\n", lpMsgBuf);
         p11ThrowIOException(env, (char*)lpMsgBuf);
         LocalFree(lpMsgBuf);
         return 0;
     }
-    dprintf2("-handle: %d (0X%X)\n", hModule, hModule);
+    debug_printf("-handle: %d (0X%X)\n", hModule, hModule);
     return (jlong)hModule;
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [6c591854](https://github.com/openjdk/jdk/commit/6c59185475eeca83153f085eba27cc0b3acf9bb4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 25 Dec 2024 and was reviewed by Kim Barrett and Valerie Peng.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345757](https://bugs.openjdk.org/browse/JDK-8345757): [ASAN] clang17 report 'dprintf' macro redefined (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22883/head:pull/22883` \
`$ git checkout pull/22883`

Update a local copy of the PR: \
`$ git checkout pull/22883` \
`$ git pull https://git.openjdk.org/jdk.git pull/22883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22883`

View PR using the GUI difftool: \
`$ git pr show -t 22883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22883.diff">https://git.openjdk.org/jdk/pull/22883.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22883#issuecomment-2562083302)
</details>
