### PR TITLE
8346880: [aix] java/lang/ProcessHandle/InfoTest.java still fails: "reported cputime less than expected"

### DIFF
--- a/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
+++ b/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
@@ -164,9 +164,8 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
 pid_t os_getParentPidAndTimings(JNIEnv *env, pid_t pid, jlong *total, jlong *start) {
     pid_t the_pid = pid;
     struct procentry64 ProcessBuffer;
-    struct fdsinfo64 FileDescBuffer;
 
-    if (getprocs64(&ProcessBuffer, sizeof(ProcessBuffer), NULL, sizeof(FileDescBuffer), &the_pid, 1 ) <= 0) {
+    if (getprocs64(&ProcessBuffer, sizeof(ProcessBuffer), NULL, sizeof(struct fdsinfo64), &the_pid, 1 ) <= 0) {
         return -1;
     }
 

--- a/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
+++ b/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
@@ -165,7 +165,7 @@ pid_t os_getParentPidAndTimings(JNIEnv *env, pid_t pid, jlong *total, jlong *sta
     pid_t the_pid = pid;
     struct procentry64 ProcessBuffer;
 
-    if (getprocs64(&ProcessBuffer, sizeof(ProcessBuffer), NULL, sizeof(struct fdsinfo64), &the_pid, 1 ) <= 0) {
+    if (getprocs64(&ProcessBuffer, sizeof(ProcessBuffer), NULL, sizeof(struct fdsinfo64), &the_pid, 1) <= 0) {
         return -1;
     }
 


### PR DESCRIPTION
The test java/lang/ProcessHandle/InfoTest.java still fails sporadically on AIX. The test exclusion was removed through [JDK-8211847](https://bugs.openjdk.org/browse/JDK-8211847) under the assumption the problem was gone. But it turned out that it was wrong.

We can see an exception like:

java.lang.AssertionError: reported cputime less than expected: PT0.2S, actual: Optional[PT0.021179882S]
at org.testng.Assert.fail(Assert.java:99)
at InfoTest.test1(InfoTest.java:110)

After a discussion with Roger Riggs and the team, we came to the following conclusion.
The problem is based on 2 independent causes; one fundamental and one AIX-specific.

The fundamental cause is as follows:
Modern hardware provides many hardware threads (up to several hundred) that enable the worker threads of the processes to be processed in real parallel. To ensure that such a worker thread does not take up a hardware thread resource for itself, it is rolled out by the OS after a few ms at the latest to make room for another worker thread, possibly from another process.
The OS continuously adds up all the times that each worker thread of a process is active as process cpu time.

It is easy to see that there is no correlation between the CPU time of a process and the real time(wall time).

If you have a system with many hardware threads and few worker threads, these are active almost all the time. If they are rolled out, they are immediately rolled back in due to a lack of competition. If a process has several worker threads, the CPU time will increase faster than the real time. In this case, cpu time > real time is to be expected, which is what the test wants.

However, if the same system is heavily loaded, i.e. there are a lot of worker threads competing on one hardware thread, each individual worker thread can only become active relatively rarely. Even if a process has several worker threads, the total CPU time will be less than the past real time. This is even more pronounced if the individual worker threads have to wait for each other via synchronization objects. Since this is the normal case, cpu time < real time usually applies.

Therefore, such a test makes little sense in principle.

The AIX-specific cause of the problem lies in the API used to get the cpu time. The `/proc/<pid>/psinfo` file is evaluated to obtain the cpu time. The /proc directory is only present on AIX for portability reasons. The data in it is only updated at long intervals. For example, the cpu time is only updated every 1-2 seconds, which can cause the error.
The better solution here would be the getprocs64() API. Here the values ​​for the cpu time are updated by the OS kernel every few ms.

It may therefore be that the error no longer occurs after adjusting the AIX coding, but in principle the problem is not solved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346880](https://bugs.openjdk.org/browse/JDK-8346880): [aix] java/lang/ProcessHandle/InfoTest.java still fails: "reported cputime less than expected" (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) Review applies to [1a5a1951](https://git.openjdk.org/jdk/pull/22966/files/1a5a19519cf7d25ca3110564381a0e91612002b0)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22966/head:pull/22966` \
`$ git checkout pull/22966`

Update a local copy of the PR: \
`$ git checkout pull/22966` \
`$ git pull https://git.openjdk.org/jdk.git pull/22966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22966`

View PR using the GUI difftool: \
`$ git pr show -t 22966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22966.diff">https://git.openjdk.org/jdk/pull/22966.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22966#issuecomment-2579792870)
</details>
