### PR TITLE
8347501: Make static-launcher fails after JDK-8346669

### DIFF
--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -59,6 +59,7 @@ JAVA_MANIFEST := $(TOPDIR)/src/java.base/windows/native/launcher/java.manifest
 # OUTPUT_DIR   Override default output directory
 # VERSION_INFO_RESOURCE   Override default Windows resource file
 # STATIC_LAUNCHER   If true, will use settings for building a static launcher
+# LIBS   Additional libraries to pass as LIBS argument to SetupJdkExecutable
 SetupBuildLauncher = $(NamedParamsMacroTemplate)
 define SetupBuildLauncherBody
   # Setup default values (unless overridden)
@@ -155,6 +156,7 @@ define SetupBuildLauncherBody
       LDFLAGS_FILTER_OUT := $$($1_LDFLAGS_FILTER_OUT), \
       JDK_LIBS := $$($1_JDK_LIBS), \
       JDK_LIBS_windows := $$($1_JDK_LIBS_windows), \
+      LIBS := $$($1_LIBS), \
       LINK_TYPE := $$($1_LINK_TYPE), \
       OUTPUT_DIR := $$($1_OUTPUT_DIR), \
       OBJECT_DIR := $$($1_OBJECT_DIR), \


### PR DESCRIPTION
Unfortunately, in [JDK-8346669](https://bugs.openjdk.org/browse/JDK-8346669) the `LIBS` argument to `SetupBuildLauncher` that was passed on to the underlying `SetupJdkExecutable` was removed, even though it was still used for the static launcher. This causes the build of the static launcher to break.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347501](https://bugs.openjdk.org/browse/JDK-8347501): Make static-launcher fails after JDK-8346669 (**Bug** - P2)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23099/head:pull/23099` \
`$ git checkout pull/23099`

Update a local copy of the PR: \
`$ git checkout pull/23099` \
`$ git pull https://git.openjdk.org/jdk.git pull/23099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23099`

View PR using the GUI difftool: \
`$ git pr show -t 23099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23099.diff">https://git.openjdk.org/jdk/pull/23099.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23099#issuecomment-2589538263)
</details>
