### PR TITLE
8346722: (fs) Files.probeContentType throws ClassCastException with custom file system provider

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/DefaultFileTypeDetector.java
+++ b/src/java.base/unix/classes/sun/nio/fs/DefaultFileTypeDetector.java
@@ -25,9 +25,7 @@
 
 package sun.nio.fs;
 
-import java.nio.file.FileSystems;
 import java.nio.file.spi.FileTypeDetector;
-import java.nio.file.spi.FileSystemProvider;
 
 public class DefaultFileTypeDetector {
     private DefaultFileTypeDetector() { }

--- a/src/java.base/unix/classes/sun/nio/fs/DefaultFileTypeDetector.java
+++ b/src/java.base/unix/classes/sun/nio/fs/DefaultFileTypeDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ public class DefaultFileTypeDetector {
     private DefaultFileTypeDetector() { }
 
     public static FileTypeDetector create() {
-        FileSystemProvider provider = FileSystems.getDefault().provider();
-        return ((UnixFileSystemProvider)provider).getFileTypeDetector();
+        return DefaultFileSystemProvider.instance().getFileTypeDetector();
     }
 }

--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @bug 4313887 7006126 8142968 8178380 8183320 8210112 8266345 8263940 8331467 8346573
+ * @bug 4313887 7006126 8142968 8178380 8183320 8210112 8266345 8263940 8331467
+ *      8346573 8346722
  * @modules jdk.jartool jdk.jlink
  * @library /test/lib
  * @build testfsp/* testapp/* CustomSystemClassLoader

--- a/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
+++ b/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
@@ -61,7 +61,5 @@ public class Main {
 
         // exercise the file type detector
         String fileType = Files.probeContentType(Path.of("."));
-        if (fileType != null)
-            throw new RuntimeException("File type non-null: " + fileType);
     }
 }

--- a/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
+++ b/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,5 +58,10 @@ public class Main {
             throw new RuntimeException("'path' not in default file system");
         if (!path.equals(foo))
             throw new RuntimeException(path + " not equal to " + foo);
+
+        // exercise the file type detector
+        String fileType = Files.probeContentType(Path.of("."));
+        if (fileType != null)
+            throw new RuntimeException("File type non-null: " + fileType);
     }
 }


### PR DESCRIPTION
Ensure the file type detection works with a custom default file system provider.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346722](https://bugs.openjdk.org/browse/JDK-8346722): (fs) Files.probeContentType throws ClassCastException with custom file system provider (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23019/head:pull/23019` \
`$ git checkout pull/23019`

Update a local copy of the PR: \
`$ git checkout pull/23019` \
`$ git pull https://git.openjdk.org/jdk.git pull/23019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23019`

View PR using the GUI difftool: \
`$ git pr show -t 23019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23019.diff">https://git.openjdk.org/jdk/pull/23019.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23019#issuecomment-2581238704)
</details>
