### PR TITLE
8347627: Compiler replay tests are failing after JDK-8346990

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -785,7 +785,7 @@ void ciMethodData::dump_replay_data(outputStream* out) {
     // We could use INTPTR_FORMAT here but that's zero justified
     // which makes comparing it with the SA version of this output
     // harder. data()'s element type is intptr_t.
-    out->print(" %#zx", data()[i]);
+    out->print(" 0x%zx", data()[i]);
   }
 
   // The MDO contained oop references as ciObjects, so scan for those

--- a/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
+++ b/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
@@ -279,6 +279,9 @@ TEST(globalDefinitions, format_specifiers) {
 
   check_format("%zd",                  (intx)123,         "123");
   check_format("%#zx",                 (intx)0x123,       "0x123");
+  check_format("%#zx",                 (intx)0x0,         "0");
+  check_format("0x%zx",                (intx)0x123,       "0x123");
+  check_format("0x%zx",                (intx)0x0,         "0x0");
   check_format("%5zd",                 (intx)123,         "  123");
   check_format("%-5zd",                (intx)123,         "123  ");
 


### PR DESCRIPTION
The `%#zx` format specifier only prepends `0x` to non-zero values but we need it for all, so switch to manual `0x%zx`. I claim this as a trivial (and urgent) fix.

The only other use of this is in a test where it is fine.

Testing:
 - compiler replay tests now pass
 - tiers 1-3 (sanity)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347627](https://bugs.openjdk.org/browse/JDK-8347627): Compiler replay tests are failing after JDK-8346990 (**Bug** - P2)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23093/head:pull/23093` \
`$ git checkout pull/23093`

Update a local copy of the PR: \
`$ git checkout pull/23093` \
`$ git pull https://git.openjdk.org/jdk.git pull/23093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23093`

View PR using the GUI difftool: \
`$ git pr show -t 23093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23093.diff">https://git.openjdk.org/jdk/pull/23093.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23093#issuecomment-2588583481)
</details>
