### PR TITLE
8346828: javax/swing/JScrollBar/4865918/bug4865918.java still fails in CI

### DIFF
--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4865918
+ * @requires (os.family != "mac")
  * @summary REGRESSION:JCK1.4a-runtime api/javax_swing/interactive/JScrollBarTests.html#JScrollBar
  * @run main bug4865918
  */

--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -45,6 +45,11 @@ public class bug4865918 {
     private static final CountDownLatch mousePressLatch = new CountDownLatch(1);
 
     public static void main(String[] argv) throws Exception {
+        String osName = System.getProperty("os.name");
+        if (osName.toLowerCase().contains("os x")) {
+            System.out.println("This test is not for MacOS, considered passed.");
+            return;
+        }
         SwingUtilities.invokeAndWait(() -> setupTest());
 
         SwingUtilities.invokeAndWait(() -> sbar.pressMouse());

--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -31,7 +31,6 @@
 import java.awt.Dimension;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import javax.swing.JFrame;
 import javax.swing.JScrollBar;
 import javax.swing.SwingUtilities;
 import java.util.concurrent.CountDownLatch;
@@ -42,7 +41,6 @@ import java.util.Date;
 public class bug4865918 {
 
     private static TestScrollBar sbar;
-    private static JFrame frame;
     private static final CountDownLatch mousePressLatch = new CountDownLatch(1);
 
     public static void main(String[] argv) throws Exception {

--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,14 +23,12 @@
 
 /*
  * @test
- * @key headful
  * @bug 4865918
  * @summary REGRESSION:JCK1.4a-runtime api/javax_swing/interactive/JScrollBarTests.html#JScrollBar
  * @run main bug4865918
  */
 
 import java.awt.Dimension;
-import java.awt.Robot;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import javax.swing.JFrame;
@@ -49,25 +47,18 @@ public class bug4865918 {
 
     public static void main(String[] argv) throws Exception {
         try {
-            Robot robot = new Robot();
-            SwingUtilities.invokeAndWait(() -> createAndShowGUI());
-
-            robot.waitForIdle();
-            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> setupTest());
 
             SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
             if (!mousePressLatch.await(2, TimeUnit.SECONDS)) {
                 throw new RuntimeException("Timed out waiting for mouse press");
             }
 
-            robot.waitForIdle();
-            robot.delay(200);
-
             if (getValue() != 9) {
                 throw new RuntimeException("The scrollbar block increment is incorrect");
             }
         } finally {
-            if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
+            //if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
         }
     }
 
@@ -78,12 +69,11 @@ public class bug4865918 {
             result[0] = sbar.getValue();
         });
 
+        System.out.println("value " + result[0]);
         return result[0];
     }
 
-    private static void createAndShowGUI() {
-        frame = new JFrame("bug4865918");
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+    private static void setupTest() {
 
         sbar = new TestScrollBar(JScrollBar.HORIZONTAL, -1, 10, -100, 100);
         sbar.setPreferredSize(new Dimension(200, 20));
@@ -94,11 +84,6 @@ public class bug4865918 {
             }
         });
 
-        frame.getContentPane().add(sbar);
-        frame.pack();
-        frame.setLocationRelativeTo(null);
-        frame.setVisible(true);
-        frame.toFront();
     }
 
     static class TestScrollBar extends JScrollBar {

--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -46,19 +46,15 @@ public class bug4865918 {
     private static final CountDownLatch mousePressLatch = new CountDownLatch(1);
 
     public static void main(String[] argv) throws Exception {
-        try {
-            SwingUtilities.invokeAndWait(() -> setupTest());
+        SwingUtilities.invokeAndWait(() -> setupTest());
 
-            SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
-            if (!mousePressLatch.await(2, TimeUnit.SECONDS)) {
-                throw new RuntimeException("Timed out waiting for mouse press");
-            }
+        SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
+        if (!mousePressLatch.await(2, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for mouse press");
+        }
 
-            if (getValue() != 9) {
-                throw new RuntimeException("The scrollbar block increment is incorrect");
-            }
-        } finally {
-            //if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
+        if (getValue() != 9) {
+            throw new RuntimeException("The scrollbar block increment is incorrect");
         }
     }
 


### PR DESCRIPTION
Test seems to still fail in CI in ubuntu22.04 intermittently even after [JDK-8346324](https://bugs.openjdk.org/browse/JDK-8346324). Made the test headless similar to javax/swing/JScrollBar/bug4842792.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346828](https://bugs.openjdk.org/browse/JDK-8346828): javax/swing/JScrollBar/4865918/bug4865918.java still fails in CI (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22937/head:pull/22937` \
`$ git checkout pull/22937`

Update a local copy of the PR: \
`$ git checkout pull/22937` \
`$ git pull https://git.openjdk.org/jdk.git pull/22937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22937`

View PR using the GUI difftool: \
`$ git pr show -t 22937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22937.diff">https://git.openjdk.org/jdk/pull/22937.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22937#issuecomment-2574316384)
</details>
