### PR TITLE
8351505: Typo in the documentation of java.nio.file.spi.FileSystemProvider.getFileSystem()

### DIFF
--- a/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
+++ b/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
@@ -244,7 +244,7 @@ public abstract class FileSystemProvider {
      *
      * <p> This method returns a reference to a {@code FileSystem} that was
      * created by invoking the {@link #newFileSystem(URI,Map) newFileSystem(URI,Map)}
-     * method. File systems created the {@link #newFileSystem(Path,Map)
+     * method. File systems created by invoking the {@link #newFileSystem(Path,Map)
      * newFileSystem(Path,Map)} method are not returned by this method.
      * The file system is identified by its {@code URI}. Its exact form
      * is highly provider dependent. In the case of the default provider the URI's


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8351505](https://bugs.openjdk.org/browse/JDK-8351505)

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/glass.png)
&nbsp;⚠️ Patch contains a binary file (src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/x.png)

### Issue
 * [JDK-8351505](https://bugs.openjdk.org/browse/JDK-8351505): (fs) Typo in the documentation of java.nio.file.spi.FileSystemProvider.getFileSystem() (**Bug** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23052/head:pull/23052` \
`$ git checkout pull/23052`

Update a local copy of the PR: \
`$ git checkout pull/23052` \
`$ git pull https://git.openjdk.org/jdk.git pull/23052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23052`

View PR using the GUI difftool: \
`$ git pr show -t 23052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23052.diff">https://git.openjdk.org/jdk/pull/23052.diff</a>

</details>
