### PR TITLE
8347047: Cleanup action passed to MemorySegment::reinterpret keeps old segment alive

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -145,10 +145,15 @@ public abstract sealed class AbstractMemorySegmentImpl
         Reflection.ensureNativeAccess(callerClass, MemorySegment.class, "reinterpret", false);
         Utils.checkNonNegativeArgument(newSize, "newSize");
         if (!isNative()) throw new UnsupportedOperationException("Not a native segment");
-        Runnable action = cleanup != null ?
-                () -> cleanup.accept(SegmentFactories.makeNativeSegmentUnchecked(address(), newSize)) :
-                null;
+        Runnable action = cleanupAction(address(), newSize, cleanup);
         return SegmentFactories.makeNativeSegmentUnchecked(address(), newSize, scope, readOnly, action);
+    }
+
+    // Using a static helper method ensures there is no unintended lambda capturing of `this`
+    private static Runnable cleanupAction(long address, long newSize, Consumer<MemorySegment> cleanup) {
+        return cleanup != null ?
+                () -> cleanup.accept(SegmentFactories.makeNativeSegmentUnchecked(address, newSize)) :
+                null;
     }
 
     private AbstractMemorySegmentImpl asSliceNoCheck(long offset, long newSize) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b0c935c0](https://github.com/openjdk/jdk/commit/b0c935c03ebb34f20f15dd8c7616c6c4526073cd) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Per Minborg on 8 Jan 2025 and was reviewed by Maurizio Cimadamore.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347047](https://bugs.openjdk.org/browse/JDK-8347047): Cleanup action passed to MemorySegment::reinterpret keeps old segment alive (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22962/head:pull/22962` \
`$ git checkout pull/22962`

Update a local copy of the PR: \
`$ git checkout pull/22962` \
`$ git pull https://git.openjdk.org/jdk.git pull/22962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22962`

View PR using the GUI difftool: \
`$ git pr show -t 22962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22962.diff">https://git.openjdk.org/jdk/pull/22962.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22962#issuecomment-2577141460)
</details>
