### PR TITLE
8347163: Javadoc error in ConstantPoolBuilder after JDK-8342468

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
@@ -400,7 +400,7 @@ public sealed interface ConstantPoolBuilder
      *
      * @param refKind the reference kind of the method handle
      * @param reference the {@code MemberRefEntry}
-     * @see MethodHandleInfo##refKinds Reference kinds
+     * @see MethodHandleInfo##refkinds Reference kinds
      * @see MethodHandleEntry#kind() MethodHandleEntry::kind
      * @see MethodHandleEntry#reference() MethodHandleEntry::reference
      */


### PR DESCRIPTION
The anchor is `refkinds` instead of `refKinds`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347163](https://bugs.openjdk.org/browse/JDK-8347163): Javadoc error in ConstantPoolBuilder after JDK-8342468 (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22961/head:pull/22961` \
`$ git checkout pull/22961`

Update a local copy of the PR: \
`$ git checkout pull/22961` \
`$ git pull https://git.openjdk.org/jdk.git pull/22961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22961`

View PR using the GUI difftool: \
`$ git pr show -t 22961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22961.diff">https://git.openjdk.org/jdk/pull/22961.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22961#issuecomment-2576824323)
</details>
