### PR TITLE
8347373: HTTP/2 flow control checks may count unprocessed data twice

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/WindowUpdateSender.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/WindowUpdateSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,18 +117,24 @@ abstract class WindowUpdateSender {
      *             the caller wants to buffer.
      */
     boolean canBufferUnprocessedBytes(int len) {
-        return !checkWindowSizeExceeded(unprocessed.addAndGet(len));
+        long buffered, rcv;
+        // get received before unprocessed in order to avoid counting
+        // unprocessed bytes that might get unbuffered asynchronously
+        // twice.
+        rcv = received.get();
+        buffered = unprocessed.addAndGet(len);
+        return !checkWindowSizeExceeded(rcv, buffered);
     }
 
     // adds the provided amount to the amount of already
     // received and processed bytes and checks whether the
     // flow control window is exceeded. If so, take
     // corrective actions and return true.
-    private boolean checkWindowSizeExceeded(long len) {
+    private boolean checkWindowSizeExceeded(long received, long len) {
         // because windowSize is bound by Integer.MAX_VALUE
         // we will never reach the point where received.get() + len
         // could overflow
-        long rcv = received.get() + len;
+        long rcv = received + len;
         return rcv > windowSize && windowSizeExceeded(rcv);
     }
 
@@ -143,6 +149,7 @@ abstract class WindowUpdateSender {
      * @param delta the amount of processed bytes to release
      */
     void processed(int delta) {
+        assert delta >= 0 : delta;
         long rest = unprocessed.addAndGet(-delta);
         assert rest >= 0;
         update(delta);
@@ -166,6 +173,7 @@ abstract class WindowUpdateSender {
      * @return the amount of remaining unprocessed bytes
      */
     long released(int delta) {
+        assert delta >= 0 : delta;
         long rest = unprocessed.addAndGet(-delta);
         assert rest >= 0;
         return rest;
@@ -195,7 +203,7 @@ abstract class WindowUpdateSender {
             try {
                 int tosend = (int)Math.min(received.get(), Integer.MAX_VALUE);
                 if (tosend > limit) {
-                    received.getAndAdd(-tosend);
+                    received.addAndGet(-tosend);
                     sendWindowUpdate(tosend);
                 }
             } finally {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/WindowUpdateSender.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/WindowUpdateSender.java
@@ -117,24 +117,24 @@ abstract class WindowUpdateSender {
      *             the caller wants to buffer.
      */
     boolean canBufferUnprocessedBytes(int len) {
-        long buffered, rcv;
+        long buffered, processed;
         // get received before unprocessed in order to avoid counting
         // unprocessed bytes that might get unbuffered asynchronously
         // twice.
-        rcv = received.get();
+        processed = received.get();
         buffered = unprocessed.addAndGet(len);
-        return !checkWindowSizeExceeded(rcv, buffered);
+        return !checkWindowSizeExceeded(processed, buffered);
     }
 
     // adds the provided amount to the amount of already
-    // received and processed bytes and checks whether the
+    // processed and processed bytes and checks whether the
     // flow control window is exceeded. If so, take
     // corrective actions and return true.
-    private boolean checkWindowSizeExceeded(long received, long len) {
+    private boolean checkWindowSizeExceeded(long processed, long len) {
         // because windowSize is bound by Integer.MAX_VALUE
         // we will never reach the point where received.get() + len
         // could overflow
-        long rcv = received + len;
+        long rcv = processed + len;
         return rcv > windowSize && windowSizeExceeded(rcv);
     }
 

--- a/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
+++ b/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.ProtocolException;
 import java.net.URI;
@@ -335,7 +336,9 @@ public class StreamFlowControlTest {
                             // to wait for the connection window
                             fct.conn.obtainConnectionWindow(resp.length);
                         } catch (InterruptedException ie) {
-                            // ignore and continue...
+                            var ioe = new InterruptedIOException(ie.toString());
+                            ioe.initCause(ie);
+                            throw ioe;
                         }
                     }
                     try {
@@ -344,6 +347,7 @@ public class StreamFlowControlTest {
                         if (t instanceof FCHttp2TestExchange fct) {
                             fct.conn.updateConnectionWindow(resp.length);
                         }
+                        throw x;
                     }
                 }
             } finally {

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,7 +239,7 @@ public interface HttpServerAdapters {
         public abstract OutputStream  getResponseBody();
         public abstract HttpTestRequestHeaders getRequestHeaders();
         public abstract HttpTestResponseHeaders getResponseHeaders();
-        public abstract void sendResponseHeaders(int code, int contentLength) throws IOException;
+        public abstract void sendResponseHeaders(int code, long contentLength) throws IOException;
         public abstract URI getRequestURI();
         public abstract String getRequestMethod();
         public abstract void close();
@@ -292,7 +292,7 @@ public interface HttpServerAdapters {
                 return HttpTestResponseHeaders.of(exchange.getResponseHeaders());
             }
             @Override
-            public void sendResponseHeaders(int code, int contentLength) throws IOException {
+            public void sendResponseHeaders(int code, long contentLength) throws IOException {
                 if (contentLength == 0) contentLength = -1;
                 else if (contentLength < 0) contentLength = 0;
                 exchange.sendResponseHeaders(code, contentLength);
@@ -355,7 +355,7 @@ public interface HttpServerAdapters {
                 return HttpTestResponseHeaders.of(exchange.getResponseHeaders());
             }
             @Override
-            public void sendResponseHeaders(int code, int contentLength) throws IOException {
+            public void sendResponseHeaders(int code, long contentLength) throws IOException {
                 if (contentLength == 0) contentLength = -1;
                 else if (contentLength < 0) contentLength = 0;
                 exchange.sendResponseHeaders(code, contentLength);


### PR DESCRIPTION
The HTTP/2 flow control logic has a potential race condition where some of the unprocessed data may be counted twice for the connection window.
A protocol exception may be raised incorrectly if there are several concurrent streams producing data and the connection window is close from being exhausted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347373](https://bugs.openjdk.org/browse/JDK-8347373): HTTP/2 flow control checks may count unprocessed data twice (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23018/head:pull/23018` \
`$ git checkout pull/23018`

Update a local copy of the PR: \
`$ git checkout pull/23018` \
`$ git pull https://git.openjdk.org/jdk.git pull/23018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23018`

View PR using the GUI difftool: \
`$ git pr show -t 23018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23018.diff">https://git.openjdk.org/jdk/pull/23018.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23018#issuecomment-2581229557)
</details>
