### PR TITLE
8347531: The signal tests are failing after JDK-8345782 due to an unrelated warning

### DIFF
--- a/test/hotspot/jtreg/runtime/signal/SigTestDriver.java
+++ b/test/hotspot/jtreg/runtime/signal/SigTestDriver.java
@@ -126,7 +126,7 @@ public class SigTestDriver {
                             // only in the correct scenarios
                             boolean deprecatedSigFunctionUsed = mode.equals("sigset");
                             boolean jvmInvolved = !scenario.contains("nojvm");
-                            boolean warningPrinted = oa.contains("VM warning");
+                            boolean warningPrinted = oa.contains("VM warning: the use of signal() and sigset()");
                             boolean sigUsedByJVM = sigIsUsedByJVM(signame);
                             if (deprecatedSigFunctionUsed && jvmInvolved && sigUsedByJVM) {
                                 if (!warningPrinted) {


### PR DESCRIPTION
Could I get a review of this fix for the SigTestDriver test?

This fix adds more context from the libjsig deprecation warning to only catch the correct scenario in the test.

Previously the test only checked for the words `VM warning` in the output to determine the deprecation warning was present. However, another VM Warning printed when running a flag on an unsupported platform made the SigTestDriver fail incorrectly (`VM warning: -XX:+UseLargePages not supported in this VM`).

## Testing
* [x] Verified test still succeeds in "normal" way
* [x] Verified test also succeeds despite having the other warning.
* [x] Tested tier1-tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347531](https://bugs.openjdk.org/browse/JDK-8347531): The signal tests are failing after JDK-8345782 due to an unrelated warning (**Bug** - P3)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23103/head:pull/23103` \
`$ git checkout pull/23103`

Update a local copy of the PR: \
`$ git checkout pull/23103` \
`$ git pull https://git.openjdk.org/jdk.git pull/23103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23103`

View PR using the GUI difftool: \
`$ git pr show -t 23103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23103.diff">https://git.openjdk.org/jdk/pull/23103.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23103#issuecomment-2589892388)
</details>
