### PR TITLE
8346260: Test "javax/swing/JOptionPane/bug4174551.java" failed because the font size of message "Hi 24" is not set to 24 in Nimbus LookAndFeel

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthDefaultLookup.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthDefaultLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javax.swing.plaf.ComponentUI;
 class SynthDefaultLookup extends DefaultLookup {
     public Object getDefault(JComponent c, ComponentUI ui, String key) {
         if (ui instanceof SynthOptionPaneUI) {
-            Object value = UIManager.get(key, c.getLocale());
+            Object value = super.getDefault(c, ui, key);
             if (value != null) {
                 return value;
             }

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthDefaultLookup.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthDefaultLookup.java
@@ -25,7 +25,9 @@
 package javax.swing.plaf.synth;
 
 import sun.swing.DefaultLookup;
+
 import javax.swing.JComponent;
+import javax.swing.UIManager;
 import javax.swing.plaf.ComponentUI;
 
 /**
@@ -35,6 +37,12 @@ import javax.swing.plaf.ComponentUI;
  */
 class SynthDefaultLookup extends DefaultLookup {
     public Object getDefault(JComponent c, ComponentUI ui, String key) {
+        if (ui instanceof SynthOptionPaneUI) {
+            Object value = UIManager.get(key, c.getLocale());
+            if (value != null) {
+                return value;
+            }
+        }
         if (!(ui instanceof SynthUI)) {
             Object value = super.getDefault(c, ui, key);
             return value;

--- a/test/jdk/javax/swing/JOptionPane/bug4174551.java
+++ b/test/jdk/javax/swing/JOptionPane/bug4174551.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4174551
+ * @bug 4174551 8346260
  * @summary JOptionPane should allow custom buttons
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame


### PR DESCRIPTION
"OptionPane.buttonFont" and "OptionPane.messageFont" property are ignored for Nimbus L&F as for Nimbus, lookup calls initiated by BasicOptionPaneUI#configureButton and BasicOptionPaneUI#configureMessageLabel, were redirected via SynthContext so UIManager.getDefaults L&F properties were ignored..
Added way to honor this properties for SynthOptionPaneUI..It could be later extended for other UI properties for other widgets which may need UIManager lookup..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346260](https://bugs.openjdk.org/browse/JDK-8346260): Test "javax/swing/JOptionPane/bug4174551.java" failed because the font size of message "Hi 24" is not set to 24 in Nimbus LookAndFeel (**Bug** - P5)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22908/head:pull/22908` \
`$ git checkout pull/22908`

Update a local copy of the PR: \
`$ git checkout pull/22908` \
`$ git pull https://git.openjdk.org/jdk.git pull/22908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22908`

View PR using the GUI difftool: \
`$ git pr show -t 22908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22908.diff">https://git.openjdk.org/jdk/pull/22908.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22908#issuecomment-2568682419)
</details>
