### PR TITLE
8346993: C2 SuperWord: refactor to make more vector nodes available in VectorNode::make

### DIFF
--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,6 +94,8 @@ class VectorNode : public TypeNode {
 
   static int opcode(int sopc, BasicType bt);         // scalar_opc -> vector_opc
   static int scalar_opcode(int vopc, BasicType bt);  // vector_opc -> scalar_opc
+
+  static int shift_count_opcode(int opc);
 
   // Limits on vector size (number of elements) for auto-vectorization.
   static bool vector_size_supported_auto_vectorization(const BasicType bt, int size);
@@ -1764,7 +1766,7 @@ class VectorCastNode : public VectorNode {
   VectorCastNode(Node* in, const TypeVect* vt) : VectorNode(in, vt) {}
   virtual int Opcode() const;
 
-  static VectorCastNode* make(int vopc, Node* n1, BasicType bt, uint vlen);
+  static VectorNode* make(int vopc, Node* n1, BasicType bt, uint vlen);
   static int  opcode(int opc, BasicType bt, bool is_signed = true);
   static bool implemented(int opc, uint vlen, BasicType src_type, BasicType dst_type);
 


### PR DESCRIPTION
Extracted from cost-model code https://github.com/openjdk/jdk/pull/20964.

Currently, some nodes are only generated in their dedicated methods:
- VectorNode::shift_count
  - LShiftCntVNode
  - RShiftCntVNode
- VectorCastNode::make
  - Vector(U)Cast...
- VectorBlendNode has no corresponding "factory" method.

The goal is to have all available under VectorNode::make, so that they can be generated simply with the vector opcode. This is helpful for the plans with the cost-model, where the VTransform nodes will only carry the vector-opc, and I need to generate vectors for these vector-opc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346993](https://bugs.openjdk.org/browse/JDK-8346993): C2 SuperWord: refactor to make more vector nodes available in VectorNode::make (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22917/head:pull/22917` \
`$ git checkout pull/22917`

Update a local copy of the PR: \
`$ git checkout pull/22917` \
`$ git pull https://git.openjdk.org/jdk.git pull/22917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22917`

View PR using the GUI difftool: \
`$ git pr show -t 22917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22917.diff">https://git.openjdk.org/jdk/pull/22917.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22917#issuecomment-2572485976)
</details>
