### PR TITLE
8347376: tools/jlink/runtimeImage/JavaSEReproducibleTest.java and PackagedModulesVsRuntimeImageLinkTest.java failed after JDK-8321413

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ModuleDescriptorBuilder.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ModuleDescriptorBuilder.java
@@ -277,7 +277,7 @@ class ModuleDescriptorBuilder implements IndexedElementSnippetBuilder<ModuleInfo
                     .classBuilder(clb)
                     .ownerClassDesc(ownerClassDesc)
                     .enablePagination("module" + index + "Provides")
-                    .build(builder.buildAll(md.provides()));
+                    .build(builder.buildAll(sorted(md.provides())));
         }
 
         private Snippet buildPackagesSet(ClassBuilder clb, Collection<String> packages) {

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -716,9 +716,6 @@ javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
 
 # core_tools
 
-tools/jlink/runtimeImage/JavaSEReproducibleTest.java 8347376 generic-all
-tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java 8347376 generic-all
-
 ############################################################################
 
 # core_svc


### PR DESCRIPTION
Sort services provided by a module to ensure reproduce same result.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347376](https://bugs.openjdk.org/browse/JDK-8347376): tools/jlink/runtimeImage/JavaSEReproducibleTest.java and PackagedModulesVsRuntimeImageLinkTest.java failed after JDK-8321413 (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23088/head:pull/23088` \
`$ git checkout pull/23088`

Update a local copy of the PR: \
`$ git checkout pull/23088` \
`$ git pull https://git.openjdk.org/jdk.git pull/23088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23088`

View PR using the GUI difftool: \
`$ git pr show -t 23088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23088.diff">https://git.openjdk.org/jdk/pull/23088.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23088#issuecomment-2588317714)
</details>
