### PR TITLE
8347597: HttpClient: improve exception reporting when closing connection

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/AsyncSSLConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/AsyncSSLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ class AsyncSSLConnection extends AbstractAsyncSSLConnection {
                     if (ex == null) {
                         return plainConnection.finishConnect();
                     } else {
-                        plainConnection.close();
+                        plainConnection.close(ex);
                         return MinimalFuture.<Void>failedFuture(ex);
                     } })
                 .thenCompose(Function.identity());

--- a/src/java.net.http/share/classes/jdk/internal/net/http/AsyncSSLTunnelConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/AsyncSSLTunnelConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ class AsyncSSLTunnelConnection extends AbstractAsyncSSLConnection {
                     if (ex == null) {
                         return plainConnection.finishConnect();
                     } else {
-                        plainConnection.close();
+                        plainConnection.close(ex);
                         return MinimalFuture.<Void>failedFuture(ex);
                     } })
                 .thenCompose(Function.identity());

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -285,7 +285,7 @@ class Http1Response<T> {
 
     // Used for those response codes that have no body associated
     public void nullBody(HttpResponse<T> resp, Throwable t) {
-        if (t != null) connection.close();
+        if (t != null) connection.close(t);
         else {
             return2Cache = !request.isWebSocket();
             onFinished();
@@ -331,7 +331,7 @@ class Http1Response<T> {
                 );
                 if (cf.isCompletedExceptionally()) {
                     // if an error occurs during subscription
-                    connection.close();
+                    connection.close(cf.exceptionNow());
                     return;
                 }
                 // increment the reference count on the HttpClientImpl
@@ -352,7 +352,7 @@ class Http1Response<T> {
                         } finally {
                             bodyReader.onComplete(t);
                             if (t != null) {
-                                connection.close();
+                                connection.close(t);
                             }
                         }
                     });
@@ -471,7 +471,7 @@ class Http1Response<T> {
             debug.log(Level.DEBUG, "onReadError", t);
         }
         debug.log(Level.DEBUG, () -> "closing connection: cause is " + t);
-        connection.close();
+        connection.close(t);
     }
 
     // ========================================================================

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -725,7 +725,10 @@ class Stream<T> extends ExchangeImpl<T> {
                 debug.log("completing requestBodyCF exceptionally due to received" +
                         " RESET(%s) (stream=%s)", frame.getErrorCode(), streamid);
             }
-            requestBodyCF.completeExceptionally(new IOException("RST_STREAM received"));
+            var exception = new IOException("RST_STREAM received " +
+                    ResetFrame.stringForCode(frame.getErrorCode()));
+            requestBodyCF.completeExceptionally(exception);
+            cancelImpl(exception, frame.getErrorCode());
         } else {
             if (debug.on()) {
                 debug.log("completing requestBodyCF normally due to received" +

--- a/test/jdk/java/net/httpclient/AbstractThrowingPublishers.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingPublishers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,6 @@
  * questions.
  */
 
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
-import com.sun.net.httpserver.HttpsServer;
 import jdk.test.lib.net.SimpleSSLContext;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
@@ -40,8 +37,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -73,7 +68,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.String.format;
 import static java.lang.System.out;
@@ -479,10 +473,12 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
                     // synchronous send will rethrow exceptions
                     Throwable throwable = t.getCause();
                     assert throwable != null;
-
-                    if (thrower.test(where, throwable)) {
-                        System.out.println(now() + "Got expected exception: " + throwable);
-                    } else throw causeNotFound(where, t);
+                    Throwable cause = findCause(where, throwable, thrower);
+                    if (cause == null) {
+                        throw causeNotFound(where, t);
+                    } else {
+                        System.out.println(now() + "Got expected exception: " + cause);
+                    }
                 }
             }
             if (response != null) {

--- a/test/jdk/java/net/httpclient/FlowAdapterPublisherTest.java
+++ b/test/jdk/java/net/httpclient/FlowAdapterPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,8 +233,12 @@ public class FlowAdapterPublisherTest implements HttpServerAdapters {
     }
 
     private void assertMessage(Throwable t, String contains) {
-        if (!t.getMessage().contains(contains)) {
-            String error = "Exception message:[" + t.toString() + "] doesn't contain [" + contains + "]";
+        Throwable cause = t;
+        do {
+            if (cause.getMessage().contains(contains)) break;
+        } while ((cause = cause.getCause()) != null);
+        if (cause == null) {
+            String error = "Exception message:[" + t + "] doesn't contain [" + contains + "]";
             throw new AssertionError(error, t);
         }
     }

--- a/test/jdk/java/net/httpclient/http2/ExpectContinueResetTest.java
+++ b/test/jdk/java/net/httpclient/http2/ExpectContinueResetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,6 +73,7 @@ public class ExpectContinueResetTest {
     URI warmup, partialResponseResetNoError, partialResponseResetError, fullResponseResetNoError, fullResponseResetError;
 
     static PrintStream err = new PrintStream(System.err);
+    static PrintStream out = System.out;
 
     @DataProvider(name = "testData")
     public Object[][] testData() {
@@ -88,15 +89,19 @@ public class ExpectContinueResetTest {
 
     @Test(dataProvider = "testData")
     public void test(URI uri) {
+        out.printf("\nTesting with Version: %s, URI: %s\n", HTTP_2, uri.toASCIIString());
         err.printf("\nTesting with Version: %s, URI: %s\n", HTTP_2, uri.toASCIIString());
         Iterable<byte[]> iterable = EndlessDataChunks::new;
         HttpRequest.BodyPublisher testPub = HttpRequest.BodyPublishers.ofByteArrays(iterable);
+        Exception exception = null;
         Throwable testThrowable = null;
         try {
             performRequest(testPub, uri);
         } catch (Exception e) {
+            exception = e;
             testThrowable = e.getCause();
         }
+        assertNotNull(exception, "Request should have completed exceptionally but exception is null");
         assertNotNull(testThrowable, "Request should have completed exceptionally but testThrowable is null");
         assertEquals(testThrowable.getClass(), IOException.class, "Test should have closed with an IOException");
         testThrowable.printStackTrace();
@@ -177,7 +182,7 @@ public class ExpectContinueResetTest {
         @Override
         public void handle(Http2TestExchange exchange) throws IOException {
             err.println("Sending 100");
-            exchange.sendResponseHeaders(100, 0);
+            exchange.sendResponseHeaders(100, -1);
             if (exchange instanceof ExpectContinueResetTestExchangeImpl testExchange) {
                 err.println("Sending Reset");
                 err.println(exchange.getRequestURI().getPath());
@@ -197,8 +202,9 @@ public class ExpectContinueResetTest {
         @Override
         public void handle(Http2TestExchange exchange) throws IOException {
             err.println("Sending 100");
-            exchange.sendResponseHeaders(100, 0);
+            exchange.sendResponseHeaders(100, -1);
             err.println("Sending 200");
+
             exchange.sendResponseHeaders(200, 0);
             if (exchange instanceof ExpectContinueResetTestExchangeImpl testExchange) {
                 err.println("Sending Reset");


### PR DESCRIPTION
There are a few places in the HttpClient code base where we close the connection when some error/exception happens. This can some time trigger a race condition where closing the connection in turns causes a "connection closed locally" exception to get reported instead of the original exception. This typically happens if another thread is attempting to read from / write to the connection concurrently when the original exception that caused the connection to get closed occurred. 

The fix makes sure that we store the first exception in the underlying connection before closing it, and that this is the exception that gets subsequently reported.

Some minor drive by test fixes. No new regression test.