### PR TITLE
8347491: IllegalArgumentationException thrown by ThreadPoolExecutor doesn't have a useful message

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
@@ -1261,7 +1261,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
         if (maximumPoolSize <= 0 || maximumPoolSize < corePoolSize)
             throw new IllegalArgumentException("maximumPoolSize must be positive and greater-or-equal to corePoolSize");
         if (keepAliveTime < 0)
-            throw new IllegalArgumentException("keepAliveTime must not be negative");
+            throw new IllegalArgumentException("keepAliveTime must be non-negative");
 
         Objects.requireNonNull(workQueue, "workQueue");
         Objects.requireNonNull(threadFactory, "threadFactory");

--- a/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
@@ -1256,13 +1256,17 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
                               BlockingQueue<Runnable> workQueue,
                               ThreadFactory threadFactory,
                               RejectedExecutionHandler handler) {
-        if (corePoolSize < 0 ||
-            maximumPoolSize <= 0 ||
-            maximumPoolSize < corePoolSize ||
-            keepAliveTime < 0)
-            throw new IllegalArgumentException();
-        if (workQueue == null || threadFactory == null || handler == null)
-            throw new NullPointerException();
+        if (corePoolSize < 0)
+            throw new IllegalArgumentException("corePoolSize must be non-negative");
+        if (maximumPoolSize <= 0 || maximumPoolSize < corePoolSize)
+            throw new IllegalArgumentException("maximumPoolSize must be positive and greater-or-equal to corePoolSize");
+        if (keepAliveTime < 0)
+            throw new IllegalArgumentException("keepAliveTime must not be negative");
+
+        Objects.requireNonNull(workQueue, "workQueue");
+        Objects.requireNonNull(threadFactory, "threadFactory");
+        Objects.requireNonNull(handler, "handler");
+
         this.corePoolSize = corePoolSize;
         this.maximumPoolSize = maximumPoolSize;
         this.workQueue = workQueue;
@@ -1289,8 +1293,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      * @throws NullPointerException if {@code command} is null
      */
     public void execute(Runnable command) {
-        if (command == null)
-            throw new NullPointerException();
+        Objects.requireNonNull(command, "command");
         /*
          * Proceed in 3 steps:
          *
@@ -1451,9 +1454,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      * @see #getThreadFactory
      */
     public void setThreadFactory(ThreadFactory threadFactory) {
-        if (threadFactory == null)
-            throw new NullPointerException();
-        this.threadFactory = threadFactory;
+        this.threadFactory = Objects.requireNonNull(threadFactory, "threadFactory");
     }
 
     /**
@@ -1474,9 +1475,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      * @see #getRejectedExecutionHandler
      */
     public void setRejectedExecutionHandler(RejectedExecutionHandler handler) {
-        if (handler == null)
-            throw new NullPointerException();
-        this.handler = handler;
+        this.handler = Objects.requireNonNull(handler, "handler");
     }
 
     /**
@@ -1503,8 +1502,10 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      * @see #getCorePoolSize
      */
     public void setCorePoolSize(int corePoolSize) {
-        if (corePoolSize < 0 || maximumPoolSize < corePoolSize)
-            throw new IllegalArgumentException();
+        if (corePoolSize < 0)
+            throw new IllegalArgumentException("corePoolSize must be non-negative");
+        if (maximumPoolSize < corePoolSize)
+            throw new IllegalArgumentException("corePoolSize must be lesser-or-equal to maximumPoolSize");
         int delta = corePoolSize - this.corePoolSize;
         this.corePoolSize = corePoolSize;
         if (workerCountOf(ctl.get()) > corePoolSize)
@@ -1629,7 +1630,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setMaximumPoolSize(int maximumPoolSize) {
         if (maximumPoolSize <= 0 || maximumPoolSize < corePoolSize)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("maximumPoolSize must be positive and greater-or-equal to corePoolSize");
         this.maximumPoolSize = maximumPoolSize;
         if (workerCountOf(ctl.get()) > maximumPoolSize)
             interruptIdleWorkers();
@@ -1663,7 +1664,7 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
      */
     public void setKeepAliveTime(long time, TimeUnit unit) {
         if (time < 0)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("time must be non-negative");
         if (time == 0 && allowsCoreThreadTimeOut())
             throw new IllegalArgumentException("Core threads must have nonzero keep alive times");
         long keepAliveTime = unit.toNanos(time);

--- a/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
+++ b/test/jdk/java/util/concurrent/tck/ThreadPoolExecutorTest.java
@@ -737,7 +737,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(-1, 1, 1L, SECONDS,
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals("corePoolSize must be non-negative", success.getMessage());
+        }
     }
 
     /**
@@ -748,7 +750,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(1, -1, 1L, SECONDS,
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -759,7 +766,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(1, 0, 1L, SECONDS,
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -770,7 +782,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(1, 2, -1L, SECONDS,
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals("keepAliveTime must be non-negative", success.getMessage());
+        }
     }
 
     /**
@@ -781,7 +795,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(2, 1, 1L, SECONDS,
                                    new ArrayBlockingQueue<Runnable>(10));
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -792,7 +811,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             new ThreadPoolExecutor(1, 2, 1L, SECONDS,
                                    (BlockingQueue<Runnable>) null);
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            assertEquals("workQueue", success.getMessage());
+        }
     }
 
     /**
@@ -804,7 +825,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals("corePoolSize must be non-negative", success.getMessage());
+        }
     }
 
     /**
@@ -816,7 +839,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -828,7 +856,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -840,7 +873,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals("keepAliveTime must be non-negative", success.getMessage());
+        }
     }
 
     /**
@@ -852,7 +887,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -864,7 +904,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (BlockingQueue<Runnable>) null,
                                    new SimpleThreadFactory());
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            assertEquals("workQueue", success.getMessage());
+        }
     }
 
     /**
@@ -876,7 +918,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    (ThreadFactory) null);
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            assertEquals("threadFactory", success.getMessage());
+        }
     }
 
     /**
@@ -888,7 +932,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals("corePoolSize must be non-negative", success.getMessage());
+        }
     }
 
     /**
@@ -900,7 +946,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -912,7 +963,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -924,7 +980,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals("keepAliveTime must be non-negative", success.getMessage());
+        }
     }
 
     /**
@@ -936,7 +994,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -948,7 +1011,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (BlockingQueue<Runnable>) null,
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            assertEquals("workQueue", success.getMessage());
+        }
     }
 
     /**
@@ -960,7 +1025,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new ArrayBlockingQueue<Runnable>(10),
                                    (RejectedExecutionHandler) null);
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            assertEquals("handler", success.getMessage());
+        }
     }
 
     /**
@@ -973,7 +1040,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals("corePoolSize must be non-negative", success.getMessage());
+        }
     }
 
     /**
@@ -986,7 +1055,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -999,7 +1073,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -1012,7 +1091,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals("keepAliveTime must be non-negative", success.getMessage());
+        }
     }
 
     /**
@@ -1025,7 +1106,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (IllegalArgumentException success) {}
+        } catch (IllegalArgumentException success) {
+            assertEquals(
+                "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                success.getMessage()
+            );
+        }
     }
 
     /**
@@ -1038,7 +1124,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            assertEquals("workQueue", success.getMessage());
+        }
     }
 
     /**
@@ -1051,7 +1139,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    new SimpleThreadFactory(),
                                    (RejectedExecutionHandler) null);
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            assertEquals("handler", success.getMessage());
+        }
     }
 
     /**
@@ -1064,7 +1154,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                                    (ThreadFactory) null,
                                    new NoOpREHandler());
             shouldThrow();
-        } catch (NullPointerException success) {}
+        } catch (NullPointerException success) {
+            assertEquals("threadFactory", success.getMessage());
+        }
     }
 
     /**
@@ -1228,7 +1320,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 p.setCorePoolSize(-1);
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                assertEquals("corePoolSize must be non-negative", success.getMessage());
+            }
         }
     }
 
@@ -1245,7 +1339,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 p.setMaximumPoolSize(1);
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                assertEquals(
+                    "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                    success.getMessage()
+                );
+            }
         }
     }
 
@@ -1262,7 +1361,12 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 p.setMaximumPoolSize(-1);
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                assertEquals(
+                    "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                    success.getMessage()
+                );
+            }
         }
     }
 
@@ -1282,13 +1386,23 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
                 try {
                     p.setMaximumPoolSize(s - 1);
                     shouldThrow();
-                } catch (IllegalArgumentException success) {}
+                } catch (IllegalArgumentException success) {
+                    assertEquals(
+                        "maximumPoolSize must be positive and greater-or-equal to corePoolSize",
+                        success.getMessage()
+                    );
+                }
                 assertEquals(s, p.getCorePoolSize());
                 assertEquals(s, p.getMaximumPoolSize());
                 try {
                     p.setCorePoolSize(s + 1);
                     shouldThrow();
-                } catch (IllegalArgumentException success) {}
+                } catch (IllegalArgumentException success) {
+                    assertEquals(
+                        "corePoolSize must be lesser-or-equal to maximumPoolSize",
+                        success.getMessage()
+                    );
+                }
                 assertEquals(s, p.getCorePoolSize());
                 assertEquals(s, p.getMaximumPoolSize());
             }
@@ -1308,7 +1422,9 @@ public class ThreadPoolExecutorTest extends JSR166TestCase {
             try {
                 p.setKeepAliveTime(-1, MILLISECONDS);
                 shouldThrow();
-            } catch (IllegalArgumentException success) {}
+            } catch (IllegalArgumentException success) {
+                assertEquals("time must be non-negative", success.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
Seems sensible to improve this given that it can be tricky to figure out which parameter caused the exception to be thrown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347491](https://bugs.openjdk.org/browse/JDK-8347491): IllegalArgumentationException thrown by ThreadPoolExecutor doesn't have a useful message (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23081/head:pull/23081` \
`$ git checkout pull/23081`

Update a local copy of the PR: \
`$ git checkout pull/23081` \
`$ git pull https://git.openjdk.org/jdk.git pull/23081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23081`

View PR using the GUI difftool: \
`$ git pr show -t 23081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23081.diff">https://git.openjdk.org/jdk/pull/23081.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23081#issuecomment-2587612482)
</details>
