### PR TITLE
8347171: (dc) java/nio/channels/DatagramChannel/InterruptibleOrNot.java fails with virtual thread factory

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/InterruptibleOrNot.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/InterruptibleOrNot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.function.Executable;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class InterruptibleOrNot {
     // DatagramChannel implementation class
@@ -98,6 +99,7 @@ public class InterruptibleOrNot {
      */
     @Test
     public void testInterruptBeforeUninterruptibleReceive() throws Exception {
+        assumeFalse(Thread.currentThread().isVirtual());
         try (DatagramChannel dc = boundDatagramChannel(false)) {
             ByteBuffer buf = ByteBuffer.allocate(100);
             onReceive(() -> {


### PR DESCRIPTION
Do not run `testInterruptBeforeUninterruptibleReceive` when the thread is virtual.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347171](https://bugs.openjdk.org/browse/JDK-8347171): (dc) java/nio/channels/DatagramChannel/InterruptibleOrNot.java fails with virtual thread factory (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22981/head:pull/22981` \
`$ git checkout pull/22981`

Update a local copy of the PR: \
`$ git checkout pull/22981` \
`$ git pull https://git.openjdk.org/jdk.git pull/22981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22981`

View PR using the GUI difftool: \
`$ git pr show -t 22981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22981.diff">https://git.openjdk.org/jdk/pull/22981.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22981#issuecomment-2578650119)
</details>
