### PR TITLE
8346924: TestVectorizationNegativeScale.java fails without the rvv extension on RISCV fastdebug VM

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorizationNegativeScale.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorizationNegativeScale.java
@@ -25,7 +25,8 @@
  * @test
  * @bug 8332827
  * @summary [REDO] C2: crash in compiled code because of dependency on removed range check CastIIs
- *
+ * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x") |
+ *           (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @library /test/lib /
  * @run driver TestVectorizationNegativeScale
  *

--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorizationNegativeScale.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorizationNegativeScale.java
@@ -25,8 +25,7 @@
  * @test
  * @bug 8332827
  * @summary [REDO] C2: crash in compiled code because of dependency on removed range check CastIIs
- * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x") |
- *           (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
+ * @requires os.arch != "riscv64" | vm.cpu.features ~= ".*rvv.*"
  * @library /test/lib /
  * @run driver TestVectorizationNegativeScale
  *


### PR DESCRIPTION
Hi, TestVectorizationNegativeScale.java fails without the rvv extension on RISCV fastdebug VM, on riscv platform need to have rvv extension to run it.

### Testing
- [x] Run TestVectorizationNegativeScale.java tests on SOPHON SG2042 without rvv1.0 (fastdebug)
- [x] Run TestVectorizationNegativeScale.java tests on Banana Pi BPI-F3 board (with RVV1.0) (fastdebug)
- [x] Run TestVectorizationNegativeScale.java tests on aarch64 with neon
- [x] Run TestVectorizationNegativeScale.java tests on Xeon(R) Platinum 8378A CPU

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346924](https://bugs.openjdk.org/browse/JDK-8346924): TestVectorizationNegativeScale.java fails without the rvv extension on RISCV fastdebug VM (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22902/head:pull/22902` \
`$ git checkout pull/22902`

Update a local copy of the PR: \
`$ git checkout pull/22902` \
`$ git pull https://git.openjdk.org/jdk.git pull/22902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22902`

View PR using the GUI difftool: \
`$ git pr show -t 22902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22902.diff">https://git.openjdk.org/jdk/pull/22902.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22902#issuecomment-2567383666)
</details>
