### PR TITLE
8337978: Verify OopHandles oops on access

### DIFF
--- a/src/hotspot/share/oops/oopHandle.inline.hpp
+++ b/src/hotspot/share/oops/oopHandle.inline.hpp
@@ -31,11 +31,23 @@
 #include "gc/shared/oopStorage.inline.hpp"
 
 inline oop OopHandle::resolve() const {
-  return (_obj == nullptr) ? (oop)nullptr : NativeAccess<>::oop_load(_obj);
+  if (_obj == nullptr) {
+    return (oop) nullptr;
+  } else {
+    oop oop = NativeAccess<>::oop_load(_obj);
+    assert(oopDesc::is_oop_or_null(oop), "Should be oop: " PTR_FORMAT, p2i(oop));
+    return oop;
+  }
 }
 
 inline oop OopHandle::peek() const {
-  return (_obj == nullptr) ? (oop)nullptr : NativeAccess<AS_NO_KEEPALIVE>::oop_load(_obj);
+  if (_obj == nullptr) {
+    return (oop) nullptr;
+  } else {
+    oop obj = NativeAccess<AS_NO_KEEPALIVE>::oop_load(_obj);
+    assert(oopDesc::is_oop_or_null(obj), "Should be oop: " PTR_FORMAT, p2i(obj));
+    return obj;
+  }
 }
 
 inline OopHandle::OopHandle(OopStorage* storage, oop obj) :
@@ -44,6 +56,7 @@ inline OopHandle::OopHandle(OopStorage* storage, oop obj) :
     vm_exit_out_of_memory(sizeof(oop), OOM_MALLOC_ERROR,
                           "Cannot create oop handle");
   }
+  assert(oopDesc::is_oop_or_null(obj), "Should be oop: " PTR_FORMAT, p2i(obj));
   NativeAccess<>::oop_store(_obj, obj);
 }
 
@@ -58,15 +71,22 @@ inline void OopHandle::release(OopStorage* storage) {
 
 inline void OopHandle::replace(oop obj) {
   assert(!is_empty(), "should not use replace");
+  assert(oopDesc::is_oop_or_null(obj), "Should be oop: " PTR_FORMAT, p2i(obj));
   NativeAccess<>::oop_store(_obj, obj);
 }
 
 inline oop OopHandle::xchg(oop new_value) {
-  return NativeAccess<MO_SEQ_CST>::oop_atomic_xchg(_obj, new_value);
+  assert(oopDesc::is_oop_or_null(new_value), "Should be oop: " PTR_FORMAT, p2i(new_value));
+  oop obj = NativeAccess<MO_SEQ_CST>::oop_atomic_xchg(_obj, new_value);
+  assert(oopDesc::is_oop_or_null(obj), "Should be oop: " PTR_FORMAT, p2i(obj));
+  return obj;
 }
 
 inline oop OopHandle::cmpxchg(oop old_value, oop new_value) {
-  return NativeAccess<MO_SEQ_CST>::oop_atomic_cmpxchg(_obj, old_value, new_value);
+  assert(oopDesc::is_oop_or_null(new_value), "Should be oop: " PTR_FORMAT, p2i(new_value));
+  oop obj = NativeAccess<MO_SEQ_CST>::oop_atomic_cmpxchg(_obj, old_value, new_value);
+  assert(oopDesc::is_oop_or_null(obj), "Should be oop: " PTR_FORMAT, p2i(obj));
+  return obj;
 }
 
 #endif // SHARE_OOPS_OOPHANDLE_INLINE_HPP


### PR DESCRIPTION
Detecting failures like [JDK-8337941](https://bugs.openjdk.org/browse/JDK-8337941) would be more convenient if we verified the oops we put/get to/from `OopHandles`-s explicitly. This will stop the leakage of incorrect oops (e.g. bad Java klass mirrors seen in [JDK-8337941](https://bugs.openjdk.org/browse/JDK-8337941)) to the runtime.

I was curious how this affects testing time, and I cannot see a big difference at least on `tier1`:

```
# Baseline
CONF=linux-aarch64-server-fastdebug make test TEST=tier1  60427.40s user 4604.67s system 3775% cpu 28:42.39 total
CONF=linux-aarch64-server-fastdebug make test TEST=tier1  61364.50s user 4563.23s system 3806% cpu 28:52.20 total
CONF=linux-aarch64-server-fastdebug make test TEST=tier1  60192.57s user 4610.89s system 3788% cpu 28:30.51 total

# With OopHandle verification
CONF=linux-aarch64-server-fastdebug make test TEST=tier1  60410.88s user 4601.52s system 3740% cpu 28:58.20 total
CONF=linux-aarch64-server-fastdebug make test TEST=tier1  60389.57s user 4572.23s system 3752% cpu 28:50.96 total
CONF=linux-aarch64-server-fastdebug make test TEST=tier1  60845.41s user 4578.50s system 3757% cpu 29:01.08 total
```

Additional testing:
 - [x] Linux AArch64 server fastdebug, `tier1`
 - [x] Linux AArch64 server fastdebug, `all`
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337978](https://bugs.openjdk.org/browse/JDK-8337978): Verify OopHandles oops on access (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23043/head:pull/23043` \
`$ git checkout pull/23043`

Update a local copy of the PR: \
`$ git checkout pull/23043` \
`$ git pull https://git.openjdk.org/jdk.git pull/23043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23043`

View PR using the GUI difftool: \
`$ git pr show -t 23043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23043.diff">https://git.openjdk.org/jdk/pull/23043.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23043#issuecomment-2583332872)
</details>
