### PR TITLE
8346871: Improve robustness of java/util/zip/EntryCount64k.java test

### DIFF
--- a/test/jdk/java/util/zip/EntryCount64k.java
+++ b/test/jdk/java/util/zip/EntryCount64k.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013 Google Inc. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,9 +48,12 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 public class EntryCount64k {
+
+    private static final String MAIN_CLASS_MSG = "foo bar hello world Main";
+
     public static class Main {
         public static void main(String[] args) {
-            System.out.print("Main");
+            System.out.println(MAIN_CLASS_MSG);
         }
     }
 
@@ -162,7 +166,10 @@ public class EntryCount64k {
         // Check java -jar
         OutputAnalyzer a = ProcessTools.executeTestJava("-jar", zipFile.getName());
         a.shouldHaveExitValue(0);
-        a.stdoutShouldMatch("\\AMain\\Z");
+        // expect the message from the application on stdout
+        a.stdoutContains(MAIN_CLASS_MSG);
+        // nothing is expected on stderr (apart from any probable deprecation
+        // warnings from the launcher/JVM)
         a.stderrShouldMatchIgnoreDeprecatedWarnings("\\A\\Z");
     }
 }


### PR DESCRIPTION
Can I please get a review of this test-only change which improves the `test/jdk/java/util/zip/EntryCount64k.java` test code to allow for it to pass when the JVM logs any warning when launching an application through `java -jar ...`?

The proposed change merely relaxes a check to allow for additional content to be present in the launched process' stdout. This doesn't change any of the original goals of the test.

The test failure was reproduced (on Linux) by launching the test through `jtreg` with `-javaoption:"-XX:+UseNUMA"`. With the proposed change in this PR, the test now passes when launched in that manner (and even without that option).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346871](https://bugs.openjdk.org/browse/JDK-8346871): Improve robustness of java/util/zip/EntryCount64k.java test (**Sub-task** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22892/head:pull/22892` \
`$ git checkout pull/22892`

Update a local copy of the PR: \
`$ git checkout pull/22892` \
`$ git pull https://git.openjdk.org/jdk.git pull/22892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22892`

View PR using the GUI difftool: \
`$ git pr show -t 22892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22892.diff">https://git.openjdk.org/jdk/pull/22892.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22892#issuecomment-2564749435)
</details>
