### PR TITLE
8346705: SNI not sent with Java 22+ using java.net.http.HttpClient.Builder#sslParameters

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/AbstractAsyncSSLConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/AbstractAsyncSSLConnection.java
@@ -152,7 +152,7 @@ abstract class AbstractAsyncSSLConnection extends HttpConnection
      * configure the {@link SSLEngine} used by this connection.
      * <p>
      * The given {@code serverName} is given preference, and if it is not null and
-     * is not a IP address literal, then the returned list will contain only one
+     * is not an IP address literal, then the returned list will contain only one
      * {@code SNIServerName} formed out of the {@code serverName}. If {@code serverName}
      * is null or is an IP address literal then the {@code SNIServerName}(s)
      * configured through {@link HttpClient#sslParameters()} will be returned. If none have

--- a/src/java.net.http/share/classes/jdk/internal/net/http/AbstractAsyncSSLConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/AbstractAsyncSSLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package jdk.internal.net.http;
 
 import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
 import java.util.Arrays;
 import java.util.ArrayDeque;
 import java.util.List;
@@ -75,7 +76,7 @@ abstract class AbstractAsyncSSLConnection extends HttpConnection
                                ServerName serverName, int port,
                                String[] alpn) {
         super(addr, client);
-        this.sniServerNames = formSNIServerNames(serverName);
+        this.sniServerNames = formSNIServerNames(serverName, client);
         SSLContext context = client.theSSLContext();
         sslParameters = createSSLParameters(client, this.sniServerNames, alpn);
         Log.logParams(sslParameters);
@@ -102,6 +103,20 @@ abstract class AbstractAsyncSSLConnection extends HttpConnection
         return false;
     }
 
+    /**
+     * Returns the {@link SSLParameters} to be used by the {@link SSLEngine} for this connection.
+     * <p>
+     * The returned {@code SSLParameters} will have its {@link SNIServerName}s set to the given
+     * {@code sniServerNames}. If {@code alpn} is non-null then the returned {@code SSLParameters}
+     * will have its {@linkplain SSLParameters#getApplicationProtocols() application layer protocols}
+     * set to this value. All other parameters in the returned {@code SSLParameters} will be
+     * copied over from {@link HttpClient#sslParameters()} of the given {@code client}.
+     *
+     * @param client         the HttpClient
+     * @param sniServerNames the SNIServerName(s)
+     * @param alpn           the application layer protocols
+     * @return the SSLParameters to be set on the SSLEngine used by this connection.
+     */
     private static SSLParameters createSSLParameters(HttpClientImpl client,
                                                      List<SNIServerName> sniServerNames,
                                                      String[] alpn) {
@@ -132,22 +147,39 @@ abstract class AbstractAsyncSSLConnection extends HttpConnection
         return sslParameters;
     }
 
-    private static List<SNIServerName> formSNIServerNames(final ServerName serverName) {
-        if (serverName == null) {
-            return List.of();
-        }
-        if (!serverName.isLiteral()) {
-            String name = serverName.name();
-            if (name != null && name.length() > 0) {
+    /**
+     * Returns a list of {@link SNIServerName}s that are expected to be used to
+     * configure the {@link SSLEngine} used by this connection.
+     * <p>
+     * The given {@code serverName} is given preference, and if it is not null and
+     * is not a IP address literal, then the returned list will contain only one
+     * {@code SNIServerName} formed out of the {@code serverName}. If {@code serverName}
+     * is null or is an IP address literal then the {@code SNIServerName}(s)
+     * configured through {@link HttpClient#sslParameters()} will be returned. If none have
+     * been configured, then an empty list is returned.
+     *
+     * @param serverName the {@link ServerName}, typically computed based on the request URI
+     * @param client     the {@code HttpClient}
+     * @return a list of {@code SNIServerName}s to be used by the {@code SSLEngine}
+     *         of this connection.
+     */
+    private static List<SNIServerName> formSNIServerNames(final ServerName serverName,
+                                                          final HttpClientImpl client) {
+        if (serverName != null && !serverName.isLiteral()) {
+            final String name = serverName.name();
+            if (name != null && !name.isEmpty()) {
                 return List.of(new SNIHostName(name));
             }
         }
-        return List.of();
+        // fallback on any SNIServerName(s) configured through HttpClient.sslParameters()
+        final SSLParameters clientSSLParams = client.sslParameters();
+        final List<SNIServerName> clientConfigured = clientSSLParams.getServerNames();
+        return clientConfigured != null ? clientConfigured : List.of();
     }
 
-    private static SSLEngine createEngine(SSLContext context, String serverName, int port,
+    private static SSLEngine createEngine(SSLContext context, String peerHost, int port,
                                           SSLParameters sslParameters) {
-        SSLEngine engine = context.createSSLEngine(serverName, port);
+        SSLEngine engine = context.createSSLEngine(peerHost, port);
         engine.setUseClientMode(true);
 
         engine.setSSLParameters(sslParameters);

--- a/test/jdk/java/net/httpclient/HttpClientSNITest.java
+++ b/test/jdk/java/net/httpclient/HttpClientSNITest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIMatcher;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsParameters;
+import com.sun.net.httpserver.HttpsServer;
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestExchange;
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestHandler;
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestServer;
+import jdk.httpclient.test.lib.common.ServerNameMatcher;
+import jdk.test.lib.net.SimpleSSLContext;
+import jdk.test.lib.net.URIBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * @test
+ * @bug 8346705
+ * @summary verify the behaviour of java.net.http.HttpClient
+ *          when sending a Server Name Indication in the TLS
+ *          connections that it establishes for the requests
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.httpclient.test.lib.common.HttpServerAdapters
+ *        jdk.test.lib.net.SimpleSSLContext
+ *        jdk.test.lib.net.URIBuilder
+ * @run junit HttpClientSNITest
+ */
+public class HttpClientSNITest {
+    private static final String RESP_BODY_TEXT = "hello world";
+
+    private static SSLContext sslContext;
+
+    private static final class Handler implements HttpTestHandler {
+
+        @Override
+        public void handle(final HttpTestExchange exch) throws IOException {
+            System.out.println("handling request " + exch.getRequestURI());
+            final byte[] respBody = RESP_BODY_TEXT.getBytes(US_ASCII);
+            exch.sendResponseHeaders(200, respBody.length);
+            try (final OutputStream os = exch.getResponseBody()) {
+                os.write(respBody);
+            }
+        }
+    }
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        sslContext = new SimpleSSLContext().get();
+        assertNotNull(sslContext, "could not create a SSLContext");
+    }
+
+    /*
+     * Creates and configures a HTTPS server with a SNIMatcher that
+     * expects a specific SNI name to be sent by the connection client.
+     * The test uses a HttpClient to issue a couple of requests with the URI having
+     * a IP address literal as the host. For one of the request, the HttpClient
+     * is configured with specific ServerName(s) through HttpClient.sslParameters()
+     * and for the other request, it isn't.
+     * The test then verifies that for such requests with a IP address literal as the host,
+     * the HttpClient sends across the ServerName(s) if any has been configured on the client.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testRequestToIPLiteralHost(final boolean sniConfiguredOnClient) throws Exception {
+        final String expectedSNI = "non-dns-resolvable.foo.bar.localhost";
+        final ServerNameMatcher matcher = new ServerNameMatcher(expectedSNI);
+        final HttpTestServer server = createServer(matcher);
+        try {
+            final HttpClient.Builder builder = HttpClient.newBuilder().sslContext(sslContext);
+            if (sniConfiguredOnClient) {
+                final SSLParameters clientConfiguredSSLParams = new SSLParameters();
+                clientConfiguredSSLParams.setServerNames(List.of(new SNIHostName(expectedSNI)));
+                builder.sslParameters(clientConfiguredSSLParams);
+            }
+            try (final HttpClient client = builder.build()) {
+                final String ipLiteral = InetAddress.getLoopbackAddress().getHostAddress();
+                final URI reqURI = URIBuilder.newBuilder()
+                        .host(ipLiteral)
+                        .port(server.getAddress().getPort())
+                        .scheme("https")
+                        .path("/")
+                        .build();
+                final HttpRequest req = HttpRequest.newBuilder(reqURI).build();
+                System.out.println("issuing request " + reqURI);
+                final HttpResponse<String> resp = client.send(req, BodyHandlers.ofString(US_ASCII));
+                assertEquals(200, resp.statusCode(), "unexpected response status code");
+                assertEquals(RESP_BODY_TEXT, resp.body(), "unexpected response body");
+                if (sniConfiguredOnClient) {
+                    assertTrue(matcher.wasInvoked(), "SNIMatcher wasn't invoked on the server");
+                } else {
+                    assertFalse(matcher.wasInvoked(), "SNIMatcher was unexpectedly invoked" +
+                            " on the server");
+                }
+            }
+        } finally {
+            System.out.println("stopping server " + server.getAddress());
+            server.stop();
+        }
+    }
+
+    /*
+     * Creates and configures a HTTPS server with a SNIMatcher that
+     * expects a specific SNI name to be sent by the connection client.
+     * The test uses a HttpClient to issue a couple of requests with the URI having
+     * a hostname (i.e. not a IP address literal) as the host. For one of the request,
+     * the HttpClient is configured with specific ServerName(s) through
+     * HttpClient.sslParameters() and for the other request, it isn't.
+     * The test then verifies that for such requests with a hostname
+     * (i.e. not a IP address literal) in the request URI,
+     * the HttpClient never sends ServerName(s) that may have been configured on the
+     * client and instead it sends the hostname (from the request URI) as the ServerName
+     * for each of the request.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testRequestResolvedHostName(final boolean sniConfiguredOnClient) throws Exception {
+        final String resolvedHostName = InetAddress.getLoopbackAddress().getHostName();
+        final String expectedSNI = resolvedHostName;
+        final ServerNameMatcher matcher = new ServerNameMatcher(expectedSNI);
+        final HttpTestServer server = createServer(matcher);
+        try {
+            final HttpClient.Builder builder = HttpClient.newBuilder().sslContext(sslContext);
+            if (sniConfiguredOnClient) {
+                final SSLParameters clientConfiguredSSLParams = new SSLParameters();
+                clientConfiguredSSLParams.setServerNames(List.of(new SNIHostName("does-not-matter")));
+                builder.sslParameters(clientConfiguredSSLParams);
+            }
+            try (final HttpClient client = builder.build()) {
+                final URI reqURI = URIBuilder.newBuilder()
+                        .host(resolvedHostName)
+                        .port(server.getAddress().getPort())
+                        .scheme("https")
+                        .path("/")
+                        .build();
+                final HttpRequest req = HttpRequest.newBuilder(reqURI).build();
+                System.out.println("issuing request " + reqURI);
+                final HttpResponse<String> resp = client.send(req, BodyHandlers.ofString(US_ASCII));
+                assertEquals(200, resp.statusCode(), "unexpected response status code");
+                assertEquals(RESP_BODY_TEXT, resp.body(), "unexpected response body");
+                assertTrue(matcher.wasInvoked(), "SNIMatcher wasn't invoked on the server");
+            }
+        } finally {
+            System.out.println("stopping server " + server.getAddress());
+            server.stop();
+        }
+    }
+
+    /*
+     * Creates a HttpsServer configured to use the given SNIMatcher
+     */
+    private static HttpTestServer createServer(final SNIMatcher matcher) throws Exception {
+        final InetSocketAddress addr = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        final int backlog = 0;
+        final HttpsServer httpsServer = HttpsServer.create(addr, backlog);
+        final HttpsConfigurator configurator = new HttpsConfigurator(sslContext) {
+            @Override
+            public void configure(final HttpsParameters params) {
+                final SSLParameters sslParameters = sslContext.getDefaultSSLParameters();
+                // add the SNIMatcher
+                sslParameters.setSNIMatchers(List.of(matcher));
+                params.setSSLParameters(sslParameters);
+                System.out.println("configured HttpsServer with SNIMatcher: " + matcher);
+            }
+        };
+        httpsServer.setHttpsConfigurator(configurator);
+        final HttpTestServer server = HttpTestServer.of(httpsServer);
+        server.addHandler(new Handler(), "/");
+        server.start();
+        System.out.println("server started at " + server.getAddress());
+        return server;
+    }
+}

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/ServerNameMatcher.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/ServerNameMatcher.java
@@ -58,6 +58,7 @@ public class ServerNameMatcher extends SNIMatcher {
     private final Logger debug;
     private final boolean attemptDNSResolution;
     private final Set<String> recognizedSNINames;
+    private volatile boolean invoked;
 
     /**
      * Creates a ServerNameMatcher which recognizes the passed {@code recognizedSNIName}
@@ -97,6 +98,7 @@ public class ServerNameMatcher extends SNIMatcher {
      */
     @Override
     public boolean matches(final SNIServerName clientRequestedSNI) {
+        this.invoked = true;
         Objects.requireNonNull(clientRequestedSNI);
         if (!SNIHostName.class.isInstance(clientRequestedSNI)) {
             if (debug.on()) {
@@ -126,6 +128,14 @@ public class ServerNameMatcher extends SNIMatcher {
             debug.log("SNI match (against " + recognizedSNINames + ") failed: " + clientRequestedSNI);
         }
         return false;
+    }
+
+    /**
+     * @return true if the {@link #matches(SNIServerName)} method of this SNIMatcher instance
+     * was invoked at least once, false otherwise.
+     */
+    public boolean wasInvoked() {
+        return this.invoked;
     }
 
     private boolean matchesAfterDNSResolution(final String clientRequestedSNI) {


### PR DESCRIPTION
Can I please get a review of this change which fixes a regression that was introduced in Java 22 release in the implementation of `java.net.http.HttpClient`? This addresses https://bugs.openjdk.org/browse/JDK-8346705.

A client intiating a TLS handshake (through the `ClientHello`) can send a "Server Name Indication" to tell the server, the name of the server it is communicating with (https://www.rfc-editor.org/rfc/rfc6066#section-3). When a `java.net.http.HttpClient` is establishing a (TLS) connection to serve a HTTP request, it determines the SNI server name to send in the handshake.

In Java 22, through https://bugs.openjdk.org/browse/JDK-8309910, we did an (internal implementation detail) change to allow for the internal implementation classes to keep track of what SNI server name was used for the connection, so that that detail can be used for other purposes after the connection has been established. That change wasn't meant to affect the logic that determined the SNI server name to be sent across in the TLS handshake. However, due to an oversight in the refactoring, a regression got introduced which caused the HttpClient to no longer send a SNI server name for a certain scenario (described below).

The implementation of the HttpClient first looks at the request URI to determine the SNI. If the request URI host is a IP address literal, then the HttpClient implementation looks at the `HttpClient.sslParameters()` to see if the application has configured any ServerName(s) through `SSLParameters.setServerNames(...)`. If any are set, then the HttpClient uses those ServerName(s) and sends them in the SNI, else it doesn't set the SNI. On the other hand, if the URI host is not a IP address literal, then the HttpClient implementation doesn't use any application configured ServerName(s) and instead uses the request URI host as the SNI name and sends it in the TLS handshake.

The oversight in JDK-8309910 caused a regression where if the request URI host is a IP address literal, then we no longer looked at the application configured ServerName(s), thus causing the HttpClient to no longer set the SNI server name in the TLS handshake. This can cause (and indeed does cause) the TLS handshakes to fail if the server rejects the handshake due to the missing SNI.

The commit in this PR addresses this regression by making sure that the HttpClient continues to behave the way it used to before JDK-8309910. A new jtreg test case has been introduced to verify this existing behaviour and reproduces the failure in the absence of this proposed fix.

Existing tests in tier1, tier2, tier3 continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346705](https://bugs.openjdk.org/browse/JDK-8346705): SNI not sent with Java 22+ using java.net.http.HttpClient.Builder#sslParameters (**Bug** - P3)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) Review applies to [a3841f5c](https://git.openjdk.org/jdk/pull/22927/files/a3841f5c08b3ddf203b627f4628dcb8198710ae3)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22927/head:pull/22927` \
`$ git checkout pull/22927`

Update a local copy of the PR: \
`$ git checkout pull/22927` \
`$ git pull https://git.openjdk.org/jdk.git pull/22927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22927`

View PR using the GUI difftool: \
`$ git pr show -t 22927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22927.diff">https://git.openjdk.org/jdk/pull/22927.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22927#issuecomment-2573052031)
</details>
