### PR TITLE
8347563: C2: clean up ModRefBarrierSetC2

### DIFF
--- a/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.cpp
@@ -50,13 +50,9 @@ Node* CardTableBarrierSetC2::byte_map_base_node(GraphKit* kit) const {
 // Insert a write-barrier store.  This is to let generational GC work; we have
 // to flag all oop-stores before the next GC point.
 void CardTableBarrierSetC2::post_barrier(GraphKit* kit,
-                                         Node* ctl,
-                                         Node* oop_store,
                                          Node* obj,
                                          Node* adr,
-                                         uint  adr_idx,
                                          Node* val,
-                                         BasicType bt,
                                          bool use_precise) const {
   // No store check needed if we're storing a null.
   if (val != nullptr && val->is_Con()) {

--- a/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.hpp
@@ -30,13 +30,9 @@
 class CardTableBarrierSetC2: public ModRefBarrierSetC2 {
 protected:
   virtual void post_barrier(GraphKit* kit,
-                            Node* ctl,
-                            Node* store,
                             Node* obj,
                             Node* adr,
-                            uint adr_idx,
                             Node* val,
-                            BasicType bt,
                             bool use_precise) const;
 
   Node* byte_map_base_node(GraphKit* kit) const;

--- a/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.cpp
@@ -32,7 +32,6 @@
 Node* ModRefBarrierSetC2::store_at_resolved(C2Access& access, C2AccessValue& val) const {
   DecoratorSet decorators = access.decorators();
 
-  const TypePtr* adr_type = access.addr().type();
   Node* adr = access.addr().node();
 
   bool is_array = (decorators & IS_ARRAY) != 0;
@@ -47,30 +46,22 @@ Node* ModRefBarrierSetC2::store_at_resolved(C2Access& access, C2AccessValue& val
 
   assert(access.is_parse_access(), "entry not supported at optimization time");
   C2ParseAccess& parse_access = static_cast<C2ParseAccess&>(access);
-  GraphKit* kit = parse_access.kit();
-
-  uint adr_idx = kit->C->get_alias_index(adr_type);
-  assert(adr_idx != Compile::AliasIdxTop, "use other store_to_memory factory" );
 
   Node* store = BarrierSetC2::store_at_resolved(access, val);
-  post_barrier(kit, kit->control(), access.raw_access(), access.base(), adr, adr_idx, val.node(),
-               access.type(), use_precise);
+  post_barrier(parse_access.kit(), access.base(), adr, val.node(), use_precise);
 
   return store;
 }
 
 Node* ModRefBarrierSetC2::atomic_cmpxchg_val_at_resolved(C2AtomicParseAccess& access, Node* expected_val,
                                                          Node* new_val, const Type* value_type) const {
-  GraphKit* kit = access.kit();
-
   if (!access.is_oop()) {
     return BarrierSetC2::atomic_cmpxchg_val_at_resolved(access, expected_val, new_val, value_type);
   }
 
   Node* result = BarrierSetC2::atomic_cmpxchg_val_at_resolved(access, expected_val, new_val, value_type);
 
-  post_barrier(kit, kit->control(), access.raw_access(), access.base(),
-               access.addr().node(), access.alias_idx(), new_val, T_OBJECT, true);
+  post_barrier(access.kit(), access.base(), access.addr().node(), new_val, true);
 
   return result;
 }
@@ -98,8 +89,7 @@ Node* ModRefBarrierSetC2::atomic_cmpxchg_bool_at_resolved(C2AtomicParseAccess& a
   IdealKit ideal(kit);
   ideal.if_then(load_store, BoolTest::ne, ideal.ConI(0), PROB_STATIC_FREQUENT); {
     kit->sync_kit(ideal);
-    post_barrier(kit, ideal.ctrl(), access.raw_access(), access.base(),
-                 access.addr().node(), access.alias_idx(), new_val, T_OBJECT, true);
+    post_barrier(kit, access.base(), access.addr().node(), new_val, true);
     ideal.sync_kit(kit);
   } ideal.end_if();
   kit->final_sync(ideal);
@@ -108,15 +98,12 @@ Node* ModRefBarrierSetC2::atomic_cmpxchg_bool_at_resolved(C2AtomicParseAccess& a
 }
 
 Node* ModRefBarrierSetC2::atomic_xchg_at_resolved(C2AtomicParseAccess& access, Node* new_val, const Type* value_type) const {
-  GraphKit* kit = access.kit();
-
   Node* result = BarrierSetC2::atomic_xchg_at_resolved(access, new_val, value_type);
   if (!access.is_oop()) {
     return result;
   }
 
-  post_barrier(kit, kit->control(), access.raw_access(), access.base(), access.addr().node(),
-               access.alias_idx(), new_val, T_OBJECT, true);
+  post_barrier(access.kit(), access.base(), access.addr().node(), new_val, true);
 
   return result;
 }

--- a/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.cpp
@@ -27,7 +27,6 @@
 #include "opto/graphKit.hpp"
 #include "opto/idealKit.hpp"
 #include "gc/shared/c2/modRefBarrierSetC2.hpp"
-#include "utilities/macros.hpp"
 
 Node* ModRefBarrierSetC2::store_at_resolved(C2Access& access, C2AccessValue& val) const {
   DecoratorSet decorators = access.decorators();

--- a/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,8 +53,6 @@ Node* ModRefBarrierSetC2::store_at_resolved(C2Access& access, C2AccessValue& val
   uint adr_idx = kit->C->get_alias_index(adr_type);
   assert(adr_idx != Compile::AliasIdxTop, "use other store_to_memory factory" );
 
-  pre_barrier(kit, true /* do_load */, kit->control(), access.base(), adr, adr_idx, val.node(),
-              static_cast<const TypeOopPtr*>(val.type()), nullptr /* pre_val */, access.type());
   Node* store = BarrierSetC2::store_at_resolved(access, val);
   post_barrier(kit, kit->control(), access.raw_access(), access.base(), adr, adr_idx, val.node(),
                access.type(), use_precise);
@@ -69,10 +67,6 @@ Node* ModRefBarrierSetC2::atomic_cmpxchg_val_at_resolved(C2AtomicParseAccess& ac
   if (!access.is_oop()) {
     return BarrierSetC2::atomic_cmpxchg_val_at_resolved(access, expected_val, new_val, value_type);
   }
-
-  pre_barrier(kit, false /* do_load */,
-              kit->control(), nullptr, nullptr, max_juint, nullptr, nullptr,
-              expected_val /* pre_val */, T_OBJECT);
 
   Node* result = BarrierSetC2::atomic_cmpxchg_val_at_resolved(access, expected_val, new_val, value_type);
 
@@ -89,10 +83,6 @@ Node* ModRefBarrierSetC2::atomic_cmpxchg_bool_at_resolved(C2AtomicParseAccess& a
   if (!access.is_oop()) {
     return BarrierSetC2::atomic_cmpxchg_bool_at_resolved(access, expected_val, new_val, value_type);
   }
-
-  pre_barrier(kit, false /* do_load */,
-              kit->control(), nullptr, nullptr, max_juint, nullptr, nullptr,
-              expected_val /* pre_val */, T_OBJECT);
 
   Node* load_store = BarrierSetC2::atomic_cmpxchg_bool_at_resolved(access, expected_val, new_val, value_type);
 
@@ -126,12 +116,6 @@ Node* ModRefBarrierSetC2::atomic_xchg_at_resolved(C2AtomicParseAccess& access, N
     return result;
   }
 
-  // Don't need to load pre_val. The old value is returned by load_store.
-  // The pre_barrier can execute after the xchg as long as no safepoint
-  // gets inserted between them.
-  pre_barrier(kit, false /* do_load */,
-              kit->control(), nullptr, nullptr, max_juint, nullptr, nullptr,
-              result /* pre_val */, T_OBJECT);
   post_barrier(kit, kit->control(), access.raw_access(), access.base(), access.addr().node(),
                access.alias_idx(), new_val, T_OBJECT, true);
 

--- a/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.cpp
@@ -26,7 +26,6 @@
 #include "opto/arraycopynode.hpp"
 #include "opto/graphKit.hpp"
 #include "opto/idealKit.hpp"
-#include "opto/narrowptrnode.hpp"
 #include "gc/shared/c2/modRefBarrierSetC2.hpp"
 #include "utilities/macros.hpp"
 

--- a/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,17 +31,6 @@ class TypeOopPtr;
 
 class ModRefBarrierSetC2: public BarrierSetC2 {
 protected:
-  virtual void pre_barrier(GraphKit* kit,
-                           bool do_load,
-                           Node* ctl,
-                           Node* obj,
-                           Node* adr,
-                           uint adr_idx,
-                           Node* val,
-                           const TypeOopPtr* val_type,
-                           Node* pre_val,
-                           BasicType bt) const {}
-
   virtual void post_barrier(GraphKit* kit,
                             Node* ctl,
                             Node* store,

--- a/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/modRefBarrierSetC2.hpp
@@ -32,13 +32,9 @@ class TypeOopPtr;
 class ModRefBarrierSetC2: public BarrierSetC2 {
 protected:
   virtual void post_barrier(GraphKit* kit,
-                            Node* ctl,
-                            Node* store,
                             Node* obj,
                             Node* adr,
-                            uint adr_idx,
                             Node* val,
-                            BasicType bt,
                             bool use_precise) const {}
 
   virtual Node* store_at_resolved(C2Access& access, C2AccessValue& val) const;


### PR DESCRIPTION
This cleanup removes `ModRefBarrierSetC2::pre_barrier()` (which is a no-op after [JDK-8334060](https://bugs.openjdk.org/browse/JDK-8334060)) and unused arguments of `ModRefBarrierSetC2::post_barrier()`. Thanks to @TobiHartmann for reporting!

**Testing:** tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347563](https://bugs.openjdk.org/browse/JDK-8347563): C2: clean up ModRefBarrierSetC2 (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23112/head:pull/23112` \
`$ git checkout pull/23112`

Update a local copy of the PR: \
`$ git checkout pull/23112` \
`$ git pull https://git.openjdk.org/jdk.git pull/23112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23112`

View PR using the GUI difftool: \
`$ git pr show -t 23112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23112.diff">https://git.openjdk.org/jdk/pull/23112.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23112#issuecomment-2601911317)
</details>
