### PR TITLE
8346834: Tests failing with -XX:+UseNUMA due to "NUMA support disabled" warning

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4537,7 +4537,7 @@ void os::Linux::disable_numa(const char* reason) {
   if ((UseNUMA && FLAG_IS_CMDLINE(UseNUMA)) ||
       (UseNUMAInterleaving && FLAG_IS_CMDLINE(UseNUMAInterleaving))) {
     // Only issue a warning if the user explicitly asked for NUMA support
-    log_warning(os)("NUMA support disabled: %s", reason);
+    log_info(os)("NUMA support disabled: %s", reason);
   }
   FLAG_SET_ERGO(UseNUMA, false);
   FLAG_SET_ERGO(UseNUMAInterleaving, false);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4483,15 +4483,15 @@ void os::Linux::numa_init() {
   // bitmask when externally configured to run on all or fewer nodes.
 
   if (!Linux::libnuma_init()) {
-    disable_numa("Failed to initialize libnuma");
+    disable_numa("Failed to initialize libnuma", true);
   } else {
     Linux::set_configured_numa_policy(Linux::identify_numa_policy());
     if (Linux::numa_max_node() < 1) {
-      disable_numa("Only a single NUMA node is available");
+      disable_numa("Only a single NUMA node is available", false);
     } else if (Linux::is_bound_to_single_mem_node()) {
-      disable_numa("The process is bound to a single NUMA node");
+      disable_numa("The process is bound to a single NUMA node", true);
     } else if (Linux::mem_and_cpu_node_mismatch()) {
-      disable_numa("The process memory and cpu node configuration does not match");
+      disable_numa("The process memory and cpu node configuration does not match", true);
     } else {
       LogTarget(Info,os) log;
       LogStream ls(log);
@@ -4533,11 +4533,15 @@ void os::Linux::numa_init() {
   }
 }
 
-void os::Linux::disable_numa(const char* reason) {
+void os::Linux::disable_numa(const char* reason, bool warning) {
   if ((UseNUMA && FLAG_IS_CMDLINE(UseNUMA)) ||
       (UseNUMAInterleaving && FLAG_IS_CMDLINE(UseNUMAInterleaving))) {
-    // Only issue a warning if the user explicitly asked for NUMA support
-    log_info(os)("NUMA support disabled: %s", reason);
+    // Only issue a message if the user explicitly asked for NUMA support
+    if (warning) {
+      log_warning(os)("NUMA support disabled: %s", reason);
+    } else {
+      log_info(os)("NUMA support disabled: %s", reason);
+    }
   }
   FLAG_SET_ERGO(UseNUMA, false);
   FLAG_SET_ERGO(UseNUMAInterleaving, false);

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -193,7 +193,7 @@ class os::Linux {
  private:
   static void numa_init();
 
-  static void disable_numa(const char* reason);
+  static void disable_numa(const char* reason, bool warning);
   typedef int (*sched_getcpu_func_t)(void);
   typedef int (*numa_node_to_cpus_func_t)(int node, unsigned long *buffer, int bufferlen);
   typedef int (*numa_node_to_cpus_v2_func_t)(int node, void *mask);

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -727,8 +727,6 @@ javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
 
 # jdk_jdi
 
-com/sun/jdi/ProcessAttachTest.java         8346827 linux-all
-com/sun/jdi/ReattachStressTest.java        8346827 linux-all
 com/sun/jdi/RepStep.java                                        8043571 generic-all
 
 com/sun/jdi/InvokeHangTest.java                                 8218463 linux-all


### PR DESCRIPTION
Hi All,

A number of tests launch VMs and read the output of the sub-process. The changes in [JDK-8205051](https://bugs.openjdk.org/browse/JDK-8205051) mean the warning message "NUMA support disabled: Only a single NUMA node is available" is printed when running the tests -XX:+UseNUMA on system that only have one node, this breaks several tests. After update in some tests, so far, the failures are with:

java/util/logging/LoggingDeadlock2.java
tools/jar/modularJar/Basic.java

As a fix have changed logging level from "log_warning" to "log_info" when UseNUMA flag is disabled. 

Thanks,
Swati Sharma
Intel

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346834](https://bugs.openjdk.org/browse/JDK-8346834): Tests failing with -XX:+UseNUMA due to "NUMA support disabled" warning (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22948/head:pull/22948` \
`$ git checkout pull/22948`

Update a local copy of the PR: \
`$ git checkout pull/22948` \
`$ git pull https://git.openjdk.org/jdk.git pull/22948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22948`

View PR using the GUI difftool: \
`$ git pr show -t 22948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22948.diff">https://git.openjdk.org/jdk/pull/22948.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22948#issuecomment-2575346586)
</details>
