### PR TITLE
8338428: Add logging of final VM flags while setting properties

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,6 @@ groups=TEST.groups TEST.quick-groups
 requires.extraPropDefns = ../../jtreg-ext/requires/VMProps.java
 requires.extraPropDefns.bootlibs = ../../lib/jdk/test/whitebox
 requires.extraPropDefns.libs = \
-    ../../lib/jdk/test/lib/JDKToolFinder.java \
     ../../lib/jdk/test/lib/Platform.java \
     ../../lib/jdk/test/lib/Container.java
 requires.extraPropDefns.javacOpts = --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ groups=TEST.groups TEST.quick-groups
 requires.extraPropDefns = ../../jtreg-ext/requires/VMProps.java
 requires.extraPropDefns.bootlibs = ../../lib/jdk/test/whitebox
 requires.extraPropDefns.libs = \
+    ../../lib/jdk/test/lib/JDKToolFinder.java \
     ../../lib/jdk/test/lib/Platform.java \
     ../../lib/jdk/test/lib/Container.java
 requires.extraPropDefns.javacOpts = --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -48,7 +48,7 @@ requires.extraPropDefns.libs = \
     ../../lib/jdk/test/lib/Container.java
 requires.extraPropDefns.javacOpts = --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED
 requires.extraPropDefns.vmOpts = \
-    -XX:+LogVMOutput -XX:-DisplayVMOutput -XX:LogFile=vmprops.flags.final.vm.log \
+    -XX:+UnlockDiagnosticVMOptions -XX:+LogVMOutput -XX:-DisplayVMOutput -XX:LogFile=vmprops.flags.final.vm.log \
     -XX:+PrintFlagsFinal \
     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI \
     --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -48,9 +48,10 @@ requires.extraPropDefns.libs = \
     ../../lib/jdk/test/lib/Container.java
 requires.extraPropDefns.javacOpts = --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED
 requires.extraPropDefns.vmOpts = \
-    -XX:+UnlockDiagnosticVMOptions -XX:+LogVMOutput -XX:-DisplayVMOutput -XX:LogFile=vmprops.flags.final.vm.log \
+    -XX:+UnlockDiagnosticVMOptions \
+    -XX:+LogVMOutput -XX:-DisplayVMOutput -XX:LogFile=vmprops.flags.final.vm.log \
     -XX:+PrintFlagsFinal \
-    -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI \
+    -XX:+WhiteBoxAPI \
     --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED
 requires.properties= \
     sun.arch.data.model \

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -48,6 +48,8 @@ requires.extraPropDefns.libs = \
     ../../lib/jdk/test/lib/Container.java
 requires.extraPropDefns.javacOpts = --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED
 requires.extraPropDefns.vmOpts = \
+    -XX:+LogVMOutput -XX:-DisplayVMOutput -XX:LogFile=vmprops.flags.final.vm.log \
+    -XX:+PrintFlagsFinal \
     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI \
     --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED
 requires.properties= \

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -1,6 +1,10 @@
+#
+# Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
 # This file identifies the root of the test-suite hierarchy.
 # It also contains test-suite configuration information.
-
+#
 # The list of keywords supported in the entire test suite.  The
 # "intermittent" keyword marks tests known to fail intermittently.
 # The "randomness" keyword marks tests using randomness with test

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -72,7 +72,7 @@ requires.extraPropDefns.libs = \
     ../lib/jdk/test/lib/Container.java
 requires.extraPropDefns.javacOpts = --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED
 requires.extraPropDefns.vmOpts = \
-    -XX:+LogVMOutput -XX:-DisplayVMOutput -XX:LogFile=vmprops.flags.final.vm.log \
+    -XX:+UnlockDiagnosticVMOptions -XX:+LogVMOutput -XX:-DisplayVMOutput -XX:LogFile=vmprops.flags.final.vm.log \
     -XX:+PrintFlagsFinal \
     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI \
     --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -76,9 +76,10 @@ requires.extraPropDefns.libs = \
     ../lib/jdk/test/lib/Container.java
 requires.extraPropDefns.javacOpts = --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED
 requires.extraPropDefns.vmOpts = \
-    -XX:+UnlockDiagnosticVMOptions -XX:+LogVMOutput -XX:-DisplayVMOutput -XX:LogFile=vmprops.flags.final.vm.log \
+    -XX:+UnlockDiagnosticVMOptions \
+    -XX:+LogVMOutput -XX:-DisplayVMOutput -XX:LogFile=vmprops.flags.final.vm.log \
     -XX:+PrintFlagsFinal \
-    -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI \
+    -XX:+WhiteBoxAPI \
     --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED
 requires.properties= \
     sun.arch.data.model \

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -72,6 +72,8 @@ requires.extraPropDefns.libs = \
     ../lib/jdk/test/lib/Container.java
 requires.extraPropDefns.javacOpts = --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED
 requires.extraPropDefns.vmOpts = \
+    -XX:+LogVMOutput -XX:-DisplayVMOutput -XX:LogFile=vmprops.flags.final.vm.log \
+    -XX:+PrintFlagsFinal \
     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI \
     --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED
 requires.properties= \

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -56,7 +56,6 @@ import jdk.test.whitebox.gc.GC;
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.Platform;
 import jdk.test.lib.Container;
-import jdk.test.lib.JDKToolFinder;
 
 /**
  * The Class to be invoked by jtreg prior Test Suite execution to
@@ -701,11 +700,14 @@ public class VMProps implements Callable<Map<String, String>> {
     private void dumpFlags() {
         log("dumpFlags() entering:");
         try {
-            String javapath = JDKToolFinder.getJDKTool("java");
+            String testJdk = System.getProperty("test.jdk");
+            String toolName = "java" + (Platform.isWindows() ? ".exe" : "");
+            Path javaPath = Paths.get(testJdk, "bin", toolName);
+
             String options =  System.getProperty("test.vm.opts", "")
                     + System.getProperty("test.java.opts", "");
             ArrayList<String> args = new ArrayList<>();
-            args.add(javapath);
+            args.add(javaPath.toAbsolutePath().toString());
             Collections.addAll(args, options.trim().split("\\s+"));
             args.add("-XX:+PrintFlagsFinal");
             args.add("-version");

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,6 @@ import jdk.test.whitebox.gc.GC;
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.Platform;
 import jdk.test.lib.Container;
-import jdk.test.lib.JDKToolFinder;
 
 /**
  * The Class to be invoked by jtreg prior Test Suite execution to
@@ -146,7 +145,6 @@ public class VMProps implements Callable<Map<String, String>> {
         vmOptFinalFlags(map);
 
         dump(map.map);
-        dumpFlags();
         log("Leaving call()");
         return map.map;
     }
@@ -697,34 +695,6 @@ public class VMProps implements Callable<Map<String, String>> {
 
         return (exitValue == 0);
     }
-
-    private void dumpFlags() {
-        log("dumpFlags() entering:");
-        try {
-            String javapath = JDKToolFinder.getJDKTool("java");
-            String options =  System.getProperty("test.vm.opts", "")
-                    + System.getProperty("test.java.opts", "");
-            ArrayList<String> args = new ArrayList<>();
-            args.add(javapath);
-            Collections.addAll(args, options.trim().split("\\s+"));
-            args.add("-XX:+PrintFlagsFinal");
-            args.add("-version");
-            ProcessBuilder pb = new ProcessBuilder(args);
-            File output = new File("jvm.flags.final.log");
-            pb.redirectOutput(output);
-            pb.redirectErrorStream();
-            Process p = pb.start();
-            p.waitFor(120, TimeUnit.SECONDS);
-
-            log("The test jvm options: " + options);
-            log("The final jvm flags are saved to: " + output.getAbsolutePath());
-        } catch (Throwable t) {
-            log("Erro while printing JVM flags " + t.getMessage());
-        }
-
-        log("dumpFlags() leaving:");
-    }
-
 
     /**
      * Checks musl libc.

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -56,6 +56,7 @@ import jdk.test.whitebox.gc.GC;
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.Platform;
 import jdk.test.lib.Container;
+import jdk.test.lib.JDKToolFinder;
 
 /**
  * The Class to be invoked by jtreg prior Test Suite execution to
@@ -700,14 +701,11 @@ public class VMProps implements Callable<Map<String, String>> {
     private void dumpFlags() {
         log("dumpFlags() entering:");
         try {
-            String testJdk = System.getProperty("test.jdk");
-            String toolName = "java" + (Platform.isWindows() ? ".exe" : "");
-            Path javaPath = Paths.get(testJdk, "bin", toolName);
-
+            String javapath = JDKToolFinder.getJDKTool("java");
             String options =  System.getProperty("test.vm.opts", "")
                     + System.getProperty("test.java.opts", "");
             ArrayList<String> args = new ArrayList<>();
-            args.add(javaPath.toAbsolutePath().toString());
+            args.add(javapath);
             Collections.addAll(args, options.trim().split("\\s+"));
             args.add("-XX:+PrintFlagsFinal");
             args.add("-version");


### PR DESCRIPTION
Some VM flags might depend on the environment and it makes sense to log final flags so it is possible to get their value when investigating failures.

I added them to VMProps, so it is always dump final flags before running tests using "-XX:+PrintFlagsFinal".

Update:
There were intermittent compilation failures when I tried to use classes from testlibrary, so I rewrtite the code without them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8338428](https://bugs.openjdk.org/browse/JDK-8338428): Add logging of final VM flags while setting properties (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23054/head:pull/23054` \
`$ git checkout pull/23054`

Update a local copy of the PR: \
`$ git checkout pull/23054` \
`$ git pull https://git.openjdk.org/jdk.git pull/23054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23054`

View PR using the GUI difftool: \
`$ git pr show -t 23054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23054.diff">https://git.openjdk.org/jdk/pull/23054.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23054#issuecomment-2585603897)
</details>
