### PR TITLE
8346920

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -50,6 +50,7 @@ class STWGCTimer;
 
 class DefNewGeneration: public Generation {
   friend class VMStructs;
+  friend class SerialHeap;
 
   TenuredGeneration* _old_gen;
 

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -120,6 +120,8 @@ public:
 
   bool is_in_reserved(const void* addr) const { return _reserved.contains(addr); }
 
+  bool is_long_enough_from_prev_gc_pause_end() const;
+
   // Performance Counter support
   GCPolicyCounters* counters()     { return _gc_policy_counters; }
 


### PR DESCRIPTION
This PR introduces a new strategy to determine whether an allocation should be attempted in the old generation or if a GC cycle should be initiated, based on the `GCTimeRatio`. With this change, the benchmark attached to the ticket now completes in ~13 GC, a significant improvement compared to the >1000 GC observed previously.

Test: tier1-3