### PR TITLE
8347717: Small MaxHeapSize gets increased a lot on platform with large page size

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1438,6 +1438,12 @@ void Arguments::set_conservative_max_heap_alignment() {
 jint Arguments::set_ergonomics_flags() {
   GCConfig::initialize();
 
+  if (FLAG_IS_DEFAULT(GCCardSizeInBytes) && (os::vm_page_size() > 4*K) && (MaxHeapSize < 32*M)) {
+    // Large GCCardSizeInBytes would prevent a small heap size on platforms with large page size.
+    // See CardTable::ct_max_alignment_constraint() and GCArguments::compute_heap_alignment().
+    FLAG_SET_ERGO(GCCardSizeInBytes, 128);
+  }
+
   set_conservative_max_heap_alignment();
 
 #ifdef _LP64

--- a/test/hotspot/jtreg/gc/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/TestSmallHeap.java
@@ -40,7 +40,7 @@ package gc;
  * means that on most platforms, where the minimal page size is 4k, we get a
  * minimal heap size of 2m but on Solaris/Sparc we have a page size of 8k and
  * get a minimal heap size of 4m. And on platforms where the page size is 64k
- * we get a minimal heap size of 32m. We never use large pages for the card table.
+ * we get a minimal heap size of 8m. We never use large pages for the card table.
  *
  * There is also no check in the VM for verifying that the maximum heap size
  * is larger than the supported minimal heap size.
@@ -73,7 +73,7 @@ public class TestSmallHeap {
         // possible to avoid hitting an OOME.
         WhiteBox wb = WhiteBox.getWhiteBox();
         int pageSize = wb.getVMPageSize();
-        int heapBytesPerCard = 512;
+        int heapBytesPerCard = (pageSize > 4096) ? 128 : 512;
         long expectedMaxHeap = pageSize * heapBytesPerCard;
         boolean noneGCSupported = true;
 


### PR DESCRIPTION
`GCArguments::compute_heap_alignment()` is currently problematic for platforms with large page size. E.g. on PPC64 with 64k pages:
`java -XX:+PrintFlagsFinal -Xmx8m -version |grep -E "GCCardSizeInBytes|MaxHeapSize"` says:
```
     uint GCCardSizeInBytes                        = 512                                       {product} {default}
   size_t MaxHeapSize                              = 33554432                                  {product} {command line, ergonomic}
   size_t SoftMaxHeapSize                          = 33554432                               {manageable} {ergonomic}
openjdk version "25-internal" 2025-09-16

```

I suggest to adapt `GCCardSizeInBytes` such that we get the following in this case:
```
     uint GCCardSizeInBytes                        = 128                                       {product} {ergonomic}
   size_t MaxHeapSize                              = 8388608                                   {product} {command line}
   size_t SoftMaxHeapSize                          = 8388608                                {manageable} {ergonomic}
```

Please review. Are there good alternatives / other proposals?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347717](https://bugs.openjdk.org/browse/JDK-8347717): Small MaxHeapSize gets increased a lot on platform with large page size (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23107/head:pull/23107` \
`$ git checkout pull/23107`

Update a local copy of the PR: \
`$ git checkout pull/23107` \
`$ git pull https://git.openjdk.org/jdk.git pull/23107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23107`

View PR using the GUI difftool: \
`$ git pr show -t 23107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23107.diff">https://git.openjdk.org/jdk/pull/23107.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23107#issuecomment-2590367573)
</details>
