### PR TITLE
8346985: Convert test/jdk/com/sun/jdi/ClassUnloadEventTest.java to Class-File API

### DIFF
--- a/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
+++ b/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
+++ b/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
@@ -24,18 +24,13 @@
 /*
  * @test
  * @bug 8256811
- * @modules java.base/jdk.internal.org.objectweb.asm
- *          java.base/jdk.internal.misc
+ * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/native ClassUnloadEventTest run
  */
 
-import jdk.internal.org.objectweb.asm.ClassWriter;
-import jdk.internal.org.objectweb.asm.Label;
-import jdk.internal.org.objectweb.asm.MethodVisitor;
-import jdk.internal.org.objectweb.asm.Opcodes;
 import jdk.test.lib.classloader.ClassUnloadCommon;
 
 import com.sun.jdi.*;
@@ -45,6 +40,9 @@ import com.sun.jdi.request.*;
 
 import java.util.*;
 import java.io.*;
+import java.lang.classfile.ClassFile;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
 
 public class ClassUnloadEventTest {
     static final String CLASS_NAME_PREFIX = "SampleClass__";
@@ -65,18 +63,13 @@ public class ClassUnloadEventTest {
         }
     }
 
-    private static class TestClassLoader extends ClassLoader implements Opcodes {
+    private static class TestClassLoader extends ClassLoader {
         private static byte[] generateSampleClass(String name) {
-            ClassWriter cw = new ClassWriter(0);
-
-            cw.visit(52, ACC_SUPER | ACC_PUBLIC, name, null, "java/lang/Object", null);
-            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "m", "()V", null, null);
-            mv.visitCode();
-            mv.visitInsn(RETURN);
-            mv.visitMaxs(0, 0);
-            mv.visitEnd();
-            cw.visitEnd();
-            return cw.toByteArray();
+            return ClassFile.of().build(ClassDesc.of(name), clb ->
+                clb.withVersion(52, 0)
+                   .withFlags(ClassFile.ACC_SUPER | ClassFile.ACC_PUBLIC)
+                   .withMethodBody("m", ConstantDescs.MTD_void, ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC, cob ->
+                           cob.return_()));
         }
 
         @Override


### PR DESCRIPTION
This patch converts the remaining test/jdk/com/sun/jdi/ClassUnloadEventTest.java from ASM to Class-File API.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346985](https://bugs.openjdk.org/browse/JDK-8346985): Convert test/jdk/com/sun/jdi/ClassUnloadEventTest.java to Class-File API (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22915/head:pull/22915` \
`$ git checkout pull/22915`

Update a local copy of the PR: \
`$ git checkout pull/22915` \
`$ git pull https://git.openjdk.org/jdk.git pull/22915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22915`

View PR using the GUI difftool: \
`$ git pr show -t 22915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22915.diff">https://git.openjdk.org/jdk/pull/22915.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22915#issuecomment-2569196885)
</details>
