### PR TITLE
8347038: [JMH] jdk.incubator.vector.SpiltReplicate.testFloat fails java.lang.NoClassDefFoundError: jdk/incubator/vector/FloatVector

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/SpiltReplicate.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/SpiltReplicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(1)
+@Fork(value=1, jvmArgs={"--add-modules=jdk.incubator.vector"})
 public class SpiltReplicate {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public long broadcastInt() {


### PR DESCRIPTION
Hi all,
  This PR add JVM option `jvmArgs={"--add-modules=jdk.incubator.vector"}` for test/micro/org/openjdk/bench/jdk/incubator/vector/SpiltReplicate.java, to fix tests fails 'java.lang.NoClassDefFoundError: jdk/incubator/vector/FloatVector'. Change has been verified locally, no risk.