### PR TITLE
8346661: Add a register print helper method and unify register printing

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -435,13 +435,14 @@ void os::print_context(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   st->print_cr("Registers:");
-  st->print("pc =" INTPTR_FORMAT "  ", (unsigned long)uc->uc_mcontext.jmp_context.iar);
-  st->print("lr =" INTPTR_FORMAT "  ", (unsigned long)uc->uc_mcontext.jmp_context.lr);
-  st->print("ctr=" INTPTR_FORMAT "  ", (unsigned long)uc->uc_mcontext.jmp_context.ctr);
+  print_reg(st, "pc =", uc->uc_mcontext.jmp_context.iar);
+  print_reg(st, "lr =", uc->uc_mcontext.jmp_context.lr);
+  print_reg(st, "ctr=", uc->uc_mcontext.jmp_context.ctr);
   st->cr();
   for (int i = 0; i < 32; i++) {
-    st->print("r%-2d=" INTPTR_FORMAT "  ", i, (unsigned long)uc->uc_mcontext.jmp_context.gpr[i]);
-    if (i % 3 == 2) st->cr();
+    char regname[6] = {0};
+    snprintf(regname, sizeof(regname), "r%-2d=", i);
+    print_reg(st, regname, uc->uc_mcontext.jmp_context.gpr[i]);
   }
   st->cr();
   st->cr();

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -403,48 +403,16 @@ void os::print_context(outputStream *st, const void *context) {
   const ucontext_t *uc = (const ucontext_t*)context;
 
   st->print_cr("Registers:");
-  st->print( " x0=" INTPTR_FORMAT, (intptr_t)uc->context_x[ 0]);
-  st->print("  x1=" INTPTR_FORMAT, (intptr_t)uc->context_x[ 1]);
-  st->print("  x2=" INTPTR_FORMAT, (intptr_t)uc->context_x[ 2]);
-  st->print("  x3=" INTPTR_FORMAT, (intptr_t)uc->context_x[ 3]);
-  st->cr();
-  st->print( " x4=" INTPTR_FORMAT, (intptr_t)uc->context_x[ 4]);
-  st->print("  x5=" INTPTR_FORMAT, (intptr_t)uc->context_x[ 5]);
-  st->print("  x6=" INTPTR_FORMAT, (intptr_t)uc->context_x[ 6]);
-  st->print("  x7=" INTPTR_FORMAT, (intptr_t)uc->context_x[ 7]);
-  st->cr();
-  st->print( " x8=" INTPTR_FORMAT, (intptr_t)uc->context_x[ 8]);
-  st->print("  x9=" INTPTR_FORMAT, (intptr_t)uc->context_x[ 9]);
-  st->print(" x10=" INTPTR_FORMAT, (intptr_t)uc->context_x[10]);
-  st->print(" x11=" INTPTR_FORMAT, (intptr_t)uc->context_x[11]);
-  st->cr();
-  st->print( "x12=" INTPTR_FORMAT, (intptr_t)uc->context_x[12]);
-  st->print(" x13=" INTPTR_FORMAT, (intptr_t)uc->context_x[13]);
-  st->print(" x14=" INTPTR_FORMAT, (intptr_t)uc->context_x[14]);
-  st->print(" x15=" INTPTR_FORMAT, (intptr_t)uc->context_x[15]);
-  st->cr();
-  st->print( "x16=" INTPTR_FORMAT, (intptr_t)uc->context_x[16]);
-  st->print(" x17=" INTPTR_FORMAT, (intptr_t)uc->context_x[17]);
-  st->print(" x18=" INTPTR_FORMAT, (intptr_t)uc->context_x[18]);
-  st->print(" x19=" INTPTR_FORMAT, (intptr_t)uc->context_x[19]);
-  st->cr();
-  st->print( "x20=" INTPTR_FORMAT, (intptr_t)uc->context_x[20]);
-  st->print(" x21=" INTPTR_FORMAT, (intptr_t)uc->context_x[21]);
-  st->print(" x22=" INTPTR_FORMAT, (intptr_t)uc->context_x[22]);
-  st->print(" x23=" INTPTR_FORMAT, (intptr_t)uc->context_x[23]);
-  st->cr();
-  st->print( "x24=" INTPTR_FORMAT, (intptr_t)uc->context_x[24]);
-  st->print(" x25=" INTPTR_FORMAT, (intptr_t)uc->context_x[25]);
-  st->print(" x26=" INTPTR_FORMAT, (intptr_t)uc->context_x[26]);
-  st->print(" x27=" INTPTR_FORMAT, (intptr_t)uc->context_x[27]);
-  st->cr();
-  st->print( "x28=" INTPTR_FORMAT, (intptr_t)uc->context_x[28]);
-  st->print("  fp=" INTPTR_FORMAT, (intptr_t)uc->context_fp);
-  st->print("  lr=" INTPTR_FORMAT, (intptr_t)uc->context_lr);
-  st->print("  sp=" INTPTR_FORMAT, (intptr_t)uc->context_sp);
-  st->cr();
-  st->print(  "pc=" INTPTR_FORMAT,  (intptr_t)uc->context_pc);
-  st->print(" cpsr=" INTPTR_FORMAT, (intptr_t)uc->context_cpsr);
+  for (int r = 0; r < 29; r++) {
+    char regname[6] = {0};
+    snprintf(regname, sizeof(regname), "x%-2d=", r);
+    print_reg(st, regname, uc->context_x[r]);
+  }
+  print_reg(st, "fp=", (intptr_t)uc->context_fp);
+  print_reg(st, "lr=", (intptr_t)uc->context_lr);
+  print_reg(st, "sp=", (intptr_t)uc->context_sp);
+  print_reg(st, "pc=", (intptr_t)uc->context_pc);
+  print_reg(st, "cpsr=", (intptr_t)uc->context_cpsr);
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -799,47 +799,28 @@ void os::print_context(outputStream *st, const void *context) {
 
   st->print_cr("Registers:");
 #ifdef AMD64
-  st->print(  "RAX=" INTPTR_FORMAT, (intptr_t)uc->context_rax);
-  st->print(", RBX=" INTPTR_FORMAT, (intptr_t)uc->context_rbx);
-  st->print(", RCX=" INTPTR_FORMAT, (intptr_t)uc->context_rcx);
-  st->print(", RDX=" INTPTR_FORMAT, (intptr_t)uc->context_rdx);
+  print_reg(st, "RAX=", (intptr_t)uc->context_rax);
+  print_reg(st, "RBX=", (intptr_t)uc->context_rbx);
+  print_reg(st, "RCX=", (intptr_t)uc->context_rcx);
+  print_reg(st, "RDX=", (intptr_t)uc->context_rdx);
+  print_reg(st, "RSP=", (intptr_t)uc->context_rsp);
+  print_reg(st, "RBP=", (intptr_t)uc->context_rbp);
+  print_reg(st, "RSI=", (intptr_t)uc->context_rsi);
+  print_reg(st, "RDI=", (intptr_t)uc->context_rdi);
+  print_reg(st, "R8 =", (intptr_t)uc->context_r8);
+  print_reg(st, "R9 =", (intptr_t)uc->context_r9);
+  print_reg(st, "R10=", (intptr_t)uc->context_r10);
+  print_reg(st, "R11=", (intptr_t)uc->context_r11);
+  print_reg(st, "R12=", (intptr_t)uc->context_r12);
+  print_reg(st, "R13=", (intptr_t)uc->context_r13);
+  print_reg(st, "R14=", (intptr_t)uc->context_r14);
+  print_reg(st, "R15=", (intptr_t)uc->context_r15);
+  print_reg(st, "RIP=", (intptr_t)uc->context_rip);
+  print_reg(st, "EFLAGS=",(intptr_t)uc->context_flags);
+  print_reg(st, "ERR=", (intptr_t)uc->context_err);
+  print_reg(st, "TRAPNO=", (intptr_t)uc->context_trapno);
   st->cr();
-  st->print(  "RSP=" INTPTR_FORMAT, (intptr_t)uc->context_rsp);
-  st->print(", RBP=" INTPTR_FORMAT, (intptr_t)uc->context_rbp);
-  st->print(", RSI=" INTPTR_FORMAT, (intptr_t)uc->context_rsi);
-  st->print(", RDI=" INTPTR_FORMAT, (intptr_t)uc->context_rdi);
-  st->cr();
-  st->print(  "R8 =" INTPTR_FORMAT, (intptr_t)uc->context_r8);
-  st->print(", R9 =" INTPTR_FORMAT, (intptr_t)uc->context_r9);
-  st->print(", R10=" INTPTR_FORMAT, (intptr_t)uc->context_r10);
-  st->print(", R11=" INTPTR_FORMAT, (intptr_t)uc->context_r11);
-  st->cr();
-  st->print(  "R12=" INTPTR_FORMAT, (intptr_t)uc->context_r12);
-  st->print(", R13=" INTPTR_FORMAT, (intptr_t)uc->context_r13);
-  st->print(", R14=" INTPTR_FORMAT, (intptr_t)uc->context_r14);
-  st->print(", R15=" INTPTR_FORMAT, (intptr_t)uc->context_r15);
-  st->cr();
-  st->print(  "RIP=" INTPTR_FORMAT, (intptr_t)uc->context_rip);
-  st->print(", EFLAGS=" INTPTR_FORMAT, (intptr_t)uc->context_flags);
-  st->print(", ERR=" INTPTR_FORMAT, (intptr_t)uc->context_err);
-  st->cr();
-  st->print("  TRAPNO=" INTPTR_FORMAT, (intptr_t)uc->context_trapno);
-#else
-  st->print(  "EAX=" INTPTR_FORMAT, (intptr_t)uc->context_eax);
-  st->print(", EBX=" INTPTR_FORMAT, (intptr_t)uc->context_ebx);
-  st->print(", ECX=" INTPTR_FORMAT, (intptr_t)uc->context_ecx);
-  st->print(", EDX=" INTPTR_FORMAT, (intptr_t)uc->context_edx);
-  st->cr();
-  st->print(  "ESP=" INTPTR_FORMAT, (intptr_t)uc->context_esp);
-  st->print(", EBP=" INTPTR_FORMAT, (intptr_t)uc->context_ebp);
-  st->print(", ESI=" INTPTR_FORMAT, (intptr_t)uc->context_esi);
-  st->print(", EDI=" INTPTR_FORMAT, (intptr_t)uc->context_edi);
-  st->cr();
-  st->print(  "EIP=" INTPTR_FORMAT, (intptr_t)uc->context_eip);
-  st->print(", EFLAGS=" INTPTR_FORMAT, (intptr_t)uc->context_eflags);
-#endif // AMD64
-  st->cr();
-  st->cr();
+#endif
 }
 
 void os::print_register_info(outputStream *st, const void *context, int& continuation) {

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -349,7 +349,9 @@ void os::print_context(outputStream *st, const void *context) {
 
   st->print_cr("Registers:");
   for (int r = 0; r < 31; r++) {
-    st->print_cr(  "R%d=" INTPTR_FORMAT, r, (uintptr_t)uc->uc_mcontext.regs[r]);
+    char regname[6] = {0};
+    snprintf(regname, sizeof(regname), "R%d=", r);
+    print_reg(st, regname, uc->uc_mcontext.regs[r]);
   }
   st->cr();
 }

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -455,15 +455,14 @@ void os::print_context(outputStream *st, const void *context) {
   const ucontext_t* uc = (const ucontext_t*)context;
 
   st->print_cr("Registers:");
-  st->print("pc =" INTPTR_FORMAT "  ", uc->uc_mcontext.regs->nip);
-  st->print("lr =" INTPTR_FORMAT "  ", uc->uc_mcontext.regs->link);
-  st->print("ctr=" INTPTR_FORMAT "  ", uc->uc_mcontext.regs->ctr);
-  st->cr();
+  print_reg(st, "pc =", uc->uc_mcontext.regs->nip);
+  print_reg(st, "lr =", uc->uc_mcontext.regs->link);
+  print_reg(st, "ctr=", uc->uc_mcontext.regs->ctr);
   for (int i = 0; i < 32; i++) {
-    st->print("r%-2d=" INTPTR_FORMAT "  ", i, uc->uc_mcontext.regs->gpr[i]);
-    if (i % 3 == 2) st->cr();
+    char regname[6] = {0};
+    snprintf(regname, sizeof(regname), "r%-2d=", i);
+    print_reg(st, regname, uc->uc_mcontext.regs->gpr[i]);
   }
-  st->cr();
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -516,36 +516,31 @@ void os::print_context(outputStream *st, const void *context) {
 
   const ucontext_t *uc = (const ucontext_t*)context;
 
+  st->cr();
   st->print_cr("Registers:");
 #ifdef AMD64
-  st->print(  "RAX=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_RAX]);
-  st->print(", RBX=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_RBX]);
-  st->print(", RCX=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_RCX]);
-  st->print(", RDX=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_RDX]);
-  st->cr();
-  st->print(  "RSP=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_RSP]);
-  st->print(", RBP=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_RBP]);
-  st->print(", RSI=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_RSI]);
-  st->print(", RDI=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_RDI]);
-  st->cr();
-  st->print(  "R8 =" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_R8]);
-  st->print(", R9 =" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_R9]);
-  st->print(", R10=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_R10]);
-  st->print(", R11=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_R11]);
-  st->cr();
-  st->print(  "R12=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_R12]);
-  st->print(", R13=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_R13]);
-  st->print(", R14=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_R14]);
-  st->print(", R15=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_R15]);
-  st->cr();
-  st->print(  "RIP=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_RIP]);
-  st->print(", EFLAGS=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_EFL]);
-  st->print(", CSGSFS=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_CSGSFS]);
-  st->print(", ERR=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_ERR]);
-  st->cr();
-  st->print("  TRAPNO=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_TRAPNO]);
+  print_reg(st, "RAX=", (intptr_t)uc->uc_mcontext.gregs[REG_RAX]);
+  print_reg(st, "RBX=", (intptr_t)uc->uc_mcontext.gregs[REG_RBX]);
+  print_reg(st, "RCX=", (intptr_t)uc->uc_mcontext.gregs[REG_RCX]);
+  print_reg(st, "RDX=", (intptr_t)uc->uc_mcontext.gregs[REG_RDX]);
+  print_reg(st, "RSP=", (intptr_t)uc->uc_mcontext.gregs[REG_RSP]);
+  print_reg(st, "RBP=", (intptr_t)uc->uc_mcontext.gregs[REG_RBP]);
+  print_reg(st, "RSI=", (intptr_t)uc->uc_mcontext.gregs[REG_RSI]);
+  print_reg(st, "RDI=", (intptr_t)uc->uc_mcontext.gregs[REG_RDI]);
+  print_reg(st, "R8 =", (intptr_t)uc->uc_mcontext.gregs[REG_R8]);
+  print_reg(st, "R9 =", (intptr_t)uc->uc_mcontext.gregs[REG_R9]);
+  print_reg(st, "R10=", (intptr_t)uc->uc_mcontext.gregs[REG_R10]);
+  print_reg(st, "R11=", (intptr_t)uc->uc_mcontext.gregs[REG_R11]);
+  print_reg(st, "R12=", (intptr_t)uc->uc_mcontext.gregs[REG_R12]);
+  print_reg(st, "R13=", (intptr_t)uc->uc_mcontext.gregs[REG_R13]);
+  print_reg(st, "R14=", (intptr_t)uc->uc_mcontext.gregs[REG_R14]);
+  print_reg(st, "R15=", (intptr_t)uc->uc_mcontext.gregs[REG_R15]);
+  print_reg(st, "RIP=", (intptr_t)uc->uc_mcontext.gregs[REG_RIP]);
+  print_reg(st, "EFLAGS=", (intptr_t)uc->uc_mcontext.gregs[REG_EFL]);
+  print_reg(st, "CSGSFS=", (intptr_t)uc->uc_mcontext.gregs[REG_CSGSFS]);
+  print_reg(st, "ERR=", (intptr_t)uc->uc_mcontext.gregs[REG_ERR]);
+  print_reg(st, "TRAPNO=", (intptr_t)uc->uc_mcontext.gregs[REG_TRAPNO]);
   // Add XMM registers + MXCSR. Note that C2 uses XMM to spill GPR values including pointers.
-  st->cr();
   st->cr();
   // Sanity check: fpregs should point into the context.
   if ((address)uc->uc_mcontext.fpregs < (address)uc ||
@@ -557,24 +552,21 @@ void os::print_context(outputStream *st, const void *context) {
       const int64_t* xmm_val_addr = (int64_t*)&(uc->uc_mcontext.fpregs->_xmm[i]);
       st->print_cr("XMM[%d]=" INTPTR_FORMAT " " INTPTR_FORMAT, i, xmm_val_addr[1], xmm_val_addr[0]);
     }
-    st->print("  MXCSR=" UINT32_FORMAT_X_0, uc->uc_mcontext.fpregs->mxcsr);
+    st->print_cr("  MXCSR=" UINT32_FORMAT_X_0, uc->uc_mcontext.fpregs->mxcsr);
   }
 #else
-  st->print(  "EAX=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EAX]);
-  st->print(", EBX=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EBX]);
-  st->print(", ECX=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_ECX]);
-  st->print(", EDX=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EDX]);
-  st->cr();
-  st->print(  "ESP=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_UESP]);
-  st->print(", EBP=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EBP]);
-  st->print(", ESI=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_ESI]);
-  st->print(", EDI=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EDI]);
-  st->cr();
-  st->print(  "EIP=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EIP]);
-  st->print(", EFLAGS=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EFL]);
-  st->print(", CR2=" UINT64_FORMAT_X_0, (uint64_t)uc->uc_mcontext.cr2);
+  print_reg(st, "EAX=", (intptr_t) uc->uc_mcontext.gregs[REG_EAX]);
+  print_reg(st, "EBX=", (intptr_t) uc->uc_mcontext.gregs[REG_EBX]);
+  print_reg(st, "ECX=", (intptr_t) uc->uc_mcontext.gregs[REG_ECX]);
+  print_reg(st, "EDX=", (intptr_t) uc->uc_mcontext.gregs[REG_EDX]);
+  print_reg(st, "ESP=", (intptr_t) uc->uc_mcontext.gregs[REG_UESP]);
+  print_reg(st, "EBP=", (intptr_t) uc->uc_mcontext.gregs[REG_EBP]);
+  print_reg(st, "ESI=", (intptr_t) uc->uc_mcontext.gregs[REG_ESI]);
+  print_reg(st, "EDI=", (intptr_t) uc->uc_mcontext.gregs[REG_EDI]);
+  print_reg(st, "EIP=", (intptr_t) uc->uc_mcontext.gregs[REG_EIP]);
+  print_reg(st, "EFLAGS=", (intptr_t) uc->uc_mcontext.gregs[REG_EFL]);
+  st->print_cr("CR2=" UINT64_FORMAT_X_0, (uint64_t)uc->uc_mcontext.cr2);
 #endif // AMD64
-  st->cr();
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -348,39 +348,34 @@ void os::print_context(outputStream *st, const void *context) {
 
   const CONTEXT* uc = (const CONTEXT*)context;
 
+  st->cr();
   st->print_cr("Registers:");
-  st->print(  "RAX=" INTPTR_FORMAT, uc->Rax);
-  st->print(", RBX=" INTPTR_FORMAT, uc->Rbx);
-  st->print(", RCX=" INTPTR_FORMAT, uc->Rcx);
-  st->print(", RDX=" INTPTR_FORMAT, uc->Rdx);
-  st->cr();
-  st->print(  "RSP=" INTPTR_FORMAT, uc->Rsp);
-  st->print(", RBP=" INTPTR_FORMAT, uc->Rbp);
-  st->print(", RSI=" INTPTR_FORMAT, uc->Rsi);
-  st->print(", RDI=" INTPTR_FORMAT, uc->Rdi);
-  st->cr();
-  st->print(  "R8 =" INTPTR_FORMAT, uc->R8);
-  st->print(", R9 =" INTPTR_FORMAT, uc->R9);
-  st->print(", R10=" INTPTR_FORMAT, uc->R10);
-  st->print(", R11=" INTPTR_FORMAT, uc->R11);
-  st->cr();
-  st->print(  "R12=" INTPTR_FORMAT, uc->R12);
-  st->print(", R13=" INTPTR_FORMAT, uc->R13);
-  st->print(", R14=" INTPTR_FORMAT, uc->R14);
-  st->print(", R15=" INTPTR_FORMAT, uc->R15);
-  st->cr();
-  st->print(  "RIP=" INTPTR_FORMAT, uc->Rip);
-  st->print(", EFLAGS=" INTPTR_FORMAT, uc->EFlags);
+  print_reg(st, "RAX=", uc->Rax);
+  print_reg(st, "RBX=", uc->Rbx);
+  print_reg(st, "RCX=", uc->Rcx);
+  print_reg(st, "RDX=", uc->Rdx);
+  print_reg(st, "RSP=", uc->Rsp);
+  print_reg(st, "RBP=", uc->Rbp);
+  print_reg(st, "RSI=", uc->Rsi);
+  print_reg(st, "RDI=", uc->Rdi);
+  print_reg(st, "R8 =", uc->R8);
+  print_reg(st, "R9 =", uc->R9);
+  print_reg(st, "R10=", uc->R10);
+  print_reg(st, "R11=", uc->R11);
+  print_reg(st, "R12=", uc->R12);
+  print_reg(st, "R13=", uc->R13);
+  print_reg(st, "R14=", uc->R14);
+  print_reg(st, "R15=", uc->R15);
+  print_reg(st, "RIP=", uc->Rip);
+  print_reg(st, "EFLAGS=", uc->EFlags);
   // Add XMM registers + MXCSR. Note that C2 uses XMM to spill GPR values including pointers.
-  st->cr();
   st->cr();
   for (int i = 0; i < 16; ++i) {
     const uint64_t *xmm = ((const uint64_t*)&(uc->Xmm0)) + 2 * i;
     st->print_cr("XMM[%d]=" INTPTR_FORMAT " " INTPTR_FORMAT,
                  i, xmm[1], xmm[0]);
   }
-  st->print("  MXCSR=" UINT32_FORMAT_X_0, uc->MxCsr);
-  st->cr();
+  st->print_cr("  MXCSR=" UINT32_FORMAT_X_0, uc->MxCsr);
   st->cr();
 }
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1388,6 +1388,10 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
 
 }
 
+void os::print_reg(outputStream *st, const char* reg, intptr_t val) {
+  st->print_cr("%s" INTPTR_FORMAT, reg, val);
+}
+
 static bool is_pointer_bad(intptr_t* ptr) {
   return !is_aligned(ptr, sizeof(uintptr_t)) || !os::is_readable_pointer(ptr);
 }

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -834,6 +834,7 @@ class os: AllStatic {
   static void print_dhm(outputStream* st, const char* startStr, long sec);
 
   static void print_location(outputStream* st, intptr_t x, bool verbose = false);
+  static void print_reg(outputStream *st, const char* reg, intptr_t val);
   static size_t lasterror(char *buf, size_t len);
   static int get_last_error();
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
@@ -143,6 +143,7 @@ public class TestDwarf {
 
             // Check all stack entries after the line starting with "Native frames" in the hs_err_file until an empty line
             // is found which denotes the end of the stack frames.
+            // ATTENTION - register printing lines might start with CSGSFS ('C') so add a empty line before Register printing
             while ((line = reader.readLine()) != null) {
                 if (foundNativeFrames) {
                     if (line.isEmpty()) {


### PR DESCRIPTION
For printing registers we can add a little helper method to shorten the coding. Also some of the register printing code can use loops.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346661](https://bugs.openjdk.org/browse/JDK-8346661): Add a register print helper method and unify register printing (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22894/head:pull/22894` \
`$ git checkout pull/22894`

Update a local copy of the PR: \
`$ git checkout pull/22894` \
`$ git pull https://git.openjdk.org/jdk.git pull/22894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22894`

View PR using the GUI difftool: \
`$ git pr show -t 22894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22894.diff">https://git.openjdk.org/jdk/pull/22894.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22894#issuecomment-2565170744)
</details>
