### PR TITLE
8346953: Remove unnecessary @SuppressWarnings annotations (client, #2)

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -621,7 +621,6 @@ class GTKFileChooserUI extends SynthFileChooserUI {
 
         fc.add(interior, BorderLayout.CENTER);
 
-        @SuppressWarnings("serial") // anonymous class
         JPanel comboBoxPanel = new JPanel(new FlowLayout(FlowLayout.CENTER,
                                                          0, 0) {
             public void layoutContainer(Container target) {
@@ -733,7 +732,6 @@ class GTKFileChooserUI extends SynthFileChooserUI {
         if (currentDirectory != null) {
             curDirName = currentDirectory.getPath();
         }
-        @SuppressWarnings("serial") // anonymous class
         JLabel tmp = new JLabel(curDirName) {
             public Dimension getMaximumSize() {
                 Dimension d = super.getMaximumSize();
@@ -748,7 +746,6 @@ class GTKFileChooserUI extends SynthFileChooserUI {
         interior.add(pathFieldPanel);
 
         // add the fileName field
-        @SuppressWarnings("serial") // anonymous class
         JTextField tmp2 = new JTextField() {
             public Dimension getMaximumSize() {
                 Dimension d = super.getMaximumSize();

--- a/src/java.desktop/unix/classes/sun/awt/X11/XComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XComponentPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,7 +168,6 @@ public class XComponentPeer extends XWindow implements ComponentPeer, DropTarget
         return System.getProperty("sun.awt.X11.XComponentPeer.reparentNotSupported", "false").equals("false");
     }
 
-    @SuppressWarnings("deprecation")
     public boolean isObscured() {
         Container container  = (target instanceof Container) ?
             (Container)target : target.getParent();
@@ -244,7 +243,6 @@ public class XComponentPeer extends XWindow implements ComponentPeer, DropTarget
     }
 
     // TODO: consider moving it to KeyboardFocusManagerPeerImpl
-    @SuppressWarnings("deprecation")
     public final boolean requestFocus(Component lightweightChild, boolean temporary,
                                       boolean focusedWindowChangeAllowed, long time,
                                       FocusEvent.Cause cause)

--- a/src/java.desktop/unix/classes/sun/awt/X11/XFileDialogPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XFileDialogPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -197,7 +197,6 @@ class XFileDialogPeer extends XDialogPeer
         // After showing we should display 'user.dir' as current directory
         // if user didn't set directory programmatically
         pathField = new TextField(savedDir != null ? savedDir : userDir);
-        @SuppressWarnings("serial") // Anonymous class
         Choice tmp = new Choice() {
                 public Dimension getPreferredSize() {
                     return new Dimension(PATH_CHOICE_WIDTH, pathField.getPreferredSize().height);
@@ -778,7 +777,6 @@ class XFileDialogPeer extends XDialogPeer
     }
 
     // 03/02/2005 b5097243 Pressing 'ESC' on a file dlg does not dispose the dlg on Xtoolkit
-    @SuppressWarnings("deprecation")
     public void setVisible(boolean b){
         if (fileDialog == null) {
             init(target);

--- a/src/java.desktop/unix/classes/sun/awt/X11/XFramePeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XFramePeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,7 +137,6 @@ class XFramePeer extends XDecoratedPeer implements FramePeer {
         setExtendedState(state);
     }
 
-    @SuppressWarnings("deprecation")
     public void setMenuBar(MenuBar mb) {
         // state_lock should always be the second after awt_lock
         XToolkit.awtLock();

--- a/src/java.desktop/unix/classes/sun/awt/X11/XMouseInfoPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XMouseInfoPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,6 @@ public final class XMouseInfoPeer implements MouseInfoPeer {
         return 0;
     }
 
-    @SuppressWarnings("deprecation")
     public boolean isWindowUnderMouse(Window w) {
         if (w == null) {
             return false;

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -214,7 +214,6 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
     private static native String getLocalHostname();
     private static native int getJvmPID();
 
-    @SuppressWarnings("deprecation")
     void postInit(XCreateWindowParams params) {
         super.postInit(params);
 

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -273,7 +273,6 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
         fc.add(topPanel, BorderLayout.NORTH);
 
         // ComboBox Label
-        @SuppressWarnings("serial") // anonymous class
         JLabel tmp1 = new JLabel(lookInLabelText, JLabel.TRAILING) {
             public Dimension getPreferredSize() {
                 return getMinimumSize();
@@ -295,7 +294,6 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
         topPanel.add(Box.createRigidArea(new Dimension(8,0)));
 
         // CurrentDir ComboBox
-        @SuppressWarnings("serial") // anonymous class
         JComboBox<File> tmp2 = new JComboBox<File>() {
             public Dimension getMinimumSize() {
                 Dimension d = super.getMinimumSize();
@@ -477,7 +475,6 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
         fileAndFilterPanel.add(Box.createRigidArea(vstrut8));
         fileAndFilterPanel.setLayout(new BoxLayout(fileAndFilterPanel, BoxLayout.Y_AXIS));
 
-        @SuppressWarnings("serial") // anonymous class
         JTextField tmp3 = new JTextField(35) {
             public Dimension getMaximumSize() {
                 return new Dimension(Short.MAX_VALUE, super.getPreferredSize().height);
@@ -518,7 +515,6 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
         // buttons
         getButtonPanel().setLayout(new BoxLayout(getButtonPanel(), BoxLayout.Y_AXIS));
 
-        @SuppressWarnings("serial") // anonymous class
         JButton tmp4 = new JButton(getApproveButtonText(fc)) {
             public Dimension getMaximumSize() {
                 return approveButton.getPreferredSize().width > cancelButton.getPreferredSize().width ?
@@ -537,7 +533,6 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
         getButtonPanel().add(approveButton);
         getButtonPanel().add(Box.createRigidArea(vstrut4));
 
-        @SuppressWarnings("serial") // anonymous class
         JButton tmp5 = new JButton(cancelButtonText) {
             public Dimension getMaximumSize() {
                 return approveButton.getPreferredSize().width > cancelButton.getPreferredSize().width ?
@@ -974,7 +969,6 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
         return new DirectoryComboBoxRenderer();
     }
 
-    @SuppressWarnings("serial") // anonymous class
     private static JButton createToolButton(Action a, Icon defaultIcon, String toolTipText, String accessibleName) {
         final JButton result = new JButton(a);
 

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsInternalFrameTitlePane.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsInternalFrameTitlePane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -289,7 +289,6 @@ public class WindowsInternalFrameTitlePane extends BasicInternalFrameTitlePane {
         systemPopupMenu = new JPopupMenu();
         addSystemMenuItems(systemPopupMenu);
         enableActions();
-        @SuppressWarnings("serial") // anonymous class
         JLabel tmp = new JLabel(frame.getFrameIcon()) {
             protected void paintComponent(Graphics g) {
                 int x = 0;

--- a/src/java.desktop/windows/classes/sun/awt/windows/WDialogPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WDialogPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,6 @@ final class WDialogPeer extends WWindowPeer implements DialogPeer {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     void hide() {
         Dialog dlg = (Dialog)target;
         if (dlg.getModalityType() != Dialog.ModalityType.MODELESS) {


### PR DESCRIPTION
Please review this patch which removes unnecessary `@SuppressWarnings` annotations.

This issue is a follow up to [JDK-8343476](https://bugs.openjdk.org/browse/JDK-8343476) to remove some additional warnings that were missed in that issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346953](https://bugs.openjdk.org/browse/JDK-8346953): Remove unnecessary @<!---->SuppressWarnings annotations (client, #2) (**Sub-task** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22906/head:pull/22906` \
`$ git checkout pull/22906`

Update a local copy of the PR: \
`$ git checkout pull/22906` \
`$ git pull https://git.openjdk.org/jdk.git pull/22906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22906`

View PR using the GUI difftool: \
`$ git pr show -t 22906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22906.diff">https://git.openjdk.org/jdk/pull/22906.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22906#issuecomment-2568309329)
</details>
