### PR TITLE
8346457: AOT cache creation crashes with "assert(pair_at(i).match() < pair_at(i+1).match()) failed: unsorted table entries"

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -986,8 +986,10 @@ bool MetaspaceShared::try_link_class(JavaThread* current, InstanceKlass* ik) {
                     ik->external_name());
       CLEAR_PENDING_EXCEPTION;
       SystemDictionaryShared::set_class_has_failed_verification(ik);
+    } else {
+      assert(!SystemDictionaryShared::has_class_failed_verification(ik), "sanity");
+      ik->compute_has_loops_flag_for_methods();
     }
-    ik->compute_has_loops_flag_for_methods();
     BytecodeVerificationLocal = saved;
     return true;
   } else {

--- a/test/hotspot/jtreg/runtime/cds/appcds/CreateAOTCacheVerifyError.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/CreateAOTCacheVerifyError.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8346457
+ * @summary VM should not crash during AOT cache creation when encountering a
+ *          class with VerifyError.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @compile test-classes/BadLookupSwitch.jcod
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar badlookupswitch.jar BadLookupSwitch
+ * @run driver CreateAOTCacheVerifyError
+ */
+
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class CreateAOTCacheVerifyError {
+
+    public static void main(String[] args) throws Exception {
+        String appJar = ClassFileInstaller.getJarPath("badlookupswitch.jar");
+        String classList[] = { BadLookupSwitch.class.getName() };
+        OutputAnalyzer out = TestCommon.testDump(appJar, classList);
+        out.shouldContain("Preload Warning: Verification failed for BadLookupSwitch");
+        out.shouldHaveExitValue(0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/BadLookupSwitch.jcod
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/BadLookupSwitch.jcod
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+class BadLookupSwitch {
+  0xCAFEBABE;
+  0;
+  50;
+  [] { // Constant Pool
+    ; // first element is empty
+    class #12; // #1 at 0x0A
+    class #15; // #2 at 0x0D
+    Method #2 #4; // #3 at 0x10
+    NameAndType #6 #5; // #4 at 0x15
+    Utf8 "()V"; // #5 at 0x1A
+    Utf8 "<init>"; // #6 at 0x20
+    Utf8 "Code"; // #7 at 0x29
+    Utf8 "ConstantValue"; // #8 at 0x30
+    Utf8 "Exceptions"; // #9 at 0x40
+    Utf8 "LineNumberTable"; // #10 at 0x4D
+    Utf8 "LocalVariables"; // #11 at 0x5F
+    Utf8 "BadLookupSwitch"; // #12 at 0x70
+    Utf8 "SourceFile"; // #13 at 0x76
+    Utf8 "f.java"; // #14 at 0x83
+    Utf8 "java/lang/Object"; // #15 at 0x8C
+    Utf8 "m"; // #16 at 0x9F
+    Utf8 "StackMapTable"; // #17    
+  } // Constant Pool
+
+  0x0020; // access
+  #1;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // fields
+  } // fields
+
+  [2] { // methods
+    { // Member at 0xAF
+      0x0001; // access
+      #16; // name_cpx
+      #5; // sig_cpx
+      [] {  // Attributes
+        Attr(#7) { // Code at 0xB7
+          1; // max_stack
+          1; // max_locals
+          Bytes[29] {
+            0x04AB00000000001B; // iconst_1;
+/* right:
+            0x0000000200000001; // lookupswitch 27 2 1 27 2 27;
+            0x0000001B00000002;
+            0x0000001B;
+end right */
+// wrong:
+            0x0000000200000002; // lookupswitch 27 2 2 27 1 27;
+            0x0000001B00000001;
+            0x0000001B;
+// end wrong
+            0xB1;               // return
+          };
+          [0] { // Traps
+          } // end Traps
+          [] {  // Attributes
+            Attr(#17) { // StackMap
+              [] { // 
+                255b,  28, []{O,1}, []{};
+              }
+            } // end StackMap
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member at 0xD6
+      0x0000; // access
+      #6; // name_cpx
+      #5; // sig_cpx
+      [1] {  // Attributes
+        Attr(#7) { // Code at 0xDE
+          1; // max_stack
+          1; // max_locals
+          Bytes[5] {
+            0x2AB70003B1;
+          };
+          [0] { // Traps
+          } // end Traps
+          [] {  // Attributes
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [] {  // Attributes
+  } // Attributes
+} // end class


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [8d388ccd](https://github.com/openjdk/jdk/commit/8d388ccd9eae279018bf499e49152fd276aab5bf) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Calvin Cheung on 6 Jan 2025 and was reviewed by Ioi Lam and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346457](https://bugs.openjdk.org/browse/JDK-8346457): AOT cache creation crashes with "assert(pair_at(i).match() &lt; pair_at(i+1).match()) failed: unsorted table entries" (**Bug** - P2)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22975/head:pull/22975` \
`$ git checkout pull/22975`

Update a local copy of the PR: \
`$ git checkout pull/22975` \
`$ git pull https://git.openjdk.org/jdk.git pull/22975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22975`

View PR using the GUI difftool: \
`$ git pr show -t 22975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22975.diff">https://git.openjdk.org/jdk/pull/22975.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22975#issuecomment-2578186137)
</details>
