### PR TITLE
8347038: [JMH] jdk.incubator.vector.SpiltReplicate fails NoClassDefFoundError

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/SpiltReplicate.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/SpiltReplicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(1)
+@Fork(value=1, jvmArgs={"--add-modules=jdk.incubator.vector"})
 public class SpiltReplicate {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public long broadcastInt() {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4d8fb807](https://github.com/openjdk/jdk/commit/4d8fb80732fd17352c36254c6dfc1be5dbfbacf1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository to jdk24.

The commit being backported was authored by SendaoYan on 7 Jan 2025 and was reviewed by Paul Sandoz. Fix the JMH test bug, test-fix only, no risk.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347038](https://bugs.openjdk.org/browse/JDK-8347038): [JMH] jdk.incubator.vector.SpiltReplicate fails NoClassDefFoundError (**Bug** - P4)


### Reviewers
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22949/head:pull/22949` \
`$ git checkout pull/22949`

Update a local copy of the PR: \
`$ git checkout pull/22949` \
`$ git pull https://git.openjdk.org/jdk.git pull/22949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22949`

View PR using the GUI difftool: \
`$ git pr show -t 22949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22949.diff">https://git.openjdk.org/jdk/pull/22949.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22949#issuecomment-2575558894)
</details>
