### PR TITLE
8347124: Clean tests with --enable-linkable-runtime

### DIFF
--- a/test/jdk/jdk/jfr/jvm/TestModularImage.java
+++ b/test/jdk/jdk/jfr/jvm/TestModularImage.java
@@ -43,7 +43,7 @@ import jdk.test.lib.process.ProcessTools;
  *          as expected
  * @requires vm.hasJFR
  * @library /test/lib
- * @run driver jdk.jfr.jvm.TestModularImage
+ * @run main/othervm jdk.jfr.jvm.TestModularImage
  */
 public class TestModularImage {
     private static final String STARTED_RECORDING = "Started recording";

--- a/test/jdk/jdk/jfr/jvm/TestModularImage.java
+++ b/test/jdk/jdk/jfr/jvm/TestModularImage.java
@@ -44,7 +44,10 @@ import jdk.test.lib.process.ProcessTools;
  * @requires vm.hasJFR
  * @library /test/lib
  * @comment Test is being run in othervm to support JEP 493 enabled
- *          JDKs which don't allow patched modules
+ *          JDKs which don't allow patched modules. Note that jtreg patches
+ *          module java.base to add java.lang.JTRegModuleHelper. If then a
+ *          jlink run is attempted in-process - using the ToolProvider API -
+ *          on a JEP 493 enabled JDK, the test fails.
  * @run main/othervm jdk.jfr.jvm.TestModularImage
  */
 public class TestModularImage {

--- a/test/jdk/jdk/jfr/jvm/TestModularImage.java
+++ b/test/jdk/jdk/jfr/jvm/TestModularImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,8 @@ import jdk.test.lib.process.ProcessTools;
  *          as expected
  * @requires vm.hasJFR
  * @library /test/lib
+ * @comment Test is being run in othervm to support JEP 493 enabled
+ *          JDKs which don't allow patched modules
  * @run main/othervm jdk.jfr.jvm.TestModularImage
  */
 public class TestModularImage {

--- a/test/jdk/tools/launcher/SourceMode.java
+++ b/test/jdk/tools/launcher/SourceMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
  * @bug 8192920 8204588 8210275 8286571
  * @summary Test source mode
  * @modules jdk.compiler jdk.jlink
+ * @comment Test is being run in othervm to support JEP 493 enabled
+ *          JDKs which don't allow patched modules
  * @run main/othervm SourceMode
  */
 

--- a/test/jdk/tools/launcher/SourceMode.java
+++ b/test/jdk/tools/launcher/SourceMode.java
@@ -27,7 +27,10 @@
  * @summary Test source mode
  * @modules jdk.compiler jdk.jlink
  * @comment Test is being run in othervm to support JEP 493 enabled
- *          JDKs which don't allow patched modules
+ *          JDKs which don't allow patched modules. Note that jtreg patches
+ *          module java.base to add java.lang.JTRegModuleHelper. If then a
+ *          jlink run is attempted in-process - using the ToolProvider API -
+ *          on a JEP 493 enabled JDK, the test fails.
  * @run main/othervm SourceMode
  */
 

--- a/test/jdk/tools/launcher/SourceMode.java
+++ b/test/jdk/tools/launcher/SourceMode.java
@@ -26,7 +26,7 @@
  * @bug 8192920 8204588 8210275 8286571
  * @summary Test source mode
  * @modules jdk.compiler jdk.jlink
- * @run main SourceMode
+ * @run main/othervm SourceMode
  */
 
 


### PR DESCRIPTION
Please review this trivial test-only patch in support of running tests on JEP 493 enabled builds. Both tests use the `ToolProvider` API so as to run `jlink` in-process of the test JVM which includes module patches (as in - uses `--patch-module`) which is not supported for JEP 493 enabled JDKs. The proposed fix is to run those two tests in `/othervm` so as to no longer see the module patch of the test JDK.

Testing:
- [x] GHA
- [x] Affected tests which fail prior the patch and pass after with a JEP 493 enabled JDK. Also tested on a JDK that includes `jmods` folder.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347124](https://bugs.openjdk.org/browse/JDK-8347124): Clean tests with --enable-linkable-runtime (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [6eceb0de](https://git.openjdk.org/jdk/pull/22969/files/6eceb0de1476534f83836262e3ed0496ebfa87c4)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22969/head:pull/22969` \
`$ git checkout pull/22969`

Update a local copy of the PR: \
`$ git checkout pull/22969` \
`$ git pull https://git.openjdk.org/jdk.git pull/22969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22969`

View PR using the GUI difftool: \
`$ git pr show -t 22969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22969.diff">https://git.openjdk.org/jdk/pull/22969.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22969#issuecomment-2577813338)
</details>
