### PR TITLE
8346984: Remove ASM-based benchmarks from Class-File API benchmarks

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -96,8 +96,6 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
         --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.util=ALL-UNNAMED \
-        --add-exports java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED \
-        --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.vm=ALL-UNNAMED \
         --add-exports java.base/sun.invoke.util=ALL-UNNAMED \
         --add-exports java.base/sun.security.util=ALL-UNNAMED \

--- a/test/micro/org/openjdk/bench/jdk/classfile/AbstractCorpusBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/AbstractCorpusBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/jdk/classfile/AbstractCorpusBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/AbstractCorpusBenchmark.java
@@ -44,8 +44,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 2)
 @Measurement(iterations = 4)
 @Fork(value = 1, jvmArgs = {
-        "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
-        "--add-exports", "java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.components=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.impl=ALL-UNNAMED"})
 @State(Scope.Benchmark)

--- a/test/micro/org/openjdk/bench/jdk/classfile/AdaptNull.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/AdaptNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/jdk/classfile/AdaptNull.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/AdaptNull.java
@@ -35,10 +35,6 @@ public class AdaptNull extends AbstractCorpusBenchmark {
 
     @Param({
 //            "ARRAYCOPY",
-            "ASM_1",
-            "ASM_3",
-            "ASM_UNSHARED_3",
-//            "ASM_TREE",
             "SHARED_1",
             "SHARED_2",
             "SHARED_3",

--- a/test/micro/org/openjdk/bench/jdk/classfile/ReadDeep.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/ReadDeep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/jdk/classfile/ReadDeep.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/ReadDeep.java
@@ -29,12 +29,6 @@ import java.lang.classfile.CodeModel;
 import java.lang.classfile.CompoundElement;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.LoadInstruction;
-import jdk.internal.org.objectweb.asm.ClassReader;
-import jdk.internal.org.objectweb.asm.ClassVisitor;
-import jdk.internal.org.objectweb.asm.MethodVisitor;
-import jdk.internal.org.objectweb.asm.Opcodes;
-import jdk.internal.org.objectweb.asm.tree.ClassNode;
-import jdk.internal.org.objectweb.asm.tree.MethodNode;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -44,55 +38,6 @@ import org.openjdk.jmh.infra.Blackhole;
  * ReadCode
  */
 public class ReadDeep extends AbstractCorpusBenchmark {
-
-    @Benchmark
-    @BenchmarkMode(Mode.Throughput)
-    public void asmStreamCountLoads(Blackhole bh) {
-        for (byte[] bytes : classes) {
-            ClassReader cr = new ClassReader(bytes);
-
-            var mv = new MethodVisitor(Opcodes.ASM9) {
-                int count = 0;
-
-                @Override
-                public void visitVarInsn(int opcode, int var) {
-                    ++count;
-                }
-            };
-
-            var visitor = new ClassVisitor(Opcodes.ASM9) {
-                @Override
-                public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
-                    return mv;
-                }
-            };
-            cr.accept(visitor, 0);
-            bh.consume(mv.count);
-        }
-    }
-
-    @Benchmark
-    @BenchmarkMode(Mode.Throughput)
-    public void asmTreeCountLoads(Blackhole bh) {
-        for (byte[] bytes : classes) {
-            var mv = new MethodVisitor(Opcodes.ASM9) {
-                int count = 0;
-
-                @Override
-                public void visitVarInsn(int opcode, int var) {
-                    ++count;
-                }
-            };
-
-            ClassNode node = new ClassNode();
-            ClassReader cr = new ClassReader(bytes);
-            cr.accept(node, 0);
-            for (MethodNode mn : node.methods) {
-                mn.accept(mv);
-            }
-            bh.consume(mv.count);
-        }
-    }
 
     @Benchmark
     @BenchmarkMode(Mode.Throughput)

--- a/test/micro/org/openjdk/bench/jdk/classfile/ReadMetadata.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/ReadMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/jdk/classfile/ReadMetadata.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/ReadMetadata.java
@@ -27,41 +27,10 @@ import java.lang.classfile.ClassElement;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.FieldModel;
-import jdk.internal.org.objectweb.asm.*;
-import jdk.internal.org.objectweb.asm.tree.*;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
 public class ReadMetadata extends AbstractCorpusBenchmark {
-
-    @Benchmark
-    @BenchmarkMode(Mode.Throughput)
-    public void asmStreamReadName(Blackhole bh) {
-        for (byte[] bytes : classes) {
-            ClassReader cr = new ClassReader(bytes);
-            var  visitor = new ClassVisitor(Opcodes.ASM9) {
-                String theName;
-
-                @Override
-                public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-                    theName = name;
-                }
-            };
-            cr.accept(visitor, 0);
-            bh.consume(visitor.theName);
-        }
-    }
-
-    @Benchmark
-    @BenchmarkMode(Mode.Throughput)
-    public void asmTreeReadName(Blackhole bh) {
-        for (byte[] bytes : classes) {
-            ClassNode node = new ClassNode();
-            ClassReader cr = new ClassReader(bytes);
-            cr.accept(node, 0);
-            bh.consume(node.name);
-        }
-    }
 
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
@@ -87,43 +56,6 @@ public class ReadMetadata extends AbstractCorpusBenchmark {
                 bh.consume(m.methodName().stringValue());
                 bh.consume(m.methodType().stringValue());
             }
-        }
-    }
-
-    @Benchmark
-    @BenchmarkMode(Mode.Throughput)
-    public void asmStreamCountFields(Blackhole bh) {
-        for (byte[] bytes : classes) {
-            ClassReader cr = new ClassReader(bytes);
-            var visitor = new ClassVisitor(Opcodes.ASM9) {
-                int count;
-
-                @Override
-                public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
-                    if ((access & Opcodes.ACC_PUBLIC) != 1) {
-                        ++count;
-                    }
-                    return null;
-                }
-            };
-            cr.accept(visitor, 0);
-            bh.consume(visitor.count);
-        }
-    }
-
-    @Benchmark
-    @BenchmarkMode(Mode.Throughput)
-    public void asmTreeCountFields(Blackhole bh) {
-        for (byte[] bytes : classes) {
-            int count = 0;
-            ClassNode node = new ClassNode();
-            ClassReader cr = new ClassReader(bytes);
-            cr.accept(node, 0);
-            for (FieldNode fn : node.fields)
-                if ((fn.access & Opcodes.ACC_PUBLIC) != 1) {
-                    ++count;
-                }
-            bh.consume(count);
         }
     }
 

--- a/test/micro/org/openjdk/bench/jdk/classfile/Transforms.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/Transforms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/jdk/classfile/Transforms.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/Transforms.java
@@ -41,26 +41,11 @@ import java.lang.classfile.CodeTransform;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.MethodTransform;
 import jdk.internal.classfile.components.ClassRemapper;
-import jdk.internal.org.objectweb.asm.AnnotationVisitor;
-import jdk.internal.org.objectweb.asm.Attribute;
-import jdk.internal.org.objectweb.asm.ClassReader;
-import jdk.internal.org.objectweb.asm.ClassVisitor;
-import jdk.internal.org.objectweb.asm.FieldVisitor;
-import jdk.internal.org.objectweb.asm.Handle;
-import jdk.internal.org.objectweb.asm.Label;
-import jdk.internal.org.objectweb.asm.MethodVisitor;
-import jdk.internal.org.objectweb.asm.ModuleVisitor;
-import jdk.internal.org.objectweb.asm.Opcodes;
-import jdk.internal.org.objectweb.asm.RecordComponentVisitor;
-import jdk.internal.org.objectweb.asm.TypePath;
-import jdk.internal.org.objectweb.asm.tree.ClassNode;
 
 /**
  * Transforms
  */
 public class Transforms {
-
-    static int ASM9 = 9 << 16 | 0 << 8;
 
     public static final ClassTransform threeLevelNoop = (cb, ce) -> {
         if (ce instanceof MethodModel mm) {
@@ -123,38 +108,6 @@ public class Transforms {
         UNSHARED_3(false, threeLevelNoop),
         SHARED_3_NO_STACKMAP(true, threeLevelNoop, ClassFile.StackMapsOption.DROP_STACK_MAPS),
         SHARED_3_NO_DEBUG(true, threeLevelNoop, ClassFile.DebugElementsOption.DROP_DEBUG, ClassFile.LineNumbersOption.DROP_LINE_NUMBERS),
-        ASM_1(bytes -> {
-            ClassReader cr = new ClassReader(bytes);
-            jdk.internal.org.objectweb.asm.ClassWriter cw = new jdk.internal.org.objectweb.asm.ClassWriter(cr, jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_FRAMES);
-            cr.accept(cw, 0);
-            return cw.toByteArray();
-        }),
-        ASM_UNSHARED_1(bytes -> {
-            ClassReader cr = new ClassReader(bytes);
-            jdk.internal.org.objectweb.asm.ClassWriter cw = new jdk.internal.org.objectweb.asm.ClassWriter(jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_FRAMES);
-            cr.accept(cw, 0);
-            return cw.toByteArray();
-        }),
-        ASM_3(bytes -> {
-            ClassReader cr = new ClassReader(bytes);
-            jdk.internal.org.objectweb.asm.ClassWriter cw = new jdk.internal.org.objectweb.asm.ClassWriter(cr, jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_FRAMES);
-            cr.accept(new CustomClassVisitor(cw), 0);
-            return cw.toByteArray();
-        }),
-        ASM_UNSHARED_3(bytes -> {
-            ClassReader cr = new ClassReader(bytes);
-            jdk.internal.org.objectweb.asm.ClassWriter cw = new jdk.internal.org.objectweb.asm.ClassWriter(jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_FRAMES);
-            cr.accept(new CustomClassVisitor(cw), 0);
-            return cw.toByteArray();
-        }),
-        ASM_TREE(bytes -> {
-            ClassNode node = new ClassNode();
-            ClassReader cr = new ClassReader(bytes);
-            cr.accept(node, 0);
-            jdk.internal.org.objectweb.asm.ClassWriter cw = new jdk.internal.org.objectweb.asm.ClassWriter(cr, jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_FRAMES);
-            node.accept(cw);
-            return cw.toByteArray();
-        }),
         CLASS_REMAPPER(bytes ->
                 ClassRemapper.of(Map.of()).remapClass(ClassFile.of(), ClassFile.of().parse(bytes)));
 
@@ -186,12 +139,6 @@ public class Transforms {
     }
 
     public enum InjectNopTransform {
-        ASM_NOP_SHARED(bytes -> {
-            ClassReader cr = new ClassReader(bytes);
-            jdk.internal.org.objectweb.asm.ClassWriter cw = new jdk.internal.org.objectweb.asm.ClassWriter(cr, jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_FRAMES);
-            cr.accept(new NopClassVisitor(cw), 0);
-            return cw.toByteArray();
-        }),
         NOP_SHARED(bytes -> {
             var cc = ClassFile.of();
             ClassModel cm = cc.parse(bytes);
@@ -226,13 +173,6 @@ public class Transforms {
     }
 
     public enum SimpleTransform {
-        ASM_ADD_FIELD(bytes -> {
-            ClassReader cr = new ClassReader(bytes);
-            jdk.internal.org.objectweb.asm.ClassWriter cw = new jdk.internal.org.objectweb.asm.ClassWriter(cr, jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_FRAMES);
-            cr.accept(cw, 0);
-            cw.visitField(0, "argleBargleWoogaWooga", "I", null, null);
-            return cw.toByteArray();
-        }),
         HIGH_SHARED_ADD_FIELD(bytes -> {
             var cc = ClassFile.of();
             ClassModel cm = cc.parse(bytes);
@@ -256,20 +196,6 @@ public class Transforms {
                                        cm.forEach(cb);
                                        cb.withField("argleBargleWoogaWooga", ConstantDescs.CD_int, b -> { });
                                    });
-        }),
-        ASM_DEL_METHOD(bytes -> {
-            ClassReader cr = new ClassReader(bytes);
-            jdk.internal.org.objectweb.asm.ClassWriter cw = new jdk.internal.org.objectweb.asm.ClassWriter(cr, jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_FRAMES);
-            ClassVisitor v = new ClassVisitor(ASM9, cw) {
-                @Override
-                public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
-                    return (name.equals("hashCode") && descriptor.equals("()Z"))
-                           ? null
-                           : super.visitMethod(access, name, descriptor, signature, exceptions);
-                }
-            };
-            cr.accept(cw, 0);
-            return cw.toByteArray();
         }),
         HIGH_SHARED_DEL_METHOD(bytes -> {
             var cc = ClassFile.of();
@@ -300,279 +226,6 @@ public class Transforms {
 
         SimpleTransform(UnaryOperator<byte[]> transform) {
             this.transform = transform;
-        }
-    }
-
-    static class CustomClassVisitor extends ClassVisitor {
-
-        public CustomClassVisitor(ClassVisitor writer) {
-            super(ASM9, writer);
-        }
-
-        @Override
-        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-            super.visit(version, access, name, signature, superName, interfaces);
-        }
-
-        @Override
-        public void visitSource(String source, String debug) {
-            super.visitSource(source, debug);
-        }
-
-        @Override
-        public ModuleVisitor visitModule(String name, int access, String version) {
-            return super.visitModule(name, access, version);
-        }
-
-        @Override
-        public void visitNestHost(String nestHost) {
-            super.visitNestHost(nestHost);
-        }
-
-        @Override
-        public void visitOuterClass(String owner, String name, String descriptor) {
-            super.visitOuterClass(owner, name, descriptor);
-        }
-
-        @Override
-        public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
-            return super.visitAnnotation(descriptor, visible);
-        }
-
-        @Override
-        public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
-            return super.visitTypeAnnotation(typeRef, typePath, descriptor, visible);
-        }
-
-        @Override
-        public void visitAttribute(Attribute attribute) {
-            super.visitAttribute(attribute);
-        }
-
-        @Override
-        public void visitNestMember(String nestMember) {
-            super.visitNestMember(nestMember);
-        }
-
-        @Override
-        public void visitInnerClass(String name, String outerName, String innerName, int access) {
-            super.visitInnerClass(name, outerName, innerName, access);
-        }
-
-        @Override
-        public RecordComponentVisitor visitRecordComponent(String name, String descriptor, String signature) {
-            return super.visitRecordComponent(name, descriptor, signature);
-        }
-
-        @Override
-        public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
-            return super.visitField(access, name, descriptor, signature, value);
-        }
-
-        @Override
-        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
-            MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
-            return new CustomMethodVisitor(mv);
-        }
-
-        @Override
-        public void visitEnd() {
-            super.visitEnd();
-        }
-    };
-
-
-    static class CustomMethodVisitor extends MethodVisitor {
-
-        public CustomMethodVisitor(MethodVisitor methodVisitor) {
-            super(ASM9, methodVisitor);
-        }
-
-        @Override
-        public void visitParameter(String name, int access) {
-            super.visitParameter(name, access);
-        }
-
-        @Override
-        public AnnotationVisitor visitAnnotationDefault() {
-            return super.visitAnnotationDefault();
-        }
-
-        @Override
-        public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
-            return super.visitAnnotation(descriptor, visible);
-        }
-
-        @Override
-        public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
-            return super.visitTypeAnnotation(typeRef, typePath, descriptor, visible);
-        }
-
-        @Override
-        public void visitAnnotableParameterCount(int parameterCount, boolean visible) {
-            super.visitAnnotableParameterCount(parameterCount, visible);
-        }
-
-        @Override
-        public AnnotationVisitor visitParameterAnnotation(int parameter, String descriptor, boolean visible) {
-            return super.visitParameterAnnotation(parameter, descriptor, visible);
-        }
-
-        @Override
-        public void visitAttribute(Attribute attribute) {
-            super.visitAttribute(attribute);
-        }
-
-        @Override
-        public void visitCode() {
-            super.visitCode();
-        }
-
-        @Override
-        public void visitFrame(int type, int numLocal, Object[] local, int numStack, Object[] stack) {
-            super.visitFrame(type, numLocal, local, numStack, stack);
-        }
-
-        @Override
-        public void visitInsn(int opcode) {
-            super.visitInsn(opcode);
-        }
-
-        @Override
-        public void visitIntInsn(int opcode, int operand) {
-            super.visitIntInsn(opcode, operand);
-        }
-
-        @Override
-        public void visitVarInsn(int opcode, int var) {
-            super.visitVarInsn(opcode, var);
-        }
-
-        @Override
-        public void visitTypeInsn(int opcode, String type) {
-            super.visitTypeInsn(opcode, type);
-        }
-
-        @Override
-        public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
-            super.visitFieldInsn(opcode, owner, name, descriptor);
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public void visitMethodInsn(int opcode, String owner, String name, String descriptor) {
-            super.visitMethodInsn(opcode, owner, name, descriptor);
-        }
-
-        @Override
-        public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
-            super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
-        }
-
-        @Override
-        public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
-            super.visitInvokeDynamicInsn(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
-        }
-
-        @Override
-        public void visitJumpInsn(int opcode, Label label) {
-            super.visitJumpInsn(opcode, label);
-        }
-
-        @Override
-        public void visitLabel(Label label) {
-            super.visitLabel(label);
-        }
-
-        @Override
-        public void visitLdcInsn(Object value) {
-            super.visitLdcInsn(value);
-        }
-
-        @Override
-        public void visitIincInsn(int var, int increment) {
-            super.visitIincInsn(var, increment);
-        }
-
-        @Override
-        public void visitTableSwitchInsn(int min, int max, Label dflt, Label... labels) {
-            super.visitTableSwitchInsn(min, max, dflt, labels);
-        }
-
-        @Override
-        public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
-            super.visitLookupSwitchInsn(dflt, keys, labels);
-        }
-
-        @Override
-        public void visitMultiANewArrayInsn(String descriptor, int numDimensions) {
-            super.visitMultiANewArrayInsn(descriptor, numDimensions);
-        }
-
-        @Override
-        public AnnotationVisitor visitInsnAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
-            return super.visitInsnAnnotation(typeRef, typePath, descriptor, visible);
-        }
-
-        @Override
-        public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
-            super.visitTryCatchBlock(start, end, handler, type);
-        }
-
-        @Override
-        public AnnotationVisitor visitTryCatchAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
-            return super.visitTryCatchAnnotation(typeRef, typePath, descriptor, visible);
-        }
-
-        @Override
-        public void visitLocalVariable(String name, String descriptor, String signature, Label start, Label end, int index) {
-            super.visitLocalVariable(name, descriptor, signature, start, end, index);
-        }
-
-        @Override
-        public AnnotationVisitor visitLocalVariableAnnotation(int typeRef, TypePath typePath, Label[] start, Label[] end, int[] index, String descriptor, boolean visible) {
-            return super.visitLocalVariableAnnotation(typeRef, typePath, start, end, index, descriptor, visible);
-        }
-
-        @Override
-        public void visitLineNumber(int line, Label start) {
-            super.visitLineNumber(line, start);
-        }
-
-        @Override
-        public void visitMaxs(int maxStack, int maxLocals) {
-            super.visitMaxs(maxStack, maxLocals);
-        }
-
-        @Override
-        public void visitEnd() {
-            super.visitEnd();
-        }
-    };
-
-    static class NopClassVisitor extends CustomClassVisitor {
-
-        public NopClassVisitor(ClassVisitor writer) {
-            super(writer);
-        }
-
-        @Override
-        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
-            MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
-            return new NopMethodVisitor(mv);
-        }
-    }
-
-    static class NopMethodVisitor extends CustomMethodVisitor {
-
-        public NopMethodVisitor(MethodVisitor methodVisitor) {
-            super(methodVisitor);
-        }
-
-        @Override
-        public void visitCode() {
-            super.visitCode();
-            visitInsn(Opcodes.NOP);
         }
     }
 

--- a/test/micro/org/openjdk/bench/jdk/classfile/Write.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/jdk/classfile/Write.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/Write.java
@@ -25,7 +25,6 @@ package org.openjdk.bench.jdk.classfile;
 import java.lang.reflect.AccessFlag;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.attribute.SourceFileAttribute;
-import jdk.internal.org.objectweb.asm.*;
 import org.openjdk.jmh.annotations.*;
 import java.io.FileOutputStream;
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
@@ -57,8 +56,6 @@ import static org.openjdk.bench.jdk.classfile.TestConstants.*;
 @Warmup(iterations = 3)
 @Measurement(iterations = 5)
 @Fork(value = 1, jvmArgs = {
-        "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
-        "--add-exports", "java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.impl=ALL-UNNAMED"})
 public class Write {
     static final int REPEATS = 40;
@@ -70,75 +67,8 @@ public class Write {
         }
         METHOD_NAMES = names;
     }
-    static String checkFileAsm = "/tmp/asw/MyClass.class";
     static String checkFileBc = "/tmp/byw/MyClass.class";
-    static boolean writeClassAsm = Files.exists(Paths.get(checkFileAsm).getParent());
     static boolean writeClassBc = Files.exists(Paths.get(checkFileBc).getParent());
-
-
-    @Benchmark
-    @BenchmarkMode(Mode.Throughput)
-    public byte[] asmStream() {
-        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-        cw.visit(Opcodes.V12, Opcodes.ACC_PUBLIC, "MyClass", null, "java/lang/Object", null);
-        cw.visitSource("MyClass.java", null);
-
-        {
-            MethodVisitor mv = cw.visitMethod(0, INIT_NAME, "()V", null, null);
-            mv.visitCode();
-            Label startLabel = new Label();
-            Label endLabel = new Label();
-            mv.visitLabel(startLabel);
-            mv.visitVarInsn(Opcodes.ALOAD, 0);
-            mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", INIT_NAME, "()V", false);
-            mv.visitInsn(Opcodes.RETURN);
-            mv.visitLabel(endLabel);
-            mv.visitLocalVariable("this", "LMyClass;", null, startLabel, endLabel, 1);
-            mv.visitMaxs(-1, -1);
-            mv.visitEnd();
-        }
-
-        for (int xi = 0; xi < REPEATS; ++xi) {
-            MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC+Opcodes.ACC_STATIC, METHOD_NAMES[xi], "([Ljava/lang/String;)V", null, null);
-            mv.visitCode();
-            Label loopTop = new Label();
-            Label loopEnd = new Label();
-            Label startLabel = new Label();
-            Label endLabel = new Label();
-            Label iStart = new Label();
-            mv.visitLabel(startLabel);
-            mv.visitInsn(Opcodes.ICONST_1);
-            mv.visitVarInsn(Opcodes.ISTORE, 1);
-            mv.visitLabel(iStart);
-            mv.visitInsn(Opcodes.ICONST_1);
-            mv.visitVarInsn(Opcodes.ISTORE, 2);
-            mv.visitLabel(loopTop);
-            mv.visitVarInsn(Opcodes.ILOAD, 2);
-            mv.visitIntInsn(Opcodes.BIPUSH, 10);
-            mv.visitJumpInsn(Opcodes.IF_ICMPGE, loopEnd);
-            mv.visitVarInsn(Opcodes.ILOAD, 1);
-            mv.visitVarInsn(Opcodes.ILOAD, 2);
-            mv.visitInsn(Opcodes.IMUL);
-            mv.visitVarInsn(Opcodes.ISTORE, 1);
-            mv.visitIincInsn(2, 1);
-            mv.visitJumpInsn(Opcodes.GOTO, loopTop);
-            mv.visitLabel(loopEnd);
-            mv.visitFieldInsn(Opcodes.GETSTATIC,"java/lang/System", "out", "Ljava/io/PrintStream;");
-            mv.visitVarInsn(Opcodes.ILOAD, 1);
-            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/io/PrintStream", "println", "(I)V", false);
-            mv.visitLabel(endLabel);
-            mv.visitInsn(Opcodes.RETURN);
-            mv.visitLocalVariable("fac", "I", null, startLabel, endLabel, 1);
-            mv.visitLocalVariable("i",   "I", null, iStart, loopEnd, 2);
-            mv.visitMaxs(-1, -1);
-            mv.visitEnd();
-        }
-        cw.visitEnd();
-
-        byte[] bytes = cw.toByteArray();
-        if (writeClassAsm) writeClass(bytes, checkFileAsm);
-        return bytes;
-    }
 
     @Benchmark
     @BenchmarkMode(Mode.Throughput)


### PR DESCRIPTION
ASM-based benchmarks were useful to directly compare performance of ASM and Class-File API.
However Class-File API performance history is now continuously tracked and direct comparison to ASM becomes obsolete.

This patch removes ASM-based benchmarks from test/micro/org/openjdk/bench/jdk/classfile.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346984](https://bugs.openjdk.org/browse/JDK-8346984): Remove ASM-based benchmarks from Class-File API benchmarks (**Sub-task** - P4)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) Review applies to [fea29a38](https://git.openjdk.org/jdk/pull/22914/files/fea29a38d1365713f0ffab6d4dddcbdf828aa01f)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) Review applies to [fea29a38](https://git.openjdk.org/jdk/pull/22914/files/fea29a38d1365713f0ffab6d4dddcbdf828aa01f)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22914/head:pull/22914` \
`$ git checkout pull/22914`

Update a local copy of the PR: \
`$ git checkout pull/22914` \
`$ git pull https://git.openjdk.org/jdk.git pull/22914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22914`

View PR using the GUI difftool: \
`$ git pr show -t 22914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22914.diff">https://git.openjdk.org/jdk/pull/22914.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22914#issuecomment-2569176102)
</details>
