### PR TITLE
8347127: CTW fails to build after JDK-8334733

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/Makefile
+++ b/test/hotspot/jtreg/testlibrary/ctw/Makefile
@@ -53,6 +53,7 @@ WB_CLASS_FILES := $(subst $(TESTLIBRARY_DIR)/,,$(WB_SRC_FILES))
 WB_CLASS_FILES := $(patsubst %.java,%.class,$(WB_CLASS_FILES))
 EXPORTS=--add-exports java.base/jdk.internal.jimage=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.module=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.access=ALL-UNNAMED
 


### PR DESCRIPTION
[JDK-8334733](https://bugs.openjdk.org/browse/JDK-8334733) removed the filter for `ModuleInfoWriter`, which now causes standalone CTW to fail when building:

```
$ export JAVA_HOME=<point to fastdebug build>
$ export PATH=$JAVA_HOME/bin:$PATH
$ cd test/hotspot/jtreg/testlibrary/ctw
$ make 

/home/shipilev/shipilev-jdk/build/linux-x86_64-server-fastdebug/images/jdk/bin/../bin/javac --add-exports java.base/jdk.internal.jimage=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED --add-exports java.base/jdk.internal.access=ALL-UNNAMED -sourcepath src -d build/classes -cp dist/wb.jar @filelist
../../../../../test/lib/jdk/test/lib/util/ModuleInfoWriter.java:44: error: package jdk.internal.module is not visible
import jdk.internal.module.ModuleResolution;
                   ^
  (package jdk.internal.module is declared in module java.base, which does not export it to the unnamed module)
../../../../../test/lib/jdk/test/lib/util/ModuleInfoWriter.java:45: error: package jdk.internal.module is not visible
import jdk.internal.module.ModuleTarget;
                   ^
  (package jdk.internal.module is declared in module java.base, which does not export it to the unnamed module)
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
2 errors
make: *** [dist/ctw.jar] Error 1
```

Additional testing: 
 - [x] CTW `make` works now
 - [x] Standalone CTW works now

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347127](https://bugs.openjdk.org/browse/JDK-8347127): CTW fails to build after JDK-8334733 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22952/head:pull/22952` \
`$ git checkout pull/22952`

Update a local copy of the PR: \
`$ git checkout pull/22952` \
`$ git pull https://git.openjdk.org/jdk.git pull/22952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22952`

View PR using the GUI difftool: \
`$ git pr show -t 22952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22952.diff">https://git.openjdk.org/jdk/pull/22952.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22952#issuecomment-2575768679)
</details>
