### PR TITLE
8347162: Update problemlist CR for vmTestbase/nsk/jdi/VMOutOfMemoryException

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location002/TestDescription.java
 # the debuggee, which can lead to I/O poller threads exiting. Because
 # of this no vthreads can complete their reads, and the test times out as a result.
 
-vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemoryException001.java 8285417 generic-all
+vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemoryException001.java 8347137 generic-all
 
 ###
 # Fails because resume of a virtual thread is not enough to allow the virtual thread


### PR DESCRIPTION
Since [JDK-8285417](https://bugs.openjdk.org/browse/JDK-8285417) is now closed as a dup of [JDK-8347137](https://bugs.openjdk.org/browse/JDK-8347137), its problem list entry needs to be updated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347162](https://bugs.openjdk.org/browse/JDK-8347162): Update problemlist CR for vmTestbase/nsk/jdi/VMOutOfMemoryException (**Sub-task** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22960/head:pull/22960` \
`$ git checkout pull/22960`

Update a local copy of the PR: \
`$ git checkout pull/22960` \
`$ git pull https://git.openjdk.org/jdk.git pull/22960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22960`

View PR using the GUI difftool: \
`$ git pr show -t 22960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22960.diff">https://git.openjdk.org/jdk/pull/22960.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22960#issuecomment-2576926148)
</details>
