### PR TITLE
8346831: Remove the extra closing parenthesis in CTW Makefile

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/Makefile
+++ b/test/hotspot/jtreg/testlibrary/ctw/Makefile
@@ -47,7 +47,7 @@ LIB_FILES = $(shell find $(TESTLIBRARY_DIR)/jdk/test/lib/ \
     $(TESTLIBRARY_DIR)/jdk/test/lib/process \
     $(TESTLIBRARY_DIR)/jdk/test/lib/util \
     $(TESTLIBRARY_DIR)/jtreg \
-    -maxdepth 1 -name '*.java'))
+    -maxdepth 1 -name '*.java')
 WB_SRC_FILES = $(shell find $(TESTLIBRARY_DIR)/jdk/test/lib/compiler $(TESTLIBRARY_DIR)/jdk/test/whitebox -name '*.java')
 WB_CLASS_FILES := $(subst $(TESTLIBRARY_DIR)/,,$(WB_SRC_FILES))
 WB_CLASS_FILES := $(patsubst %.java,%.class,$(WB_CLASS_FILES))


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [79958470](https://github.com/openjdk/jdk/commit/79958470e08ade2d3584748e020bd2e18092c0cf) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Qizheng Xing on 29 Dec 2024 and was reviewed by Chen Liang, Kim Barrett, Leonid Mesnik and Julian Waters.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346831](https://bugs.openjdk.org/browse/JDK-8346831): Remove the extra closing parenthesis in CTW Makefile (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22891/head:pull/22891` \
`$ git checkout pull/22891`

Update a local copy of the PR: \
`$ git checkout pull/22891` \
`$ git pull https://git.openjdk.org/jdk.git pull/22891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22891`

View PR using the GUI difftool: \
`$ git pr show -t 22891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22891.diff">https://git.openjdk.org/jdk/pull/22891.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22891#issuecomment-2564696381)
</details>
