### PR TITLE
8342550: Log warning for using JDK1.1 compatible time zone IDs for future removal

### DIFF
--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@ import jdk.internal.util.StaticProperty;
 import sun.util.calendar.ZoneInfo;
 import sun.util.calendar.ZoneInfoFile;
 import sun.util.locale.provider.TimeZoneNameUtility;
+import sun.util.logging.PlatformLogger;
 
 /**
  * {@code TimeZone} represents a time zone offset, and also figures out daylight
@@ -596,6 +597,11 @@ public abstract class TimeZone implements Serializable, Cloneable {
     }
 
     private static TimeZone getTimeZone(String ID, boolean fallback) {
+        if (ZoneId.SHORT_IDS.containsKey(ID)) {
+            PlatformLogger.getLogger(TimeZone.class.getName())
+                .warning("Use of the three-letter time zone ID \"%s\" is deprecated and it will be removed in a future release"
+                    .formatted(ID));
+        }
         TimeZone tz = ZoneInfo.getTimeZone(ID);
         if (tz == null) {
             tz = parseCustomTimeZone(ID);

--- a/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,8 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Set;
-import java.util.TimeZone;
+
+import sun.util.calendar.ZoneInfo;
 import sun.util.calendar.ZoneInfoFile;
 import sun.util.locale.provider.LocaleProviderAdapter;
 import sun.util.locale.provider.LocaleResources;
@@ -93,7 +94,7 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
                 case "":
                     // Fill in empty elements
                     deriveFallbackName(namesSuper, i, locale,
-                                       TimeZone.getTimeZone(id).toZoneId().getRules().isFixedOffset());
+                                       ZoneInfo.getTimeZone(id).toZoneId().getRules().isFixedOffset());
                     break;
                 case NO_INHERITANCE_MARKER:
                     // CLDR's "no inheritance marker"
@@ -131,7 +132,7 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
 
     // Derive fallback time zone name according to LDML's logic
     private void deriveFallbackNames(String[] names, Locale locale) {
-        boolean noDST = TimeZone.getTimeZone(names[0]).toZoneId().getRules().isFixedOffset();
+        boolean noDST = ZoneInfo.getTimeZone(names[0]).toZoneId().getRules().isFixedOffset();
 
         for (int i = INDEX_STD_LONG; i <= INDEX_GEN_SHORT; i++) {
             deriveFallbackName(names, i, locale, noDST);

--- a/test/jdk/java/util/TimeZone/ThreeLetterZoneID.java
+++ b/test/jdk/java/util/TimeZone/ThreeLetterZoneID.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8342550
+ * @summary Three-letter time zone IDs should output a deprecated warning
+ *          message.
+ * @library /test/lib
+ * @build jdk.test.lib.process.ProcessTools
+ * @run main ThreeLetterZoneID
+ */
+import java.util.TimeZone;
+import jdk.test.lib.process.ProcessTools;
+
+public class ThreeLetterZoneID {
+    public static void main(String... args) throws Exception {
+        if (args.length > 0) {
+            TimeZone.getTimeZone("PST");
+        } else {
+            checkWarningMessage();
+        }
+    }
+
+    public static void checkWarningMessage() throws Exception {
+        ProcessTools.executeTestJava("ThreeLetterZoneID", "dummy")
+            .shouldContain("Use of the three-letter time zone ID \"PST\" is deprecated and it will be removed in a future release");
+    }
+}


### PR DESCRIPTION
The use of [three-letter time zone IDs](https://download.java.net/java/early_access/jdk24/docs/api/java.base/java/util/TimeZone.html#three-letter-time-zone-ids-heading) has long been deprecated. For their actual removal in the future, making the runtime emit warnings for using those IDs would be desirable.

---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342550](https://bugs.openjdk.org/browse/JDK-8342550): Log warning for using JDK1.1 compatible time zone IDs for future removal (**Enhancement** - P4)


### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23049/head:pull/23049` \
`$ git checkout pull/23049`

Update a local copy of the PR: \
`$ git checkout pull/23049` \
`$ git pull https://git.openjdk.org/jdk.git pull/23049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23049`

View PR using the GUI difftool: \
`$ git pr show -t 23049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23049.diff">https://git.openjdk.org/jdk/pull/23049.diff</a>

</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342550](https://bugs.openjdk.org/browse/JDK-8342550): Log warning for using JDK1.1 compatible time zone IDs for future removal (**Enhancement** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23049/head:pull/23049` \
`$ git checkout pull/23049`

Update a local copy of the PR: \
`$ git checkout pull/23049` \
`$ git pull https://git.openjdk.org/jdk.git pull/23049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23049`

View PR using the GUI difftool: \
`$ git pr show -t 23049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23049.diff">https://git.openjdk.org/jdk/pull/23049.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23049#issuecomment-2587966058)
</details>
