### PR TITLE
8347727: Replace SIZE_FORMAT in shared gc

### DIFF
--- a/src/hotspot/share/gc/shared/adaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/shared/adaptiveSizePolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -337,11 +337,11 @@ class AdaptiveSizePolicySpaceOverheadTester: public GCOverheadTester {
 
     log_trace(gc, ergo)(
           "AdaptiveSizePolicySpaceOverheadTester::is_exceeded:"
-          " promo_limit: " SIZE_FORMAT
-          " total_free_limit: " SIZE_FORMAT
-          " max_old_gen_size: " SIZE_FORMAT
-          " max_eden_size: " SIZE_FORMAT
-          " mem_free_limit: " SIZE_FORMAT,
+          " promo_limit: %zu"
+          " total_free_limit: %zu"
+          " max_old_gen_size: %zu"
+          " max_eden_size: %zu"
+          " mem_free_limit: %zu",
           promo_limit, total_free_limit,
           _max_old_gen_size, _max_eden_size,
           (size_t)mem_free_limit);

--- a/src/hotspot/share/gc/shared/ageTable.cpp
+++ b/src/hotspot/share/gc/shared/ageTable.cpp
@@ -131,7 +131,7 @@ void AgeTable::print_on(outputStream* st) {
     size_t word_size = sizes[age];
     total += word_size;
     if (word_size > 0) {
-      st->print_cr("- age %3u: " SIZE_FORMAT_W(10) " bytes, " SIZE_FORMAT_W(10) " total",
+      st->print_cr("- age %3u: %10zu bytes, %10zu total",
                    age, word_size * oopSize, total * oopSize);
     }
     AgeTableTracer::send_tenuring_distribution_event(age, word_size * oopSize);

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -405,7 +405,7 @@ MetaWord* CollectedHeap::satisfy_failed_metadata_allocation(ClassLoaderData* loa
     if ((QueuedAllocationWarningCount > 0) &&
         (loop_count % QueuedAllocationWarningCount == 0)) {
       log_warning(gc, ergo)("satisfy_failed_metadata_allocation() retries %d times,"
-                            " size=" SIZE_FORMAT, loop_count, word_size);
+                            " size=%zu", loop_count, word_size);
     }
   } while (true);  // Until a GC is done
 }
@@ -481,7 +481,7 @@ CollectedHeap::fill_with_array(HeapWord* start, size_t words, bool zap)
 
   const size_t payload_size = words - filler_array_hdr_size();
   const size_t len = payload_size * HeapWordSize / sizeof(jint);
-  assert((int)len >= 0, "size too large " SIZE_FORMAT " becomes %d", words, (int)len);
+  assert((int)len >= 0, "size too large %zu becomes %d", words, (int)len);
 
   ObjArrayAllocator allocator(Universe::fillerArrayKlass(), words, (int)len, /* do_zero */ false);
   allocator.initialize(start);

--- a/src/hotspot/share/gc/shared/fullGCForwarding.cpp
+++ b/src/hotspot/share/gc/shared/fullGCForwarding.cpp
@@ -34,8 +34,8 @@ void FullGCForwarding::initialize_flags(size_t max_heap_size) {
 #ifdef _LP64
   size_t max_narrow_heap_size = right_n_bits(NumLowBitsNarrow - Shift);
   if (UseCompactObjectHeaders && max_heap_size > max_narrow_heap_size * HeapWordSize) {
-    warning("Compact object headers require a java heap size smaller than " SIZE_FORMAT
-            "%s (given: " SIZE_FORMAT "%s). Disabling compact object headers.",
+    warning("Compact object headers require a java heap size smaller than %zu"
+            "%s (given: %zu%s). Disabling compact object headers.",
             byte_size_in_proper_unit(max_narrow_heap_size * HeapWordSize),
             proper_unit_for_byte_size(max_narrow_heap_size * HeapWordSize),
             byte_size_in_proper_unit(max_heap_size),

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Red Hat, Inc. and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -99,7 +99,7 @@ void GCArguments::assert_size_info() {
 #endif // ASSERT
 
 void GCArguments::initialize_size_info() {
-  log_debug(gc, heap)("Minimum heap " SIZE_FORMAT "  Initial heap " SIZE_FORMAT "  Maximum heap " SIZE_FORMAT,
+  log_debug(gc, heap)("Minimum heap %zu  Initial heap %zu  Maximum heap %zu",
                       MinHeapSize, InitialHeapSize, MaxHeapSize);
 
   DEBUG_ONLY(assert_size_info();)
@@ -109,10 +109,10 @@ void GCArguments::initialize_heap_flags_and_sizes() {
   assert(SpaceAlignment != 0, "Space alignment not set up properly");
   assert(HeapAlignment != 0, "Heap alignment not set up properly");
   assert(HeapAlignment >= SpaceAlignment,
-         "HeapAlignment: " SIZE_FORMAT " less than SpaceAlignment: " SIZE_FORMAT,
+         "HeapAlignment: %zu less than SpaceAlignment: %zu",
          HeapAlignment, SpaceAlignment);
   assert(HeapAlignment % SpaceAlignment == 0,
-         "HeapAlignment: " SIZE_FORMAT " not aligned by SpaceAlignment: " SIZE_FORMAT,
+         "HeapAlignment: %zu not aligned by SpaceAlignment: %zu",
          HeapAlignment, SpaceAlignment);
 
   if (FLAG_IS_CMDLINE(MaxHeapSize)) {

--- a/src/hotspot/share/gc/shared/gcInitLogger.cpp
+++ b/src/hotspot/share/gc/shared/gcInitLogger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ void GCInitLogger::print_large_pages() {
 void GCInitLogger::print_numa() {
   if (UseNUMA) {
     log_info_p(gc, init)("NUMA Support: Enabled");
-    log_info_p(gc, init)("NUMA Nodes: " SIZE_FORMAT, os::numa_get_groups_num());
+    log_info_p(gc, init)("NUMA Nodes: %zu", os::numa_get_groups_num());
   } else {
     log_info_p(gc, init)("NUMA Support: Disabled");
   }
@@ -91,11 +91,11 @@ void GCInitLogger::print_compressed_oops() {
 }
 
 void GCInitLogger::print_heap() {
-  log_info_p(gc, init)("Heap Min Capacity: " SIZE_FORMAT "%s",
+  log_info_p(gc, init)("Heap Min Capacity: %zu%s",
                        byte_size_in_exact_unit(MinHeapSize), exact_unit_for_byte_size(MinHeapSize));
-  log_info_p(gc, init)("Heap Initial Capacity: " SIZE_FORMAT "%s",
+  log_info_p(gc, init)("Heap Initial Capacity: %zu%s",
                        byte_size_in_exact_unit(InitialHeapSize), exact_unit_for_byte_size(InitialHeapSize));
-  log_info_p(gc, init)("Heap Max Capacity: " SIZE_FORMAT "%s",
+  log_info_p(gc, init)("Heap Max Capacity: %zu%s",
                        byte_size_in_exact_unit(MaxHeapSize), exact_unit_for_byte_size(MaxHeapSize));
 
   log_info_p(gc, init)("Pre-touch: %s", AlwaysPreTouch ? "Enabled" : "Disabled");

--- a/src/hotspot/share/gc/shared/gcTraceTime.cpp
+++ b/src/hotspot/share/gc/shared/gcTraceTime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ void GCTraceTimeLoggerImpl::log_end(Ticks end) {
     size_t used_before_m = _heap_usage_before / M;
     size_t used_m = heap->used() / M;
     size_t capacity_m = heap->capacity() / M;
-    out.print(" " SIZE_FORMAT "M->" SIZE_FORMAT "M("  SIZE_FORMAT "M)", used_before_m, used_m, capacity_m);
+    out.print(" %zuM->%zuM(%zuM)", used_before_m, used_m, capacity_m);
   }
 
   out.print_cr(" %.3fms", duration_in_ms);

--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,7 @@ bool VM_GC_Operation::doit_prologue() {
   if (!is_init_completed()) {
     vm_exit_during_initialization(
       err_msg("GC triggered before VM initialization completed. Try increasing "
-              "NewSize, current value " SIZE_FORMAT "%s.",
+              "NewSize, current value %zu%s.",
               byte_size_in_proper_unit(NewSize),
               proper_unit_for_byte_size(NewSize)));
   }
@@ -259,7 +259,7 @@ void VM_CollectForMetadataAllocation::doit() {
     return;
   }
 
-  log_debug(gc)("After Metaspace GC failed to allocate size " SIZE_FORMAT, _size);
+  log_debug(gc)("After Metaspace GC failed to allocate size %zu", _size);
 
   if (GCLocker::is_active_and_needs_gc()) {
     set_gc_locked();

--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,13 +79,13 @@ void GenArguments::initialize_heap_flags_and_sizes() {
 
   assert(GenAlignment != 0, "Generation alignment not set up properly");
   assert(HeapAlignment >= GenAlignment,
-         "HeapAlignment: " SIZE_FORMAT " less than GenAlignment: " SIZE_FORMAT,
+         "HeapAlignment: %zu less than GenAlignment: %zu",
          HeapAlignment, GenAlignment);
   assert(GenAlignment % SpaceAlignment == 0,
-         "GenAlignment: " SIZE_FORMAT " not aligned by SpaceAlignment: " SIZE_FORMAT,
+         "GenAlignment: %zu not aligned by SpaceAlignment: %zu",
          GenAlignment, SpaceAlignment);
   assert(HeapAlignment % GenAlignment == 0,
-         "HeapAlignment: " SIZE_FORMAT " not aligned by GenAlignment: " SIZE_FORMAT,
+         "HeapAlignment: %zu not aligned by GenAlignment: %zu",
          HeapAlignment, GenAlignment);
 
   // All generational heaps have a young gen; handle those flags here
@@ -128,8 +128,8 @@ void GenArguments::initialize_heap_flags_and_sizes() {
       // Make sure there is room for an old generation
       size_t smaller_max_new_size = MaxHeapSize - GenAlignment;
       if (FLAG_IS_CMDLINE(MaxNewSize)) {
-        log_warning(gc, ergo)("MaxNewSize (" SIZE_FORMAT "k) is equal to or greater than the entire "
-                              "heap (" SIZE_FORMAT "k).  A new max generation size of " SIZE_FORMAT "k will be used.",
+        log_warning(gc, ergo)("MaxNewSize (%zuk) is equal to or greater than the entire "
+                              "heap (%zuk).  A new max generation size of %zuk will be used.",
                               MaxNewSize/K, MaxHeapSize/K, smaller_max_new_size/K);
       }
       FLAG_SET_ERGO(MaxNewSize, smaller_max_new_size);
@@ -147,8 +147,8 @@ void GenArguments::initialize_heap_flags_and_sizes() {
     // At this point this should only happen if the user specifies a large NewSize and/or
     // a small (but not too small) MaxNewSize.
     if (FLAG_IS_CMDLINE(MaxNewSize)) {
-      log_warning(gc, ergo)("NewSize (" SIZE_FORMAT "k) is greater than the MaxNewSize (" SIZE_FORMAT "k). "
-                            "A new max generation size of " SIZE_FORMAT "k will be used.",
+      log_warning(gc, ergo)("NewSize (%zuk) is greater than the MaxNewSize (%zuk). "
+                            "A new max generation size of %zuk will be used.",
                             NewSize/K, MaxNewSize/K, NewSize/K);
     }
     FLAG_SET_ERGO(MaxNewSize, NewSize);
@@ -245,7 +245,7 @@ void GenArguments::initialize_size_info() {
     }
   }
 
-  log_trace(gc, heap)("1: Minimum young " SIZE_FORMAT "  Initial young " SIZE_FORMAT "  Maximum young " SIZE_FORMAT,
+  log_trace(gc, heap)("1: Minimum young %zu  Initial young %zu  Maximum young %zu",
                       MinNewSize, initial_young_size, max_young_size);
 
   // At this point the minimum, initial and maximum sizes
@@ -287,7 +287,7 @@ void GenArguments::initialize_size_info() {
       initial_young_size = desired_young_size;
     }
 
-    log_trace(gc, heap)("2: Minimum young " SIZE_FORMAT "  Initial young " SIZE_FORMAT "  Maximum young " SIZE_FORMAT,
+    log_trace(gc, heap)("2: Minimum young %zu  Initial young %zu  Maximum young %zu",
                         MinNewSize, initial_young_size, max_young_size);
   }
 
@@ -304,7 +304,7 @@ void GenArguments::initialize_size_info() {
     OldSize = initial_old_size;
   }
 
-  log_trace(gc, heap)("Minimum old " SIZE_FORMAT "  Initial old " SIZE_FORMAT "  Maximum old " SIZE_FORMAT,
+  log_trace(gc, heap)("Minimum old %zu  Initial old %zu  Maximum old %zu",
                       MinOldSize, OldSize, MaxOldSize);
 
   DEBUG_ONLY(assert_size_info();)

--- a/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
+++ b/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
@@ -57,8 +57,8 @@ static JVMFlag::Error MinPLABSizeBounds(const char* name, size_t value, bool ver
   if ((GCConfig::is_gc_selected(CollectedHeap::G1) || GCConfig::is_gc_selected(CollectedHeap::Parallel)) &&
       (value < PLAB::min_size())) {
     JVMFlag::printError(verbose,
-                        "%s (" SIZE_FORMAT ") must be "
-                        "greater than or equal to ergonomic PLAB minimum size (" SIZE_FORMAT ")\n",
+                        "%s (%zu) must be "
+                        "greater than or equal to ergonomic PLAB minimum size (%zu)\n",
                         name, value, PLAB::min_size());
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
@@ -70,8 +70,8 @@ JVMFlag::Error MaxPLABSizeBounds(const char* name, size_t value, bool verbose) {
   if ((GCConfig::is_gc_selected(CollectedHeap::G1) ||
        GCConfig::is_gc_selected(CollectedHeap::Parallel)) && (value > PLAB::max_size())) {
     JVMFlag::printError(verbose,
-                        "%s (" SIZE_FORMAT ") must be "
-                        "less than or equal to ergonomic PLAB maximum size (" SIZE_FORMAT ")\n",
+                        "%s (%zu) must be "
+                        "less than or equal to ergonomic PLAB maximum size (%zu)\n",
                         name, value, PLAB::max_size());
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
@@ -124,7 +124,7 @@ static JVMFlag::Error CheckMaxHeapSizeAndSoftRefLRUPolicyMSPerMB(size_t maxHeap,
   if ((softRef > 0) && ((maxHeap / M) > (max_uintx / softRef))) {
     JVMFlag::printError(verbose,
                         "Desired lifetime of SoftReferences cannot be expressed correctly. "
-                        "MaxHeapSize (" SIZE_FORMAT ") or SoftRefLRUPolicyMSPerMB "
+                        "MaxHeapSize (%zu) or SoftRefLRUPolicyMSPerMB "
                         "(%zd) is too large\n",
                         maxHeap, softRef);
     return JVMFlag::VIOLATES_CONSTRAINT;
@@ -141,8 +141,8 @@ JVMFlag::Error MarkStackSizeConstraintFunc(size_t value, bool verbose) {
   // value == 0 is handled by the range constraint.
   if (value > MarkStackSizeMax) {
     JVMFlag::printError(verbose,
-                        "MarkStackSize (" SIZE_FORMAT ") must be "
-                        "less than or equal to MarkStackSizeMax (" SIZE_FORMAT ")\n",
+                        "MarkStackSize (%zu) must be "
+                        "less than or equal to MarkStackSizeMax (%zu)\n",
                         value, MarkStackSizeMax);
     return JVMFlag::VIOLATES_CONSTRAINT;
   } else {
@@ -233,8 +233,8 @@ static JVMFlag::Error MaxSizeForAlignment(const char* name, size_t value, size_t
   size_t aligned_max = ((max_uintx - alignment) & ~(alignment-1));
   if (value > aligned_max) {
     JVMFlag::printError(verbose,
-                        "%s (" SIZE_FORMAT ") must be "
-                        "less than or equal to aligned maximum value (" SIZE_FORMAT ")\n",
+                        "%s (%zu) must be "
+                        "less than or equal to aligned maximum value (%zu)\n",
                         name, value, aligned_max);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
@@ -288,8 +288,8 @@ JVMFlag::Error HeapBaseMinAddressConstraintFunc(size_t value, bool verbose) {
   // Check for this by ensuring that MaxHeapSize plus the requested min base address still fit within max_uintx.
   if (UseCompressedOops && FLAG_IS_ERGO(MaxHeapSize) && (value > (max_uintx - MaxHeapSize))) {
     JVMFlag::printError(verbose,
-                        "HeapBaseMinAddress (" SIZE_FORMAT ") or MaxHeapSize (" SIZE_FORMAT ") is too large. "
-                        "Sum of them must be less than or equal to maximum of size_t (" SIZE_FORMAT ")\n",
+                        "HeapBaseMinAddress (%zu) or MaxHeapSize (%zu) is too large. "
+                        "Sum of them must be less than or equal to maximum of size_t (%zu)\n",
                         value, MaxHeapSize, max_uintx);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
@@ -312,15 +312,15 @@ JVMFlag::Error MinTLABSizeConstraintFunc(size_t value, bool verbose) {
   // At least, alignment reserve area is needed.
   if (value < ThreadLocalAllocBuffer::alignment_reserve_in_bytes()) {
     JVMFlag::printError(verbose,
-                        "MinTLABSize (" SIZE_FORMAT ") must be "
-                        "greater than or equal to reserved area in TLAB (" SIZE_FORMAT ")\n",
+                        "MinTLABSize (%zu) must be "
+                        "greater than or equal to reserved area in TLAB (%zu)\n",
                         value, ThreadLocalAllocBuffer::alignment_reserve_in_bytes());
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
   if (value > (ThreadLocalAllocBuffer::max_size() * HeapWordSize)) {
     JVMFlag::printError(verbose,
-                        "MinTLABSize (" SIZE_FORMAT ") must be "
-                        "less than or equal to ergonomic TLAB maximum (" SIZE_FORMAT ")\n",
+                        "MinTLABSize (%zu) must be "
+                        "less than or equal to ergonomic TLAB maximum (%zu)\n",
                         value, ThreadLocalAllocBuffer::max_size() * HeapWordSize);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
@@ -332,15 +332,15 @@ JVMFlag::Error TLABSizeConstraintFunc(size_t value, bool verbose) {
   if (FLAG_IS_CMDLINE(TLABSize)) {
     if (value < MinTLABSize) {
       JVMFlag::printError(verbose,
-                          "TLABSize (" SIZE_FORMAT ") must be "
-                          "greater than or equal to MinTLABSize (" SIZE_FORMAT ")\n",
+                          "TLABSize (%zu) must be "
+                          "greater than or equal to MinTLABSize (%zu)\n",
                           value, MinTLABSize);
       return JVMFlag::VIOLATES_CONSTRAINT;
     }
     if (value > (ThreadLocalAllocBuffer::max_size() * HeapWordSize)) {
       JVMFlag::printError(verbose,
-                          "TLABSize (" SIZE_FORMAT ") must be "
-                          "less than or equal to ergonomic TLAB maximum size (" SIZE_FORMAT ")\n",
+                          "TLABSize (%zu) must be "
+                          "less than or equal to ergonomic TLAB maximum size (%zu)\n",
                           value, (ThreadLocalAllocBuffer::max_size() * HeapWordSize));
       return JVMFlag::VIOLATES_CONSTRAINT;
     }
@@ -358,7 +358,7 @@ JVMFlag::Error TLABWasteIncrementConstraintFunc(uintx value, bool verbose) {
     if (refill_waste_limit > (max_uintx - value)) {
       JVMFlag::printError(verbose,
                           "TLABWasteIncrement (%zu) must be "
-                          "less than or equal to ergonomic TLAB waste increment maximum size(" SIZE_FORMAT ")\n",
+                          "less than or equal to ergonomic TLAB waste increment maximum size(%zu)\n",
                           value, (max_uintx - refill_waste_limit));
       return JVMFlag::VIOLATES_CONSTRAINT;
     }
@@ -371,7 +371,7 @@ JVMFlag::Error SurvivorRatioConstraintFunc(uintx value, bool verbose) {
       (value > (MaxHeapSize / SpaceAlignment))) {
     JVMFlag::printError(verbose,
                         "SurvivorRatio (%zu) must be "
-                        "less than or equal to ergonomic SurvivorRatio maximum (" SIZE_FORMAT ")\n",
+                        "less than or equal to ergonomic SurvivorRatio maximum (%zu)\n",
                         value,
                         (MaxHeapSize / SpaceAlignment));
     return JVMFlag::VIOLATES_CONSTRAINT;
@@ -383,8 +383,8 @@ JVMFlag::Error SurvivorRatioConstraintFunc(uintx value, bool verbose) {
 JVMFlag::Error MetaspaceSizeConstraintFunc(size_t value, bool verbose) {
   if (value > MaxMetaspaceSize) {
     JVMFlag::printError(verbose,
-                        "MetaspaceSize (" SIZE_FORMAT ") must be "
-                        "less than or equal to MaxMetaspaceSize (" SIZE_FORMAT ")\n",
+                        "MetaspaceSize (%zu) must be "
+                        "less than or equal to MaxMetaspaceSize (%zu)\n",
                         value, MaxMetaspaceSize);
     return JVMFlag::VIOLATES_CONSTRAINT;
   } else {
@@ -395,8 +395,8 @@ JVMFlag::Error MetaspaceSizeConstraintFunc(size_t value, bool verbose) {
 JVMFlag::Error MaxMetaspaceSizeConstraintFunc(size_t value, bool verbose) {
   if (value < MetaspaceSize) {
     JVMFlag::printError(verbose,
-                        "MaxMetaspaceSize (" SIZE_FORMAT ") must be "
-                        "greater than or equal to MetaspaceSize (" SIZE_FORMAT ")\n",
+                        "MaxMetaspaceSize (%zu) must be "
+                        "greater than or equal to MetaspaceSize (%zu)\n",
                         value, MaxMetaspaceSize);
     return JVMFlag::VIOLATES_CONSTRAINT;
   } else {

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -294,13 +294,13 @@ HeapWord* MemAllocator::mem_allocate_inside_tlab_slow(Allocation& allocation) co
   mem = Universe::heap()->allocate_new_tlab(min_tlab_size, new_tlab_size, &allocation._allocated_tlab_size);
   if (mem == nullptr) {
     assert(allocation._allocated_tlab_size == 0,
-           "Allocation failed, but actual size was updated. min: " SIZE_FORMAT
-           ", desired: " SIZE_FORMAT ", actual: " SIZE_FORMAT,
+           "Allocation failed, but actual size was updated. min: %zu"
+           ", desired: %zu, actual: %zu",
            min_tlab_size, new_tlab_size, allocation._allocated_tlab_size);
     return nullptr;
   }
   assert(allocation._allocated_tlab_size != 0, "Allocation succeeded but actual size not updated. mem at: "
-         PTR_FORMAT " min: " SIZE_FORMAT ", desired: " SIZE_FORMAT,
+         PTR_FORMAT " min: %zu, desired: %zu",
          p2i(mem), min_tlab_size, new_tlab_size);
 
   // ...and clear or zap just allocated TLAB, if needed.

--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -579,7 +579,7 @@ bool OopStorage::expand_active_array() {
   assert_lock_strong(_allocation_mutex);
   ActiveArray* old_array = _active_array;
   size_t new_size = 2 * old_array->size();
-  log_debug(oopstorage, blocks)("%s: expand active array " SIZE_FORMAT,
+  log_debug(oopstorage, blocks)("%s: expand active array %zu",
                                 name(), new_size);
   ActiveArray* new_array = ActiveArray::create(new_size,
                                                mem_tag(),
@@ -1121,8 +1121,8 @@ bool OopStorage::BasicParState::claim_next_segment(IterationData* data) {
 
 bool OopStorage::BasicParState::finish_iteration(const IterationData* data) const {
   log_info(oopstorage, blocks, stats)
-          ("Parallel iteration on %s: blocks = " SIZE_FORMAT
-           ", processed = " SIZE_FORMAT " (%2.f%%)",
+          ("Parallel iteration on %s: blocks = %zu"
+           ", processed = %zu (%2.f%%)",
            _storage->name(), _block_count, data->_processed,
            percent_of(data->_processed, _block_count));
   return false;
@@ -1171,7 +1171,7 @@ void OopStorage::print_on(outputStream* st) const {
   double data_size = section_size * section_count;
   double alloc_percentage = percent_of((double)allocations, blocks * data_size);
 
-  st->print("%s: " SIZE_FORMAT " entries in " SIZE_FORMAT " blocks (%.F%%), " SIZE_FORMAT " bytes",
+  st->print("%s: %zu entries in %zu blocks (%.F%%), %zu bytes",
             name(), allocations, blocks, alloc_percentage, total_memory_usage());
   if (_concurrent_iteration_count > 0) {
     st->print(", concurrent iteration active");

--- a/src/hotspot/share/gc/shared/plab.cpp
+++ b/src/hotspot/share/gc/shared/plab.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ PLAB::PLAB(size_t desired_plab_sz_) :
   _end(nullptr), _hard_end(nullptr), _allocated(0), _wasted(0), _undo_wasted(0)
 {
   assert(min_size() > CollectedHeap::lab_alignment_reserve(),
-         "Minimum PLAB size " SIZE_FORMAT " must be larger than alignment reserve " SIZE_FORMAT " "
+         "Minimum PLAB size %zu must be larger than alignment reserve %zu "
          "to be able to contain objects", min_size(), CollectedHeap::lab_alignment_reserve());
 }
 

--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,10 +67,10 @@ void PreservedMarks::restore_and_increment(volatile size_t* const total_size_add
 
 #ifndef PRODUCT
 void PreservedMarks::assert_empty() {
-  assert(_stack.is_empty(), "stack expected to be empty, size = " SIZE_FORMAT,
+  assert(_stack.is_empty(), "stack expected to be empty, size = %zu",
          _stack.size());
   assert(_stack.cache_size() == 0,
-         "stack expected to have no cached segments, cache size = " SIZE_FORMAT,
+         "stack expected to have no cached segments, cache size = %zu",
          _stack.cache_size());
 }
 #endif // ndef PRODUCT

--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ PretouchTask::PretouchTask(const char* task_name,
     _chunk_size(chunk_size) {
 
   assert(chunk_size >= page_size,
-         "Chunk size " SIZE_FORMAT " is smaller than page size " SIZE_FORMAT,
+         "Chunk size %zu is smaller than page size %zu",
          chunk_size, page_size);
 }
 
@@ -79,12 +79,12 @@ void PretouchTask::pretouch(const char* task_name, char* start_address, char* en
     size_t num_chunks = ((total_bytes - 1) / chunk_size) + 1;
 
     uint num_workers = (uint)MIN2(num_chunks, (size_t)pretouch_workers->max_workers());
-    log_debug(gc, heap)("Running %s with %u workers for " SIZE_FORMAT " work units pre-touching " SIZE_FORMAT "B.",
+    log_debug(gc, heap)("Running %s with %u workers for %zu work units pre-touching %zuB.",
                         task.name(), num_workers, num_chunks, total_bytes);
 
     pretouch_workers->run_task(&task, num_workers);
   } else {
-    log_debug(gc, heap)("Running %s pre-touching " SIZE_FORMAT "B.",
+    log_debug(gc, heap)("Running %s pre-touching %zuB.",
                         task.name(), total_bytes);
     task.work(0);
   }

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -175,7 +175,7 @@ size_t ReferenceProcessor::total_count(DiscoveredList lists[]) const {
 #ifdef ASSERT
 void ReferenceProcessor::verify_total_count_zero(DiscoveredList lists[], const char* type) {
   size_t count = total_count(lists);
-  assert(count == 0, "%ss must be empty but has " SIZE_FORMAT " elements", type, count);
+  assert(count == 0, "%ss must be empty but has %zu elements", type, count);
 }
 #endif
 
@@ -365,7 +365,7 @@ size_t ReferenceProcessor::process_discovered_list_work(DiscoveredList&    refs_
     refs_list.clear();
   }
 
-  log_develop_trace(gc, ref)(" Dropped " SIZE_FORMAT " active Refs out of " SIZE_FORMAT
+  log_develop_trace(gc, ref)(" Dropped %zu active Refs out of %zu"
                              " Refs in discovered list " PTR_FORMAT,
                              iter.removed(), iter.processed(), p2i(&refs_list));
   return iter.removed();
@@ -559,10 +559,10 @@ void ReferenceProcessor::log_reflist(const char* prefix, DiscoveredList list[], 
   LogStream ls(lt);
   ls.print("%s", prefix);
   for (uint i = 0; i < num_active_queues; i++) {
-    ls.print(SIZE_FORMAT " ", list[i].length());
+    ls.print("%zu ", list[i].length());
     total += list[i].length();
   }
-  ls.print_cr("(" SIZE_FORMAT ")", total);
+  ls.print_cr("(%zu)", total);
 }
 
 #ifndef PRODUCT
@@ -574,7 +574,7 @@ void ReferenceProcessor::log_reflist_counts(DiscoveredList ref_lists[], uint num
   log_reflist("", ref_lists, num_active_queues);
 #ifdef ASSERT
   for (uint i = num_active_queues; i < _max_num_queues; i++) {
-    assert(ref_lists[i].length() == 0, SIZE_FORMAT " unexpected References in %u",
+    assert(ref_lists[i].length() == 0, "%zu unexpected References in %u",
            ref_lists[i].length(), i);
   }
 #endif
@@ -1095,7 +1095,7 @@ bool ReferenceProcessor::preclean_discovered_reflist(DiscoveredList&    refs_lis
   }
 
   if (iter.processed() > 0) {
-    log_develop_trace(gc, ref)(" Dropped " SIZE_FORMAT " Refs out of " SIZE_FORMAT " Refs in discovered list " PTR_FORMAT,
+    log_develop_trace(gc, ref)(" Dropped %zu Refs out of %zu Refs in discovered list " PTR_FORMAT,
                                iter.removed(), iter.processed(), p2i(&refs_list));
   }
   return false;

--- a/src/hotspot/share/gc/shared/satbMarkQueue.cpp
+++ b/src/hotspot/share/gc/shared/satbMarkQueue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,8 +54,8 @@ static void print_satb_buffer(const char* name,
                               void** buf,
                               size_t index,
                               size_t capacity) {
-  tty->print_cr("  SATB BUFFER [%s] buf: " PTR_FORMAT " index: " SIZE_FORMAT
-                " capacity: " SIZE_FORMAT,
+  tty->print_cr("  SATB BUFFER [%s] buf: " PTR_FORMAT " index: %zu"
+                " capacity: %zu",
                 name, p2i(buf), index, capacity);
 }
 

--- a/src/hotspot/share/gc/shared/taskqueue.cpp
+++ b/src/hotspot/share/gc/shared/taskqueue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,10 +75,9 @@ void TaskQueueStats::print_header(unsigned int line, outputStream* const stream,
 
 void TaskQueueStats::print(outputStream* stream, unsigned int width) const
 {
-  #define FMT SIZE_FORMAT_W(*)
-  stream->print(FMT, width, _stats[0]);
+  stream->print("%*zu", width, _stats[0]);
   for (unsigned int i = 1; i < last_stat_id; ++i) {
-    stream->print(" " FMT, width, _stats[i]);
+    stream->print(" %*zu", width, _stats[i]);
   }
   #undef FMT
 }

--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -164,7 +164,7 @@ void ThreadLocalAllocBuffer::resize() {
   size_t aligned_new_size = align_object_size(new_size);
 
   log_trace(gc, tlab)("TLAB new size: thread: " PTR_FORMAT " [id: %2d]"
-                      " refills %d  alloc: %8.6f desired_size: " SIZE_FORMAT " -> " SIZE_FORMAT,
+                      " refills %d  alloc: %8.6f desired_size: %zu -> %zu",
                       p2i(thread()), thread()->osthread()->thread_id(),
                       _target_refills, _allocation_fraction.average(), desired_size(), aligned_new_size);
 
@@ -263,7 +263,7 @@ void ThreadLocalAllocBuffer::startup_initialization() {
   guarantee(Thread::current()->is_Java_thread(), "tlab initialization thread not Java thread");
   Thread::current()->tlab().initialize();
 
-  log_develop_trace(gc, tlab)("TLAB min: " SIZE_FORMAT " initial: " SIZE_FORMAT " max: " SIZE_FORMAT,
+  log_develop_trace(gc, tlab)("TLAB min: %zu initial: %zu max: %zu",
                                min_size(), Thread::current()->tlab().initial_desired_size(), max_size());
 }
 
@@ -299,8 +299,8 @@ void ThreadLocalAllocBuffer::print_stats(const char* tag) {
   double waste_percent = percent_of(waste, _allocated_size);
   size_t tlab_used  = Universe::heap()->tlab_used(thrd);
   log.trace("TLAB: %s thread: " PTR_FORMAT " [id: %2d]"
-            " desired_size: " SIZE_FORMAT "KB"
-            " slow allocs: %d  refill waste: " SIZE_FORMAT "B"
+            " desired_size: %zuKB"
+            " slow allocs: %d  refill waste: %zuB"
             " alloc:%8.5f %8.0fKB refills: %d waste %4.1f%% gc: %dB"
             " slow: %dB",
             tag, p2i(thrd), thrd->osthread()->thread_id(),
@@ -451,8 +451,8 @@ void ThreadLocalAllocStats::publish() {
   const double waste_percent = percent_of(waste, _total_allocations);
   log_debug(gc, tlab)("TLAB totals: thrds: %d  refills: %d max: %d"
                       " slow allocs: %d max %d waste: %4.1f%%"
-                      " gc: " SIZE_FORMAT "B max: " SIZE_FORMAT "B"
-                      " slow: " SIZE_FORMAT "B max: " SIZE_FORMAT "B",
+                      " gc: %zuB max: %zuB"
+                      " slow: %zuB max: %zuB",
                       _allocating_threads, _total_refills, _max_refills,
                       _total_slow_allocations, _max_slow_allocations, waste_percent,
                       _total_gc_waste * HeapWordSize, _max_gc_waste * HeapWordSize,

--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.inline.hpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,11 +61,11 @@ inline size_t ThreadLocalAllocBuffer::compute_size(size_t obj_size) {
   // Make sure there's enough room for object and filler int[].
   if (new_tlab_size < compute_min_size(obj_size)) {
     // If there isn't enough room for the allocation, return failure.
-    log_trace(gc, tlab)("ThreadLocalAllocBuffer::compute_size(" SIZE_FORMAT ") returns failure",
+    log_trace(gc, tlab)("ThreadLocalAllocBuffer::compute_size(%zu) returns failure",
                         obj_size);
     return 0;
   }
-  log_trace(gc, tlab)("ThreadLocalAllocBuffer::compute_size(" SIZE_FORMAT ") returns " SIZE_FORMAT,
+  log_trace(gc, tlab)("ThreadLocalAllocBuffer::compute_size(%zu) returns %zu",
                       obj_size, new_tlab_size);
   return new_tlab_size;
 }
@@ -86,9 +86,9 @@ void ThreadLocalAllocBuffer::record_slow_allocation(size_t obj_size) {
   _slow_allocations++;
 
   log_develop_trace(gc, tlab)("TLAB: %s thread: " PTR_FORMAT " [id: %2d]"
-                              " obj: " SIZE_FORMAT
-                              " free: " SIZE_FORMAT
-                              " waste: " SIZE_FORMAT,
+                              " obj: %zu"
+                              " free: %zu"
+                              " waste: %zu",
                               "slow", p2i(thread()), thread()->osthread()->thread_id(),
                               obj_size, free(), refill_waste_limit());
 }

--- a/src/hotspot/share/gc/shared/workerDataArray.cpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,9 +49,9 @@ void WorkerDataArray<double>::WDAPrinter::summary(outputStream* out, double min,
 
 template <>
 void WorkerDataArray<size_t>::WDAPrinter::summary(outputStream* out, size_t min, double avg, size_t max, size_t diff, size_t sum, bool print_sum) {
-  out->print(" Min: " SIZE_FORMAT ", Avg: %4.1lf, Max: " SIZE_FORMAT ", Diff: " SIZE_FORMAT, min, avg, max, diff);
+  out->print(" Min: %zu, Avg: %4.1lf, Max: %zu, Diff: %zu", min, avg, max, diff);
   if (print_sum) {
-    out->print(", Sum: " SIZE_FORMAT, sum);
+    out->print(", Sum: %zu", sum);
   }
 }
 
@@ -75,7 +75,7 @@ void WorkerDataArray<size_t>::WDAPrinter::details(const WorkerDataArray<size_t>*
   for (uint i = 0; i < phase->_length; ++i) {
     size_t value = phase->get(i);
     if (value != phase->uninitialized()) {
-      out->print("  " SIZE_FORMAT, phase->get(i));
+      out->print("  %zu", phase->get(i));
     } else {
       out->print(" -");
     }


### PR DESCRIPTION
Please review this change to replace SIZE_FORMAT with %zu in the shared gc directory.  Most replacements were done with a script but I had a hand-edit in TaskQueueStats.
Tested all the GC changes together (other PRs coming) with tier1-4 on x86 and aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347727](https://bugs.openjdk.org/browse/JDK-8347727): Replace SIZE_FORMAT in shared gc (**Sub-task** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23111/head:pull/23111` \
`$ git checkout pull/23111`

Update a local copy of the PR: \
`$ git checkout pull/23111` \
`$ git pull https://git.openjdk.org/jdk.git pull/23111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23111`

View PR using the GUI difftool: \
`$ git pr show -t 23111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23111.diff">https://git.openjdk.org/jdk/pull/23111.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23111#issuecomment-2590612146)
</details>
