### PR TITLE
8347122: Add missing @serial tags to module java.desktop

### DIFF
--- a/src/java.desktop/share/classes/java/applet/Applet.java
+++ b/src/java.desktop/share/classes/java/applet/Applet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -541,7 +541,7 @@ public class Applet extends Panel {
     //
 
     /**
-     * The accessible context associated with this {@code Applet}.
+     * @serial The accessible context associated with this {@code Applet}.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     AccessibleContext accessibleContext = null;

--- a/src/java.desktop/share/classes/java/awt/AWTEvent.java
+++ b/src/java.desktop/share/classes/java/awt/AWTEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ import sun.awt.AWTAccessor;
 public abstract class AWTEvent extends EventObject {
 
     /**
-     * The private data.
+     * @serial The private data.
      */
     private byte[] bdata;
 

--- a/src/java.desktop/share/classes/java/awt/AWTKeyStroke.java
+++ b/src/java.desktop/share/classes/java/awt/AWTKeyStroke.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,22 +86,22 @@ public class AWTKeyStroke implements Serializable {
     private static AWTKeyStroke APP_CONTEXT_KEYSTROKE_KEY = new AWTKeyStroke();
 
     /**
-     * The character value for a keyboard key.
+     * @serial The character value for a keyboard key.
      */
     private char keyChar = KeyEvent.CHAR_UNDEFINED;
 
     /**
-     * The key code for this {@code AWTKeyStroke}.
+     * @serial The key code for this {@code AWTKeyStroke}.
      */
     private int keyCode = KeyEvent.VK_UNDEFINED;
 
     /**
-     * The bitwise-ored combination of any modifiers.
+     * @serial The bitwise-ored combination of any modifiers.
      */
     private int modifiers;
 
     /**
-     * {@code true} if this {@code AWTKeyStroke} corresponds to a key release;
+     * @serial {@code true} if this {@code AWTKeyStroke} corresponds to a key release;
      * {@code false} otherwise.
      */
     private boolean onKeyRelease;

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -305,7 +305,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
     volatile Font font;
 
     /**
-     * The font which the peer is currently using.
+     * @serial The font which the peer is currently using.
      * ({@code null} if no peer exists.)
      */
     Font        peerFont;
@@ -508,7 +508,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
     Dimension minSize;
 
     /**
-     * Whether or not setMinimumSize has been invoked with a non-null value.
+     * @serial Whether or not setMinimumSize has been invoked with a non-null value.
      */
     boolean minSizeSet;
 
@@ -521,7 +521,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
     Dimension prefSize;
 
     /**
-     * Whether or not setPreferredSize has been invoked with a non-null value.
+     * @serial Whether or not setPreferredSize has been invoked with a non-null value.
      */
     boolean prefSizeSet;
 
@@ -533,7 +533,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
     Dimension maxSize;
 
     /**
-     * Whether or not setMaximumSize has been invoked with a non-null value.
+     * @serial Whether or not setMaximumSize has been invoked with a non-null value.
      */
     boolean maxSizeSet;
 
@@ -698,12 +698,12 @@ public abstract class Component implements ImageObserver, MenuContainer,
     }
 
     /**
-     * Whether the component is packed or not;
+     * @serial Whether the component is packed or not;
      */
     boolean isPacked = false;
 
     /**
-     * Pseudoparameter for direct Geometry API (setLocation, setBounds setSize
+     * @serial Pseudoparameter for direct Geometry API (setLocation, setBounds setSize
      * to signal setBounds what's changing. Should be used under TreeLock.
      * This is only needed due to the inability to change the cross-calling
      * order of public and deprecated methods.
@@ -8290,7 +8290,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
     }
 
     /**
-     * Used to disallow auto-focus-transfer on disposal of the focus owner
+     * @serial Used to disallow auto-focus-transfer on disposal of the focus owner
      * in the process of disposing its parent container.
      */
     private boolean autoFocusTransferOnDisposal = true;
@@ -9234,6 +9234,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
 
     /**
      * The {@code AccessibleContext} associated with this {@code Component}.
+     * @serial
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     protected AccessibleContext accessibleContext = null;
@@ -9290,6 +9291,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
         /**
          * A component listener to track show/hide/resize events
          * and convert them to PropertyChange events.
+         * @serial
          */
         @SuppressWarnings("serial") // Not statically typed as Serializable
         protected ComponentListener accessibleAWTComponentHandler = null;
@@ -9297,6 +9299,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
         /**
          * A listener to track focus events
          * and convert them to PropertyChange events.
+         * @serial
          */
         @SuppressWarnings("serial") // Not statically typed as Serializable
         protected FocusListener accessibleAWTFocusHandler = null;

--- a/src/java.desktop/share/classes/java/awt/ComponentOrientation.java
+++ b/src/java.desktop/share/classes/java/awt/ComponentOrientation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,7 +200,7 @@ public final class ComponentOrientation implements java.io.Serializable
     }
 
     /**
-     * The bitwise-ored combination of flags.
+     * @serial The bitwise-ored combination of flags.
      */
     private int orientation;
 

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3853,6 +3853,7 @@ public class Container extends Component {
         /**
          * The handler to fire {@code PropertyChange}
          * when children are added or removed
+         * @serial
          */
         @SuppressWarnings("serial") // Not statically typed as Serializable
         protected ContainerListener accessibleContainerHandler = null;

--- a/src/java.desktop/share/classes/java/awt/ContainerOrderFocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/java/awt/ContainerOrderFocusTraversalPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,12 +66,12 @@ public class ContainerOrderFocusTraversalPolicy extends FocusTraversalPolicy
     private static final PlatformLogger log = PlatformLogger.getLogger("java.awt.ContainerOrderFocusTraversalPolicy");
 
     /**
-     * This constant is used when the forward focus traversal order is active.
+     * @serial This constant is used when the forward focus traversal order is active.
      */
     private final int FORWARD_TRAVERSAL = 0;
 
     /**
-     * This constant is used when the backward focus traversal order is active.
+     * @serial This constant is used when the backward focus traversal order is active.
      */
     private final int BACKWARD_TRAVERSAL = 1;
 
@@ -82,7 +82,7 @@ public class ContainerOrderFocusTraversalPolicy extends FocusTraversalPolicy
     private static final long serialVersionUID = 486933713763926351L;
 
     /**
-     * Whether this {@code ContainerOrderFocusTraversalPolicy} transfers focus
+     * @serial Whether this {@code ContainerOrderFocusTraversalPolicy} transfers focus
      * down-cycle implicitly.
      */
     private boolean implicitDownCycleTraversal = true;

--- a/src/java.desktop/share/classes/java/awt/FlowLayout.java
+++ b/src/java.desktop/share/classes/java/awt/FlowLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,7 +188,7 @@ public class FlowLayout implements LayoutManager, java.io.Serializable {
     int vgap;
 
     /**
-     * If true, components will be aligned on their baseline.
+     * @serial If true, components will be aligned on their baseline.
      */
     private boolean alignOnBaseline;
 

--- a/src/java.desktop/share/classes/java/awt/Frame.java
+++ b/src/java.desktop/share/classes/java/awt/Frame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,7 +347,7 @@ public class Frame extends Window implements MenuContainer {
     boolean     mbManagement = false;   /* used only by the Motif impl. */
 
     /**
-     * The bitwise mask of frame state constants.
+     * @serial The bitwise mask of frame state constants.
      */
     // XXX: uwe: abuse old field for now
     // will need to take care of serialization

--- a/src/java.desktop/share/classes/java/awt/GridBagLayout.java
+++ b/src/java.desktop/share/classes/java/awt/GridBagLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -473,7 +473,7 @@ java.io.Serializable {
     public double[] rowWeights;
 
     /**
-     * The component being positioned.  This is set before calling into
+     * @serial The component being positioned.  This is set before calling into
      * {@code adjustForGravity}.
      */
     private Component componentAdjusting;

--- a/src/java.desktop/share/classes/java/awt/GridBagLayoutInfo.java
+++ b/src/java.desktop/share/classes/java/awt/GridBagLayoutInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,37 +45,37 @@ public final class GridBagLayoutInfo implements java.io.Serializable {
     private static final long serialVersionUID = -4899416460737170217L;
 
     /**
-     * The number of cells: horizontal and vertical.
+     * @serial The number of cells: horizontal and vertical.
      */
     int width, height;
 
     /**
-     * The starting point for layout.
+     * @serial The starting point for layout.
      */
     int startx, starty;
 
     /**
-     * The largest minWidth in each column.
+     * @serial The largest minWidth in each column.
      */
     int[] minWidth;
 
     /**
-     * The largest minHeight in each row.
+     * @serial The largest minHeight in each row.
      */
     int[] minHeight;
 
     /**
-     * The largest weight in each column.
+     * @serial The largest weight in each column.
      */
     double[] weightX;
 
     /**
-     * The largest weight in each row.
+     * @serial The largest weight in each row.
      */
     double[] weightY;
 
     /**
-     * Whether or not baseline layout has been requested and one of the
+     * @serial Whether or not baseline layout has been requested and one of the
      * components has a valid baseline.
      */
     boolean hasBaseline;
@@ -83,18 +83,18 @@ public final class GridBagLayoutInfo implements java.io.Serializable {
     // These are only valid if hasBaseline is true and are indexed by
     // row.
     /**
-     * The type of baseline for a particular row. A mix of the
+     * @serial The type of baseline for a particular row. A mix of the
      * BaselineResizeBehavior constants {@code (1 << ordinal())}
      */
     short[] baselineType;
 
     /**
-     * Max ascent (baseline).
+     * @serial Max ascent (baseline).
      */
     int[] maxAscent;
 
     /**
-     * Max descent (height - baseline)
+     * @serial Max descent (height - baseline)
      */
     int[] maxDescent;
 

--- a/src/java.desktop/share/classes/java/awt/List.java
+++ b/src/java.desktop/share/classes/java/awt/List.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1552,12 +1552,12 @@ public class List extends Component implements ItemSelectable, Accessible {
         // [[[FIXME]]] need to finish implementing this!!!
 
            /**
-            * The parent {@code List}.
+            * @serial The parent {@code List}.
             */
            private List parent;
 
            /**
-            * The index in the parent.
+            * @serial The index in the parent.
             */
            private int indexInParent;
 

--- a/src/java.desktop/share/classes/java/awt/MenuComponent.java
+++ b/src/java.desktop/share/classes/java/awt/MenuComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -436,7 +436,7 @@ public abstract class MenuComponent implements java.io.Serializable {
      * --- Accessibility Support ---
      */
     /**
-     * MenuComponent will contain all of the methods in interface Accessible,
+     * @serial MenuComponent will contain all of the methods in interface Accessible,
      * though it won't actually implement the interface - that will be up
      * to the individual objects which extend MenuComponent.
      */

--- a/src/java.desktop/share/classes/java/awt/ScrollPaneAdjustable.java
+++ b/src/java.desktop/share/classes/java/awt/ScrollPaneAdjustable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,7 +140,7 @@ public final class ScrollPaneAdjustable implements Adjustable, Serializable {
     private int blockIncrement = 1;
 
     /**
-     * Specified adjustment listener to receive adjustment events from this
+     * @serial Specified adjustment listener to receive adjustment events from this
      * {@code ScrollPaneAdjustable}.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable

--- a/src/java.desktop/share/classes/java/awt/TextComponent.java
+++ b/src/java.desktop/share/classes/java/awt/TextComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ public sealed class TextComponent extends Component implements Accessible
     int selectionEnd;
 
     /**
-     * A flag used to tell whether the background has been set by
+     * @serial A flag used to tell whether the background has been set by
      * developer code (as opposed to AWT code).  Used to determine
      * the background color of non-editable TextComponents.
      */
@@ -1207,7 +1207,7 @@ public sealed class TextComponent extends Component implements Accessible
     }  // end of AccessibleAWTTextComponent
 
     /**
-     * Whether support of input methods should be checked or not.
+     * @serial Whether support of input methods should be checked or not.
      */
     private boolean checkForEnableIM = true;
 }

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,7 +229,7 @@ public class Window extends Container implements Accessible {
     static boolean systemSyncLWRequests = false;
 
     /**
-     * Focus transfers should be synchronous for lightweight component requests.
+     * @serial Focus transfers should be synchronous for lightweight component requests.
      */
     boolean syncLWRequests = false;
     transient boolean beforeFirstShow = true;
@@ -2777,7 +2777,7 @@ public class Window extends Container implements Accessible {
     }
 
     /**
-     * Window type.
+     * @serial Window type.
      *
      * Synchronization: ObjectLock
      */
@@ -3337,7 +3337,7 @@ public class Window extends Container implements Accessible {
     }
 
     /**
-     * {@code true} if this Window should appear at the default location,
+     * @serial {@code true} if this Window should appear at the default location,
      * {@code false} if at the current location.
      */
     private volatile boolean locationByPlatform = locationByPlatformProp;

--- a/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ColorSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,12 +100,12 @@ public abstract class ColorSpace implements Serializable {
     private static final long serialVersionUID = -409452704308689724L;
 
     /**
-     * One of the {@code ColorSpace} type constants.
+     * @serial One of the {@code ColorSpace} type constants.
      */
     private final int type;
 
     /**
-     * The number of components in the color space.
+     * @serial The number of components in the color space.
      */
     private final int numComponents;
 

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,32 +88,32 @@ public class ICC_ColorSpace extends ColorSpace {
     private static final long serialVersionUID = 3455889114070431483L;
 
     /**
-     * The specified {@code ICC_Profile} object.
+     * @serial The specified {@code ICC_Profile} object.
      */
     private ICC_Profile thisProfile;
 
     /**
-     * The minimum normalized component values.
+     * @serial The minimum normalized component values.
      */
     private float[] minVal;
 
     /**
-     * The maximum normalized component values.
+     * @serial The maximum normalized component values.
      */
     private float[] maxVal;
 
     /**
-     * Difference between min and max values.
+     * @serial Difference between min and max values.
      */
     private float[] diffMinMax;
 
     /**
-     * Inverted value of the difference between min and max values.
+     * @serial Inverted value of the difference between min and max values.
      */
     private float[] invDiffMinMax;
 
     /**
-     * Whether the values should be scaled or not.
+     * @serial Whether the values should be scaled or not.
      */
     private boolean needScaleInit = true;
 

--- a/src/java.desktop/share/classes/java/awt/desktop/FilesEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/FilesEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public sealed class FilesEvent extends AppEvent
     private static final long serialVersionUID = 5271763715462312871L;
 
     /**
-     * The list of files.
+     * @serial The list of files.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     final List<File> files;

--- a/src/java.desktop/share/classes/java/awt/desktop/OpenFilesEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/OpenFilesEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public final class OpenFilesEvent extends FilesEvent {
     private static final long serialVersionUID = -3982871005867718956L;
 
     /**
-     * The search term used to find the files.
+     * @serial The search term used to find the files.
      */
     final String searchTerm;
 

--- a/src/java.desktop/share/classes/java/awt/desktop/OpenURIEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/OpenURIEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public final class OpenURIEvent extends AppEvent {
     private static final long serialVersionUID = 221209100935933476L;
 
     /**
-     * The {@code URI} the app was asked to open.
+     * @serial The {@code URI} the app was asked to open.
      */
     final URI uri;
 

--- a/src/java.desktop/share/classes/java/awt/desktop/UserSessionEvent.java
+++ b/src/java.desktop/share/classes/java/awt/desktop/UserSessionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public final class UserSessionEvent extends AppEvent {
     private static final long serialVersionUID = 6747138462796569055L;
 
     /**
-     * The reason of the user session change.
+     * @serial The reason of the user session change.
      */
     private final Reason reason;
 

--- a/src/java.desktop/share/classes/java/awt/event/HierarchyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/HierarchyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,18 +166,18 @@ public class HierarchyEvent extends AWTEvent {
     public static final int SHOWING_CHANGED = 0x4;
 
     /**
-     * The {@code Component} at the top of the hierarchy which was changed.
+     * @serial The {@code Component} at the top of the hierarchy which was changed.
      */
     Component changed;
 
     /**
-     * The parent of the {@code changed} component. This may be the parent
+     * @serial The parent of the {@code changed} component. This may be the parent
      * before or after the change, depending on the type of change.
      */
     Container changedParent;
 
     /**
-     * A bitmask which indicates the type(s) of the {@code HIERARCHY_CHANGED}
+     * @serial A bitmask which indicates the type(s) of the {@code HIERARCHY_CHANGED}
      * events represented in this event object. For information on allowable
      * values, see the class description for {@link HierarchyEvent}
      */

--- a/src/java.desktop/share/classes/java/awt/event/InvocationEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/InvocationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,6 +85,8 @@ public class InvocationEvent extends AWTEvent implements ActiveEvent {
 
     /**
      * The Runnable whose run() method will be called.
+     *
+     * @serial
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     protected Runnable runnable;
@@ -95,12 +97,13 @@ public class InvocationEvent extends AWTEvent implements ActiveEvent {
      * or after the event was disposed.
      *
      * @see #isDispatched
+     * @serial
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     protected volatile Object notifier;
 
     /**
-     * The (potentially null) Runnable whose run() method will be called
+     * @serial The (potentially null) Runnable whose run() method will be called
      * immediately after the event was dispatched or disposed.
      *
      * @see #isDispatched
@@ -110,7 +113,7 @@ public class InvocationEvent extends AWTEvent implements ActiveEvent {
     private final Runnable listener;
 
     /**
-     * Indicates whether the {@code run()} method of the {@code runnable}
+     * @serial Indicates whether the {@code run()} method of the {@code runnable}
      * was executed or not.
      *
      * @see #isDispatched
@@ -122,18 +125,20 @@ public class InvocationEvent extends AWTEvent implements ActiveEvent {
      * Set to true if dispatch() catches Throwable and stores it in the
      * exception instance variable. If false, Throwables are propagated up
      * to the EventDispatchThread's dispatch loop.
+     *
+     * @serial
      */
     protected boolean catchExceptions;
 
     /**
-     * The (potentially null) Exception thrown during execution of the
+     * @serial The (potentially null) Exception thrown during execution of the
      * Runnable.run() method. This variable will also be null if a particular
      * instance does not catch exceptions.
      */
     private Exception exception = null;
 
     /**
-     * The (potentially null) Throwable thrown during execution of the
+     * @serial The (potentially null) Throwable thrown during execution of the
      * Runnable.run() method. This variable will also be null if a particular
      * instance does not catch exceptions.
      */

--- a/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,7 +154,7 @@ import sun.awt.AWTAccessor;
 public non-sealed class KeyEvent extends InputEvent {
 
     /**
-     * Stores the state of native event dispatching system
+     * @serial Stores the state of native event dispatching system
      * - true, if when the event was created event proxying
      *         mechanism was active
      * - false, if it was inactive
@@ -1229,7 +1229,7 @@ public non-sealed class KeyEvent extends InputEvent {
     private static native void initIDs();
 
     /**
-     * The original event source.
+     * @serial The original event source.
      *
      * Event source can be changed during processing, but in some cases
      * we need to be able to obtain original source.

--- a/src/java.desktop/share/classes/java/awt/event/MouseEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/MouseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,7 +334,7 @@ public non-sealed class MouseEvent extends InputEvent {
     int clickCount;
 
     /**
-     * Indicates whether the event is a result of a touch event.
+     * @serial Indicates whether the event is a result of a touch event.
      */
     private boolean causedByTouchEvent;
 

--- a/src/java.desktop/share/classes/java/awt/event/MouseWheelEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/MouseWheelEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,7 +118,7 @@ public class MouseWheelEvent extends MouseEvent {
     @Native public static final int WHEEL_BLOCK_SCROLL = 1;
 
     /**
-     * Indicates what sort of scrolling should take place in response to this
+     * @serial Indicates what sort of scrolling should take place in response to this
      * event, based on platform settings.  Legal values are:
      * <ul>
      * <li> WHEEL_UNIT_SCROLL
@@ -130,7 +130,7 @@ public class MouseWheelEvent extends MouseEvent {
     int scrollType;
 
     /**
-     * Only valid for scrollType WHEEL_UNIT_SCROLL.
+     * @serial Only valid for scrollType WHEEL_UNIT_SCROLL.
      * Indicates number of units that should be scrolled per
      * click of mouse wheel rotation, based on platform settings.
      *
@@ -140,14 +140,14 @@ public class MouseWheelEvent extends MouseEvent {
     int scrollAmount;
 
     /**
-     * Indicates how far the mouse wheel was rotated.
+     * @serial Indicates how far the mouse wheel was rotated.
      *
      * @see #getWheelRotation
      */
     int wheelRotation;
 
     /**
-     * Indicates how far the mouse wheel was rotated.
+     * @serial Indicates how far the mouse wheel was rotated.
      *
      * @see #getPreciseWheelRotation
      */

--- a/src/java.desktop/share/classes/java/awt/event/WindowEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/WindowEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,12 +165,12 @@ public class WindowEvent extends ComponentEvent {
     transient Window opposite;
 
     /**
-     * Previous state of the window for window state change event.
+     * @serial Previous state of the window for window state change event.
      */
     int oldState;
 
     /**
-     * New state of the window for window state change event.
+     * @serial New state of the window for window state change event.
      */
     int newState;
 

--- a/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
+++ b/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -393,16 +393,16 @@ public final class NumericShaper implements java.io.Serializable {
         }
     }
 
-    /** index of context for contextual shaping - values range from 0 to 18 */
+    /** @serial index of context for contextual shaping - values range from 0 to 18 */
     private int key;
 
-    /** flag indicating whether to shape contextually (high bit) and which
+    /** @serial flag indicating whether to shape contextually (high bit) and which
      *  digit ranges to shape (bits 0-18)
      */
     private int mask;
 
     /**
-     * The context {@code Range} for contextual shaping or the {@code
+     * @serial The context {@code Range} for contextual shaping or the {@code
      * Range} for non-contextual shaping. {@code null} for the bit
      * mask-based API.
      *

--- a/src/java.desktop/share/classes/java/awt/font/TransformAttribute.java
+++ b/src/java.desktop/share/classes/java/awt/font/TransformAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ import java.io.Serializable;
 public final class TransformAttribute implements Serializable {
 
     /**
-     * The {@code AffineTransform} for this
+     * @serial The {@code AffineTransform} for this
      * {@code TransformAttribute}, or {@code null}
      * if {@code AffineTransform} is the identity transform.
      */

--- a/src/java.desktop/share/classes/java/awt/image/renderable/ParameterBlock.java
+++ b/src/java.desktop/share/classes/java/awt/image/renderable/ParameterBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,10 +102,16 @@ public class ParameterBlock implements Cloneable, Serializable {
     @Serial
     private static final long serialVersionUID = -7577115551785240750L;
 
-    /** A Vector of sources, stored as arbitrary Objects. */
+    /**
+     * A Vector of sources, stored as arbitrary Objects.
+     * @serial
+     */
     protected Vector<Object> sources = new Vector<Object>();
 
-    /** A Vector of non-source parameters, stored as arbitrary Objects. */
+    /**
+     * A Vector of non-source parameters, stored as arbitrary Objects.
+     * @serial
+     */
     protected Vector<Object> parameters = new Vector<Object>();
 
     /** A dummy constructor. */

--- a/src/java.desktop/share/classes/java/beans/IndexedPropertyChangeEvent.java
+++ b/src/java.desktop/share/classes/java/beans/IndexedPropertyChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public class IndexedPropertyChangeEvent extends PropertyChangeEvent {
     private static final long serialVersionUID = -320227448495806870L;
 
     /**
-     * The index of the property element that was changed.
+     * @serial The index of the property element that was changed.
      */
     private int index;
 

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -358,6 +358,8 @@ public class BeanContextChildSupport implements BeanContextChild, BeanContextSer
     /**
      * The {@code BeanContext} in which
      * this {@code BeanContextChild} is nested.
+     *
+     * @serial
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     public    BeanContextChild      beanContextChildPeer;
@@ -365,12 +367,16 @@ public class BeanContextChildSupport implements BeanContextChild, BeanContextSer
    /**
     * The {@code PropertyChangeSupport} associated with this
     * {@code BeanContextChildSupport}.
+    *
+    * @serial
     */
     protected PropertyChangeSupport pcSupport;
 
    /**
     * The {@code VetoableChangeSupport} associated with this
     * {@code BeanContextChildSupport}.
+    *
+    * @serial
     */
     protected VetoableChangeSupport vcSupport;
 

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,6 +105,8 @@ public abstract class BeanContextEvent extends EventObject {
 
     /**
      * The {@code BeanContext} from which this event was propagated
+     *
+     * @serial
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     protected BeanContext propagatedFrom;

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextMembershipEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextMembershipEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,6 +133,8 @@ public class BeanContextMembershipEvent extends BeanContextEvent {
    /**
     * The list of children affected by this
     * event notification.
+    *
+    * @serial
     */
     @SuppressWarnings({"rawtypes",
                        "serial"}) // Not statically typed as Serializable

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceAvailableEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceAvailableEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,6 +84,8 @@ public class BeanContextServiceAvailableEvent extends BeanContextEvent {
 
     /**
      * A {@code Class} reference to the newly available service
+     *
+     * @serial
      */
     protected Class<?>                   serviceClass;
 }

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceRevokedEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceRevokedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,11 +99,13 @@ public class BeanContextServiceRevokedEvent extends BeanContextEvent {
 
     /**
      * A {@code Class} reference to the service that is being revoked.
+     *
+     * @serial
      */
     protected Class<?> serviceClass;
 
     /**
-     * {@code true} if current service is being forcibly revoked.
+     * @serial {@code true} if current service is being forcibly revoked.
      */
     private boolean invalidateRefs;
 }

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -627,6 +627,8 @@ public class      BeanContextServicesSupport extends BeanContextSupport
 
             /**
              * The service provider.
+             *
+             * @serial
              */
             @SuppressWarnings("serial") // Not statically typed as Serializable
             protected BeanContextServiceProvider serviceProvider;

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -342,13 +342,13 @@ public class      BeanContextSupport extends BeanContextChildSupport
 
 
         /**
-         * The child.
+         * @serial The child.
          */
         @SuppressWarnings("serial") // Not statically typed as Serializable
         private Object child;
 
         /**
-         * The peer if the child and the peer are related by an implementation
+         * @serial The peer if the child and the peer are related by an implementation
          * of BeanContextProxy
          */
         @SuppressWarnings("serial") // Not statically typed as Serializable
@@ -1393,7 +1393,7 @@ public class      BeanContextSupport extends BeanContextChildSupport
     protected transient HashMap<Object, BCSChild>         children;
 
     /**
-     * Currently serializable children.
+     * @serial Currently serializable children.
      */
     private int serializable = 0; // children serializable
 
@@ -1407,12 +1407,16 @@ public class      BeanContextSupport extends BeanContextChildSupport
 
     /**
      * The current locale of this BeanContext.
+     *
+     * @serial
      */
     protected           Locale          locale;
 
     /**
      * A {@code boolean} indicating if this
      * instance may now render a GUI.
+     *
+     * @serial
      */
     protected           boolean         okToUseGui;
 
@@ -1420,6 +1424,8 @@ public class      BeanContextSupport extends BeanContextChildSupport
     /**
      * A {@code boolean} indicating whether or not
      * this object is currently in design time mode.
+     *
+     * @serial
      */
     protected           boolean         designTime;
 

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOInvalidTreeException.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOInvalidTreeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,8 @@ public class IIOInvalidTreeException extends IIOException {
     /**
      * The {@code Node} that led to the parsing error, or
      * {@code null}.
+     *
+     * @serial
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     protected Node offendingNode = null;

--- a/src/java.desktop/share/classes/javax/print/attribute/AttributeSetUtilities.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/AttributeSetUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ public final class AttributeSetUtilities {
         private static final long serialVersionUID = -6131802583863447813L;
 
         /**
-         * The attribute set.
+         * @serial The attribute set.
          */
         @SuppressWarnings("serial") // Not statically typed as Serializable
         private AttributeSet attrset;
@@ -352,7 +352,7 @@ public final class AttributeSetUtilities {
         private static final long serialVersionUID = 8365731020128564925L;
 
         /**
-         * The attribute set.
+         * @serial The attribute set.
          */
         @SuppressWarnings("serial") // Not statically typed as Serializable
         private AttributeSet attrset;

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/DialogOwner.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/DialogOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public final class DialogOwner implements PrintRequestAttribute {
     private static final long serialVersionUID = -1901909867156076547L;
 
     /**
-     * The owner of the dialog.
+     * @serial The owner of the dialog.
      */
     private Window owner;
     private transient long id;

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/MediaPrintableArea.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/MediaPrintableArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,12 +85,12 @@ public final class MediaPrintableArea
       implements DocAttribute, PrintRequestAttribute, PrintJobAttribute {
 
     /**
-     * Printable {@code x}, {@code y}, {@code width} and {@code height}.
+     * @serial Printable {@code x}, {@code y}, {@code width} and {@code height}.
      */
     private int x, y, w, h;
 
     /**
-     * The units in which the values are expressed.
+     * @serial The units in which the values are expressed.
      */
     private int units;
 

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/MediaSize.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/MediaSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class MediaSize extends Size2DSyntax implements Attribute {
     private static final long serialVersionUID = -1967958664615414771L;
 
     /**
-     * The media name.
+     * @serial The media name.
      */
     private MediaSizeName mediaName;
 

--- a/src/java.desktop/share/classes/javax/print/event/PrintJobAttributeEvent.java
+++ b/src/java.desktop/share/classes/javax/print/event/PrintJobAttributeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class PrintJobAttributeEvent extends PrintEvent {
     private static final long serialVersionUID = -6534469883874742101L;
 
     /**
-     * The printing service attributes that changed.
+     * @serial The printing service attributes that changed.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     private PrintJobAttributeSet attributes;

--- a/src/java.desktop/share/classes/javax/print/event/PrintJobEvent.java
+++ b/src/java.desktop/share/classes/javax/print/event/PrintJobEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class PrintJobEvent extends PrintEvent {
     private static final long serialVersionUID = -1711656903622072997L;
 
     /**
-     * The reason of this event.
+     * @serial The reason of this event.
      */
     private int reason;
 

--- a/src/java.desktop/share/classes/javax/print/event/PrintServiceAttributeEvent.java
+++ b/src/java.desktop/share/classes/javax/print/event/PrintServiceAttributeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class PrintServiceAttributeEvent extends PrintEvent {
     private static final long serialVersionUID = -7565987018140326600L;
 
     /**
-     * The printing service attributes that changed.
+     * @serial The printing service attributes that changed.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     private PrintServiceAttributeSet attributes;


### PR DESCRIPTION
Please review a doc-only change to add missing `@serial` javadoc tags in module `java.desktop`. This is a sub-task of [JDK-8286931] to allow us to re-enable the javadoc `-serialwarn` option in the JDK doc build, which has been disabled since JDK 19.

[JDK-8286931]: https://bugs.openjdk.org/browse/JDK-8286931

For private and package-private serialized fields that already have a doc comment, the main description is converted to a block tag by prepending `@serial` since these fields do not require a main description. For protected and public serialized fields that require a main description, an empty `@serial` block tag is appended to the doc comment instead. The effect is the same, as the main description is used in `serial-form.html` if the `@serial` tag is missing or empty. For those fields that do not have a doc comment, a doc comment with an empty `@serial` tag is added. 

This change has no effect on the generated documentation (apart from muting the warnings for missing `@serial` tags when building documentation with `-serialwarn` enabled).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347122](https://bugs.openjdk.org/browse/JDK-8347122): Add missing @<!---->serial tags to module java.desktop (**Sub-task** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22979/head:pull/22979` \
`$ git checkout pull/22979`

Update a local copy of the PR: \
`$ git checkout pull/22979` \
`$ git pull https://git.openjdk.org/jdk.git pull/22979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22979`

View PR using the GUI difftool: \
`$ git pr show -t 22979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22979.diff">https://git.openjdk.org/jdk/pull/22979.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22979#issuecomment-2578534669)
</details>
