### PR TITLE
8345374: Ubsan: runtime error: division by zero

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
@@ -198,6 +198,14 @@ size_t G1HeapSizingPolicy::young_collection_expansion_amount() {
 }
 
 static size_t target_heap_capacity(size_t used_bytes, uintx free_ratio) {
+  assert(free_ratio <= 100, "precondition");
+  if (free_ratio == 100) {
+    // If 100 then below calculations will divide by zero and return min of
+    // resulting infinity and MaxHeapSize.  Avoid issues of UB vs is_iec559
+    // and ubsan warnings, and just immediately return MaxHeapSize.
+    return MaxHeapSize;
+  }
+
   const double desired_free_percentage = (double) free_ratio / 100.0;
   const double desired_used_percentage = 1.0 - desired_free_percentage;
 


### PR DESCRIPTION
Please review this change to G1HeapSizingPolicy to avoid a float division by
zero when calculating the maximum desired capacity with a MaxHeapFreeRatio
value of 100%.

Testing: mach5 tier1 with G1 and MaxHeapFreeRatio=100.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345374](https://bugs.openjdk.org/browse/JDK-8345374): Ubsan: runtime error: division by zero (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22893/head:pull/22893` \
`$ git checkout pull/22893`

Update a local copy of the PR: \
`$ git checkout pull/22893` \
`$ git pull https://git.openjdk.org/jdk.git pull/22893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22893`

View PR using the GUI difftool: \
`$ git pr show -t 22893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22893.diff">https://git.openjdk.org/jdk/pull/22893.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22893#issuecomment-2564930873)
</details>
