### PR TITLE
8347127: CTW fails to build after JDK-8334733

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/Makefile
+++ b/test/hotspot/jtreg/testlibrary/ctw/Makefile
@@ -53,6 +53,7 @@ WB_CLASS_FILES := $(subst $(TESTLIBRARY_DIR)/,,$(WB_SRC_FILES))
 WB_CLASS_FILES := $(patsubst %.java,%.class,$(WB_CLASS_FILES))
 EXPORTS=--add-exports java.base/jdk.internal.jimage=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.module=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.access=ALL-UNNAMED
 


### PR DESCRIPTION
Fixes the JDK 24 regression for standalone CTW runner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347127](https://bugs.openjdk.org/browse/JDK-8347127): CTW fails to build after JDK-8334733 (**Bug** - P3)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22964/head:pull/22964` \
`$ git checkout pull/22964`

Update a local copy of the PR: \
`$ git checkout pull/22964` \
`$ git pull https://git.openjdk.org/jdk.git pull/22964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22964`

View PR using the GUI difftool: \
`$ git pr show -t 22964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22964.diff">https://git.openjdk.org/jdk/pull/22964.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22964#issuecomment-2577219018)
</details>
