### PR TITLE
8347286: (fs) Remove some extensions from java/nio/file/Files/probeContentType/Basic.java

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -189,18 +189,8 @@ public class Basic {
         exTypes.add(new ExType("xlsx", List.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")));
         exTypes.add(new ExType("wasm", List.of("application/wasm")));
 
-        // extensions with content type that differs on Windows 11+ and
-        // Windows Server 2025
-        if (OperatingSystem.isWindows() &&
-            (StaticProperty.osName().matches("^.*[11|2025]$") ||
-                new OSVersion(10, 0).compareTo(OSVersion.current()) > 0)) {
-            System.out.println("Windows 11+ detected: using different types");
-            exTypes.add(new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip", "application/x-compressed")));
-            exTypes.add(new ExType("csv", List.of("text/csv", "application/vnd.ms-excel")));
-            exTypes.add(new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar", "application/x-rar-compressed", "application/x-compressed")));
-            exTypes.add(new ExType("rtf", List.of("application/rtf", "text/rtf", "application/msword")));
-            exTypes.add(new ExType("7z", List.of("application/x-7z-compressed", "application/x-compressed")));
-        } else {
+        // extensions with consistent content type on Unix (but not on Windows)
+        if (!OperatingSystem.isWindows()) {
             exTypes.add(new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip")));
             exTypes.add(new ExType("csv", List.of("text/csv")));
             exTypes.add(new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar", "application/x-rar-compressed")));

--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import jdk.internal.util.OperatingSystem;
-import jdk.internal.util.OSVersion;
 import jdk.internal.util.StaticProperty;
 
 /**


### PR DESCRIPTION
Remove testing on Windows of file extensions which do not consistently map to the same content type across different versions of Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347286](https://bugs.openjdk.org/browse/JDK-8347286): (fs) Remove some extensions from java/nio/file/Files/probeContentType/Basic.java (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) Review applies to [b25fa735](https://git.openjdk.org/jdk/pull/23085/files/b25fa735223018867ffa3480535cd0105370a918)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23085/head:pull/23085` \
`$ git checkout pull/23085`

Update a local copy of the PR: \
`$ git checkout pull/23085` \
`$ git pull https://git.openjdk.org/jdk.git pull/23085/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23085`

View PR using the GUI difftool: \
`$ git pr show -t 23085`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23085.diff">https://git.openjdk.org/jdk/pull/23085.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23085#issuecomment-2588004852)
</details>
