### PR TITLE
8346946: Allow class loaders to bind to layers for service loading

### DIFF
--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -1919,6 +1920,20 @@ public abstract class ClassLoader {
     // The system class loader
     // @GuardedBy("ClassLoader.class")
     private static volatile ClassLoader scl;
+
+    /**
+     * Register a module layer to search for service providers when
+     * {@linkplain ServiceLoader#load(Class, ClassLoader) loading services by class loader}.
+     * The layer will then be searched in addition to any layers defined to this
+     * class loader.
+     *
+     * @param layer the module layer to register (must not be {@code null})
+     *
+     * @since 25
+     */
+    protected void registerModuleLayer(ModuleLayer layer) {
+        layer.bindToLoader(this);
+    }
 
     // -- Package --
 

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -39,7 +39,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -942,13 +942,13 @@ public final class ModuleLayer {
      */
     void bindToLoader(ClassLoader loader) {
         // CLV.computeIfAbsent(loader, (cl, clv) -> new CopyOnWriteArrayList<>())
-        List<ModuleLayer> list = CLV.get(loader);
-        if (list == null) {
-            list = new CopyOnWriteArrayList<>();
-            List<ModuleLayer> previous = CLV.putIfAbsent(loader, list);
-            if (previous != null) list = previous;
+        Set<ModuleLayer> set = CLV.get(loader);
+        if (set == null) {
+            set = new CopyOnWriteArraySet<>();
+            Set<ModuleLayer> previous = CLV.putIfAbsent(loader, set);
+            if (previous != null) set = previous;
         }
-        list.add(this);
+        set.add(this);
     }
 
     /**
@@ -956,14 +956,14 @@ public final class ModuleLayer {
      * the given class loader.
      */
     static Stream<ModuleLayer> layers(ClassLoader loader) {
-        List<ModuleLayer> list = CLV.get(loader);
-        if (list != null) {
-            return list.stream();
+        Set<ModuleLayer> set = CLV.get(loader);
+        if (set != null) {
+            return set.stream();
         } else {
             return Stream.empty();
         }
     }
 
     // the list of layers with modules defined to a class loader
-    private static final ClassLoaderValue<List<ModuleLayer>> CLV = new ClassLoaderValue<>();
+    private static final ClassLoaderValue<Set<ModuleLayer>> CLV = new ClassLoaderValue<>();
 }


### PR DESCRIPTION
When loading services by class loader (`ServiceLoader.load(Class,ClassLoader)`), the module layers bound to the given class loader are searched for services, along with the layers bound to class loader's parent, and so on. For non-hierarchical class loader arrangements, this breaks down because the parent class loader of non-hierarchical class loaders is typically `null` (i.e. the boot class loader), while the class loader might have multiple dependency class loaders which replace the role of parent.

Add an API to `ClassLoader` which allows additional layers to be bound to the class loader for the purpose of service loading by class loader, without affecting reliable configuration of modules (see [JDK-8346439](https://bugs.openjdk.org/browse/JDK-8346439)), which allows non-hierarchical class loaders to resolve service providers in dependency class loaders.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 25 to be approved (needs to be created)

### Issue
 * [JDK-8346946](https://bugs.openjdk.org/browse/JDK-8346946): Allow class loaders to bind to layers for service loading (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22905/head:pull/22905` \
`$ git checkout pull/22905`

Update a local copy of the PR: \
`$ git checkout pull/22905` \
`$ git pull https://git.openjdk.org/jdk.git pull/22905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22905`

View PR using the GUI difftool: \
`$ git pr show -t 22905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22905.diff">https://git.openjdk.org/jdk/pull/22905.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22905#issuecomment-2568112846)
</details>
