### PR TITLE
8347173: java/net/DatagramSocket/InterruptibleDatagramSocket.java fails with virtual thread factory

### DIFF
--- a/test/jdk/java/net/DatagramSocket/InterruptibleDatagramSocket.java
+++ b/test/jdk/java/net/DatagramSocket/InterruptibleDatagramSocket.java
@@ -99,7 +99,8 @@ public class InterruptibleDatagramSocket {
 
     public static void main(String[] args) throws Exception {
         if (Thread.currentThread().isVirtual()) {
-            throw new jtreg.SkippedException("skipping test execution through a virtual thread");
+            throw new jtreg.SkippedException(
+                    "skipping test execution - main thread is a virtual thread");
         }
         try (DatagramSocket s = new DatagramSocket()) {
             System.out.println("Testing interrupt of DatagramSocket receive " +

--- a/test/jdk/java/net/DatagramSocket/InterruptibleDatagramSocket.java
+++ b/test/jdk/java/net/DatagramSocket/InterruptibleDatagramSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import static java.lang.Thread.sleep;
  * @test
  * @summary Check interrupt mechanism for DatagramSocket,
  *      MulticastSocket, and DatagramSocketAdaptor
+ * @library /test/lib
  * @run main InterruptibleDatagramSocket
  */
 
@@ -97,6 +98,9 @@ public class InterruptibleDatagramSocket {
     }
 
     public static void main(String[] args) throws Exception {
+        if (Thread.currentThread().isVirtual()) {
+            throw new jtreg.SkippedException("skipping test execution through a virtual thread");
+        }
         try (DatagramSocket s = new DatagramSocket()) {
             System.out.println("Testing interrupt of DatagramSocket receive " +
                     "on endpoint " + s.getLocalSocketAddress());


### PR DESCRIPTION
Can I please get a review for this test-only change which proposes to skip this test when the `main()` is launched through a virtual thread?

This test was introduced in https://bugs.openjdk.org/browse/JDK-8233018 , before virtual threads were introduced. In its current form the test doesn't take into account the specification of `DatagramSocket.receive()` when a virtual thread is doing the `receive()`. There's already the `test/jdk/java/net/vthread/BlockingSocketOps.java` test which exercises the `receive()` through a virtual thread and verifies its specified behaviour, so we can skip this `InterruptibleDatagramSocket` test when a virtual thread is involved.

With the proposed change, the test no longer fails and is reported as skipped by jtreg.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347173](https://bugs.openjdk.org/browse/JDK-8347173): java/net/DatagramSocket/InterruptibleDatagramSocket.java fails with virtual thread factory (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23074/head:pull/23074` \
`$ git checkout pull/23074`

Update a local copy of the PR: \
`$ git checkout pull/23074` \
`$ git pull https://git.openjdk.org/jdk.git pull/23074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23074`

View PR using the GUI difftool: \
`$ git pr show -t 23074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23074.diff">https://git.openjdk.org/jdk/pull/23074.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23074#issuecomment-2587251933)
</details>
