### PR TITLE
8347006: LoadRangeNode floats above array guard in arraycopy intrinsic

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5915,8 +5915,13 @@ bool LibraryCallKit::inline_arraycopy() {
     record_for_igvn(slow_region);
 
     // (1) src and dest are arrays.
+    // Keep track of the information that src/dest are arrays to prevent below array specific accesses from floating above.
     generate_non_array_guard(load_object_klass(src), slow_region);
+    const Type* tary = TypeAryPtr::make(TypePtr::BotPTR, TypeAry::make(Type::BOTTOM, TypeInt::POS), nullptr, false, Type::OffsetBot);
+    src = _gvn.transform(new CheckCastPPNode(control(), src, tary));
+
     generate_non_array_guard(load_object_klass(dest), slow_region);
+    dest = _gvn.transform(new CheckCastPPNode(control(), dest, tary));
 
     // (2) src and dest arrays must have elements of the same BasicType
     // done at macro expansion or at Ideal transformation time

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyNoInit.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyNoInit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,13 @@
 
 /*
  * @test
- * @bug 8064703
+ * @bug 8064703 8347006
  * @summary Deoptimization between array allocation and arraycopy may result in non initialized array
  *
  * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:TypeProfileLevel=020
+ *                   compiler.arraycopy.TestArrayCopyNoInit
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:TypeProfileLevel=020
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseCompactObjectHeaders -XX:-UseTLAB
  *                   compiler.arraycopy.TestArrayCopyNoInit
  */
 


### PR DESCRIPTION
C2's arraycopy intrinsic adds guards that check that the source and destination objects are arrays:
https://github.com/openjdk/jdk/blob/afe543414f58a04832d4f07dea88881d64954a0b/src/hotspot/share/opto/library_call.cpp#L5917-L5919

If these guards pass, the array length is loaded:
https://github.com/openjdk/jdk/blob/afe543414f58a04832d4f07dea88881d64954a0b/src/hotspot/share/opto/library_call.cpp#L5930-L5933

But since the `LoadRangeNode` is not pinned, it might float above the array guard:
https://github.com/openjdk/jdk/blob/afe543414f58a04832d4f07dea88881d64954a0b/src/hotspot/share/opto/graphKit.cpp#L1214

If the object is not an array, we will read garbage. That's usually fine because the result will not be used (the array guard will trigger) but with `-XX:+UseCompactObjectHeaders` it can happen that the memory right after the header is not mapped and we crash.

The fix is to add a `CheckCastPPNode` to propagate the information that the operand is an array and prevent the load from floating. 

Thanks to @shipilev for identifying the root cause!

Best regards,
Tobias