### PR TITLE
8347302: Update ProcessTools.java to support virtual test factory for Xbootclasspath/a:

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -393,6 +393,7 @@ public final class ProcessTools {
 
         final List<String> doubleWordArgs = List.of(
                 "--add-opens", "--upgrade-module-path", "--add-modules", "--add-exports", "--enable-native-access",
+                "-Xbootclasspath/a:",
                 "--limit-modules", "--add-reads", "--patch-module", "--module-path", "-p");
 
         ArrayList<String> args = new ArrayList<>();


### PR DESCRIPTION
Test
runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
uses
-Xbootclasspath/a: classpath
(2 arguments)

Such usage of options -Xbootclasspath/a: should be correctly processed by virtual thread factory support in ProcessTools.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8347302](https://bugs.openjdk.org/browse/JDK-8347302)

### Issue
 * [JDK-8347302](https://bugs.openjdk.org/browse/JDK-8347302): Mark test tools/jimage/JImageToolTest.java as flagless (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22993/head:pull/22993` \
`$ git checkout pull/22993`

Update a local copy of the PR: \
`$ git checkout pull/22993` \
`$ git pull https://git.openjdk.org/jdk.git pull/22993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22993`

View PR using the GUI difftool: \
`$ git pr show -t 22993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22993.diff">https://git.openjdk.org/jdk/pull/22993.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22993#issuecomment-2578931657)
</details>
