### PR TITLE
8346972: Test java/nio/channels/FileChannel/LoopingTruncate.java fails sometimes with IOException: There is not enough space on the disk

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/LoopingTruncate.java
+++ b/test/jdk/java/nio/channels/FileChannel/LoopingTruncate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8137121 8137230
  * @summary (fc) Infinite loop FileChannel.truncate
@@ -31,12 +31,12 @@
  */
 
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.channels.ClosedByInterruptException;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import static java.nio.file.StandardOpenOption.*;
 import java.util.concurrent.TimeUnit;
+import static java.nio.file.StandardOpenOption.*;
 import static jdk.test.lib.Utils.adjustTimeout;
 
 public class LoopingTruncate {
@@ -48,7 +48,10 @@ public class LoopingTruncate {
     static long TIMEOUT = adjustTimeout(20_000);
 
     public static void main(String[] args) throws Throwable {
-        Path path = Files.createTempFile("LoopingTruncate.tmp", null);
+        // Intentionally opting out from the default `java.io.tmpdir`.
+        // It occasionally lacks the sufficient disk space this test needs.
+        Path pathDir = Path.of(System.getProperty("user.dir"));
+        Path path = Files.createTempFile(pathDir, "LoopingTruncate.tmp", null);
         try (FileChannel fc = FileChannel.open(path, CREATE, WRITE)) {
             fc.position(FATEFUL_SIZE + 1L);
             System.out.println("  Writing large file...");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4e0ffda5](https://github.com/openjdk/jdk/commit/4e0ffda5b1d82449d2d6f639be7641b69d6cb520) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository to jdk24. This backport make test more rubustness, test-fix only, no risk.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346972](https://bugs.openjdk.org/browse/JDK-8346972): Test java/nio/channels/FileChannel/LoopingTruncate.java fails sometimes with IOException: There is not enough space on the disk (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23094/head:pull/23094` \
`$ git checkout pull/23094`

Update a local copy of the PR: \
`$ git checkout pull/23094` \
`$ git pull https://git.openjdk.org/jdk.git pull/23094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23094`

View PR using the GUI difftool: \
`$ git pr show -t 23094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23094.diff">https://git.openjdk.org/jdk/pull/23094.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23094#issuecomment-2588591059)
</details>
