### PR TITLE
8282862: AwtWindow::SetIconData leaks old icon handles if an exception is detected

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -2121,9 +2121,19 @@ void AwtWindow::SetIconData(JNIEnv* env, jintArray iconRaster, jint w, jint h,
         hOldIconSm = m_hIconSm;
     }
     m_hIconSm = NULL;
-    m_hIcon = CreateIconFromRaster(env, iconRaster, w, h);
-    JNU_CHECK_EXCEPTION(env);
-    m_hIconSm = CreateIconFromRaster(env, smallIconRaster, smw, smh);
+
+    try {
+        m_hIcon = CreateIconFromRaster(env, iconRaster, w, h);
+        JNU_CHECK_EXCEPTION(env); // Might throw here
+        m_hIconSm = CreateIconFromRaster(env, smallIconRaster, smw, smh);
+        JNU_CHECK_EXCEPTION(env); // Or here
+        } catch (...) {
+            // Clean up any allocated resources here
+            if (m_hIcon != NULL) {
+                DestroyIcon(m_hIcon);
+            }
+            throw; // Re-throw the exception
+    }
 
     m_iconInherited = (m_hIcon == NULL);
     if (m_iconInherited) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -2127,12 +2127,15 @@ void AwtWindow::SetIconData(JNIEnv* env, jintArray iconRaster, jint w, jint h,
         JNU_CHECK_EXCEPTION(env); // Might throw here
         m_hIconSm = CreateIconFromRaster(env, smallIconRaster, smw, smh);
         JNU_CHECK_EXCEPTION(env); // Or here
-        } catch (...) {
-            // Clean up any allocated resources here
-            if (m_hIcon != NULL) {
-                DestroyIcon(m_hIcon);
-            }
-            throw; // Re-throw the exception
+    } catch (...) {
+        // Clean up any allocated resources here
+        if (m_hIcon != NULL) {
+            DestroyIcon(m_hIcon);
+        }
+        if (m_hIconSm != NULL) {
+            DestroyIcon(m_hIconSm);
+        }
+        throw; // Re-throw the exception
     }
 
     m_iconInherited = (m_hIcon == NULL);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -2108,7 +2108,8 @@ done:
 }
 
 void AwtWindow::SetIconData(JNIEnv* env, jintArray iconRaster, jint w, jint h,
-                             jintArray smallIconRaster, jint smw, jint smh) {
+                             jintArray smallIconRaster, jint smw, jint smh)
+{
     HICON hNewIcon = NULL;
     HICON hNewIconSm = NULL;
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -2116,7 +2116,7 @@ void AwtWindow::SetIconData(JNIEnv* env, jintArray iconRaster, jint w, jint h,
     try {
         hNewIcon = CreateIconFromRaster(env, iconRaster, w, h);
         if (env->ExceptionCheck()) {
-            if (hNewIcon) {
+            if (hNewIcon != NULL) {
                 DestroyIcon(hNewIcon);
             }
             return;

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -2108,35 +2108,50 @@ done:
 }
 
 void AwtWindow::SetIconData(JNIEnv* env, jintArray iconRaster, jint w, jint h,
-                             jintArray smallIconRaster, jint smw, jint smh)
-{
+                             jintArray smallIconRaster, jint smw, jint smh) {
+    HICON hNewIcon = NULL;
+    HICON hNewIconSm = NULL;
+
+    try {
+        hNewIcon = CreateIconFromRaster(env, iconRaster, w, h);
+        if (env->ExceptionCheck()) {
+            if (hNewIcon) {
+                DestroyIcon(hNewIcon);
+            }
+            return;
+        }
+
+        hNewIconSm = CreateIconFromRaster(env, smallIconRaster, smw, smh);
+        if (env->ExceptionCheck()) {
+            if (hNewIcon != NULL) {
+                DestroyIcon(hNewIcon);
+            }
+            if (hNewIconSm != NULL) {
+                DestroyIcon(hNewIconSm);
+            }
+            return;
+        }
+    } catch (...) {
+        if (hNewIcon != NULL) {
+            DestroyIcon(hNewIcon);
+        }
+        if (hNewIconSm != NULL) {
+            DestroyIcon(hNewIconSm);
+        }
+        return;
+    }
+
     HICON hOldIcon = NULL;
     HICON hOldIconSm = NULL;
-    //Destroy previous icon if it isn't inherited
     if ((m_hIcon != NULL) && !m_iconInherited) {
         hOldIcon = m_hIcon;
     }
-    m_hIcon = NULL;
     if ((m_hIconSm != NULL) && !m_iconInherited) {
         hOldIconSm = m_hIconSm;
     }
-    m_hIconSm = NULL;
 
-    try {
-        m_hIcon = CreateIconFromRaster(env, iconRaster, w, h);
-        JNU_CHECK_EXCEPTION(env); // Might throw here
-        m_hIconSm = CreateIconFromRaster(env, smallIconRaster, smw, smh);
-        JNU_CHECK_EXCEPTION(env); // Or here
-    } catch (...) {
-        // Clean up any allocated resources here
-        if (m_hIcon != NULL) {
-            DestroyIcon(m_hIcon);
-        }
-        if (m_hIconSm != NULL) {
-            DestroyIcon(m_hIconSm);
-        }
-        throw; // Re-throw the exception
-    }
+    m_hIcon = hNewIcon;
+    m_hIconSm = hNewIconSm;
 
     m_iconInherited = (m_hIcon == NULL);
     if (m_iconInherited) {
@@ -2149,8 +2164,11 @@ void AwtWindow::SetIconData(JNIEnv* env, jintArray iconRaster, jint w, jint h,
             m_iconInherited = FALSE;
         }
     }
+
     DoUpdateIcon();
     EnumThreadWindows(AwtToolkit::MainThread(), UpdateOwnedIconCallback, (LPARAM)this);
+
+    // Destroy previous icons if they were not inherited
     if (hOldIcon != NULL) {
         DestroyIcon(hOldIcon);
     }


### PR DESCRIPTION
**Issue:** 
AwtWindow::SetIconData leaks the old icon handles in hOldIcon and hOldIconSm if CreateIconFromRaster raises an exception. Additionally, an exception is checked only after the first call to CreateIconFromRaster.

**Solution:**
I have added the exception handling code to take care that the handles are properly destroyed and not leaked.

**Testing:**
I have tested the code to make sure there are no regressions caused by this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282862](https://bugs.openjdk.org/browse/JDK-8282862): AwtWindow::SetIconData leaks old icon handles if an exception is detected (**Bug** - P3)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**) Review applies to [505f804b](https://git.openjdk.org/jdk/pull/22932/files/505f804ba3a5047397e287c373a19c736ec1c10f)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) Review applies to [e22d8119](https://git.openjdk.org/jdk/pull/22932/files/e22d8119689d1ea4ae6e76788782451ce71cdfa5)
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22932/head:pull/22932` \
`$ git checkout pull/22932`

Update a local copy of the PR: \
`$ git checkout pull/22932` \
`$ git pull https://git.openjdk.org/jdk.git pull/22932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22932`

View PR using the GUI difftool: \
`$ git pr show -t 22932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22932.diff">https://git.openjdk.org/jdk/pull/22932.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22932#issuecomment-2573600514)
</details>
