### PR TITLE
8347256: Epsilon: Demote heap size and AlwaysPreTouch warnings to info level

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
@@ -64,18 +64,6 @@ void EpsilonArguments::initialize() {
     }
   }
 #endif
-
-  // Suggest that non-resizable heap might be better for some configurations.
-  // We are not adjusting the heap size by ourselves, because it affects startup time.
-  if (InitialHeapSize != MaxHeapSize) {
-    log_info(gc)("Consider setting -Xms equal to -Xmx to avoid resizing hiccups");
-  }
-
-  // Suggest that AlwaysPreTouch might be better for some configurations.
-  // We are not turning this on by ourselves, because it affects startup time.
-  if (FLAG_IS_DEFAULT(AlwaysPreTouch) && !AlwaysPreTouch) {
-    log_info(gc)("Consider enabling -XX:+AlwaysPreTouch to avoid memory commit hiccups");
-  }
 }
 
 void EpsilonArguments::initialize_alignments() {

--- a/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
@@ -64,6 +64,18 @@ void EpsilonArguments::initialize() {
     }
   }
 #endif
+
+  // Suggest that non-resizable heap might be better for some configurations.
+  // We are not adjusting the heap size by ourselves, because it affects startup time.
+  if (InitialHeapSize != MaxHeapSize) {
+    log_info(gc)("Consider setting -Xms equal to -Xmx to avoid resizing hiccups");
+  }
+
+  // Suggest that AlwaysPreTouch might be better for some configurations.
+  // We are not turning this on by ourselves, because it affects startup time.
+  if (FLAG_IS_DEFAULT(AlwaysPreTouch) && !AlwaysPreTouch) {
+    log_info(gc)("Consider enabling -XX:+AlwaysPreTouch to avoid memory commit hiccups");
+  }
 }
 
 void EpsilonArguments::initialize_alignments() {

--- a/src/hotspot/share/gc/epsilon/epsilonInitLogger.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonInitLogger.cpp
@@ -32,18 +32,6 @@
 #include "utilities/globalDefinitions.hpp"
 
 void EpsilonInitLogger::print_gc_specific() {
-  // Warn users that non-resizable heap might be better for some configurations.
-  // We are not adjusting the heap size by ourselves, because it affects startup time.
-  if (InitialHeapSize != MaxHeapSize) {
-    log_warning(gc, init)("Consider setting -Xms equal to -Xmx to avoid resizing hiccups");
-  }
-
-  // Warn users that AlwaysPreTouch might be better for some configurations.
-  // We are not turning this on by ourselves, because it affects startup time.
-  if (FLAG_IS_DEFAULT(AlwaysPreTouch) && !AlwaysPreTouch) {
-    log_warning(gc, init)("Consider enabling -XX:+AlwaysPreTouch to avoid memory commit hiccups");
-  }
-
   if (UseTLAB) {
     size_t max_tlab = EpsilonHeap::heap()->max_tlab_size() * HeapWordSize;
     log_info(gc, init)("TLAB Size Max: " SIZE_FORMAT "%s",

--- a/src/hotspot/share/gc/epsilon/epsilonInitLogger.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonInitLogger.cpp
@@ -45,6 +45,18 @@ void EpsilonInitLogger::print_gc_specific() {
   } else {
     log_info(gc, init)("TLAB: Disabled");
   }
+
+  // Suggest that non-resizable heap might be better for some configurations.
+  // We are not adjusting the heap size by ourselves, because it affects startup time.
+  if (InitialHeapSize != MaxHeapSize) {
+    log_info(gc)("Consider setting -Xms equal to -Xmx to avoid resizing hiccups");
+  }
+
+  // Suggest that AlwaysPreTouch might be better for some configurations.
+  // We are not turning this on by ourselves, because it affects startup time.
+  if (FLAG_IS_DEFAULT(AlwaysPreTouch) && !AlwaysPreTouch) {
+    log_info(gc)("Consider enabling -XX:+AlwaysPreTouch to avoid memory commit hiccups");
+  }
 }
 
 void EpsilonInitLogger::print() {


### PR DESCRIPTION
For Epsilon, we have added `log_warning` messages when heap size and AlwaysPreTouch configuration is not great with [JDK-8232051](https://bugs.openjdk.org/browse/JDK-8232051). Unfortunately, this means we print this warning all the time, even though users might not actually run into problems there, or when users tried to implement these suggestions and still decided to run against them.

I think we want to emit the suggestions in the normal GC log instead, so they are not printed all the time. Additionally, I moved the printing at the end of init logger, so it does not come in the middle of `gc,init` block.

Output before:

```
$ java -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC Hello.java 
[0.008s][warning][gc,init] Consider setting -Xms equal to -Xmx to avoid resizing hiccups
[0.008s][warning][gc,init] Consider enabling -XX:+AlwaysPreTouch to avoid memory commit hiccups
Hello!

$ java -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc Hello.java 
[0.008s][info][gc] Using Epsilon
[0.008s][warning][gc,init] Consider setting -Xms equal to -Xmx to avoid resizing hiccups
[0.008s][warning][gc,init] Consider enabling -XX:+AlwaysPreTouch to avoid memory commit hiccups
Hello!
[0.757s][info   ][gc     ] Heap: 1024M reserved, 129M (12.60%) committed, 23906K (2.28%) used
```

Output after:

```
$ java -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC Hello.java 
Hello!

$ java -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc Hello.java 
[0.009s][info][gc] Using Epsilon
[0.009s][info][gc] Consider setting -Xms equal to -Xmx to avoid resizing hiccups
[0.009s][info][gc] Consider enabling -XX:+AlwaysPreTouch to avoid memory commit hiccups
Hello!
[0.753s][info][gc] Heap: 1024M reserved, 129M (12.60%) committed, 23908K (2.28%) used
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347256](https://bugs.openjdk.org/browse/JDK-8347256): Epsilon: Demote heap size and AlwaysPreTouch warnings to info level (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22965/head:pull/22965` \
`$ git checkout pull/22965`

Update a local copy of the PR: \
`$ git checkout pull/22965` \
`$ git pull https://git.openjdk.org/jdk.git pull/22965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22965`

View PR using the GUI difftool: \
`$ git pr show -t 22965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22965.diff">https://git.openjdk.org/jdk/pull/22965.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22965#issuecomment-2577396022)
</details>
