### PR TITLE
8347129: cpuset cgroups controller is required for no good reason

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -37,7 +37,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 // controller names have to match the *_IDX indices
-static const char* cg_controller_name[] = { "cpu", "cpuset", "cpuacct", "memory", "pids" };
+static const char* cg_controller_name[] = { "cpuset", "cpu", "cpuacct", "memory", "pids" };
 
 CgroupSubsystem* CgroupSubsystemFactory::create() {
   CgroupV1MemoryController* memory = nullptr;

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -226,9 +226,10 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
   char buf[MAXPATHLEN+1];
   char *p;
   bool is_cgroupsV2;
-  // true iff all required controllers, memory, cpu, cpuset, cpuacct are enabled
+  // true iff all required controllers, memory, cpu, cpuacct are enabled
   // at the kernel level.
   // pids might not be enabled on older Linux distros (SLES 12.1, RHEL 7.1)
+  // cpuset might not be enabled on newer Linux distros (Fedora 41)
   bool all_required_controllers_enabled;
 
   /*
@@ -260,6 +261,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
       cg_infos[MEMORY_IDX]._hierarchy_id = hierarchy_id;
       cg_infos[MEMORY_IDX]._enabled = (enabled == 1);
     } else if (strcmp(name, "cpuset") == 0) {
+      log_debug(os, container)("Detected optional cpuset controller entry in %s", proc_cgroups);
       cg_infos[CPUSET_IDX]._name = os::strdup(name);
       cg_infos[CPUSET_IDX]._hierarchy_id = hierarchy_id;
       cg_infos[CPUSET_IDX]._enabled = (enabled == 1);
@@ -284,7 +286,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
   all_required_controllers_enabled = true;
   for (int i = 0; i < CG_INFO_LENGTH; i++) {
     // pids controller is optional. All other controllers are required
-    if (i != PIDS_IDX) {
+    if (i != PIDS_IDX && i != CPUSET_IDX) {
       is_cgroupsV2 = is_cgroupsV2 && cg_infos[i]._hierarchy_id == 0;
       all_required_controllers_enabled = all_required_controllers_enabled && cg_infos[i]._enabled;
     }

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -285,7 +285,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
   is_cgroupsV2 = true;
   all_required_controllers_enabled = true;
   for (int i = 0; i < CG_INFO_LENGTH; i++) {
-    // pids controller is optional. All other controllers are required
+    // pids and cpuset controllers are optional. All other controllers are required
     if (i != PIDS_IDX && i != CPUSET_IDX) {
       is_cgroupsV2 = is_cgroupsV2 && cg_infos[i]._hierarchy_id == 0;
       all_required_controllers_enabled = all_required_controllers_enabled && cg_infos[i]._enabled;


### PR DESCRIPTION
Please review this small change to make the `cpuset` cgroups controller optional as far as the JDK is concerned. The rationale is that:

- Some distributions now don't have it enabled by default (e.g. Fedora 41), which breaks automatic container detection logic.
- CPU limits enforced with `--cpuset-cpus` is reflected with the `sched_getaffinity` system call and, thus, the controller doesn't need to be mandatory. The current failure to detect the controller results in no container limits being detected with is bad.

The fix is rather simple. Make `cpuset` controller look-up from `/proc/cgroups` optional (like the `pids` controller) and continue. `OSContainer::active_processor_count()` still behaves as before (should there be a `cpuset` limit) as it's covered by `os::Linux::active_processor_count()` which serves as the upper bound of other container cpu limits.

While at it, I've also fixed the logging bug by re-arranging the `const char*` values. `cpuset` is index `0`, `cpu` is index `1`.

Testing:
- [x] GHA
- [x] Linux container tests in `test/hotspot/jtreg/containers` on Linux cgroups v1 and cgroups v2 as well as on an affected system (F41 on cg v2). All pass.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8347129: cpuset cgroups controller is required for no good reason`

### Issue
 * [JDK-8347129](https://bugs.openjdk.org/browse/JDK-8347129): cpuset cgroups controller is required for no good reason (**Bug** - P3)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23037/head:pull/23037` \
`$ git checkout pull/23037`

Update a local copy of the PR: \
`$ git checkout pull/23037` \
`$ git pull https://git.openjdk.org/jdk.git pull/23037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23037`

View PR using the GUI difftool: \
`$ git pr show -t 23037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23037.diff">https://git.openjdk.org/jdk/pull/23037.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23037#issuecomment-2582819277)
</details>
