### PR TITLE
8347422: Crash during safepoint handler execution with -XX:+UseAPX

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -3020,7 +3020,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
 
   // Allocate space for the code.  Setup code generation tools.
   const char* name = SharedRuntime::stub_name(id);
-  CodeBuffer buffer(name, 2348, 1024);
+  CodeBuffer buffer(name, 2548, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
   address start   = __ pc();
@@ -3086,7 +3086,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
   Label bail;
 #endif
   if (!cause_return) {
-    Label no_prefix, not_special;
+    Label no_prefix, not_special, check_rex_prefix;
 
     // If our stashed return pc was modified by the runtime we avoid touching it
     __ cmpptr(rbx, Address(rbp, wordSize));
@@ -3113,7 +3113,27 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
     //   41 85 04 24    test   %eax,(%r12)
     //      85 45 00    test   %eax,0x0(%rbp)
     //   41 85 45 00    test   %eax,0x0(%r13)
+    //
+    // Notes:
+    //  Format of legacy MAP0 test instruction:-
+    //  [REX/REX2] [OPCODE] [ModRM] [SIB] [DISP] [IMM32]
+    //  o  For safepoint polling instruction "test %eax,(%rax)", encoding of first register
+    //     operand and base register of memory operand is b/w [0-8), hence we do not require
+    //     additional REX prefix where REX.B bit stores MSB bit of register encoding, which
+    //     is why two byte encoding is sufficient here.
+    //  o  For safepoint polling instruction like "test %eax,(%r8)", register encoding of BASE
+    //     register of memory operand is 1000, thus we need additional REX prefix in this case,
+    //     there by adding additional byte to instruction encoding.
+    //  o  In case BASE register is one of the 32 extended GPR registers available only on targets
+    //     supporting Intel APX extension, then we need to emit two byte REX2 prefix to hold
+    //     most significant two bits of 5 bit register encoding.
 
+    if (VM_Version::supports_apx_f()) {
+      __ cmpb(Address(rbx, 0), Assembler::REX2);
+      __ jcc(Assembler::notEqual, check_rex_prefix);
+      __ addptr(rbx, 2);
+      __ bind(check_rex_prefix);
+    }
     __ cmpb(Address(rbx, 0), NativeTstRegMem::instruction_rex_b_prefix);
     __ jcc(Assembler::notEqual, no_prefix);
     __ addptr(rbx, 1);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -3090,7 +3090,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
 
     // If our stashed return pc was modified by the runtime we avoid touching it
     __ cmpptr(rbx, Address(rbp, wordSize));
-    __ jccb(Assembler::notEqual, no_adjust);
+    __ jcc(Assembler::notEqual, no_adjust);
 
     // Skip over the poll instruction.
     // See NativeInstruction::is_safepoint_poll()
@@ -3120,22 +3120,22 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
     //  o  For safepoint polling instruction "test %eax,(%rax)", encoding of first register
     //     operand and base register of memory operand is b/w [0-8), hence we do not require
     //     additional REX prefix where REX.B bit stores MSB bit of register encoding, which
-    //     is why two byte encoding is sufficient here.
+    //     is why two bytes encoding is sufficient here.
     //  o  For safepoint polling instruction like "test %eax,(%r8)", register encoding of BASE
     //     register of memory operand is 1000, thus we need additional REX prefix in this case,
     //     there by adding additional byte to instruction encoding.
     //  o  In case BASE register is one of the 32 extended GPR registers available only on targets
-    //     supporting Intel APX extension, then we need to emit two byte REX2 prefix to hold
+    //     supporting Intel APX extension, then we need to emit two bytes REX2 prefix to hold
     //     most significant two bits of 5 bit register encoding.
 
     if (VM_Version::supports_apx_f()) {
       __ cmpb(Address(rbx, 0), Assembler::REX2);
-      __ jcc(Assembler::notEqual, check_rex_prefix);
+      __ jccb(Assembler::notEqual, check_rex_prefix);
       __ addptr(rbx, 2);
       __ bind(check_rex_prefix);
     }
     __ cmpb(Address(rbx, 0), NativeTstRegMem::instruction_rex_b_prefix);
-    __ jcc(Assembler::notEqual, no_prefix);
+    __ jccb(Assembler::notEqual, no_prefix);
     __ addptr(rbx, 1);
     __ bind(no_prefix);
 #ifdef ASSERT
@@ -3148,7 +3148,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
     __ andptr(rcx, 0x07); // looking for 0x04 .. 0x05
     __ subptr(rcx, 4);    // looking for 0x00 .. 0x01
     __ cmpptr(rcx, 1);
-    __ jcc(Assembler::above, not_special);
+    __ jccb(Assembler::above, not_special);
     __ addptr(rbx, 1);
     __ bind(not_special);
 #ifdef ASSERT


### PR DESCRIPTION
This bug fix patch fixes an internal error seen during safepoint handler execution.
The problem occurs due to missing handling for REX2 prefixed polling test instruction.

Manually verified the patch with the -XX:+SafepointALot runtime flag.

Best Regards,
Jatin
PS: Patch will be opened for review after some validation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8347422](https://bugs.openjdk.org/browse/JDK-8347422): Crash during safepoint handler execution with -XX:+UseAPX (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) Review applies to [4071a9d1](https://git.openjdk.org/jdk/pull/23035/files/4071a9d19f0b28a278fc3656cddfd55c18b3e676)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23035/head:pull/23035` \
`$ git checkout pull/23035`

Update a local copy of the PR: \
`$ git checkout pull/23035` \
`$ git pull https://git.openjdk.org/jdk.git pull/23035/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23035`

View PR using the GUI difftool: \
`$ git pr show -t 23035`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23035.diff">https://git.openjdk.org/jdk/pull/23035.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23035#issuecomment-2586643624)
</details>
