### PR TITLE
8347279: Problemlist TestEvilSyncBug.java#generational

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -96,6 +96,7 @@ gc/TestAlwaysPreTouchBehavior.java#Z 8334513 generic-all
 gc/TestAlwaysPreTouchBehavior.java#Epsilon 8334513 generic-all
 gc/stress/gclocker/TestExcessGCLockerCollections.java 8229120 generic-all
 gc/shenandoah/oom/TestAllocOutOfMemory.java#large 8344312 linux-ppc64le
+gc/shenandoah/TestEvilSyncBug.java#generational 8345501 generic-all
 
 #############################################################################
 


### PR DESCRIPTION
Hi all,
Test gc/shenandoah/TestEvilSyncBug.java#generational was observed times out on a lot of platforms (various Linux and Windows too) several times recently. Should we Problemlist this test before the failure root cause been fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347279](https://bugs.openjdk.org/browse/JDK-8347279): Problemlist TestEvilSyncBug.java#generational (**Sub-task** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22996/head:pull/22996` \
`$ git checkout pull/22996`

Update a local copy of the PR: \
`$ git checkout pull/22996` \
`$ git pull https://git.openjdk.org/jdk.git pull/22996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22996`

View PR using the GUI difftool: \
`$ git pr show -t 22996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22996.diff">https://git.openjdk.org/jdk/pull/22996.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22996#issuecomment-2579133268)
</details>
