### PR TITLE
8347724: Replace SIZE_FORMAT in jfr directory

### DIFF
--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1322,7 +1322,7 @@ static u1* schema_extend_event_subklass_bytes(const InstanceKlass* ik,
   const jint new_buffer_size = extra_stream_bytes + orig_stream_size;
   u1* const new_buffer = NEW_RESOURCE_ARRAY_IN_THREAD_RETURN_NULL(THREAD, u1, new_buffer_size);
   if (new_buffer == nullptr) {
-    log_error(jfr, system) ("Thread local allocation (native) for " SIZE_FORMAT
+    log_error(jfr, system) ("Thread local allocation (native) for %zu"
       " bytes failed in JfrEventClassTransformer::on_klass_creation", static_cast<size_t>(new_buffer_size));
     return nullptr;
   }
@@ -1563,7 +1563,7 @@ static void cache_class_file_data(InstanceKlass* new_ik, const ClassFileStream* 
   JvmtiCachedClassFileData* p =
     (JvmtiCachedClassFileData*)NEW_C_HEAP_ARRAY_RETURN_NULL(u1, offset_of(JvmtiCachedClassFileData, data) + stream_len, mtInternal);
   if (p == nullptr) {
-    log_error(jfr, system)("Allocation using C_HEAP_ARRAY for " SIZE_FORMAT " bytes failed in JfrEventClassTransformer::cache_class_file_data",
+    log_error(jfr, system)("Allocation using C_HEAP_ARRAY for %zu bytes failed in JfrEventClassTransformer::cache_class_file_data",
       static_cast<size_t>(offset_of(JvmtiCachedClassFileData, data) + stream_len));
     return;
   }

--- a/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,7 @@ static jclass* create_classes_array(jint classes_count, TRAPS) {
   if (nullptr == classes) {
     char error_buffer[ERROR_MSG_BUFFER_SIZE];
     jio_snprintf(error_buffer, ERROR_MSG_BUFFER_SIZE,
-      "Thread local allocation (native) of " SIZE_FORMAT " bytes failed "
+      "Thread local allocation (native) of %zu bytes failed "
       "in retransform classes", sizeof(jclass) * classes_count);
     log_error(jfr, system)("%s", error_buffer);
     JfrJavaSupport::throw_out_of_memory_error(error_buffer, CHECK_NULL);

--- a/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
+++ b/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ static const size_t ERROR_MSG_BUFFER_SIZE = 256;
 static void log_error_and_throw_oom(jint new_bytes_length, TRAPS) {
   char error_buffer[ERROR_MSG_BUFFER_SIZE];
   jio_snprintf(error_buffer, ERROR_MSG_BUFFER_SIZE,
-    "Thread local allocation (native) for " SIZE_FORMAT " bytes failed in JfrUpcalls", (size_t)new_bytes_length);
+    "Thread local allocation (native) for %zu bytes failed in JfrUpcalls", (size_t)new_bytes_length);
   log_error(jfr, system)("%s", error_buffer);
   JfrJavaSupport::throw_out_of_memory_error(error_buffer, CHECK);
 }

--- a/src/hotspot/share/jfr/leakprofiler/chains/bfsClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bfsClosure.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ static void log_frontier_level_summary(size_t level,
                                        size_t edge_size) {
   const size_t nof_edges_in_frontier = high_idx - low_idx;
   log_trace(jfr, system)(
-      "BFS front: " SIZE_FORMAT " edges: " SIZE_FORMAT " size: " SIZE_FORMAT " [KB]",
+      "BFS front: %zu edges: %zu size: %zu [KB]",
       level,
       nof_edges_in_frontier,
       (nof_edges_in_frontier * edge_size) / K
@@ -85,14 +85,14 @@ void BFSClosure::log_dfs_fallback() const {
 
   // additional information about DFS fallover
   log_trace(jfr, system)(
-      "BFS front: " SIZE_FORMAT " filled edge queue at edge: " SIZE_FORMAT,
+      "BFS front: %zu filled edge queue at edge: %zu",
       _current_frontier_level,
       _dfs_fallback_idx
                         );
 
   const size_t nof_dfs_completed_edges = _edge_queue->bottom() - _dfs_fallback_idx;
   log_trace(jfr, system)(
-      "DFS to complete " SIZE_FORMAT " edges size: " SIZE_FORMAT " [KB]",
+      "DFS to complete %zu edges size: %zu [KB]",
       nof_dfs_completed_edges,
       (nof_dfs_completed_edges * edge_size) / K
                         );

--- a/src/hotspot/share/jfr/leakprofiler/chains/pathToGcRootsOperation.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/pathToGcRootsOperation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,9 +70,9 @@ static size_t edge_queue_memory_commit_size(size_t memory_reservation_bytes) {
 }
 
 static void log_edge_queue_summary(const EdgeQueue& edge_queue) {
-  log_trace(jfr, system)("EdgeQueue reserved size total: " SIZE_FORMAT " [KB]", edge_queue.reserved_size() / K);
-  log_trace(jfr, system)("EdgeQueue edges total: " SIZE_FORMAT, edge_queue.top());
-  log_trace(jfr, system)("EdgeQueue liveset total: " SIZE_FORMAT " [KB]", edge_queue.live_set() / K);
+  log_trace(jfr, system)("EdgeQueue reserved size total: %zu [KB]", edge_queue.reserved_size() / K);
+  log_trace(jfr, system)("EdgeQueue edges total: %zu", edge_queue.top());
+  log_trace(jfr, system)("EdgeQueue liveset total: %zu [KB]", edge_queue.live_set() / K);
   if (edge_queue.reserved_size() > 0) {
     log_trace(jfr, system)("EdgeQueue commit reserve ratio: %f\n",
       ((double)edge_queue.live_set() / (double)edge_queue.reserved_size()));

--- a/src/hotspot/share/jfr/recorder/storage/jfrEpochStorage.inline.hpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrEpochStorage.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ template <typename NodeType, template <typename> class RetrievalPolicy, bool Eag
 inline NodeType* JfrEpochStorageHost<NodeType, RetrievalPolicy, EagerReclaim>::acquire(size_t size, Thread* thread) {
   BufferPtr buffer = mspace_acquire_to_live_list(size, _mspace, thread);
   if (buffer == nullptr) {
-    log_warning(jfr)("Unable to allocate " SIZE_FORMAT " bytes of %s.", _mspace->min_element_size(), "epoch storage");
+    log_warning(jfr)("Unable to allocate %zu bytes of %s.", _mspace->min_element_size(), "epoch storage");
     return nullptr;
   }
   assert(buffer->acquired_by_self(), "invariant");

--- a/src/hotspot/share/jfr/recorder/storage/jfrMemorySpace.inline.hpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrMemorySpace.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,7 +203,7 @@ inline bool JfrMemorySpace< Client, RetrievalPolicy, FreeListType, FullListType,
 // allocations are even multiples of the mspace min size
 static inline size_t align_allocation_size(size_t requested_size, size_t min_element_size) {
   if (requested_size > static_cast<size_t>(min_intx)) {
-    assert(false, "requested size: " SIZE_FORMAT " is too large", requested_size);
+    assert(false, "requested size: %zu is too large", requested_size);
     return 0;
   }
   u8 alloc_size_bytes = min_element_size;

--- a/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,7 +137,7 @@ JfrStorageControl& JfrStorage::control() {
 }
 
 static void log_allocation_failure(const char* msg, size_t size) {
-  log_warning(jfr)("Unable to allocate " SIZE_FORMAT " bytes of %s.", size, msg);
+  log_warning(jfr)("Unable to allocate %zu bytes of %s.", size, msg);
 }
 
 BufferPtr JfrStorage::acquire_thread_local(Thread* thread, size_t size /* 0 */) {
@@ -327,8 +327,8 @@ static void log_discard(size_t pre_full_count, size_t post_full_count, size_t am
   if (log_is_enabled(Debug, jfr, system)) {
     const size_t number_of_discards = pre_full_count - post_full_count;
     if (number_of_discards > 0) {
-      log_debug(jfr, system)("Cleared " SIZE_FORMAT " full buffer(s) of " SIZE_FORMAT" bytes.", number_of_discards, amount);
-      log_debug(jfr, system)("Current number of full buffers " SIZE_FORMAT "", number_of_discards);
+      log_debug(jfr, system)("Cleared %zu full buffer(s) of %zu bytes.", number_of_discards, amount);
+      log_debug(jfr, system)("Current number of full buffers %zu", number_of_discards);
     }
   }
 }
@@ -566,7 +566,7 @@ static size_t process_full(Processor& processor, JfrFullList* list, JfrStorageCo
 static void log(size_t count, size_t amount, bool clear = false) {
   if (log_is_enabled(Debug, jfr, system)) {
     if (count > 0) {
-      log_debug(jfr, system)("%s " SIZE_FORMAT " full buffer(s) of " SIZE_FORMAT" B of data%s",
+      log_debug(jfr, system)("%s %zu full buffer(s) of %zu B of data%s",
         clear ? "Discarded" : "Wrote", count, amount, clear ? "." : " to chunk.");
     }
   }

--- a/src/hotspot/share/jfr/utilities/jfrAllocation.cpp
+++ b/src/hotspot/share/jfr/utilities/jfrAllocation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ static void add(size_t alloc_size) {
   if (!JfrRecorder::is_created()) {
     const jlong total_allocated = atomic_add_jlong((jlong)alloc_size, &_allocated_bytes);
     const jlong current_live_set = atomic_add_jlong((jlong)alloc_size, &_live_set_bytes);
-    log_trace(jfr, system)("Allocation: [" SIZE_FORMAT "] bytes", alloc_size);
+    log_trace(jfr, system)("Allocation: [%zu] bytes", alloc_size);
     log_trace(jfr, system)("Total alloc [" JLONG_FORMAT "] bytes", total_allocated);
     log_trace(jfr, system)("Liveset:    [" JLONG_FORMAT "] bytes", current_live_set);
   }
@@ -63,7 +63,7 @@ static void subtract(size_t dealloc_size) {
   if (!JfrRecorder::is_created()) {
     const jlong total_deallocated = atomic_add_jlong((jlong)dealloc_size, &_deallocated_bytes);
     const jlong current_live_set = atomic_add_jlong(((jlong)dealloc_size * -1), &_live_set_bytes);
-    log_trace(jfr, system)("Deallocation: [" SIZE_FORMAT "] bytes", dealloc_size);
+    log_trace(jfr, system)("Deallocation: [%zu] bytes", dealloc_size);
     log_trace(jfr, system)("Total dealloc [" JLONG_FORMAT "] bytes", total_deallocated);
     log_trace(jfr, system)("Liveset:      [" JLONG_FORMAT "] bytes", current_live_set);
   }
@@ -77,7 +77,7 @@ static void hook_memory_deallocation(size_t dealloc_size) {
 static void hook_memory_allocation(const char* allocation, size_t alloc_size) {
   if (nullptr == allocation) {
     if (!JfrRecorder::is_created()) {
-      log_warning(jfr, system)("Memory allocation failed for size [" SIZE_FORMAT "] bytes", alloc_size);
+      log_warning(jfr, system)("Memory allocation failed for size [%zu] bytes", alloc_size);
       return;
     } else {
       // after critical startup, fail as by default


### PR DESCRIPTION
Please review this change to replace SIZE_FORMAT with %zu in the jfr directory.  Most were done with a script with no hand-editing.

Tested just now with tier1-4 on x86 and aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347724](https://bugs.openjdk.org/browse/JDK-8347724): Replace SIZE_FORMAT in jfr directory (**Sub-task** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23109/head:pull/23109` \
`$ git checkout pull/23109`

Update a local copy of the PR: \
`$ git checkout pull/23109` \
`$ git pull https://git.openjdk.org/jdk.git pull/23109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23109`

View PR using the GUI difftool: \
`$ git pr show -t 23109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23109.diff">https://git.openjdk.org/jdk/pull/23109.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23109#issuecomment-2590503615)
</details>
