### PR TITLE
8328919: Add BodyHandlers / BodySubscribers methods to handle excessive server input

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -755,21 +755,17 @@ public interface HttpResponse<T> {
          *
          * @param downstreamHandler the downstream handler to pass received data to
          * @param capacity the maximum number of bytes that are allowed
-         * @param discardExcess if {@code true}, excessive input will be discarded; otherwise, it will throw an exception
          * @throws IllegalArgumentException if {@code capacity < 0}
          * @since 25
          */
-        public static <T> BodyHandler<T> limiting(
-                BodyHandler<T> downstreamHandler,
-                long capacity,
-                boolean discardExcess) {
+        public static <T> BodyHandler<T> limiting(BodyHandler<T> downstreamHandler, long capacity) {
             Objects.requireNonNull(downstreamHandler, "downstreamHandler");
             if (capacity < 0) {
                 throw new IllegalArgumentException("was expecting \"capacity >= 0\", found: " + capacity);
             }
             return responseInfo -> {
                 BodySubscriber<T> downstreamSubscriber = downstreamHandler.apply(responseInfo);
-                return BodySubscribers.limiting(downstreamSubscriber, capacity, discardExcess);
+                return BodySubscribers.limiting(downstreamSubscriber, capacity);
             };
         }
 
@@ -1381,16 +1377,12 @@ public interface HttpResponse<T> {
          *
          * @param downstreamSubscriber the downstream subscriber to pass received data to
          * @param capacity the maximum number of bytes that are allowed
-         * @param discardExcess if {@code true}, excessive input will be discarded; otherwise, it will throw an exception
          * @throws IllegalArgumentException if {@code capacity < 0}
          * @since 25
          */
-        public static <T> BodySubscriber<T> limiting(
-                BodySubscriber<T> downstreamSubscriber,
-                long capacity,
-                boolean discardExcess) {
+        public static <T> BodySubscriber<T> limiting(BodySubscriber<T> downstreamSubscriber, long capacity) {
             Objects.requireNonNull(downstreamSubscriber, "downstreamSubscriber");
-            return new LimitingSubscriber<>(downstreamSubscriber, capacity, discardExcess);
+            return new LimitingSubscriber<>(downstreamSubscriber, capacity);
         }
 
     }

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -755,20 +755,20 @@ public interface HttpResponse<T> {
          *
          * @param downstreamHandler the downstream handler to pass received data to
          * @param capacity the maximum number of bytes that are allowed
-         * @param excessDiscarded if {@code true}, excessive input will be discarded; otherwise, it will throw an exception
+         * @param discardExcess if {@code true}, excessive input will be discarded; otherwise, it will throw an exception
          * @throws IllegalArgumentException if {@code capacity < 0}
          */
         public static <T> BodyHandler<T> limiting(
                 BodyHandler<T> downstreamHandler,
                 long capacity,
-                boolean excessDiscarded) {
+                boolean discardExcess) {
             Objects.requireNonNull(downstreamHandler, "downstreamHandler");
             if (capacity < 0) {
                 throw new IllegalArgumentException("was expecting \"capacity >= 0\", found: " + capacity);
             }
             return responseInfo -> {
                 BodySubscriber<T> downstreamSubscriber = downstreamHandler.apply(responseInfo);
-                return BodySubscribers.limiting(downstreamSubscriber, capacity, excessDiscarded);
+                return BodySubscribers.limiting(downstreamSubscriber, capacity, discardExcess);
             };
         }
 
@@ -1380,15 +1380,15 @@ public interface HttpResponse<T> {
          *
          * @param downstreamSubscriber the downstream subscriber to pass received data to
          * @param capacity the maximum number of bytes that are allowed
-         * @param excessDiscarded if {@code true}, excessive input will be discarded; otherwise, it will throw an exception
+         * @param discardExcess if {@code true}, excessive input will be discarded; otherwise, it will throw an exception
          * @throws IllegalArgumentException if {@code capacity < 0}
          */
         public static <T> BodySubscriber<T> limiting(
                 BodySubscriber<T> downstreamSubscriber,
                 long capacity,
-                boolean excessDiscarded) {
+                boolean discardExcess) {
             Objects.requireNonNull(downstreamSubscriber, "downstreamSubscriber");
-            return new LimitingSubscriber<>(downstreamSubscriber, capacity, excessDiscarded);
+            return new LimitingSubscriber<>(downstreamSubscriber, capacity, discardExcess);
         }
 
     }

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -751,7 +751,15 @@ public interface HttpResponse<T> {
          }
 
         /**
-         * {@return a handler limiting the number of bytes consumed and passed to the given downstream}
+         * {@return a {@code BodyHandler} limiting the number of bytes consumed
+         * and passed to the given downstream {@code BodyHandler}}
+         * <p>
+         * If the number of bytes received exceeds the maximum number of bytes
+         * desired as indicated by the given {@code capacity},
+         * {@link BodySubscriber#onError(Throwable) onError} is called on the
+         * downstream {@code BodySubscriber} with an {@link IOException}
+         * indicating that the capacity is exceeded, and the upstream
+         * subscription is cancelled.
          *
          * @param downstreamHandler the downstream handler to pass received data to
          * @param capacity the maximum number of bytes that are allowed
@@ -1373,7 +1381,15 @@ public interface HttpResponse<T> {
         }
 
         /**
-         * {@return a subscriber limiting the number of bytes consumed and passed to the given downstream}
+         * {@return a {@code BodySubscriber} limiting the number of bytes
+         * consumed and passed to the given downstream {@code BodySubscriber}}
+         * <p>
+         * If the number of bytes received exceeds the maximum number of bytes
+         * desired as indicated by the given {@code capacity},
+         * {@link BodySubscriber#onError(Throwable) onError} is called on the
+         * downstream {@code BodySubscriber} with an {@link IOException}
+         * indicating that the capacity is exceeded, and the upstream
+         * subscription is cancelled.
          *
          * @param downstreamSubscriber the downstream subscriber to pass received data to
          * @param capacity the maximum number of bytes that are allowed

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -750,13 +750,14 @@ public interface HttpResponse<T> {
                                 bufferSize);
          }
 
-         /**
+        /**
          * {@return a handler limiting the number of bytes consumed and passed to the given downstream}
          *
          * @param downstreamHandler the downstream handler to pass received data to
          * @param capacity the maximum number of bytes that are allowed
          * @param discardExcess if {@code true}, excessive input will be discarded; otherwise, it will throw an exception
          * @throws IllegalArgumentException if {@code capacity < 0}
+         * @since 25
          */
         public static <T> BodyHandler<T> limiting(
                 BodyHandler<T> downstreamHandler,
@@ -1382,6 +1383,7 @@ public interface HttpResponse<T> {
          * @param capacity the maximum number of bytes that are allowed
          * @param discardExcess if {@code true}, excessive input will be discarded; otherwise, it will throw an exception
          * @throws IllegalArgumentException if {@code capacity < 0}
+         * @since 25
          */
         public static <T> BodySubscriber<T> limiting(
                 BodySubscriber<T> downstreamSubscriber,

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -1398,6 +1398,9 @@ public interface HttpResponse<T> {
          */
         public static <T> BodySubscriber<T> limiting(BodySubscriber<T> downstreamSubscriber, long capacity) {
             Objects.requireNonNull(downstreamSubscriber, "downstreamSubscriber");
+            if (capacity < 0) {
+                throw new IllegalArgumentException("was expecting \"capacity >= 0\", found: " + capacity);
+            }
             return new LimitingSubscriber<>(downstreamSubscriber, capacity);
         }
 

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -751,25 +751,24 @@ public interface HttpResponse<T> {
          }
 
         /**
-         * {@return a {@code BodyHandler} limiting the number of bytes consumed
-         * and passed to the given downstream {@code BodyHandler}}
+         * {@return a {@code BodyHandler} limiting the number of body bytes
+         * consumed and passed to the given downstream {@code BodyHandler}}
          * <p>
-         * If the number of bytes received exceeds the maximum number of bytes
-         * desired as indicated by the given {@code capacity},
-         * {@link BodySubscriber#onError(Throwable) onError} is called on the
-         * downstream {@code BodySubscriber} with an {@link IOException}
-         * indicating that the capacity is exceeded, and the upstream
-         * subscription is cancelled.
+         * If the number of body bytes received exceeds the the given
+         * {@code capacity}, {@link BodySubscriber#onError(Throwable) onError}
+         * is called on the downstream {@code BodySubscriber} with an
+         * {@link IOException} indicating that the capacity is exceeded, and
+         * the upstream subscription is cancelled.
          *
          * @param downstreamHandler the downstream handler to pass received data to
          * @param capacity the maximum number of bytes that are allowed
-         * @throws IllegalArgumentException if {@code capacity < 0}
+         * @throws IllegalArgumentException if {@code capacity} is negative
          * @since 25
          */
         public static <T> BodyHandler<T> limiting(BodyHandler<T> downstreamHandler, long capacity) {
             Objects.requireNonNull(downstreamHandler, "downstreamHandler");
             if (capacity < 0) {
-                throw new IllegalArgumentException("was expecting \"capacity >= 0\", found: " + capacity);
+                throw new IllegalArgumentException("capacity must not be negative: " + capacity);
             }
             return responseInfo -> {
                 BodySubscriber<T> downstreamSubscriber = downstreamHandler.apply(responseInfo);
@@ -1381,25 +1380,24 @@ public interface HttpResponse<T> {
         }
 
         /**
-         * {@return a {@code BodySubscriber} limiting the number of bytes
+         * {@return a {@code BodySubscriber} limiting the number of body bytes
          * consumed and passed to the given downstream {@code BodySubscriber}}
          * <p>
-         * If the number of bytes received exceeds the maximum number of bytes
-         * desired as indicated by the given {@code capacity},
-         * {@link BodySubscriber#onError(Throwable) onError} is called on the
-         * downstream {@code BodySubscriber} with an {@link IOException}
-         * indicating that the capacity is exceeded, and the upstream
-         * subscription is cancelled.
+         * If the number of body bytes received exceeds the given
+         * {@code capacity}, {@link BodySubscriber#onError(Throwable) onError}
+         * is called on the downstream {@code BodySubscriber} with an
+         * {@link IOException} indicating that the capacity is exceeded, and
+         * the upstream subscription is cancelled.
          *
          * @param downstreamSubscriber the downstream subscriber to pass received data to
          * @param capacity the maximum number of bytes that are allowed
-         * @throws IllegalArgumentException if {@code capacity < 0}
+         * @throws IllegalArgumentException if {@code capacity} is negative
          * @since 25
          */
         public static <T> BodySubscriber<T> limiting(BodySubscriber<T> downstreamSubscriber, long capacity) {
             Objects.requireNonNull(downstreamSubscriber, "downstreamSubscriber");
             if (capacity < 0) {
-                throw new IllegalArgumentException("was expecting \"capacity >= 0\", found: " + capacity);
+                throw new IllegalArgumentException("capacity must not be negative: " + capacity);
             }
             return new LimitingSubscriber<>(downstreamSubscriber, capacity);
         }

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -754,7 +754,7 @@ public interface HttpResponse<T> {
          * {@return a {@code BodyHandler} limiting the number of body bytes
          * consumed and passed to the given downstream {@code BodyHandler}}
          * <p>
-         * If the number of body bytes received exceeds the the given
+         * If the number of body bytes received exceeds the given
          * {@code capacity}, {@link BodySubscriber#onError(Throwable) onError}
          * is called on the downstream {@code BodySubscriber} with an
          * {@link IOException} indicating that the capacity is exceeded, and

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -751,8 +751,8 @@ public interface HttpResponse<T> {
          }
 
         /**
-         * {@return a {@code BodyHandler} limiting the number of body bytes
-         * consumed and passed to the given downstream {@code BodyHandler}}
+         * {@return a {@code BodyHandler} that limits the number of body bytes
+         * that are delivered to the given {@code downstreamHandler}}
          * <p>
          * If the number of body bytes received exceeds the given
          * {@code capacity}, {@link BodySubscriber#onError(Throwable) onError}
@@ -1380,8 +1380,8 @@ public interface HttpResponse<T> {
         }
 
         /**
-         * {@return a {@code BodySubscriber} limiting the number of body bytes
-         * consumed and passed to the given downstream {@code BodySubscriber}}
+         * {@return a {@code BodySubscriber} that limits the number of body
+         * bytes that are delivered to the given {@code downstreamSubscriber}}
          * <p>
          * If the number of body bytes received exceeds the given
          * {@code capacity}, {@link BodySubscriber#onError(Throwable) onError}

--- a/src/java.net.http/share/classes/jdk/internal/net/http/LimitingSubscriber.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/LimitingSubscriber.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.net.http;
+
+import jdk.internal.net.http.ResponseSubscribers.TrustedSubscriber;
+import jdk.internal.net.http.common.Utils;
+
+import java.net.http.HttpResponse.BodySubscriber;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A subscriber limiting the maximum number of bytes that are allowed to be consumed by a downstream subscriber.
+ *
+ * @param <T> the response type
+ */
+public final class LimitingSubscriber<T> implements TrustedSubscriber<T> {
+
+    private final BodySubscriber<T> downstreamSubscriber;
+
+    private final long capacity;
+
+    private final boolean excessDiscarded;
+
+    private final AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
+
+    private long length;
+
+    /**
+     * @param downstreamSubscriber the downstream subscriber to pass received data to
+     * @param capacity the maximum number of bytes that are allowed
+     * @param excessDiscarded if {@code true}, excessive input will be discarded; otherwise, it will throw an exception
+     * @throws IllegalArgumentException if {@code capacity < 0}
+     */
+    public LimitingSubscriber(BodySubscriber<T> downstreamSubscriber, long capacity, boolean excessDiscarded) {
+        if (capacity < 0) {
+            throw new IllegalArgumentException("was expecting \"capacity >= 0\", found: " + capacity);
+        }
+        this.downstreamSubscriber = requireNonNull(downstreamSubscriber, "downstreamSubscriber");
+        this.capacity = capacity;
+        this.excessDiscarded = excessDiscarded;
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        requireNonNull(subscription, "subscription");
+        boolean alreadySubscribed = !subscriptionRef.compareAndSet(null, subscription);
+        if (alreadySubscribed) {
+            subscription.cancel();
+        } else {
+            downstreamSubscriber.onSubscribe(subscription);
+            length = 0;
+            subscription.request(1);    // Request piecemeal
+        }
+    }
+
+    @Override
+    public void onNext(List<ByteBuffer> buffers) {
+
+        // Check arguments
+        requireNonNull(buffers, "buffers");
+        assert Utils.hasRemaining(buffers);
+
+        // See if we can consume the input completely
+        boolean lengthAllocated = allocateLength(buffers);
+        Subscription subscription = subscriptionRef.get();
+        assert subscription != null;
+        if (lengthAllocated) {
+            downstreamSubscriber.onNext(buffers);
+            subscription.request(1);    // Request piecemeal
+        }
+
+        // See if we can consume the input partially
+        else if (excessDiscarded) {
+            List<ByteBuffer> retainedBuffers = removeExcess(buffers);
+            if (!retainedBuffers.isEmpty()) {
+                downstreamSubscriber.onNext(retainedBuffers);
+            }
+            subscription.cancel();
+            downstreamSubscriber.onComplete();
+        }
+
+        // Partial consumption is not allowed, trigger failure
+        else {
+            subscription.cancel();
+            downstreamSubscriber.onError(new IllegalStateException(
+                    "the maximum number of bytes that are allowed to be consumed is exceeded"));
+        }
+
+    }
+
+    private boolean allocateLength(List<ByteBuffer> buffers) {
+        long bufferLength = buffers.stream().mapToLong(Buffer::remaining).sum();
+        long nextReceivedByteCount = Math.addExact(length, bufferLength);
+        if (nextReceivedByteCount > capacity) {
+            return false;
+        }
+        length = nextReceivedByteCount;
+        return true;
+    }
+
+    private List<ByteBuffer> removeExcess(List<ByteBuffer> buffers) {
+        List<ByteBuffer> retainedBuffers = new ArrayList<>(buffers.size());
+        long remaining = capacity - length;
+        for (ByteBuffer buffer : buffers) {
+            // No capacity left; stop
+            if (remaining < 1) {
+                break;
+            }
+            // Buffer fits as is; keep it
+            else if (buffer.remaining() <= remaining) {
+                retainedBuffers.add(buffer);
+                remaining -= buffer.remaining();
+            }
+            // There is capacity, but the buffer doesn't fit; truncate and keep it
+            else {
+                buffer.limit(Math.toIntExact(Math.addExact(buffer.position(), remaining)));
+                retainedBuffers.add(buffer);
+                remaining = 0;
+            }
+        }
+        return retainedBuffers;
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        requireNonNull(throwable, "throwable");
+        downstreamSubscriber.onError(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        downstreamSubscriber.onComplete();
+    }
+
+    @Override
+    public CompletionStage<T> getBody() {
+        return downstreamSubscriber.getBody();
+    }
+
+}

--- a/src/java.net.http/share/classes/jdk/internal/net/http/LimitingSubscriber.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/LimitingSubscriber.java
@@ -28,6 +28,7 @@ package jdk.internal.net.http;
 import jdk.internal.net.http.ResponseSubscribers.TrustedSubscriber;
 import jdk.internal.net.http.common.Utils;
 
+import java.io.IOException;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -95,7 +96,7 @@ public final class LimitingSubscriber<T> implements TrustedSubscriber<T> {
 
         // Otherwise, trigger failure
         else {
-            downstreamSubscriber.onError(new IllegalStateException(
+            downstreamSubscriber.onError(new IOException(
                     "the maximum number of bytes that are allowed to be consumed is exceeded"));
             subscription.cancel();
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/LimitingSubscriber.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/LimitingSubscriber.java
@@ -104,15 +104,15 @@ public final class LimitingSubscriber<T> implements TrustedSubscriber<T> {
             if (!retainedBuffers.isEmpty()) {
                 downstreamSubscriber.onNext(retainedBuffers);
             }
-            subscription.cancel();
             downstreamSubscriber.onComplete();
+            subscription.cancel();
         }
 
         // Partial consumption is not allowed, trigger failure
         else {
-            subscription.cancel();
             downstreamSubscriber.onError(new IllegalStateException(
                     "the maximum number of bytes that are allowed to be consumed is exceeded"));
+            subscription.cancel();
         }
 
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/LimitingSubscriber.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/LimitingSubscriber.java
@@ -78,9 +78,8 @@ public final class LimitingSubscriber<T> implements TrustedSubscriber<T> {
         if (alreadySubscribed) {
             subscription.cancel();
         } else {
-            downstreamSubscriber.onSubscribe(subscription);
             length = 0;
-            subscription.request(1);    // Request piecemeal
+            downstreamSubscriber.onSubscribe(subscription);
         }
     }
 
@@ -97,7 +96,6 @@ public final class LimitingSubscriber<T> implements TrustedSubscriber<T> {
         assert subscription != null;
         if (lengthAllocated) {
             downstreamSubscriber.onNext(buffers);
-            subscription.request(1);    // Request piecemeal
         }
 
         // See if we can consume the input partially

--- a/src/java.net.http/share/classes/jdk/internal/net/http/LimitingSubscriber.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/LimitingSubscriber.java
@@ -50,7 +50,7 @@ public final class LimitingSubscriber<T> implements TrustedSubscriber<T> {
 
     private final long capacity;
 
-    private final boolean excessDiscarded;
+    private final boolean discardExcess;
 
     private final AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
 
@@ -59,16 +59,16 @@ public final class LimitingSubscriber<T> implements TrustedSubscriber<T> {
     /**
      * @param downstreamSubscriber the downstream subscriber to pass received data to
      * @param capacity the maximum number of bytes that are allowed
-     * @param excessDiscarded if {@code true}, excessive input will be discarded; otherwise, it will throw an exception
+     * @param discardExcess if {@code true}, excessive input will be discarded; otherwise, it will throw an exception
      * @throws IllegalArgumentException if {@code capacity < 0}
      */
-    public LimitingSubscriber(BodySubscriber<T> downstreamSubscriber, long capacity, boolean excessDiscarded) {
+    public LimitingSubscriber(BodySubscriber<T> downstreamSubscriber, long capacity, boolean discardExcess) {
         if (capacity < 0) {
             throw new IllegalArgumentException("was expecting \"capacity >= 0\", found: " + capacity);
         }
         this.downstreamSubscriber = requireNonNull(downstreamSubscriber, "downstreamSubscriber");
         this.capacity = capacity;
-        this.excessDiscarded = excessDiscarded;
+        this.discardExcess = discardExcess;
     }
 
     @Override
@@ -101,7 +101,7 @@ public final class LimitingSubscriber<T> implements TrustedSubscriber<T> {
         }
 
         // See if we can consume the input partially
-        else if (excessDiscarded) {
+        else if (discardExcess) {
             List<ByteBuffer> retainedBuffers = removeExcess(buffers);
             if (!retainedBuffers.isEmpty()) {
                 downstreamSubscriber.onNext(retainedBuffers);

--- a/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
+++ b/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
+++ b/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8328919
+ * @summary verifies `BodyHandlers.limiting()` behaviour
+ * @library /test/lib
+ * @run junit HttpResponseLimitingTest
+ */
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.net.http.HttpResponse.BodySubscribers;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow.Subscription;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.copyOfRange;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HttpResponseLimitingTest {
+
+    private static final Charset CHARSET = StandardCharsets.UTF_8;
+
+    private static final HttpServer SERVER = new HttpServer();
+
+    private static final HttpRequest REQUEST = HttpRequest
+            .newBuilder(URI.create("http://localhost:" + SERVER.socket.getLocalPort()))
+            .timeout(Duration.ofSeconds(5))
+            .build();
+
+    private static final HttpClient CLIENT = HttpClient
+            .newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        CLIENT.close();
+        SERVER.close();
+    }
+
+    @ParameterizedTest
+    @MethodSource("sufficientCapacities")
+    void testSuccessOnSufficientCapacity(long sufficientCapacity) throws Exception {
+        BodyHandler<byte[]> handler =
+                BodyHandlers.limiting(BodyHandlers.ofByteArray(), sufficientCapacity, false);
+        HttpResponse<byte[]> response = CLIENT.send(REQUEST, handler);
+        assertArrayEquals(HttpServer.RESPONSE_BODY, response.body());
+    }
+
+    static long[] sufficientCapacities() {
+        return new long[]{Long.MAX_VALUE, HttpServer.RESPONSE_BODY.length};
+    }
+
+    @ParameterizedTest
+    @MethodSource("insufficientCapacities")
+    void testFailureOnInsufficientCapacity(long insufficientCapacity) {
+        assertThrows(
+                IOException.class,
+                () -> {
+                    BodyHandler<byte[]> handler =
+                            BodyHandlers.limiting(BodyHandlers.ofByteArray(), insufficientCapacity, false);
+                    CLIENT.send(REQUEST, handler);
+                },
+                "the maximum number of bytes that are allowed to be consumed is exceeded");
+    }
+
+    @ParameterizedTest
+    @MethodSource("insufficientCapacities")
+    void testTruncationOnInsufficientCapacity(long insufficientCapacity) throws Exception {
+        BodyHandler<byte[]> handler =
+                BodyHandlers.limiting(BodyHandlers.ofByteArray(), insufficientCapacity, true);
+        HttpResponse<byte[]> response = CLIENT.send(REQUEST, handler);
+        byte[] expectedResponseBody = new byte[(int) insufficientCapacity];
+        System.arraycopy(HttpServer.RESPONSE_BODY, 0, expectedResponseBody, 0, expectedResponseBody.length);
+        assertArrayEquals(expectedResponseBody, response.body());
+    }
+
+    static long[] insufficientCapacities() {
+        return new long[]{0, HttpServer.RESPONSE_BODY.length - 1};
+    }
+
+    @Test
+    void testSubscriberForCompleteConsumption() {
+
+        // Create the subscriber (with sufficient capacity)
+        ObserverSubscriber downstreamSubscriber = new ObserverSubscriber();
+        int sufficientCapacity = HttpServer.RESPONSE_BODY.length;
+        BodySubscriber<String> subscriber = BodySubscribers.limiting(downstreamSubscriber, sufficientCapacity, false);
+
+        // Emit values
+        subscriber.onSubscribe(DummySubscription.INSTANCE);
+        byte[] responseBodyPart1 = {HttpServer.RESPONSE_BODY[0]};
+        byte[] responseBodyPart2 = copyOfRange(HttpServer.RESPONSE_BODY, 1, HttpServer.RESPONSE_BODY.length);
+        List<ByteBuffer> buffers = toByteBuffers(responseBodyPart1, responseBodyPart2);
+        subscriber.onNext(buffers);
+
+        // Verify the downstream propagation
+        assertSame(buffers, downstreamSubscriber.lastBuffers);
+        assertNull(downstreamSubscriber.lastThrowable);
+        assertFalse(downstreamSubscriber.completed);
+
+    }
+
+    @Test
+    void testSubscriberForTruncationOnExcess() {
+
+        // Create the subscriber (with insufficient capacity)
+        ObserverSubscriber downstreamSubscriber = new ObserverSubscriber();
+        int insufficientCapacity = 4;
+        BodySubscriber<String> subscriber = BodySubscribers.limiting(downstreamSubscriber, insufficientCapacity, true);
+
+        // Emit values
+        subscriber.onSubscribe(DummySubscription.INSTANCE);
+        byte[] responseBodyPart1 = {HttpServer.RESPONSE_BODY[0]};
+        byte[] responseBodyPart2 = {HttpServer.RESPONSE_BODY[1], HttpServer.RESPONSE_BODY[2]};
+        byte[] responseBodyPart3 = copyOfRange(HttpServer.RESPONSE_BODY, 3, HttpServer.RESPONSE_BODY.length);
+        List<ByteBuffer> buffers = toByteBuffers(responseBodyPart1, responseBodyPart2, responseBodyPart3);
+        subscriber.onNext(buffers);
+
+        // Verify the downstream propagation
+        assertNotNull(downstreamSubscriber.lastBuffers);
+        List<ByteBuffer> expectedBuffers = toByteBuffers(
+                responseBodyPart1,
+                responseBodyPart2,
+                copyOfRange(HttpServer.RESPONSE_BODY, 3, 4));
+        assertEquals(expectedBuffers, downstreamSubscriber.lastBuffers);
+        assertNull(downstreamSubscriber.lastThrowable);
+        assertTrue(downstreamSubscriber.completed);
+
+    }
+
+    @Test
+    void testSubscriberForFailureOnExcess() {
+
+        // Create the subscriber (with insufficient capacity)
+        ObserverSubscriber downstreamSubscriber = new ObserverSubscriber();
+        int insufficientCapacity = 2;
+        BodySubscriber<String> subscriber = BodySubscribers.limiting(downstreamSubscriber, insufficientCapacity, false);
+
+        // Emit values
+        subscriber.onSubscribe(DummySubscription.INSTANCE);
+        byte[] responseBodyPart1 = {HttpServer.RESPONSE_BODY[0]};
+        byte[] responseBodyPart2 = copyOfRange(HttpServer.RESPONSE_BODY, 1, HttpServer.RESPONSE_BODY.length);
+        List<ByteBuffer> buffers = toByteBuffers(responseBodyPart1, responseBodyPart2);
+        subscriber.onNext(buffers);
+
+        // Verify the downstream propagation
+        assertNull(downstreamSubscriber.lastBuffers);
+        assertNotNull(downstreamSubscriber.lastThrowable);
+        assertEquals(
+                "the maximum number of bytes that are allowed to be consumed is exceeded",
+                downstreamSubscriber.lastThrowable.getMessage());
+        assertFalse(downstreamSubscriber.completed);
+
+    }
+
+    private static List<ByteBuffer> toByteBuffers(byte[]... buffers) {
+        return Arrays.stream(buffers).map(ByteBuffer::wrap).collect(Collectors.toList());
+    }
+
+    /**
+     * An HTTP server always returning an excessive response.
+     */
+    private static final class HttpServer implements Runnable, AutoCloseable {
+
+        private static final byte[] RESPONSE_BODY = "random non-empty body".getBytes(CHARSET);
+
+        private static final byte[] RESPONSE = (
+                "HTTP/1.2 200 OK\r\n" +
+                        "Content-Length: " + RESPONSE_BODY.length + "\r\n" +
+                        "\r\n" +
+                        new String(RESPONSE_BODY, CHARSET))
+                .getBytes(CHARSET);
+
+        private final ServerSocket socket;
+
+        private final Thread thread;
+
+        private HttpServer() {
+            try {
+                this.socket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
+            } catch (IOException exception) {
+                throw new UncheckedIOException(exception);
+            }
+            this.thread = new Thread(this);
+            thread.setDaemon(true);     // Avoid blocking JVM exit
+            thread.start();
+        }
+
+        @Override
+        public void run() {
+            while (!Thread.currentThread().isInterrupted()) {
+                try (Socket clientSocket = socket.accept();
+                     OutputStream outputStream = clientSocket.getOutputStream()) {
+                    outputStream.write(RESPONSE);
+                } catch (IOException _) {
+                    // Do nothing
+                }
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            socket.close();
+            thread.interrupt();
+        }
+
+    }
+
+    private static final class ObserverSubscriber implements BodySubscriber<String> {
+
+        private List<ByteBuffer> lastBuffers;
+
+        private Throwable lastThrowable;
+
+        private boolean completed;
+
+        @Override
+        public CompletionStage<String> getBody() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            // Do nothing
+        }
+
+        @Override
+        public void onNext(List<ByteBuffer> buffers) {
+            lastBuffers = buffers;
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            lastThrowable = throwable;
+        }
+
+        @Override
+        public void onComplete() {
+            completed = true;
+        }
+
+    }
+
+    private enum DummySubscription implements Subscription {
+
+        INSTANCE;
+
+        @Override
+        public void request(long n) {
+            // Do nothing
+        }
+
+        @Override
+        public void cancel() {
+            // Do nothing
+        }
+
+    }
+
+}

--- a/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
+++ b/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
@@ -276,7 +276,7 @@ class HttpResponseLimitingTest {
 
         @Override
         public void onSubscribe(Subscription subscription) {
-            // Do nothing
+            subscription.request(Long.MAX_VALUE);
         }
 
         @Override

--- a/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
+++ b/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
@@ -85,10 +85,8 @@ class HttpResponseLimitingTest {
     @ParameterizedTest
     @MethodSource("insufficientCapacities")
     void testFailureOnInsufficientCapacity(HttpClient.Version version, boolean secure, long insufficientCapacity) {
-        assertThrows(
-                IOException.class,
-                () -> requestBytes(version, secure, insufficientCapacity),
-                "body exceeds capacity: " + RESPONSE_BODY.length);
+        var exception = assertThrows(IOException.class, () -> requestBytes(version, secure, insufficientCapacity));
+        assertEquals(exception.getMessage(), "body exceeds capacity: " + insufficientCapacity);
     }
 
     static Arguments[] insufficientCapacities() {

--- a/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
+++ b/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
@@ -51,7 +51,6 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.net.http.HttpResponse.BodySubscribers;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
@@ -61,6 +60,7 @@ import java.util.concurrent.Flow.Subscription;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.copyOfRange;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -72,9 +72,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class HttpResponseLimitingTest {
 
-    private static final Charset CHARSET = StandardCharsets.UTF_8;
-
-    private static final byte[] RESPONSE_BODY = "random non-empty body".getBytes(CHARSET);
+    private static final byte[] RESPONSE_BODY = "random non-empty body".getBytes(UTF_8);
 
     @ParameterizedTest
     @MethodSource("sufficientCapacities")

--- a/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
+++ b/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
@@ -51,7 +51,6 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.net.http.HttpResponse.BodySubscribers;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;

--- a/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
+++ b/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
@@ -173,7 +173,7 @@ class HttpResponseLimitingTest {
     }
 
     /**
-     * An HTTP server always returning an excessive response.
+     * An HTTP server always returning a fixed response containing a non-empty body.
      */
     private static final class HttpServer implements Runnable, AutoCloseable {
 

--- a/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
+++ b/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
@@ -114,7 +114,7 @@ class HttpResponseLimitingTest {
                             BodyHandlers.limiting(BodyHandlers.ofByteArray(), insufficientCapacity);
                     CLIENT.send(REQUEST, handler);
                 },
-                "the maximum number of bytes that are allowed to be consumed is exceeded");
+                "body exceeds capacity: " + HttpServer.RESPONSE_BODY.length);
     }
 
     static long[] insufficientCapacities() {
@@ -162,7 +162,7 @@ class HttpResponseLimitingTest {
         assertNull(downstreamSubscriber.lastBuffers);
         assertNotNull(downstreamSubscriber.lastThrowable);
         assertEquals(
-                "the maximum number of bytes that are allowed to be consumed is exceeded",
+                "body exceeds capacity: " + insufficientCapacity,
                 downstreamSubscriber.lastThrowable.getMessage());
         assertFalse(downstreamSubscriber.completed);
 
@@ -180,7 +180,7 @@ class HttpResponseLimitingTest {
         private static final byte[] RESPONSE_BODY = "random non-empty body".getBytes(CHARSET);
 
         private static final byte[] RESPONSE = (
-                "HTTP/1.2 200 OK\r\n" +
+                "HTTP/1.1 200 OK\r\n" +
                         "Content-Length: " + RESPONSE_BODY.length + "\r\n" +
                         "\r\n" +
                         new String(RESPONSE_BODY, CHARSET))

--- a/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
+++ b/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
@@ -87,7 +87,7 @@ class HttpResponseLimitingTest {
     /**
      * A header value larger than {@link #RESPONSE_BODY} to verify that {@code limiting()} doesn't affect header parsing.
      */
-    private static final String RESPONSE_HEADER_VALUE = "!".repeat(RESPONSE_BODY.length);
+    private static final String RESPONSE_HEADER_VALUE = "!".repeat(RESPONSE_BODY.length + 1);
 
     private static final ServerClientPair HTTP1 = ServerClientPair.of(HttpClient.Version.HTTP_1_1, false);
 

--- a/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
+++ b/test/jdk/java/net/httpclient/HttpResponseLimitingTest.java
@@ -220,9 +220,7 @@ class HttpResponseLimitingTest {
         HttpResponse<InputStream> response = pair.request(BodyHandlers.ofInputStream(), sufficientCapacity);
         verifyHeaders(response.headers());
         try (InputStream responseBodyStream = response.body()) {
-            byte[] responseBodyBuffer = new byte[RESPONSE_BODY.length];
-            int responseBodyBufferLength = responseBodyStream.read(responseBodyBuffer);
-            assertEquals(responseBodyBuffer.length, responseBodyBufferLength);
+            byte[] responseBodyBuffer = responseBodyStream.readAllBytes();
             assertArrayEquals(RESPONSE_BODY, responseBodyBuffer);
         }
     }
@@ -251,9 +249,7 @@ class HttpResponseLimitingTest {
         HttpResponse<InputStream> response = pair.request(BodyHandlers.ofInputStream(), insufficientCapacity);
         verifyHeaders(response.headers());
         try (InputStream responseBodyStream = response.body()) {
-            var exception = assertThrows(
-                    IOException.class,
-                    () -> responseBodyStream.read(new byte[RESPONSE_BODY.length]));
+            var exception = assertThrows(IOException.class, responseBodyStream::readAllBytes);
             assertNotNull(exception.getCause());
             assertEquals(exception.getCause().getMessage(), "body exceeds capacity: " + insufficientCapacity);
         }


### PR DESCRIPTION
Adds `limiting()` factory methods to `HttpResponse.Body{Handlers,Subscribers}` to handle excessive server input in `HttpClient`. I would appreciate your input whether `discardExcess` should be kept or dropped. I plan to file a CSR once there is an agreement on the PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8347904](https://bugs.openjdk.org/browse/JDK-8347904) to be approved

### Issues
 * [JDK-8328919](https://bugs.openjdk.org/browse/JDK-8328919): Add BodyHandlers / BodySubscribers methods to handle excessive server input (**Enhancement** - P4)
 * [JDK-8347904](https://bugs.openjdk.org/browse/JDK-8347904): Add BodyHandlers / BodySubscribers methods to handle excessive server input (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23096/head:pull/23096` \
`$ git checkout pull/23096`

Update a local copy of the PR: \
`$ git checkout pull/23096` \
`$ git pull https://git.openjdk.org/jdk.git pull/23096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23096`

View PR using the GUI difftool: \
`$ git pr show -t 23096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23096.diff">https://git.openjdk.org/jdk/pull/23096.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23096#issuecomment-2589357620)
</details>
