### PR TITLE
8346921: Remove unused arg in markWord::must_be_preserved

### DIFF
--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -188,7 +188,7 @@ class markWord {
   static markWord INFLATING() { return zero(); }    // inflate-in-progress
 
   // Should this header be preserved during GC?
-  bool must_be_preserved(const oopDesc* obj) const {
+  bool must_be_preserved() const {
     return (!is_unlocked() || !has_no_hash());
   }
 

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -452,7 +452,7 @@ bool oopDesc::mark_must_be_preserved() const {
 }
 
 bool oopDesc::mark_must_be_preserved(markWord m) const {
-  return m.must_be_preserved(this);
+  return m.must_be_preserved();
 }
 
 #endif // SHARE_OOPS_OOP_INLINE_HPP


### PR DESCRIPTION
Trivial removing unused method arg.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346921](https://bugs.openjdk.org/browse/JDK-8346921): Remove unused arg in markWord::must_be_preserved (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22900/head:pull/22900` \
`$ git checkout pull/22900`

Update a local copy of the PR: \
`$ git checkout pull/22900` \
`$ git pull https://git.openjdk.org/jdk.git pull/22900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22900`

View PR using the GUI difftool: \
`$ git pr show -t 22900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22900.diff">https://git.openjdk.org/jdk/pull/22900.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22900#issuecomment-2567343593)
</details>
