### PR TITLE
8347300: Don't exclude the "PATH" var from the environment when running app launchers in jpackage tests

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Executor.java
@@ -53,7 +53,6 @@ public final class Executor extends CommandArguments<Executor> {
 
     public Executor() {
         saveOutputType = new HashSet<>(Set.of(SaveOutputType.NONE));
-        removePathEnvVar = false;
         winEnglishOutput = false;
     }
 
@@ -86,8 +85,8 @@ public final class Executor extends CommandArguments<Executor> {
         return setExecutable(v.getPath());
     }
 
-    public Executor setRemovePathEnvVar(boolean value) {
-        removePathEnvVar = value;
+    public Executor removeEnvVar(String envVarName) {
+        removeEnvVars.add(Objects.requireNonNull(envVarName));
         return this;
     }
 
@@ -372,10 +371,12 @@ public final class Executor extends CommandArguments<Executor> {
             builder.directory(directory.toFile());
             sb.append(String.format("; in directory [%s]", directory));
         }
-        if (removePathEnvVar) {
-            // run this with cleared Path in Environment
-            TKit.trace("Clearing PATH in environment");
-            builder.environment().remove("PATH");
+        if (!removeEnvVars.isEmpty()) {
+            final var envComm = Comm.compare(builder.environment().keySet(), removeEnvVars);
+            builder.environment().keySet().removeAll(envComm.common());
+            envComm.common().forEach(envVar -> {
+                TKit.trace(String.format("Clearing %s in environment", envVar));
+            });
         }
 
         trace("Execute " + sb.toString() + "...");
@@ -504,7 +505,7 @@ public final class Executor extends CommandArguments<Executor> {
     private Path executable;
     private Set<SaveOutputType> saveOutputType;
     private Path directory;
-    private boolean removePathEnvVar;
+    private Set<String> removeEnvVars = new HashSet<>();
     private boolean winEnglishOutput;
     private String winTmpDir = null;
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
@@ -472,14 +472,14 @@ public final class HelloApp {
                 }
             }
 
-            final List<String> launcherArgs = List.of(args);
-            return new Executor()
+            final var executor = new Executor()
                     .setDirectory(outputFile.getParent())
                     .saveOutput(saveOutput)
                     .dumpOutput()
-                    .setRemovePathEnvVar(removePathEnvVar)
                     .setExecutable(executablePath)
-                    .addArguments(launcherArgs);
+                    .addArguments(List.of(args));
+
+            return configureEnvironment(executor);
         }
 
         private boolean launcherNoExit;
@@ -496,6 +496,14 @@ public final class HelloApp {
         return new AppOutputVerifier(helloAppLauncher);
     }
 
+    public static Executor configureEnvironment(Executor executor) {
+        if (CLEAR_JAVA_ENV_VARS) {
+            executor.removeEnvVar("JAVA_TOOL_OPTIONS");
+            executor.removeEnvVar("_JAVA_OPTIONS");
+        }
+        return executor;
+    }
+
     static final String OUTPUT_FILENAME = "appOutput.txt";
 
     private final JavaAppDesc appDesc;
@@ -505,4 +513,7 @@ public final class HelloApp {
 
     private static final String CLASS_NAME = HELLO_JAVA.getFileName().toString().split(
             "\\.", 2)[0];
+
+    private static final boolean CLEAR_JAVA_ENV_VARS = Optional.ofNullable(
+            TKit.getConfigProperty("clear-app-launcher-java-env-vars")).map(Boolean::parseBoolean).orElse(false);
 }

--- a/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
+++ b/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
+++ b/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Executor;
+import static jdk.jpackage.test.HelloApp.configureEnvironment;
 import jdk.jpackage.test.TKit;
 
 /**
@@ -53,6 +54,7 @@ public class AppLauncherEnvTest {
 
         JPackageCommand cmd = JPackageCommand
                 .helloAppImage(TEST_APP_JAVA + "*Hello")
+                .ignoreFakeRuntime()
                 .addArguments("--java-options", "-D" + testAddDirProp
                         + "=$APPDIR");
 
@@ -62,7 +64,7 @@ public class AppLauncherEnvTest {
 
         final int attempts = 3;
         final int waitBetweenAttemptsSeconds = 5;
-        List<String> output = new Executor()
+        List<String> output = configureEnvironment(new Executor())
                 .saveOutput()
                 .setExecutable(cmd.appLauncherPath().toAbsolutePath())
                 .addArguments("--print-env-var=" + envVarName)

--- a/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
+++ b/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
+++ b/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import java.nio.file.Path;
 
 import jdk.jpackage.test.JPackageCommand;
+import static jdk.jpackage.test.HelloApp.configureEnvironment;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Executor;
 import jdk.jpackage.test.TKit;
@@ -54,14 +55,15 @@ public class WinChildProcessTest {
         long childPid = 0;
         try {
             JPackageCommand cmd = JPackageCommand
-                    .helloAppImage(TEST_APP_JAVA + "*Hello");
+                    .helloAppImage(TEST_APP_JAVA + "*Hello")
+                    .ignoreFakeRuntime();
 
             // Create the image of the third party application launcher
             cmd.executeAndAssertImageCreated();
 
             // Start the third party application launcher and dump and save the
             // output of the application
-            List<String> output = new Executor().saveOutput().dumpOutput()
+            List<String> output = configureEnvironment(new Executor()).saveOutput().dumpOutput()
                     .setExecutable(cmd.appLauncherPath().toAbsolutePath())
                     .execute(0).getOutput();
             String pidStr = output.get(0);


### PR DESCRIPTION
- Don't remove the `PATH` variable from the environment when running app launchers in jpackage tests;
- Fix tests that use `Executor` rather than `HelloApp` class to run app launchers: apply the same changes to the environment as would be applied by `HelloApp` class.
- Replace `Executor.setRemovePathEnvVar()` with `Executor.removeEnvVar()` to support removal of any variable from the environment of a child process executed in jpackage tests;
- Add support of a new boolean property `jpackage.test.clear-app-launcher-java-env-vars` in jpackage tests. If it is set to "true", the `JAVA_TOOL_OPTIONS` and `_JAVA_OPTIONS` variables will be removed from the environment of app launchers executed in jpackage tests. It is handy in local testing using jpackage test runner instead of the jtreg.

The first and the second changes are unrelated to other changes. They are bundled together as they apply to the same source code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347300](https://bugs.openjdk.org/browse/JDK-8347300): Don't exclude the "PATH" var from the environment when running app launchers in jpackage tests (**Enhancement** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22983/head:pull/22983` \
`$ git checkout pull/22983`

Update a local copy of the PR: \
`$ git checkout pull/22983` \
`$ git pull https://git.openjdk.org/jdk.git pull/22983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22983`

View PR using the GUI difftool: \
`$ git pr show -t 22983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22983.diff">https://git.openjdk.org/jdk/pull/22983.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22983#issuecomment-2578808415)
</details>
