### PR TITLE
8336920: ArithmeticException in javax.sound.sampled.AudioInputStream

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftLinearResampler2.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftLinearResampler2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,10 @@ public final class SoftLinearResampler2 extends SoftAbstractResampler {
         int p_ix = (int) (ix * (1 << 15));
         int p_ix_end = (int) (ix_end * (1 << 15));
         int p_pitch = (int) (pitch * (1 << 15));
+        if (p_pitch == 0) {
+            // If pitch falls below the minimum assume minimum pitch
+            p_pitch = 1;
+        }
         // Pitch needs to recalculated
         // to ensure no drift between p_ix and ix.
         pitch = p_pitch * (1f / (1 << 15));


### PR DESCRIPTION
If pitch drifts too low assume minimum allowed pitch to continue sampling.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336920](https://bugs.openjdk.org/browse/JDK-8336920): ArithmeticException in javax.sound.sampled.AudioInputStream (**Bug** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23064/head:pull/23064` \
`$ git checkout pull/23064`

Update a local copy of the PR: \
`$ git checkout pull/23064` \
`$ git pull https://git.openjdk.org/jdk.git pull/23064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23064`

View PR using the GUI difftool: \
`$ git pr show -t 23064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23064.diff">https://git.openjdk.org/jdk/pull/23064.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23064#issuecomment-2586729634)
</details>
