### PR TITLE
8347268: [ubsan] logOutput.cpp:357:21: runtime error: applying non-zero offset 1 to null pointer

### DIFF
--- a/src/hotspot/share/logging/logOutput.cpp
+++ b/src/hotspot/share/logging/logOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/logging/logOutput.cpp
+++ b/src/hotspot/share/logging/logOutput.cpp
@@ -354,7 +354,9 @@ bool LogOutput::parse_options(const char* options, outputStream* errstream) {
       }
       break;
     }
-    pos = comma_pos + 1;
+    if (comma_pos != nullptr) {
+      pos = comma_pos + 1;
+    }
   } while (comma_pos != nullptr);
 
   os::free(opts);


### PR DESCRIPTION
When running ubsan-enabled binaries on macOS aarch64, the following issue is reported in the test
jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java
src/hotspot/share/logging/logOutput.cpp:357:21: runtime error: applying non-zero offset 1 to null pointer
UndefinedBehaviorSanitizer:DEADLYSIGNAL
UndefinedBehaviorSanitizer: nested bug in the same thread, aborting.

This is similar to [JDK-8346881](https://bugs.openjdk.org/browse/JDK-8346881) .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347268](https://bugs.openjdk.org/browse/JDK-8347268): [ubsan] logOutput.cpp:357:21: runtime error: applying non-zero offset 1 to null pointer (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22971/head:pull/22971` \
`$ git checkout pull/22971`

Update a local copy of the PR: \
`$ git checkout pull/22971` \
`$ git pull https://git.openjdk.org/jdk.git pull/22971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22971`

View PR using the GUI difftool: \
`$ git pr show -t 22971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22971.diff">https://git.openjdk.org/jdk/pull/22971.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22971#issuecomment-2577882077)
</details>
