### PR TITLE
8347613: Remove leftover doPrivileged call in Currency test: CheckDataVersion.java

### DIFF
--- a/test/jdk/java/util/Currency/CheckDataVersion.java
+++ b/test/jdk/java/util/Currency/CheckDataVersion.java
@@ -76,7 +76,7 @@ class CheckDataVersion {
                 System.out.println("test: (file: "+fileVersion+" data: "+dataVersion+"), JRE: (file: "+fileVerNumber+" data: "+dataVerNumber+")");
             } catch (IOException ioe) {
                 throw new RuntimeException(
-                        "CheckDataVersion was not set up properly: " + ioe);
+                        "currency.data was not retrieved properly", ioe);
             }
             checked = true;
         }

--- a/test/jdk/java/util/Currency/CheckDataVersion.java
+++ b/test/jdk/java/util/Currency/CheckDataVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Currency;
 
 class CheckDataVersion {
@@ -63,33 +61,23 @@ class CheckDataVersion {
                         break;
                     }
                 }
-            } catch (IOException ioe) {
-                throw new RuntimeException(ioe);
-            }
-
-            AccessController.doPrivileged(new PrivilegedAction<Object>() {
-                public Object run() {
-                    try {
-                        InputStream in = Currency.class.getModule().getResourceAsStream("java/util/currency.data");
-                        String sep = File.separator;
-                        DataInputStream dis = new DataInputStream(in);
-                        int magic = dis.readInt();
-                        if (magic != 0x43757244) {
-                            throw new RuntimeException("The magic number in the JRE's currency data is incorrect.  Expected: 0x43757244, Got: 0x"+magic);
-                        }
-                        int fileVerNumber = dis.readInt();
-                        int dataVerNumber = dis.readInt();
-                        if (Integer.parseInt(fileVersion) != fileVerNumber ||
-                            Integer.parseInt(dataVersion) != dataVerNumber) {
-                            throw new RuntimeException("Test data and JRE's currency data are inconsistent.  test: (file: "+fileVersion+" data: "+dataVersion+"), JRE: (file: "+fileVerNumber+" data: "+dataVerNumber+")");
-                        }
-System.out.println("test: (file: "+fileVersion+" data: "+dataVersion+"), JRE: (file: "+fileVerNumber+" data: "+dataVerNumber+")");
-                    } catch (IOException ioe) {
-                        throw new RuntimeException(ioe);
-                    }
-                    return null;
+                InputStream JREdata = Currency.class.getModule().getResourceAsStream("java/util/currency.data");
+                DataInputStream dis = new DataInputStream(JREdata);
+                int magic = dis.readInt();
+                if (magic != 0x43757244) {
+                    throw new RuntimeException("The magic number in the JRE's currency data is incorrect.  Expected: 0x43757244, Got: 0x"+magic);
                 }
-            });
+                int fileVerNumber = dis.readInt();
+                int dataVerNumber = dis.readInt();
+                if (Integer.parseInt(fileVersion) != fileVerNumber ||
+                        Integer.parseInt(dataVersion) != dataVerNumber) {
+                    throw new RuntimeException("Test data and JRE's currency data are inconsistent.  test: (file: "+fileVersion+" data: "+dataVersion+"), JRE: (file: "+fileVerNumber+" data: "+dataVerNumber+")");
+                }
+                System.out.println("test: (file: "+fileVersion+" data: "+dataVersion+"), JRE: (file: "+fileVerNumber+" data: "+dataVerNumber+")");
+            } catch (IOException ioe) {
+                throw new RuntimeException(
+                        "CheckDataVersion was not set up properly: " + ioe);
+            }
             checked = true;
         }
     }


### PR DESCRIPTION
Please review this PR which removes a leftover `doPrivileged` call in the Currency test, _CheckDataVersion.java_.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347613](https://bugs.openjdk.org/browse/JDK-8347613): Remove leftover doPrivileged call in Currency test: CheckDataVersion.java (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23087/head:pull/23087` \
`$ git checkout pull/23087`

Update a local copy of the PR: \
`$ git checkout pull/23087` \
`$ git pull https://git.openjdk.org/jdk.git pull/23087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23087`

View PR using the GUI difftool: \
`$ git pr show -t 23087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23087.diff">https://git.openjdk.org/jdk/pull/23087.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23087#issuecomment-2588282799)
</details>
