### PR TITLE
8334644 : Automate javax/print/attribute/PageRangesException.java

### DIFF
--- a/test/jdk/javax/print/attribute/PageRangesException.java
+++ b/test/jdk/javax/print/attribute/PageRangesException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.print.attribute.standard.PageRanges;
+
+/*
+ * @test
+ * @bug 4433126 4433096
+ * @key printer
+ * @summary  The line "ERROR: <message>" should NOT appear.
+ * @run main PageRangesException
+ */
+
+public class PageRangesException {
+    public static void main(String[] args) throws Exception {
+        // test 4433126
+        try {
+            PageRanges pr = new PageRanges("0:22");
+            throw new RuntimeException("ERROR: no exceptions");
+        } catch (IllegalArgumentException ie) {
+            System.out.println("OKAY: IllegalArgumentException " + ie);
+        }
+
+        //test 4433096
+        try {
+            int[][] m = null;
+            PageRanges pr = new PageRanges(m);
+            throw new RuntimeException("ERROR: NullPointerException expected");
+        } catch (IllegalArgumentException ie) {
+            throw new RuntimeException("ERROR: IllegalArgumentException", ie);
+        } catch (NullPointerException e) {
+            System.out.println("OKAY: NullPointerException");
+        }
+    }
+}

--- a/test/jdk/javax/print/attribute/PageRangesException.java
+++ b/test/jdk/javax/print/attribute/PageRangesException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class PageRangesException {
             System.out.println("OKAY: IllegalArgumentException " + ie);
         }
 
-        //test 4433096
+        // test 4433096
         try {
             int[][] m = null;
             PageRanges pr = new PageRanges(m);


### PR DESCRIPTION
Hi All,

I have updated the test and made it automation friendly. Please review and let me know your suggestions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334644](https://bugs.openjdk.org/browse/JDK-8334644): Automate javax/print/attribute/PageRangesException.java (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22909/head:pull/22909` \
`$ git checkout pull/22909`

Update a local copy of the PR: \
`$ git checkout pull/22909` \
`$ git pull https://git.openjdk.org/jdk.git pull/22909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22909`

View PR using the GUI difftool: \
`$ git pr show -t 22909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22909.diff">https://git.openjdk.org/jdk/pull/22909.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22909#issuecomment-2568691034)
</details>
