### PR TITLE
8347431: Update ObjectMonitor comments

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,12 +84,6 @@ class ObjectWaiter : public CHeapObj<mtThread> {
 //
 // ObjectMonitor Layout Overview/Highlights/Restrictions:
 //
-// - The _metadata field must be at offset 0 because the displaced header
-//   from markWord is stored there. We do not want markWord.hpp to include
-//   ObjectMonitor.hpp to avoid exposing ObjectMonitor everywhere. This
-//   means that ObjectMonitor cannot inherit from any other class nor can
-//   it use any virtual member functions. This restriction is critical to
-//   the proper functioning of the VM.
 // - The _metadata and _owner fields should be separated by enough space
 //   to avoid false sharing due to parallel access by different threads.
 //   This is an advisory recommendation.
@@ -117,11 +111,7 @@ class ObjectWaiter : public CHeapObj<mtThread> {
 //
 // - See TEST_VM(ObjectMonitor, sanity) gtest for how critical restrictions are
 //   enforced.
-// - Adjacent ObjectMonitors should be separated by enough space to avoid
-//   false sharing. This is handled by the ObjectMonitor allocation code
-//   in synchronizer.cpp. Also see TEST_VM(SynchronizerTest, sanity) gtest.
 //
-// Futures notes:
 // - Separating _owner from the <remaining_fields> by enough space to
 //   avoid false sharing might be profitable. Given that the CAS in
 //   monitorenter will invalidate the line underlying _owner. We want
@@ -151,7 +141,7 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   // ParkEvent of unblocker thread.
   static ParkEvent* _vthread_unparker_ParkEvent;
 
-  // The sync code expects the metadata field to be at offset zero (0).
+  // Because of frequent access, the the metadata field is at offset zero (0).
   // Enforced by the assert() in metadata_addr().
   // * LM_LIGHTWEIGHT with UseObjectMonitorTable:
   // Contains the _object's hashCode.

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -84,6 +84,9 @@ class ObjectWaiter : public CHeapObj<mtThread> {
 //
 // ObjectMonitor Layout Overview/Highlights/Restrictions:
 //
+// - For performance reasons we ensure the _metadata field is located at offset 0,
+//   which in turn means that ObjectMonitor can't inherit from any other class nor use
+//   any virtual member functions.
 // - The _metadata and _owner fields should be separated by enough space
 //   to avoid false sharing due to parallel access by different threads.
 //   This is an advisory recommendation.

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -125,7 +125,7 @@ class ObjectWaiter : public CHeapObj<mtThread> {
 //   would make them immune to CAS-based invalidation from the _owner
 //   field.
 //
-// - The _recursions field should be of type int, or int32_t but not
+// - TODO: The _recursions field should be of type int, or int32_t but not
 //   intptr_t. There's no reason to use a 64-bit type for this field
 //   in a 64-bit JVM.
 


### PR DESCRIPTION
Please review this change that removes a couple of comments that are not true (verified with testing metadata at offset 8).  There are no functional changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347431](https://bugs.openjdk.org/browse/JDK-8347431): Update ObjectMonitor comments (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23042/head:pull/23042` \
`$ git checkout pull/23042`

Update a local copy of the PR: \
`$ git checkout pull/23042` \
`$ git pull https://git.openjdk.org/jdk.git pull/23042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23042`

View PR using the GUI difftool: \
`$ git pr show -t 23042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23042.diff">https://git.openjdk.org/jdk/pull/23042.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23042#issuecomment-2583163424)
</details>
