### PR TITLE
8347499: C2: Make `PhaseIdealLoop` eliminate more redundant safepoints in loops

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3865,9 +3865,7 @@ void IdealLoopTree::check_safepts(VectorSet &visited, Node_List &stack) {
         } else if (n->Opcode() == Op_SafePoint) {
           if (_phase->get_loop(n) == this) {
             has_local_ncsfpt = true;
-            break;
-          }
-          if (nonlocal_ncsfpt == nullptr) {
+          } else if (nonlocal_ncsfpt == nullptr) {
             nonlocal_ncsfpt = n; // save the one closest to the tail
           }
         } else {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestLoopSafepoint.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestLoopSafepoint.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8347499
+ * @summary Tests that redundant safepoints can be eliminated in loops.
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run main compiler.c2.irTests.TestLoopSafepoint
+ */
+public class TestLoopSafepoint {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    static int loopCount = 100000;
+    static int anotherInt = 1;
+
+    @DontInline
+    private void empty() {}
+
+    @DontInline
+    private int constInt() {
+        return 100000;
+    }
+
+    @Test
+    @IR(failOn = IRNode.SAFEPOINT)
+    public void loopConst() {
+        for (int i = 0; i < 100000; i++) {
+            empty();
+        }
+    }
+
+    @Test
+    @IR(failOn = IRNode.SAFEPOINT)
+    public void loopVar() {
+        for (int i = 0; i < loopCount; i++) {
+            empty();
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.SAFEPOINT, "1"})
+    public int loopVarWithoutCall() {
+        int sum = 0;
+        for (int i = 0; i < loopCount; i++) {
+            sum += anotherInt;
+        }
+        return sum;
+    }
+
+    @Test
+    @IR(failOn = IRNode.SAFEPOINT)
+    public void loopFunc() {
+        for (int i = 0; i < constInt(); i++) {
+            empty();
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/LoopSafepoint.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/LoopSafepoint.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 3)
+@State(Scope.Thread)
+public class LoopSafepoint {
+    static int loopCount = 100000;
+    static int anotherInt = 1;
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private void empty() {}
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private int constInt() {
+        return 100000;
+    }
+
+    @Benchmark
+    public int loopConst() {
+        int sum = 0;
+        for (int i = 0; i < 100000; i++) {
+            sum += anotherInt;
+            empty();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int loopVar() {
+        int sum = 0;
+        for (int i = 0; i < loopCount; i++) {
+            sum += anotherInt;
+            empty();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int loopFunc() {
+        int sum = 0;
+        for (int i = 0; i < constInt(); i++) {
+            sum += anotherInt;
+            empty();
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
In `PhaseIdealLoop`, `IdealLoopTree::check_safepts` method checks if any call that is guaranteed to have a safepoint dominates the tail of the loop. In the previous implementation, `check_safepts` would stop if it found a local non-call safepoint. At this time, if there was a call before the safepoint in the dom-path, this safepoint would not be eliminated.

<img width="353" alt="loop-safepoint" src="https://github.com/user-attachments/assets/c220e103-aaba-4e3f-98ac-1ddb6465c309" />

This patch changes the behavior of `check_safepts` to not stop when it finds a non-local safepoint. This makes simple loops with one method call ~3.8% faster (on aarch64).

```
Benchmark                Mode  Cnt       Score      Error  Units
LoopSafepoint.loopVar    avgt   15  208296.259 ± 1350.409  ns/op   # baseline
LoopSafepoint.loopVar    avgt   15  200692.874 ±  616.770  ns/op   # this patch
```

Testing: tier1-2 on x86_64 and aarch64.
