### PR TITLE
8290043: serviceability/attach/ConcAttachTest.java failed "guarantee(!CheckJNICalls) failed: Attached JNI thread exited without being detached"

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3841,6 +3841,7 @@ static jint attach_current_thread(JavaVM *vm, void **penv, void *_args, bool dae
     // Added missing cleanup
     thread->cleanup_failed_attach_current_thread(daemon);
     thread->unregister_thread_stack_with_NMT();
+    thread->smr_delete();
     return JNI_ERR;
   }
 

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2024 Red Hat, Inc.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -3795,6 +3795,7 @@ static jint attach_current_thread(JavaVM *vm, void **penv, void *_args, bool dae
   MACOS_AARCH64_ONLY(thread->init_wx());
 
   if (!os::create_attached_thread(thread)) {
+    thread->unregister_thread_stack_with_NMT();
     thread->smr_delete();
     return JNI_ERR;
   }
@@ -3839,6 +3840,7 @@ static jint attach_current_thread(JavaVM *vm, void **penv, void *_args, bool dae
   if (attach_failed) {
     // Added missing cleanup
     thread->cleanup_failed_attach_current_thread(daemon);
+    thread->unregister_thread_stack_with_NMT();
     return JNI_ERR;
   }
 
@@ -3935,6 +3937,7 @@ jint JNICALL jni_DetachCurrentThread(JavaVM *vm)  {
   // (platform-dependent) methods where we do alternate stack
   // maintenance work?)
   thread->exit(false, JavaThread::jni_detach);
+  thread->unregister_thread_stack_with_NMT();
   thread->smr_delete();
 
   // Go to the execute mode, the initial state of the thread on creation.

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1051,7 +1051,6 @@ void JavaThread::cleanup_failed_attach_current_thread(bool is_daemon) {
   }
 
   Threads::remove(this, is_daemon);
-  this->smr_delete();
 }
 
 JavaThread* JavaThread::active() {

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -785,6 +785,7 @@ void JavaThread::thread_main_inner() {
 // Shared teardown for all JavaThreads
 void JavaThread::post_run() {
   this->exit(false);
+  this->unregister_thread_stack_with_NMT();
   // Defer deletion to here to ensure 'this' is still referenceable in call_run
   // for any shared tear-down.
   this->smr_delete();
@@ -1027,8 +1028,6 @@ void JavaThread::exit(bool destroy_vm, ExitType exit_type) {
                                  _timer_exit_phase4.milliseconds());
     os::free(thread_name);
   }
-
-  this->unregister_thread_stack_with_NMT();
 }
 
 void JavaThread::cleanup_failed_attach_current_thread(bool is_daemon) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -246,6 +246,9 @@ void Thread::call_run() {
   // delete themselves when they terminate. But no thread should ever be deleted
   // asynchronously with respect to its termination - that is what _run_state can
   // be used to check.
+
+  // Logically we should do this->unregister_thread_stack_with_NMT() here, but we
+  // had to move that into post_run() because of the `this` deletion issue.
 
   assert(Thread::current_or_null() == nullptr, "current thread still present");
 }

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -143,8 +143,6 @@ serviceability/sa/ClhsdbPmap.java#core            8267433,8318754 macosx-x64,mac
 serviceability/sa/ClhsdbPstack.java#core          8267433,8318754 macosx-x64,macosx-aarch64
 serviceability/sa/TestJmapCore.java               8267433,8318754 macosx-x64,macosx-aarch64
 serviceability/sa/TestJmapCoreMetaspace.java      8267433,8318754 macosx-x64,macosx-aarch64
-
-serviceability/attach/ConcAttachTest.java 8290043 linux-all
 
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java 8315980 linux-all,windows-x64
 

--- a/test/hotspot/jtreg/runtime/jni/terminatedThread/TestTerminatedThread.java
+++ b/test/hotspot/jtreg/runtime/jni/terminatedThread/TestTerminatedThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,10 @@ import java.lang.management.*;
  * @library /testlibrary
  * @summary Basic test of Thread and ThreadMXBean queries on a natively
  *          attached thread that has failed to detach before terminating.
- * @comment The native code only supports POSIX so no windows testing
- * @run main/othervm/native TestTerminatedThread
+ * @comment The native code only supports POSIX so no windows testing.
+ * @comment Disable -Xcheck:jni else NMT can report a fatal error because
+ *          we did not detach before exiting.
+ * @run main/othervm/native -XX:-CheckJNICalls TestTerminatedThread
  */
 
 import jvmti.JVMTIUtils;


### PR DESCRIPTION
This bug was introduced by [JDK-8252921](https://bugs.openjdk.org/browse/JDK-8252921) which moved the `unregister_thread_stack_with_NMT` call from the thread destructor (because it was not called for all threads) to the `post_run()` method. But this totally overlooked native threads that attach and detach!

Update: it was incorrect for the unregister call to ever be in the destructor**, and it only worked by accident. The register/unregister calls have to be done by the current thread on itself. The register call occurs in `Thread::call_run` so logically we should have:
```
this->register_thread_stack_with_NMT();
this->pre_run(); // virtual call for per-thread type init
this->run();
this->post_run();
this->unregister_thread_stack_with_NMT();
```
However in practice we have to move the unregister inside `post_run` because after `post_run` the thread may have already been deleted and the call would not be valid.

On the JNI side we should simply register in attach, and unregister in detach. When unregister was in the destructor this was all handled implicitly because the destructor was always run by the current thread for itself. When it got moved out of the destructor we not only failed to unregister when detaching, we also failed to unregister if there was a failed attach attempt. The fix here requires that we explicitly unregister on the failure paths, which in turn, to keep things consistent, requires that we explicitly do the `smr_delete` as the final cleanup action.

** When new Java threads are created the destructor can run in the context of the current creating thread, if starting the new thread fails. If that happens no register call ever occurred and we would then try to unregister in the destructor - which would fail as there was no stack established for the new thread.

We also update the ProblemList and disable -Xcheck:JNI for a test that does actually terminate threads without detaching.

Testing: tiers 1-4

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290043](https://bugs.openjdk.org/browse/JDK-8290043): serviceability/attach/ConcAttachTest.java failed "guarantee(!CheckJNICalls) failed: Attached JNI thread exited without being detached" (**Bug** - P3)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22924/head:pull/22924` \
`$ git checkout pull/22924`

Update a local copy of the PR: \
`$ git checkout pull/22924` \
`$ git pull https://git.openjdk.org/jdk.git pull/22924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22924`

View PR using the GUI difftool: \
`$ git pr show -t 22924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22924.diff">https://git.openjdk.org/jdk/pull/22924.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22924#issuecomment-2572730484)
</details>
