### PR TITLE
8347576: Error output in libjsound has non matching format strings

### DIFF
--- a/src/java.desktop/share/native/libjsound/MidiInDevice.c
+++ b/src/java.desktop/share/native/libjsound/MidiInDevice.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,7 +137,7 @@ Java_com_sun_media_sound_MidiInDevice_nGetTimeStamp(JNIEnv* e, jobject thisObj, 
 
     /* Handle error codes. */
     if (ret < -1) {
-        ERROR1("Java_com_sun_media_sound_MidiInDevice_nGetTimeStamp: MIDI_IN_GetTimeStamp returned %lld\n", ret);
+        ERROR1("Java_com_sun_media_sound_MidiInDevice_nGetTimeStamp: MIDI_IN_GetTimeStamp returned %lld\n", (long long int) ret);
         ret = -1;
     }
     return ret;

--- a/src/java.desktop/share/native/libjsound/MidiOutDevice.c
+++ b/src/java.desktop/share/native/libjsound/MidiOutDevice.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,7 @@ Java_com_sun_media_sound_MidiOutDevice_nGetTimeStamp(JNIEnv* e, jobject thisObj,
 
     /* Handle error codes. */
     if (ret < -1) {
-        ERROR1("Java_com_sun_media_sound_MidiOutDevice_nGetTimeStamp: MIDI_IN_GetTimeStamp returned %lld\n", ret);
+        ERROR1("Java_com_sun_media_sound_MidiOutDevice_nGetTimeStamp: MIDI_IN_GetTimeStamp returned %lld\n", (long long int) ret);
         ret = -1;
     }
     return ret;

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiIn.cpp
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiIn.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiIn.cpp
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiIn.cpp
@@ -55,8 +55,8 @@ void CALLBACK MIDI_IN_PutMessage( HMIDIIN hMidiIn, UINT wMsg, UINT_PTR dwInstanc
 
     MidiDeviceHandle* handle = (MidiDeviceHandle*) dwInstance;
 
-    TRACE3("> MIDI_IN_PutMessage, hMidiIn: %x, wMsg: %x, dwInstance: %x\n", hMidiIn, wMsg, dwInstance);
-    TRACE2("                      dwParam1: %x, dwParam2: %x\n", dwParam1, dwParam2);
+    TRACE3("> MIDI_IN_PutMessage, hMidiIn: %p, wMsg: %x, dwInstance: %p\n", (void*)hMidiIn, wMsg, (void*)dwInstance);
+    TRACE2("                      dwParam1: %p, dwParam2: %p\n", (void*)dwParam1, (void*)dwParam2);
 
     switch(wMsg) {
 
@@ -70,8 +70,8 @@ void CALLBACK MIDI_IN_PutMessage( HMIDIIN hMidiIn, UINT wMsg, UINT_PTR dwInstanc
 
     case MIM_MOREDATA:
     case MIM_DATA:
-        TRACE3("  MIDI_IN_PutMessage: MIM_MOREDATA or MIM_DATA. status=%x  data1=%x  data2=%x\n",
-               dwParam1 & 0xFF, (dwParam1 & 0xFF00)>>8, (dwParam1 & 0xFF0000)>>16);
+        TRACE3("  MIDI_IN_PutMessage: MIM_MOREDATA or MIM_DATA. status=%p  data1=%p  data2=%p\n",
+               (void*)(dwParam1 & 0xFF), (void*)((dwParam1 & 0xFF00)>>8), (void*)((dwParam1 & 0xFF0000)>>16));
         if (handle!=NULL && handle->queue!=NULL && handle->platformData) {
             MIDI_QueueAddShort(handle->queue,
                                // queue stores packedMsg in big endian

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiIn.cpp
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiIn.cpp
@@ -72,8 +72,8 @@ void CALLBACK MIDI_IN_PutMessage( HMIDIIN hMidiIn, UINT wMsg, UINT_PTR dwInstanc
 
     case MIM_MOREDATA:
     case MIM_DATA:
-        TRACE3("  MIDI_IN_PutMessage: MIM_MOREDATA or MIM_DATA. status=0x%" PRIxPTR " data1=0x%" PRIxPTR " data2=0x%" PRIxPTR "\n",
-               (uintptr_t)(dwParam1 & 0xFF), (uintptr_t)((dwParam1 & 0xFF00)>>8), (uintptr_t)((dwParam1 & 0xFF0000)>>16));
+        TRACE3("  MIDI_IN_PutMessage: MIM_MOREDATA or MIM_DATA. status=%x data1=%x data2=%x\n",
+               (int)(dwParam1 & 0xFF), (int)((dwParam1 & 0xFF00)>>8), (int)((dwParam1 & 0xFF0000)>>16));
         if (handle!=NULL && handle->queue!=NULL && handle->platformData) {
             MIDI_QueueAddShort(handle->queue,
                                // queue stores packedMsg in big endian

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiIn.cpp
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_MidiIn.cpp
@@ -47,6 +47,8 @@ extern "C" {
 #define MIDIIN_CHECK_ERROR
 #endif
 
+#include <inttypes.h>
+
 /*
  * Callback from the MIDI device for all messages.
  */
@@ -55,8 +57,8 @@ void CALLBACK MIDI_IN_PutMessage( HMIDIIN hMidiIn, UINT wMsg, UINT_PTR dwInstanc
 
     MidiDeviceHandle* handle = (MidiDeviceHandle*) dwInstance;
 
-    TRACE3("> MIDI_IN_PutMessage, hMidiIn: %p, wMsg: %x, dwInstance: %p\n", (void*)hMidiIn, wMsg, (void*)dwInstance);
-    TRACE2("                      dwParam1: %p, dwParam2: %p\n", (void*)dwParam1, (void*)dwParam2);
+    TRACE3("> MIDI_IN_PutMessage, hMidiIn: 0x%" PRIxPTR ", wMsg: %x, dwInstance: 0x%" PRIxPTR "\n", (uintptr_t)hMidiIn, wMsg, (uintptr_t)dwInstance);
+    TRACE2("                      dwParam1: 0x%" PRIxPTR ", dwParam2: 0x%" PRIxPTR "\n", (uintptr_t)dwParam1, (uintptr_t)dwParam2);
 
     switch(wMsg) {
 
@@ -70,8 +72,8 @@ void CALLBACK MIDI_IN_PutMessage( HMIDIIN hMidiIn, UINT wMsg, UINT_PTR dwInstanc
 
     case MIM_MOREDATA:
     case MIM_DATA:
-        TRACE3("  MIDI_IN_PutMessage: MIM_MOREDATA or MIM_DATA. status=%p  data1=%p  data2=%p\n",
-               (void*)(dwParam1 & 0xFF), (void*)((dwParam1 & 0xFF00)>>8), (void*)((dwParam1 & 0xFF0000)>>16));
+        TRACE3("  MIDI_IN_PutMessage: MIM_MOREDATA or MIM_DATA. status=0x%" PRIxPTR " data1=0x%" PRIxPTR " data2=0x%" PRIxPTR "\n",
+               (uintptr_t)(dwParam1 & 0xFF), (uintptr_t)((dwParam1 & 0xFF00)>>8), (uintptr_t)((dwParam1 & 0xFF0000)>>16));
         if (handle!=NULL && handle->queue!=NULL && handle->platformData) {
             MIDI_QueueAddShort(handle->queue,
                                // queue stores packedMsg in big endian

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Ports.c
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Ports.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Ports.c
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Ports.c
@@ -251,7 +251,7 @@ void printInfo(PortInfo* info) {
     TRACE5(" PortInfo %p: handle=%p, mixerIndex=%d, dstLineCount=%d, dstLines=%p, ", info, (void*) info->handle, info->mixerIndex, info->dstLineCount, info->dstLines);
     TRACE5("srcLineCount=%d, srcLines=%p, targetPortCount=%d, sourcePortCount=%d, ports=%p, ", info->srcLineCount, info->srcLines, info->targetPortCount, info->sourcePortCount, info->ports);
     TRACE3("maxControlCount=%d, usedControlIDs=%d, controlIDs=%p \n", info->maxControlCount, info->usedControlIDs, info->controlIDs);
-    TRACE2("usedMuxData=%d, muxData=%p, controlIDs=%p \n", info->usedMuxData, info->muxData);
+    TRACE3("usedMuxData=%d, muxData=%p, controlIDs=%p \n", info->usedMuxData, info->muxData, info->controlIDs);
 }
 
 #endif // USE_TRACE


### PR DESCRIPTION
When enabling the jsound ERROR and TRACE reporting (see src/java.desktop/share/native/libjsound/Configure.h https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/native/libjsound/Configure.h#L32 ), we run into some build warnings as errors  (when building on Linux) because at 2 places the format specifiers do not match the number types .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347576](https://bugs.openjdk.org/browse/JDK-8347576): Error output in libjsound has non matching format strings (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) Review applies to [e2b414ed](https://git.openjdk.org/jdk/pull/23076/files/e2b414eda48482917ef381a508a7be1872076efd)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) Review applies to [d5a9f0fa](https://git.openjdk.org/jdk/pull/23076/files/d5a9f0fa3f8a6729003df27b4949f4b262dec00c)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23076/head:pull/23076` \
`$ git checkout pull/23076`

Update a local copy of the PR: \
`$ git checkout pull/23076` \
`$ git pull https://git.openjdk.org/jdk.git pull/23076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23076`

View PR using the GUI difftool: \
`$ git pr show -t 23076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23076.diff">https://git.openjdk.org/jdk/pull/23076.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23076#issuecomment-2587339078)
</details>
