### PR TITLE
8342062: Reformat keytool and jarsigner output for keys with a named parameter set

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Resources.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -307,10 +307,12 @@ public class Resources extends java.util.ListResourceBundle {
                 "Specifying -keysize for generating EC keys is deprecated, please use \"-groupname %s\" instead."},
         {"Key.pair.not.generated.alias.alias.already.exists",
                 "Key pair not generated, alias <{0}> already exists"},
-        {"Generating.keysize.bit.keyAlgName.key.pair.and.self.signed.certificate.sigAlgName.with.a.validity.of.validality.days.for",
-                "Generating {0} bit {1} key pair and self-signed certificate ({2}) with a validity of {3} days\n\tfor: {4}"},
-        {"Generating.keysize.bit.keyAlgName.key.pair.and.a.certificate.sigAlgName.issued.by.signerAlias.with.a.validity.of.validality.days.for",
-                "Generating {0} bit {1} key pair and a certificate ({2}) issued by <{3}> with a validity of {4} days\n\tfor: {5}"},
+        {"size.bit.alg",
+                "%1$d-bit %2$s"},
+        {"Generating.full.keyAlgName.key.pair.and.self.signed.certificate.sigAlgName.with.a.validity.of.days.for",
+                "Generating {0} key pair and self-signed certificate ({1}) with a validity of {2} days\n\tfor: {3}"},
+        {"Generating.full.keyAlgName.key.pair.and.a.certificate.sigAlgName.issued.by.signerAlias.with.a.validity.of.days.for",
+                "Generating {0} key pair and a certificate ({1}) issued by <{2}> with a validity of {3} days\n\tfor: {4}"},
         {"Enter.key.password.for.alias.", "Enter key password for <{0}>"},
         {".RETURN.if.same.as.keystore.password.",
                 "\t(RETURN if same as keystore password):  "},
@@ -479,10 +481,9 @@ public class Resources extends java.util.ListResourceBundle {
         {"alias.in.keystore", "Issuer <%s>"},
         {"with.weak", "%s (weak)"},
         {"with.disabled", "%s (disabled)"},
-        {"key.bit", "%1$d-bit %2$s key"},
-        {"key.bit.weak", "%1$d-bit %2$s key (weak)"},
-        {"key.bit.disabled", "%1$d-bit %2$s key (disabled)"},
-        {"unknown.size.1", "%s key of unknown size"},
+        {"key.bit", "%s key"},
+        {"key.bit.weak", "%s key (weak)"},
+        {"key.bit.disabled", "%s key (disabled)"},
         {".PATTERN.printX509Cert.with.weak",
                 "Owner: {0}\nIssuer: {1}\nSerial number: {2}\nValid from: {3} until: {4}\nCertificate fingerprints:\n\t SHA1: {5}\n\t SHA256: {6}\nSignature algorithm name: {7}\nSubject Public Key Algorithm: {8}\nVersion: {9}"},
         {"PKCS.10.with.weak",
@@ -494,7 +495,7 @@ public class Resources extends java.util.ListResourceBundle {
         {"Unable.to.parse.denyAfter.string.in.exception.message", "Unable to parse denyAfter date string in exception message"},
         {"whose.sigalg.weak", "%1$s uses the %2$s signature algorithm which is considered a security risk."},
         {"whose.key.disabled", "%1$s uses a %2$s which is considered a security risk and is disabled."},
-        {"whose.key.weak", "%1$s uses a %2$s which is considered a security risk. This key size will be disabled in a future update."},
+        {"whose.key.weak", "%1$s uses a %2$s which is considered a security risk. It will be disabled in a future update."},
         {"jks.storetype.warning", "The %1$s keystore uses a proprietary format. It is recommended to migrate to PKCS12 which is an industry standard format using \"keytool -importkeystore -srckeystore %2$s -destkeystore %2$s -deststoretype pkcs12\"."},
         {"migrate.keystore.warning", "Migrated \"%1$s\" to %4$s. The %2$s keystore is backed up as \"%3$s\"."},
         {"backup.keystore.warning", "The original keystore \"%1$s\" is backed up as \"%3$s\"..."},

--- a/src/java.base/share/classes/sun/security/util/KeyUtil.java
+++ b/src/java.base/share/classes/sun/security/util/KeyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,27 +172,6 @@ public final class KeyUtil {
         }
 
         return -1;
-    }
-
-    /**
-     * Returns the algorithm name of the given key object. If an EC key is
-     * specified, returns the algorithm name and its named curve.
-     *
-     * @param key the key object, cannot be null
-     * @return the algorithm name of the given key object, or return in the
-     *       form of "EC (named curve)" if the given key object is an EC key
-     */
-    public static final String fullDisplayAlgName(Key key) {
-        String result = key.getAlgorithm();
-        if (key instanceof AsymmetricKey ak) {
-            AlgorithmParameterSpec paramSpec = ak.getParams();
-            if (paramSpec instanceof NamedCurve nc) {
-                result += " (" + nc.getNameAndAliases()[0] + ")";
-            } else if (paramSpec instanceof NamedParameterSpec nps) {
-                result = nps.getName();
-            }
-        }
-        return result;
     }
 
     /**

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,12 +173,9 @@ public class Resources extends java.util.ListResourceBundle {
         {"with.algparams.weak", "%1$s using %2$s (weak)"},
         {"with.disabled", "%s (disabled)"},
         {"with.algparams.disabled", "%1$s using %2$s (disabled)"},
-        {"key.bit", "%d-bit key"},
-        {"key.bit.weak", "%d-bit key (weak)"},
-        {"key.bit.eccurve.weak", "%1$d-bit %2$s key (weak)"},
-        {"key.bit.disabled", "%d-bit key (disabled)"},
-        {"key.bit.eccurve.disabled", "%1$d-bit %2$s key (disabled)"},
-        {"unknown.size", "unknown size"},
+        {"key.bit", "%s key"},
+        {"key.bit.weak", "%s key (weak)"},
+        {"key.bit.disabled", "%s key (disabled)"},
         {"nonexistent.entries.found", "This jar contains signed entries for files that do not exist. See the -verbose output for more details."},
         {"external.file.attributes.detected", "POSIX file permission and/or symlink attributes detected. These attributes are ignored when signing and are not protected by the signature."},
 
@@ -297,10 +294,12 @@ public class Resources extends java.util.ListResourceBundle {
                 "The %1$s digest algorithm is considered a security risk. This algorithm will be disabled in a future update."},
         {"The.signature.algorithm.1.is.considered.a.security.risk..This.algorithm.will.be.disabled.in.a.future.update.",
                 "The %1$s signature algorithm is considered a security risk. This algorithm will be disabled in a future update."},
-        {"The.1.signing.key.has.a.keysize.of.2.which.is.considered.a.security.risk..This.key.size.will.be.disabled.in.a.future.update.",
-                "The %1$s signing key has a keysize of %2$d which is considered a security risk. This key size will be disabled in a future update."},
-        {"The.1.signing.key.has.a.keysize.of.2.which.is.considered.a.security.risk.and.is.disabled.",
-                "The %1$s signing key has a keysize of %2$d which is considered a security risk and is disabled."},
+        {"size.bit.alg",
+                "%1$d-bit %2$s"},
+        {"The.full.keyAlgName.signing.key.is.considered.a.security.risk..It.will.be.disabled.in.a.future.update.",
+                "The %s signing key is considered a security risk. It will be disabled in a future update."},
+        {"The.full.keyAlgName.signing.key.is.considered.a.security.risk.and.is.disabled.",
+                "The %s signing key is considered a security risk and is disabled."},
         {"This.jar.contains.entries.whose.certificate.chain.is.invalid.reason.1",
                  "This jar contains entries whose certificate chain is invalid. Reason: %s"},
         {"This.jar.contains.entries.whose.tsa.certificate.chain.is.invalid.reason.1",

--- a/test/jdk/sun/security/tools/jarsigner/CheckSignerCertChain.java
+++ b/test/jdk/sun/security/tools/jarsigner/CheckSignerCertChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,10 +81,10 @@ public class CheckSignerCertChain {
                 "-sigalg SHA256withRSA " +
                 "-verbose" +
                 " a.jar e1")
-                .shouldContain("Signature algorithm: SHA1withRSA (disabled), 2048-bit key")
+                .shouldContain("Signature algorithm: SHA1withRSA (disabled), 2048-bit RSA key")
                 // For trusted cert, warning should be generated for its weak 1024-bit
                 // key, but not for its SHA1withRSA algorithm.
-                .shouldContain("Signature algorithm: SHA1withRSA, 1024-bit key (weak)")
+                .shouldContain("Signature algorithm: SHA1withRSA, 1024-bit RSA key (weak)")
                 .shouldHaveExitValue(0);
 
         kt("-exportcert -alias ca -rfc -file cacert", "ks");
@@ -92,10 +92,10 @@ public class CheckSignerCertChain {
 
         SecurityTools.jarsigner("-verify -certs signeda.jar " +
                 "-keystore caks -storepass changeit -verbose -debug")
-                .shouldContain("Signature algorithm: SHA1withRSA (disabled), 2048-bit key")
+                .shouldContain("Signature algorithm: SHA1withRSA (disabled), 2048-bit RSA key")
                 // For trusted cert, warning should be generated for its weak 1024-bit
                 // key, but not for its SHA1withRSA algorithm.
-                .shouldContain("Signature algorithm: SHA1withRSA, 1024-bit key (weak)")
+                .shouldContain("Signature algorithm: SHA1withRSA, 1024-bit RSA key (weak)")
                 .shouldHaveExitValue(0);
 
         /*
@@ -118,8 +118,8 @@ public class CheckSignerCertChain {
                 "-J-Djava.security.properties=" +
                 JAVA_SECURITY_FILE +
                 " a.jar ee")
-                .shouldNotContain("Signature algorithm: MD5withRSA (disabled), 2048-bit key")
-                .shouldContain("Signature algorithm: SHA384withRSA, 2048-bit key")
+                .shouldNotContain("Signature algorithm: MD5withRSA (disabled), 2048-bit RSA key")
+                .shouldContain("Signature algorithm: SHA384withRSA, 2048-bit RSA key")
                 .shouldNotContain("Invalid certificate chain: Algorithm constraints check failed on signature algorithm: MD5withRSA")
                 .shouldHaveExitValue(0);
 
@@ -134,8 +134,8 @@ public class CheckSignerCertChain {
                 "-J-Djava.security.properties=" +
                 JAVA_SECURITY_FILE +
                 " a.jar ee")
-                .shouldContain("Signature algorithm: MD5withRSA (disabled), 2048-bit key")
-                .shouldContain("Signature algorithm: SHA384withRSA, 2048-bit key")
+                .shouldContain("Signature algorithm: MD5withRSA (disabled), 2048-bit RSA key")
+                .shouldContain("Signature algorithm: SHA384withRSA, 2048-bit RSA key")
                 .shouldContain("Invalid certificate chain: Algorithm constraints check failed on disabled algorithm: MD5 used with certificate: CN=EE")
                 .shouldHaveExitValue(0);
 
@@ -144,8 +144,8 @@ public class CheckSignerCertChain {
 
         SecurityTools.jarsigner("-verify -certs signeda.jar " +
                 "-keystore caks1 -storepass changeit -verbose -debug")
-                .shouldContain("Signature algorithm: MD5withRSA (disabled), 2048-bit key")
-                .shouldContain("Signature algorithm: SHA384withRSA, 2048-bit key")
+                .shouldContain("Signature algorithm: MD5withRSA (disabled), 2048-bit RSA key")
+                .shouldContain("Signature algorithm: SHA384withRSA, 2048-bit RSA key")
                 .shouldContain("Invalid certificate chain: Algorithm constraints check failed on disabled algorithm: MD5 used with certificate: CN=EE")
                 .shouldHaveExitValue(0);
     }

--- a/test/jdk/sun/security/tools/jarsigner/DisableCurveTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/DisableCurveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class DisableCurveTest {
                 .shouldContain(">>> Signer")
                 .shouldContain("Signature algorithm: SHA384withECDSA, 256-bit EC (secp256r1) key (disabled)")
                 .shouldContain("Warning:")
-                .shouldContain("The EC (secp256r1) signing key has a keysize of 256 which is considered a security risk and is disabled")
+                .shouldContain("The 256-bit EC (secp256r1) signing key is considered a security risk and is disabled")
                 .shouldHaveExitValue(0);
 
         SecurityTools.jarsigner("-verify signeda.jar " +
@@ -84,7 +84,7 @@ public class DisableCurveTest {
                 .shouldContain(">>> Signer")
                 .shouldContain("Signature algorithm: SHA384withECDSA, 256-bit EC (secp256r1) key (weak)")
                 .shouldContain("Warning:")
-                .shouldContain("The EC (secp256r1) signing key has a keysize of 256 which is considered a security risk. This key size will be disabled in a future update")
+                .shouldContain("The 256-bit EC (secp256r1) signing key is considered a security risk. It will be disabled in a future update")
                 .shouldHaveExitValue(0);
 
         SecurityTools.jarsigner("-verify signeda.jar " +
@@ -94,7 +94,7 @@ public class DisableCurveTest {
                 .shouldContain("- Signed by")
                 .shouldContain("Signature algorithm: SHA384withECDSA, 256-bit EC (secp256r1) key (weak)")
                 .shouldContain("jar verified")
-                .shouldContain("The EC (secp256r1) signing key has a keysize of 256 which is considered a security risk. This key size will be disabled in a future update")
+                .shouldContain("The 256-bit EC (secp256r1) signing key is considered a security risk. It will be disabled in a future update")
                 .shouldHaveExitValue(0);
     }
 }

--- a/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
+++ b/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -448,8 +448,8 @@ public class TimestampCheck {
                         .shouldNotContain("The SHA-256 algorithm specified " +
                             "for the -tsadigestalg option is considered a " +
                             "security risk")
-                        .shouldContain("The RSA signing key has a keysize " +
-                            "of 1024 which is considered a security risk")
+                        .shouldContain("The 1024-bit RSA signing key " +
+                            "is considered a security risk")
                         .shouldHaveExitValue(0);
                 checkMultipleWeak("sign2.jar");
 

--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -717,7 +717,8 @@ public class Compatibility {
             String match = "^  ("
                     + "  Signature algorithm: " + signItem.certInfo.
                             expectedSigalg(signItem) + ", " + signItem.certInfo.
-                            expectedKeySize() + "-bit key"
+                            expectedKeySize() + "-bit " + signItem.certInfo.
+                            expectedKeyAlgorithm() + " key"
                     + ")|("
                     + "  Digest algorithm: " + signItem.expectedDigestAlg()
                     + (isWeakAlg(signItem.expectedDigestAlg()) ? " \\(weak\\)" : "")
@@ -1221,6 +1222,12 @@ public class Compatibility {
                         throw new RuntimeException("Unsupported/expected key algorithm: " + keyAlgorithm);
                 }
             }
+        }
+
+        private String expectedKeyAlgorithm() {
+            return keyAlgorithm.equals("EC")
+                    ? ("EC .secp" + expectedKeySize() + "r1.")
+                    : keyAlgorithm;
         }
 
         private int expectedKeySize() {

--- a/test/jdk/sun/security/tools/jarsigner/warnings/Test.java
+++ b/test/jdk/sun/security/tools/jarsigner/warnings/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,7 +149,7 @@ public abstract class Test {
             + "This algorithm will be disabled in a future update.";
 
     static final String WEAK_KEY_WARNING
-            = "This key size will be disabled in a future update.";
+            = "It will be disabled in a future update.";
 
     static final String JAR_SIGNED = "jar signed.";
 

--- a/test/jdk/sun/security/tools/keytool/GenKeyPairSigner.java
+++ b/test/jdk/sun/security/tools/keytool/GenKeyPairSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,14 +77,14 @@ public class GenKeyPairSigner {
         SecurityTools.keytool("-keystore ks -storepass changeit " +
                 "-genkeypair -keyalg EdDSA -alias ca -dname CN=CA -ext bc:c " +
                 "-ext 2.5.29.14=04:14:00:01:02:03:04:05:06:07:08:09:10:11:12:13:14:15:16:17:18:19")
-                .shouldContain("Generating 255 bit Ed25519 key pair and self-signed certificate (Ed25519) with a validity of 90 days")
+                .shouldContain("Generating Ed25519 key pair and self-signed certificate (Ed25519) with a validity of 90 days")
                 .shouldContain("for: CN=CA")
                 .shouldHaveExitValue(0);
 
         System.out.println("Generating an XDH cert with -signer option");
         SecurityTools.keytool("-keystore ks -storepass changeit " +
                 "-genkeypair -keyalg XDH -alias e1 -dname CN=E1 -signer ca")
-                .shouldContain("Generating 255 bit X25519 key pair and a certificate (Ed25519) issued by <ca> with a validity of 90 days")
+                .shouldContain("Generating X25519 key pair and a certificate (Ed25519) issued by <ca> with a validity of 90 days")
                 .shouldContain("for: CN=E1")
                 .shouldHaveExitValue(0);
 
@@ -118,7 +118,7 @@ public class GenKeyPairSigner {
                 .shouldContain("Alias name: e1")
                 .shouldContain("Certificate chain length: 2")
                 .shouldContain("Signature algorithm name: Ed25519")
-                .shouldContain("Subject Public Key Algorithm: 255-bit X25519 key")
+                .shouldContain("Subject Public Key Algorithm: X25519 key")
                 .shouldHaveExitValue(0);
 
         // check to make sure that cert's AKID is created from the SKID of the signing cert
@@ -150,7 +150,7 @@ public class GenKeyPairSigner {
         System.out.println("Generating an X448 cert with -signer option");
         SecurityTools.keytool("-keystore ks -storepass changeit " +
                 "-genkeypair -keyalg X448 -alias e2 -dname CN=E2 -sigalg SHA384withRSA -signer ca2")
-                .shouldContain("Generating 448 bit X448 key pair and a certificate (SHA384withRSA) issued by <ca2> with a validity of 90 days")
+                .shouldContain("Generating X448 key pair and a certificate (SHA384withRSA) issued by <ca2> with a validity of 90 days")
                 .shouldContain("for: CN=E2")
                 .shouldHaveExitValue(0);
 
@@ -177,7 +177,7 @@ public class GenKeyPairSigner {
                 "-list -v")
                 .shouldContain("Alias name: e2")
                 .shouldContain("Signature algorithm name: SHA384withRSA")
-                .shouldContain("Subject Public Key Algorithm: 448-bit X448 key")
+                .shouldContain("Subject Public Key Algorithm: X448 key")
                 .shouldHaveExitValue(0);
 
         kt("-genkeypair -keyalg DSA -alias ca3 -dname CN=CA3 -ext bc:c ",
@@ -186,7 +186,7 @@ public class GenKeyPairSigner {
         System.out.println("Generating a DH cert with -signer option");
         SecurityTools.keytool("-keystore ks -storepass changeit " +
                 "-genkeypair -keyalg DH -alias e3 -dname CN=E3 -signer ca3")
-                .shouldContain("Generating 3,072 bit DH key pair and a certificate (SHA256withDSA) issued by <ca3> with a validity of 90 days")
+                .shouldContain("Generating 3072-bit DH key pair and a certificate (SHA256withDSA) issued by <ca3> with a validity of 90 days")
                 .shouldContain("for: CN=E3")
                 .shouldHaveExitValue(0);
 
@@ -239,7 +239,7 @@ public class GenKeyPairSigner {
         SecurityTools.keytool("-keystore ksjks -storepass changeit -storetype jks " +
                 "-genkeypair -keyalg DSA -keysize 1024 -alias ca1 -dname CN=CA1 " +
                 "-keypass ca1keypass -signer ca -signerkeypass cakeypass")
-                .shouldContain("Generating 1,024 bit DSA key pair and a certificate (SHA384withRSA) issued by <ca> with a validity of 90 days")
+                .shouldContain("Generating 1024-bit DSA key pair and a certificate (SHA384withRSA) issued by <ca> with a validity of 90 days")
                 .shouldContain("for: CN=CA1")
                 .shouldContain("The generated certificate #1 of 2 uses a 1024-bit DSA key which is considered a security risk")
                 .shouldContain("The generated certificate #2 of 2 uses a 1024-bit RSA key which is considered a security risk")
@@ -249,7 +249,7 @@ public class GenKeyPairSigner {
         SecurityTools.keytool("-keystore ksjks -storepass changeit -storetype jks " +
                 "-genkeypair -keyalg XDH -alias e1 -dname CN=E1 " +
                 "-keypass e1keypass -signer ca1 -signerkeypass ca1keypass")
-                .shouldContain("Generating 255 bit X25519 key pair and a certificate (SHA256withDSA) issued by <ca1> with a validity of 90 days")
+                .shouldContain("Generating X25519 key pair and a certificate (SHA256withDSA) issued by <ca1> with a validity of 90 days")
                 .shouldContain("for: CN=E1")
                 .shouldContain("The generated certificate #2 of 3 uses a 1024-bit DSA key which is considered a security risk")
                 .shouldContain("The generated certificate #3 of 3 uses a 1024-bit RSA key which is considered a security risk")
@@ -285,7 +285,7 @@ public class GenKeyPairSigner {
                 .shouldContain("Alias name: e1")
                 .shouldContain("Certificate chain length: 3")
                 .shouldContain("Signature algorithm name: SHA256withDSA")
-                .shouldContain("Subject Public Key Algorithm: 255-bit X25519 key")
+                .shouldContain("Subject Public Key Algorithm: X25519 key")
                 .shouldHaveExitValue(0);
     }
 

--- a/test/jdk/sun/security/tools/keytool/KeyAlg.java
+++ b/test/jdk/sun/security/tools/keytool/KeyAlg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,9 +42,9 @@ public class KeyAlg {
                 .shouldMatch("Signature algorithm name:.*SHA1withECDSA")
                 .shouldMatch("Subject Public Key Algorithm:.*1024.*RSA");
         keytool("-genkeypair -alias g -dname CN=g -keyalg EC -keysize 256")
-                .shouldContain("Generating 256 bit EC (secp256r1) key pair");
+                .shouldContain("Generating 256-bit EC (secp256r1) key pair");
         keytool("-genkeypair -alias f -dname CN=f -keyalg EC")
-                .shouldContain("Generating 384 bit EC (secp384r1) key pair");
+                .shouldContain("Generating 384-bit EC (secp384r1) key pair");
     }
 
     static OutputAnalyzer keytool(String s) throws Exception {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342062](https://bugs.openjdk.org/browse/JDK-8342062): Reformat keytool and jarsigner output for keys with a named parameter set (**Bug** - P3)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23092/head:pull/23092` \
`$ git checkout pull/23092`

Update a local copy of the PR: \
`$ git checkout pull/23092` \
`$ git pull https://git.openjdk.org/jdk.git pull/23092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23092`

View PR using the GUI difftool: \
`$ git pr show -t 23092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23092.diff">https://git.openjdk.org/jdk/pull/23092.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23092#issuecomment-2588407392)
</details>
