### PR TITLE
8347491: IllegalArgumentationException thrown by ThreadPoolExecutor doesn't have a useful message

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/AbstractExecutorService.java
+++ b/src/java.base/share/classes/java/util/concurrent/AbstractExecutorService.java
@@ -155,7 +155,7 @@ public abstract class AbstractExecutorService implements ExecutorService {
      */
     private <T> T doInvokeAny(Collection<? extends Callable<T>> tasks,
                               boolean timed, long nanos)
-        throws InterruptedException, ExecutionException, TimeoutException, NullPointerException {
+        throws InterruptedException, ExecutionException, TimeoutException {
         Objects.requireNonNull(tasks, "tasks");
         int ntasks = tasks.size();
         if (ntasks == 0)

--- a/src/java.base/share/classes/java/util/concurrent/AbstractExecutorService.java
+++ b/src/java.base/share/classes/java/util/concurrent/AbstractExecutorService.java
@@ -261,7 +261,7 @@ public abstract class AbstractExecutorService implements ExecutorService {
      */
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
-        throws InterruptedException , NullPointerException {
+        throws InterruptedException {
         Objects.requireNonNull(tasks, "tasks");
         ArrayList<Future<T>> futures = new ArrayList<>(tasks.size());
         try {

--- a/src/java.base/share/classes/java/util/concurrent/AbstractExecutorService.java
+++ b/src/java.base/share/classes/java/util/concurrent/AbstractExecutorService.java
@@ -119,7 +119,7 @@ public abstract class AbstractExecutorService implements ExecutorService {
      */
     @Override
     public Future<?> submit(Runnable task) {
-        if (task == null) throw new NullPointerException();
+        if (task == null) throw new NullPointerException("task can't be null");
         RunnableFuture<Void> ftask = newTaskFor(task, null);
         execute(ftask);
         return ftask;
@@ -131,7 +131,7 @@ public abstract class AbstractExecutorService implements ExecutorService {
      */
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        if (task == null) throw new NullPointerException();
+        if (task == null) throw new NullPointerException("task can't be null");
         RunnableFuture<T> ftask = newTaskFor(task, result);
         execute(ftask);
         return ftask;
@@ -143,7 +143,7 @@ public abstract class AbstractExecutorService implements ExecutorService {
      */
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        if (task == null) throw new NullPointerException();
+        if (task == null) throw new NullPointerException("task can't be null");
         RunnableFuture<T> ftask = newTaskFor(task);
         execute(ftask);
         return ftask;
@@ -156,7 +156,7 @@ public abstract class AbstractExecutorService implements ExecutorService {
                               boolean timed, long nanos)
         throws InterruptedException, ExecutionException, TimeoutException {
         if (tasks == null)
-            throw new NullPointerException();
+            throw new NullPointerException("tasks can't be null");
         int ntasks = tasks.size();
         if (ntasks == 0)
             throw new IllegalArgumentException();
@@ -263,7 +263,7 @@ public abstract class AbstractExecutorService implements ExecutorService {
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
         throws InterruptedException {
         if (tasks == null)
-            throw new NullPointerException();
+            throw new NullPointerException("tasks can't be null");
         ArrayList<Future<T>> futures = new ArrayList<>(tasks.size());
         try {
             for (Callable<T> t : tasks) {
@@ -295,7 +295,7 @@ public abstract class AbstractExecutorService implements ExecutorService {
                                          long timeout, TimeUnit unit)
         throws InterruptedException {
         if (tasks == null)
-            throw new NullPointerException();
+            throw new NullPointerException("tasks can't be null");
         final long nanos = unit.toNanos(timeout);
         final long deadline = System.nanoTime() + nanos;
         ArrayList<Future<T>> futures = new ArrayList<>(tasks.size());

--- a/src/java.base/share/classes/java/util/concurrent/AbstractExecutorService.java
+++ b/src/java.base/share/classes/java/util/concurrent/AbstractExecutorService.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Provides default implementations of {@link ExecutorService}
@@ -119,7 +120,7 @@ public abstract class AbstractExecutorService implements ExecutorService {
      */
     @Override
     public Future<?> submit(Runnable task) {
-        if (task == null) throw new NullPointerException("task can't be null");
+        Objects.requireNonNull(task, "task");
         RunnableFuture<Void> ftask = newTaskFor(task, null);
         execute(ftask);
         return ftask;
@@ -131,7 +132,7 @@ public abstract class AbstractExecutorService implements ExecutorService {
      */
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        if (task == null) throw new NullPointerException("task can't be null");
+        Objects.requireNonNull(task, "task");
         RunnableFuture<T> ftask = newTaskFor(task, result);
         execute(ftask);
         return ftask;
@@ -143,7 +144,7 @@ public abstract class AbstractExecutorService implements ExecutorService {
      */
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        if (task == null) throw new NullPointerException("task can't be null");
+        Objects.requireNonNull(task, "task");
         RunnableFuture<T> ftask = newTaskFor(task);
         execute(ftask);
         return ftask;
@@ -154,12 +155,11 @@ public abstract class AbstractExecutorService implements ExecutorService {
      */
     private <T> T doInvokeAny(Collection<? extends Callable<T>> tasks,
                               boolean timed, long nanos)
-        throws InterruptedException, ExecutionException, TimeoutException {
-        if (tasks == null)
-            throw new NullPointerException("tasks can't be null");
+        throws InterruptedException, ExecutionException, TimeoutException, NullPointerException {
+        Objects.requireNonNull(tasks, "tasks");
         int ntasks = tasks.size();
         if (ntasks == 0)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("tasks is empty");
         ArrayList<Future<T>> futures = new ArrayList<>(ntasks);
         ExecutorCompletionService<T> ecs =
             new ExecutorCompletionService<T>(this);
@@ -261,9 +261,8 @@ public abstract class AbstractExecutorService implements ExecutorService {
      */
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
-        throws InterruptedException {
-        if (tasks == null)
-            throw new NullPointerException("tasks can't be null");
+        throws InterruptedException , NullPointerException {
+        Objects.requireNonNull(tasks, "tasks");
         ArrayList<Future<T>> futures = new ArrayList<>(tasks.size());
         try {
             for (Callable<T> t : tasks) {
@@ -294,8 +293,8 @@ public abstract class AbstractExecutorService implements ExecutorService {
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks,
                                          long timeout, TimeUnit unit)
         throws InterruptedException {
-        if (tasks == null)
-            throw new NullPointerException("tasks can't be null");
+        Objects.requireNonNull(tasks, "tasks");
+        Objects.requireNonNull(unit, "unit");
         final long nanos = unit.toNanos(timeout);
         final long deadline = System.nanoTime() + nanos;
         ArrayList<Future<T>> futures = new ArrayList<>(tasks.size());

--- a/src/java.base/share/classes/java/util/concurrent/ExecutorCompletionService.java
+++ b/src/java.base/share/classes/java/util/concurrent/ExecutorCompletionService.java
@@ -35,6 +35,8 @@
 
 package java.util.concurrent;
 
+import java.util.Objects;
+
 /**
  * A {@link CompletionService} that uses a supplied {@link Executor}
  * to execute tasks.  This class arranges that submitted tasks are,
@@ -145,8 +147,7 @@ public class ExecutorCompletionService<V> implements CompletionService<V> {
      * @throws NullPointerException if executor is {@code null}
      */
     public ExecutorCompletionService(Executor executor) {
-        if (executor == null)
-            throw new NullPointerException();
+        Objects.requireNonNull(executor, "executor");
         this.executor = executor;
         this.aes = (executor instanceof AbstractExecutorService) ?
             (AbstractExecutorService) executor : null;
@@ -168,8 +169,8 @@ public class ExecutorCompletionService<V> implements CompletionService<V> {
      */
     public ExecutorCompletionService(Executor executor,
                                      BlockingQueue<Future<V>> completionQueue) {
-        if (executor == null || completionQueue == null)
-            throw new NullPointerException();
+        Objects.requireNonNull(executor, "executor");
+        Objects.requireNonNull(completionQueue, "completionQueue");
         this.executor = executor;
         this.aes = (executor instanceof AbstractExecutorService) ?
             (AbstractExecutorService) executor : null;
@@ -181,7 +182,7 @@ public class ExecutorCompletionService<V> implements CompletionService<V> {
      * @throws NullPointerException       {@inheritDoc}
      */
     public Future<V> submit(Callable<V> task) {
-        if (task == null) throw new NullPointerException();
+        Objects.requireNonNull(task, "task");
         RunnableFuture<V> f = newTaskFor(task);
         executor.execute(new QueueingFuture<V>(f, completionQueue));
         return f;
@@ -192,7 +193,7 @@ public class ExecutorCompletionService<V> implements CompletionService<V> {
      * @throws NullPointerException       {@inheritDoc}
      */
     public Future<V> submit(Runnable task, V result) {
-        if (task == null) throw new NullPointerException();
+        Objects.requireNonNull(task, "task");
         RunnableFuture<V> f = newTaskFor(task, result);
         executor.execute(new QueueingFuture<V>(f, completionQueue));
         return f;

--- a/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
@@ -1257,13 +1257,14 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
                               ThreadFactory threadFactory,
                               RejectedExecutionHandler handler) {
         if (corePoolSize < 0) {
-            throw new IllegalArgumentException("corePoolSize < 0");
+            throw new IllegalArgumentException("corePoolSize can't be negative, but got " + corePoolSize);
         } else if (maximumPoolSize <= 0) {
-            throw new IllegalArgumentException("maximumPoolSize <= 0");
+            throw new IllegalArgumentException("maximumPoolSize must be positive, but got " + maximumPoolSize);
         } else if (maximumPoolSize < corePoolSize) {
-            throw new IllegalArgumentException("maximumPoolSize < corePoolSize");
+            throw new IllegalArgumentException("maximumPoolSize must >= corePoolSize , " +
+                "but got maximumPoolSize:" + maximumPoolSize + " corePoolSize :" + corePoolSize);
         } else if (keepAliveTime < 0) {
-            throw new IllegalArgumentException("keepAliveTime < 0");
+            throw new IllegalArgumentException("keepAliveTime can't be negative, but got " + keepAliveTime);
         }
         if (workQueue == null || threadFactory == null || handler == null)
             throw new NullPointerException();
@@ -1508,9 +1509,10 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setCorePoolSize(int corePoolSize) {
         if (corePoolSize < 0) {
-            throw new IllegalArgumentException("corePoolSize < 0");
+            throw new IllegalArgumentException("corePoolSize can't be negative, but got " + corePoolSize);
         } else if (corePoolSize > maximumPoolSize) {
-            throw new IllegalArgumentException("corePoolSize > maximumPoolSize");
+            throw new IllegalArgumentException("maximumPoolSize must >= corePoolSize , " +
+                "but got maximumPoolSize:" + maximumPoolSize + " corePoolSize :" + corePoolSize);
         }
         int delta = corePoolSize - this.corePoolSize;
         this.corePoolSize = corePoolSize;
@@ -1636,9 +1638,10 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setMaximumPoolSize(int maximumPoolSize) {
         if (maximumPoolSize <= 0) {
-            throw new IllegalArgumentException("maximumPoolSize <= 0");
+            throw new IllegalArgumentException("maximumPoolSize must be positive, but got " + maximumPoolSize);
         } else if (maximumPoolSize < corePoolSize) {
-            throw new IllegalArgumentException("maximumPoolSize < corePoolSize");
+            throw new IllegalArgumentException("maximumPoolSize must >= corePoolSize , " +
+                "but got maximumPoolSize:" + maximumPoolSize + " corePoolSize :" + corePoolSize);
         }
         this.maximumPoolSize = maximumPoolSize;
         if (workerCountOf(ctl.get()) > maximumPoolSize)
@@ -1673,7 +1676,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setKeepAliveTime(long time, TimeUnit unit) {
         if (time < 0)
-            throw new IllegalArgumentException("time < 0");
+            throw new IllegalArgumentException("time can't be negative, but got " + time);
         if (time == 0 && allowsCoreThreadTimeOut())
             throw new IllegalArgumentException("Core threads must have nonzero keep alive times");
         long keepAliveTime = unit.toNanos(time);

--- a/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
@@ -1261,13 +1261,16 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
         } else if (maximumPoolSize <= 0) {
             throw new IllegalArgumentException("maximumPoolSize must be positive, but got " + maximumPoolSize);
         } else if (maximumPoolSize < corePoolSize) {
-            throw new IllegalArgumentException("maximumPoolSize must >= corePoolSize , " +
-                "but got maximumPoolSize:" + maximumPoolSize + " corePoolSize :" + corePoolSize);
+            throw new IllegalArgumentException("maximumPoolSize must >= corePoolSize , " + "but got maximumPoolSize:" + maximumPoolSize + " corePoolSize :" + corePoolSize);
         } else if (keepAliveTime < 0) {
             throw new IllegalArgumentException("keepAliveTime can't be negative, but got " + keepAliveTime);
+        } else if (workQueue == null) {
+            throw new NullPointerException("workQueue can't be null");
+        } else if (threadFactory == null) {
+            throw new NullPointerException("threadFactory can't be null");
+        } else if (handler == null) {
+            throw new NullPointerException("handler can't be null");
         }
-        if (workQueue == null || threadFactory == null || handler == null)
-            throw new NullPointerException();
         this.corePoolSize = corePoolSize;
         this.maximumPoolSize = maximumPoolSize;
         this.workQueue = workQueue;
@@ -1295,7 +1298,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void execute(Runnable command) {
         if (command == null)
-            throw new NullPointerException();
+            throw new NullPointerException("command can't be null");
         /*
          * Proceed in 3 steps:
          *
@@ -1457,7 +1460,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setThreadFactory(ThreadFactory threadFactory) {
         if (threadFactory == null)
-            throw new NullPointerException();
+            throw new NullPointerException("threadFactory can't be null");
         this.threadFactory = threadFactory;
     }
 
@@ -1480,7 +1483,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setRejectedExecutionHandler(RejectedExecutionHandler handler) {
         if (handler == null)
-            throw new NullPointerException();
+            throw new NullPointerException("handler can't be null");
         this.handler = handler;
     }
 

--- a/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
@@ -1256,11 +1256,15 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
                               BlockingQueue<Runnable> workQueue,
                               ThreadFactory threadFactory,
                               RejectedExecutionHandler handler) {
-        if (corePoolSize < 0 ||
-            maximumPoolSize <= 0 ||
-            maximumPoolSize < corePoolSize ||
-            keepAliveTime < 0)
-            throw new IllegalArgumentException();
+        if (corePoolSize < 0) {
+            throw new IllegalArgumentException("corePoolSize < 0");
+        } else if (maximumPoolSize <= 0) {
+            throw new IllegalArgumentException("maximumPoolSize <= 0");
+        } else if (maximumPoolSize < corePoolSize) {
+            throw new IllegalArgumentException("maximumPoolSize < corePoolSize");
+        } else if (keepAliveTime < 0) {
+            throw new IllegalArgumentException("keepAliveTime < 0");
+        }
         if (workQueue == null || threadFactory == null || handler == null)
             throw new NullPointerException();
         this.corePoolSize = corePoolSize;
@@ -1503,8 +1507,11 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      * @see #getCorePoolSize
      */
     public void setCorePoolSize(int corePoolSize) {
-        if (corePoolSize < 0 || maximumPoolSize < corePoolSize)
-            throw new IllegalArgumentException();
+        if (corePoolSize < 0) {
+            throw new IllegalArgumentException("corePoolSize < 0");
+        } else if (corePoolSize > maximumPoolSize) {
+            throw new IllegalArgumentException("corePoolSize > maximumPoolSize");
+        }
         int delta = corePoolSize - this.corePoolSize;
         this.corePoolSize = corePoolSize;
         if (workerCountOf(ctl.get()) > corePoolSize)
@@ -1628,8 +1635,11 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      * @see #getMaximumPoolSize
      */
     public void setMaximumPoolSize(int maximumPoolSize) {
-        if (maximumPoolSize <= 0 || maximumPoolSize < corePoolSize)
-            throw new IllegalArgumentException();
+        if (maximumPoolSize <= 0) {
+            throw new IllegalArgumentException("maximumPoolSize <= 0");
+        } else if (maximumPoolSize < corePoolSize) {
+            throw new IllegalArgumentException("maximumPoolSize < corePoolSize");
+        }
         this.maximumPoolSize = maximumPoolSize;
         if (workerCountOf(ctl.get()) > maximumPoolSize)
             interruptIdleWorkers();
@@ -1663,7 +1673,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setKeepAliveTime(long time, TimeUnit unit) {
         if (time < 0)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("time < 0");
         if (time == 0 && allowsCoreThreadTimeOut())
             throw new IllegalArgumentException("Core threads must have nonzero keep alive times");
         long keepAliveTime = unit.toNanos(time);

--- a/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
@@ -1257,20 +1257,18 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
                               ThreadFactory threadFactory,
                               RejectedExecutionHandler handler) {
         if (corePoolSize < 0) {
-            throw new IllegalArgumentException("corePoolSize can't be negative, but got " + corePoolSize);
+            throw new IllegalArgumentException("corePoolSize must be non-negative, but got " + corePoolSize);
         } else if (maximumPoolSize <= 0) {
             throw new IllegalArgumentException("maximumPoolSize must be positive, but got " + maximumPoolSize);
         } else if (maximumPoolSize < corePoolSize) {
-            throw new IllegalArgumentException("maximumPoolSize must >= corePoolSize , " + "but got maximumPoolSize:" + maximumPoolSize + " corePoolSize :" + corePoolSize);
+            throw new IllegalArgumentException("maximumPoolSize must be greater than or equal to corePoolSize , " + "but got maximumPoolSize:" + maximumPoolSize + " ,corePoolSize:" + corePoolSize);
         } else if (keepAliveTime < 0) {
-            throw new IllegalArgumentException("keepAliveTime can't be negative, but got " + keepAliveTime);
-        } else if (workQueue == null) {
-            throw new NullPointerException("workQueue can't be null");
-        } else if (threadFactory == null) {
-            throw new NullPointerException("threadFactory can't be null");
-        } else if (handler == null) {
-            throw new NullPointerException("handler can't be null");
+            throw new IllegalArgumentException("keepAliveTime must be non-negative, but got " + keepAliveTime);
         }
+        Objects.requireNonNull(unit, "unit");
+        Objects.requireNonNull(workQueue, "workQueue");
+        Objects.requireNonNull(threadFactory, "threadFactory");
+        Objects.requireNonNull(handler, "handler");
         this.corePoolSize = corePoolSize;
         this.maximumPoolSize = maximumPoolSize;
         this.workQueue = workQueue;
@@ -1297,8 +1295,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      * @throws NullPointerException if {@code command} is null
      */
     public void execute(Runnable command) {
-        if (command == null)
-            throw new NullPointerException("command can't be null");
+        Objects.requireNonNull(command, "command");
         /*
          * Proceed in 3 steps:
          *
@@ -1459,8 +1456,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      * @see #getThreadFactory
      */
     public void setThreadFactory(ThreadFactory threadFactory) {
-        if (threadFactory == null)
-            throw new NullPointerException("threadFactory can't be null");
+        Objects.requireNonNull(threadFactory, "threadFactory");
         this.threadFactory = threadFactory;
     }
 
@@ -1482,8 +1478,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      * @see #getRejectedExecutionHandler
      */
     public void setRejectedExecutionHandler(RejectedExecutionHandler handler) {
-        if (handler == null)
-            throw new NullPointerException("handler can't be null");
+        Objects.requireNonNull(handler, "handler");
         this.handler = handler;
     }
 
@@ -1512,9 +1507,9 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setCorePoolSize(int corePoolSize) {
         if (corePoolSize < 0) {
-            throw new IllegalArgumentException("corePoolSize can't be negative, but got " + corePoolSize);
+            throw new IllegalArgumentException("corePoolSize must be non-negative, but got " + corePoolSize);
         } else if (corePoolSize > maximumPoolSize) {
-            throw new IllegalArgumentException("maximumPoolSize must >= corePoolSize , " +
+            throw new IllegalArgumentException("corePoolSize must be less than or equal to maximumPoolSize, " +
                 "but got maximumPoolSize:" + maximumPoolSize + " corePoolSize :" + corePoolSize);
         }
         int delta = corePoolSize - this.corePoolSize;
@@ -1643,7 +1638,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
         if (maximumPoolSize <= 0) {
             throw new IllegalArgumentException("maximumPoolSize must be positive, but got " + maximumPoolSize);
         } else if (maximumPoolSize < corePoolSize) {
-            throw new IllegalArgumentException("maximumPoolSize must >= corePoolSize , " +
+            throw new IllegalArgumentException("maximumPoolSize must be greater than or equal to corePoolSize , " +
                 "but got maximumPoolSize:" + maximumPoolSize + " corePoolSize :" + corePoolSize);
         }
         this.maximumPoolSize = maximumPoolSize;
@@ -1679,7 +1674,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setKeepAliveTime(long time, TimeUnit unit) {
         if (time < 0)
-            throw new IllegalArgumentException("time can't be negative, but got " + time);
+            throw new IllegalArgumentException("time must be non-negative, but got " + time);
         if (time == 0 && allowsCoreThreadTimeOut())
             throw new IllegalArgumentException("Core threads must have nonzero keep alive times");
         long keepAliveTime = unit.toNanos(time);

--- a/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
@@ -1675,6 +1675,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
             throw new IllegalArgumentException("time must be non-negative");
         if (time == 0 && allowsCoreThreadTimeOut())
             throw new IllegalArgumentException("Core threads must have nonzero keep alive times");
+        Objects.requireNonNull(unit, "unit");
         long keepAliveTime = unit.toNanos(time);
         long delta = keepAliveTime - this.keepAliveTime;
         this.keepAliveTime = keepAliveTime;

--- a/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
@@ -1257,13 +1257,13 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
                               ThreadFactory threadFactory,
                               RejectedExecutionHandler handler) {
         if (corePoolSize < 0) {
-            throw new IllegalArgumentException("corePoolSize must be non-negative, but got " + corePoolSize);
+            throw new IllegalArgumentException("corePoolSize must be non-negative");
         } else if (maximumPoolSize <= 0) {
-            throw new IllegalArgumentException("maximumPoolSize must be positive, but got " + maximumPoolSize);
+            throw new IllegalArgumentException("maximumPoolSize must be positive");
         } else if (maximumPoolSize < corePoolSize) {
-            throw new IllegalArgumentException("maximumPoolSize must be greater than or equal to corePoolSize , " + "but got maximumPoolSize:" + maximumPoolSize + " ,corePoolSize:" + corePoolSize);
+            throw new IllegalArgumentException("maximumPoolSize must be greater than or equal to corePoolSize");
         } else if (keepAliveTime < 0) {
-            throw new IllegalArgumentException("keepAliveTime must be non-negative, but got " + keepAliveTime);
+            throw new IllegalArgumentException("keepAliveTime must be non-negative");
         }
         Objects.requireNonNull(unit, "unit");
         Objects.requireNonNull(workQueue, "workQueue");
@@ -1507,10 +1507,9 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setCorePoolSize(int corePoolSize) {
         if (corePoolSize < 0) {
-            throw new IllegalArgumentException("corePoolSize must be non-negative, but got " + corePoolSize);
+            throw new IllegalArgumentException("corePoolSize must be non-negative");
         } else if (corePoolSize > maximumPoolSize) {
-            throw new IllegalArgumentException("corePoolSize must be less than or equal to maximumPoolSize, " +
-                "but got maximumPoolSize:" + maximumPoolSize + " corePoolSize :" + corePoolSize);
+            throw new IllegalArgumentException("corePoolSize must be less than or equal to maximumPoolSize");
         }
         int delta = corePoolSize - this.corePoolSize;
         this.corePoolSize = corePoolSize;
@@ -1636,10 +1635,9 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setMaximumPoolSize(int maximumPoolSize) {
         if (maximumPoolSize <= 0) {
-            throw new IllegalArgumentException("maximumPoolSize must be positive, but got " + maximumPoolSize);
+            throw new IllegalArgumentException("maximumPoolSize must be positive");
         } else if (maximumPoolSize < corePoolSize) {
-            throw new IllegalArgumentException("maximumPoolSize must be greater than or equal to corePoolSize , " +
-                "but got maximumPoolSize:" + maximumPoolSize + " corePoolSize :" + corePoolSize);
+            throw new IllegalArgumentException("maximumPoolSize must be greater than or equal to corePoolSize");
         }
         this.maximumPoolSize = maximumPoolSize;
         if (workerCountOf(ctl.get()) > maximumPoolSize)
@@ -1674,7 +1672,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setKeepAliveTime(long time, TimeUnit unit) {
         if (time < 0)
-            throw new IllegalArgumentException("time must be non-negative, but got " + time);
+            throw new IllegalArgumentException("time must be non-negative");
         if (time == 0 && allowsCoreThreadTimeOut())
             throw new IllegalArgumentException("Core threads must have nonzero keep alive times");
         long keepAliveTime = unit.toNanos(time);

--- a/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
+++ b/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
@@ -66,6 +66,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 public class ThreadPoolExecutorTest extends JSR166TestCase {
     public static void main(String[] args) {
@@ -304,7 +305,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 p.setThreadFactory(null);
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -364,7 +367,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 p.setRejectedExecutionHandler(null);
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -802,7 +807,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(1, 2, 1L, SECONDS,
                                    (BlockingQueue<Runnable>) null);
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -884,7 +891,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (BlockingQueue<Runnable>) null,
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -896,7 +905,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    (ThreadFactory) null);
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -978,7 +989,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (BlockingQueue<Runnable>) null,
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -990,7 +1003,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    (RejectedExecutionHandler) null);
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -1078,7 +1093,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -1091,7 +1108,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    (RejectedExecutionHandler) null);
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -1104,7 +1123,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (ThreadFactory) null,
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -1451,7 +1472,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(null);
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1489,7 +1512,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(l);
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
             latch.countDown();
         }
     }
@@ -1543,7 +1568,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAll(null);
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1578,7 +1605,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAll(l);
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1635,7 +1664,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(null, randomTimeout(), randomTimeUnit());
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1653,7 +1684,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(l, randomTimeout(), null);
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1692,7 +1725,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(l, randomTimeout(), randomTimeUnit());
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
             latch.countDown();
         }
     }
@@ -1750,7 +1785,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAll(null, randomTimeout(), randomTimeUnit());
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1768,7 +1805,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAll(l, randomTimeout(), null);
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1804,7 +1843,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAll(l, randomTimeout(), randomTimeUnit());
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 

--- a/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
+++ b/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
@@ -737,7 +737,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(-1, 1, 1L, SECONDS,
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -748,7 +750,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(1, -1, 1L, SECONDS,
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -759,7 +763,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(1, 0, 1L, SECONDS,
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -770,7 +776,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(1, 2, -1L, SECONDS,
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -781,7 +789,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(2, 1, 1L, SECONDS,
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -804,7 +814,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -816,7 +828,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -828,7 +842,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -840,7 +856,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -852,7 +870,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -888,7 +908,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -900,7 +922,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -912,7 +936,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -924,7 +950,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -936,7 +964,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -973,7 +1003,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -986,7 +1018,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -999,7 +1033,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -1012,7 +1048,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -1025,7 +1063,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            Assert.assertNotNull(success.getMessage());
+        }
     }
 
     /**
@@ -1228,7 +1268,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 p.setCorePoolSize(-1);
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1245,7 +1287,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 p.setMaximumPoolSize(1);
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1262,7 +1306,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 p.setMaximumPoolSize(-1);
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1282,13 +1328,17 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 try {
                     p.setMaximumPoolSize(s - 1);
                     shouldThrow();
-                } catch (IllegalArgumentException success) {}
+                } catch (IllegalArgumentException success) {
+                    Assert.assertNotNull(success.getMessage());
+                }
                 assertEquals(s, p.getCorePoolSize());
                 assertEquals(s, p.getMaximumPoolSize());
                 try {
                     p.setCorePoolSize(s + 1);
                     shouldThrow();
-                } catch (IllegalArgumentException success) {}
+                } catch (IllegalArgumentException success) {
+                    Assert.assertNotNull(success.getMessage());
+                }
                 assertEquals(s, p.getCorePoolSize());
                 assertEquals(s, p.getMaximumPoolSize());
             }
@@ -1308,7 +1358,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 p.setKeepAliveTime(-1, MILLISECONDS);
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1415,7 +1467,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(new ArrayList<Callable<String>>());
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 
@@ -1616,7 +1670,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(new ArrayList<Callable<String>>(),
                             randomTimeout(), randomTimeUnit());
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                Assert.assertNotNull(success.getMessage());
+            }
         }
     }
 

--- a/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
+++ b/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
@@ -1490,9 +1490,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(new ArrayList<Callable<String>>());
                 shouldThrow();
-            } catch (IllegalArgumentException success) {
-                Assert.assertNotNull(success.getMessage());
-            }
+            } catch (IllegalArgumentException success) {}
         }
     }
 
@@ -1512,9 +1510,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(l);
                 shouldThrow();
-            } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
-            }
+            } catch (NullPointerException success) {}
             latch.countDown();
         }
     }
@@ -1605,9 +1601,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAll(l);
                 shouldThrow();
-            } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
-            }
+            } catch (NullPointerException success) {}
         }
     }
 
@@ -1703,9 +1697,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(new ArrayList<Callable<String>>(),
                             randomTimeout(), randomTimeUnit());
                 shouldThrow();
-            } catch (IllegalArgumentException success) {
-                Assert.assertNotNull(success.getMessage());
-            }
+            } catch (IllegalArgumentException success) {}
         }
     }
 
@@ -1725,9 +1717,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(l, randomTimeout(), randomTimeUnit());
                 shouldThrow();
-            } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
-            }
+            } catch (NullPointerException success) {}
             latch.countDown();
         }
     }
@@ -1843,9 +1833,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAll(l, randomTimeout(), randomTimeUnit());
                 shouldThrow();
-            } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
-            }
+            } catch (NullPointerException success) {}
         }
     }
 

--- a/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
+++ b/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
@@ -291,7 +291,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setThreadFactory(null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("threadFactory", success.getMessage());
+                assertEquals("threadFactory", success.getMessage());
             }
         }
     }
@@ -353,7 +353,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setRejectedExecutionHandler(null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("handler", success.getMessage());
+                assertEquals("handler", success.getMessage());
             }
         }
     }
@@ -728,7 +728,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("corePoolSize must be non-negative");
+            assertEquals("corePoolSize must be non-negative", success.getMessage());
         }
     }
 
@@ -741,7 +741,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive");
+            assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -754,7 +754,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
+            assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -767,7 +767,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("keepAliveTime must be non-negative", success.getMessage());
+            assertEquals("keepAliveTime must be non-negative", success.getMessage());
         }
     }
 
@@ -780,7 +780,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals(
+            assertEquals(
                 "maximumPoolSize must be greater than or equal to corePoolSize",
                 success.getMessage()
             );
@@ -796,7 +796,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (BlockingQueue<Runnable>) null);
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertEquals("workQueue", success.getMessage());
+            assertEquals("workQueue", success.getMessage());
         }
     }
 
@@ -810,7 +810,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("corePoolSize must be non-negative", success.getMessage());
+            assertEquals("corePoolSize must be non-negative", success.getMessage());
         }
     }
 
@@ -824,7 +824,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
+            assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -838,7 +838,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
+            assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -852,7 +852,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("keepAliveTime must be non-negative", success.getMessage());
+            assertEquals("keepAliveTime must be non-negative", success.getMessage());
         }
     }
 
@@ -866,7 +866,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals(
+            assertEquals(
                 "maximumPoolSize must be greater than or equal to corePoolSize",
                 success.getMessage()
             );
@@ -883,7 +883,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertEquals("workQueue", success.getMessage());
+            assertEquals("workQueue", success.getMessage());
         }
     }
 
@@ -897,7 +897,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (ThreadFactory) null);
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertEquals("threadFactory", success.getMessage());
+            assertEquals("threadFactory", success.getMessage());
         }
     }
 
@@ -911,7 +911,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("corePoolSize must be non-negative", success.getMessage());
+            assertEquals("corePoolSize must be non-negative", success.getMessage());
         }
     }
 
@@ -925,7 +925,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
+            assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -939,7 +939,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
+            assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -953,7 +953,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("keepAliveTime must be non-negative", success.getMessage());
+            assertEquals("keepAliveTime must be non-negative", success.getMessage());
         }
     }
 
@@ -967,7 +967,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals(
+            assertEquals(
                 "maximumPoolSize must be greater than or equal to corePoolSize",
                 success.getMessage()
             );
@@ -984,7 +984,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertEquals("workQueue", success.getMessage());
+            assertEquals("workQueue", success.getMessage());
         }
     }
 
@@ -998,7 +998,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (RejectedExecutionHandler) null);
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertEquals("handler", success.getMessage());
+            assertEquals("handler", success.getMessage());
         }
     }
 
@@ -1013,7 +1013,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("corePoolSize must be non-negative", success.getMessage());
+            assertEquals("corePoolSize must be non-negative", success.getMessage());
         }
     }
 
@@ -1028,7 +1028,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
+            assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -1043,7 +1043,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
+            assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -1058,7 +1058,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("keepAliveTime must be non-negative", success.getMessage());
+            assertEquals("keepAliveTime must be non-negative", success.getMessage());
         }
     }
 
@@ -1073,7 +1073,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals(
+            assertEquals(
                 "maximumPoolSize must be greater than or equal to corePoolSize",
                 success.getMessage()
             );
@@ -1091,7 +1091,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertEquals("workQueue", success.getMessage());
+            assertEquals("workQueue", success.getMessage());
         }
     }
 
@@ -1106,7 +1106,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (RejectedExecutionHandler) null);
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertEquals("handler", success.getMessage());
+            assertEquals("handler", success.getMessage());
         }
     }
 
@@ -1121,7 +1121,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertEquals("threadFactory", success.getMessage());
+            assertEquals("threadFactory", success.getMessage());
         }
     }
 
@@ -1136,7 +1136,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 new NoOpREHandler());
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertEquals("unit", success.getMessage());
+            assertEquals("unit", success.getMessage());
         }
     }
 
@@ -1302,7 +1302,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setCorePoolSize(-1);
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertEquals("corePoolSize must be non-negative", success.getMessage());
+                assertEquals("corePoolSize must be non-negative", success.getMessage());
             }
         }
     }
@@ -1321,7 +1321,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setMaximumPoolSize(1);
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertEquals(
+                assertEquals(
                     "maximumPoolSize must be greater than or equal to corePoolSize",
                     success.getMessage()
                 );
@@ -1343,7 +1343,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setMaximumPoolSize(-1);
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertEquals("maximumPoolSize must be positive");
+                assertEquals("maximumPoolSize must be positive", success.getMessage());
             }
         }
     }
@@ -1365,8 +1365,10 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                     p.setMaximumPoolSize(s - 1);
                     shouldThrow();
                 } catch (IllegalArgumentException success) {
-                    Assert.assertEquals(
-                        "maximumPoolSize must be greater than or equal to corePoolSize",
+                    assertEquals(
+                        s == 1
+                        ? "maximumPoolSize must be positive"
+                        : "maximumPoolSize must be greater than or equal to corePoolSize",
                         success.getMessage()
                     );
                 }
@@ -1376,8 +1378,8 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                     p.setCorePoolSize(s + 1);
                     shouldThrow();
                 } catch (IllegalArgumentException success) {
-                    Assert.assertEquals(
-                        "maximumPoolSize must be greater than or equal to corePoolSize",
+                    assertEquals(
+                        "corePoolSize must be less than or equal to maximumPoolSize",
                         success.getMessage()
                     );
                 }
@@ -1391,7 +1393,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
      * setKeepAliveTime throws IllegalArgumentException
      * when given a negative value
      */
-    public void testKeepAliveTimeIllegalArgumentException() {
+    public void testKeepAliveTimeInvalidLengthIllegalArgumentException() {
         final ThreadPoolExecutor p =
             new ThreadPoolExecutor(2, 3,
                                    LONG_DELAY_MS, MILLISECONDS,
@@ -1401,7 +1403,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setKeepAliveTime(-1, MILLISECONDS);
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertEquals("keepAliveTime must be non-negative");
+                assertEquals("time must be non-negative", success.getMessage());
             }
         }
     }
@@ -1410,7 +1412,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
      * setKeepAliveTime throws IllegalArgumentException
      * when given a null unit
      */
-    public void testKeepAliveTimeIllegalArgumentException() {
+    public void testKeepAliveTimeNullTimeUnitIllegalArgumentException() {
         final ThreadPoolExecutor p =
             new ThreadPoolExecutor(2, 3,
                 LONG_DELAY_MS, MILLISECONDS,
@@ -1419,8 +1421,8 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 p.setKeepAliveTime(1, (TimeUnit) null);
                 shouldThrow();
-            } catch (IllegalArgumentException success) {
-                Assert.assertEquals("unit", success.getMessage());
+            } catch (NullPointerException success) {
+                assertEquals("unit", success.getMessage());
             }
         }
     }
@@ -1513,7 +1515,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("tasks", success.getMessage());
+                assertEquals("tasks", success.getMessage());
             }
         }
     }
@@ -1531,7 +1533,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(new ArrayList<Callable<String>>());
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertEquals("tasks is empty", success.getMessage());
+                assertEquals("tasks is empty", success.getMessage());
             }
         }
     }
@@ -1553,7 +1555,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(l);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("tasks", success.getMessage());
+                assertEquals("task", success.getMessage());
             }
             latch.countDown();
         }
@@ -1609,7 +1611,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAll(null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("tasks", success.getMessage());
+                assertEquals("tasks", success.getMessage());
             }
         }
     }
@@ -1646,7 +1648,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAll(l);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("tasks", success.getMessage());
+                assertEquals(null, success.getMessage());
             }
         }
     }
@@ -1705,7 +1707,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(null, randomTimeout(), randomTimeUnit());
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("tasks", success.getMessage());
+                assertEquals("tasks", success.getMessage());
             }
         }
     }
@@ -1725,7 +1727,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(l, randomTimeout(), null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("tasks", success.getMessage());
+                assertEquals("Cannot invoke \"java.util.concurrent.TimeUnit.toNanos(long)\" because \"unit\" is null", success.getMessage());
             }
         }
     }
@@ -1744,7 +1746,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                             randomTimeout(), randomTimeUnit());
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertEquals("tasks is empty", success.getMessage());
+                assertEquals("tasks is empty", success.getMessage());
             }
         }
     }
@@ -1766,7 +1768,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(l, randomTimeout(), randomTimeUnit());
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("task", success.getMessage());
+                assertEquals("task", success.getMessage());
             }
             latch.countDown();
         }
@@ -1826,7 +1828,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAll(null, randomTimeout(), randomTimeUnit());
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("tasks", success.getMessage());
+                assertEquals("tasks", success.getMessage());
             }
         }
     }
@@ -1846,7 +1848,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAll(l, randomTimeout(), null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("unit", success.getMessage());
+                assertEquals("unit", success.getMessage());
             }
         }
     }
@@ -1884,7 +1886,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAll(l, randomTimeout(), randomTimeUnit());
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertEquals("task", success.getMessage());
+                assertEquals(null, success.getMessage());
             }
         }
     }

--- a/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
+++ b/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
@@ -743,7 +743,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("corePoolSize must be non-negative, but got -1", success.getMessage());
+            Assert.assertEquals("corePoolSize must be non-negative");
         }
     }
 
@@ -756,7 +756,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive, but got -1", success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive");
         }
     }
 
@@ -769,7 +769,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive, but got 0", success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -782,7 +782,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("keepAliveTime must be non-negative, but got -1", success.getMessage());
+            Assert.assertEquals("keepAliveTime must be non-negative", success.getMessage());
         }
     }
 
@@ -796,8 +796,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             shouldThrow();
         } catch (IllegalArgumentException success) {
             Assert.assertEquals(
-                "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:1 ," +
-                    "corePoolSize:2",
+                "maximumPoolSize must be greater than or equal to corePoolSize",
                 success.getMessage()
             );
         }
@@ -826,7 +825,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("corePoolSize must be non-negative, but got -1", success.getMessage());
+            Assert.assertEquals("corePoolSize must be non-negative", success.getMessage());
         }
     }
 
@@ -840,7 +839,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive, but got -1", success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -854,7 +853,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive, but got 0", success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -868,7 +867,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("keepAliveTime must be non-negative, but got -1", success.getMessage());
+            Assert.assertEquals("keepAliveTime must be non-negative", success.getMessage());
         }
     }
 
@@ -883,8 +882,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             shouldThrow();
         } catch (IllegalArgumentException success) {
             Assert.assertEquals(
-                "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:1 ," +
-                    "corePoolSize:2",
+                "maximumPoolSize must be greater than or equal to corePoolSize",
                 success.getMessage()
             );
         }
@@ -928,7 +926,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("corePoolSize must be non-negative, but got -1", success.getMessage());
+            Assert.assertEquals("corePoolSize must be non-negative", success.getMessage());
         }
     }
 
@@ -942,7 +940,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive, but got -1", success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -956,7 +954,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive, but got 0", success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -970,7 +968,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("keepAliveTime must be non-negative, but got -1", success.getMessage());
+            Assert.assertEquals("keepAliveTime must be non-negative", success.getMessage());
         }
     }
 
@@ -985,8 +983,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             shouldThrow();
         } catch (IllegalArgumentException success) {
             Assert.assertEquals(
-                "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:1 ," +
-                    "corePoolSize:2",
+                "maximumPoolSize must be greater than or equal to corePoolSize",
                 success.getMessage()
             );
         }
@@ -1031,7 +1028,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("corePoolSize must be non-negative, but got -1", success.getMessage());
+            Assert.assertEquals("corePoolSize must be non-negative", success.getMessage());
         }
     }
 
@@ -1046,7 +1043,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive, but got -1", success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -1061,7 +1058,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("maximumPoolSize must be positive, but got 0", success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive", success.getMessage());
         }
     }
 
@@ -1076,7 +1073,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertEquals("keepAliveTime must be non-negative, but got -1", success.getMessage());
+            Assert.assertEquals("keepAliveTime must be non-negative", success.getMessage());
         }
     }
 
@@ -1092,8 +1089,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             shouldThrow();
         } catch (IllegalArgumentException success) {
             Assert.assertEquals(
-                "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:1 ," +
-                    "corePoolSize:2",
+                "maximumPoolSize must be greater than or equal to corePoolSize",
                 success.getMessage()
             );
         }
@@ -1155,7 +1151,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 new NoOpREHandler());
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertEquals("threadFactory", success.getMessage());
+            Assert.assertEquals("unit", success.getMessage());
         }
     }
 
@@ -1321,7 +1317,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setCorePoolSize(-1);
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertEquals("corePoolSize must be non-negative, but got -1", success.getMessage());
+                Assert.assertEquals("corePoolSize must be non-negative", success.getMessage());
             }
         }
     }
@@ -1341,8 +1337,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 shouldThrow();
             } catch (IllegalArgumentException success) {
                 Assert.assertEquals(
-                    "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:1 ," +
-                        "corePoolSize:2",
+                    "maximumPoolSize must be greater than or equal to corePoolSize",
                     success.getMessage()
                 );
             }
@@ -1363,7 +1358,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setMaximumPoolSize(-1);
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertEquals("maximumPoolSize must be positive, but got -1", success.getMessage());
+                Assert.assertEquals("maximumPoolSize must be positive");
             }
         }
     }
@@ -1381,27 +1376,23 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             for (int s = 1; s < 5; s++) {
                 p.setMaximumPoolSize(s);
                 p.setCorePoolSize(s);
-                int s1 = s - 1;
                 try {
-                    p.setMaximumPoolSize(s1);
+                    p.setMaximumPoolSize(s - 1);
                     shouldThrow();
                 } catch (IllegalArgumentException success) {
                     Assert.assertEquals(
-                        "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:" +
-                            s1 + " ,corePoolSize:" + s,
+                        "maximumPoolSize must be greater than or equal to corePoolSize",
                         success.getMessage()
                     );
                 }
                 assertEquals(s, p.getCorePoolSize());
                 assertEquals(s, p.getMaximumPoolSize());
-                int s2 = s + 1;
                 try {
-                    p.setCorePoolSize(s2);
+                    p.setCorePoolSize(s + 1);
                     shouldThrow();
                 } catch (IllegalArgumentException success) {
                     Assert.assertEquals(
-                        "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:" +
-                            s + " ,corePoolSize:" + s2,
+                        "maximumPoolSize must be greater than or equal to corePoolSize",
                         success.getMessage()
                     );
                 }
@@ -1425,7 +1416,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setKeepAliveTime(-1, MILLISECONDS);
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertEquals("keepAliveTime must be non-negative, but got -1", success.getMessage());
+                Assert.assertEquals("keepAliveTime must be non-negative");
             }
         }
     }

--- a/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
+++ b/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
@@ -41,22 +41,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.RejectedExecutionHandler;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.*;
 import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
 import java.util.concurrent.ThreadPoolExecutor.DiscardPolicy;
@@ -1417,6 +1402,25 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 shouldThrow();
             } catch (IllegalArgumentException success) {
                 Assert.assertEquals("keepAliveTime must be non-negative");
+            }
+        }
+    }
+
+    /**
+     * setKeepAliveTime throws IllegalArgumentException
+     * when given a null unit
+     */
+    public void testKeepAliveTimeIllegalArgumentException() {
+        final ThreadPoolExecutor p =
+            new ThreadPoolExecutor(2, 3,
+                LONG_DELAY_MS, MILLISECONDS,
+                new ArrayBlockingQueue<Runnable>(10));
+        try (PoolCleaner cleaner = cleaner(p)) {
+            try {
+                p.setKeepAliveTime(1, (TimeUnit) null);
+                shouldThrow();
+            } catch (IllegalArgumentException success) {
+                Assert.assertEquals("unit", success.getMessage());
             }
         }
     }

--- a/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
+++ b/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
@@ -306,7 +306,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setThreadFactory(null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals("threadFactory", success.getMessage());
             }
         }
     }
@@ -368,7 +368,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setRejectedExecutionHandler(null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals("handler", success.getMessage());
             }
         }
     }
@@ -743,7 +743,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("corePoolSize must be non-negative, but got -1", success.getMessage());
         }
     }
 
@@ -756,7 +756,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive, but got -1", success.getMessage());
         }
     }
 
@@ -769,7 +769,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive, but got 0", success.getMessage());
         }
     }
 
@@ -782,7 +782,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("keepAliveTime must be non-negative, but got -1", success.getMessage());
         }
     }
 
@@ -795,7 +795,11 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals(
+                "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:1 ," +
+                    "corePoolSize:2",
+                success.getMessage()
+            );
         }
     }
 
@@ -808,7 +812,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (BlockingQueue<Runnable>) null);
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("workQueue", success.getMessage());
         }
     }
 
@@ -822,7 +826,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("corePoolSize must be non-negative, but got -1", success.getMessage());
         }
     }
 
@@ -836,7 +840,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive, but got -1", success.getMessage());
         }
     }
 
@@ -850,7 +854,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive, but got 0", success.getMessage());
         }
     }
 
@@ -864,7 +868,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("keepAliveTime must be non-negative, but got -1", success.getMessage());
         }
     }
 
@@ -878,7 +882,11 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals(
+                "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:1 ," +
+                    "corePoolSize:2",
+                success.getMessage()
+            );
         }
     }
 
@@ -892,7 +900,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory());
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("workQueue", success.getMessage());
         }
     }
 
@@ -906,7 +914,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (ThreadFactory) null);
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("threadFactory", success.getMessage());
         }
     }
 
@@ -920,7 +928,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("corePoolSize must be non-negative, but got -1", success.getMessage());
         }
     }
 
@@ -934,7 +942,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive, but got -1", success.getMessage());
         }
     }
 
@@ -948,7 +956,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive, but got 0", success.getMessage());
         }
     }
 
@@ -962,7 +970,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("keepAliveTime must be non-negative, but got -1", success.getMessage());
         }
     }
 
@@ -976,7 +984,11 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals(
+                "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:1 ," +
+                    "corePoolSize:2",
+                success.getMessage()
+            );
         }
     }
 
@@ -990,7 +1002,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("workQueue", success.getMessage());
         }
     }
 
@@ -1004,7 +1016,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (RejectedExecutionHandler) null);
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("handler", success.getMessage());
         }
     }
 
@@ -1019,7 +1031,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("corePoolSize must be non-negative, but got -1", success.getMessage());
         }
     }
 
@@ -1034,7 +1046,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive, but got -1", success.getMessage());
         }
     }
 
@@ -1049,7 +1061,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("maximumPoolSize must be positive, but got 0", success.getMessage());
         }
     }
 
@@ -1064,7 +1076,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("keepAliveTime must be non-negative, but got -1", success.getMessage());
         }
     }
 
@@ -1079,7 +1091,11 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (IllegalArgumentException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals(
+                "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:1 ," +
+                    "corePoolSize:2",
+                success.getMessage()
+            );
         }
     }
 
@@ -1094,7 +1110,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("workQueue", success.getMessage());
         }
     }
 
@@ -1109,7 +1125,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (RejectedExecutionHandler) null);
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("handler", success.getMessage());
         }
     }
 
@@ -1124,7 +1140,22 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new NoOpREHandler());
             shouldThrow();
         } catch (NullPointerException success) {
-            Assert.assertNotNull(success.getMessage());
+            Assert.assertEquals("threadFactory", success.getMessage());
+        }
+    }
+
+    /**
+     * Constructor throws if unit is null
+     */
+    public void testConstructorNullPointerException9() {
+        try {
+            new ThreadPoolExecutor(1, 2, 1L, (TimeUnit) null,
+                new ArrayBlockingQueue<Runnable>(10),
+                new SimpleThreadFactory(),
+                new NoOpREHandler());
+            shouldThrow();
+        } catch (NullPointerException success) {
+            Assert.assertEquals("threadFactory", success.getMessage());
         }
     }
 
@@ -1290,7 +1321,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setCorePoolSize(-1);
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals("corePoolSize must be non-negative, but got -1", success.getMessage());
             }
         }
     }
@@ -1309,7 +1340,11 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setMaximumPoolSize(1);
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals(
+                    "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:1 ," +
+                        "corePoolSize:2",
+                    success.getMessage()
+                );
             }
         }
     }
@@ -1328,7 +1363,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setMaximumPoolSize(-1);
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals("maximumPoolSize must be positive, but got -1", success.getMessage());
             }
         }
     }
@@ -1346,19 +1381,29 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             for (int s = 1; s < 5; s++) {
                 p.setMaximumPoolSize(s);
                 p.setCorePoolSize(s);
+                int s1 = s - 1;
                 try {
-                    p.setMaximumPoolSize(s - 1);
+                    p.setMaximumPoolSize(s1);
                     shouldThrow();
                 } catch (IllegalArgumentException success) {
-                    Assert.assertNotNull(success.getMessage());
+                    Assert.assertEquals(
+                        "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:" +
+                            s1 + " ,corePoolSize:" + s,
+                        success.getMessage()
+                    );
                 }
                 assertEquals(s, p.getCorePoolSize());
                 assertEquals(s, p.getMaximumPoolSize());
+                int s2 = s + 1;
                 try {
-                    p.setCorePoolSize(s + 1);
+                    p.setCorePoolSize(s2);
                     shouldThrow();
                 } catch (IllegalArgumentException success) {
-                    Assert.assertNotNull(success.getMessage());
+                    Assert.assertEquals(
+                        "maximumPoolSize must be greater than or equal to corePoolSize ,but got maximumPoolSize:" +
+                            s + " ,corePoolSize:" + s2,
+                        success.getMessage()
+                    );
                 }
                 assertEquals(s, p.getCorePoolSize());
                 assertEquals(s, p.getMaximumPoolSize());
@@ -1380,7 +1425,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 p.setKeepAliveTime(-1, MILLISECONDS);
                 shouldThrow();
             } catch (IllegalArgumentException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals("keepAliveTime must be non-negative, but got -1", success.getMessage());
             }
         }
     }
@@ -1473,7 +1518,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals("tasks", success.getMessage());
             }
         }
     }
@@ -1490,7 +1535,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(new ArrayList<Callable<String>>());
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                Assert.assertEquals("tasks is empty", success.getMessage());
+            }
         }
     }
 
@@ -1510,7 +1557,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(l);
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertEquals("tasks", success.getMessage());
+            }
             latch.countDown();
         }
     }
@@ -1565,7 +1614,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAll(null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals("tasks", success.getMessage());
             }
         }
     }
@@ -1601,7 +1650,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAll(l);
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertEquals("tasks", success.getMessage());
+            }
         }
     }
 
@@ -1659,7 +1710,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(null, randomTimeout(), randomTimeUnit());
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals("tasks", success.getMessage());
             }
         }
     }
@@ -1679,7 +1730,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(l, randomTimeout(), null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals("tasks", success.getMessage());
             }
         }
     }
@@ -1697,7 +1748,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAny(new ArrayList<Callable<String>>(),
                             randomTimeout(), randomTimeUnit());
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                Assert.assertEquals("tasks is empty", success.getMessage());
+            }
         }
     }
 
@@ -1717,7 +1770,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAny(l, randomTimeout(), randomTimeUnit());
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertEquals("task", success.getMessage());
+            }
             latch.countDown();
         }
     }
@@ -1776,7 +1831,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAll(null, randomTimeout(), randomTimeUnit());
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals("tasks", success.getMessage());
             }
         }
     }
@@ -1796,7 +1851,7 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 e.invokeAll(l, randomTimeout(), null);
                 shouldThrow();
             } catch (NullPointerException success) {
-                Assert.assertNotNull(success.getMessage());
+                Assert.assertEquals("unit", success.getMessage());
             }
         }
     }
@@ -1833,7 +1888,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 e.invokeAll(l, randomTimeout(), randomTimeUnit());
                 shouldThrow();
-            } catch (NullPointerException success) {}
+            } catch (NullPointerException success) {
+                Assert.assertEquals("task", success.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:
When a user passes a wrong parameter, the current implementation throws an IllegalArgumentException with an error message `null`, which is not helpful.

Modification:
Add detail error messages.

Result:
Helpful messages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8347491](https://bugs.openjdk.org/browse/JDK-8347491): IllegalArgumentationException thrown by ThreadPoolExecutor doesn't have a useful message (**Bug** - P4)


### Reviewers
 * [Viktor Klang](https://openjdk.org/census#vklang) (@viktorklang-ora - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23050/head:pull/23050` \
`$ git checkout pull/23050`

Update a local copy of the PR: \
`$ git checkout pull/23050` \
`$ git pull https://git.openjdk.org/jdk.git pull/23050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23050`

View PR using the GUI difftool: \
`$ git pr show -t 23050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23050.diff">https://git.openjdk.org/jdk/pull/23050.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23050#issuecomment-2613306153)
</details>
