### PR TITLE
8347302: Mark test tools/jimage/JImageToolTest.java as flagless

### DIFF
--- a/test/jdk/tools/jimage/JImageToolTest.java
+++ b/test/jdk/tools/jimage/JImageToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 /*
  * @test
  * @library /test/lib
+ * @requires vm.flagless
  * @build jdk.test.lib.process.ProcessTools
  * @summary Test to check if jimage tool exists and is working
  * @run main/timeout=360 JImageToolTest


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e7e8f60c](https://github.com/openjdk/jdk/commit/e7e8f60c9bedd5622525cc4339300b438eedc9fd) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository to jdk24.

Test test/jdk/tools/jimage/JImageToolTest.java ignore vm flags and should be marked as flagless. Test-fix only, no risk.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347302](https://bugs.openjdk.org/browse/JDK-8347302): Mark test tools/jimage/JImageToolTest.java as flagless (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23058/head:pull/23058` \
`$ git checkout pull/23058`

Update a local copy of the PR: \
`$ git checkout pull/23058` \
`$ git pull https://git.openjdk.org/jdk.git pull/23058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23058`

View PR using the GUI difftool: \
`$ git pr show -t 23058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23058.diff">https://git.openjdk.org/jdk/pull/23058.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23058#issuecomment-2586093230)
</details>
