### PR TITLE
8310340: assert(_thread->is_interp_only_mode() || stub_caller) failed: expected a stub-caller

### DIFF
--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -598,7 +598,7 @@ JvmtiEventControllerPrivate::recompute_thread_enabled(JvmtiThreadState *state) {
   }
   // compute interp_only mode
   bool should_be_interp = (any_env_enabled & INTERP_EVENT_BITS) != 0 || has_frame_pops;
-  bool is_now_interp = state->is_interp_only_mode();
+  bool is_now_interp = state->is_interp_only_mode() || state->is_pending_interp_only_mode();
 
   if (should_be_interp != is_now_interp) {
     if (should_be_interp) {

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2603,6 +2603,7 @@ void ThawBase::recurse_thaw_compiled_frame(const frame& hf, frame& caller, int n
               || (stub_caller && f.cb()->as_nmethod()->is_marked_for_deoptimization())) {
     // The caller of the safepoint stub when the continuation is preempted is not at a call instruction, and so
     // cannot rely on nmethod patching for deopt.
+    assert(_thread->is_interp_only_mode() || stub_caller, "expected a stub-caller");
 
     log_develop_trace(continuations)("Deoptimizing thawed frame");
     DEBUG_ONLY(ContinuationHelper::Frame::patch_pc(f, nullptr));


### PR DESCRIPTION
Please review the following fix. In method `JvmtiEventControllerPrivate::recompute_thread_enabled()`, we are missing to call `leave_interp_only_mode()` for the case where `should_be_interp` is computed as false and `state->is_pending_interp_only_mode()` is true. I added the full trace leading to the crash in the bug comments.
In JDK-8338383 I removed this assert because the branch condition changed and it became sort of a redundant check. But given that it was able to find this issue I added it back.
I was able to reproduce the crash easily by adding an extra delay before the assert. I verified the crash doesn’t reproduce anymore with this fix. I also run the patch through mach5 tiers 1-7.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310340](https://bugs.openjdk.org/browse/JDK-8310340): assert(_thread-&gt;is_interp_only_mode() || stub_caller) failed: expected a stub-caller (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22931/head:pull/22931` \
`$ git checkout pull/22931`

Update a local copy of the PR: \
`$ git checkout pull/22931` \
`$ git pull https://git.openjdk.org/jdk.git pull/22931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22931`

View PR using the GUI difftool: \
`$ git pr show -t 22931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22931.diff">https://git.openjdk.org/jdk/pull/22931.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22931#issuecomment-2573598849)
</details>
