### PR TITLE
8343510: JFR: Remove AccessControlContext from FlightRecorder::addListener specification

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/FlightRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/FlightRecorder.java
@@ -249,8 +249,7 @@ public final class FlightRecorder {
     }
 
     /**
-     * Adds a recorder listener and captures the {@code AccessControlContext} to
-     * use when invoking the listener.
+     * Adds a recorder listener.
      * <p>
      * If Flight Recorder is already initialized when the listener is added, then the method
      * {@link FlightRecorderListener#recorderInitialized(FlightRecorder)} method is


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8345610](https://bugs.openjdk.org/browse/JDK-8345610) to be approved

### Issues
 * [JDK-8343510](https://bugs.openjdk.org/browse/JDK-8343510): JFR: Remove AccessControlContext from FlightRecorder::addListener specification (**Bug** - P3)
 * [JDK-8345610](https://bugs.openjdk.org/browse/JDK-8345610): JFR: Remove AccessControlContext from FlightRecorder::addListener specification (**CSR**)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23041/head:pull/23041` \
`$ git checkout pull/23041`

Update a local copy of the PR: \
`$ git checkout pull/23041` \
`$ git pull https://git.openjdk.org/jdk.git pull/23041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23041`

View PR using the GUI difftool: \
`$ git pr show -t 23041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23041.diff">https://git.openjdk.org/jdk/pull/23041.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23041#issuecomment-2583199884)
</details>
