### PR TITLE
8347094: Inline CollectedHeap::increment_total_full_collections

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -383,11 +383,9 @@ protected:
   void increment_total_collections(bool full = false) {
     _total_collections++;
     if (full) {
-      increment_total_full_collections();
+      _total_full_collections++;
     }
   }
-
-  void increment_total_full_collections() { _total_full_collections++; }
 
   // Return the SoftRefPolicy for the heap;
   SoftRefPolicy* soft_ref_policy() { return &_soft_ref_policy; }


### PR DESCRIPTION
Trivial inlining a method to its sole caller.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347094](https://bugs.openjdk.org/browse/JDK-8347094): Inline CollectedHeap::increment_total_full_collections (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22940/head:pull/22940` \
`$ git checkout pull/22940`

Update a local copy of the PR: \
`$ git checkout pull/22940` \
`$ git pull https://git.openjdk.org/jdk.git pull/22940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22940`

View PR using the GUI difftool: \
`$ git pr show -t 22940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22940.diff">https://git.openjdk.org/jdk/pull/22940.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22940#issuecomment-2574724180)
</details>
