### PR TITLE
8347496: Test jdk/jfr/jvm/TestModularImage.java fails after JDK-8347124: No javac

### DIFF
--- a/test/jdk/jdk/jfr/jvm/TestModularImage.java
+++ b/test/jdk/jdk/jfr/jvm/TestModularImage.java
@@ -43,6 +43,7 @@ import jdk.test.lib.process.ProcessTools;
  *          as expected
  * @requires vm.hasJFR
  * @library /test/lib
+ * @modules jdk.compiler jdk.jlink
  * @comment Test is being run in othervm to support JEP 493 enabled
  *          JDKs which don't allow patched modules. Note that jtreg patches
  *          module java.base to add java.lang.JTRegModuleHelper. If then a


### PR DESCRIPTION
Please review this test-only fix. Apparently there are some test configurations out there that run `jdk/jfr/jvm/TestModularImage.java` with limited modules. Specifically `--limit-modules java.base,jdk.jfr`. For this particular test that is not sufficient to be able to run the test. `TestModularImage.java` uses the `ToolProvider` API to get a hold of `javac` as well as for `jlink` without them being present the test should be skipped.

I've done that by adding those two required modules in the `@modules` tag.

Testing:
- [x] GHA
- [x] `jdk/jfr/jvm/TestModularImage.java` with test option `--limit-modules jdk.jfr,java.base` which now skips the test (instead of failing the test). Running `TestModularImage.java` without the `--limit-modules` option and it passes.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347496](https://bugs.openjdk.org/browse/JDK-8347496): Test jdk/jfr/jvm/TestModularImage.java fails after JDK-8347124: No javac (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23079/head:pull/23079` \
`$ git checkout pull/23079`

Update a local copy of the PR: \
`$ git checkout pull/23079` \
`$ git pull https://git.openjdk.org/jdk.git pull/23079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23079`

View PR using the GUI difftool: \
`$ git pr show -t 23079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23079.diff">https://git.openjdk.org/jdk/pull/23079.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23079#issuecomment-2587479241)
</details>
