### PR TITLE
8174840: Elements.overrides does not check the return type of the methods

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -778,11 +778,11 @@ public interface Elements {
      *                           elements.getTypeElement("I"));
      * }
      *
-     * @apiNote The notion of overriding, by itself, does not involve the
-     * method's return type, listed exceptions, or, to some extent, access
-     * modifiers. These are additional requirements checked by the compiler;
-     * see JLS {@jls 8.4.8.3} for details. An implementation may choose not
-     * to check the additional requirements under some conditions.
+     * @apiNote This method implements the overrides relation as specified in JLS {@jls 8.4.8.1}.
+     * It may not implement the additional compile-time checks that Java compilers follow,
+     * specified in JLS {@jls 8.4.8.1} and {@jls 8.4.8.3}. In particular, the additional constraints
+     * on thrown types, return types and those constraints on method modifiers not directly
+     * bound to the overriding relation as such.
      *
      * @param overrider  the first method, possible overrider
      * @param overridden  the second method, possibly being overridden

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -778,6 +778,12 @@ public interface Elements {
      *                           elements.getTypeElement("I"));
      * }
      *
+     * @apiNote The notion of overriding, by itself, does not involve the
+     * method's return type, listed exceptions, or, to some extent, access
+     * modifiers. These are additional requirements checked by the compiler;
+     * see JLS {@jls 8.4.8.3} for details. An implementation may choose not
+     * to check the additional requirements under some conditions.
+     *
      * @param overrider  the first method, possible overrider
      * @param overridden  the second method, possibly being overridden
      * @param type   the class or interface of which the first method is a member

--- a/test/langtools/tools/javac/processing/model/util/elements/overrides/S.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/overrides/S.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/processing/model/util/elements/overrides/S.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/overrides/S.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+class S {
+
+    public void m() { }
+}
+
+class T1 extends S {
+
+    protected void m() { }
+}
+
+class T2 extends S {
+
+    void m() { }
+}
+
+class T3 extends S {
+
+    private void m() { }
+}
+
+class T4 extends S {
+
+    public int m() { return 0; }
+}
+
+class T5 extends S {
+
+    public void m() throws Exception { }
+}

--- a/test/langtools/tools/javac/processing/model/util/elements/overrides/TestOverrides.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/overrides/TestOverrides.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/processing/model/util/elements/overrides/TestOverrides.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/overrides/TestOverrides.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8174840
+ * @library /tools/javac/lib
+ * @build   JavacTestingAbstractProcessor TestOverrides
+ * @compile -processor TestOverrides -proc:only S.java
+ */
+
+import java.util.Set;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+
+import static javax.lang.model.element.ElementKind.METHOD;
+
+/*
+ * This test models a few cases where Elements.overrides produces a false
+ * positive which warrants @apiNote.
+ */
+public class TestOverrides extends JavacTestingAbstractProcessor {
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment round) {
+        if (!round.processingOver()) {
+            var sm = mIn(elements.getTypeElement("S"));
+            for (var subtypeName : new String[]{"T1", "T2", "T3", "T4", "T5"}) {
+                var t = elements.getTypeElement(subtypeName);
+                var tm = mIn(t);
+                if (!elements.overrides(tm, sm, t))
+                    messager.printError(String.format(
+                            "%s does not override %s from %s", tm, sm, t.getQualifiedName()));
+            }
+        }
+        return true;
+    }
+
+    private ExecutableElement mIn(TypeElement t) {
+        return t.getEnclosedElements().stream()
+                .filter(e -> e.getKind() == METHOD)
+                .filter(e -> e.getSimpleName().toString().equals("m"))
+                .map(e -> (ExecutableElement) e)
+                .findAny()
+                .get();
+    }
+}


### PR DESCRIPTION
Please review this PR to clarify the documentation of `Elements.overrides` through an `@apiNote`, this PR is essentially a doc-only change.
