### PR TITLE
8346581: JRadioButton/ButtonGroupFocusTest.java fails in CI on Linux

### DIFF
--- a/test/jdk/javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java
+++ b/test/jdk/javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java
@@ -108,20 +108,23 @@ public final class ButtonGroupFocusTest {
 
             button2.setSelected(true);
 
+            // Debugging aid: log focus owner changes...
             KeyboardFocusManager focusManager = getCurrentKeyboardFocusManager();
-            focusManager.addPropertyChangeListener(new PropertyChangeListener() {
-                @Override
-                public void propertyChange(PropertyChangeEvent evt) {
-                    System.out.println(evt.getPropertyName()
-                                       + "\n\t" + evt.getOldValue()
-                                       + "\n\t" + evt.getNewValue());
-                }
-            });
+            focusManager.addPropertyChangeListener("focusOwner",
+                    new PropertyChangeListener() {
+                        @Override
+                        public void propertyChange(PropertyChangeEvent evt) {
+                            System.out.println(evt.getPropertyName()
+                                               + "\n\t" + evt.getOldValue()
+                                               + "\n\t" + evt.getNewValue());
+                        }
+                    });
 
+            // ...and dispatched key events
             Toolkit.getDefaultToolkit().addAWTEventListener(new AWTEventListener() {
                 @Override
                 public void eventDispatched(AWTEvent event) {
-                    System.out.println("  Dispatched " + event);
+                    System.out.println("Dispatched " + event);
                 }
             }, AWTEvent.KEY_EVENT_MASK);
 

--- a/test/jdk/javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java
+++ b/test/jdk/javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java
@@ -69,13 +69,12 @@ public final class ButtonGroupFocusTest {
 
     private static final CountDownLatch button2FocusLatch2 = new CountDownLatch(2);
 
-    private static final long FOCUS_TIMEOUT = 3;
+    private static final long FOCUS_TIMEOUT = 4;
 
     private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
         final Robot robot = new Robot();
-        robot.setAutoDelay(100);
 
         SwingUtilities.invokeAndWait(() -> {
             frame = new JFrame("ButtonGroupFocusTest");

--- a/test/jdk/javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java
+++ b/test/jdk/javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java
@@ -52,6 +52,7 @@ import javax.swing.JRadioButton;
 import javax.swing.SwingUtilities;
 
 import static java.awt.KeyboardFocusManager.getCurrentKeyboardFocusManager;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public final class ButtonGroupFocusTest {
@@ -65,6 +66,8 @@ public final class ButtonGroupFocusTest {
     private static final CountDownLatch button2FocusLatch = new CountDownLatch(1);
     private static final CountDownLatch button3FocusLatch = new CountDownLatch(1);
     private static final CountDownLatch button4FocusLatch = new CountDownLatch(1);
+
+    private static final CountDownLatch button2FocusLatch2 = new CountDownLatch(2);
 
     private static final long FOCUS_TIMEOUT = 3;
 
@@ -101,6 +104,8 @@ public final class ButtonGroupFocusTest {
             button2.addFocusListener(new LatchFocusListener(button2FocusLatch));
             button3.addFocusListener(new LatchFocusListener(button3FocusLatch));
             button4.addFocusListener(new LatchFocusListener(button4FocusLatch));
+
+            button2.addFocusListener(new LatchFocusListener(button2FocusLatch2));
 
             button2.setSelected(true);
 
@@ -143,6 +148,10 @@ public final class ButtonGroupFocusTest {
             }
             robot.waitForIdle();
             robot.delay(200);
+
+            if (button2FocusLatch2.await(1, MILLISECONDS)) {
+                throw new RuntimeException("Focus moved back to Button 2");
+            }
 
             SwingUtilities.invokeAndWait(() -> button3.setSelected(true));
             robot.waitForIdle();

--- a/test/jdk/javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java
+++ b/test/jdk/javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,26 +28,54 @@
  * @run main ButtonGroupFocusTest
  */
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.AWTEvent;
+import java.awt.Container;
+import java.awt.FlowLayout;
+import java.awt.KeyboardFocusManager;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.AWTEventListener;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
 import java.awt.event.KeyEvent;
+import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
 
-public class ButtonGroupFocusTest {
+import javax.imageio.ImageIO;
+import javax.swing.ButtonGroup;
+import javax.swing.JFrame;
+import javax.swing.JRadioButton;
+import javax.swing.SwingUtilities;
+
+import static java.awt.KeyboardFocusManager.getCurrentKeyboardFocusManager;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public final class ButtonGroupFocusTest {
 
     private static JRadioButton button1;
     private static JRadioButton button2;
     private static JRadioButton button3;
     private static JRadioButton button4;
     private static JRadioButton button5;
-    private static Robot robot;
+
+    private static final CountDownLatch button2FocusLatch = new CountDownLatch(1);
+    private static final CountDownLatch button3FocusLatch = new CountDownLatch(1);
+    private static final CountDownLatch button4FocusLatch = new CountDownLatch(1);
+
+    private static final long FOCUS_TIMEOUT = 3;
+
     private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
-        robot = new Robot();
+        final Robot robot = new Robot();
         robot.setAutoDelay(100);
 
         SwingUtilities.invokeAndWait(() -> {
-            frame = new JFrame();
+            frame = new JFrame("ButtonGroupFocusTest");
             Container contentPane = frame.getContentPane();
             contentPane.setLayout(new FlowLayout());
             button1 = new JRadioButton("Button 1");
@@ -60,6 +88,7 @@ public class ButtonGroupFocusTest {
             contentPane.add(button4);
             button5 = new JRadioButton("Button 5");
             contentPane.add(button5);
+
             ButtonGroup group = new ButtonGroup();
             group.add(button1);
             group.add(button2);
@@ -69,52 +98,95 @@ public class ButtonGroupFocusTest {
             group.add(button4);
             group.add(button5);
 
+            button2.addFocusListener(new LatchFocusListener(button2FocusLatch));
+            button3.addFocusListener(new LatchFocusListener(button3FocusLatch));
+            button4.addFocusListener(new LatchFocusListener(button4FocusLatch));
+
             button2.setSelected(true);
 
+            KeyboardFocusManager focusManager = getCurrentKeyboardFocusManager();
+            focusManager.addPropertyChangeListener(new PropertyChangeListener() {
+                @Override
+                public void propertyChange(PropertyChangeEvent evt) {
+                    System.out.println(evt.getPropertyName()
+                                       + "\n\t" + evt.getOldValue()
+                                       + "\n\t" + evt.getNewValue());
+                }
+            });
+
+            Toolkit.getDefaultToolkit().addAWTEventListener(new AWTEventListener() {
+                @Override
+                public void eventDispatched(AWTEvent event) {
+                    System.out.println("  Dispatched " + event);
+                }
+            }, AWTEvent.KEY_EVENT_MASK);
+
             frame.pack();
+            frame.setLocationRelativeTo(null);
             frame.setVisible(true);
         });
 
-        robot.waitForIdle();
-        robot.delay(200);
-
-        SwingUtilities.invokeAndWait(() -> {
-            if( !button2.hasFocus() ) {
-                frame.dispose();
-                throw new RuntimeException(
-                        "Button 2 should get focus after activation");
+        try {
+            if (!button2FocusLatch.await(FOCUS_TIMEOUT, SECONDS)) {
+                throw new RuntimeException("Button 2 should get focus "
+                                           + "after activation");
             }
-        });
+            robot.waitForIdle();
+            robot.delay(200);
 
-        robot.keyPress(KeyEvent.VK_TAB);
-        robot.keyRelease(KeyEvent.VK_TAB);
+            System.out.println("\n\n*** Tab 1st");
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
 
-        robot.waitForIdle();
-        robot.delay(200);
-
-        SwingUtilities.invokeAndWait(() -> {
-            if( !button4.hasFocus() ) {
-                frame.dispose();
-                throw new RuntimeException(
-                        "Button 4 should get focus");
+            if (!button4FocusLatch.await(FOCUS_TIMEOUT, SECONDS)) {
+                throw new RuntimeException("Button 4 should get focus");
             }
-            button3.setSelected(true);
-        });
+            robot.waitForIdle();
+            robot.delay(200);
 
-        robot.keyPress(KeyEvent.VK_TAB);
-        robot.keyRelease(KeyEvent.VK_TAB);
+            SwingUtilities.invokeAndWait(() -> button3.setSelected(true));
+            robot.waitForIdle();
+            robot.delay(200);
 
-        robot.waitForIdle();
-        robot.delay(200);
+            System.out.println("\n\n*** Tab 2nd");
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
 
-        SwingUtilities.invokeAndWait(() -> {
-            if( !button3.hasFocus() ) {
-                frame.dispose();
-                throw new RuntimeException(
-                        "selected Button 3 should get focus");
+            if (!button3FocusLatch.await(FOCUS_TIMEOUT, SECONDS)) {
+                throw new RuntimeException("Selected Button 3 should get focus");
             }
-        });
+        } catch (Exception e) {
+            BufferedImage image = robot.createScreenCapture(getFrameBounds());
+            ImageIO.write(image, "png",
+                          new File("image.png"));
 
-        SwingUtilities.invokeLater(frame::dispose);
+            SwingUtilities.invokeAndWait(() ->
+                    System.err.println("Current focus owner: "
+                                       + getCurrentKeyboardFocusManager()
+                                         .getFocusOwner()));
+
+            throw e;
+        } finally {
+            SwingUtilities.invokeAndWait(frame::dispose);
+        }
+    }
+
+    private static Rectangle getFrameBounds() throws Exception {
+        Rectangle[] bounds = new Rectangle[1];
+        SwingUtilities.invokeAndWait(() -> bounds[0] = frame.getBounds());
+        return bounds[0];
+    }
+
+    private static final class LatchFocusListener extends FocusAdapter {
+        private final CountDownLatch focusGainedLatch;
+
+        private LatchFocusListener(CountDownLatch focusGainedLatch) {
+            this.focusGainedLatch = focusGainedLatch;
+        }
+
+        @Override
+        public void focusGained(FocusEvent e) {
+            focusGainedLatch.countDown();
+        }
     }
 }


### PR DESCRIPTION
**Problem:**

The `javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java` test fails in CI on Linux.

The focus is on _Button 2_ instead of _Button 4_.

**Root cause:**

The additional logging revealed, an expected `KEY_PRESS` event. The test uses `Robot` API to press the <kbd>Tab</kbd> key and release it. When the test fails, there are two `KEY_PRESS` events followed by a single `KEY_RELEASE` event. Because the <kbd>Tab</kbd> key is pressed twice, the focus moves twice: from _Button&nbsp;2_ (the initial state) to _Button&nbsp;4_ and then back to _Button&nbsp;2_.

**Fix:**

Use `CountDownLatch`es to track whether a radio button received focus. Detect the case where two `KEY_PRESS` events moved focus to _Button&nbsp;2_ and report the failure.

Log focus movements and dispatched key events to facilitate failure analysis.

Take a screenshot of the test frame in case of failure.

These CI hosts seem to be quite slow, removing the delay added by `robot.setAutoDelay(100)` has reduced the number of unexpected `KEY_PRESS` events. This didn't affect Windows or macOS.