### PR TITLE
8347000: Bug in com/sun/net/httpserver/bugs/B6361557.java test

### DIFF
--- a/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class B6361557 {
     }
 
     final static String request = "GET /test/foo.html HTTP/1.1\r\nContent-length: 0\r\n\r\n";
-    final static ByteBuffer requestBuf = ByteBuffer.allocate(64).put(request.getBytes());
+    final static ByteBuffer requestBuf = ByteBuffer.wrap(request.getBytes());
 
     public static void main (String[] args) throws Exception {
         Handler handler = new Handler();


### PR DESCRIPTION
Can I please get a review of this change which proposes to address the test-only issue noted in https://bugs.openjdk.org/browse/JDK-8347000?

As noted in that issue, the test issues HTTP requests with `Content-Length` set to `0` implying no request body. However, the code unintentionally sends additional bytes (14 bytes each request) as part of the request. The JDK's `HttpServer` implementation currently doesn't cause errors for such requests (although the HTTP/1.1 RFC expects an error to be raised). 

The change in this PR merely addresses the test code to not send these additional bytes. The test continues to pass after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347000](https://bugs.openjdk.org/browse/JDK-8347000): Bug in com/sun/net/httpserver/bugs/B6361557.java test (**Bug** - P4)


### Reviewers
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22921/head:pull/22921` \
`$ git checkout pull/22921`

Update a local copy of the PR: \
`$ git checkout pull/22921` \
`$ git pull https://git.openjdk.org/jdk.git pull/22921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22921`

View PR using the GUI difftool: \
`$ git pr show -t 22921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22921.diff">https://git.openjdk.org/jdk/pull/22921.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22921#issuecomment-2572328423)
</details>
