### PR TITLE
8347267: [macOS]: UnixOperatingSystem.c:67:40: runtime error: division by zero

### DIFF
--- a/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,9 @@ Java_com_sun_management_internal_OperatingSystemImpl_getCpuLoad0
 
     jlong used_delta  = used - last_used;
     jlong total_delta = total - last_total;
+    if (total_delta == 0) {
+        return 0;
+    }
 
     jdouble cpu = (jdouble) used_delta / total_delta;
 


### PR DESCRIPTION
When running ubsan-enabled binaries on macOS aarch64, in test
javax/management/MBeanServer/OldMBeanServerTest.java
the following division by zero is shown :
src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c:67:40: runtime error: division by zero
UndefinedBehaviorSanitizer:DEADLYSIGNAL
UndefinedBehaviorSanitizer: nested bug in the same thread, aborting.

We should add special handling for the case ` (total_delta == 0)` .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347267](https://bugs.openjdk.org/browse/JDK-8347267): [macOS]: UnixOperatingSystem.c:67:40: runtime error: division by zero (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23010/head:pull/23010` \
`$ git checkout pull/23010`

Update a local copy of the PR: \
`$ git checkout pull/23010` \
`$ git pull https://git.openjdk.org/jdk.git pull/23010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23010`

View PR using the GUI difftool: \
`$ git pr show -t 23010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23010.diff">https://git.openjdk.org/jdk/pull/23010.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23010#issuecomment-2580543108)
</details>
