### PR TITLE
8347123: Add missing @serial tags to other modules

### DIFF
--- a/src/java.datatransfer/share/classes/java/awt/datatransfer/DataFlavor.java
+++ b/src/java.datatransfer/share/classes/java/awt/datatransfer/DataFlavor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1286,6 +1286,9 @@ public class DataFlavor implements Externalizable, Cloneable {
 
     /**
      * Serializes this {@code DataFlavor}.
+     *
+     * @serialData The "mimeType" field with the "humanPresentableName" parameter set,
+     * followed by the "representationClass" field
      */
    public synchronized void writeExternal(ObjectOutput os) throws IOException {
        if (mimeType != null) {

--- a/src/java.datatransfer/share/classes/java/awt/datatransfer/DataFlavor.java
+++ b/src/java.datatransfer/share/classes/java/awt/datatransfer/DataFlavor.java
@@ -1287,8 +1287,8 @@ public class DataFlavor implements Externalizable, Cloneable {
     /**
      * Serializes this {@code DataFlavor}.
      *
-     * @serialData The "mimeType" field with the "humanPresentableName" parameter set,
-     * followed by the "representationClass" field
+     * @serialData The {@code mimeType} field with the {@code humanPresentableName} parameter set,
+     * followed by the {@code representationClass} field
      */
    public synchronized void writeExternal(ObjectOutput os) throws IOException {
        if (mimeType != null) {

--- a/src/java.management/share/classes/javax/management/ImmutableDescriptor.java
+++ b/src/java.management/share/classes/javax/management/ImmutableDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,13 +42,13 @@ public class ImmutableDescriptor implements Descriptor {
     private static final long serialVersionUID = 8853308591080540165L;
 
     /**
-     * The names of the fields in this ImmutableDescriptor with their
+     * @serial The names of the fields in this ImmutableDescriptor with their
      * original case.  The names must be in alphabetical order as determined
      * by {@link String#CASE_INSENSITIVE_ORDER}.
      */
     private final String[] names;
     /**
-     * The values of the fields in this ImmutableDescriptor.  The
+     * @serial The values of the fields in this ImmutableDescriptor.  The
      * elements in this array match the corresponding elements in the
      * {@code names} array.
      */

--- a/src/java.management/share/classes/javax/management/MBeanPermission.java
+++ b/src/java.management/share/classes/javax/management/MBeanPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -217,7 +217,7 @@ public class MBeanPermission extends Permission {
         UnregisterMBean;
 
     /**
-     * The actions string.
+     * @serial The actions string.
      */
     private String actions;
 

--- a/src/java.management/share/classes/javax/management/remote/JMXServiceURL.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXServiceURL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -758,22 +758,22 @@ public class JMXServiceURL implements Serializable {
     }
 
     /**
-     * The value returned by {@link #getProtocol()}.
+     * @serial The value returned by {@link #getProtocol()}.
      */
     private String protocol;
 
     /**
-     * The value returned by {@link #getHost()}.
+     * @serial The value returned by {@link #getHost()}.
      */
     private String host;
 
     /**
-     * The value returned by {@link #getPort()}.
+     * @serial The value returned by {@link #getPort()}.
      */
     private int port;
 
     /**
-     * The value returned by {@link #getURLPath()}.
+     * @serial The value returned by {@link #getURLPath()}.
      */
     private String urlPath;
 

--- a/src/java.management/share/classes/javax/management/remote/NotificationResult.java
+++ b/src/java.management/share/classes/javax/management/remote/NotificationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,8 +148,11 @@ public class NotificationResult implements Serializable {
         }
     }
 
+    /** @serial */
     private long earliestSequenceNumber;
+    /** @serial */
     private long nextSequenceNumber;
+    /** @serial */
     private TargetedNotification[] targetedNotifications;
 
     private static void validate(TargetedNotification[] targetedNotifications,

--- a/src/java.scripting/share/classes/javax/script/ScriptException.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,11 @@ public class ScriptException extends Exception {
 
     private static final long serialVersionUID = 8265071037049225001L;
 
+    /** @serial */
     private final String fileName;
+    /** @serial */
     private final int lineNumber;
+    /** @serial */
     private final int columnNumber;
 
     /**

--- a/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KerberosTicket.java
+++ b/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KerberosTicket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,7 +187,7 @@ public class KerberosTicket implements Destroyable, Refreshable,
     private InetAddress[] clientAddresses;
 
     /**
-     * Evidence ticket if proxy_impersonator. This field can be accessed
+     * @serial Evidence ticket if proxy_impersonator. This field can be accessed
      * by KerberosSecrets. It's serialized.
      */
     KerberosTicket proxy = null;

--- a/src/java.smartcardio/share/classes/javax/smartcardio/ATR.java
+++ b/src/java.smartcardio/share/classes/javax/smartcardio/ATR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@ public final class ATR implements java.io.Serializable {
 
     private static final long serialVersionUID = 6695383790847736493L;
 
+    /** @serial */
     private byte[] atr;
 
     private transient int startHistorical, nHistorical;

--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SerialBlob.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SerialBlob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ public class SerialBlob implements Blob, Serializable, Cloneable {
     private byte[] buf;
 
     /**
-     * The internal representation of the <code>Blob</code> object on which this
+     * @serial The internal representation of the <code>Blob</code> object on which this
      * <code>SerialBlob</code> object is based.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable; checked in writeObject

--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SerialClob.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SerialClob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class SerialClob implements Clob, Serializable, Cloneable {
     private char buf[];
 
     /**
-     * Internal Clob representation if SerialClob is initialized with a
+     * @serial Internal Clob representation if SerialClob is initialized with a
      * Clob. Null if SerialClob is initialized with a char[].
      */
     @SuppressWarnings("serial")  // Not statically typed as Serializable; checked in writeObject

--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SerialJavaObject.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SerialJavaObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ import javax.sql.rowset.RowSetWarning;
 public class SerialJavaObject implements Serializable, Cloneable {
 
     /**
-     * Placeholder for object to be serialized.
+     * @serial Placeholder for object to be serialized.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     private Object obj;
@@ -139,7 +139,7 @@ public class SerialJavaObject implements Serializable, Cloneable {
     static final long serialVersionUID = -1465795139032831023L;
 
     /**
-     * A container for the warnings issued on this <code>SerialJavaObject</code>
+     * @serial A container for the warnings issued on this <code>SerialJavaObject</code>
      * object. When there are multiple warnings, each warning is chained to the
      * previous warning.
      */

--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SerialRef.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SerialRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,13 +54,13 @@ public class SerialRef implements Ref, Serializable, Cloneable {
     private String baseTypeName;
 
     /**
-     * This will store the type <code>Ref</code> as an <code>Object</code>.
+     * @serial This will store the type <code>Ref</code> as an <code>Object</code>.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     private Object object;
 
     /**
-     * Private copy of the Ref reference.
+     * @serial Private copy of the Ref reference.
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable; checked in writeObject
     private Ref reference;

--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/spi/SyncProviderException.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/spi/SyncProviderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ import javax.sql.rowset.*;
 public class SyncProviderException extends java.sql.SQLException {
 
     /**
-     * The instance of <code>javax.sql.rowset.spi.SyncResolver</code> that
+     * @serial The instance of <code>javax.sql.rowset.spi.SyncResolver</code> that
      * this <code>SyncProviderException</code> object will return when its
      * <code>getSyncResolver</code> method is called.
      */

--- a/src/java.sql/share/classes/java/sql/SQLClientInfoException.java
+++ b/src/java.sql/share/classes/java/sql/SQLClientInfoException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import java.util.Map;
 public class SQLClientInfoException extends SQLException {
 
         /**
-         * A {@code Map} containing the client info properties that could not be set.
+         * @serial A {@code Map} containing the client info properties that could not be set.
          */
         @SuppressWarnings("serial") // Not statically typed as Serializable
         private Map<String, ClientInfoStatus>   failedProperties;

--- a/src/java.sql/share/classes/javax/sql/StatementEvent.java
+++ b/src/java.sql/share/classes/javax/sql/StatementEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,12 +44,12 @@ public class StatementEvent extends EventObject {
 
         static final long serialVersionUID = -8089573731826608315L;
         /**
-         * The {@code SQLException} the driver is about to throw to the application.
+         * @serial The {@code SQLException} the driver is about to throw to the application.
          */
         private SQLException            exception;
 
         /**
-         * The {@code PreparedStatement} that is being closed or is invalid.
+         * @serial The {@code PreparedStatement} that is being closed or is invalid.
          */
         @SuppressWarnings("serial") // Not statically typed as Serializable
         private PreparedStatement       statement;

--- a/src/java.xml.crypto/share/classes/javax/xml/crypto/URIReferenceException.java
+++ b/src/java.xml.crypto/share/classes/javax/xml/crypto/URIReferenceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public class URIReferenceException extends Exception {
     private Throwable cause;
 
     /**
-     * The {@code URIReference} that was being dereferenced
+     * @serial The {@code URIReference} that was being dereferenced
      * when the exception was thrown, or {@code null} if not specified.
      */
     @SuppressWarnings("serial") // Type of field is not Serializable

--- a/src/java.xml/share/classes/javax/xml/namespace/QName.java
+++ b/src/java.xml/share/classes/javax/xml/namespace/QName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,17 +70,17 @@ public class QName implements Serializable {
     private static final long serialVersionUID = -9120448754896609940L;
 
     /**
-     * <p>Namespace URI of this <code>QName</code>.</p>
+     * @serial <p>Namespace URI of this <code>QName</code>.</p>
      */
     private final String namespaceURI;
 
     /**
-     * <p>local part of this <code>QName</code>.</p>
+     * @serial <p>local part of this <code>QName</code>.</p>
      */
     private final String localPart;
 
     /**
-     * <p>prefix of this <code>QName</code>.</p>
+     * @serial <p>prefix of this <code>QName</code>.</p>
      */
     private final String prefix;
 

--- a/src/java.xml/share/classes/javax/xml/parsers/FactoryConfigurationError.java
+++ b/src/java.xml/share/classes/javax/xml/parsers/FactoryConfigurationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class FactoryConfigurationError extends Error {
     private static final long serialVersionUID = -827108682472263355L;
 
     /**
-     *<code>Exception</code> that represents the error.
+     * @serial <code>Exception</code> that represents the error.
      */
     private Exception exception;
 

--- a/src/java.xml/share/classes/javax/xml/stream/FactoryConfigurationError.java
+++ b/src/java.xml/share/classes/javax/xml/stream/FactoryConfigurationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class FactoryConfigurationError extends Error {
     private static final long serialVersionUID = -2994412584589975744L;
 
   /**
-   * The nested exception.
+   * @serial The nested exception.
    */
   Exception nested;
 

--- a/src/java.xml/share/classes/javax/xml/stream/XMLStreamException.java
+++ b/src/java.xml/share/classes/javax/xml/stream/XMLStreamException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,11 +39,15 @@ public class XMLStreamException extends Exception {
 
   /**
    * The nested exception.
+   *
+   * @serial
    */
   protected Throwable nested;
 
   /**
    * The location of the error.
+   *
+   * @serial
    */
   @SuppressWarnings("serial") // Type of field is not Serializable
   protected Location location;

--- a/src/java.xml/share/classes/javax/xml/transform/TransformerException.java
+++ b/src/java.xml/share/classes/javax/xml/transform/TransformerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class TransformerException extends Exception {
 
     private static final long serialVersionUID = 975798773772956428L;
 
-    /** Field locator specifies where the error occurred */
+    /** @serial Field locator specifies where the error occurred */
     @SuppressWarnings("serial") // Type of field is not Serializable
     SourceLocator locator;
 
@@ -68,7 +68,7 @@ public class TransformerException extends Exception {
         this.locator = location;
     }
 
-    /** Field containedException specifies a wrapped exception.  May be null. */
+    /** @serial Field containedException specifies a wrapped exception.  May be null. */
     Throwable containedException;
 
     /**

--- a/src/java.xml/share/classes/javax/xml/transform/TransformerFactoryConfigurationError.java
+++ b/src/java.xml/share/classes/javax/xml/transform/TransformerFactoryConfigurationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class TransformerFactoryConfigurationError extends Error {
     private static final long serialVersionUID = -6527718720676281516L;
 
     /**
-     * <code>Exception</code> for the
+     * @serial <code>Exception</code> for the
      *  <code>TransformerFactoryConfigurationError</code>.
      */
     private Exception exception;

--- a/src/java.xml/share/classes/org/w3c/dom/DOMException.java
+++ b/src/java.xml/share/classes/org/w3c/dom/DOMException.java
@@ -66,6 +66,10 @@ public class DOMException extends RuntimeException {
        super(message);
        this.code = code;
     }
+
+    /**
+     * @serial
+     */
     public short   code;
     // ExceptionCode
     /**

--- a/src/java.xml/share/classes/org/w3c/dom/events/EventException.java
+++ b/src/java.xml/share/classes/org/w3c/dom/events/EventException.java
@@ -54,6 +54,9 @@ public class EventException extends RuntimeException {
        super(message);
        this.code = code;
     }
+    /**
+     * @serial
+     */
     public short   code;
     // EventExceptionCode
     /**

--- a/src/java.xml/share/classes/org/w3c/dom/ls/LSException.java
+++ b/src/java.xml/share/classes/org/w3c/dom/ls/LSException.java
@@ -64,6 +64,9 @@ public class LSException extends RuntimeException {
        super(message);
        this.code = code;
     }
+    /**
+     * @serial
+     */
     public short   code;
     // LSExceptionCode
     /**

--- a/src/java.xml/share/classes/org/w3c/dom/ranges/RangeException.java
+++ b/src/java.xml/share/classes/org/w3c/dom/ranges/RangeException.java
@@ -54,6 +54,9 @@ public class RangeException extends RuntimeException {
        super(message);
        this.code = code;
     }
+    /**
+     * @serial
+     */
     public short   code;
     // RangeExceptionCode
     /**

--- a/src/jdk.attach/share/classes/com/sun/tools/attach/AgentInitializationException.java
+++ b/src/jdk.attach/share/classes/com/sun/tools/attach/AgentInitializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ public class AgentInitializationException extends Exception {
     /** use serialVersionUID for interoperability */
     static final long serialVersionUID = -1508756333332806353L;
 
+    /** @serial */
     private int returnValue;
 
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/beans/StaticClass.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/beans/StaticClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ public final class StaticClass implements Serializable {
     private static final long serialVersionUID = 1L;
 
     /**
-     * The runtime {@code Class} object whose static members this
+     * @serial The runtime {@code Class} object whose static members this
      * {@code StaticClass} represents.
      */
     private final Class<?> clazz;

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,6 +99,7 @@ import static java.lang.Math.multiplyHigh;
 public final class Float16
     extends Number
     implements Comparable<Float16> {
+    /** @serial */
     private final short value;
     private static final long serialVersionUID = 16; // May not be needed when a value class?
 

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ClassNotLoadedException.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ClassNotLoadedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,7 @@ public class ClassNotLoadedException extends Exception {
 
     private static final long serialVersionUID = -6242978768444298722L;
 
+    /** @serial */
     private String className;
 
     public ClassNotLoadedException(String className) {

--- a/src/jdk.jdi/share/classes/com/sun/jdi/InternalException.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/InternalException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ public class InternalException extends RuntimeException {
 
     private static final long serialVersionUID = -9171606393104480607L;
 
+    /** @serial */
     private int errorCode;
 
     public InternalException() {

--- a/src/jdk.jdi/share/classes/com/sun/jdi/InvocationException.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/InvocationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ public class InvocationException extends Exception {
 
     private static final long serialVersionUID = 6066780907971918568L;
 
+    /** @serial */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     ObjectReference exception;
 

--- a/src/jdk.jdi/share/classes/com/sun/jdi/connect/IllegalConnectorArgumentsException.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/connect/IllegalConnectorArgumentsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ public class IllegalConnectorArgumentsException extends Exception {
 
     private static final long serialVersionUID = -3042212603611350941L;
 
+    /** @serial */
     @SuppressWarnings("serial") // Conditionally serializable
     List<String> names;
 

--- a/src/jdk.jdi/share/classes/com/sun/jdi/connect/VMStartException.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/connect/VMStartException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ public class VMStartException extends Exception {
 
     private static final long serialVersionUID = 6408644824640801020L;
 
+    /** @serial */
     @SuppressWarnings("serial") // Not statically typed as Serializable
     Process process;
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/EvalException.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/EvalException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ package jdk.jshell;
  */
 @SuppressWarnings("serial")             // serialVersionUID intentionally omitted
 public class EvalException extends JShellException {
+    /** @serial */
     private final String exceptionClass;
 
     EvalException(String message, String exceptionClass,

--- a/src/jdk.jshell/share/classes/jdk/jshell/UnresolvedReferenceException.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/UnresolvedReferenceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ package jdk.jshell;
 @SuppressWarnings("serial")             // serialVersionUID intentionally omitted
 public class UnresolvedReferenceException extends JShellException {
 
+    /** @serial */
     final DeclarationSnippet snippet;
 
     UnresolvedReferenceException(DeclarationSnippet snippet, StackTraceElement[] stackElements) {

--- a/src/jdk.jshell/share/classes/jdk/jshell/spi/ExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/spi/ExecutionControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,7 +302,9 @@ public interface ExecutionControl extends AutoCloseable {
     public static final class ClassBytecodes implements Serializable {
 
         private static final long serialVersionUID = 0xC1A55B47EC0DE5L;
+        /** @serial */
         private final String name;
+        /** @serial */
         private final byte[] bytecodes;
 
         /**
@@ -389,6 +391,7 @@ public interface ExecutionControl extends AutoCloseable {
 
         private static final long serialVersionUID = 1L;
 
+        /** @serial */
         private final boolean[] installed;
 
         public ClassInstallException(String message, boolean[] installed) {
@@ -426,6 +429,7 @@ public interface ExecutionControl extends AutoCloseable {
 
         private static final long serialVersionUID = 1L;
 
+        /** @serial */
         private final String causeExceptionClass;
 
         @SuppressWarnings("this-escape")
@@ -459,6 +463,7 @@ public interface ExecutionControl extends AutoCloseable {
 
         private static final long serialVersionUID = 1L;
 
+        /** @serial */
         private final int id;
 
         /**

--- a/src/jdk.jshell/share/classes/jdk/jshell/spi/SPIResolutionException.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/spi/SPIResolutionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ package jdk.jshell.spi;
 @SuppressWarnings("serial")             // serialVersionUID intentionally omitted
 public class SPIResolutionException extends RuntimeException {
 
+    /** @serial */
     private final int id;
 
     /**

--- a/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathException.java
+++ b/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathException.java
@@ -62,6 +62,9 @@ public class XPathException extends RuntimeException {
        super(message);
        this.code = code;
     }
+    /**
+     * @serial
+     */
     public short   code;
     // XPathExceptionCode
     /**


### PR DESCRIPTION
Please review a doc-only change to mostly add missing `@serial` javadoc tags. This is a sub-task of [JDK-8286931] to allow us to re-enable the javadoc `-serialwarn` option in the JDK doc build, which has been disabled since JDK 19.

[JDK-8286931]: https://bugs.openjdk.org/browse/JDK-8286931

For private and package-private serialized fields that already have a doc comment, the main description is converted to a block tag by prepending `@serial` since these fields do not require a main description. For protected and public serialized fields that require a main description, an empty `@serial` block tag is appended to the doc comment instead. The effect is the same, as the main description is used in `serial-form.html` if the `@serial` tag is missing or empty. For those fields that do not have a doc comment, a doc comment with an empty `@serial` tag is added. 

Apart from missing `@serial` tags, this PR also adds a `@serialData` tag to `java.awt.datatransfer.DataFlavor.writeExternal(ObjectOutput)` that the javadoc `-serialwarn` option complains about. This is the only change in this PR that adds documentation text and causes a change in the generated documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8348408](https://bugs.openjdk.org/browse/JDK-8348408) to be approved

### Issues
 * [JDK-8347123](https://bugs.openjdk.org/browse/JDK-8347123): Add missing @<!---->serial tags to other modules (**Sub-task** - P4)
 * [JDK-8348408](https://bugs.openjdk.org/browse/JDK-8348408): Add missing @<!---->serial tags to other modules (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - Committer)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22980/head:pull/22980` \
`$ git checkout pull/22980`

Update a local copy of the PR: \
`$ git checkout pull/22980` \
`$ git pull https://git.openjdk.org/jdk.git pull/22980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22980`

View PR using the GUI difftool: \
`$ git pr show -t 22980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22980.diff">https://git.openjdk.org/jdk/pull/22980.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22980#issuecomment-2578598191)
</details>
