### PR TITLE
8347295: Fix WinResourceTest to make it work with WiX v4.0+

### DIFF
--- a/test/jdk/tools/jpackage/windows/WinResourceTest.java
+++ b/test/jdk/tools/jpackage/windows/WinResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jpackage/windows/WinResourceTest.java
+++ b/test/jdk/tools/jpackage/windows/WinResourceTest.java
@@ -30,6 +30,8 @@ import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Annotations.Parameters;
 import java.util.List;
+import static jdk.jpackage.test.WindowsHelper.WixType.WIX3;
+import static jdk.jpackage.test.WindowsHelper.getWixTypeFromVerboseJPackageOutput;
 
 /**
  * Test --resource-dir option. The test should set --resource-dir to point to
@@ -83,11 +85,18 @@ public class WinResourceTest {
         .addBundleVerifier((cmd, result) -> {
             // Assert jpackage picked custom main.wxs and failed as expected by
             // examining its output
+            final String expectedWixErrorMsg;
+            if (getWixTypeFromVerboseJPackageOutput(result) == WIX3) {
+                expectedWixErrorMsg = "error CNDL0104 : Not a valid source file";
+            } else {
+                expectedWixErrorMsg = "error WIX0104: Not a valid source file";
+            }
+
             TKit.assertTextStream(expectedLogMessage)
                     .predicate(String::startsWith)
                     .apply(JPackageCommand.stripTimestamps(
                             result.getOutput().stream()));
-            TKit.assertTextStream("error CNDL0104 : Not a valid source file")
+            TKit.assertTextStream(expectedWixErrorMsg)
                     .apply(result.getOutput().stream());
         })
         .setExpectedExitCode(1)


### PR DESCRIPTION
Look up different patterns in WiX output based on the version of the WiX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347295](https://bugs.openjdk.org/browse/JDK-8347295): Fix WinResourceTest to make it work with WiX v4.0+ (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22989/head:pull/22989` \
`$ git checkout pull/22989`

Update a local copy of the PR: \
`$ git checkout pull/22989` \
`$ git pull https://git.openjdk.org/jdk.git pull/22989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22989`

View PR using the GUI difftool: \
`$ git pr show -t 22989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22989.diff">https://git.openjdk.org/jdk/pull/22989.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22989#issuecomment-2578897071)
</details>
