### PR TITLE
8343978: Update the default value of CodeEntryAlignment for Ampere-1A and 1B

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -158,6 +158,10 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {
       FLAG_SET_DEFAULT(OnSpinWaitInstCount, 2);
     }
+    if (FLAG_IS_DEFAULT(CodeEntryAlignment) &&
+        (_model == CPU_MODEL_AMPERE_1A || _model == CPU_MODEL_AMPERE_1B)) {
+      FLAG_SET_DEFAULT(CodeEntryAlignment, 32);
+    }
   }
 
   // ThunderX


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 89ee1a55 from the openjdk/jdk repository.

The commit being backported was authored by Liming Liu on 9 Jan 2025 and was reviewed by Dean Long and Vladimir Kozlov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343978](https://bugs.openjdk.org/browse/JDK-8343978): Update the default value of CodeEntryAlignment for Ampere-1A and 1B (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23027/head:pull/23027` \
`$ git checkout pull/23027`

Update a local copy of the PR: \
`$ git checkout pull/23027` \
`$ git pull https://git.openjdk.org/jdk.git pull/23027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23027`

View PR using the GUI difftool: \
`$ git pr show -t 23027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23027.diff">https://git.openjdk.org/jdk/pull/23027.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23027#issuecomment-2581983398)
</details>
