### PR TITLE
8347126: gc/stress/TestStressG1Uncommit.java gets OOM-killed

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestStressG1Uncommit.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressG1Uncommit.java
@@ -57,6 +57,7 @@ public class TestStressG1Uncommit {
         Collections.addAll(options,
             "-Xlog:gc,gc+heap+region=debug",
             "-XX:+UseG1GC",
+            "-Xmx1g",
             StressUncommit.class.getName()
         );
         OutputAnalyzer output = ProcessTools.executeLimitedTestJava(options);
@@ -79,9 +80,9 @@ class StressUncommit {
         // Leave 20% head room to try to avoid Full GCs.
         long allocationSize = (long) (Runtime.getRuntime().maxMemory() * 0.8);
 
-        // Figure out suitable number of workers (~1 per gig).
-        int gigsOfAllocation = (int) Math.ceil((double) allocationSize / G);
-        int numWorkers = Math.min(gigsOfAllocation, Runtime.getRuntime().availableProcessors());
+        // Figure out suitable number of workers (~1 per 100M).
+        int allocationChunk = (int) Math.ceil((double) allocationSize * 100 / M);
+        int numWorkers = Math.min(allocationChunk, Runtime.getRuntime().availableProcessors());
         long workerAllocation = allocationSize / numWorkers;
 
         log("Using " + numWorkers + " workers, each allocating: ~" + (workerAllocation / M) + "M");

--- a/test/hotspot/jtreg/gc/stress/TestStressG1Uncommit.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressG1Uncommit.java
@@ -81,8 +81,8 @@ class StressUncommit {
         long allocationSize = (long) (Runtime.getRuntime().maxMemory() * 0.8);
 
         // Figure out suitable number of workers (~1 per 100M).
-        int allocationChunk = (int) Math.ceil((double) allocationSize * 100 / M);
-        int numWorkers = Math.min(allocationChunk, Runtime.getRuntime().availableProcessors());
+        int allocationChunks = (int) Math.ceil((double) allocationSize / (100 * M));
+        int numWorkers = Math.min(allocationChunks, Runtime.getRuntime().availableProcessors());
         long workerAllocation = allocationSize / numWorkers;
 
         log("Using " + numWorkers + " workers, each allocating: ~" + (workerAllocation / M) + "M");


### PR DESCRIPTION
One of my testing nodes caught the OOM kill for the VM carrying the test. The default configuration turns the VM that test runs as the driver into a memory hog. On 48-core / 64G machine, the test configured itself to take 13 workers each allocating 1G. This ballooned the heap size to 13G -- e.g. about 25% of host memory  -- which is well beyond the usual footprint for a single test VM (~2GB). Naturally, this runs into a high chance of being OOM killed under high test parallelism.

I think the solution is to cut down the heap size we run with, and balance the number of workers a bit more finely. I looked around at sibling tests and 1G seems to be a common heap size for these tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347126](https://bugs.openjdk.org/browse/JDK-8347126): gc/stress/TestStressG1Uncommit.java gets OOM-killed (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22954/head:pull/22954` \
`$ git checkout pull/22954`

Update a local copy of the PR: \
`$ git checkout pull/22954` \
`$ git pull https://git.openjdk.org/jdk.git pull/22954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22954`

View PR using the GUI difftool: \
`$ git pr show -t 22954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22954.diff">https://git.openjdk.org/jdk/pull/22954.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22954#issuecomment-2575940297)
</details>
