### PR TITLE
8347063: Add comments in ClassFileFormatVersion for class file format evolution history

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
+++ b/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
@@ -52,43 +52,43 @@ public enum ClassFileFormatVersion {
     /*
      * Summary of class file format evolution; previews are listed for
      * convenience, but they are not modeled by this enum.
-     *  1: InnerClasses, Synthetic, Deprecated attributes
-     *  2: ACC_STRICT modifier
-     *  3: no changes
-     *  4: no changes
-     *  5: Annotations (Runtime(Inv/V)isible(Parameter)Annotations attributes);
-     *     Generics (Signature, LocalVariableTypeTable attributes);
-     *     EnclosingMethod attribute
-     *  6: Verification by type checking (StackMapTable attribute)
-     *  7: Verification by type checking enforced (jsr and ret opcodes
-     *     obsolete); java.lang.invoke support (JSR 292) (CONSTANT_MethodHandle,
-     *     CONSTANT_MethodType, CONSTANT_InvokeDynamic constant pool entries,
-     *     BoostrapMethods attribute); <clinit> method must be ACC_STATIC
-     *  8: private, static, and non-abstract (default) methods in interfaces;
-     *     Type Annotations (JEP 104) (Runtime(Inv/V)isibleTypeAnnotations
-     *     attribute); MethodParameters attribute
-     *  9: JSR 376 - modules (JSR 376, JEP 261) (Module, ModuleMainClass,
-     *     ModulePackages attributes, CONSTANT_Module, CONSTANT_Package constant
-     *     pool entries, ACC_MODULE modifier)
-     * 10: minor tweak to requires_flags in Module attribute
-     * 11: Nest mates (JEP 181) (NestHost, NestMembers attributes);
-     *     CONSTANT_Dynamic (JEP 309) constant pool entry
-     * 12: Preview Features (JEP 12) (minor version must be 0 or 65535)
-     * 13: no changes
-     * 14: no changes; (JEP 359 Records in Preview)
-     * 15: no changes; (JEP 384 Records in 2nd Preview, JEP 360 Sealed Classes
-     *     in Preview)
-     * 16: Records (JEP 395) (Record attribute); (JEP 397 Sealed Classes in 2nd
-     *     Preview)
-     * 17: Sealed Classes (JEP 409) (PermittedSubclasses attribute); ACC_STRICT
-     *     modifier obsolete (JEP 306)
-     * 18: no changes
-     * 19: no changes
-     * 20: no changes
-     * 21: no changes
-     * 22: no changes
-     * 23: no changes
-     * 24: no changes
+     * 1.1: InnerClasses, Synthetic, Deprecated attributes
+     * 1.2: ACC_STRICT modifier
+     * 1.3: no changes
+     * 1.4: no changes
+     * 1.5: Annotations (Runtime(Inv/V)isible(Parameter)Annotations attributes);
+     *      Generics (Signature, LocalVariableTypeTable attributes);
+     *      EnclosingMethod attribute
+     * 1.6: Verification by type checking (StackMapTable attribute)
+     * 1.7: Verification by type checking enforced (jsr and ret opcodes
+     *      obsolete); java.lang.invoke support (JSR 292) (CONSTANT_MethodHandle,
+     *      CONSTANT_MethodType, CONSTANT_InvokeDynamic constant pool entries,
+     *      BoostrapMethods attribute); <clinit> method must be ACC_STATIC
+     * 1.8: private, static, and non-abstract (default) methods in interfaces;
+     *      Type Annotations (JEP 104) (Runtime(Inv/V)isibleTypeAnnotations
+     *      attribute); MethodParameters attribute
+     *   9: JSR 376 - modules (JSR 376, JEP 261) (Module, ModuleMainClass,
+     *      ModulePackages attributes, CONSTANT_Module, CONSTANT_Package
+     *      constant pool entries, ACC_MODULE modifier)
+     *  10: minor tweak to requires_flags in Module attribute
+     *  11: Nest mates (JEP 181) (NestHost, NestMembers attributes);
+     *      CONSTANT_Dynamic (JEP 309) constant pool entry
+     *  12: Preview Features (JEP 12) (minor version must be 0 or 65535)
+     *  13: no changes
+     *  14: no changes; (JEP 359 Records in Preview)
+     *  15: no changes; (JEP 384 Records in 2nd Preview, JEP 360 Sealed Classes
+     *      in Preview)
+     *  16: Records (JEP 395) (Record attribute); (JEP 397 Sealed Classes in 2nd
+     *      Preview)
+     *  17: Sealed Classes (JEP 409) (PermittedSubclasses attribute); ACC_STRICT
+     *      modifier obsolete (JEP 306)
+     *  18: no changes
+     *  19: no changes
+     *  20: no changes
+     *  21: no changes
+     *  22: no changes
+     *  23: no changes
+     *  24: no changes
      */
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
+++ b/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,41 @@ package java.lang.reflect;
  */
 @SuppressWarnings("doclint:reference") // cross-module links
 public enum ClassFileFormatVersion {
+    /*
+     * Summary of class file format evolution; previews are listed for
+     * convenience, but they are not modeled by this enum
+     *  1: InnerClasses; Synthetic; Deprecated
+     *  2: ACC_STRICT
+     *  3: no changes
+     *  4: no changes
+     *  5: annotations (Runtime(Inv/V)isible(Parameter)Annotations);
+     *     generics (Signature, LocalVariableTypeTable); EnclosingMethod
+     *  6: verification by type checking (StackMapTable)
+     *  7: verification by type checking enforced (jsr and ret obsolete);
+     *     JSR 292 support (java.lang.invoke) (CONSTANT_MethodHandle,
+     *     CONSTANT_MethodType, CONSTANT_InvokeDynamic, BoostrapMethods);
+     *     <clinit> must be ACC_STATIC
+     *  8: private, static, and non-abstract (default) methods in interfaces;
+     *     type annotations (Runtime(Inv/V)isibleTypeAnnotations);
+     *     MethodParameters
+     *  9: modules (Module, ModuleMainClass, ModulePackages, CONSTANT_Module,
+     *     CONSTANT_Package, ACC_MODULE)
+     * 10: minor tweak to requires_flags in Module attribute
+     * 11: nestmate (NestHost, NestMembers); CONSTANT_Dynamic
+     * 12: preview features (minor version must be 0 or 65535)
+     * 13: no changes
+     * 14: no changes; (record in preview)
+     * 15: no changes; (record in 2nd preview, sealed classes in preview)
+     * 16: record (Record); (sealed classes in 2nd preview)
+     * 17: sealed classes (PermittedSubclasses); ACC_STRICT obsolete
+     * 18: no changes
+     * 19: no changes
+     * 20: no changes
+     * 21: no changes
+     * 22: no changes
+     * 23: no changes
+     * 24: no changes
+     */
 
     /**
      * The original version.

--- a/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
+++ b/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
@@ -51,31 +51,37 @@ package java.lang.reflect;
 public enum ClassFileFormatVersion {
     /*
      * Summary of class file format evolution; previews are listed for
-     * convenience, but they are not modeled by this enum
-     *  1: InnerClasses; Synthetic; Deprecated
-     *  2: ACC_STRICT
+     * convenience, but they are not modeled by this enum.
+     *  1: InnerClasses, Synthetic, Deprecated attributes
+     *  2: ACC_STRICT modifier
      *  3: no changes
      *  4: no changes
-     *  5: annotations (Runtime(Inv/V)isible(Parameter)Annotations);
-     *     generics (Signature, LocalVariableTypeTable); EnclosingMethod
-     *  6: verification by type checking (StackMapTable)
-     *  7: verification by type checking enforced (jsr and ret obsolete);
-     *     JSR 292 support (java.lang.invoke) (CONSTANT_MethodHandle,
-     *     CONSTANT_MethodType, CONSTANT_InvokeDynamic, BoostrapMethods);
-     *     <clinit> must be ACC_STATIC
+     *  5: Annotations (Runtime(Inv/V)isible(Parameter)Annotations attributes);
+     *     Generics (Signature, LocalVariableTypeTable attributes);
+     *     EnclosingMethod attribute
+     *  6: Verification by type checking (StackMapTable attribute)
+     *  7: Verification by type checking enforced (jsr and ret opcodes
+     *     obsolete); java.lang.invoke support (JSR 292) (CONSTANT_MethodHandle,
+     *     CONSTANT_MethodType, CONSTANT_InvokeDynamic constant pool entries,
+     *     BoostrapMethods attribute); <clinit> method must be ACC_STATIC
      *  8: private, static, and non-abstract (default) methods in interfaces;
-     *     type annotations (Runtime(Inv/V)isibleTypeAnnotations);
-     *     MethodParameters
-     *  9: modules (Module, ModuleMainClass, ModulePackages, CONSTANT_Module,
-     *     CONSTANT_Package, ACC_MODULE)
+     *     Type Annotations (JEP 104) (Runtime(Inv/V)isibleTypeAnnotations
+     *     attribute); MethodParameters attribute
+     *  9: JSR 376 - modules (JSR 376, JEP 261) (Module, ModuleMainClass,
+     *     ModulePackages attributes, CONSTANT_Module, CONSTANT_Package constant
+     *     pool entries, ACC_MODULE modifier)
      * 10: minor tweak to requires_flags in Module attribute
-     * 11: nestmate (NestHost, NestMembers); CONSTANT_Dynamic
-     * 12: preview features (minor version must be 0 or 65535)
+     * 11: Nest mates (JEP 181) (NestHost, NestMembers attributes);
+     *     CONSTANT_Dynamic (JEP 309) constant pool entry
+     * 12: Preview Features (JEP 12) (minor version must be 0 or 65535)
      * 13: no changes
-     * 14: no changes; (record in preview)
-     * 15: no changes; (record in 2nd preview, sealed classes in preview)
-     * 16: record (Record); (sealed classes in 2nd preview)
-     * 17: sealed classes (PermittedSubclasses); ACC_STRICT obsolete
+     * 14: no changes; (JEP 359 Records in Preview)
+     * 15: no changes; (JEP 384 Records in 2nd Preview, JEP 360 Sealed Classes
+     *     in Preview)
+     * 16: Records (JEP 395) (Record attribute); (JEP 397 Sealed Classes in 2nd
+     *     Preview)
+     * 17: Sealed Classes (JEP 409) (PermittedSubclasses attribute); ACC_STRICT
+     *     modifier obsolete (JEP 306)
      * 18: no changes
      * 19: no changes
      * 20: no changes


### PR DESCRIPTION
`javax.lang.model.SourceVersion` has a series of comments describing the new language features present in each source version. Similar comments for the `ClassFileFormatVersion` would be helpful, so readers no longer need to search through the JVMS to find changes in new versions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8347063](https://bugs.openjdk.org/browse/JDK-8347063): Add comments in ClassFileFormatVersion for class file format evolution history (**Enhancement** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22934/head:pull/22934` \
`$ git checkout pull/22934`

Update a local copy of the PR: \
`$ git checkout pull/22934` \
`$ git pull https://git.openjdk.org/jdk.git pull/22934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22934`

View PR using the GUI difftool: \
`$ git pr show -t 22934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22934.diff">https://git.openjdk.org/jdk/pull/22934.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22934#issuecomment-2573680345)
</details>
