### PR TITLE
8344316: security/auth/callback/TextCallbackHandler/Password.java make runnable with JTReg and add the UI

### DIFF
--- a/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
+++ b/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,9 @@
  */
 
 /*
+ * This test should not be run with JTreg. If it is run using JTreg the test will fail.
+ * Please use the following instructions:
+ *
  * This scenario cannot be automated because util/Password.java verifies the given input stream is
  * equal to the initialSystemIn. This prevents the test from providing a custom input stream.
  *
@@ -45,6 +48,11 @@ import javax.security.auth.callback.*;
 
 public class Password {
    public static void main(String args[]) throws Exception {
+
+       if (System.getProperty("java.class.path").contains("jtreg")){
+           throw new RuntimeException("This is a manual testing, it shouldn't be run with jtreg.");
+       }
+
         TextCallbackHandler h = new TextCallbackHandler();
         PasswordCallback nc = new PasswordCallback("Invisible: ", false);
         PasswordCallback nc2 = new PasswordCallback("Visible: ", true);
@@ -55,5 +63,6 @@ public class Password {
         h.handle(callbacks);
         System.out.println("You input " + new String(nc.getPassword()) +
                 " and " + new String(nc2.getPassword()));
+
    }
 }

--- a/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
+++ b/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6825240 6829785
+ * @bug 6825240 6829785 8345134
  * @summary Password.readPassword() echos the input when System.Console is null
  * @run main/manual Password
  */

--- a/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
+++ b/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
@@ -49,9 +49,9 @@ import javax.security.auth.callback.*;
 public class Password {
    public static void main(String args[]) throws Exception {
 
-       if (System.getProperty("java.class.path").contains("jtreg")){
-           throw new RuntimeException("This is a manual testing, it shouldn't be run with jtreg.");
-       }
+        if (System.getProperty("java.class.path").contains("jtreg")){
+            throw new RuntimeException("This is a manual testing, it shouldn't be run with jtreg.");
+        }
 
         TextCallbackHandler h = new TextCallbackHandler();
         PasswordCallback nc = new PasswordCallback("Invisible: ", false);

--- a/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
+++ b/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6825240 6829785 8345134
+ * @bug 6825240 6829785
  * @summary Password.readPassword() echos the input when System.Console is null
  * @run main/manual Password
  */
@@ -50,7 +50,8 @@ public class Password {
    public static void main(String args[]) throws Exception {
 
         if (System.getProperty("java.class.path").contains("jtreg")){
-            throw new RuntimeException("This is a manual testing, it shouldn't be run with jtreg.");
+            throw new RuntimeException("This test is designated as manual and will fail if run with jtreg. " +
+                    "Please read the instruction/steps in the file comments before proceeding with manual execution.");
         }
 
         TextCallbackHandler h = new TextCallbackHandler();

--- a/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
+++ b/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
@@ -64,6 +64,5 @@ public class Password {
         h.handle(callbacks);
         System.out.println("You input " + new String(nc.getPassword()) +
                 " and " + new String(nc2.getPassword()));
-
    }
 }

--- a/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
+++ b/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
@@ -49,8 +49,10 @@ public class Password {
     public static void password() throws Exception {
 
         TextCallbackHandler h = new TextCallbackHandler();
-        PasswordCallback nc = new PasswordCallback("Visible: ", true);
-        PasswordCallback nc2 = new PasswordCallback("Invisible: ", false);
+        PasswordCallback nc =
+                new PasswordCallback("Please input something, your input should be VISIBLE: ", true);
+        PasswordCallback nc2 =
+                new PasswordCallback("Please input something again, your input should be INVISIBLE: ", false);
         Callback[] callbacks = {nc, nc2};
         h.handle(callbacks);
         System.out.println("You input " + new String(nc.getPassword()) +
@@ -67,10 +69,10 @@ public class Password {
             );
 
             boolean testFailed = new Password().validate(
-                    "Please copy and execute the following script in the terminal / Windows Command Prompt window, " +
+                    "Please copy and execute the following script in the terminal / Windows Command Prompt window. " +
                             "Two passwords will be prompted for.\n" +
                             "Enter something at each prompt and press Enter/Return.\n" +
-                            "If the first input is invisible and the second is visible, this test PASSES. Otherwise, this test FAILS\n" +
+                            "If the first input is visible and the second is invisible, this test PASSES. Otherwise, this test FAILS.\n" +
                             "Once the test is complete please select whether the test has passed.\n",
                     instructions);
 

--- a/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
+++ b/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
@@ -63,7 +63,7 @@ public class Password {
         if (Arrays.asList(args).contains("--password")) {
             password();
         } else {
-            final String instructions = String.format("%s/bin/java -cp \n%s \nPassword  \n--password",
+            final String instructions = String.format("%s/bin/java -cp \\\n%s \\\nPassword  \\\n--password",
                     System.getProperty("java.home"),
                     System.getProperty("java.class.path")
             );
@@ -71,7 +71,7 @@ public class Password {
             boolean testFailed = new Password().validate(
                     "Please copy and execute the following script in the terminal/cmd, " +
                             "then follow the instructions. \n" +
-                            "Once the test is complete please select weather the test has passed.",
+                            "Once the test is complete please select whether the test has passed.",
                     instructions);
 
             if (testFailed) {

--- a/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
+++ b/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
@@ -49,11 +49,8 @@ public class Password {
     public static void password() throws Exception {
 
         TextCallbackHandler h = new TextCallbackHandler();
-        PasswordCallback nc = new PasswordCallback("Invisible: ", false);
-        PasswordCallback nc2 = new PasswordCallback("Visible: ", true);
-        System.out.println("Two passwords will be prompted for.\n" +
-                "Enter something at each prompt and press Enter/Return.\n" +
-                "If the first input is invisible and the second is visible, this test PASSES.");
+        PasswordCallback nc = new PasswordCallback("Visible: ", true);
+        PasswordCallback nc2 = new PasswordCallback("Invisible: ", false);
         Callback[] callbacks = {nc, nc2};
         h.handle(callbacks);
         System.out.println("You input " + new String(nc.getPassword()) +
@@ -64,15 +61,17 @@ public class Password {
         if (Arrays.asList(args).contains("--password")) {
             password();
         } else {
-            final String instructions = String.format("%s/bin/java -cp %s Password --password",
-                    System.getProperty("java.home"),
-                    System.getProperty("java.class.path")
+            final String instructions = String.format("%s/bin/java -cp \"%s\" Password --password",
+                    System.getProperty("java.home").replace("\\","/"),
+                    System.getProperty("java.class.path").replace("\\","/")
             );
 
             boolean testFailed = new Password().validate(
                     "Please copy and execute the following script in the terminal / Windows Command Prompt window, " +
-                            "then follow the instructions. \n" +
-                            "Once the test is complete please select whether the test has passed.",
+                            "Two passwords will be prompted for.\n" +
+                            "Enter something at each prompt and press Enter/Return.\n" +
+                            "If the first input is invisible and the second is visible, this test PASSES. Otherwise, this test FAILS\n" +
+                            "Once the test is complete please select whether the test has passed.\n",
                     instructions);
 
             if (testFailed) {

--- a/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
+++ b/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
@@ -26,7 +26,7 @@
  * @bug 6825240 6829785
  * @summary Password.readPassword() echos the input when System.Console is null
  * @library /test/lib
- * @run main/manual Password
+ * @run main/manual/othervm Password
  */
 
 import com.sun.security.auth.callback.TextCallbackHandler;
@@ -51,8 +51,9 @@ public class Password {
         TextCallbackHandler h = new TextCallbackHandler();
         PasswordCallback nc = new PasswordCallback("Invisible: ", false);
         PasswordCallback nc2 = new PasswordCallback("Visible: ", true);
-        System.out.println("Two passwords will be prompted for. The first one " +
-                "should have echo off, the second one on. Otherwise, this test fails");
+        System.out.println("Two passwords will be prompted for.\n" +
+                "Enter something at each prompt and press Enter/Return.\n" +
+                "If the first input is invisible and the second is visible, this test PASSES.");
         Callback[] callbacks = {nc, nc2};
         h.handle(callbacks);
         System.out.println("You input " + new String(nc.getPassword()) +
@@ -63,13 +64,13 @@ public class Password {
         if (Arrays.asList(args).contains("--password")) {
             password();
         } else {
-            final String instructions = String.format("%s/bin/java -cp \\\n%s \\\nPassword  \\\n--password",
+            final String instructions = String.format("%s/bin/java -cp %s Password --password",
                     System.getProperty("java.home"),
                     System.getProperty("java.class.path")
             );
 
             boolean testFailed = new Password().validate(
-                    "Please copy and execute the following script in the terminal/cmd, " +
+                    "Please copy and execute the following script in the terminal / Windows Command Prompt window, " +
                             "then follow the instructions. \n" +
                             "Once the test is complete please select whether the test has passed.",
                     instructions);


### PR DESCRIPTION
* Changed security/auth/callback/TextCallbackHandler/Password.java to run with JTReg, now the dialog box with instructions will appear as a ui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344316](https://bugs.openjdk.org/browse/JDK-8344316): security/auth/callback/TextCallbackHandler/Password.java make runnable with JTReg and add the UI (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22951/head:pull/22951` \
`$ git checkout pull/22951`

Update a local copy of the PR: \
`$ git checkout pull/22951` \
`$ git pull https://git.openjdk.org/jdk.git pull/22951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22951`

View PR using the GUI difftool: \
`$ git pr show -t 22951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22951.diff">https://git.openjdk.org/jdk/pull/22951.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22951#issuecomment-2577837346)
</details>
