### PR TITLE
8347646: module-info classfile missing the preview flag

### DIFF
--- a/test/langtools/tools/javac/ImportModule.java
+++ b/test/langtools/tools/javac/ImportModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8328481 8332236 8332890 8344647
+ * @bug 8328481 8332236 8332890 8344647 8347646
  * @summary Check behavior of module imports.
  * @library /tools/lib
  * @modules java.logging
@@ -39,6 +39,7 @@ import com.sun.source.tree.Tree;
 import com.sun.source.util.TaskEvent;
 import com.sun.source.util.TaskEvent.Kind;
 import com.sun.source.util.TaskListener;
+import java.lang.classfile.ClassFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -965,5 +966,85 @@ public class ImportModule extends TestRunner {
                 .files(tb.findJavaFiles(test))
                 .run(Task.Expect.SUCCESS)
                 .writeAll();
+    }
+
+    @Test //JDK-8347646
+    public void testRequiresTransitiveJavaBase(Path base) throws Exception {
+        Path current = base.resolve(".");
+        Path src = current.resolve("src");
+        Path classes = current.resolve("classes");
+        Path ma = src.resolve("ma");
+        Path maClasses = classes.resolve("ma");
+        tb.writeJavaFiles(ma,
+                          """
+                          module ma {
+                             requires transitive java.base;
+                          }
+                          """);
+        Path test = src.resolve("test");
+        tb.writeJavaFiles(test,
+                          """
+                          module test {
+                              requires ma;
+                          }
+                          """,
+                          """
+                          package test;
+                          import module ma;
+                          public class Test {
+                              public static void main(String... args) {
+                                  System.out.println(List.of("Hello"));
+                              }
+                          }
+                          """);
+
+        Files.createDirectories(maClasses);
+
+        List<String> actualErrors = new JavacTask(tb)
+                .options("-XDrawDiagnostics")
+                .outdir(maClasses)
+                .files(tb.findJavaFiles(ma))
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        List<String> expectedErrors = List.of(
+                "module-info.java:2:4: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.java.base.transitive)",
+                "1 error"
+        );
+
+        if (!Objects.equals(expectedErrors, actualErrors)) {
+            throw new AssertionError("Incorrect Output, expected: " + expectedErrors +
+                                      ", actual: " + actualErrors);
+
+        }
+
+        new JavacTask(tb)
+            .options("-XDrawDiagnostics",
+                     "--source", "9")
+            .outdir(maClasses)
+            .files(tb.findJavaFiles(ma))
+            .run()
+            .writeAll();
+
+        Path maModuleInfo = maClasses.resolve("module-info.class");
+
+        if (ClassFile.of().parse(maModuleInfo).minorVersion() == ClassFile.PREVIEW_MINOR_VERSION) {
+            throw new AssertionError("wrong minor version");
+        }
+
+        new JavacTask(tb)
+            .options("-XDrawDiagnostics",
+                     "--enable-preview", "--release", SOURCE_VERSION)
+            .outdir(maClasses)
+            .files(tb.findJavaFiles(ma))
+            .run()
+            .writeAll();
+
+        Path maModuleInfo2 = maClasses.resolve("module-info.class");
+
+        if (ClassFile.of().parse(maModuleInfo2).minorVersion() != ClassFile.PREVIEW_MINOR_VERSION) {
+            throw new AssertionError("wrong minor version");
+        }
     }
 }

--- a/test/langtools/tools/javac/diags/examples/ModifierNotAllowed/module-info.java
+++ b/test/langtools/tools/javac/diags/examples/ModifierNotAllowed/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-// key: compiler.err.feature.not.supported.in.source.plural
+// key: compiler.err.preview.feature.disabled.plural
 // key: compiler.misc.feature.java.base.transitive
 
 module m {

--- a/test/langtools/tools/javac/modules/JavaBaseTest.java
+++ b/test/langtools/tools/javac/modules/JavaBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,7 +166,7 @@ public class JavaBaseTest {
             for (String mod : mods) {
                 String key = mod.equals("static")
                     ? "compiler.err.mod.not.allowed.here: " + mod
-                    : "compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.java.base.transitive)";
+                    : "compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.java.base.transitive)";
                 String message = "module-info.java:1:12: " + key;
                 if (log.contains(message)) {
                     foundErrorMessage = true;


### PR DESCRIPTION
Consider module-info.java like this:
```
module m {
    requires transitive java.base;
}
```

When compiled with `--enable-preview --source 24/25`, the resulting classfile is missing the preview flag.

This PR proposes to use `Preview.checkSourceLevel` to check the source level, which marks the source to use the preview feature.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347646](https://bugs.openjdk.org/browse/JDK-8347646): module-info classfile missing the preview flag (**Bug** - P3)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23097/head:pull/23097` \
`$ git checkout pull/23097`

Update a local copy of the PR: \
`$ git checkout pull/23097` \
`$ git pull https://git.openjdk.org/jdk.git pull/23097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23097`

View PR using the GUI difftool: \
`$ git pr show -t 23097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23097.diff">https://git.openjdk.org/jdk/pull/23097.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23097#issuecomment-2589431561)
</details>
