### PR TITLE
8345493: JFR: JVM.flush hangs intermittently

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrPostBox.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrPostBox.cpp
@@ -166,7 +166,7 @@ void JfrPostBox::notify_waiters() {
   assert(JfrMsg_lock->owned_by_self(), "incrementing _msg_handled_serial is protected by JfrMsg_lock.");
   // Update made visible on release of JfrMsg_lock via fence instruction in Monitor::IUnlock.
   ++_msg_handled_serial;
-  JfrMsg_lock->notify();
+  JfrMsg_lock->notify_all();
 }
 
 // safeguard to ensure no threads are left waiting

--- a/src/hotspot/share/jfr/recorder/service/jfrPostBox.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrPostBox.cpp
@@ -166,7 +166,7 @@ void JfrPostBox::notify_waiters() {
   assert(JfrMsg_lock->owned_by_self(), "incrementing _msg_handled_serial is protected by JfrMsg_lock.");
   // Update made visible on release of JfrMsg_lock via fence instruction in Monitor::IUnlock.
   ++_msg_handled_serial;
-  JfrMsg_lock->notify_all();
+  JfrMsg_lock->notify();
 }
 
 // safeguard to ensure no threads are left waiting

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -650,4 +650,8 @@ public final class PlatformRecorder {
     public RepositoryChunk getCurrentChunk() {
         return currentChunk;
     }
+
+    public synchronized void flush() {
+        MetadataRepository.getInstance().flush();
+    }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/FlushTask.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/FlushTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@ package jdk.jfr.internal.periodic;
 
 import jdk.jfr.internal.JVM;
 import jdk.jfr.internal.MetadataRepository;
+import jdk.jfr.internal.PlatformRecorder;
+import jdk.jfr.internal.PrivateAccess;
 import jdk.jfr.internal.util.Utils;
 
 /**
@@ -44,7 +46,8 @@ final class FlushTask extends PeriodicTask {
 
     @Override
     public void execute(long timestamp, PeriodicType periodicType) {
-        MetadataRepository.getInstance().flush();
+        PlatformRecorder recorder = PrivateAccess.getInstance().getPlatformRecorder();
+        recorder.flush();
         Utils.notifyFlush();
     }
 


### PR DESCRIPTION
Greetings,

This is the fix for JDK-8345493.

Problem Summary:
1. Threads calling JVM.begin_recording() and JVM.end_recording() only hold the PlatformRecorder lock (not the MetadataRepository lock)
2. The periodic flush thread only holds the MetadataRepository lock, not the PlatformRecorder lock.

Problem solution:
The periodic flush thread must acquire both the PlatformRecorder lock and the MetadataRepository lock (in that order). 

Testing: jdk_jfr, stress testing.

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345493](https://bugs.openjdk.org/browse/JDK-8345493): JFR: JVM.flush hangs intermittently (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23105/head:pull/23105` \
`$ git checkout pull/23105`

Update a local copy of the PR: \
`$ git checkout pull/23105` \
`$ git pull https://git.openjdk.org/jdk.git pull/23105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23105`

View PR using the GUI difftool: \
`$ git pr show -t 23105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23105.diff">https://git.openjdk.org/jdk/pull/23105.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23105#issuecomment-2590103562)
</details>
