### PR TITLE
8346868: RISC-V: compiler/sharedstubs tests fail after JDK-8332689

### DIFF
--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
@@ -33,6 +33,6 @@ private:
 
 public:
   void flush_bundle(bool start_new_bundle) {}
-  static bool supports_shared_stubs() { return false; }
+  static bool supports_shared_stubs() { return true; }
 
 #endif // CPU_RISCV_CODEBUFFER_RISCV_HPP

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
@@ -30,7 +30,7 @@
  *
  * @requires vm.compiler2.enabled
  * @requires vm.opt.TieredCompilation == null
- * @requires os.arch=="aarch64" | os.arch=="riscv64"
+ * @requires os.arch=="aarch64"
  * @requires vm.debug
  *
  * @run driver compiler.sharedstubs.SharedTrampolineTest -XX:-TieredCompilation


### PR DESCRIPTION
Hi all,

Same issue is there in jdk24 repo.

This pull request contains a backport of commit [3f7052ed](https://github.com/openjdk/jdk/commit/3f7052ed7af89efd1c6977df0b4f3b95fcfec764) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Fei Yang on 7 Jan 2025 and was reviewed by Robbin Ehn and Hamlin Li.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346868](https://bugs.openjdk.org/browse/JDK-8346868): RISC-V: compiler/sharedstubs tests fail after JDK-8332689 (**Bug** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22945/head:pull/22945` \
`$ git checkout pull/22945`

Update a local copy of the PR: \
`$ git checkout pull/22945` \
`$ git pull https://git.openjdk.org/jdk.git pull/22945/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22945`

View PR using the GUI difftool: \
`$ git pr show -t 22945`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22945.diff">https://git.openjdk.org/jdk/pull/22945.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22945#issuecomment-2575008928)
</details>
