### PR TITLE
8346881: [ubsan] logSelection.cpp:154:24  / logSelectionList.cpp:72:94 : runtime error: applying non-zero offset 1 to null pointer

### DIFF
--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,9 @@ bool LogDecorators::parse(const char* decorator_args, outputStream* errstream) {
       break;
     }
     tmp_decorators |= mask(d);
-    token = comma_pos + 1;
+    if (comma_pos != nullptr) {
+      token = comma_pos + 1;
+    }
   } while (comma_pos != nullptr);
   os::free(args_copy);
   if (result) {

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,7 +151,9 @@ static LogSelection parse_internal(char *str, outputStream* errstream) {
       return LogSelection::Invalid;
     }
     tags[ntags++] = tag;
-    cur_tag = plus_pos + 1;
+    if (plus_pos != nullptr) {
+      cur_tag = plus_pos + 1;
+    }
   } while (plus_pos != nullptr);
 
   for (size_t i = 0; i < ntags; i++) {

--- a/src/hotspot/share/logging/logSelectionList.cpp
+++ b/src/hotspot/share/logging/logSelectionList.cpp
@@ -69,7 +69,7 @@ bool LogSelectionList::parse(const char* str, outputStream* errstream) {
   }
   char* copy = os::strdup_check_oom(str, mtLogging);
   // Split string on commas
-  for (char *comma_pos = copy, *cur = copy; success && comma_pos != nullptr; cur = comma_pos + 1) {
+  for (char *comma_pos = copy, *cur = copy; success; cur = comma_pos + 1) {
     if (_nselections == MaxSelections) {
       if (errstream != nullptr) {
         errstream->print_cr("Can not have more than " SIZE_FORMAT " log selections in a single configuration.",

--- a/src/hotspot/share/logging/logSelectionList.cpp
+++ b/src/hotspot/share/logging/logSelectionList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,6 +90,10 @@ bool LogSelectionList::parse(const char* str, outputStream* errstream) {
       break;
     }
     _selections[_nselections++] = selection;
+
+    if (comma_pos == nullptr) {
+      break;
+    }
   }
 
   os::free(copy);


### PR DESCRIPTION
When running jtreg tests on macOS aarch64 with ubsanized binaries, the following error is reported :

```
jdk/src/hotspot/share/logging/logSelection.cpp:154:24: runtime error: applying non-zero offset 1 to null pointer
UndefinedBehaviorSanitizer:DEADLYSIGNAL
UndefinedBehaviorSanitizer: nested bug in the same thread, aborting.
```

(XCode 13.1 was used)

This can be seen e.g. in these jdk jtreg tests :
jdk/internal/misc/CDS/ArchivedEnumTest.java
jdk/jfr/event/gc/collection/TestGCGarbageCollectionEvent.java
jdk/jfr/startupargs/TestDumpOnExit.java

There is another issue observed here (also when running on macOS aarch64) , seems this happens in the for loop when incrementing comma_pos
" for (char *comma_pos = copy, *cur = copy; success && comma_pos != nullptr; cur = comma_pos + 1) { ..."

```
src/hotspot/share/logging/logSelectionList.cpp:72:94: runtime error: applying non-zero offset 1 to null pointer
UndefinedBehaviorSanitizer:DEADLYSIGNAL
UndefinedBehaviorSanitizer: nested bug in the same thread, aborting.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346881](https://bugs.openjdk.org/browse/JDK-8346881): [ubsan] logSelection.cpp:154:24  / logSelectionList.cpp:72:94 : runtime error: applying non-zero offset 1 to null pointer (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22903/head:pull/22903` \
`$ git checkout pull/22903`

Update a local copy of the PR: \
`$ git checkout pull/22903` \
`$ git pull https://git.openjdk.org/jdk.git pull/22903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22903`

View PR using the GUI difftool: \
`$ git pr show -t 22903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22903.diff">https://git.openjdk.org/jdk/pull/22903.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22903#issuecomment-2567746686)
</details>
