### PR TITLE
8347545: C2 SuperWord: AutoVectorization benchmark to motivate future work

### DIFF
--- a/test/micro/org/openjdk/bench/vm/compiler/AutoVectorization.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/AutoVectorization.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.Random;
+
+import java.lang.foreign.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 1)
+public class AutoVectorization {
+    @Param({"10000"})
+    public static int SIZE;
+
+    private byte[] aB;
+    private byte[] bB;
+    private byte[] rB;
+
+    private short[] aS;
+    private short[] bS;
+    private short[] rS;
+
+    private char[] aC;
+    private char[] bC;
+    private char[] rC;
+
+    private int[] aI;
+    private int[] bI;
+    private int[] rI;
+
+    private long[] aL;
+    private long[] bL;
+    private long[] rL;
+
+    private float[] aF;
+    private float[] bF;
+    private float[] rF;
+
+    private double[] aD;
+    private double[] bD;
+    private double[] rD;
+
+    private MemorySegment aN;
+    private MemorySegment bN;
+    private MemorySegment rN;
+
+    private static int zeroI = 0;
+
+    @Param("42")
+    private int seed;
+    private Random r = new Random(seed);
+
+    @Setup
+    public void init() {
+        aI = new int[SIZE];
+        bI = new int[SIZE];
+        rI = new int[SIZE];
+
+        aL = new long[SIZE];
+        bL = new long[SIZE];
+        rL = new long[SIZE];
+
+        aS = new short[SIZE];
+        bS = new short[SIZE];
+        rS = new short[SIZE];
+
+        aC = new char[SIZE];
+        bC = new char[SIZE];
+        rC = new char[SIZE];
+
+        aB = new byte[SIZE];
+        bB = new byte[SIZE];
+        rB = new byte[SIZE];
+
+        aF = new float[SIZE];
+        bF = new float[SIZE];
+        rF = new float[SIZE];
+
+        aD = new double[SIZE];
+        bD = new double[SIZE];
+        rD = new double[SIZE];
+
+        aN = Arena.ofAuto().allocate(SIZE * 8);
+        bN = Arena.ofAuto().allocate(SIZE * 8);
+        rN = Arena.ofAuto().allocate(SIZE * 8);
+
+        for (int i = 0; i < SIZE; i++) {
+            aB[i] = (byte) r.nextInt();
+            bB[i] = (byte) r.nextInt();
+
+            aS[i] = (short) r.nextInt();
+            bS[i] = (short) r.nextInt();
+
+            aC[i] = (char) r.nextInt();
+            bC[i] = (char) r.nextInt();
+
+            aI[i] = r.nextInt();
+            bI[i] = r.nextInt();
+
+            aL[i] = r.nextLong();
+            bL[i] = r.nextLong();
+
+            aF[i] = r.nextFloat();
+            bF[i] = r.nextFloat();
+
+            aD[i] = r.nextDouble();
+            bD[i] = r.nextDouble();
+        }
+    }
+
+    // ------------------------------------- ELEMENT-WISE
+
+    // TODO rm or expand
+    @Benchmark
+    public void elementwiseByteAdd() {
+        for (int i = 0; i < aB.length; i++) {
+            rB[i] = (byte)(aB[i] + bB[i]);
+        }
+    }
+
+    // ------------------------------------- REDUCTION
+
+    @Benchmark
+    public int reductionIntAdd() {
+        int sum = 0;
+        for (int i = 0; i < aI.length; i++) {
+            sum += aI[i];
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int reductionIntAddDotProduct() {
+        int sum = 0;
+        for (int i = 0; i < aI.length; i++) {
+            sum += aI[i] * bI[i];
+        }
+        return sum;
+    }
+
+    // ------------------------------------- OFFSET
+
+    @Benchmark
+    public void offsetM002IntAdd() {
+        for (int i = 2; i < aI.length; i++) {
+            rI[i] += rI[i - 2];
+        }
+    }
+
+    @Benchmark
+    public void offsetM003IntAdd() {
+        for (int i = 3; i < aI.length; i++) {
+            rI[i] += rI[i - 3];
+        }
+    }
+
+    @Benchmark
+    public void offsetM128IntAdd() {
+        for (int i = 128; i < aI.length; i++) {
+            rI[i] += rI[i - 128];
+        }
+    }
+
+    @Benchmark
+    public void offsetP002IntAdd() {
+        for (int i = 0; i < aI.length - 2; i++) {
+            rI[i] += rI[i + 2];
+        }
+    }
+
+    @Benchmark
+    public void offsetP003IntAdd() {
+        for (int i = 0; i < aI.length - 3; i++) {
+            rI[i] += rI[i + 3];
+        }
+    }
+
+    @Benchmark
+    public void offsetP128IntAdd() {
+        for (int i = 0; i < aI.length - 128; i++) {
+            rI[i] += rI[i + 128];
+        }
+    }
+
+    @Benchmark
+    public void offsetM002IntAdd2A() {
+        for (int i = 2; i < aI.length; i++) {
+            rI[i] += aI[i - 2];
+        }
+    }
+
+    @Benchmark
+    public void offsetM003IntAdd2A() {
+        for (int i = 3; i < aI.length; i++) {
+            rI[i] += aI[i - 3];
+        }
+    }
+
+    @Benchmark
+    public void offsetM128IntAdd2A() {
+        for (int i = 128; i < aI.length; i++) {
+            rI[i] += aI[i - 128];
+        }
+    }
+
+    @Benchmark
+    public void offsetP002IntAdd2A() {
+        for (int i = 0; i < aI.length - 2; i++) {
+            rI[i] += aI[i + 2];
+        }
+    }
+
+    @Benchmark
+    public void offsetP003IntAdd2A() {
+        for (int i = 0; i < aI.length - 3; i++) {
+            rI[i] += aI[i + 3];
+        }
+    }
+
+    @Benchmark
+    public void offsetP128IntAdd2A() {
+        for (int i = 0; i < aI.length - 128; i++) {
+            rI[i] += aI[i + 128];
+        }
+    }
+
+    // ------------------------------------- Aliasing Analysis Runtime Check
+
+    @Benchmark
+    public void aliasingCopyInt() {
+        for (int i = 0; i < aI.length; i++) {
+            rI[i] = aI[i];
+        }
+    }
+
+    @Benchmark
+    public void aliasingCopyInvarInt() {
+        for (int i = 0; i < aI.length; i++) {
+            rI[i] = aI[i + zeroI];
+        }
+    }
+
+    @Benchmark
+    public void aliasingBoxKernelInt() {
+        for (int i = 1; i < aI.length - 1; i++) {
+            rI[i] = aI[i - 1] + aI[i] + aI[i + 1];
+        }
+    }
+
+    // ------------------------------------- MEMORY SEGMENT
+
+    @Benchmark
+    public void memorySegmentNativeElementwiseIntIncr() {
+        for (long i = 0; i < aN.byteSize() / 4; i++) {
+            int v = rN.get(ValueLayout.JAVA_INT, i * 4L);
+            rN.set(ValueLayout.JAVA_INT, i * 4L, v + 1);
+        }
+    }
+
+    @Benchmark
+    public void memorySegmentNativeElementwiseIntAdd() {
+        for (long i = 0; i < aN.byteSize() / 4; i++) {
+            int v1 = aN.get(ValueLayout.JAVA_INT, i * 4L);
+            int v2 = bN.get(ValueLayout.JAVA_INT, i * 4L);
+            rN.set(ValueLayout.JAVA_INT, i * 4L, v1 + v2);
+        }
+    }
+
+    // ------------------------------------- CFG / IF-Conversion / Masking
+
+    @Benchmark
+    public void ifDiamondInt() {
+        for (int i = 0; i < aI.length; i++) {
+            int aa = aI[i];
+            rI[i] = (aa > 0) ? (aa + 1) : (aa * 2);
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/AutoVectorization.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/AutoVectorization.java
@@ -28,8 +28,6 @@ import org.openjdk.jmh.infra.*;
 import java.util.concurrent.TimeUnit;
 import java.util.Random;
 
-import java.lang.foreign.*;
-
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
@@ -67,10 +65,6 @@ public class AutoVectorization {
     private double[] aD;
     private double[] bD;
     private double[] rD;
-
-    private MemorySegment aN;
-    private MemorySegment bN;
-    private MemorySegment rN;
 
     private static int zeroI = 0;
 
@@ -111,10 +105,6 @@ public class AutoVectorization {
         aD = new double[SIZE];
         bD = new double[SIZE];
         rD = new double[SIZE];
-
-        aN = Arena.ofAuto().allocate(SIZE * 8);
-        bN = Arena.ofAuto().allocate(SIZE * 8);
-        rN = Arena.ofAuto().allocate(SIZE * 8);
 
         for (int i = 0; i < SIZE; i++) {
             aB[i] = (byte) r.nextInt();
@@ -339,25 +329,6 @@ public class AutoVectorization {
     public void aliasingCopyReverseIntFloat() {
         for (int i = 0; i < aI.length; i++) {
             rI[i] = (int)aF[aI.length - i - 1];
-        }
-    }
-
-    // ------------------------------------- MEMORY SEGMENT
-
-    @Benchmark
-    public void memorySegmentNativeElementwiseByteIncr() {
-        for (long i = 0; i < aN.byteSize(); i++) {
-            byte v = rN.get(ValueLayout.JAVA_BYTE, i);
-            rN.set(ValueLayout.JAVA_BYTE, i, (byte)(v + 1));
-        }
-    }
-
-    @Benchmark
-    public void memorySegmentNativeElementwiseByteAdd() {
-        for (long i = 0; i < aN.byteSize(); i++) {
-            byte v1 = aN.get(ValueLayout.JAVA_BYTE, i);
-            byte v2 = bN.get(ValueLayout.JAVA_BYTE, i);
-            rN.set(ValueLayout.JAVA_BYTE, i, (byte)(v1 + v2));
         }
     }
 

--- a/test/micro/org/openjdk/bench/vm/compiler/AutoVectorizationMemorySegment.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/AutoVectorizationMemorySegment.java
@@ -28,7 +28,17 @@ import org.openjdk.jmh.infra.*;
 import java.util.concurrent.TimeUnit;
 import java.util.Random;
 
+import java.nio.ByteBuffer;
 import java.lang.foreign.*;
+
+/**
+ * We test MemorySegment vectorization:
+ * - Various backing types
+ * - Various access types / sizes
+ * - Various pointer forms
+ *
+ * Related IR test: test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegment.java
+ */
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -64,17 +74,17 @@ public class AutoVectorizationMemorySegment {
     MemorySegment allocate() {
         switch (BACKING_TYPE) {
             case "ByteArray"        -> { return MemorySegment.ofArray(new byte[SIZE]); }
-            case "CharArray"        -> { return MemorySegment.ofArray(new char[BACKING_SIZE / 2]); }
-            case "ShortArray"       -> { return MemorySegment.ofArray(new short[BACKING_SIZE / 2]); }
-            case "IntArray"         -> { return MemorySegment.ofArray(new int[BACKING_SIZE / 4]); }
-            case "LongArray"        -> { return MemorySegment.ofArray(new long[BACKING_SIZE / 8]); }
-            case "FloatArray"       -> { return MemorySegment.ofArray(new float[BACKING_SIZE / 4]); }
-            case "DoubleArray"      -> { return MemorySegment.ofArray(new double[BACKING_SIZE / 8]); }
-            case "ByteBuffer"       -> { return MemorySegment.ofBuffer(ByteBuffer.allocate(BACKING_SIZE)); }
-            case "ByteBufferDirect" -> { return MemorySegment.ofBuffer(ByteBuffer.allocateDirect(BACKING_SIZE)); }
-            case "Native"           -> { return Arena.ofAuto().allocate(BACKING_SIZE, 1); }
+            case "CharArray"        -> { return MemorySegment.ofArray(new char[SIZE / 2]); }
+            case "ShortArray"       -> { return MemorySegment.ofArray(new short[SIZE / 2]); }
+            case "IntArray"         -> { return MemorySegment.ofArray(new int[SIZE / 4]); }
+            case "LongArray"        -> { return MemorySegment.ofArray(new long[SIZE / 8]); }
+            case "FloatArray"       -> { return MemorySegment.ofArray(new float[SIZE / 4]); }
+            case "DoubleArray"      -> { return MemorySegment.ofArray(new double[SIZE / 8]); }
+            case "ByteBuffer"       -> { return MemorySegment.ofBuffer(ByteBuffer.allocate(SIZE)); }
+            case "ByteBufferDirect" -> { return MemorySegment.ofBuffer(ByteBuffer.allocateDirect(SIZE)); }
+            case "Native"           -> { return Arena.ofAuto().allocate(SIZE, 1); }
             default -> throw new RuntimeException("BACKING_TYPE not supported: " + BACKING_TYPE);
-        };
+        }
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/vm/compiler/AutoVectorizationMemorySegment.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/AutoVectorizationMemorySegment.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.Random;
+
+import java.lang.foreign.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 1)
+public class AutoVectorizationMemorySegment {
+    @Param({"10000"})
+    public static int SIZE;
+
+    @Param({"ByteArray", "CharArray", "ShortArray", "IntArray", "LongArray", "FloatArray", "DoubleArray",
+            "Native",
+            "ByteBuffer", "ByteBufferDirect"})
+    public static String BACKING_TYPE;
+
+    @Param("42")
+    private int seed;
+    private Random r = new Random(seed);
+
+    // MemorySegments, allocated according to BACKING_TYPE.
+    private MemorySegment aMS;
+    private MemorySegment bMS;
+    private MemorySegment rMS;
+
+    @Setup
+    public void init() {
+        aMS = allocate();
+        bMS = allocate();
+        rMS = allocate();
+    }
+
+    MemorySegment allocate() {
+        switch (BACKING_TYPE) {
+            case "ByteArray"        -> { return MemorySegment.ofArray(new byte[SIZE]); }
+            case "CharArray"        -> { return MemorySegment.ofArray(new char[BACKING_SIZE / 2]); }
+            case "ShortArray"       -> { return MemorySegment.ofArray(new short[BACKING_SIZE / 2]); }
+            case "IntArray"         -> { return MemorySegment.ofArray(new int[BACKING_SIZE / 4]); }
+            case "LongArray"        -> { return MemorySegment.ofArray(new long[BACKING_SIZE / 8]); }
+            case "FloatArray"       -> { return MemorySegment.ofArray(new float[BACKING_SIZE / 4]); }
+            case "DoubleArray"      -> { return MemorySegment.ofArray(new double[BACKING_SIZE / 8]); }
+            case "ByteBuffer"       -> { return MemorySegment.ofBuffer(ByteBuffer.allocate(BACKING_SIZE)); }
+            case "ByteBufferDirect" -> { return MemorySegment.ofBuffer(ByteBuffer.allocateDirect(BACKING_SIZE)); }
+            case "Native"           -> { return Arena.ofAuto().allocate(BACKING_SIZE, 1); }
+            default -> throw new RuntimeException("BACKING_TYPE not supported: " + BACKING_TYPE);
+        };
+    }
+
+    @Benchmark
+    public void elementwiseByteIncr() {
+        for (long i = 0; i < aMS.byteSize(); i++) {
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, i);
+            rMS.set(ValueLayout.JAVA_BYTE, i, (byte)(v + 1));
+        }
+    }
+
+    @Benchmark
+    public void elementwiseByteAdd() {
+        for (long i = 0; i < aMS.byteSize(); i++) {
+            byte v1 = aMS.get(ValueLayout.JAVA_BYTE, i);
+            byte v2 = bMS.get(ValueLayout.JAVA_BYTE, i);
+            rMS.set(ValueLayout.JAVA_BYTE, i, (byte)(v1 + v2));
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/AutoVectorizationMemorySegment.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/AutoVectorizationMemorySegment.java
@@ -64,6 +64,9 @@ public class AutoVectorizationMemorySegment {
     private MemorySegment bMS;
     private MemorySegment rMS;
 
+    private int  zeroInvarI = 0;
+    private long zeroInvarL = 0;
+
     @Setup
     public void init() {
         aMS = allocate();
@@ -88,19 +91,269 @@ public class AutoVectorizationMemorySegment {
     }
 
     @Benchmark
-    public void elementwiseByteIncr() {
-        for (long i = 0; i < aMS.byteSize(); i++) {
-            byte v = rMS.get(ValueLayout.JAVA_BYTE, i);
-            rMS.set(ValueLayout.JAVA_BYTE, i, (byte)(v + 1));
-        }
-    }
-
-    @Benchmark
-    public void elementwiseByteAdd() {
+    public void longLoopElementwiseByteAdd() {
         for (long i = 0; i < aMS.byteSize(); i++) {
             byte v1 = aMS.get(ValueLayout.JAVA_BYTE, i);
             byte v2 = bMS.get(ValueLayout.JAVA_BYTE, i);
             rMS.set(ValueLayout.JAVA_BYTE, i, (byte)(v1 + v2));
+        }
+    }
+
+    // see TestMemorySegment.testMemorySegmentBadExitCheck
+    @Benchmark
+    public void intLoopWithLongLimitElementByteIncrSameLongAdr() {
+        for (int i = 0; i < rMS.byteSize(); i++) {
+            long adr = i;
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, adr);
+            rMS.set(ValueLayout.JAVA_BYTE, adr, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_iv_byte
+    @Benchmark
+    public void intLoopElementWiseByteIncrSameLongAdr() {
+        for (int i = 0; i < (int)rMS.byteSize(); i++) {
+            long adr = i;
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, adr);
+            rMS.set(ValueLayout.JAVA_BYTE, adr, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_longIndex_intInvar_sameAdr_byte
+    @Benchmark
+    public void intLoopElementWiseByteIncrWithIntInvarSameLongAdr() {
+        for (int i = 0; i < (int)rMS.byteSize(); i++) {
+            long adr = (long)(i) + (long)(zeroInvarI);
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, adr);
+            rMS.set(ValueLayout.JAVA_BYTE, adr, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_longIndex_longInvar_sameAdr_byte
+    @Benchmark
+    public void intLoopElementWiseByteIncrWithLongInvarSameLongAdr() {
+        for (int i = 0; i < (int)rMS.byteSize(); i++) {
+            long adr = (long)(i) + (long)(zeroInvarL);
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, adr);
+            rMS.set(ValueLayout.JAVA_BYTE, adr, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_longIndex_intInvar_byte
+    @Benchmark
+    public void intLoopElementWiseByteIncrWithIntInvarSeparateLongAdr() {
+        for (int i = 0; i < (int)rMS.byteSize(); i++) {
+            long adr1 = (long)(i) + (long)(zeroInvarI);
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, adr1);
+            long adr2 = (long)(i) + (long)(zeroInvarI);
+            rMS.set(ValueLayout.JAVA_BYTE, adr2, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_longIndex_longInvar_byte
+    @Benchmark
+    public void intLoopElementWiseByteIncrWithLongInvarSeparateLongAdr() {
+        for (int i = 0; i < (int)rMS.byteSize(); i++) {
+            long adr1 = (long)(i) + (long)(zeroInvarL);
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, adr1);
+            long adr2 = (long)(i) + (long)(zeroInvarL);
+            rMS.set(ValueLayout.JAVA_BYTE, adr2, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_intIndex_intInvar_byte
+    @Benchmark
+    public void intLoopElementWiseByteIncrWithIntInvarSameIntIndex() {
+        for (int i = 0; i < (int)rMS.byteSize(); i++) {
+            int int_index = i + zeroInvarI;
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, int_index);
+            rMS.set(ValueLayout.JAVA_BYTE, int_index, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_iv_int
+    @Benchmark
+    public void intLoopElementWiseIntIncrSameLongAdr() {
+        for (int i = 0; i < (int)rMS.byteSize()/4; i++ ) {
+            long adr = 4L * i;
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, adr);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, adr, (int)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_longIndex_intInvar_sameAdr_int
+    @Benchmark
+    public void intLoopElementWiseIntIncrWithIntInvarSameLongAdr() {
+        for (int i = 0; i < (int)rMS.byteSize()/4; i++) {
+            long adr = 4L * (long)(i) + 4L * (long)(zeroInvarI);
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, adr);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, adr, (int)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_longIndex_longInvar_sameAdr_int
+    @Benchmark
+    public void intLoopElementWiseIntIncrWithLongInvarSameLongAdr() {
+        for (int i = 0; i < (int)rMS.byteSize()/4; i++) {
+            long adr = 4L * (long)(i) + 4L * (long)(zeroInvarL);
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, adr);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, adr, (int)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_longIndex_intInvar_int
+    @Benchmark
+    public void intLoopElementWiseIntIncrWithIntInvarSeparateLongAdr() {
+        for (int i = 0; i < (int)rMS.byteSize()/4; i++) {
+            long adr1 = 4L * (long)(i) + 4L * (long)(zeroInvarI);
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, adr1);
+            long adr2 = 4L * (long)(i) + 4L * (long)(zeroInvarI);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, adr2, (int)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_longIndex_longInvar_int
+    @Benchmark
+    public void intLoopElementWiseIntIncrWithLongInvarSeparateLongAdr() {
+        for (int i = 0; i < (int)rMS.byteSize()/4; i++) {
+            long adr1 = 4L * (long)(i) + 4L * (long)(zeroInvarL);
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, adr1);
+            long adr2 = 4L * (long)(i) + 4L * (long)(zeroInvarL);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, adr2, (int)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testIntLoop_intIndex_intInvar_int
+    @Benchmark
+    public void intLoopElementWiseIntIncrWithIntInvarSameIntIndex() {
+        for (int i = 0; i < (int)rMS.byteSize()/4; i++) {
+            int int_index = i + zeroInvarI;
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, 4L * int_index);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, 4L * int_index, (int)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_iv_byte
+    @Benchmark
+    public void longLoopElementWiseByteIncrSameLongAdr() {
+        for (long i = 0; i < rMS.byteSize(); i++) {
+            long adr = i;
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, adr);
+            rMS.set(ValueLayout.JAVA_BYTE, adr, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_longIndex_intInvar_sameAdr_byte
+    @Benchmark
+    public void longLoopElementWiseByteIncrWithIntInvarSameLongAdr() {
+        for (long i = 0; i < rMS.byteSize(); i++) {
+            long adr = (long)(i) + (long)(zeroInvarI);
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, adr);
+            rMS.set(ValueLayout.JAVA_BYTE, adr, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_longIndex_longInvar_sameAdr_byte
+    @Benchmark
+    public void longLoopElementWiseByteIncrWithLongInvarSameLongAdr() {
+        for (long i = 0; i < rMS.byteSize(); i++) {
+            long adr = (long)(i) + (long)(zeroInvarL);
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, adr);
+            rMS.set(ValueLayout.JAVA_BYTE, adr, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_longIndex_intInvar_byte
+    @Benchmark
+    public void longLoopElementWiseByteIncrWithIntInvarSeparateLongAdr() {
+        for (long i = 0; i < rMS.byteSize(); i++) {
+            long adr1 = (long)(i) + (long)(zeroInvarI);
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, adr1);
+            long adr2 = (long)(i) + (long)(zeroInvarI);
+            rMS.set(ValueLayout.JAVA_BYTE, adr2, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_longIndex_longInvar_byte
+    @Benchmark
+    public void longLoopElementWiseByteIncrWithLongInvarSeparateLongAdr() {
+        for (long i = 0; i < rMS.byteSize(); i++) {
+            long adr1 = (long)(i) + (long)(zeroInvarL);
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, adr1);
+            long adr2 = (long)(i) + (long)(zeroInvarL);
+            rMS.set(ValueLayout.JAVA_BYTE, adr2, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_intIndex_intInvar_byte
+    @Benchmark
+    public void longLoopElementWiseByteIncrWithIntInvarSameIntIndex() {
+        for (long i = 0; i < rMS.byteSize(); i++) {
+            int int_index = (int)(i + zeroInvarI);
+            byte v = rMS.get(ValueLayout.JAVA_BYTE, int_index);
+            rMS.set(ValueLayout.JAVA_BYTE, int_index, (byte)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_iv_int
+    @Benchmark
+    public void longLoopElementWiseIntIncrSameLongAdr() {
+        for (long i = 0; i < rMS.byteSize()/4; i++ ) {
+            long adr = 4L * i;
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, adr);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, adr, (int)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_longIndex_intInvar_sameAdr_int
+    @Benchmark
+    public void longLoopElementWiseIntIncrWithIntInvarSameLongAdr() {
+        for (long i = 0; i < rMS.byteSize()/4; i++) {
+            long adr = 4L * (long)(i) + 4L * (long)(zeroInvarI);
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, adr);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, adr, (int)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_longIndex_longInvar_sameAdr_int
+    @Benchmark
+    public void longLoopElementWiseIntIncrWithLongInvarSameLongAdr() {
+        for (long i = 0; i < rMS.byteSize()/4; i++) {
+            long adr = 4L * (long)(i) + 4L * (long)(zeroInvarL);
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, adr);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, adr, (int)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_longIndex_intInvar_int
+    @Benchmark
+    public void longLoopElementWiseIntIncrWithIntInvarSeparateLongAdr() {
+        for (long i = 0; i < rMS.byteSize()/4; i++) {
+            long adr1 = 4L * (long)(i) + 4L * (long)(zeroInvarI);
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, adr1);
+            long adr2 = 4L * (long)(i) + 4L * (long)(zeroInvarI);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, adr2, (int)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_longIndex_longInvar_int
+    @Benchmark
+    public void longLoopElementWiseIntIncrWithLongInvarSeparateLongAdr() {
+        for (long i = 0; i < rMS.byteSize()/4; i++) {
+            long adr1 = 4L * (long)(i) + 4L * (long)(zeroInvarL);
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, adr1);
+            long adr2 = 4L * (long)(i) + 4L * (long)(zeroInvarL);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, adr2, (int)(v + 1));
+        }
+    }
+
+    // see TestMemorySegment.testLongLoop_intIndex_intInvar_int
+    @Benchmark
+    public void longLoopElementWiseIntIncrWithIntInvarSameIntIndex() {
+        for (long i = 0; i < rMS.byteSize()/4; i++) {
+            int int_index = (int)(i + zeroInvarI);
+            int v = rMS.get(ValueLayout.JAVA_INT_UNALIGNED, 4L * int_index);
+            rMS.set(ValueLayout.JAVA_INT_UNALIGNED, 4L * int_index, (int)(v + 1));
         }
     }
 }


### PR DESCRIPTION
TODO

Add benchmark for all types, and aligned / not aligned!

Disclaimer: work in progress, interpret micro-benchmarks with a grain of salt ;)

--------------------------------

On my AVX512 machine, for `AutoVectorization`, with `C2`:
```
Benchmark                         (SIZE)       Score       Error  Units
aliasingBoxKernelInt               10000    7046.950 ±    32.178  ns/op
aliasingCopyInt                    10000    1211.992 ±   101.449  ns/op
aliasingCopyInvarInt               10000    4213.778 ±   128.420  ns/op
aliasingCopyReverseInt             10000    3781.683 ±   236.690  ns/op
aliasingCopyReverseIntFloat        10000    7715.002 ± 10089.161  ns/op
aliasingCopyStridedInt             10000    2209.936 ±  1935.368  ns/op
elementwiseIntAdd                  10000    1609.376 ±     3.901  ns/op
handunrolledIntAdd                 10000    1626.904 ±   589.120  ns/op
ifDiamondInt                       10000   11481.476 ±  7430.576  ns/op
ifDiamondIntV2                     10000   10926.587 ±  9082.790  ns/op
ifMaskedCopyInt                    10000    7872.642 ±   955.375  ns/op
ifMaskedLoadInt                    10000   10580.964 ±  1342.605  ns/op
ifSearchInt                        10000    1248.318 ±   387.591  ns/op
indexPopulateInt                   10000     389.598 ±     6.101  ns/op
indexSquareInt                     10000    4044.168 ±   277.707  ns/op
offsetM002IntAdd                   10000    3280.284 ±    26.596  ns/op
offsetM002IntAdd2A                 10000    3363.295 ±   106.930  ns/op
offsetM003IntAdd                   10000    8402.720 ±  6978.554  ns/op
offsetM003IntAdd2A                 10000    3536.923 ±   273.513  ns/op
offsetM128IntAdd                   10000     328.625 ±     3.012  ns/op
offsetM128IntAdd2A                 10000    1322.798 ±    28.724  ns/op
offsetP002IntAdd                   10000    1278.408 ±   434.852  ns/op
offsetP002IntAdd2A                 10000    1347.604 ±    24.504  ns/op
offsetP003IntAdd                   10000    1525.370 ±   160.195  ns/op
offsetP003IntAdd2A                 10000    1349.738 ±    38.997  ns/op
offsetP128IntAdd                   10000     316.263 ±     2.394  ns/op
offsetP128IntAdd2A                 10000    1346.922 ±    91.892  ns/op
reductionIntAdd                    10000    4003.681 ±    78.588  ns/op
reductionIntAddDotProduct          10000    1143.622 ±  1094.813  ns/op
reductionIntAddStrided             10000    2248.609 ±  1789.602  ns/op
reductionIntAddStridedDotProduct   10000    3087.340 ±  1016.100  ns/op
```

And for `GraalJIT`:
```
Benchmark                         (SIZE)       Score       Error  Units
aliasingBoxKernelInt               10000    1671.252 ±   139.337  ns/op
aliasingCopyInt                    10000    1269.384 ±   112.245  ns/op
aliasingCopyInvarInt               10000    1267.684 ±   491.916  ns/op
aliasingCopyReverseInt             10000    5115.872 ±  1537.268  ns/op
aliasingCopyReverseIntFloat        10000    8176.474 ±  2830.894  ns/op
aliasingCopyStridedInt             10000    2198.863 ±  1635.155  ns/op
elementwiseIntAdd                  10000    1810.144 ±   255.315  ns/op
handunrolledIntAdd                 10000    4816.311 ±   424.661  ns/op
ifDiamondInt                       10000    1795.279 ±    33.882  ns/op
ifDiamondIntV2                     10000    1348.762 ±    24.080  ns/op
ifMaskedCopyInt                    10000    7425.984 ±    99.452  ns/op
ifMaskedLoadInt                    10000   10931.133 ±  7607.978  ns/op
ifSearchInt                        10000    3320.391 ±  2528.234  ns/op
indexPopulateInt                   10000     597.258 ±    27.001  ns/op
indexSquareInt                     10000     638.230 ±    45.580  ns/op
offsetM002IntAdd                   10000   14329.987 ± 24456.055  ns/op
offsetM002IntAdd2A                 10000    1600.136 ±   246.503  ns/op
offsetM003IntAdd                   10000    8423.147 ±   938.348  ns/op
offsetM003IntAdd2A                 10000    1432.009 ±    45.845  ns/op
offsetM128IntAdd                   10000    4021.391 ±    15.283  ns/op
offsetM128IntAdd2A                 10000    1415.604 ±   246.853  ns/op
offsetP002IntAdd                   10000     691.942 ±   224.703  ns/op
offsetP002IntAdd2A                 10000    1596.192 ±    44.582  ns/op
offsetP003IntAdd                   10000     683.285 ±     2.077  ns/op
offsetP003IntAdd2A                 10000    1597.012 ±   111.832  ns/op
offsetP128IntAdd                   10000     673.346 ±     3.175  ns/op
offsetP128IntAdd2A                 10000    1571.344 ±    16.608  ns/op
reductionIntAdd                    10000     319.081 ±    25.427  ns/op
reductionIntAddDotProduct          10000    1533.761 ±    78.734  ns/op
reductionIntAddStrided             10000    1896.635 ±    44.118  ns/op
reductionIntAddStridedDotProduct   10000    3170.813 ±    17.980  ns/op
```

In this measurement, we have "strong wins" for `C2`:
- `handunrolledIntAdd` - hand-unrolling is where SuperWord shines
- `offsetM002IntAdd`, `offsetM128IntAdd` - GraalJIT blocks backwards dependencies completely, C2 adjusts vector-length
- `offsetP128IntAdd` not sure why ?

In this measurement, we have "mild wins" for `C2` (i.e. only a few percent difference):
- `aliasingCopyInt` - better unrolling?
- `aliasingCopyReverseInt` and `aliasingCopyReverseIntFloat` -  both do not vectorize - better unrolling?
- `elementwiseIntAdd` - better unrolling?
- `indexPopulateInt` - better unrolling?
- `offsetP002IntAdd2A`, `offsetP003IntAdd2A`, `offsetP128IntAdd2A` - unclear why, would have expected aliasing analysis runtime check to help GrallJIT here
- `reductionIntAddDotProduct` - better unrolling?

In this measurement, we have "strong wins" for `GraalJIT`:
- `aliasingBoxKernelInt` - requires aliasing analysis runtime check, and difficult to pack for SuperWord
- `aliasingCopyInvarInt` - requires aliasing analysis runtime check
- `ifDiamondInt`, `ifDiamondIntV2`
- `indexSquareInt` - not well handled in C2 ?
- `offsetM002IntAdd2A`, `offsetM003IntAdd2A` - requires aliasing analysis runtime check
- `offsetP002IntAdd`, `offsetP003IntAdd` - SuperWord gets confused about which loads to pack together
- `reductionIntAdd` - C2 needs improved heuristic for profitability

Generally no vectorization:
- `ifMaskedCopyInt`, `ifMaskedLoadInt`
- `ifSearchInt`
- `offsetM003IntAdd` - vectorization would lead to store-to-load-forwarding failures - not profitable.
- `reductionIntAddStrided`, `reductionIntAddStridedDotProduct`, `aliasingCopyStridedInt` striding seems not to be implemented generally for C2 and GraalJIT

--------------------------------

On my AVX512 machine, for `AutoVectorizationMemorySegment`, with `C2`:
```
Benchmark                                                (BACKING_TYPE)  (SIZE)       Score       Error  Units
intLoopElementWiseByteIncrSameLongAdr                            Native   10000     135.114 ±    31.327  ns/op
intLoopElementWiseByteIncrWithIntInvarSameIntIndex               Native   10000    7119.883 ±  1074.509  ns/op
intLoopElementWiseByteIncrWithIntInvarSameLongAdr                Native   10000     159.661 ±    29.039  ns/op
intLoopElementWiseByteIncrWithIntInvarSeparateLongAdr            Native   10000    2817.278 ±    22.036  ns/op
intLoopElementWiseByteIncrWithLongInvarSameLongAdr               Native   10000     135.674 ±    15.212  ns/op
intLoopElementWiseByteIncrWithLongInvarSeparateLongAdr           Native   10000    2844.861 ±    15.336  ns/op
intLoopElementWiseIntIncrSameLongAdr                             Native   10000      78.486 ±     0.275  ns/op
intLoopElementWiseIntIncrWithIntInvarSameIntIndex                Native   10000    2793.770 ±   326.376  ns/op
intLoopElementWiseIntIncrWithIntInvarSameLongAdr                 Native   10000      87.547 ±     5.698  ns/op
intLoopElementWiseIntIncrWithIntInvarSeparateLongAdr             Native   10000    1056.081 ±    96.219  ns/op
intLoopElementWiseIntIncrWithLongInvarSameLongAdr                Native   10000      78.500 ±     8.250  ns/op
intLoopElementWiseIntIncrWithLongInvarSeparateLongAdr            Native   10000     725.477 ±     4.115  ns/op
intLoopWithLongLimitElementByteIncrSameLongAdr                   Native   10000   13166.114 ± 16375.874  ns/op
longLoopElementWiseByteIncrSameLongAdr                           Native   10000     132.018 ±     1.402  ns/op     
longLoopElementWiseByteIncrWithIntInvarSameIntIndex              Native   10000    8728.581 ±   166.342  ns/op    
longLoopElementWiseByteIncrWithIntInvarSameLongAdr               Native   10000    4786.400 ±   217.934  ns/op    
longLoopElementWiseByteIncrWithIntInvarSeparateLongAdr           Native   10000    4743.712 ±   947.308  ns/op    
longLoopElementWiseByteIncrWithLongInvarSameLongAdr              Native   10000    4655.055 ±  1688.295  ns/op    
longLoopElementWiseByteIncrWithLongInvarSeparateLongAdr          Native   10000    4704.852 ±   401.996  ns/op    
longLoopElementWiseIntIncrSameLongAdr                            Native   10000    1295.460 ±    38.940  ns/op    
longLoopElementWiseIntIncrWithIntInvarSameIntIndex               Native   10000    2774.433 ±    10.494  ns/op    
longLoopElementWiseIntIncrWithIntInvarSameLongAdr                Native   10000    1191.305 ±    82.797  ns/op    
longLoopElementWiseIntIncrWithIntInvarSeparateLongAdr            Native   10000    1303.522 ±   713.440  ns/op    
longLoopElementWiseIntIncrWithLongInvarSameLongAdr               Native   10000    1350.577 ±   720.714  ns/op    
longLoopElementWiseIntIncrWithLongInvarSeparateLongAdr           Native   10000    1189.553 ±   384.350  ns/op    
longLoopElementwiseByteAdd                                       Native   10000    4079.910 ±   305.650  ns/op
```

There should be some improvements after integration of https://github.com/openjdk/jdk/pull/21926
```
Benchmark                                                (BACKING_TYPE)  (SIZE)       Score       Error  Units
intLoopElementWiseByteIncrSameLongAdr                            Native   10000     134.193 ±     0.371  ns/op     
intLoopElementWiseByteIncrWithIntInvarSameIntIndex               Native   10000    7108.813 ±   384.575  ns/op    
intLoopElementWiseByteIncrWithIntInvarSameLongAdr                Native   10000     157.105 ±    72.163  ns/op     
intLoopElementWiseByteIncrWithIntInvarSeparateLongAdr            Native   10000     153.072 ±   174.524  ns/op     
intLoopElementWiseByteIncrWithLongInvarSameLongAdr               Native   10000     152.810 ±    53.172  ns/op     
intLoopElementWiseByteIncrWithLongInvarSeparateLongAdr           Native   10000     145.069 ±     2.627  ns/op     
intLoopElementWiseIntIncrSameLongAdr                             Native   10000      77.564 ±     2.103  ns/op      
intLoopElementWiseIntIncrWithIntInvarSameIntIndex                Native   10000    2772.255 ±    38.315  ns/op    
intLoopElementWiseIntIncrWithIntInvarSameLongAdr                 Native   10000      87.175 ±     0.506  ns/op      
intLoopElementWiseIntIncrWithIntInvarSeparateLongAdr             Native   10000      73.416 ±     6.496  ns/op      
intLoopElementWiseIntIncrWithLongInvarSameLongAdr                Native   10000      80.590 ±    25.571  ns/op      
intLoopElementWiseIntIncrWithLongInvarSeparateLongAdr            Native   10000      72.496 ±     1.699  ns/op      
intLoopWithLongLimitElementByteIncrSameLongAdr                   Native   10000   13204.103 ± 16846.516  ns/op   
longLoopElementWiseByteIncrSameLongAdr                           Native   10000     131.832 ±     1.461  ns/op     
longLoopElementWiseByteIncrWithIntInvarSameIntIndex              Native   10000    8720.757 ±   627.322  ns/op    
longLoopElementWiseByteIncrWithIntInvarSameLongAdr               Native   10000    4797.433 ±   203.585  ns/op    
longLoopElementWiseByteIncrWithIntInvarSeparateLongAdr           Native   10000    4735.335 ±   535.335  ns/op    
longLoopElementWiseByteIncrWithLongInvarSameLongAdr              Native   10000    4614.763 ±    22.246  ns/op    
longLoopElementWiseByteIncrWithLongInvarSeparateLongAdr          Native   10000    4734.520 ±   235.533  ns/op    
longLoopElementWiseIntIncrSameLongAdr                            Native   10000    1297.569 ±    80.562  ns/op    
longLoopElementWiseIntIncrWithIntInvarSameIntIndex               Native   10000    2775.877 ±    27.916  ns/op    
longLoopElementWiseIntIncrWithIntInvarSameLongAdr                Native   10000    1192.117 ±   169.478  ns/op    
longLoopElementWiseIntIncrWithIntInvarSeparateLongAdr            Native   10000    1195.616 ±   313.734  ns/op    
longLoopElementWiseIntIncrWithLongInvarSameLongAdr               Native   10000    1181.284 ±     9.214  ns/op    
longLoopElementWiseIntIncrWithLongInvarSeparateLongAdr           Native   10000    1178.567 ±    32.480  ns/op    
longLoopElementwiseByteAdd                                       Native   10000    4123.496 ±  1206.628  ns/op
```

On my AVX512 machine, for `AutoVectorizationMemorySegment`, with `GraalJIT`:
```
Benchmark                                                (BACKING_TYPE)  (SIZE)       Score       Error  Units
intLoopElementWiseByteIncrSameLongAdr                            Native   10000    5294.934 ±   196.205  ns/op
intLoopElementWiseByteIncrWithIntInvarSameIntIndex               Native   10000    5611.931 ±  2087.741  ns/op
intLoopElementWiseByteIncrWithIntInvarSameLongAdr                Native   10000    6831.506 ±  8623.116  ns/op
intLoopElementWiseByteIncrWithIntInvarSeparateLongAdr            Native   10000    7164.615 ±  4717.268  ns/op
intLoopElementWiseByteIncrWithLongInvarSameLongAdr               Native   10000    6822.328 ±  6576.528  ns/op
intLoopElementWiseByteIncrWithLongInvarSeparateLongAdr           Native   10000    6774.501 ±  7282.981  ns/op
intLoopElementWiseIntIncrSameLongAdr                             Native   10000    1304.528 ±   166.904  ns/op
intLoopElementWiseIntIncrWithIntInvarSameIntIndex                Native   10000    2939.079 ±   306.469  ns/op
intLoopElementWiseIntIncrWithIntInvarSameLongAdr                 Native   10000    1715.813 ±   207.836  ns/op
intLoopElementWiseIntIncrWithIntInvarSeparateLongAdr             Native   10000    1806.235 ±   970.635  ns/op
intLoopElementWiseIntIncrWithLongInvarSameLongAdr                Native   10000    1843.123 ±  2290.506  ns/op
intLoopElementWiseIntIncrWithLongInvarSeparateLongAdr            Native   10000    1734.210 ±   340.241  ns/op
intLoopWithLongLimitElementByteIncrSameLongAdr                   Native   10000   16103.736 ±   551.591  ns/op
longLoopElementWiseByteIncrSameLongAdr                           Native   10000     159.096 ±     1.505  ns/op
longLoopElementWiseByteIncrWithIntInvarSameIntIndex              Native   10000   10945.956 ±  6461.361  ns/op
longLoopElementWiseByteIncrWithIntInvarSameLongAdr               Native   10000     162.059 ±    11.948  ns/op
longLoopElementWiseByteIncrWithIntInvarSeparateLongAdr           Native   10000     161.700 ±    21.347  ns/op
longLoopElementWiseByteIncrWithLongInvarSameLongAdr              Native   10000     164.661 ±    57.912  ns/op
longLoopElementWiseByteIncrWithLongInvarSeparateLongAdr          Native   10000     160.911 ±     5.824  ns/op
longLoopElementWiseIntIncrSameLongAdr                            Native   10000    1190.031 ±     3.819  ns/op
longLoopElementWiseIntIncrWithIntInvarSameIntIndex               Native   10000    3166.645 ±    60.104  ns/op
longLoopElementWiseIntIncrWithIntInvarSameLongAdr                Native   10000    1610.986 ±    11.209  ns/op
longLoopElementWiseIntIncrWithIntInvarSeparateLongAdr            Native   10000    1648.823 ±    40.619  ns/op
longLoopElementWiseIntIncrWithLongInvarSameLongAdr               Native   10000    1628.063 ±  1229.682  ns/op
longLoopElementWiseIntIncrWithLongInvarSeparateLongAdr           Native   10000    1615.049 ±   398.152  ns/op
longLoopElementwiseByteAdd                                       Native   10000    5859.709 ±  7463.134  ns/op
```

Interesting to see: some cases work better with `C2`, others work better with `GraalJIT`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347545](https://bugs.openjdk.org/browse/JDK-8347545): C2 SuperWord: AutoVectorization benchmark to motivate future work (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23067/head:pull/23067` \
`$ git checkout pull/23067`

Update a local copy of the PR: \
`$ git checkout pull/23067` \
`$ git pull https://git.openjdk.org/jdk.git pull/23067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23067`

View PR using the GUI difftool: \
`$ git pr show -t 23067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23067.diff">https://git.openjdk.org/jdk/pull/23067.diff</a>

</details>
