### PR TITLE
8345134: Test sun/security/tools/jarsigner/ConciseJarsigner.java failed: unable to find valid certification path to requested target

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/ConciseJarsigner.java
+++ b/test/jdk/sun/security/tools/jarsigner/ConciseJarsigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/tools/jarsigner/ConciseJarsigner.java
+++ b/test/jdk/sun/security/tools/jarsigner/ConciseJarsigner.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6802846 8172529 8227758 8260960 8345134
+ * @bug 6802846 8172529 8227758 8260960
  * @summary jarsigner needs enhanced cert validation(options)
  * @library /test/lib
  * @run main/timeout=240 ConciseJarsigner

--- a/test/jdk/sun/security/tools/jarsigner/ConciseJarsigner.java
+++ b/test/jdk/sun/security/tools/jarsigner/ConciseJarsigner.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6802846 8172529 8227758 8260960
+ * @bug 6802846 8172529 8227758 8260960 8345134
  * @summary jarsigner needs enhanced cert validation(options)
  * @library /test/lib
  * @run main/timeout=240 ConciseJarsigner
@@ -256,9 +256,9 @@ public class ConciseJarsigner {
 
         // This certchain contains a cross-signed weak catwo.cert
         Files.write(Path.of("ee2"), List.of(
-                kt("-gencert -alias catwo -rfc -infile ee.req").getOutput(),
+                kt("-gencert -alias catwo -rfc -infile ee.req -startdate -1M").getOutput(),
                 kt("-gencert -alias caone -sigalg MD5withRSA -rfc "
-                        + "-infile catwo.req").getOutput()));
+                        + "-infile catwo.req -startdate -1M").getOutput()));
 
         kt("-importcert -alias ee -file ee2");
 

--- a/test/jdk/sun/security/tools/jarsigner/ConciseJarsigner.java
+++ b/test/jdk/sun/security/tools/jarsigner/ConciseJarsigner.java
@@ -43,8 +43,15 @@ public class ConciseJarsigner {
     static OutputAnalyzer kt(String cmd) throws Exception {
         // Choose 2048-bit RSA to make sure it runs fine and fast. In
         // fact, every keyalg/keysize combination is OK for this test.
-        return SecurityTools.keytool("-storepass changeit -keypass changeit "
-                + "-keystore ks -keyalg rsa -keysize 2048 " + cmd);
+        // The start date is set to -1M to prevent the certificate not yet valid during fast enough execution.
+        // If -startdate is specified in cmd, cmd version will be used.
+        if (cmd.contains("-startdate")) {
+            return SecurityTools.keytool("-storepass changeit -keypass changeit "
+                    + "-keystore ks -keyalg rsa -keysize 2048 " + cmd);
+        } else {
+            return SecurityTools.keytool("-storepass changeit -keypass changeit "
+                    + "-keystore ks -keyalg rsa -keysize 2048 -startdate -1M " + cmd);
+        }
     }
 
     static void gencert(String owner, String cmd) throws Exception {
@@ -256,9 +263,9 @@ public class ConciseJarsigner {
 
         // This certchain contains a cross-signed weak catwo.cert
         Files.write(Path.of("ee2"), List.of(
-                kt("-gencert -alias catwo -rfc -infile ee.req -startdate -1M").getOutput(),
+                kt("-gencert -alias catwo -rfc -infile ee.req").getOutput(),
                 kt("-gencert -alias caone -sigalg MD5withRSA -rfc "
-                        + "-infile catwo.req -startdate -1M").getOutput()));
+                        + "-infile catwo.req").getOutput()));
 
         kt("-importcert -alias ee -file ee2");
 


### PR DESCRIPTION
Changed the gencert, so the certificate is now initialised to be with a start time of -1M. This prevents a potential error with the certificate not yet being valid. 
Similar solution to [this pull request](https://github.com/openjdk/jdk/pull/22592)
Have tested the test 6000 times for stability and all have passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345134](https://bugs.openjdk.org/browse/JDK-8345134): Test sun/security/tools/jarsigner/ConciseJarsigner.java failed: unable to find valid certification path to requested target (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23001/head:pull/23001` \
`$ git checkout pull/23001`

Update a local copy of the PR: \
`$ git checkout pull/23001` \
`$ git pull https://git.openjdk.org/jdk.git pull/23001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23001`

View PR using the GUI difftool: \
`$ git pr show -t 23001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23001.diff">https://git.openjdk.org/jdk/pull/23001.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23001#issuecomment-2579833706)
</details>
