### PR TITLE
8346868: RISC-V: compiler/sharedstubs tests fail after JDK-8332689

### DIFF
--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
@@ -33,6 +33,6 @@ private:
 
 public:
   void flush_bundle(bool start_new_bundle) {}
-  static bool supports_shared_stubs() { return false; }
+  static bool supports_shared_stubs() { return true; }
 
 #endif // CPU_RISCV_CODEBUFFER_RISCV_HPP

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
@@ -30,7 +30,7 @@
  *
  * @requires vm.compiler2.enabled
  * @requires vm.opt.TieredCompilation == null
- * @requires os.arch=="aarch64" | os.arch=="riscv64"
+ * @requires os.arch=="aarch64"
  * @requires vm.debug
  *
  * @run driver compiler.sharedstubs.SharedTrampolineTest -XX:-TieredCompilation


### PR DESCRIPTION
Hi, please review this change.

Here is the change history. [JDK-8293011](https://bugs.openjdk.org/browse/JDK-8293011) shared stubs to interpreter for static calls. And [JDK-8293770](https://bugs.openjdk.org/browse/JDK-8293770) further reused runtime call trampolines. So we have `static constexpr bool supports_shared_stubs() { return true; }`. And both cases are handled in `CodeBuffer::pd_finalize_stubs`.

```
bool CodeBuffer::pd_finalize_stubs() {
  return emit_shared_stubs_to_interp<MacroAssembler>(this, _shared_stub_to_interp_requests)
         && emit_shared_trampolines(this, _shared_trampoline_requests);
}
```

Then [JDK-8332689](https://bugs.openjdk.org/browse/JDK-8332689) turned off uses of trampolines for far calls by default and changed this function into: `static bool supports_shared_stubs() { return UseTrampolines; }`. This will cause the two test failures as option `UseTrampolines` is off by default. Further, [JDK-8343430](https://bugs.openjdk.org/browse/JDK-8343430) removed old trampoline call and option `UseTrampolines` as well. So now we have `static bool supports_shared_stubs() { return false; }` and a simplified `CodeBuffer::pd_finalize_stubs`.

```
bool CodeBuffer::pd_finalize_stubs() {
  return emit_shared_stubs_to_interp<MacroAssembler>(this, _shared_stub_to_interp_requests);
}
```

But [JDK-8332689](https://bugs.openjdk.org/browse/JDK-8332689) is supposed to only make reusing of the runtime call trampolines depend on option `UseTrampolines`. It should not affect the use of shared stubs to interpreter for static calls. So this restores `CodeBuffer::pd_finalize_stubs` letting it return true and disables SharedTrampolineTest.java test for this platform. Tagging @robehn.

Testing on Premier P550 SBC:
- [x] SharedStubToInterpTest.java (fastdebug)
- [x] Tier1-3 and gtest:all (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346868](https://bugs.openjdk.org/browse/JDK-8346868): RISC-V: compiler/sharedstubs tests fail after JDK-8332689 (**Bug** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22888/head:pull/22888` \
`$ git checkout pull/22888`

Update a local copy of the PR: \
`$ git checkout pull/22888` \
`$ git pull https://git.openjdk.org/jdk.git pull/22888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22888`

View PR using the GUI difftool: \
`$ git pr show -t 22888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22888.diff">https://git.openjdk.org/jdk/pull/22888.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22888#issuecomment-2564268298)
</details>
