### PR TITLE
8347352: RISC-V: Cleanup bitwise AND assembler routines

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -835,7 +835,7 @@ enum operand_size { int8, int16, int32, uint32, int64 };
 
 // Immediate Instruction
 #define INSN(NAME, op, funct3)                                                              \
-  void NAME(Register Rd, Register Rs1, int32_t imm) {                                       \
+  void NAME(Register Rd, Register Rs1, int64_t imm) {                                       \
     guarantee(is_simm12(imm), "Immediate is out of validity");                              \
     unsigned insn = 0;                                                                      \
     patch((address)&insn, 6, 0, op);                                                        \
@@ -846,17 +846,17 @@ enum operand_size { int8, int16, int32, uint32, int64 };
     emit(insn);                                                                             \
   }
 
-  INSN(_addi,      0b0010011, 0b000);
-  INSN(slti,       0b0010011, 0b010);
-  INSN(_addiw,     0b0011011, 0b000);
-  INSN(_and_imm12, 0b0010011, 0b111);
-  INSN(ori,        0b0010011, 0b110);
-  INSN(xori,       0b0010011, 0b100);
+  INSN(_addi,  0b0010011, 0b000);
+  INSN(_addiw, 0b0011011, 0b000);
+  INSN(_andi,  0b0010011, 0b111);
+  INSN(ori,    0b0010011, 0b110);
+  INSN(xori,   0b0010011, 0b100);
+  INSN(slti,   0b0010011, 0b010);
 
 #undef INSN
 
 #define INSN(NAME, op, funct3)                                                              \
-  void NAME(Register Rd, Register Rs1, uint32_t imm) {                                      \
+  void NAME(Register Rd, Register Rs1, uint64_t imm) {                                      \
     guarantee(is_uimm12(imm), "Immediate is out of validity");                              \
     unsigned insn = 0;                                                                      \
     patch((address)&insn,6, 0,  op);                                                        \
@@ -2230,7 +2230,7 @@ public:
   }
 
 #define INSN(NAME, funct3, op)                                                               \
-  void NAME(Register Rd_Rs1, int32_t imm) {                                                  \
+  void NAME(Register Rd_Rs1, int64_t imm) {                                                  \
     assert_cond(is_simm6(imm));                                                              \
     uint16_t insn = 0;                                                                       \
     c_patch((address)&insn, 1, 0, op);                                                       \
@@ -2247,7 +2247,7 @@ public:
 #undef INSN
 
 #define INSN(NAME, funct3, op)                                                               \
-  void NAME(int32_t imm) {                                                                   \
+  void NAME(int64_t imm) {                                                                   \
     assert_cond(is_simm10(imm));                                                             \
     assert_cond((imm & 0b1111) == 0);                                                        \
     assert_cond(imm != 0);                                                                   \
@@ -2268,7 +2268,7 @@ public:
 #undef INSN
 
 #define INSN(NAME, funct3, op)                                                               \
-  void NAME(Register Rd, uint32_t uimm) {                                                    \
+  void NAME(Register Rd, uint64_t uimm) {                                                    \
     assert_cond(is_uimm10(uimm));                                                            \
     assert_cond((uimm & 0b11) == 0);                                                         \
     assert_cond(uimm != 0);                                                                  \
@@ -2325,7 +2325,7 @@ public:
 #undef INSN
 
 #define INSN(NAME, funct3, funct2, op)                                                       \
-  void NAME(Register Rd_Rs1, int32_t imm) {                                                  \
+  void NAME(Register Rd_Rs1, int64_t imm) {                                                  \
     assert_cond(is_simm6(imm));                                                              \
     uint16_t insn = 0;                                                                       \
     c_patch((address)&insn, 1, 0, op);                                                       \
@@ -2950,7 +2950,7 @@ public:
 // Immediate Instructions
 // --------------------------
 #define INSN(NAME)                                                                           \
-  void NAME(Register Rd, Register Rs1, int32_t imm) {                                        \
+  void NAME(Register Rd, Register Rs1, int64_t imm) {                                        \
     /* addi -> c.addi/c.nop/c.mv/c.addi16sp/c.addi4spn */                                    \
     if (do_compress()) {                                                                     \
       if (Rd == Rs1 && is_simm6(imm)) {                                                      \
@@ -2978,7 +2978,7 @@ public:
 
 // --------------------------
 #define INSN(NAME)                                                                           \
-  void NAME(Register Rd, Register Rs1, int32_t imm) {                                        \
+  void NAME(Register Rd, Register Rs1, int64_t imm) {                                        \
     /* addiw -> c.addiw */                                                                   \
     if (do_compress() && (Rd == Rs1 && Rd != x0 && is_simm6(imm))) {                         \
       c_addiw(Rd, imm);                                                                      \
@@ -2993,17 +2993,17 @@ public:
 
 // --------------------------
 #define INSN(NAME)                                                                           \
-  void NAME(Register Rd, Register Rs1, int32_t imm) {                                        \
-    /* and_imm12 -> c.andi */                                                                \
+  void NAME(Register Rd, Register Rs1, int64_t imm) {                                        \
+    /* andi -> c.andi */                                                                     \
     if (do_compress() &&                                                                     \
         (Rd == Rs1 && Rd->is_compressed_valid() && is_simm6(imm))) {                         \
       c_andi(Rd, imm);                                                                       \
       return;                                                                                \
     }                                                                                        \
-    _and_imm12(Rd, Rs1, imm);                                                                \
+    _andi(Rd, Rs1, imm);                                                                     \
   }
 
-  INSN(and_imm12);
+  INSN(andi);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -301,7 +301,7 @@ void C1_MacroAssembler::allocate_array(Register obj, Register len, Register tmp1
   // align object end
   mv(arr_size, (int32_t)base_offset_in_bytes + MinObjAlignmentInBytesMask);
   shadd(arr_size, len, arr_size, t0, f);
-  andi(arr_size, arr_size, ~(uint)MinObjAlignmentInBytesMask);
+  andi(arr_size, arr_size, ~MinObjAlignmentInBytesMask);
 
   try_allocate(obj, arr_size, 0, tmp1, tmp2, slow_case);
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2619,7 +2619,7 @@ void MacroAssembler::sub(Register Rd, Register Rn, int64_t decrement, Register t
   add(Rd, Rn, -decrement, tmp);
 }
 
-void MacroAssembler::addw(Register Rd, Register Rn, int32_t increment, Register tmp) {
+void MacroAssembler::addw(Register Rd, Register Rn, int64_t increment, Register tmp) {
   if (is_simm12(increment)) {
     addiw(Rd, Rn, increment);
   } else {
@@ -2629,7 +2629,7 @@ void MacroAssembler::addw(Register Rd, Register Rn, int32_t increment, Register 
   }
 }
 
-void MacroAssembler::subw(Register Rd, Register Rn, int32_t decrement, Register tmp) {
+void MacroAssembler::subw(Register Rd, Register Rn, int64_t decrement, Register tmp) {
   addw(Rd, Rn, -decrement, tmp);
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2901,16 +2901,6 @@ void MacroAssembler::rolw(Register dst, Register src, uint32_t shift, Register t
   orr(dst, dst, tmp);
 }
 
-void MacroAssembler::andi(Register Rd, Register Rn, int64_t imm, Register tmp) {
-  if (is_simm12(imm)) {
-    and_imm12(Rd, Rn, imm);
-  } else {
-    assert_different_registers(Rn, tmp);
-    mv(tmp, imm);
-    andr(Rd, Rn, tmp);
-  }
-}
-
 void MacroAssembler::orptr(Address adr, RegisterOrConstant src, Register tmp1, Register tmp2) {
   ld(tmp1, adr);
   if (src.is_register()) {
@@ -6142,10 +6132,10 @@ void MacroAssembler::test_bit(Register Rd, Register Rs, uint32_t bit_pos) {
   }
   int64_t imm = (int64_t)(1UL << bit_pos);
   if (is_simm12(imm)) {
-    and_imm12(Rd, Rs, imm);
+    andi(Rd, Rs, imm);
   } else {
     srli(Rd, Rs, bit_pos);
-    and_imm12(Rd, Rd, 1);
+    andi(Rd, Rd, 1);
   }
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -886,17 +886,17 @@ public:
  public:
 
   // arith
-  void add(Register Rd, Register Rn, int64_t increment, Register tmp = t0);
-  void sub(Register Rd, Register Rn, int64_t decrement, Register tmp = t0);
-  void addw(Register Rd, Register Rn, int32_t increment, Register tmp = t0);
-  void subw(Register Rd, Register Rn, int32_t decrement, Register tmp = t0);
+  void add (Register Rd, Register Rn, int64_t increment, Register tmp = t0);
+  void sub (Register Rd, Register Rn, int64_t decrement, Register tmp = t0);
+  void addw(Register Rd, Register Rn, int64_t increment, Register tmp = t0);
+  void subw(Register Rd, Register Rn, int64_t decrement, Register tmp = t0);
 
-  void subi(Register Rd, Register Rn, int32_t decrement) {
+  void subi(Register Rd, Register Rn, int64_t decrement) {
     assert(is_simm12(-decrement), "Must be");
     addi(Rd, Rn, -decrement);
   }
 
-  void subiw(Register Rd, Register Rn, int32_t decrement) {
+  void subiw(Register Rd, Register Rn, int64_t decrement) {
     assert(is_simm12(-decrement), "Must be");
     addiw(Rd, Rn, -decrement);
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -928,7 +928,7 @@ public:
 
   void ror(Register dst, Register src, uint32_t shift, Register tmp = t0);
   void rolw(Register dst, Register src, uint32_t shift, Register tmp = t0);
-  void andi(Register Rd, Register Rn, int64_t imm, Register tmp = t0);
+
   void orptr(Address adr, RegisterOrConstant src, Register tmp1 = t0, Register tmp2 = t1);
 
 // Load and Store Instructions

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1715,7 +1715,8 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       // NOTE: the oopMark is in swap_reg % 10 as the result of cmpxchg
 
       __ sub(swap_reg, swap_reg, sp);
-      __ andi(swap_reg, swap_reg, 3 - (int)os::vm_page_size());
+      __ mv(t0, 3 - (int)os::vm_page_size());
+      __ andr(swap_reg, swap_reg, t0);
 
       // Save the test result, for recursive case, the result is zero
       __ sd(swap_reg, Address(lock_reg, mark_word_offset));


### PR DESCRIPTION
Hi, Please consider this small refactoring work.

It's a bit strange that we have `Assembler::_and_imm12` and `MacroAssembler::andi`, which is quite different from friends `Assembler::ori` and `Assembler::xori`. And it doesn't seem necessary to have this `MacroAssembler::andi` which checks the immediate range. I find the immediate is within signed 12-bit range for most of the cases. One exception is in file `sharedRuntime_riscv.cpp` where I think we can do `mv` + `andr` instead.

Testing on linux-riscv64:
- [x] tier1-3 and gtest:all (release)
- [x] hotspot:tier1 (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347352](https://bugs.openjdk.org/browse/JDK-8347352): RISC-V: Cleanup bitwise AND assembler routines (**Enhancement** - P4)


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer) Review applies to [5c45a475](https://git.openjdk.org/jdk/pull/23008/files/5c45a475eae379007e5a173325f8cc99eeb29abb)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**) Review applies to [47adf1fc](https://git.openjdk.org/jdk/pull/23008/files/47adf1fcd7306ae3c70fb57b96419efccb02e625)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23008/head:pull/23008` \
`$ git checkout pull/23008`

Update a local copy of the PR: \
`$ git checkout pull/23008` \
`$ git pull https://git.openjdk.org/jdk.git pull/23008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23008`

View PR using the GUI difftool: \
`$ git pr show -t 23008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23008.diff">https://git.openjdk.org/jdk/pull/23008.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23008#issuecomment-2580506152)
</details>
