### PR TITLE
8346965: Test compiler/ciReplay/TestInlining.java fails with -XX:+SegmentedCodeCache

### DIFF
--- a/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,7 @@ public abstract class CiReplayBase {
         "-XX:-BackgroundCompilation", "-XX:CompileCommand=inline,java.io.PrintStream::*",
         "-XX:+IgnoreUnrecognizedVMOptions", "-XX:TypeProfileLevel=222", // extra profile data as a stress test
         "-XX:+CICountNative", "-XX:CICrashAt=1", "-XX:+DumpReplayDataOnError",
+        "-XX:-SegmentedCodeCache",
         REPLAY_FILE_OPTION};
     private static final String[] REPLAY_OPTIONS = new String[]{DISABLE_COREDUMP_ON_CRASH,
         "-XX:+IgnoreUnrecognizedVMOptions", "-XX:TypeProfileLevel=222",


### PR DESCRIPTION
Hi all,
There are 4 tests fails run with JVM option '-XX:+SegmentedCodeCache'. JVM option '-XX:ReservedCodeCacheSize=4m' [inside test](https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java#L68) conflict with JVM option '-XX:+SegmentedCodeCache' which pass from outside test. This PR add '-XX:-SegmentedCodeCache' explicitly inside test to make test run success whenever received '-XX:+SegmentedCodeCache' outside or not. Change has been verified locally, test-fix only, make test more robustness, no risk.

'SegmentedCodeCache' is enable by default
```shell
> java -XX:+PrintFlagsFinal 2>&1 | grep -P "(SegmentedCodeCache)|(ReservedCodeCacheSize)"
    uintx ReservedCodeCacheSize                    = 251658240                              {pd product} {ergonomic}
     bool SegmentedCodeCache                       = true                                      {product} {ergonomic}
```

Pass '-XX:ReservedCodeCacheSize=4m' to JVM will automatic disable `SegmentedCodeCache`
```shell
> java -XX:ReservedCodeCacheSize=4m -XX:+PrintFlagsFinal 2>&1 | grep -P "(SegmentedCodeCache)|(ReservedCodeCacheSize)"
    uintx ReservedCodeCacheSize                    = 4194304                                {pd product} {command line}
     bool SegmentedCodeCache                       = false                                     {product} {default}
```

'-XX:+SegmentedCodeCache' conflict with '-XX:ReservedCodeCacheSize=4m'
```shell
> java -XX:ReservedCodeCacheSize=4m -XX:+SegmentedCodeCache -version
Error occurred during initialization of VM
Invalid code heap sizes: NonNMethodCodeHeapSize (8006K) + ProfiledCodeHeapSize (4K) + NonProfiledCodeHeapSize (4K) = 8014K is greater than ReservedCodeCacheSize (4096K).
```

