### PR TITLE
8347500: hsdis cannot be built with Capstone.next

### DIFF
--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,9 @@ AC_DEFUN([LIB_SETUP_HSDIS_CAPSTONE],
     HSDIS_CFLAGS="-I${CAPSTONE}/include/capstone"
     if test "x$OPENJDK_TARGET_OS" != xwindows; then
       HSDIS_LDFLAGS="-L${CAPSTONE}/lib"
+      if test $OPENJDK_TARGET_CPU_BITS -eq 64; then
+        HSDIS_LDFLAGS="-L${CAPSTONE}/lib64 $HSDIS_LDFLAGS"
+      fi
       HSDIS_LIBS="-lcapstone"
     else
       HSDIS_LDFLAGS="-nodefaultlib:libcmt.lib"

--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -40,7 +40,7 @@ AC_DEFUN([LIB_SETUP_HSDIS_CAPSTONE],
     HSDIS_CFLAGS="-I${CAPSTONE}/include/capstone"
     if test "x$OPENJDK_TARGET_OS" != xwindows; then
       HSDIS_LDFLAGS="-L${CAPSTONE}/lib"
-      if test $OPENJDK_TARGET_CPU_BITS -eq 64; then
+      if test "x$OPENJDK_TARGET_CPU_BITS" = "x64" ; then
         HSDIS_LDFLAGS="-L${CAPSTONE}/lib64 $HSDIS_LDFLAGS"
       fi
       HSDIS_LIBS="-lcapstone"


### PR DESCRIPTION
Next version of Capstone (6.0.0-Alpha1 at least) would locate the library into `lib64` directory rather than `lib` on 64bit Linux due to following PR.
https://github.com/capstone-engine/capstone/pull/2214

Thus hsdis build should follow this change for the future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8347500: hsdis cannot be built with Capstone.next`

### Issue
 * [JDK-8347500](https://bugs.openjdk.org/browse/JDK-8347500): hsdis cannot be built with Capstone.next (**Bug** - P4)


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**) Review applies to [61631620](https://git.openjdk.org/jdk/pull/23059/files/61631620c338dab60922802c1906fd2ba8ac8207)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23059/head:pull/23059` \
`$ git checkout pull/23059`

Update a local copy of the PR: \
`$ git checkout pull/23059` \
`$ git pull https://git.openjdk.org/jdk.git pull/23059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23059`

View PR using the GUI difftool: \
`$ git pr show -t 23059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23059.diff">https://git.openjdk.org/jdk/pull/23059.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23059#issuecomment-2586094619)
</details>
