### PR TITLE
8346954: [JMH] jdk.incubator.vector.MaskedLogicOpts fails due to IndexOutOfBoundsException

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskedLogicOpts.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskedLogicOpts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,9 +81,6 @@ public class MaskedLogicOpts {
     VectorSpecies<Long> lspecies;
 
     int int512_arr_idx;
-    int int256_arr_idx;
-    int int128_arr_idx;
-    int long256_arr_idx;
     int long512_arr_idx;
 
     private Random r = new Random();
@@ -91,9 +88,6 @@ public class MaskedLogicOpts {
     @Setup(Level.Trial)
     public void init() {
         int512_arr_idx = 0;
-        int256_arr_idx = 0;
-        int128_arr_idx = 0;
-        long256_arr_idx = 0;
         long512_arr_idx = 0;
         i1 = new int[ARRAYLEN];
         i2 = new int[ARRAYLEN];
@@ -126,10 +120,7 @@ public class MaskedLogicOpts {
     @Setup(Level.Invocation)
     public void init_per_invoc() {
         int512_arr_idx = (int512_arr_idx + 16) & (ARRAYLEN-1);
-        int256_arr_idx = (int256_arr_idx + 8) & (ARRAYLEN-1);
-        int128_arr_idx = (int128_arr_idx + 4) & (ARRAYLEN-1);
         long512_arr_idx = (long512_arr_idx + 8) & (ARRAYLEN-1);
-        long256_arr_idx = (long256_arr_idx + 4) & (ARRAYLEN-1);
     }
 
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -243,10 +234,10 @@ public class MaskedLogicOpts {
     @CompilerControl(CompilerControl.Mode.INLINE)
     public void maskedLogicOperationsLongKernel(VectorSpecies<Long> SPECIES) {
        lmask = VectorMask.fromArray(SPECIES, mask_arr, 0);
-       lv2 = LongVector.fromArray(SPECIES, l2, long256_arr_idx);
-       lv3 = LongVector.fromArray(SPECIES, l3, long256_arr_idx);
-       lv4 = LongVector.fromArray(SPECIES, l4, long256_arr_idx);
-       lv5 = LongVector.fromArray(SPECIES, l5, long256_arr_idx);
+       lv2 = LongVector.fromArray(SPECIES, l2, long512_arr_idx);
+       lv3 = LongVector.fromArray(SPECIES, l3, long512_arr_idx);
+       lv4 = LongVector.fromArray(SPECIES, l4, long512_arr_idx);
+       lv5 = LongVector.fromArray(SPECIES, l5, long512_arr_idx);
        for(int i = 0; i < INVOC_COUNTER; i++) {
            for(int j = 0 ; j < ARRAYLEN; j+= SPECIES.length()) {
                LongVector.fromArray(SPECIES, l1, j)

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskedLogicOpts.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskedLogicOpts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,9 @@ public class MaskedLogicOpts {
     VectorSpecies<Long> lspecies;
 
     int int512_arr_idx;
+    int int256_arr_idx;
+    int int128_arr_idx;
+    int long256_arr_idx;
     int long512_arr_idx;
 
     private Random r = new Random();
@@ -88,6 +91,9 @@ public class MaskedLogicOpts {
     @Setup(Level.Trial)
     public void init() {
         int512_arr_idx = 0;
+        int256_arr_idx = 0;
+        int128_arr_idx = 0;
+        long256_arr_idx = 0;
         long512_arr_idx = 0;
         i1 = new int[ARRAYLEN];
         i2 = new int[ARRAYLEN];
@@ -120,7 +126,10 @@ public class MaskedLogicOpts {
     @Setup(Level.Invocation)
     public void init_per_invoc() {
         int512_arr_idx = (int512_arr_idx + 16) & (ARRAYLEN-1);
+        int256_arr_idx = (int256_arr_idx + 8) & (ARRAYLEN-1);
+        int128_arr_idx = (int128_arr_idx + 4) & (ARRAYLEN-1);
         long512_arr_idx = (long512_arr_idx + 8) & (ARRAYLEN-1);
+        long256_arr_idx = (long256_arr_idx + 4) & (ARRAYLEN-1);
     }
 
     @CompilerControl(CompilerControl.Mode.INLINE)
@@ -234,10 +243,10 @@ public class MaskedLogicOpts {
     @CompilerControl(CompilerControl.Mode.INLINE)
     public void maskedLogicOperationsLongKernel(VectorSpecies<Long> SPECIES) {
        lmask = VectorMask.fromArray(SPECIES, mask_arr, 0);
-       lv2 = LongVector.fromArray(SPECIES, l2, long512_arr_idx);
-       lv3 = LongVector.fromArray(SPECIES, l3, long512_arr_idx);
-       lv4 = LongVector.fromArray(SPECIES, l4, long512_arr_idx);
-       lv5 = LongVector.fromArray(SPECIES, l5, long512_arr_idx);
+       lv2 = LongVector.fromArray(SPECIES, l2, long256_arr_idx);
+       lv3 = LongVector.fromArray(SPECIES, l3, long256_arr_idx);
+       lv4 = LongVector.fromArray(SPECIES, l4, long256_arr_idx);
+       lv5 = LongVector.fromArray(SPECIES, l5, long256_arr_idx);
        for(int i = 0; i < INVOC_COUNTER; i++) {
            for(int j = 0 ; j < ARRAYLEN; j+= SPECIES.length()) {
                LongVector.fromArray(SPECIES, l1, j)


### PR DESCRIPTION
Suite `MaskedLogicOpts.maskedLogicOperationsLong512()` failed on both x86 and AArch64 with the following error:

```
java.lang.IndexOutOfBoundsException: Index 252 out of bounds for length 249
```

The variable `long256_arr_idx` is misused when indexing `LongVector l2`, `l3`, `l4`, `l5` in function `maskedLogicOperationsLongKernel()` resulting in the IndexOutOfBoundsException error. On the other hand, the unified index for 128-bit, 256-bit and 512-bit species might not be proper since it leaves gaps in between when accessing the data for 128-bit and 256-bit species. This will unnecessarily include the noise due to cache misses or (on some targets) prefetching additional cache lines which are not usable, thereby impacting the crispness of microbenchmark.

Hence, we improved the benchmark from several aspects,
1. Used sufficient number of predicated operations within the vector loop while minimizing the noise due to memory operations.
2. Modified the index computation logic which can now withstand any ARRAYLEN without resulting in an IOOBE.
3. Removed redundant vector read/writes to instance fields, thus eliminating significant boxing penalty which translates into throughput gains.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346954](https://bugs.openjdk.org/browse/JDK-8346954): [JMH] jdk.incubator.vector.MaskedLogicOpts fails due to IndexOutOfBoundsException (**Bug** - P4)


### Reviewers
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer) Review applies to [083bedec](https://git.openjdk.org/jdk/pull/22963/files/083bedec04d5ab78a420e156e74c1257ce30aee8)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)

### Contributors
 * Jatin Bhateja `<jbhateja@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22963/head:pull/22963` \
`$ git checkout pull/22963`

Update a local copy of the PR: \
`$ git checkout pull/22963` \
`$ git pull https://git.openjdk.org/jdk.git pull/22963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22963`

View PR using the GUI difftool: \
`$ git pr show -t 22963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22963.diff">https://git.openjdk.org/jdk/pull/22963.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22963#issuecomment-2638273429)
</details>
