### PR TITLE
8325030: PhaseMacroExpand::value_from_mem_phi assert with "unknown node on this path"

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -430,6 +430,10 @@ Node *PhaseMacroExpand::value_from_mem_phi(Node *mem, BasicType ft, const Type *
           return nullptr;
         }
         values.at_put(j, res);
+      } else if (val->is_top()) {
+        // This indicates that this path into the phi is dead. Top will eventually also propagate into the Region.
+        // IGVN will clean this up later.
+        values.at_put(j, val);
       } else {
         DEBUG_ONLY( val->dump(); )
         assert(false, "unknown node on this path");

--- a/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
+++ b/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
@@ -26,8 +26,6 @@
  * @bug 8325030
  * @summary Regression test for an assert triggered during allocation elimination because top is found during
  * constructing new phis.
- * @modules java.base/jdk.internal.misc
- * @library /test/lib /
  * @run main/othervm -XX:-ProfileExceptionHandlers compiler.macronodes.TestTopInMacroElimination
  */
 

--- a/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
+++ b/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8325030
  * @summary Regression test for an assert triggered during allocation elimination because top is found during
  * constructing new phis.
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
+++ b/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
@@ -27,7 +27,7 @@
  * constructing new phis.
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver compiler.macronodes.TestTopInMacroElimination
+ * @run main/othervm -XX:-ProfileExceptionHandlers compiler.macronodes.TestTopInMacroElimination
  */
 
 package compiler.macronodes;

--- a/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
+++ b/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Regression test for an assert triggered during allocation elimination because top is found during
+ * constructing new phis.
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @run driver compiler.macronodes.TestEliminateAllocationPhi
+ */
+
+package compiler.macronodes;
+
+class TestEliminateAllocationPhi {
+    static class A {
+        int a;
+    }
+
+    public static void main(String[] strArr) {
+        int i2 = 0;
+        for (int i = 0; i < 50; ++i)
+            try {
+                synchronized (new A()) {
+                    synchronized (Test.class) {
+                        for (int var19 = 0; var19 < Integer.valueOf(i2);) {
+                            Integer.valueOf(var19);
+                        }
+                    }
+                }
+                for (int var8 = 0; var8 < 10000; ++var8) ;
+            } catch (ArithmeticException a_e) {
+            }
+    }
+}

--- a/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
+++ b/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
@@ -27,13 +27,13 @@
  * constructing new phis.
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver compiler.macronodes.TestEliminateAllocationPhi
+ * @run driver compiler.macronodes.TestTopInMacroElimination
  */
 
 package compiler.macronodes;
 
-class TestEliminateAllocationPhi {
-    static class A {
+public class TestTopInMacroElimination {
+    public static class A {
         int a;
     }
 
@@ -42,7 +42,7 @@ class TestEliminateAllocationPhi {
         for (int i = 0; i < 50; ++i)
             try {
                 synchronized (new A()) {
-                    synchronized (Test.class) {
+                    synchronized (TestTopInMacroElimination.class) {
                         for (int var19 = 0; var19 < Integer.valueOf(i2);) {
                             Integer.valueOf(var19);
                         }

--- a/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
+++ b/test/hotspot/jtreg/compiler/macronodes/TestTopInMacroElimination.java
@@ -38,7 +38,7 @@ public class TestTopInMacroElimination {
 
     public static void main(String[] strArr) {
         int i2 = 0;
-        for (int i = 0; i < 50; ++i)
+        for (int i = 0; i < 50; ++i) {
             try {
                 synchronized (new A()) {
                     synchronized (TestTopInMacroElimination.class) {
@@ -50,5 +50,6 @@ public class TestTopInMacroElimination {
                 for (int var8 = 0; var8 < 10000; ++var8) ;
             } catch (ArithmeticException a_e) {
             }
+        }
     }
 }


### PR DESCRIPTION
The following code triggers an assert:

```
class Test {
    static class A {
        int a;
    }

    public static void main(String[] strArr) {
        int i2 = 0;
        for (int i = 0; i < 50; ++i)
            try {
                synchronized (new A()) {
                    synchronized (Test.class) {
                        for (int var19 = 0; var19 < Integer.valueOf(i2);) {
                            Integer.valueOf(var19);
                        }
                    }
                }
                for (int var8 = 0; var8 < 10000; ++var8) ;
            } catch (ArithmeticException a_e) {
            }
    }
}
```

```
#  Internal Error (/Users/theo/jdk/open/src/hotspot/share/opto/macro.cpp:435), pid=37385, tid=27651
#  assert(false) failed: unknown node on this path
```

when run with `-XX:-ProfileExceptionHandlers`. With different flag configurations this can be reproduced back as far as JDK 11. (See issue in JBS.)

The issue is caused during OSR compilation in macro expansion (`PhaseMacroExpand::eliminate_macro_nodes`):

During `eliminate_macro_nodes`, the boxing call `Integer.valueOf(var19)` (which can be seen in the graph below as node 359) is eliminated:

<img width="545" alt="Screenshot 2025-01-14 at 14 56 27" src="https://github.com/user-attachments/assets/233d0972-a477-4d7a-8cdc-adee3e670d45" />

Note that on the catch path we have MemBarReleaseLock node (462) whose control and memory input become top after 359 CallStaticJava is eliminated. This elimination is correct per se.

`PhaseMacroExpand::eliminate_macro_nodes` will then continue with the next macro node in its list, the allocation `new A()`, which it tries to eliminate using scalar replacement. Note that IGVN does not run in-between this macro elimination attempts.

During scalar replacement, while finding the values for each field and walking along the memory edges, 462 MemBarReleaseLock, whose memory input is still top, is hit in `PhaseMacroExpand::value_from_mem_phi`. `PhaseMacroExpand::value_from_mem_phi` does not expect top and the assert triggers.

A naive solution for this problem would be to run IGVN in between each macro elimination attempt in order to ensure the entire catch path with 462 MemBarReleaseLock is removed. This does indeed solve the problem but the performance impact of running IGVN in between each macro elimination is unclear.

Instead, we observe that `PhaseMacroExpand::value_from_mem_phi` tries to convert a memory phi to a value phi node. It is fine for a PhiNode to have top as an input, so our fix is to simply to adding top as the input to the phi node in the case it is found in `PhaseMacroExpand::value_from_mem_phi`.

After all macro eliminations another IGVN run occurs. In this run, the catch path with 462 MemBarReleaseLock dies and the Top propagates down into the Region node belonging to the phi node into which we stored top. Through idealization this path (and thus input) is removed from the RegionNode and PhiNode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325030](https://bugs.openjdk.org/browse/JDK-8325030): PhaseMacroExpand::value_from_mem_phi assert with "unknown node on this path" (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [9b59fb9e](https://git.openjdk.org/jdk/pull/23104/files/9b59fb9ea96651cd331ff96119b6830dbf1c7ad8)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23104/head:pull/23104` \
`$ git checkout pull/23104`

Update a local copy of the PR: \
`$ git checkout pull/23104` \
`$ git pull https://git.openjdk.org/jdk.git pull/23104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23104`

View PR using the GUI difftool: \
`$ git pr show -t 23104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23104.diff">https://git.openjdk.org/jdk/pull/23104.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23104#issuecomment-2590074659)
</details>
