### PR TITLE
8343747: C2: TestReplicateAtConv.java crashes with -XX:MaxVectorSize=8

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1466,6 +1466,9 @@ bool VectorCastNode::implemented(int opc, uint vlen, BasicType src_type, BasicTy
   if (is_java_primitive(dst_type) &&
       is_java_primitive(src_type) &&
       (vlen > 1) && is_power_of_2(vlen) &&
+      // In rare case, the input to the VectorCast could be a Replicate node. We need to make sure creating is supported:
+      // check the src_type:
+      VectorNode::vector_size_supported_auto_vectorization(src_type, vlen) &&
       VectorNode::vector_size_supported_auto_vectorization(dst_type, vlen)) {
     int vopc = VectorCastNode::opcode(opc, src_type);
     return vopc > 0 && Matcher::match_rule_supported_auto_vectorization(vopc, vlen, dst_type);

--- a/test/hotspot/jtreg/compiler/vectorization/TestReplicateAtConv.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReplicateAtConv.java
@@ -23,9 +23,10 @@
 
 /**
  * @test
- * @bug 8341834
- * @summary C2 compilation fails with "bad AD file" due to Replicate
+ * @bug 8341834 8343747
+ * @summary Replicate node at a VectorCast (ConvL2I) causes superword to fail
  * @run main/othervm -XX:CompileCommand=compileonly,TestReplicateAtConv::test -Xcomp TestReplicateAtConv
+ * @run main/othervm -XX:CompileCommand=compileonly,TestReplicateAtConv::test -Xcomp -XX:MaxVectorSize=8 TestReplicateAtConv
  */
 
 public class TestReplicateAtConv {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [874d68a9](https://github.com/openjdk/jdk/commit/874d68a96ce67caaf944dd25fbfb44eab965dfd3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Roland Westrelin on 6 Dec 2024 and was reviewed by Emanuel Peter and Vladimir Kozlov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343747](https://bugs.openjdk.org/browse/JDK-8343747): C2: TestReplicateAtConv.java crashes with -XX:MaxVectorSize=8 (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22938/head:pull/22938` \
`$ git checkout pull/22938`

Update a local copy of the PR: \
`$ git checkout pull/22938` \
`$ git pull https://git.openjdk.org/jdk.git pull/22938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22938`

View PR using the GUI difftool: \
`$ git pr show -t 22938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22938.diff">https://git.openjdk.org/jdk/pull/22938.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22938#issuecomment-2574603479)
</details>
