### PR TITLE
JDK-8345676: [ubsan] ProcessImpl_md.c:561:40: runtime error: applying zero offset to null pointer on macOS aarch64

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -558,7 +558,9 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
         return -1;
     }
     offset = copystrings(buf, 0, &c->argv[0]);
-    offset = copystrings(buf, offset, &c->envv[0]);
+    if (c->envv != NULL) {
+        offset = copystrings(buf, offset, &c->envv[0]);
+    }
     if (c->pdir != NULL) {
         if (sp.dirlen > 0) {
             memcpy(buf+offset, c->pdir, sp.dirlen);


### PR DESCRIPTION
When starting :tier1 jdk jtreg tests with
/jtreg_latest/bin/jtreg
this error is show when running ubsanized binaries on macOS aarch64 (XCode 13.1 and 15.4 show this)

src/java.base/unix/native/libjava/ProcessImpl_md.c:561:40: runtime error: applying zero offset to null pointer
    #0 0x102a6552c in startChild ProcessImpl_md.c:621
    #1 0x102a64480 in Java_java_lang_ProcessImpl_forkAndExec ProcessImpl_md.c:721
    #2 0x13f53c4fc (<unknown module>)
    #3 0x13f5387cc (<unknown module>)
    #4 0x13f53894c (<unknown module>)
    #5 0x13f5386dc (<unknown module>)
    #6 0x13f5386dc (<unknown module>)
    #7 0x13f5386dc (<unknown module>)
    #8 0x13f53894c (<unknown module>)
    #9 0x13f53894c (<unknown module>)
    #10 0x13f534110 (<unknown module>)
    #11 0x107de60e0 in JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*) javaCalls.cpp:416
    #12 0x107ebf778 in jni_invoke_static(JNIEnv_*, JavaValue*, _jobject*, JNICallType, _jmethodID*, JNI_ArgumentPusher*, JavaThread*) jni.cpp:885
    #13 0x107ec2778 in jni_CallStaticVoidMethod jni.cpp:1714
    #14 0x102e86210 in invokeStaticMainWithArgs java.c:392
    #15 0x102e884e8 in JavaMain java.c:640
    #16 0x102e8d79c in ThreadJavaMain java_md_macosx.m:679
    #17 0x19d38ef90 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6f90)
    #18 0x19d389d30 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1d30)

Looks similar to
https://www.reddit.com/r/C_Programming/comments/133oxnc/null_0_is_ub_this_is_not_what_you_would_expect/?rdt=41590
and
https://trac.ffmpeg.org/changeset/9c0b3eddf4262f9dcea479091f1307444e614e88/ffmpeg