### PR TITLE
8346727: JvmtiVTMSTransitionDisabler deadlock

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2501,7 +2501,7 @@ void JvmtiExport::post_compiled_method_load(nmethod *nm) {
   }
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->should_hide_jvmti_events(), "compiled method load events are not allowed in VTMS transition");
+  assert(!thread->should_hide_jvmti_events(), "compiled method load events are not allowed in critical sections");
 
   EVT_TRIG_TRACE(JVMTI_EVENT_COMPILED_METHOD_LOAD,
                  ("[%s] method compile load event triggered",
@@ -2524,7 +2524,7 @@ void JvmtiExport::post_compiled_method_load(JvmtiEnv* env, nmethod *nm) {
   }
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->should_hide_jvmti_events(), "compiled method load events are not allowed in VTMS transition");
+  assert(!thread->should_hide_jvmti_events(), "compiled method load events are not allowed in critical sections");
 
   EVT_TRACE(JVMTI_EVENT_COMPILED_METHOD_LOAD,
            ("[%s] method compile load event sent %s.%s  ",
@@ -2549,7 +2549,7 @@ void JvmtiExport::post_dynamic_code_generated_internal(const char *name, const v
 
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->should_hide_jvmti_events(), "dynamic code generated events are not allowed in VTMS transition");
+  assert(!thread->should_hide_jvmti_events(), "dynamic code generated events are not allowed in critical sections");
 
   // In theory everyone coming thru here is in_vm but we need to be certain
   // because a callee will do a vm->native transition
@@ -2597,7 +2597,7 @@ void JvmtiExport::post_dynamic_code_generated(JvmtiEnv* env, const char *name,
 {
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->should_hide_jvmti_events(), "dynamic code generated events are not allowed in VTMS transition");
+  assert(!thread->should_hide_jvmti_events(), "dynamic code generated events are not allowed in critical sections");
 
   EVT_TRIG_TRACE(JVMTI_EVENT_DYNAMIC_CODE_GENERATED,
                  ("[%s] dynamic code generated event triggered (by GenerateEvents)",

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -929,7 +929,7 @@ class JvmtiClassFileLoadHookPoster : public StackObj {
     _cached_class_file_ptr = cache_ptr;
     _has_been_modified = false;
 
-    assert(!_thread->is_in_VTMS_transition(), "CFLH events are not allowed in VTMS transition");
+    assert(!_thread->hide_jvmti_events(), "CFLH events are not allowed in VTMS alike transition");
 
     _state = JvmtiExport::get_jvmti_thread_state(_thread);
     if (_state != nullptr) {
@@ -1101,8 +1101,8 @@ bool JvmtiExport::post_class_file_load_hook(Symbol* h_name,
     return false;
   }
 
-  if (JavaThread::current()->is_in_VTMS_transition()) {
-    return false; // no events should be posted if thread is in VTMS transition
+  if (JavaThread::current()->hide_jvmti_events()) {
+    return false; // no events should be posted if thread is in VTMS alike transition
   }
 
   JvmtiClassFileLoadHookPoster poster(h_name, class_loader,
@@ -1238,8 +1238,8 @@ void JvmtiExport::post_raw_breakpoint(JavaThread *thread, Method* method, addres
   if (state == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_BREAKPOINT, ("[%s] Trg Breakpoint triggered",
@@ -1378,8 +1378,8 @@ void JvmtiExport::post_class_load(JavaThread *thread, Klass* klass) {
   if (state == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_CLASS_LOAD, ("[%s] Trg Class Load triggered",
@@ -1415,8 +1415,8 @@ void JvmtiExport::post_class_prepare(JavaThread *thread, Klass* klass) {
   if (state == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_CLASS_PREPARE, ("[%s] Trg Class Prepare triggered",
@@ -1753,8 +1753,8 @@ void JvmtiExport::post_object_free(JvmtiEnv* env, GrowableArray<jlong>* objects)
   assert(objects != nullptr, "Nothing to post");
 
   JavaThread *javaThread = JavaThread::current();
-  if (javaThread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (javaThread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
   if (!env->is_enabled(JVMTI_EVENT_OBJECT_FREE)) {
     return; // the event type has been already disabled
@@ -1777,8 +1777,8 @@ void JvmtiExport::post_resource_exhausted(jint resource_exhausted_flags, const c
 
   JavaThread *thread  = JavaThread::current();
 
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   log_error(jvmti)("Posting Resource Exhausted event: %s",
@@ -1820,8 +1820,8 @@ void JvmtiExport::post_method_entry(JavaThread *thread, Method* method, frame cu
     // for any thread that actually wants method entry, interp_only_mode is set
     return;
   }
-  if (mh->jvmti_mount_transition() || thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (mh->jvmti_mount_transition() || thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
   EVT_TRIG_TRACE(JVMTI_EVENT_METHOD_ENTRY, ("[%s] Trg Method Entry triggered %s.%s",
                      JvmtiTrace::safe_get_thread_name(thread),
@@ -1912,8 +1912,8 @@ void JvmtiExport::post_method_exit_inner(JavaThread* thread,
                                          bool exception_exit,
                                          frame current_frame,
                                          jvalue& value) {
-  if (mh->jvmti_mount_transition() || thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (mh->jvmti_mount_transition() || thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_METHOD_EXIT, ("[%s] Trg Method Exit triggered %s.%s",
@@ -1988,8 +1988,8 @@ void JvmtiExport::post_single_step(JavaThread *thread, Method* method, address l
   if (state == nullptr) {
     return;
   }
-  if (mh->jvmti_mount_transition() || thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (mh->jvmti_mount_transition() || thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   JvmtiEnvThreadStateIterator it(state);
@@ -2030,8 +2030,8 @@ void JvmtiExport::post_exception_throw(JavaThread *thread, Method* method, addre
   if (state == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_EXCEPTION, ("[%s] Trg Exception thrown triggered",
@@ -2152,8 +2152,8 @@ void JvmtiExport::notice_unwind_due_to_exception(JavaThread *thread, Method* met
       assert(!state->is_exception_caught(), "exception must not be caught yet.");
       state->set_exception_caught();
 
-      if (mh->jvmti_mount_transition() || thread->is_in_VTMS_transition()) {
-        return; // no events should be posted if thread is in VTMS transition
+      if (mh->jvmti_mount_transition() || thread->hide_jvmti_events()) {
+        return; // no events should be posted if thread is in VTMS alike transition
       }
       JvmtiEnvThreadStateIterator it(state);
       for (JvmtiEnvThreadState* ets = it.first(); ets != nullptr; ets = it.next(ets)) {
@@ -2198,8 +2198,8 @@ void JvmtiExport::post_field_access_by_jni(JavaThread *thread, oop obj,
   // function don't make the call unless there is a Java context.
   assert(thread->has_last_Java_frame(), "must be called with a Java context");
 
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   ResourceMark rm;
@@ -2234,8 +2234,8 @@ void JvmtiExport::post_field_access(JavaThread *thread, Method* method,
   if (state == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_FIELD_ACCESS, ("[%s] Trg Field Access event triggered",
@@ -2284,8 +2284,8 @@ void JvmtiExport::post_field_modification_by_jni(JavaThread *thread, oop obj,
   // function don't make the call unless there is a Java context.
   assert(thread->has_last_Java_frame(), "must be called with Java context");
 
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   ResourceMark rm;
@@ -2315,8 +2315,8 @@ void JvmtiExport::post_raw_field_modification(JavaThread *thread, Method* method
   address location, Klass* field_klass, Handle object, jfieldID field,
   char sig_type, jvalue *value) {
 
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   if (sig_type == JVM_SIGNATURE_INT || sig_type == JVM_SIGNATURE_BOOLEAN ||
@@ -2390,8 +2390,8 @@ void JvmtiExport::post_field_modification(JavaThread *thread, Method* method,
   if (state == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_FIELD_MODIFICATION,
@@ -2429,8 +2429,8 @@ void JvmtiExport::post_native_method_bind(Method* method, address* function_ptr)
   HandleMark hm(thread);
   methodHandle mh(thread, method);
 
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
   EVT_TRIG_TRACE(JVMTI_EVENT_NATIVE_METHOD_BIND, ("[%s] Trg Native Method Bind event triggered",
                       JvmtiTrace::safe_get_thread_name(thread)));
@@ -2503,7 +2503,7 @@ void JvmtiExport::post_compiled_method_load(nmethod *nm) {
   }
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->is_in_VTMS_transition(), "compiled method load events are not allowed in VTMS transition");
+  assert(!thread->hide_jvmti_events(), "compiled method load events are not allowed in VTMS transition");
 
   EVT_TRIG_TRACE(JVMTI_EVENT_COMPILED_METHOD_LOAD,
                  ("[%s] method compile load event triggered",
@@ -2526,7 +2526,7 @@ void JvmtiExport::post_compiled_method_load(JvmtiEnv* env, nmethod *nm) {
   }
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->is_in_VTMS_transition(), "compiled method load events are not allowed in VTMS transition");
+  assert(!thread->hide_jvmti_events(), "compiled method load events are not allowed in VTMS transition");
 
   EVT_TRACE(JVMTI_EVENT_COMPILED_METHOD_LOAD,
            ("[%s] method compile load event sent %s.%s  ",
@@ -2551,7 +2551,7 @@ void JvmtiExport::post_dynamic_code_generated_internal(const char *name, const v
 
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->is_in_VTMS_transition(), "dynamic code generated events are not allowed in VTMS transition");
+  assert(!thread->hide_jvmti_events(), "dynamic code generated events are not allowed in VTMS transition");
 
   // In theory everyone coming thru here is in_vm but we need to be certain
   // because a callee will do a vm->native transition
@@ -2599,7 +2599,7 @@ void JvmtiExport::post_dynamic_code_generated(JvmtiEnv* env, const char *name,
 {
   JavaThread* thread = JavaThread::current();
 
-  assert(!thread->is_in_VTMS_transition(), "dynamic code generated events are not allowed in VTMS transition");
+  assert(!thread->hide_jvmti_events(), "dynamic code generated events are not allowed in VTMS transition");
 
   EVT_TRIG_TRACE(JVMTI_EVENT_DYNAMIC_CODE_GENERATED,
                  ("[%s] dynamic code generated event triggered (by GenerateEvents)",
@@ -2754,8 +2754,8 @@ void JvmtiExport::post_monitor_contended_enter(JavaThread *thread, ObjectMonitor
   if (state == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_MONITOR_CONTENDED_ENTER,
@@ -2787,8 +2787,8 @@ void JvmtiExport::post_monitor_contended_entered(JavaThread *thread, ObjectMonit
   if (state == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_MONITOR_CONTENDED_ENTERED,
@@ -2821,8 +2821,8 @@ void JvmtiExport::post_monitor_wait(JavaThread *thread, oop object,
   if (state == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_MONITOR_WAIT,
@@ -2855,8 +2855,8 @@ void JvmtiExport::post_monitor_waited(JavaThread *thread, ObjectMonitor *obj_mnt
   if (state == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_MONITOR_WAITED,
@@ -2897,8 +2897,8 @@ void JvmtiExport::post_vm_object_alloc(JavaThread *thread, oop object) {
   if (object == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
   HandleMark hm(thread);
   Handle h(thread, object);
@@ -2934,8 +2934,8 @@ void JvmtiExport::post_sampled_object_alloc(JavaThread *thread, oop object) {
   if (object == nullptr) {
     return;
   }
-  if (thread->is_in_VTMS_transition()) {
-    return; // no events should be posted if thread is in VTMS transition
+  if (thread->hide_jvmti_events()) {
+    return; // no events should be posted if thread is in VTMS alike transition
   }
 
   EVT_TRIG_TRACE(JVMTI_EVENT_SAMPLED_OBJECT_ALLOC,

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -721,6 +721,8 @@ private:
   bool VTMS_transition_mark() const              { return Atomic::load(&_VTMS_transition_mark); }
   void set_VTMS_transition_mark(bool val)        { Atomic::store(&_VTMS_transition_mark, val); }
 
+  bool hide_jvmti_events() const                 { return _is_in_VTMS_transition || _is_disable_suspend; }
+
   bool on_monitor_waited_event()             { return _on_monitor_waited_event; }
   void set_on_monitor_waited_event(bool val) { _on_monitor_waited_event = val; }
 

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -721,7 +721,7 @@ private:
   bool VTMS_transition_mark() const              { return Atomic::load(&_VTMS_transition_mark); }
   void set_VTMS_transition_mark(bool val)        { Atomic::store(&_VTMS_transition_mark, val); }
 
-  // Temporarily skip posting JVMTI events for safety reasons when executions is in ia critical section:
+  // Temporarily skip posting JVMTI events for safety reasons when executions is in a critical section:
   // - is in a VTMS transition (_is_in_VTMS_transition)
   // - is in an interruptLock or similar critical section (_is_disable_suspend)
   bool should_hide_jvmti_events() const          { return _is_in_VTMS_transition || _is_disable_suspend; }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -721,7 +721,10 @@ private:
   bool VTMS_transition_mark() const              { return Atomic::load(&_VTMS_transition_mark); }
   void set_VTMS_transition_mark(bool val)        { Atomic::store(&_VTMS_transition_mark, val); }
 
-  bool hide_jvmti_events() const                 { return _is_in_VTMS_transition || _is_disable_suspend; }
+  // Temporarily skip posting JVMTI events for safety reasons when executions is in ia critical section:
+  // - is in a VTMS transition (_is_in_VTMS_transition)
+  // - is in an interruptLock or similar critical section (_is_disable_suspend)
+  bool should_hide_jvmti_events() const          { return _is_in_VTMS_transition || _is_disable_suspend; }
 
   bool on_monitor_waited_event()             { return _on_monitor_waited_event; }
   void set_on_monitor_waited_event(bool val) { _on_monitor_waited_event = val; }


### PR DESCRIPTION
This is a fix of one more deadlock issue related to `interruptLock` critical sections. When the `interruptLock` is hold by the target virtual thread it is unsafe to suspend or post JVMTI events. This update is to ignore the JVMTI events when the `interruptLock` is hold. It is additionally to the cases when the target JavaThread is in a `VTMS` transition. It is based on the existing mechanism disallowing JVMTI suspends while the `interruptLock` is hold. In order to support this the target JavaThread has the `_is_disable_suspend` bit.

Testing:
- Ran mach5 tiers 1-6
- There is no regression test for this issue as it is not hard to construct one. Originally, the issue was reported by JGroups which is using the `Async` profiler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346727](https://bugs.openjdk.org/browse/JDK-8346727): JvmtiVTMSTransitionDisabler deadlock (**Bug** - P3)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) Review applies to [46527318](https://git.openjdk.org/jdk/pull/22997/files/46527318f501ff42944c4f79cdcccdca31a52aaf)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22997/head:pull/22997` \
`$ git checkout pull/22997`

Update a local copy of the PR: \
`$ git checkout pull/22997` \
`$ git pull https://git.openjdk.org/jdk.git pull/22997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22997`

View PR using the GUI difftool: \
`$ git pr show -t 22997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22997.diff">https://git.openjdk.org/jdk/pull/22997.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22997#issuecomment-2579191045)
</details>
