### PR TITLE
8347121: Add missing @serial tags to module java.base

### DIFF
--- a/src/java.base/share/classes/java/lang/EnumConstantNotPresentException.java
+++ b/src/java.base/share/classes/java/lang/EnumConstantNotPresentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,12 +42,12 @@ public class EnumConstantNotPresentException extends RuntimeException {
     private static final long serialVersionUID = -6046998521960521108L;
 
     /**
-     * The type of the missing enum constant.
+     * @serial The type of the missing enum constant.
      */
     private Class<? extends Enum> enumType;
 
     /**
-     * The name of the missing enum constant.
+     * @serial The name of the missing enum constant.
      */
     private String constantName;
 

--- a/src/java.base/share/classes/java/lang/StackTraceElement.java
+++ b/src/java.base/share/classes/java/lang/StackTraceElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,35 +64,35 @@ public final class StackTraceElement implements java.io.Serializable {
 
     // Normally initialized by VM
     /**
-     * The name of the class loader.
+     * @serial The name of the class loader.
      */
     private String classLoaderName;
     /**
-     * The module name.
+     * @serial The module name.
      */
     private String moduleName;
     /**
-     * The module version.
+     * @serial The module version.
      */
     private String moduleVersion;
     /**
-     * The declaring class.
+     * @serial The declaring class.
      */
     private String declaringClass;
     /**
-     * The method name.
+     * @serial The method name.
      */
     private String methodName;
     /**
-     * The source file name.
+     * @serial The source file name.
      */
     private String fileName;
     /**
-     * The source line number.
+     * @serial The source line number.
      */
     private int    lineNumber;
     /**
-     * Control to show full or partial module, package, and class names.
+     * @serial Control to show full or partial module, package, and class names.
      */
     private byte   format = 0; // Default to show all
 

--- a/src/java.base/share/classes/java/lang/TypeNotPresentException.java
+++ b/src/java.base/share/classes/java/lang/TypeNotPresentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class TypeNotPresentException extends RuntimeException {
     private static final long serialVersionUID = -5101214195716534496L;
 
     /**
-     * The type name or the name of a type variable.
+     * @serial The type name or the name of a type variable.
      */
     private String typeName;
 

--- a/src/java.base/share/classes/java/lang/annotation/AnnotationTypeMismatchException.java
+++ b/src/java.base/share/classes/java/lang/annotation/AnnotationTypeMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class AnnotationTypeMismatchException extends RuntimeException {
     private final transient Method element;
 
     /**
-     * The (erroneous) type of data found in the annotation.  This string
+     * @serial The (erroneous) type of data found in the annotation.  This string
      * may, but is not required to, contain the value as well.  The exact
      * format of the string is unspecified.
      */

--- a/src/java.base/share/classes/java/lang/annotation/IncompleteAnnotationException.java
+++ b/src/java.base/share/classes/java/lang/annotation/IncompleteAnnotationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,11 +43,11 @@ public class IncompleteAnnotationException extends RuntimeException {
     private static final long serialVersionUID = 8445097402741811912L;
 
     /**
-     * The annotation interface.
+     * @serial The annotation interface.
      */
     private Class<? extends Annotation> annotationType;
     /**
-     * The element name.
+     * @serial The element name.
      */
     private String elementName;
 

--- a/src/java.base/share/classes/java/lang/invoke/SerializedLambda.java
+++ b/src/java.base/share/classes/java/lang/invoke/SerializedLambda.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,43 +65,43 @@ public final class SerializedLambda implements Serializable {
     @java.io.Serial
     private static final long serialVersionUID = 8025925345765570181L;
     /**
-     * The capturing class.
+     * @serial The capturing class.
      */
     private final Class<?> capturingClass;
     /**
-     * The functional interface class.
+     * @serial The functional interface class.
      */
     private final String functionalInterfaceClass;
     /**
-     * The functional interface method name.
+     * @serial The functional interface method name.
      */
     private final String functionalInterfaceMethodName;
     /**
-     * The functional interface method signature.
+     * @serial The functional interface method signature.
      */
     private final String functionalInterfaceMethodSignature;
     /**
-     * The implementation class.
+     * @serial The implementation class.
      */
     private final String implClass;
     /**
-     * The implementation method name.
+     * @serial The implementation method name.
      */
     private final String implMethodName;
     /**
-     * The implementation method signature.
+     * @serial The implementation method signature.
      */
     private final String implMethodSignature;
     /**
-     * The implementation method kind.
+     * @serial The implementation method kind.
      */
     private final int implMethodKind;
     /**
-     * The instantiated method type.
+     * @serial The instantiated method type.
      */
     private final String instantiatedMethodType;
     /**
-     * The captured arguments.
+     * @serial The captured arguments.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     private final Object[] capturedArgs;

--- a/src/java.base/share/classes/java/net/HttpRetryException.java
+++ b/src/java.base/share/classes/java/net/HttpRetryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,12 +40,12 @@ public class HttpRetryException extends IOException {
     private static final long serialVersionUID = -9186022286469111381L;
 
     /**
-     * The response code.
+     * @serial The response code.
      */
     private final int responseCode;
 
     /**
-     * The URL to be redirected to.
+     * @serial The URL to be redirected to.
      */
     private String location;
 

--- a/src/java.base/share/classes/java/net/URISyntaxException.java
+++ b/src/java.base/share/classes/java/net/URISyntaxException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,12 +42,12 @@ public class URISyntaxException
     private static final long serialVersionUID = 2137979680897488891L;
 
     /**
-     * The input string.
+     * @serial The input string.
      */
     private final String input;
 
     /**
-     * The index at which the parse error occurred,
+     * @serial The index at which the parse error occurred,
      * or {@code -1} if the index is not known.
      */
     private final int index;

--- a/src/java.base/share/classes/java/net/URLPermission.java
+++ b/src/java.base/share/classes/java/net/URLPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,7 +168,7 @@ public final class URLPermission extends Permission {
 
     // serialized field
     /**
-     * The actions string
+     * @serial The actions string
      */
     private String actions;
 

--- a/src/java.base/share/classes/java/nio/charset/MalformedInputException.java
+++ b/src/java.base/share/classes/java/nio/charset/MalformedInputException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class MalformedInputException
     private static final long serialVersionUID = -3438823399834806194L;
 
     /**
-     * The length of the input.
+     * @serial The length of the input.
      */
     private int inputLength;
 

--- a/src/java.base/share/classes/java/nio/charset/UnmappableCharacterException.java
+++ b/src/java.base/share/classes/java/nio/charset/UnmappableCharacterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class UnmappableCharacterException
     private static final long serialVersionUID = -7026962371537706123L;
 
     /**
-     * The length of the input character (or byte) sequence.
+     * @serial The length of the input character (or byte) sequence.
      */
     private int inputLength;
 

--- a/src/java.base/share/classes/java/nio/file/FileSystemException.java
+++ b/src/java.base/share/classes/java/nio/file/FileSystemException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,12 +41,12 @@ public class FileSystemException
     static final long serialVersionUID = -3055425747967319812L;
 
     /**
-     *  String identifying the file or {@code null} if not known.
+     * @serial String identifying the file or {@code null} if not known.
      */
     private final String file;
 
     /**
-     *  String identifying the other file or {@code null} if there isn't
+     * @serial String identifying the other file or {@code null} if there isn't
      *  another file or if not known.
      */
     private final String other;

--- a/src/java.base/share/classes/java/nio/file/InvalidPathException.java
+++ b/src/java.base/share/classes/java/nio/file/InvalidPathException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,12 +40,12 @@ public class InvalidPathException
     static final long serialVersionUID = 4355821422286746137L;
 
     /**
-     * The input string.
+     * @serial The input string.
      */
     private String input;
 
     /**
-     * The index of the input string at which the error occurred or
+     * @serial The index of the input string at which the error occurred or
      * {@code -1} if not known.
      */
     private int index;

--- a/src/java.base/share/classes/java/nio/file/attribute/UserPrincipalNotFoundException.java
+++ b/src/java.base/share/classes/java/nio/file/attribute/UserPrincipalNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class UserPrincipalNotFoundException
     static final long serialVersionUID = -5369283889045833024L;
 
     /**
-     * The user principal name.
+     * @serial The user principal name.
      */
     private final String name;
 

--- a/src/java.base/share/classes/java/security/AccessControlException.java
+++ b/src/java.base/share/classes/java/security/AccessControlException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class AccessControlException extends SecurityException {
     private static final long serialVersionUID = 5138225684096988535L;
 
     /**
-     * The permission that caused the exception to be thrown.
+     * @serial The permission that caused the exception to be thrown.
      */
     private Permission perm;
 

--- a/src/java.base/share/classes/java/security/AllPermission.java
+++ b/src/java.base/share/classes/java/security/AllPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,7 +151,7 @@ final class AllPermissionCollection
     private static final long serialVersionUID = -4023755556366636806L;
 
     /**
-     * True if any {@code AllPermissionCollection} objects have been added.
+     * @serial True if any {@code AllPermissionCollection} objects have been added.
      */
     private boolean all_allowed;
 

--- a/src/java.base/share/classes/java/security/GuardedObject.java
+++ b/src/java.base/share/classes/java/security/GuardedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,13 +55,13 @@ public class GuardedObject implements java.io.Serializable {
     private static final long serialVersionUID = -5240450096227834308L;
 
     /**
-     * The object we are guarding.
+     * @serial The object we are guarding.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     private final Object object;
 
     /**
-     * The guard object.
+     * @serial The guard object.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     private final Guard guard;

--- a/src/java.base/share/classes/java/security/KeyPair.java
+++ b/src/java.base/share/classes/java/security/KeyPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,10 @@ public final class KeyPair implements java.io.Serializable {
     @java.io.Serial
     private static final long serialVersionUID = -7565189502268009837L;
 
-    /** The private key. */
+    /** @serial The private key. */
     private final PrivateKey privateKey;
 
-    /** The public key. */
+    /** @serial The public key. */
     private final PublicKey publicKey;
 
     /**

--- a/src/java.base/share/classes/java/security/Permission.java
+++ b/src/java.base/share/classes/java/security/Permission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public abstract class Permission implements Guard, java.io.Serializable {
     private static final long serialVersionUID = -5636570222231596674L;
 
     /**
-     * The permission name.
+     * @serial The permission name.
      */
     private final String name;
 

--- a/src/java.base/share/classes/java/security/PermissionCollection.java
+++ b/src/java.base/share/classes/java/security/PermissionCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,7 @@ public abstract class PermissionCollection implements java.io.Serializable {
     private static final long serialVersionUID = -6727011328946861783L;
 
     /**
-     * Whether this permission collection is read-only.
+     * @serial Whether this permission collection is read-only.
      * <p>
      * If set, the {@code add} method will throw an exception.
      */

--- a/src/java.base/share/classes/java/security/Permissions.java
+++ b/src/java.base/share/classes/java/security/Permissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,6 +92,7 @@ implements Serializable
     // checked
     private transient boolean hasUnresolved = false;
 
+    /** @serial */
     // optimization. keep track of the AllPermission collection
     // - package private for ProtectionDomain optimization
     PermissionCollection allPermission;

--- a/src/java.base/share/classes/java/security/SignedObject.java
+++ b/src/java.base/share/classes/java/security/SignedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,18 +122,18 @@ public final class SignedObject implements Serializable {
     private static final long serialVersionUID = 720502720485447167L;
 
     /**
-     * The original content is "deep copied" in its serialized format
+     * @serial The original content is "deep copied" in its serialized format
      * and stored in a byte array.
      */
     private byte[] content;
 
     /**
-     * The signature field is stored as a byte array.
+     * @serial The signature field is stored as a byte array.
      */
     private byte[] signature;
 
     /**
-     * The algorithm used to sign the object.
+     * @serial The algorithm used to sign the object.
      */
     private String thealgorithm;
 

--- a/src/java.base/share/classes/java/security/cert/CertPath.java
+++ b/src/java.base/share/classes/java/security/cert/CertPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -301,9 +301,9 @@ public abstract class CertPath implements Serializable {
         @java.io.Serial
         private static final long serialVersionUID = 3015633072427920915L;
 
-        /** The type of {@code Certificate}s in the {@code CertPath}. */
+        /** @serial The type of {@code Certificate}s in the {@code CertPath}. */
         private final String type;
-        /** The encoded form of the {@code CertPath}. */
+        /** @serial The encoded form of the {@code CertPath}. */
         private final byte[] data;
 
         /**

--- a/src/java.base/share/classes/java/security/cert/Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/Certificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,10 +244,10 @@ public abstract class Certificate implements java.io.Serializable {
         @java.io.Serial
         private static final long serialVersionUID = -8563758940495660020L;
 
-        /** The standard name of the certificate type. */
+        /** @serial The standard name of the certificate type. */
         private final String type;
 
-        /** The certificate data. */
+        /** @serial The certificate data. */
         private final byte[] data;
 
         /**

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -953,7 +953,7 @@ public abstract class DateFormat extends Format {
         private static final Field[] calendarToFieldMapping =
                                              new Field[Calendar.FIELD_COUNT];
 
-        /** Calendar field. */
+        /** @serial Calendar field. */
         private int calendarField;
 
         /**

--- a/src/java.base/share/classes/java/time/Duration.java
+++ b/src/java.base/share/classes/java/time/Duration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,11 +158,11 @@ public final class Duration
     }
 
     /**
-     * The number of seconds in the duration.
+     * @serial The number of seconds in the duration.
      */
     private final long seconds;
     /**
-     * The number of nanoseconds in the duration, expressed as a fraction of the
+     * @serial The number of nanoseconds in the duration, expressed as a fraction of the
      * number of seconds. This is always positive, and never exceeds 999,999,999.
      */
     private final int nanos;

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -252,11 +252,11 @@ public final class Instant
     private static final long serialVersionUID = -665713676816604388L;
 
     /**
-     * The number of seconds from the epoch of 1970-01-01T00:00:00Z.
+     * @serial The number of seconds from the epoch of 1970-01-01T00:00:00Z.
      */
     private final long seconds;
     /**
-     * The number of nanoseconds, later along the time-line, from the seconds field.
+     * @serial The number of nanoseconds, later along the time-line, from the seconds field.
      * This is always positive, and never exceeds 999,999,999.
      */
     private final int nanos;

--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,15 +174,15 @@ public final class LocalDate
     static final long DAYS_0000_TO_1970 = (DAYS_PER_CYCLE * 5L) - (30L * 365L + 7L);
 
     /**
-     * The year.
+     * @serial The year.
      */
     private final int year;
     /**
-     * The month-of-year.
+     * @serial The month-of-year.
      */
     private final short month;
     /**
-     * The day-of-month.
+     * @serial The day-of-month.
      */
     private final short day;
 

--- a/src/java.base/share/classes/java/time/LocalDateTime.java
+++ b/src/java.base/share/classes/java/time/LocalDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,11 +158,11 @@ public final class LocalDateTime
     private static final long serialVersionUID = 6207766400415563566L;
 
     /**
-     * The date part.
+     * @serial The date part.
      */
     private final LocalDate date;
     /**
-     * The time part.
+     * @serial The time part.
      */
     private final LocalTime time;
 

--- a/src/java.base/share/classes/java/time/LocalTime.java
+++ b/src/java.base/share/classes/java/time/LocalTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -228,19 +228,19 @@ public final class LocalTime
     private static final long serialVersionUID = 6414437269572265201L;
 
     /**
-     * The hour.
+     * @serial The hour.
      */
     private final byte hour;
     /**
-     * The minute.
+     * @serial The minute.
      */
     private final byte minute;
     /**
-     * The second.
+     * @serial The second.
      */
     private final byte second;
     /**
-     * The nanosecond.
+     * @serial The nanosecond.
      */
     private final int nano;
 

--- a/src/java.base/share/classes/java/time/MonthDay.java
+++ b/src/java.base/share/classes/java/time/MonthDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,11 +144,11 @@ public final class MonthDay
         .toFormatter();
 
     /**
-     * The month-of-year, not null.
+     * @serial The month-of-year, not null.
      */
     private final int month;
     /**
-     * The day-of-month.
+     * @serial The day-of-month.
      */
     private final int day;
 

--- a/src/java.base/share/classes/java/time/OffsetDateTime.java
+++ b/src/java.base/share/classes/java/time/OffsetDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -190,11 +190,11 @@ public final class OffsetDateTime
     private static final long serialVersionUID = 2287754244819255394L;
 
     /**
-     * The local date-time.
+     * @serial The local date-time.
      */
     private final LocalDateTime dateTime;
     /**
-     * The offset from UTC/Greenwich.
+     * @serial The offset from UTC/Greenwich.
      */
     private final ZoneOffset offset;
 

--- a/src/java.base/share/classes/java/time/OffsetTime.java
+++ b/src/java.base/share/classes/java/time/OffsetTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,11 +143,11 @@ public final class OffsetTime
     private static final long serialVersionUID = 7264499704384272492L;
 
     /**
-     * The local date-time.
+     * @serial The local date-time.
      */
     private final LocalTime time;
     /**
-     * The offset from UTC/Greenwich.
+     * @serial The offset from UTC/Greenwich.
      */
     private final ZoneOffset offset;
 

--- a/src/java.base/share/classes/java/time/Period.java
+++ b/src/java.base/share/classes/java/time/Period.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,15 +155,15 @@ public final class Period
     private static final List<TemporalUnit> SUPPORTED_UNITS = List.of(YEARS, MONTHS, DAYS);
 
     /**
-     * The number of years.
+     * @serial The number of years.
      */
     private final int years;
     /**
-     * The number of months.
+     * @serial The number of months.
      */
     private final int months;
     /**
-     * The number of days.
+     * @serial The number of days.
      */
     private final int days;
 

--- a/src/java.base/share/classes/java/time/Year.java
+++ b/src/java.base/share/classes/java/time/Year.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,7 +159,7 @@ public final class Year
         .toFormatter();
 
     /**
-     * The year being represented.
+     * @serial The year being represented.
      */
     private final int year;
 

--- a/src/java.base/share/classes/java/time/YearMonth.java
+++ b/src/java.base/share/classes/java/time/YearMonth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,11 +147,11 @@ public final class YearMonth
         .toFormatter();
 
     /**
-     * The year.
+     * @serial The year.
      */
     private final int year;
     /**
-     * The month-of-year, not null.
+     * @serial The month-of-year, not null.
      */
     private final int month;
 

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -163,7 +163,7 @@ public final class ZoneOffset
     public static final ZoneOffset MAX = ZoneOffset.ofTotalSeconds(MAX_SECONDS);
 
     /**
-     * The total offset in seconds.
+     * @serial The total offset in seconds.
      */
     private final int totalSeconds;
     /**

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,15 +172,15 @@ public final class ZonedDateTime
     private static final long serialVersionUID = -6260982410461394882L;
 
     /**
-     * The local date-time.
+     * @serial The local date-time.
      */
     private final LocalDateTime dateTime;
     /**
-     * The offset from UTC/Greenwich.
+     * @serial The offset from UTC/Greenwich.
      */
     private final ZoneOffset offset;
     /**
-     * The time-zone.
+     * @serial The time-zone.
      */
     private final ZoneId zone;
 

--- a/src/java.base/share/classes/java/time/format/DateTimeParseException.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeParseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,11 +82,11 @@ public class DateTimeParseException extends DateTimeException {
     private static final long serialVersionUID = 4304633501674722597L;
 
     /**
-     * The text that was being parsed.
+     * @serial The text that was being parsed.
      */
     private final String parsedString;
     /**
-     * The error index in the text.
+     * @serial The error index in the text.
      */
     private final int errorIndex;
 

--- a/src/java.base/share/classes/java/time/temporal/ValueRange.java
+++ b/src/java.base/share/classes/java/time/temporal/ValueRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,19 +96,19 @@ public final class ValueRange implements Serializable {
     private static final long serialVersionUID = -7317881728594519368L;
 
     /**
-     * The smallest minimum value.
+     * @serial The smallest minimum value.
      */
     private final long minSmallest;
     /**
-     * The largest minimum value.
+     * @serial The largest minimum value.
      */
     private final long minLargest;
     /**
-     * The smallest maximum value.
+     * @serial The smallest maximum value.
      */
     private final long maxSmallest;
     /**
-     * The largest maximum value.
+     * @serial The largest maximum value.
      */
     private final long maxLargest;
 

--- a/src/java.base/share/classes/java/time/temporal/WeekFields.java
+++ b/src/java.base/share/classes/java/time/temporal/WeekFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -247,11 +247,11 @@ public final class WeekFields implements Serializable {
     private static final long serialVersionUID = -1177360819670808121L;
 
     /**
-     * The first day-of-week.
+     * @serial The first day-of-week.
      */
     private final DayOfWeek firstDayOfWeek;
     /**
-     * The minimal number of days in the first week.
+     * @serial The minimal number of days in the first week.
      */
     private final int minimalDays;
     /**

--- a/src/java.base/share/classes/java/time/zone/ZoneOffsetTransition.java
+++ b/src/java.base/share/classes/java/time/zone/ZoneOffsetTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,19 +104,19 @@ public final class ZoneOffsetTransition
      */
     private static final long serialVersionUID = -6946044323557704546L;
     /**
-     * The transition epoch-second.
+     * @serial The transition epoch-second.
      */
     private final long epochSecond;
     /**
-     * The local transition date-time at the transition.
+     * @serial The local transition date-time at the transition.
      */
     private final LocalDateTime transition;
     /**
-     * The offset before transition.
+     * @serial The offset before transition.
      */
     private final ZoneOffset offsetBefore;
     /**
-     * The offset after transition.
+     * @serial The offset after transition.
      */
     private final ZoneOffset offsetAfter;
 

--- a/src/java.base/share/classes/java/time/zone/ZoneOffsetTransitionRule.java
+++ b/src/java.base/share/classes/java/time/zone/ZoneOffsetTransitionRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,12 +105,12 @@ public final class ZoneOffsetTransitionRule implements Serializable {
     private static final long serialVersionUID = 6889046316657758795L;
 
     /**
-     * The month of the month-day of the first day of the cutover week.
+     * @serial The month of the month-day of the first day of the cutover week.
      * The actual date will be adjusted by the dowChange field.
      */
     private final Month month;
     /**
-     * The day-of-month of the month-day of the cutover week.
+     * @serial The day-of-month of the month-day of the cutover week.
      * If positive, it is the start of the week where the cutover can occur.
      * If negative, it represents the end of the week where cutover can occur.
      * The value is the number of days from the end of the month, such that
@@ -119,31 +119,31 @@ public final class ZoneOffsetTransitionRule implements Serializable {
      */
     private final byte dom;
     /**
-     * The cutover day-of-week, null to retain the day-of-month.
+     * @serial The cutover day-of-week, null to retain the day-of-month.
      */
     private final DayOfWeek dow;
     /**
-     * The cutover time in the 'before' offset.
+     * @serial The cutover time in the 'before' offset.
      */
     private final LocalTime time;
     /**
-     * Whether the cutover time is midnight at the end of day.
+     * @serial Whether the cutover time is midnight at the end of day.
      */
     private final boolean timeEndOfDay;
     /**
-     * The definition of how the local time should be interpreted.
+     * @serial The definition of how the local time should be interpreted.
      */
     private final TimeDefinition timeDefinition;
     /**
-     * The standard offset at the cutover.
+     * @serial The standard offset at the cutover.
      */
     private final ZoneOffset standardOffset;
     /**
-     * The offset before the cutover.
+     * @serial The offset before the cutover.
      */
     private final ZoneOffset offsetBefore;
     /**
-     * The offset after the cutover.
+     * @serial The offset after the cutover.
      */
     private final ZoneOffset offsetAfter;
 

--- a/src/java.base/share/classes/java/time/zone/ZoneRules.java
+++ b/src/java.base/share/classes/java/time/zone/ZoneRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,29 +118,29 @@ public final class ZoneRules implements Serializable {
     private static final int LAST_CACHED_YEAR = 2100;
 
     /**
-     * The transitions between standard offsets (epoch seconds), sorted.
+     * @serial The transitions between standard offsets (epoch seconds), sorted.
      */
     private final long[] standardTransitions;
     /**
-     * The standard offsets.
+     * @serial The standard offsets.
      */
     private final ZoneOffset[] standardOffsets;
     /**
-     * The transitions between instants (epoch seconds), sorted.
+     * @serial The transitions between instants (epoch seconds), sorted.
      */
     private final long[] savingsInstantTransitions;
     /**
-     * The transitions between local date-times, sorted.
+     * @serial The transitions between local date-times, sorted.
      * This is a paired array, where the first entry is the start of the transition
      * and the second entry is the end of the transition.
      */
     private final LocalDateTime[] savingsLocalTransitions;
     /**
-     * The wall offsets.
+     * @serial The wall offsets.
      */
     private final ZoneOffset[] wallOffsets;
     /**
-     * The last rule.
+     * @serial The last rule.
      */
     private final ZoneOffsetTransitionRule[] lastRules;
     /**

--- a/src/java.base/share/classes/java/util/AbstractMap.java
+++ b/src/java.base/share/classes/java/util/AbstractMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -587,8 +587,10 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
         @java.io.Serial
         private static final long serialVersionUID = -8499721149061103585L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final K key;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private V value;
 
@@ -733,8 +735,10 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
         @java.io.Serial
         private static final long serialVersionUID = 7138329143949025153L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Not statically typed as Serializable
         private final K key;
+        /** @serial */
         @SuppressWarnings("serial") // Not statically typed as Serializable
         private final V value;
 

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4189,6 +4189,7 @@ public final class Arrays {
     {
         @java.io.Serial
         private static final long serialVersionUID = -2764017481108945198L;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final E[] a;
 

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1054,6 +1054,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 1820017752578914078L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final Collection<? extends E> c;
 
@@ -1337,6 +1338,7 @@ public class Collections {
                              implements SortedSet<E>, Serializable {
         @java.io.Serial
         private static final long serialVersionUID = -4929149591599911165L;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final SortedSet<E> ss;
 
@@ -1419,7 +1421,7 @@ public class Collections {
                 new EmptyNavigableSet<>();
 
         /**
-         * The instance we are protecting.
+         * @serial The instance we are protecting.
          */
         @SuppressWarnings("serial") // Conditionally serializable
         private final NavigableSet<E> ns;
@@ -1488,6 +1490,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = -283967356065247728L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final List<? extends E> list;
 
@@ -1641,6 +1644,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = -1034234728574286014L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final Map<? extends K, ? extends V> m;
 
@@ -2068,6 +2072,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = -8806743815996713206L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final SortedMap<K, ? extends V> sm;
 
@@ -2149,7 +2154,7 @@ public class Collections {
             new EmptyNavigableMap<>();
 
         /**
-         * The instance we wrap and protect.
+         * @serial The instance we wrap and protect.
          */
         @SuppressWarnings("serial") // Conditionally serializable
         private final NavigableMap<K, ? extends V> nm;
@@ -2283,8 +2288,10 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 3053995032091335093L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final Collection<E> c;  // Backing Collection
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final Object mutex;     // Object on which to synchronize
 
@@ -2487,6 +2494,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 8695801310862127406L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final SortedSet<E> ss;
 
@@ -2583,6 +2591,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = -5505529816273629798L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final NavigableSet<E> ns;
 
@@ -2694,6 +2703,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = -7754090372962971524L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final List<E> list;
 
@@ -2862,8 +2872,10 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 1978198479659022715L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final Map<K,V> m;     // Backing Map
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final Object      mutex;        // Object on which to synchronize
 
@@ -3061,6 +3073,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = -8798146769416483793L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final SortedMap<K,V> sm;
 
@@ -3165,6 +3178,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 699392247599746807L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final NavigableMap<K,V> nm;
 
@@ -3345,8 +3359,10 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 1578914078182001775L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final Collection<E> c;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final Class<E> type;
 
@@ -3403,6 +3419,7 @@ public class Collections {
 
         public boolean add(E e)          { return c.add(typeCheck(e)); }
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private E[] zeroLengthElementArray; // Lazily initialized
 
@@ -3497,6 +3514,7 @@ public class Collections {
     {
         @java.io.Serial
         private static final long serialVersionUID = 1433151992604707767L;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final Queue<E> queue;
 
@@ -3602,6 +3620,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 1599911165492914959L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final SortedSet<E> ss;
 
@@ -3667,6 +3686,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = -5429120189805438922L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final NavigableSet<E> ns;
 
@@ -3751,6 +3771,7 @@ public class Collections {
     {
         @java.io.Serial
         private static final long serialVersionUID = 65247728283967356L;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final List<E> list;
 
@@ -3901,10 +3922,13 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 5742860141034234728L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final Map<K, V> m;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final Class<K> keyType;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final Class<V> valueType;
 
@@ -4301,6 +4325,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 1599671320688067438L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final SortedMap<K, V> sm;
 
@@ -4377,6 +4402,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = -4852462692372534096L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final NavigableMap<K, V> nm;
 
@@ -5108,6 +5134,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 3193687207550431679L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final E element;
 
@@ -5163,6 +5190,7 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 3093736618740652951L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final E element;
 
@@ -5233,8 +5261,10 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = -6979724477215052911L;
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final K k;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final V v;
 
@@ -5373,7 +5403,9 @@ public class Collections {
         @java.io.Serial
         private static final long serialVersionUID = 2739099268398711800L;
 
+        /** @serial */
         final int n;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final E element;
 
@@ -5914,6 +5946,7 @@ public class Collections {
     private static class SetFromMap<E> extends AbstractSet<E>
         implements Set<E>, Serializable
     {
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final Map<E, Boolean> m;          // The backing map
         private transient Set<E> s;       // Its keySet
@@ -6088,6 +6121,7 @@ public class Collections {
         implements Queue<E>, Serializable {
         @java.io.Serial
         private static final long serialVersionUID = 1802017725587941708L;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final Deque<E> q;
         AsLIFOQueue(Deque<E> q)                     { this.q = q; }

--- a/src/java.base/share/classes/java/util/DuplicateFormatFlagsException.java
+++ b/src/java.base/share/classes/java/util/DuplicateFormatFlagsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ public non-sealed class DuplicateFormatFlagsException extends IllegalFormatExcep
     @java.io.Serial
     private static final long serialVersionUID = 18890531L;
 
+    /** @serial */
     private String flags;
 
     /**

--- a/src/java.base/share/classes/java/util/FormatFlagsConversionMismatchException.java
+++ b/src/java.base/share/classes/java/util/FormatFlagsConversionMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,10 @@ public non-sealed class FormatFlagsConversionMismatchException
     @java.io.Serial
     private static final long serialVersionUID = 19120414L;
 
+    /** @serial */
     private String f;
 
+    /** @serial */
     private char c;
 
     /**

--- a/src/java.base/share/classes/java/util/IllegalFormatCodePointException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatCodePointException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ public non-sealed class IllegalFormatCodePointException extends IllegalFormatExc
     @java.io.Serial
     private static final long serialVersionUID = 19080630L;
 
+    /** @serial */
     private int c;
 
     /**

--- a/src/java.base/share/classes/java/util/IllegalFormatConversionException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatConversionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,9 @@ public non-sealed class IllegalFormatConversionException extends IllegalFormatEx
     @java.io.Serial
     private static final long serialVersionUID = 17000126L;
 
+    /** @serial */
     private char c;
+    /** @serial */
     private Class<?> arg;
 
     /**

--- a/src/java.base/share/classes/java/util/IllegalFormatFlagsException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatFlagsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ public non-sealed class IllegalFormatFlagsException extends IllegalFormatExcepti
     @java.io.Serial
     private static final long serialVersionUID = 790824L;
 
+    /** @serial */
     private String flags;
 
     /**

--- a/src/java.base/share/classes/java/util/IllegalFormatPrecisionException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatPrecisionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ public non-sealed class IllegalFormatPrecisionException extends IllegalFormatExc
     @java.io.Serial
     private static final long serialVersionUID = 18711008L;
 
+    /** @serial */
     private int p;
 
     /**

--- a/src/java.base/share/classes/java/util/IllegalFormatWidthException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatWidthException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ public non-sealed class IllegalFormatWidthException extends IllegalFormatExcepti
     @java.io.Serial
     private static final long serialVersionUID = 16660902L;
 
+    /** @serial */
     private int w;
 
     /**

--- a/src/java.base/share/classes/java/util/IllformedLocaleException.java
+++ b/src/java.base/share/classes/java/util/IllformedLocaleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ public class IllformedLocaleException extends RuntimeException {
     @java.io.Serial
     private static final long serialVersionUID = -5245986824925681401L;
 
+    /** @serial */
     private int _errIdx = -1;
 
     /**

--- a/src/java.base/share/classes/java/util/MissingFormatArgumentException.java
+++ b/src/java.base/share/classes/java/util/MissingFormatArgumentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ public non-sealed class MissingFormatArgumentException extends IllegalFormatExce
     @java.io.Serial
     private static final long serialVersionUID = 19190115L;
 
+    /** @serial */
     private String s;
 
     /**

--- a/src/java.base/share/classes/java/util/MissingFormatWidthException.java
+++ b/src/java.base/share/classes/java/util/MissingFormatWidthException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ public non-sealed class MissingFormatWidthException extends IllegalFormatExcepti
     @java.io.Serial
     private static final long serialVersionUID = 15560123L;
 
+    /** @serial */
     private String s;
 
     /**

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,12 +103,12 @@ public class PriorityQueue<E> extends AbstractQueue<E>
     transient Object[] queue; // non-private to simplify nested class access
 
     /**
-     * The number of elements in the priority queue.
+     * @serial The number of elements in the priority queue.
      */
     int size;
 
     /**
-     * The comparator, or null if priority queue uses elements'
+     * @serial The comparator, or null if priority queue uses elements'
      * natural ordering.
      */
     @SuppressWarnings("serial") // Conditionally serializable

--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1656,12 +1656,12 @@ public class TreeMap<K,V>
         @java.io.Serial
         private static final long serialVersionUID = -2102997345730753016L;
         /**
-         * The backing map.
+         * @serial The backing map.
          */
         final TreeMap<K,V> m;
 
         /**
-         * Endpoints are represented as triples (fromStart, lo,
+         * @serial Endpoints are represented as triples (fromStart, lo,
          * loInclusive) and (toEnd, hi, hiInclusive). If fromStart is
          * true, then the low (absolute) bound is the start of the
          * backing map, and the other values are ignored. Otherwise,
@@ -1670,9 +1670,12 @@ public class TreeMap<K,V>
          */
         @SuppressWarnings("serial") // Conditionally serializable
         final K lo;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         final K hi;
+        /** @serial */
         final boolean fromStart, toEnd;
+        /** @serial */
         final boolean loInclusive, hiInclusive;
 
         NavigableSubMap(TreeMap<K,V> m,
@@ -2288,6 +2291,7 @@ public class TreeMap<K,V>
             super(m, fromStart, lo, loInclusive, toEnd, hi, hiInclusive);
         }
 
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final Comparator<? super K> reverseComparator =
             Collections.reverseOrder(m.comparator);
@@ -2376,9 +2380,12 @@ public class TreeMap<K,V>
         implements SortedMap<K,V>, java.io.Serializable {
         @java.io.Serial
         private static final long serialVersionUID = -6520786458950516097L;
+        /** @serial */
         private boolean fromStart = false, toEnd = false;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private K fromKey;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private K toKey;
         @java.io.Serial

--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,17 +83,13 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
     @java.io.Serial
     private static final long serialVersionUID = -4856846361193249489L;
 
-    /*
-     * The most significant 64 bits of this UUID.
-     *
-     * @serial
+    /**
+     * @serial The most significant 64 bits of this UUID.
      */
     private final long mostSigBits;
 
-    /*
-     * The least significant 64 bits of this UUID.
-     *
-     * @serial
+    /**
+     * @serial The least significant 64 bits of this UUID.
      */
     private final long leastSigBits;
 

--- a/src/java.base/share/classes/java/util/UnknownFormatConversionException.java
+++ b/src/java.base/share/classes/java/util/UnknownFormatConversionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ public non-sealed class UnknownFormatConversionException extends IllegalFormatEx
     @java.io.Serial
     private static final long serialVersionUID = 19060418L;
 
+    /** @serial */
     private String s;
 
     /**

--- a/src/java.base/share/classes/java/util/UnknownFormatFlagsException.java
+++ b/src/java.base/share/classes/java/util/UnknownFormatFlagsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ public non-sealed class UnknownFormatFlagsException extends IllegalFormatExcepti
     @java.io.Serial
     private static final long serialVersionUID = 19370506L;
 
+    /** @serial */
     private String flags;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
@@ -100,17 +100,17 @@ public class ArrayBlockingQueue<E> extends AbstractQueue<E>
      */
     private static final long serialVersionUID = -817911632652898426L;
 
-    /** The queued items */
+    /** @serial The queued items */
     @SuppressWarnings("serial") // Conditionally serializable
     final Object[] items;
 
-    /** items index for next take, poll, peek or remove */
+    /** @serial items index for next take, poll, peek or remove */
     int takeIndex;
 
-    /** items index for next put, offer, or add */
+    /** @serial items index for next put, offer, or add */
     int putIndex;
 
-    /** Number of elements in the queue */
+    /** @serial Number of elements in the queue */
     int count;
 
     /*
@@ -118,14 +118,14 @@ public class ArrayBlockingQueue<E> extends AbstractQueue<E>
      * found in any textbook.
      */
 
-    /** Main lock guarding all access */
+    /** @serial Main lock guarding all access */
     final ReentrantLock lock;
 
-    /** Condition for waiting takes */
+    /** @serial Condition for waiting takes */
     @SuppressWarnings("serial")  // Classes implementing Condition may be serializable.
     private final Condition notEmpty;
 
-    /** Condition for waiting puts */
+    /** @serial Condition for waiting puts */
     @SuppressWarnings("serial")  // Classes implementing Condition may be serializable.
     private final Condition notFull;
 

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -4611,6 +4611,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
     public static final class KeySetView<K,V> extends CollectionView<K,V,K>
         implements Set<K>, java.io.Serializable {
         private static final long serialVersionUID = 7249069246763182397L;
+        /** @serial */
         @SuppressWarnings("serial") // Conditionally serializable
         private final V value;
         KeySetView(ConcurrentHashMap<K,V> map, V value) {  // non-public

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
@@ -2401,19 +2401,19 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
         implements ConcurrentNavigableMap<K,V>, Serializable {
         private static final long serialVersionUID = -7647078645895051609L;
 
-        /** Underlying map */
+        /** @serial Underlying map */
         final ConcurrentSkipListMap<K,V> m;
-        /** lower bound key, or null if from start */
+        /** @serial lower bound key, or null if from start */
         @SuppressWarnings("serial") // Conditionally serializable
         private final K lo;
-        /** upper bound key, or null if to end */
+        /** @serial upper bound key, or null if to end */
         @SuppressWarnings("serial") // Conditionally serializable
         private final K hi;
-        /** inclusion flag for lo */
+        /** @serial inclusion flag for lo */
         private final boolean loInclusive;
-        /** inclusion flag for hi */
+        /** @serial inclusion flag for hi */
         private final boolean hiInclusive;
-        /** direction */
+        /** @serial direction */
         final boolean isDescending;
 
         // Lazily initialized view holders

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListSet.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListSet.java
@@ -99,7 +99,7 @@ public class ConcurrentSkipListSet<E>
     private static final long serialVersionUID = -2479143111061671589L;
 
     /**
-     * The underlying map. Uses Boolean.TRUE as value for each
+     * @serial The underlying map. Uses Boolean.TRUE as value for each
      * element.  This field is declared final for the sake of thread
      * safety, which entails some ugliness in clone().
      */

--- a/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArraySet.java
+++ b/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArraySet.java
@@ -99,6 +99,7 @@ public class CopyOnWriteArraySet<E> extends AbstractSet<E>
         implements java.io.Serializable {
     private static final long serialVersionUID = 5457747651344034263L;
 
+    /** @serial */
     private final CopyOnWriteArrayList<E> al;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/CountedCompleter.java
+++ b/src/java.base/share/classes/java/util/concurrent/CountedCompleter.java
@@ -427,9 +427,9 @@ import jdk.internal.misc.Unsafe;
 public abstract class CountedCompleter<T> extends ForkJoinTask<T> {
     private static final long serialVersionUID = 5232453752276485070L;
 
-    /** This task's completer, or null if none */
+    /** @serial This task's completer, or null if none */
     final CountedCompleter<?> completer;
-    /** The number of pending tasks until completion */
+    /** @serial The number of pending tasks until completion */
     volatile int pending;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
@@ -278,6 +278,7 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
     static final int UNCOMPENSATE   = 1 << 16; // helpJoin sentinel
 
     // Fields
+    /** @serial */
     volatile int status;                // accessed directly by pool and workers
     private transient volatile Aux aux; // either waiters or thrown Exception
 

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -152,17 +152,17 @@ public class LinkedBlockingDeque<E>
     /** Number of items in the deque */
     private transient int count;
 
-    /** Maximum number of items in the deque */
+    /** @serial Maximum number of items in the deque */
     private final int capacity;
 
-    /** Main lock guarding all access */
+    /** @serial Main lock guarding all access */
     final ReentrantLock lock = new ReentrantLock();
 
-    /** Condition for waiting takes */
+    /** @serial Condition for waiting takes */
     @SuppressWarnings("serial") // Classes implementing Condition may be serializable.
     private final Condition notEmpty = lock.newCondition();
 
-    /** Condition for waiting puts */
+    /** @serial Condition for waiting puts */
     @SuppressWarnings("serial") // Classes implementing Condition may be serializable.
     private final Condition notFull = lock.newCondition();
 

--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingQueue.java
@@ -134,10 +134,10 @@ public class LinkedBlockingQueue<E> extends AbstractQueue<E>
         Node(E x) { item = x; }
     }
 
-    /** The capacity bound, or Integer.MAX_VALUE if none */
+    /** @serial The capacity bound, or Integer.MAX_VALUE if none */
     private final int capacity;
 
-    /** Current number of elements */
+    /** @serial Current number of elements */
     private final AtomicInteger count = new AtomicInteger();
 
     /**
@@ -152,17 +152,17 @@ public class LinkedBlockingQueue<E> extends AbstractQueue<E>
      */
     private transient Node<E> last;
 
-    /** Lock held by take, poll, etc */
+    /** @serial Lock held by take, poll, etc */
     private final ReentrantLock takeLock = new ReentrantLock();
 
-    /** Wait queue for waiting takes */
+    /** @serial Wait queue for waiting takes */
     @SuppressWarnings("serial") // Classes implementing Condition may be serializable.
     private final Condition notEmpty = takeLock.newCondition();
 
-    /** Lock held by put, offer, etc */
+    /** @serial Lock held by put, offer, etc */
     private final ReentrantLock putLock = new ReentrantLock();
 
-    /** Wait queue for waiting puts */
+    /** @serial Wait queue for waiting puts */
     @SuppressWarnings("serial") // Classes implementing Condition may be serializable.
     private final Condition notFull = putLock.newCondition();
 

--- a/src/java.base/share/classes/java/util/concurrent/PriorityBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/PriorityBlockingQueue.java
@@ -160,12 +160,12 @@ public class PriorityBlockingQueue<E> extends AbstractQueue<E>
     private transient Comparator<? super E> comparator;
 
     /**
-     * Lock used for all public operations.
+     * @serial Lock used for all public operations.
      */
     private final ReentrantLock lock = new ReentrantLock();
 
     /**
-     * Condition for blocking when empty.
+     * @serial Condition for blocking when empty.
      */
     @SuppressWarnings("serial") // Classes implementing Condition may be serializable.
     private final Condition notEmpty = lock.newCondition();
@@ -176,7 +176,7 @@ public class PriorityBlockingQueue<E> extends AbstractQueue<E>
     private transient volatile int allocationSpinLock;
 
     /**
-     * A plain PriorityQueue used only for serialization,
+     * @serial A plain PriorityQueue used only for serialization,
      * to maintain compatibility with previous versions
      * of this class. Non-null only during serialization/deserialization.
      */

--- a/src/java.base/share/classes/java/util/concurrent/RecursiveTask.java
+++ b/src/java.base/share/classes/java/util/concurrent/RecursiveTask.java
@@ -84,7 +84,7 @@ public abstract class RecursiveTask<V> extends ForkJoinTask<V> {
     public RecursiveTask() {}
 
     /**
-     * The result of the computation.
+     * @serial The result of the computation.
      */
     @SuppressWarnings("serial") // Conditionally serializable
     V result;

--- a/src/java.base/share/classes/java/util/concurrent/Semaphore.java
+++ b/src/java.base/share/classes/java/util/concurrent/Semaphore.java
@@ -161,7 +161,7 @@ import java.util.concurrent.locks.AbstractQueuedSynchronizer;
  */
 public class Semaphore implements java.io.Serializable {
     private static final long serialVersionUID = -3222578661600680210L;
-    /** All mechanics via AbstractQueuedSynchronizer subclass */
+    /** @serial All mechanics via AbstractQueuedSynchronizer subclass */
     private final Sync sync;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/SynchronousQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/SynchronousQueue.java
@@ -555,8 +555,11 @@ public class SynchronousQueue<E> extends AbstractQueue<E>
     static class FifoWaitQueue extends WaitQueue {
         private static final long serialVersionUID = -3623113410248163686L;
     }
+    /** @serial */
     private ReentrantLock qlock;
+    /** @serial */
     private WaitQueue waitingProducers;
+    /** @serial */
     private WaitQueue waitingConsumers;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicBoolean.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicBoolean.java
@@ -55,6 +55,7 @@ public class AtomicBoolean implements java.io.Serializable {
     private static final VarHandle VALUE = MhUtil.findVarHandle(
             MethodHandles.lookup(), "value", int.class);
 
+    /** @serial */
     private volatile int value;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicInteger.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicInteger.java
@@ -63,6 +63,7 @@ public class AtomicInteger extends Number implements java.io.Serializable {
     private static final long VALUE
         = U.objectFieldOffset(AtomicInteger.class, "value");
 
+    /** @serial */
     private volatile int value;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicIntegerArray.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicIntegerArray.java
@@ -51,6 +51,7 @@ public class AtomicIntegerArray implements java.io.Serializable {
     private static final long serialVersionUID = 2862133569453604235L;
     private static final VarHandle AA
         = MethodHandles.arrayElementVarHandle(int[].class);
+    /** @serial */
     private final int[] array;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicLong.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicLong.java
@@ -63,6 +63,7 @@ public class AtomicLong extends Number implements java.io.Serializable {
     private static final long VALUE
         = U.objectFieldOffset(AtomicLong.class, "value");
 
+    /** @serial */
     private volatile long value;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicLongArray.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicLongArray.java
@@ -51,6 +51,7 @@ public class AtomicLongArray implements java.io.Serializable {
     private static final long serialVersionUID = -2308431214976778248L;
     private static final VarHandle AA
         = MethodHandles.arrayElementVarHandle(long[].class);
+    /** @serial */
     private final long[] array;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReference.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReference.java
@@ -55,6 +55,7 @@ public class AtomicReference<V> implements java.io.Serializable {
     private static final VarHandle VALUE = MhUtil.findVarHandle(
             MethodHandles.lookup(), "value", Object.class);
 
+    /** @serial */
     @SuppressWarnings("serial") // Conditionally serializable
     private volatile V value;
 

--- a/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReferenceArray.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/AtomicReferenceArray.java
@@ -55,6 +55,7 @@ public class AtomicReferenceArray<E> implements java.io.Serializable {
     private static final long serialVersionUID = -6209656149925076980L;
     private static final VarHandle AA
         = MethodHandles.arrayElementVarHandle(Object[].class);
+    /** @serial */
     @SuppressWarnings("serial") // Conditionally serializable
     private final Object[] array; // must have exact type Object[]
 

--- a/src/java.base/share/classes/java/util/concurrent/atomic/DoubleAccumulator.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/DoubleAccumulator.java
@@ -84,8 +84,10 @@ import java.util.function.DoubleBinaryOperator;
 public class DoubleAccumulator extends Striped64 implements Serializable {
     private static final long serialVersionUID = 7249069246863182397L;
 
+    /** @serial */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     private final DoubleBinaryOperator function;
+    /** @serial */
     private final long identity; // use long representation
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/atomic/LongAccumulator.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/LongAccumulator.java
@@ -82,8 +82,10 @@ import java.util.function.LongBinaryOperator;
 public class LongAccumulator extends Striped64 implements Serializable {
     private static final long serialVersionUID = 7249069246863182397L;
 
+    /** @serial */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     private final LongBinaryOperator function;
+    /** @serial */
     private final long identity;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -152,7 +152,7 @@ public abstract class AbstractQueuedLongSynchronizer
     private transient volatile Node tail;
 
     /**
-     * The synchronization state.
+     * @serial The synchronization state.
      */
     private volatile long state;
 

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -532,7 +532,7 @@ public abstract class AbstractQueuedSynchronizer
     private transient volatile Node tail;
 
     /**
-     * The synchronization state.
+     * @serial The synchronization state.
      */
     private volatile int state;
 

--- a/src/java.base/share/classes/java/util/concurrent/locks/ReentrantLock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/ReentrantLock.java
@@ -108,7 +108,7 @@ import jdk.internal.vm.annotation.ReservedStackAccess;
  */
 public class ReentrantLock implements Lock, java.io.Serializable {
     private static final long serialVersionUID = 7373984872572414699L;
-    /** Synchronizer providing all implementation mechanics */
+    /** @serial Synchronizer providing all implementation mechanics */
     private final Sync sync;
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
@@ -217,11 +217,11 @@ import jdk.internal.vm.annotation.ReservedStackAccess;
 public class ReentrantReadWriteLock
         implements ReadWriteLock, java.io.Serializable {
     private static final long serialVersionUID = -6992448646407690164L;
-    /** Inner class providing readlock */
+    /** @serial Inner class providing readlock */
     private final ReentrantReadWriteLock.ReadLock readerLock;
-    /** Inner class providing writelock */
+    /** @serial Inner class providing writelock */
     private final ReentrantReadWriteLock.WriteLock writerLock;
-    /** Performs all synchronization mechanics */
+    /** @serial Performs all synchronization mechanics */
     final Sync sync;
 
     /**
@@ -713,6 +713,7 @@ public class ReentrantReadWriteLock
      */
     public static class ReadLock implements Lock, java.io.Serializable {
         private static final long serialVersionUID = -5992448646407690164L;
+        /** @serial */
         private final Sync sync;
 
         /**
@@ -927,6 +928,7 @@ public class ReentrantReadWriteLock
      */
     public static class WriteLock implements Lock, java.io.Serializable {
         private static final long serialVersionUID = -4992448646407690164L;
+        /** @serial */
         private final Sync sync;
 
         /**

--- a/src/java.base/share/classes/java/util/regex/PatternSyntaxException.java
+++ b/src/java.base/share/classes/java/util/regex/PatternSyntaxException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,11 @@ public class PatternSyntaxException
     @java.io.Serial
     private static final long serialVersionUID = -3864639126226059218L;
 
+    /** @serial */
     private final String desc;
+    /** @serial */
     private final String pattern;
+    /** @serial */
     private final int index;
 
     /**


### PR DESCRIPTION
Please review a doc-only change to add missing `@serial` javadoc tags in module `java.base`. This is a sub-task of [JDK-8286931] to allow us to re-enable the javadoc `-serialwarn` option in the JDK doc build, which has been disabled since JDK 19.

[JDK-8286931]: https://bugs.openjdk.org/browse/JDK-8286931

For private and package-private serialized fields that already have a doc comment, the main description is converted to a block tag by prepending `@serial` since these fields do not require a main description. (For protected and public serialized fields we would have appended an empty `@serial` block tag instead with the same effect, but there are no protected/public fields in this particular sub-task.) For those fields that do not have a doc comment, a doc comment with an empty `@serial` tag is added. 

There is one special case in `java/util/UUID.java` where two private fields had plain traditional comments containing `@serial` tags instead of doc comments. Converting these comments to doc-comments is the only change in this PR that causes a change in the generated documentation, adding documentation for these two fields to the `serialized-form.html` page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347121](https://bugs.openjdk.org/browse/JDK-8347121): Add missing @<!---->serial tags to module java.base (**Sub-task** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22978/head:pull/22978` \
`$ git checkout pull/22978`

Update a local copy of the PR: \
`$ git checkout pull/22978` \
`$ git pull https://git.openjdk.org/jdk.git pull/22978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22978`

View PR using the GUI difftool: \
`$ git pr show -t 22978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22978.diff">https://git.openjdk.org/jdk/pull/22978.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22978#issuecomment-2578498999)
</details>
