### PR TITLE
C2 does not do constant-folding of xor

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -983,6 +983,11 @@ const Type* XorINode::Value(PhaseGVN* phase) const {
   // inputs have bits set. lo can always become 0.
   const TypeInt* t1i = t1->is_int();
   const TypeInt* t2i = t2->is_int();
+
+  if( t1i->is_con() && t2i->is_con() ) {
+    return TypeInt::make( t1i->get_con() ^ t2i->get_con() );
+  }
+
   if ((t1i->_lo >= 0) &&
       (t1i->_hi > 0)  &&
       (t2i->_lo >= 0) &&
@@ -1068,6 +1073,11 @@ const Type* XorLNode::Value(PhaseGVN* phase) const {
   // inputs have bits set. lo can always become 0.
   const TypeLong* t1l = t1->is_long();
   const TypeLong* t2l = t2->is_long();
+
+  if( t1l->is_con() && t2l->is_con() ){
+    return TypeLong::make( t1l->get_con() ^ t2l->get_con() );
+  }
+
   if ((t1l->_lo >= 0) &&
       (t1l->_hi > 0)  &&
       (t2l->_lo >= 0) &&

--- a/test/hotspot/jtreg/compiler/c2/irTests/ConstFoldingTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ConstFoldingTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @summary verify that constant folding is done on xor
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.c2.irTests.ConstFoldingTests
+ */
+
+public class ConstFoldingTests {
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @IR(failOn = {IRNode.XOR})
+    @IR(counts = {IRNode.CON_I, "1"})
+    // Checks (c1 ^c2)  => c3 (constant folded)
+    public int testConstXorI() {
+        int c = 42;
+        return c ^ 2025;
+    }
+
+    @Test
+    @IR(failOn = {IRNode.XOR})
+    @IR(counts = {IRNode.CON_L, "1"})
+    // Checks (c1 ^ c2)  => c3 (constant folded)
+    public long testConstXorL() {
+        long c = 42;
+        return c ^ 2025;
+    }
+
+}


### PR DESCRIPTION
C2 does not eliminate XOR nodes when it's arguments are constants. This has a noticeable effect on `Long.expand` on architectures that don't have instructions equivalent `PDEP` to be used in an intrinsic.

This patch demonstrates a potential fix to the problem, but there might well be better ways to do it.
