### PR TITLE
8347596: Update HSS/LMS public key encoding

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/HSS.java
+++ b/src/java.base/share/classes/sun/security/provider/HSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -757,12 +757,8 @@ public final class HSS extends SignatureSpi {
                                 Arrays.copyOfRange(keyArray, 4, keyArray.length),
                                 0, true);
                 algid = new AlgorithmId(ObjectIdentifier.of(KnownOIDs.HSSLMS));
-                byte[] derEncodedKeyarray =
-                        new DerOutputStream()
-                                .putOctetString(keyArray)
-                                .toByteArray();
                 this.setKey(new BitArray(
-                        8 * derEncodedKeyarray.length, derEncodedKeyarray));
+                        8 * keyArray.length, keyArray));
             }
         }
 
@@ -783,11 +779,18 @@ public final class HSS extends SignatureSpi {
         @Override
         protected void parseKeyBits() throws InvalidKeyException {
             byte[] keyArray = getKey().toByteArray();
-            if ((keyArray[0] != DerValue.tag_OctetString) || (keyArray[1] != keyArray.length -2)) {
-                throw new InvalidKeyException("Bad X509Key");
+            // Check less than minimum length to make sure this method works as expected
+            if (keyArray.length < 12) {
+                throw new InvalidKeyException("LMS public key is too short");
             }
-            L = LMSUtils.fourBytesToInt(keyArray, 2);
-            lmsPublicKey = new LMSPublicKey(keyArray, 6, true);
+            if (keyArray[0] == DerValue.tag_OctetString
+                    && keyArray[1] == keyArray.length - 2) {
+                // pre-8347596 format that has an inner OCTET STRING.
+                keyArray = Arrays.copyOfRange(keyArray, 2, keyArray.length);
+                setKey(new BitArray(keyArray.length * 8, keyArray));
+            }
+            L = LMSUtils.fourBytesToInt(keyArray, 0);
+            lmsPublicKey = new LMSPublicKey(keyArray, 4, true);
         }
 
         @java.io.Serial

--- a/src/java.base/share/classes/sun/security/provider/HSS.java
+++ b/src/java.base/share/classes/sun/security/provider/HSS.java
@@ -779,8 +779,7 @@ public final class HSS extends SignatureSpi {
         @Override
         protected void parseKeyBits() throws InvalidKeyException {
             byte[] keyArray = getKey().toByteArray();
-            // Check less than minimum length to make sure this method works as expected
-            if (keyArray.length < 12) {
+            if (keyArray.length < 12) { // More length check in LMSPublicKey
                 throw new InvalidKeyException("LMS public key is too short");
             }
             if (keyArray[0] == DerValue.tag_OctetString

--- a/src/java.base/share/classes/sun/security/util/KeyUtil.java
+++ b/src/java.base/share/classes/sun/security/util/KeyUtil.java
@@ -403,7 +403,7 @@ public final class KeyUtil {
         try {
             DerValue val = new DerValue(publicKey.getEncoded());
             val.data.getDerValue();
-            byte[] rawKey = new DerValue(val.data.getBitString()).getOctetString();
+            byte[] rawKey = val.data.getBitString();
             // According to https://www.rfc-editor.org/rfc/rfc8554.html:
             // Section 6.1: HSS public key is u32str(L) || pub[0], where pub[0]
             // is the LMS public key for the top-level tree.


### PR DESCRIPTION
Update the encoding of HSS/LMS public key to be consistent with https://www.rfc-editor.org/rfc/rfc9708.html#name-changes-since-rfc-8708 and https://datatracker.ietf.org/doc/html/draft-ietf-lamps-x509-shbs-13#name-hss-public-keys.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347596](https://bugs.openjdk.org/browse/JDK-8347596): Update HSS/LMS public key encoding (**Bug** - P3)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23083/head:pull/23083` \
`$ git checkout pull/23083`

Update a local copy of the PR: \
`$ git checkout pull/23083` \
`$ git pull https://git.openjdk.org/jdk.git pull/23083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23083`

View PR using the GUI difftool: \
`$ git pr show -t 23083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23083.diff">https://git.openjdk.org/jdk/pull/23083.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23083#issuecomment-2587781045)
</details>
