### PR TITLE
8346157: [Ubsan]: runtime error: pointer index expression with base 0x000000001000 overflowed to 0xfffffffffffffff0

### DIFF
--- a/src/hotspot/share/nmt/mallocTracker.cpp
+++ b/src/hotspot/share/nmt/mallocTracker.cpp
@@ -246,7 +246,7 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
     uintptr_t end = here - (0x1000 + sizeof(MallocHeader)); // stop searching after 4k
     for (; here >= end; here -= smallest_possible_alignment) {
       // JDK-8306561: cast to a MallocHeader needs to guarantee it can reside in readable memory
-      if (!os::is_readable_range((uint8_t*)here, (uint8_t*)(here + sizeof(MallocHeader)))) {
+      if (!os::is_readable_range((void*)here, (void*)(here + sizeof(MallocHeader)))) {
         break; // Probably OOB, give up
       }
       const MallocHeader* const candidate = (const MallocHeader*)here;

--- a/src/hotspot/share/nmt/mallocTracker.cpp
+++ b/src/hotspot/share/nmt/mallocTracker.cpp
@@ -231,7 +231,7 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
 
   address addr = (address)p;
 
-  if (p2u(addr) < MAX2(os::vm_min_address(), (size_t)16 * 0x100000 /* 16 MB */)) {
+  if (p2u(addr) < MAX2(os::vm_min_address(), (size_t)16 * M)) {
     return false; // bail out
   }
 
@@ -244,12 +244,7 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
   {
     const size_t smallest_possible_alignment = sizeof(void*);
     uintptr_t here = (uintptr_t)align_down(addr, smallest_possible_alignment);
-    if (here == 0) {
-      return false; // bail out
-    }
-    uintptr_t end = (here > (0x1000 + sizeof(MallocHeader)))
-                      ? here - (0x1000 + sizeof(MallocHeader)) // stop searching after 4k
-                      : 0;
+    uintptr_t end = MAX2(smallest_possible_alignment, here - (0x1000 + sizeof(MallocHeader))); // stop searching after 4k
     for (; here >= end; here -= smallest_possible_alignment) {
       // JDK-8306561: cast to a MallocHeader needs to guarantee it can reside in readable memory
       if (!os::is_readable_range((void*)here, (void*)(here + sizeof(MallocHeader)))) {

--- a/src/hotspot/share/nmt/mallocTracker.cpp
+++ b/src/hotspot/share/nmt/mallocTracker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, 2023 SAP SE. All rights reserved.
  * Copyright (c) 2023, 2024, Red Hat, Inc. and/or its affiliates.
  *


### PR DESCRIPTION
Fixes ubsan warning in mallocTracker.cpp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346157](https://bugs.openjdk.org/browse/JDK-8346157): [Ubsan]: runtime error: pointer index expression with base 0x000000001000 overflowed to 0xfffffffffffffff0 (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22885/head:pull/22885` \
`$ git checkout pull/22885`

Update a local copy of the PR: \
`$ git checkout pull/22885` \
`$ git pull https://git.openjdk.org/jdk.git pull/22885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22885`

View PR using the GUI difftool: \
`$ git pr show -t 22885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22885.diff">https://git.openjdk.org/jdk/pull/22885.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22885#issuecomment-2562383877)
</details>
