### PR TITLE
8347296: WinInstallerUiTest fails in local test runs if the path to test work directory is longer that regular

### DIFF
--- a/test/jdk/tools/jpackage/windows/WinInstallerUiTest.java
+++ b/test/jdk/tools/jpackage/windows/WinInstallerUiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jpackage/windows/WinInstallerUiTest.java
+++ b/test/jdk/tools/jpackage/windows/WinInstallerUiTest.java
@@ -122,13 +122,13 @@ public class WinInstallerUiTest {
         StringBuilder sb = new StringBuilder(cmd.name());
         sb.append("With");
         if (withDirChooser) {
-            sb.append("DirChooser");
+            sb.append("Dc"); // DirChooser
         }
         if (withShortcutPrompt) {
-            sb.append("ShortcutPrompt");
+            sb.append("Sp"); // ShortcutPrompt
         }
         if (withLicense) {
-            sb.append("License");
+            sb.append("L"); // License
         }
         cmd.setArgumentValue("--name", sb.toString());
     }


### PR DESCRIPTION
Make names of msi files created in test cases of WinInstallerUiTest test shorter to workaround limitations of msi.exe on file path length.

Old msi file names:
WinInstallerUiTestWithDirChooserLicense-1.0.msi
WinInstallerUiTestWithDirChooserShortcutPrompt-1.0.msi
WinInstallerUiTestWithDirChooserShortcutPromptLicense-1.0.msi
WinInstallerUiTestWithShortcutPrompt-1.0.msi
WinInstallerUiTestWithShortcutPromptLicense-1.0.msi

New msi file names:
WinInstallerUiTestWithDcL-1.0.msi
WinInstallerUiTestWithDcSp-1.0.msi
WinInstallerUiTestWithDcSpL-1.0.msi
WinInstallerUiTestWithSp-1.0.msi
WinInstallerUiTestWithSpL-1.0.msi

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347296](https://bugs.openjdk.org/browse/JDK-8347296): WinInstallerUiTest fails in local test runs if the path to test work directory is longer that regular (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22990/head:pull/22990` \
`$ git checkout pull/22990`

Update a local copy of the PR: \
`$ git checkout pull/22990` \
`$ git pull https://git.openjdk.org/jdk.git pull/22990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22990`

View PR using the GUI difftool: \
`$ git pr show -t 22990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22990.diff">https://git.openjdk.org/jdk/pull/22990.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22990#issuecomment-2578905676)
</details>
