### PR TITLE
8345337: JFR: jfr view should display all direct subfields for an event type

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
@@ -353,9 +353,10 @@ final class FieldBuilder {
                 var subFields = we.field().getFields().reversed();
                 if (!subFields.isEmpty() && !KNOWN_TYPES.contains(we.field().getTypeName())) {
                     for (ValueDescriptor subField : subFields) {
-                        String n = we.name + "." + subField.getName();
-                        String l = we.label + " : " + makeLabel(subField, false);
-                        if (stack.size() < 2) { // Limit depth to 2
+                        // Limit depth to 2
+                        if (!we.name.contains(".")) {
+                            String n = we.name + "." + subField.getName();
+                            String l = we.label + " : " + makeLabel(subField, false);
                             stack.push(new WildcardElement(n, l, subField));
                         }
                     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345337](https://bugs.openjdk.org/browse/JDK-8345337): JFR: jfr view should display all direct subfields for an event type (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23009/head:pull/23009` \
`$ git checkout pull/23009`

Update a local copy of the PR: \
`$ git checkout pull/23009` \
`$ git pull https://git.openjdk.org/jdk.git pull/23009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23009`

View PR using the GUI difftool: \
`$ git pr show -t 23009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23009.diff">https://git.openjdk.org/jdk/pull/23009.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23009#issuecomment-2580503345)
</details>
