### PR TITLE
8346998: Test nsk/jvmti/ResourceExhausted/resexhausted003 fails with java.lang.OutOfMemoryError when CDS is off

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,10 +39,7 @@
  *          /test/lib
  * @run main/othervm/native
  *      -agentlib:resexhausted=-waittime=5
- *      -Xms64m
- *      -Xmx64m
- *      -XX:MaxMetaspaceSize=9m
- *      -XX:-UseGCOverheadLimit
+ *      -XX:MaxMetaspaceSize=20m
  *      nsk.jvmti.ResourceExhausted.resexhausted003
  */
 


### PR DESCRIPTION
Test nsk/jvmti/ResourceExhausted/resexhausted003  limits metaspace size. 9m is not enough if sharing classes are disabled.
It starts failing with -XX:+UseCompactObjectHeaders just because CDS archives are no built  this mode.  Never executed with CDS off before.

Verified that it pass now with CDS off with and without UseCompactObjectHeaders.

I removed also other heap limits just because they are not needed and only might confuse test readers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346998](https://bugs.openjdk.org/browse/JDK-8346998): Test nsk/jvmti/ResourceExhausted/resexhausted003 fails with java.lang.OutOfMemoryError when CDS is off (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22936/head:pull/22936` \
`$ git checkout pull/22936`

Update a local copy of the PR: \
`$ git checkout pull/22936` \
`$ git pull https://git.openjdk.org/jdk.git pull/22936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22936`

View PR using the GUI difftool: \
`$ git pr show -t 22936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22936.diff">https://git.openjdk.org/jdk/pull/22936.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22936#issuecomment-2574310883)
</details>
