### PR TITLE
8347141: Several javac tests compile with an unnecessary -Xlint:-path flag

### DIFF
--- a/test/langtools/tools/javac/6304921/T6304921.java
+++ b/test/langtools/tools/javac/6304921/T6304921.java
@@ -1,7 +1,7 @@
 /*
  * @test (important: no SCCS keywords to affect offsets in golden file.)  /nodynamiccopyright/
  * @bug 6304921
- * @compile/fail/ref=T6304921.out -XDcompilePolicy=bytodo -XDrawDiagnostics -Xjcov -Xlint:all,-path -Werror T6304921.java
+ * @compile/fail/ref=T6304921.out -XDcompilePolicy=bytodo -XDrawDiagnostics -Xjcov -Xlint:all -Werror T6304921.java
  */
 
 import java.util.ArrayList;

--- a/test/langtools/tools/javac/T5048776.java
+++ b/test/langtools/tools/javac/T5048776.java
@@ -1,8 +1,8 @@
 /*
  * @test  /nodynamiccopyright/
  * @bug 5048776
- * @compile/ref=T5048776a.out -XDrawDiagnostics                  T5048776.java
- * @compile/ref=T5048776b.out -XDrawDiagnostics -Xlint:all,-path T5048776.java
+ * @compile/ref=T5048776a.out -XDrawDiagnostics            T5048776.java
+ * @compile/ref=T5048776b.out -XDrawDiagnostics -Xlint:all T5048776.java
  */
 class A1 {
     void foo(Object[] args) { }

--- a/test/langtools/tools/javac/T6245591.java
+++ b/test/langtools/tools/javac/T6245591.java
@@ -1,7 +1,7 @@
 /*
  * @test  /nodynamiccopyright/
  * @bug 6245591
- * @compile/ref=T6245591.out -XDrawDiagnostics -Xlint:all,-path T6245591.java
+ * @compile/ref=T6245591.out -XDrawDiagnostics -Xlint:all T6245591.java
  */
 enum Season {
     /** @deprecated */

--- a/test/langtools/tools/javac/T6247324.java
+++ b/test/langtools/tools/javac/T6247324.java
@@ -1,7 +1,7 @@
 /*
  * @test  /nodynamiccopyright/
  * @bug 6247324
- * @compile/fail/ref=T6247324.out -XDrawDiagnostics -Xlint -Xlint:-path T6247324.java
+ * @compile/fail/ref=T6247324.out -XDrawDiagnostics -Xlint T6247324.java
  */
 class Pair<X,Y> {
     private X x;

--- a/test/langtools/tools/javac/processing/TestWarnErrorCount.java
+++ b/test/langtools/tools/javac/processing/TestWarnErrorCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,7 +161,7 @@ public class TestWarnErrorCount extends JavacTestingAbstractProcessor {
             "-d", testDir.getPath(),
             "-processor", myName,
 //            "-XprintRounds",
-            "-Xlint:all,-path",
+            "-Xlint:all",
             "-AerrKind=" + ek,
             "-AmsgrWarnKind=" + mwk,
             "-AjavaWarnKind=" + jwk));

--- a/test/langtools/tools/javac/warnings/DivZero.java
+++ b/test/langtools/tools/javac/warnings/DivZero.java
@@ -3,7 +3,7 @@
  * @bug 4759494 4986256
  * @compile/ref=DivZero.noLint.out                   -XDrawDiagnostics DivZero.java
  * @compile/ref=DivZero.lint.out    -Xlint:divzero   -XDrawDiagnostics DivZero.java
- * @compile/ref=DivZero.lint.out    -Xlint:all,-path -XDrawDiagnostics DivZero.java
+ * @compile/ref=DivZero.lint.out    -Xlint:all       -XDrawDiagnostics DivZero.java
  */
 
 class DivZero

--- a/test/langtools/tools/javac/warnings/FallThrough.java
+++ b/test/langtools/tools/javac/warnings/FallThrough.java
@@ -2,7 +2,7 @@
  * @test  /nodynamiccopyright/
  * @bug 4986256
  * @compile/ref=FallThrough.noLint.out                             -XDrawDiagnostics FallThrough.java
- * @compile/ref=FallThrough.lintAll.out         -Xlint:all,-path   -XDrawDiagnostics FallThrough.java
+ * @compile/ref=FallThrough.lintAll.out         -Xlint:all         -XDrawDiagnostics FallThrough.java
  * @compile/ref=FallThrough.lintFallThrough.out -Xlint:fallthrough -XDrawDiagnostics FallThrough.java
  */
 

--- a/test/langtools/tools/javac/warnings/Unchecked.java
+++ b/test/langtools/tools/javac/warnings/Unchecked.java
@@ -3,7 +3,7 @@
  * @bug 4986256
  * @compile/ref=Unchecked.noLint.out                         -XDrawDiagnostics Unchecked.java
  * @compile/ref=Unchecked.lintUnchecked.out -Xlint:unchecked -XDrawDiagnostics Unchecked.java
- * @compile/ref=Unchecked.lintAll.out       -Xlint:all,-path -XDrawDiagnostics Unchecked.java
+ * @compile/ref=Unchecked.lintAll.out       -Xlint:all       -XDrawDiagnostics Unchecked.java
  */
 
 import java.util.ArrayList;


### PR DESCRIPTION
Please review this patch which removes unnecessary `-Xlint:-path` flags from a few javac regression tests.

These tests invoke the compiler with the `-Xlint:all,-path` flag, but the `path` option is unrelated to, and not needed for, the test.

The tests all succeed just fine without it, i.e., with `-Xlint:all` instead.

The suppression of the `path` lint category appears to be leftover cruft from long ago (at least, according to [this discussion](https://mail.openjdk.org/pipermail/compiler-dev/2024-November/028514.html)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347141](https://bugs.openjdk.org/browse/JDK-8347141): Several javac tests compile with an unnecessary -Xlint:-path flag (**Bug** - P5)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22958/head:pull/22958` \
`$ git checkout pull/22958`

Update a local copy of the PR: \
`$ git checkout pull/22958` \
`$ git pull https://git.openjdk.org/jdk.git pull/22958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22958`

View PR using the GUI difftool: \
`$ git pr show -t 22958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22958.diff">https://git.openjdk.org/jdk/pull/22958.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22958#issuecomment-2576357160)
</details>
