### PR TITLE
8347297: Skip the RuntimeImageSymbolicLinksTest test on Windows when it is executed outside of the jtreg

### DIFF
--- a/test/jdk/tools/jpackage/share/RuntimeImageSymbolicLinksTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimeImageSymbolicLinksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jpackage/share/RuntimeImageSymbolicLinksTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimeImageSymbolicLinksTest.java
@@ -23,6 +23,7 @@
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import static jdk.internal.util.OperatingSystem.WINDOWS;
 import jdk.jpackage.test.ApplicationLayout;
 import jdk.jpackage.test.TKit;
 import jdk.jpackage.test.Annotations.Test;
@@ -49,7 +50,7 @@ import jdk.jpackage.test.Executor;
 
 public class RuntimeImageSymbolicLinksTest {
 
-    @Test
+    @Test(ifNotOS = WINDOWS)
     public static void test() throws Exception {
         final Path jmods = Path.of(System.getProperty("java.home"), "jmods");
         final Path workDir = TKit.createTempDirectory("runtime").resolve("data");


### PR DESCRIPTION
Minor change affecting jpackage tests execution with jpackage test runner

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347297](https://bugs.openjdk.org/browse/JDK-8347297): Skip the RuntimeImageSymbolicLinksTest test on Windows when it is executed outside of the jtreg (**Enhancement** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22988/head:pull/22988` \
`$ git checkout pull/22988`

Update a local copy of the PR: \
`$ git checkout pull/22988` \
`$ git pull https://git.openjdk.org/jdk.git pull/22988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22988`

View PR using the GUI difftool: \
`$ git pr show -t 22988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22988.diff">https://git.openjdk.org/jdk/pull/22988.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22988#issuecomment-2578890714)
</details>
