### PR TITLE
8347274: Gatherers.mapConcurrent exhibits undesired behavior under variable delays, interruption, and finishing

### DIFF
--- a/test/jdk/java/util/stream/GatherersMapConcurrentTest.java
+++ b/test/jdk/java/util/stream/GatherersMapConcurrentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,9 @@
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.Function;
 import java.util.stream.Gatherer;
 import java.util.stream.Gatherers;
 import java.util.stream.Stream;
@@ -298,7 +301,7 @@ public class GatherersMapConcurrentTest {
 
     @ParameterizedTest
     @MethodSource("concurrencyConfigurations")
-    public void behavesAsExpectedWhenShortCircuited(ConcurrencyConfig cc) {
+    public void shortCircuits(ConcurrencyConfig cc) {
         final var limitTo = Math.max(cc.config().streamSize() / 2, 1);
 
         final var expectedResult = cc.config().stream()
@@ -310,6 +313,62 @@ public class GatherersMapConcurrentTest {
                 .gather(Gatherers.mapConcurrent(cc.concurrencyLevel(), x -> x * x))
                 .limit(limitTo)
                 .toList();
+
+        assertEquals(expectedResult, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("concurrencyConfigurations")
+    public void ignoresAndRestoresCallingThreadInterruption(ConcurrencyConfig cc) {
+        final var limitTo = Math.max(cc.config().streamSize() / 2, 1);
+
+        final var expectedResult = cc.config().stream()
+            .map(x -> x * x)
+            .limit(limitTo)
+            .toList();
+
+        // Ensure calling thread is interrupted
+        Thread.currentThread().interrupt();
+
+        final var result = cc.config().stream()
+            .gather(Gatherers.mapConcurrent(cc.concurrencyLevel(), x -> {
+                LockSupport.parkNanos(10000); // 10 us
+                return x * x;
+            }))
+            .limit(limitTo)
+            .toList();
+
+        // Ensure calling thread remains interrupted
+        assertEquals(true, Thread.interrupted());
+
+        assertEquals(expectedResult, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("concurrencyConfigurations")
+    public void limitsWorkInProgressToMaxConcurrency(ConcurrencyConfig cc) {
+        final var elementNum = new AtomicLong(0);
+        final var wipCount = new AtomicLong(0);
+        final var limitTo = Math.max(cc.config().streamSize() / 2, 1);
+
+        final var expectedResult = cc.config().stream()
+            .map(x -> x * x)
+            .limit(limitTo)
+            .toList();
+
+        Function<Integer, Integer> fun = x -> {
+            if (wipCount.incrementAndGet() > cc.concurrencyLevel)
+                throw new IllegalStateException("Too much wip!");
+            if (elementNum.getAndIncrement() == 0)
+                LockSupport.parkNanos(500_000_000); // 500 ms
+            return x * x;
+        };
+
+        final var result = cc.config().stream()
+            .gather(Gatherers.mapConcurrent(cc.concurrencyLevel(), fun))
+            .gather(Gatherer.of((v, e, d) -> wipCount.decrementAndGet() >= 0 && d.push(e)))
+            .limit(limitTo)
+            .toList();
 
         assertEquals(expectedResult, result);
     }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [450636ae](https://github.com/openjdk/jdk/commit/450636ae28b84ded083b6861c6cba85fbf87e16e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Viktor Klang on 13 Jan 2025 and was reviewed by Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347274](https://bugs.openjdk.org/browse/JDK-8347274): Gatherers.mapConcurrent exhibits undesired behavior under variable delays, interruption, and finishing (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23100/head:pull/23100` \
`$ git checkout pull/23100`

Update a local copy of the PR: \
`$ git checkout pull/23100` \
`$ git pull https://git.openjdk.org/jdk.git pull/23100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23100`

View PR using the GUI difftool: \
`$ git pr show -t 23100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23100.diff">https://git.openjdk.org/jdk/pull/23100.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23100#issuecomment-2589633539)
</details>
