### PR TITLE
8346890: AArch64: Type profile counters generate suboptimal code

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1215,18 +1215,33 @@ void LIR_Assembler::emit_alloc_array(LIR_OpAllocArray* op) {
   __ bind(*op->stub()->continuation());
 }
 
+auto receiver_offset = ReceiverTypeData::receiver_offset;
+auto receiver_count_offset = ReceiverTypeData::receiver_count_offset;
+
+template<typename T>
+Address md_at(MacroAssembler *masm, Register scratch, Register mdo, ciMethodData *md,
+               ciProfileData *data, T offset, int i) {
+  return masm->form_address(scratch, mdo,
+                            md->byte_offset_of_slot(data, offset(i)),
+                            LogBytesPerWord);
+}
+
 void LIR_Assembler::type_profile_helper(Register mdo,
                                         ciMethodData *md, ciProfileData *data,
                                         Register recv, Label* update_done) {
+  Register scratch = rscratch2;
+
+  auto data_at = [=](ByteSize (*offset)(uint), uint i) -> Address {
+    return md_at(_masm, scratch, mdo, md, data, offset, i);
+  };
+
   for (uint i = 0; i < ReceiverTypeData::row_limit(); i++) {
     Label next_test;
     // See if the receiver is receiver[n].
-    __ lea(rscratch2, Address(mdo, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_offset(i))));
-    __ ldr(rscratch1, Address(rscratch2));
+    __ ldr(rscratch1, data_at(ReceiverTypeData::receiver_offset, i));
     __ cmp(recv, rscratch1);
     __ br(Assembler::NE, next_test);
-    Address data_addr(mdo, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_count_offset(i)));
-    __ addptr(data_addr, DataLayout::counter_increment);
+    __ addptr(data_at(ReceiverTypeData::receiver_count_offset, i), DataLayout::counter_increment);
     __ b(*update_done);
     __ bind(next_test);
   }
@@ -1234,15 +1249,14 @@ void LIR_Assembler::type_profile_helper(Register mdo,
   // Didn't find receiver; find next empty slot and fill it in
   for (uint i = 0; i < ReceiverTypeData::row_limit(); i++) {
     Label next_test;
-    __ lea(rscratch2,
-           Address(mdo, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_offset(i))));
-    Address recv_addr(rscratch2);
-    __ ldr(rscratch1, recv_addr);
-    __ cbnz(rscratch1, next_test);
-    __ str(recv, recv_addr);
+    {
+      Address recv_addr(data_at(ReceiverTypeData::receiver_offset, i));
+      __ ldr(rscratch1, recv_addr);
+      __ cbnz(rscratch1, next_test);
+      __ str(recv, recv_addr);
+    }
     __ mov(rscratch1, DataLayout::counter_increment);
-    __ lea(rscratch2, Address(mdo, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_count_offset(i))));
-    __ str(rscratch1, Address(rscratch2));
+    __ str(rscratch1, data_at(ReceiverTypeData::receiver_count_offset, i));
     __ b(*update_done);
     __ bind(next_test);
   }
@@ -1414,8 +1428,7 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
       // Object is null; update MDO and exit
       Address data_addr
         = __ form_address(rscratch2, mdo,
-                          md->byte_offset_of_slot(data, DataLayout::flags_offset()),
-                          0);
+                          md->byte_offset_of_slot(data, DataLayout::flags_offset()), 0);
       __ ldrb(rscratch1, data_addr);
       __ orr(rscratch1, rscratch1, BitData::null_seen_byte_constant());
       __ strb(rscratch1, data_addr);
@@ -2518,6 +2531,8 @@ void LIR_Assembler::emit_load_klass(LIR_OpLoadKlass* op) {
   __ load_klass(result, obj);
 }
 
+using ::VirtualCallData;
+
 void LIR_Assembler::emit_profile_call(LIR_OpProfileCall* op) {
   ciMethod* method = op->profiled_method();
   int bci          = op->profiled_bci();
@@ -2566,10 +2581,11 @@ void LIR_Assembler::emit_profile_call(LIR_OpProfileCall* op) {
       for (i = 0; i < VirtualCallData::row_limit(); i++) {
         ciKlass* receiver = vc_data->receiver(i);
         if (receiver == nullptr) {
-          Address recv_addr(mdo, md->byte_offset_of_slot(data, VirtualCallData::receiver_offset(i)));
           __ mov_metadata(rscratch1, known_klass->constant_encoding());
-          __ lea(rscratch2, recv_addr);
-          __ str(rscratch1, Address(rscratch2));
+          Address recv_addr
+            = __ form_address(rscratch2, mdo,
+                              md->byte_offset_of_slot(data, VirtualCallData::receiver_offset(i)), LogBytesPerWord);
+          __ str(rscratch1, recv_addr);
           Address data_addr(mdo, md->byte_offset_of_slot(data, VirtualCallData::receiver_count_offset(i)));
           __ addptr(data_addr, DataLayout::counter_increment);
           return;

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1381,7 +1381,7 @@ void MacroAssembler::lookup_virtual_method(Register recv_klass,
   } else {
     vtable_offset_in_bytes += vtable_index.as_constant() * wordSize;
     ldr(method_result,
-        form_address(rscratch1, recv_klass, vtable_offset_in_bytes, 0));
+        form_address(rscratch1, recv_klass, vtable_offset_in_bytes, LogBytesPerWord));
   }
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1381,7 +1381,7 @@ void MacroAssembler::lookup_virtual_method(Register recv_klass,
   } else {
     vtable_offset_in_bytes += vtable_index.as_constant() * wordSize;
     ldr(method_result,
-        form_address(rscratch1, recv_klass, vtable_offset_in_bytes, LogBytesPerWord));
+        form_address(rscratch1, recv_klass, vtable_offset_in_bytes, 0));
   }
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1173,6 +1173,7 @@ public:
 
   // Arithmetics
 
+  // Clobber: rscratch2
   void addptr(const Address &dst, int32_t src);
   void cmpptr(Register src1, Address src2);
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1173,8 +1173,10 @@ public:
 
   // Arithmetics
 
-  // Clobber: rscratch2
+  // Clobber: rscratch1, rscratch2
   void addptr(const Address &dst, int32_t src);
+
+  // Clobber: rscratch1
   void cmpptr(Register src1, Address src2);
 
   void cmpoop(Register obj1, Register obj2);


### PR DESCRIPTION
Type profile counters are emitted many times in C1-generated code. The generator was written a long time ago before we knew how best to write AArch64 code, and the generated code is rather suboptimal.

This PR reduces the size of a typical bimorphic type profile counter from 33 to 27 instructions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346890](https://bugs.openjdk.org/browse/JDK-8346890): AArch64: Type profile counters generate suboptimal code (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**) Review applies to [0e84904f](https://git.openjdk.org/jdk/pull/23012/files/0e84904f9530965e1ca5337cb9f9bc7aabe0f61d)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23012/head:pull/23012` \
`$ git checkout pull/23012`

Update a local copy of the PR: \
`$ git checkout pull/23012` \
`$ git pull https://git.openjdk.org/jdk.git pull/23012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23012`

View PR using the GUI difftool: \
`$ git pr show -t 23012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23012.diff">https://git.openjdk.org/jdk/pull/23012.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23012#issuecomment-2580766037)
</details>
