### PR TITLE
8347270: Remove unix_getParentPidAndTimings, unix_getChildren and unix_getCmdlineAndUserInfo

### DIFF
--- a/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
+++ b/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
+++ b/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
@@ -30,6 +30,7 @@
 
 #include <sys/procfs.h>
 #include <procinfo.h>
+#include <string.h>
 
 /*
  * Implementation of native ProcessHandleImpl functions for AIX.
@@ -182,6 +183,62 @@ pid_t os_getParentPidAndTimings(JNIEnv *env, pid_t pid, jlong *total, jlong *sta
     return (pid_t) ProcessBuffer.pi_ppid;
 }
 
+/**
+ * Helper function to get the 'psinfo_t' data from "/proc/%d/psinfo".
+ * Returns 0 on success and -1 on error.
+ */
+static int getPsinfo(pid_t pid, psinfo_t *psinfo) {
+    FILE* fp;
+    char fn[32];
+    size_t ret;
+
+    /*
+     * Try to open /proc/%d/psinfo
+     */
+    snprintf(fn, sizeof fn, "/proc/%d/psinfo", pid);
+    fp = fopen(fn, "r");
+    if (fp == NULL) {
+        return -1;
+    }
+
+    ret = fread(psinfo, 1, sizeof(psinfo_t), fp);
+    fclose(fp);
+    if (ret < sizeof(psinfo_t)) {
+        return -1;
+    }
+    return 0;
+}
+
 void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {
-    unix_getCmdlineAndUserInfo(env, jinfo, pid);
+    psinfo_t psinfo;
+    char prargs[PRARGSZ + 1];
+    jstring cmdexe = NULL;
+
+    /*
+     * Now try to open /proc/%d/psinfo
+     */
+    if (getPsinfo(pid, &psinfo) < 0) {
+        unix_fillArgArray(env, jinfo, 0, NULL, NULL, cmdexe, NULL);
+        return;
+    }
+
+    unix_getUserInfo(env, jinfo, psinfo.pr_uid);
+
+    /*
+     * Now read psinfo.pr_psargs which contains the first PRARGSZ characters of the
+     * argument list (i.e. arg[0] arg[1] ...). Unfortunately, PRARGSZ is usually set
+     * to 80 characters only. Nevertheless it's better than nothing :)
+     */
+    strncpy(prargs, psinfo.pr_psargs, PRARGSZ);
+    prargs[PRARGSZ] = '\0';
+    if (prargs[0] == '\0') {
+        /* If psinfo.pr_psargs didn't contain any strings, use psinfo.pr_fname
+         * (which only contains the last component of exec()ed pathname) as a
+         * last resort. This is true for AIX kernel processes for example.
+         */
+        strncpy(prargs, psinfo.pr_fname, PRARGSZ);
+        prargs[PRARGSZ] = '\0';
+    }
+    unix_fillArgArray(env, jinfo, 0, NULL, NULL, cmdexe,
+                      prargs[0] == '\0' ? NULL : prargs);
 }

--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
+++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
@@ -78,7 +78,7 @@
  *   ProcessHandleImpl_unix.h which is included into every
  *   ProcessHandleImpl_<os>.c file.
  *
- * Example :
+ * Example:
  * ----------
  * The implementation of Java_java_lang_ProcessHandleImpl_initNative()
  * is the same on all platforms except on Linux where it initializes one

--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
+++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@
  * This file contains the implementation of the native ProcessHandleImpl
  * functions which are common to all Unix variants.
  *
- * The currently supported Unix variants are Solaris, Linux, MaxOS X and AIX.
+ * The currently supported Unix variants are Linux, MaxOS X and AIX.
  * The various similarities and differences between these systems make it hard
  * to find a clear boundary between platform specific and shared code.
  *
@@ -453,139 +453,4 @@ void unix_getUserInfo(JNIEnv* env, jobject jinfo, uid_t uid) {
         (*env)->SetObjectField(env, jinfo, ProcessHandleImpl_Info_userID, name);
     }
 }
-
-/*
- * The following functions are for Linux
- */
-
-#if defined (__linux__)
-
-/*
- * Return pids of active processes, and optionally parent pids and
- * start times for each process.
- * For a specific non-zero pid, only the direct children are returned.
- * If the pid is zero, all active processes are returned.
- * Reads /proc and accumulates any process following the rules above.
- * The resulting pids are stored into an array of longs named jarray.
- * The number of pids is returned if they all fit.
- * If the parentArray is non-null, store also the parent pid.
- * In this case the parentArray must have the same length as the result pid array.
- * Of course in the case of a given non-zero pid all entries in the parentArray
- * will contain this pid, so this array does only make sense in the case of a given
- * zero pid.
- * If the jstimesArray is non-null, store also the start time of the pid.
- * In this case the jstimesArray must have the same length as the result pid array.
- * If the array(s) (is|are) too short, excess pids are not stored and
- * the desired length is returned.
- */
-jint unix_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
-                      jlongArray jparentArray, jlongArray jstimesArray) {
-    DIR* dir;
-    struct dirent* ptr;
-    pid_t pid = (pid_t) jpid;
-    jlong* pids = NULL;
-    jlong* ppids = NULL;
-    jlong* stimes = NULL;
-    jsize parentArraySize = 0;
-    jsize arraySize = 0;
-    jsize stimesSize = 0;
-    jsize count = 0;
-
-    arraySize = (*env)->GetArrayLength(env, jarray);
-    JNU_CHECK_EXCEPTION_RETURN(env, -1);
-    if (jparentArray != NULL) {
-        parentArraySize = (*env)->GetArrayLength(env, jparentArray);
-        JNU_CHECK_EXCEPTION_RETURN(env, -1);
-
-        if (arraySize != parentArraySize) {
-            JNU_ThrowIllegalArgumentException(env, "array sizes not equal");
-            return 0;
-        }
-    }
-    if (jstimesArray != NULL) {
-        stimesSize = (*env)->GetArrayLength(env, jstimesArray);
-        JNU_CHECK_EXCEPTION_RETURN(env, -1);
-
-        if (arraySize != stimesSize) {
-            JNU_ThrowIllegalArgumentException(env, "array sizes not equal");
-            return 0;
-        }
-    }
-
-    /*
-     * To locate the children we scan /proc looking for files that have a
-     * position integer as a filename.
-     */
-    if ((dir = opendir("/proc")) == NULL) {
-        JNU_ThrowByNameWithMessageAndLastError(env,
-            "java/lang/RuntimeException", "Unable to open /proc");
-        return -1;
-    }
-
-    do { // Block to break out of on Exception
-        pids = (*env)->GetLongArrayElements(env, jarray, NULL);
-        if (pids == NULL) {
-            break;
-        }
-        if (jparentArray != NULL) {
-            ppids  = (*env)->GetLongArrayElements(env, jparentArray, NULL);
-            if (ppids == NULL) {
-                break;
-            }
-        }
-        if (jstimesArray != NULL) {
-            stimes  = (*env)->GetLongArrayElements(env, jstimesArray, NULL);
-            if (stimes == NULL) {
-                break;
-            }
-        }
-
-        while ((ptr = readdir(dir)) != NULL) {
-            pid_t ppid = 0;
-            jlong totalTime = 0L;
-            jlong startTime = 0L;
-
-            /* skip files that aren't numbers */
-            pid_t childpid = (pid_t) atoi(ptr->d_name);
-            if ((int) childpid <= 0) {
-                continue;
-            }
-
-            // Get the parent pid, and start time
-            ppid = os_getParentPidAndTimings(env, childpid, &totalTime, &startTime);
-            if (ppid >= 0 && (pid == 0 || ppid == pid)) {
-                if (count < arraySize) {
-                    // Only store if it fits
-                    pids[count] = (jlong) childpid;
-
-                    if (ppids != NULL) {
-                        // Store the parentPid
-                        ppids[count] = (jlong) ppid;
-                    }
-                    if (stimes != NULL) {
-                        // Store the process start time
-                        stimes[count] = startTime;
-                    }
-                }
-                count++; // Count to tabulate size needed
-            }
-        }
-    } while (0);
-
-    if (pids != NULL) {
-        (*env)->ReleaseLongArrayElements(env, jarray, pids, 0);
-    }
-    if (ppids != NULL) {
-        (*env)->ReleaseLongArrayElements(env, jparentArray, ppids, 0);
-    }
-    if (stimes != NULL) {
-        (*env)->ReleaseLongArrayElements(env, jstimesArray, stimes, 0);
-    }
-
-    closedir(dir);
-    // If more pids than array had size for; count will be greater than array size
-    return count;
-}
-
-#endif // defined (__linux__)
 

--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.h
+++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.h
@@ -56,12 +56,9 @@ extern jfieldID ProcessHandleImpl_Info_userID;
  * 'total' will contain the running time of 'pid' in nanoseconds.
  * 'start' will contain the start time of 'pid' in milliseconds since epoch.
  */
-extern pid_t unix_getParentPidAndTimings(JNIEnv *env, pid_t pid,
-                                         jlong *total, jlong *start);
 extern pid_t os_getParentPidAndTimings(JNIEnv *env, pid_t pid,
                                        jlong *total, jlong *start);
 
-extern void unix_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid);
 extern void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid);
 
 extern jint unix_getChildren(JNIEnv *env, jlong jpid, jlongArray array,

--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.h
+++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,8 +61,6 @@ extern pid_t os_getParentPidAndTimings(JNIEnv *env, pid_t pid,
 
 extern void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid);
 
-extern jint unix_getChildren(JNIEnv *env, jlong jpid, jlongArray array,
-                             jlongArray jparentArray, jlongArray jstimesArray);
 extern jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray array,
                            jlongArray jparentArray, jlongArray jstimesArray);
 


### PR DESCRIPTION
The functions unix_getParentPidAndTimings and unix_getCmdlineAndUserInfo in src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c used to hold an implementation that was shared between Solaris and AIX. Linux and MacOS already had specific implementations. After the removal of the Solaris port, these two functions can be removed in favor of inline implementations of os_getParentPidAndTimings and os_getCmdlineAndUserInfo in src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347270](https://bugs.openjdk.org/browse/JDK-8347270): Remove unix_getParentPidAndTimings, unix_getChildren and unix_getCmdlineAndUserInfo (**Bug** - P4)


### Reviewers
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer) Review applies to [d49d3d36](https://git.openjdk.org/jdk/pull/23013/files/d49d3d3616fac93730cf2f9095723f33ae083193)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23013/head:pull/23013` \
`$ git checkout pull/23013`

Update a local copy of the PR: \
`$ git checkout pull/23013` \
`$ git pull https://git.openjdk.org/jdk.git pull/23013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23013`

View PR using the GUI difftool: \
`$ git pr show -t 23013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23013.diff">https://git.openjdk.org/jdk/pull/23013.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23013#issuecomment-2580805395)
</details>
