### PR TITLE
8347379: Problem list failed tests after JDK-8321413

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -716,6 +716,8 @@ javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
 
 # core_tools
 
+tools/jlink/runtimeImage/JavaSEReproducibleTest.java 8347376 generic-all
+tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java 8347376 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Problem list two failed tests.
The failure seems to be related to jdk.jlink module not allowed with JEP 493, need more investigation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347379](https://bugs.openjdk.org/browse/JDK-8347379): Problem list failed tests after JDK-8321413 (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23021/head:pull/23021` \
`$ git checkout pull/23021`

Update a local copy of the PR: \
`$ git checkout pull/23021` \
`$ git pull https://git.openjdk.org/jdk.git pull/23021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23021`

View PR using the GUI difftool: \
`$ git pr show -t 23021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23021.diff">https://git.openjdk.org/jdk/pull/23021.diff</a>

</details>
