### PR TITLE
8347729: Replace SIZE_FORMAT in parallel and serial gc

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
@@ -46,7 +46,7 @@ void EpsilonArguments::initialize() {
   }
 
   if (EpsilonMaxTLABSize < MinTLABSize) {
-    log_warning(gc)("EpsilonMaxTLABSize < MinTLABSize, adjusting it to " SIZE_FORMAT, MinTLABSize);
+    log_warning(gc)("EpsilonMaxTLABSize < MinTLABSize, adjusting it to %zu", MinTLABSize);
     EpsilonMaxTLABSize = MinTLABSize;
   }
 

--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -103,7 +103,7 @@ EpsilonHeap* EpsilonHeap::heap() {
 }
 
 HeapWord* EpsilonHeap::allocate_work(size_t size, bool verbose) {
-  assert(is_object_aligned(size), "Allocation size should be aligned: " SIZE_FORMAT, size);
+  assert(is_object_aligned(size), "Allocation size should be aligned: %zu", size);
 
   HeapWord* res = nullptr;
   while (true) {
@@ -129,7 +129,7 @@ HeapWord* EpsilonHeap::allocate_work(size_t size, bool verbose) {
       size_t unused_space = max_capacity() - used();
       size_t want_space = MAX2(size_in_bytes, EpsilonMinHeapExpand);
       assert(unused_space >= uncommitted_space,
-             "Unused (" SIZE_FORMAT ") >= uncommitted (" SIZE_FORMAT ")",
+             "Unused (%zu) >= uncommitted (%zu)",
              unused_space, uncommitted_space);
 
       if (want_space < uncommitted_space) {
@@ -218,18 +218,18 @@ HeapWord* EpsilonHeap::allocate_new_tlab(size_t min_size,
 
   // Check that adjustments did not break local and global invariants
   assert(is_object_aligned(size),
-         "Size honors object alignment: " SIZE_FORMAT, size);
+         "Size honors object alignment: %zu", size);
   assert(min_size <= size,
-         "Size honors min size: "  SIZE_FORMAT " <= " SIZE_FORMAT, min_size, size);
+         "Size honors min size: %zu <= %zu", min_size, size);
   assert(size <= _max_tlab_size,
-         "Size honors max size: "  SIZE_FORMAT " <= " SIZE_FORMAT, size, _max_tlab_size);
+         "Size honors max size: %zu <= %zu", size, _max_tlab_size);
   assert(size <= CollectedHeap::max_tlab_size(),
-         "Size honors global max size: "  SIZE_FORMAT " <= " SIZE_FORMAT, size, CollectedHeap::max_tlab_size());
+         "Size honors global max size: %zu <= %zu", size, CollectedHeap::max_tlab_size());
 
   if (log_is_enabled(Trace, gc)) {
     ResourceMark rm;
-    log_trace(gc)("TLAB size for \"%s\" (Requested: " SIZE_FORMAT "K, Min: " SIZE_FORMAT
-                          "K, Max: " SIZE_FORMAT "K, Ergo: " SIZE_FORMAT "K) -> " SIZE_FORMAT "K",
+    log_trace(gc)("TLAB size for \"%s\" (Requested: %zuK, Min: %zu"
+                          "K, Max: %zuK, Ergo: %zuK) -> %zuK",
                   thread->name(),
                   requested_size * HeapWordSize / K,
                   min_size * HeapWordSize / K,
@@ -325,8 +325,8 @@ void EpsilonHeap::print_heap_info(size_t used) const {
   size_t committed = capacity();
 
   if (reserved != 0) {
-    log_info(gc)("Heap: " SIZE_FORMAT "%s reserved, " SIZE_FORMAT "%s (%.2f%%) committed, "
-                 SIZE_FORMAT "%s (%.2f%%) used",
+    log_info(gc)("Heap: %zu%s reserved, %zu%s (%.2f%%) committed, "
+                 "%zu%s (%.2f%%) used",
             byte_size_in_proper_unit(reserved),  proper_unit_for_byte_size(reserved),
             byte_size_in_proper_unit(committed), proper_unit_for_byte_size(committed),
             committed * 100.0 / reserved,
@@ -344,8 +344,8 @@ void EpsilonHeap::print_metaspace_info() const {
   size_t used      = stats.used();
 
   if (reserved != 0) {
-    log_info(gc, metaspace)("Metaspace: " SIZE_FORMAT "%s reserved, " SIZE_FORMAT "%s (%.2f%%) committed, "
-                            SIZE_FORMAT "%s (%.2f%%) used",
+    log_info(gc, metaspace)("Metaspace: %zu%s reserved, %zu%s (%.2f%%) committed, "
+                            "%zu%s (%.2f%%) used",
             byte_size_in_proper_unit(reserved),  proper_unit_for_byte_size(reserved),
             byte_size_in_proper_unit(committed), proper_unit_for_byte_size(committed),
             committed * 100.0 / reserved,

--- a/src/hotspot/share/gc/epsilon/epsilonInitLogger.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonInitLogger.cpp
@@ -34,13 +34,13 @@
 void EpsilonInitLogger::print_gc_specific() {
   if (UseTLAB) {
     size_t max_tlab = EpsilonHeap::heap()->max_tlab_size() * HeapWordSize;
-    log_info(gc, init)("TLAB Size Max: " SIZE_FORMAT "%s",
+    log_info(gc, init)("TLAB Size Max: %zu%s",
                        byte_size_in_exact_unit(max_tlab), exact_unit_for_byte_size(max_tlab));
     if (EpsilonElasticTLAB) {
       log_info(gc, init)("TLAB Size Elasticity: %.2fx", EpsilonTLABElasticity);
     }
     if (EpsilonElasticTLABDecay) {
-      log_info(gc, init)("TLAB Size Decay Time: " SIZE_FORMAT "ms", EpsilonTLABDecayTime);
+      log_info(gc, init)("TLAB Size Decay Time: %zums", EpsilonTLABDecayTime);
     }
   } else {
     log_info(gc, init)("TLAB: Disabled");

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,7 @@ void MutableNUMASpace::ensure_parsability() {
         while (words_left_to_fill > 0) {
           size_t words_to_fill = MIN2(words_left_to_fill, CollectedHeap::filler_array_max_size());
           assert(words_to_fill >= CollectedHeap::min_fill_size(),
-                 "Remaining size (" SIZE_FORMAT ") is too small to fill (based on " SIZE_FORMAT " and " SIZE_FORMAT ")",
+                 "Remaining size (%zu) is too small to fill (based on %zu and %zu)",
                  words_to_fill, words_left_to_fill, CollectedHeap::filler_array_max_size());
           CollectedHeap::fill_with_object(cur_top, words_to_fill);
           cur_top += words_to_fill;
@@ -619,8 +619,8 @@ void MutableNUMASpace::print_on(outputStream* st) const {
       for (int i = 0; i < lgrp_spaces()->length(); i++) {
         lgrp_spaces()->at(i)->accumulate_statistics(page_size());
       }
-      st->print("    local/remote/unbiased/uncommitted: " SIZE_FORMAT "K/"
-                SIZE_FORMAT "K/" SIZE_FORMAT "K/" SIZE_FORMAT "K\n",
+      st->print("    local/remote/unbiased/uncommitted: %zuK/"
+                "%zuK/%zuK/%zuK\n",
                 ls->space_stats()->_local_space / K,
                 ls->space_stats()->_remote_space / K,
                 ls->space_stats()->_unbiased_space / K,

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,7 +233,7 @@ void MutableSpace::object_iterate(ObjectClosure* cl) {
 
 void MutableSpace::print_short() const { print_short_on(tty); }
 void MutableSpace::print_short_on( outputStream* st) const {
-  st->print(" space " SIZE_FORMAT "K, %d%% used", capacity_in_bytes() / K,
+  st->print(" space %zuK, %d%% used", capacity_in_bytes() / K,
             (int) ((double) used_in_bytes() * 100 / capacity_in_bytes()));
 }
 

--- a/src/hotspot/share/gc/parallel/parallelInitLogger.cpp
+++ b/src/hotspot/share/gc/parallel/parallelInitLogger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,9 @@
 
 void ParallelInitLogger::print_heap() {
   log_info_p(gc, init)("Alignments:"
-                       " Space " SIZE_FORMAT "%s,"
-                       " Generation " SIZE_FORMAT "%s,"
-                       " Heap " SIZE_FORMAT "%s",
+                       " Space %zu%s,"
+                       " Generation %zu%s,"
+                       " Heap %zu%s",
                        byte_size_in_exact_unit(SpaceAlignment), exact_unit_for_byte_size(SpaceAlignment),
                        byte_size_in_exact_unit(GenAlignment), exact_unit_for_byte_size(GenAlignment),
                        byte_size_in_exact_unit(HeapAlignment), exact_unit_for_byte_size(HeapAlignment));

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -400,7 +400,7 @@ HeapWord* ParallelScavengeHeap::mem_allocate_work(size_t size,
     if ((result == nullptr) && (QueuedAllocationWarningCount > 0) &&
         (loop_count % QueuedAllocationWarningCount == 0)) {
       log_warning(gc)("ParallelScavengeHeap::mem_allocate retries %d times", loop_count);
-      log_warning(gc)("\tsize=" SIZE_FORMAT, size);
+      log_warning(gc)("\tsize=%zu", size);
     }
   }
 

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -315,12 +315,12 @@ void PSAdaptiveSizePolicy::compute_eden_space_size(
   if (desired_eden_size > eden_limit) {
     log_debug(gc, ergo)(
           "PSAdaptiveSizePolicy::compute_eden_space_size limits:"
-          " desired_eden_size: " SIZE_FORMAT
-          " old_eden_size: " SIZE_FORMAT
-          " eden_limit: " SIZE_FORMAT
-          " cur_eden: " SIZE_FORMAT
-          " max_eden_size: " SIZE_FORMAT
-          " avg_young_live: " SIZE_FORMAT,
+          " desired_eden_size: %zu"
+          " old_eden_size: %zu"
+          " eden_limit: %zu"
+          " cur_eden: %zu"
+          " max_eden_size: %zu"
+          " avg_young_live: %zu",
           desired_eden_size, _eden_size, eden_limit, cur_eden,
           max_eden_size, (size_t)avg_young_live()->average());
   }
@@ -358,14 +358,14 @@ void PSAdaptiveSizePolicy::compute_eden_space_size(
                       _avg_major_interval->average(),
                       gc_pause_goal_sec());
 
-  log_debug(gc, ergo)("Live_space: " SIZE_FORMAT " free_space: " SIZE_FORMAT,
+  log_debug(gc, ergo)("Live_space: %zu free_space: %zu",
                       live_space(), free_space());
 
-  log_trace(gc, ergo)("avg_young_live: " SIZE_FORMAT " avg_old_live: " SIZE_FORMAT,
+  log_trace(gc, ergo)("avg_young_live: %zu avg_old_live: %zu",
                       (size_t)avg_young_live()->average(),
                       (size_t)avg_old_live()->average());
 
-  log_debug(gc, ergo)("Old eden_size: " SIZE_FORMAT " desired_eden_size: " SIZE_FORMAT,
+  log_debug(gc, ergo)("Old eden_size: %zu desired_eden_size: %zu",
                       _eden_size, desired_eden_size);
 
   set_eden_size(desired_eden_size);
@@ -492,11 +492,11 @@ void PSAdaptiveSizePolicy::compute_old_gen_free_space(
     size_t free_in_old_gen = (size_t)(max_old_gen_size - avg_old_live()->average());
     log_debug(gc, ergo)(
           "PSAdaptiveSizePolicy::compute_old_gen_free_space limits:"
-          " desired_promo_size: " SIZE_FORMAT
-          " promo_limit: " SIZE_FORMAT
-          " free_in_old_gen: " SIZE_FORMAT
-          " max_old_gen_size: " SIZE_FORMAT
-          " avg_old_live: " SIZE_FORMAT,
+          " desired_promo_size: %zu"
+          " promo_limit: %zu"
+          " free_in_old_gen: %zu"
+          " max_old_gen_size: %zu"
+          " avg_old_live: %zu",
           desired_promo_size, promo_limit, free_in_old_gen,
           max_old_gen_size, (size_t) avg_old_live()->average());
   }
@@ -529,14 +529,14 @@ void PSAdaptiveSizePolicy::compute_old_gen_free_space(
                       gc_pause_goal_sec());
 
   // Footprint stats
-  log_debug(gc, ergo)("Live_space: " SIZE_FORMAT " free_space: " SIZE_FORMAT,
+  log_debug(gc, ergo)("Live_space: %zu free_space: %zu",
                       live_space(), free_space());
 
-  log_trace(gc, ergo)("avg_young_live: " SIZE_FORMAT " avg_old_live: " SIZE_FORMAT,
+  log_trace(gc, ergo)("avg_young_live: %zu avg_old_live: %zu",
                       (size_t)avg_young_live()->average(),
                       (size_t)avg_old_live()->average());
 
-  log_debug(gc, ergo)("Old promo_size: " SIZE_FORMAT " desired_promo_size: " SIZE_FORMAT,
+  log_debug(gc, ergo)("Old promo_size: %zu desired_promo_size: %zu",
                       _promo_size, desired_promo_size);
 
   set_promo_size(desired_promo_size);
@@ -603,7 +603,7 @@ void PSAdaptiveSizePolicy::adjust_promo_for_pause_time(size_t* desired_promo_siz
   log_trace(gc, ergo)(
     "PSAdaptiveSizePolicy::adjust_promo_for_pause_time "
     "adjusting gen sizes for major pause (avg %f goal %f). "
-    "desired_promo_size " SIZE_FORMAT " promo delta " SIZE_FORMAT,
+    "desired_promo_size %zu promo delta %zu",
     _avg_major_pause->average(), gc_pause_goal_sec(),
     *desired_promo_size_ptr, promo_heap_delta);
 }
@@ -620,7 +620,7 @@ void PSAdaptiveSizePolicy::adjust_eden_for_pause_time(size_t* desired_eden_size_
   log_trace(gc, ergo)(
     "PSAdaptiveSizePolicy::adjust_eden_for_pause_time "
     "adjusting gen sizes for major pause (avg %f goal %f). "
-    "desired_eden_size " SIZE_FORMAT " eden delta " SIZE_FORMAT,
+    "desired_eden_size %zu eden delta %zu",
     _avg_major_pause->average(), gc_pause_goal_sec(),
     *desired_eden_size_ptr, eden_heap_delta);
 }
@@ -636,7 +636,7 @@ void PSAdaptiveSizePolicy::adjust_promo_for_throughput(bool is_full_gc,
     return;
   }
 
-  log_trace(gc, ergo)("PSAdaptiveSizePolicy::adjust_promo_for_throughput(is_full: %d, promo: " SIZE_FORMAT "): mutator_cost %f  major_gc_cost %f minor_gc_cost %f",
+  log_trace(gc, ergo)("PSAdaptiveSizePolicy::adjust_promo_for_throughput(is_full: %d, promo: %zu): mutator_cost %f  major_gc_cost %f minor_gc_cost %f",
                       is_full_gc, *desired_promo_size_ptr, mutator_cost(), major_gc_cost(), minor_gc_cost());
 
   // Tenured generation
@@ -650,7 +650,7 @@ void PSAdaptiveSizePolicy::adjust_promo_for_throughput(bool is_full_gc,
       double scale_by_ratio = major_gc_cost() / gc_cost();
       scaled_promo_heap_delta =
         (size_t) (scale_by_ratio * (double) promo_heap_delta);
-      log_trace(gc, ergo)("Scaled tenured increment: " SIZE_FORMAT " by %f down to " SIZE_FORMAT,
+      log_trace(gc, ergo)("Scaled tenured increment: %zu by %f down to %zu",
                           promo_heap_delta, scale_by_ratio, scaled_promo_heap_delta);
     } else if (major_gc_cost() >= 0.0) {
       // Scaling is not going to work.  If the major gc time is the
@@ -697,7 +697,7 @@ void PSAdaptiveSizePolicy::adjust_promo_for_throughput(bool is_full_gc,
         _old_gen_change_for_major_throughput++;
     }
 
-    log_trace(gc, ergo)("Adjusting tenured gen for throughput (avg %f goal %f). desired_promo_size " SIZE_FORMAT " promo_delta " SIZE_FORMAT ,
+    log_trace(gc, ergo)("Adjusting tenured gen for throughput (avg %f goal %f). desired_promo_size %zu promo_delta %zu",
                         mutator_cost(),
                         _throughput_goal,
                         *desired_promo_size_ptr, scaled_promo_heap_delta);
@@ -715,7 +715,7 @@ void PSAdaptiveSizePolicy::adjust_eden_for_throughput(bool is_full_gc,
     return;
   }
 
-  log_trace(gc, ergo)("PSAdaptiveSizePolicy::adjust_eden_for_throughput(is_full: %d, cur_eden: " SIZE_FORMAT "): mutator_cost %f  major_gc_cost %f minor_gc_cost %f",
+  log_trace(gc, ergo)("PSAdaptiveSizePolicy::adjust_eden_for_throughput(is_full: %d, cur_eden: %zu): mutator_cost %f  major_gc_cost %f minor_gc_cost %f",
                       is_full_gc, *desired_eden_size_ptr, mutator_cost(), major_gc_cost(), minor_gc_cost());
 
   // Young generation
@@ -728,7 +728,7 @@ void PSAdaptiveSizePolicy::adjust_eden_for_throughput(bool is_full_gc,
     assert(scale_by_ratio <= 1.0 && scale_by_ratio >= 0.0, "Scaling is wrong");
     scaled_eden_heap_delta =
       (size_t) (scale_by_ratio * (double) eden_heap_delta);
-    log_trace(gc, ergo)("Scaled eden increment: " SIZE_FORMAT " by %f down to " SIZE_FORMAT,
+    log_trace(gc, ergo)("Scaled eden increment: %zu by %f down to %zu",
                         eden_heap_delta, scale_by_ratio, scaled_eden_heap_delta);
   } else if (minor_gc_cost() >= 0.0) {
     // Scaling is not going to work.  If the minor gc time is the
@@ -774,7 +774,7 @@ void PSAdaptiveSizePolicy::adjust_eden_for_throughput(bool is_full_gc,
       _young_gen_change_for_minor_throughput++;
   }
 
-    log_trace(gc, ergo)("Adjusting eden for throughput (avg %f goal %f). desired_eden_size " SIZE_FORMAT " eden delta " SIZE_FORMAT,
+    log_trace(gc, ergo)("Adjusting eden for throughput (avg %f goal %f). desired_eden_size %zu eden delta %zu",
                         mutator_cost(), _throughput_goal, *desired_eden_size_ptr, scaled_eden_heap_delta);
 }
 
@@ -791,9 +791,9 @@ size_t PSAdaptiveSizePolicy::adjust_promo_for_footprint(
   log_trace(gc, ergo)(
     "AdaptiveSizePolicy::adjust_promo_for_footprint "
     "adjusting tenured gen for footprint. "
-    "starting promo size " SIZE_FORMAT
-    " reduced promo size " SIZE_FORMAT
-    " promo delta " SIZE_FORMAT,
+    "starting promo size %zu"
+    " reduced promo size %zu"
+    " promo delta %zu",
     desired_promo_size, reduced_size, change );
 
   assert(reduced_size <= desired_promo_size, "Inconsistent result");
@@ -813,9 +813,9 @@ size_t PSAdaptiveSizePolicy::adjust_eden_for_footprint(
   log_trace(gc, ergo)(
     "AdaptiveSizePolicy::adjust_eden_for_footprint "
     "adjusting eden for footprint. "
-    " starting eden size " SIZE_FORMAT
-    " reduced eden size " SIZE_FORMAT
-    " eden delta " SIZE_FORMAT,
+    " starting eden size %zu"
+    " reduced eden size %zu"
+    " eden delta %zu",
     desired_eden_size, reduced_size, change);
 
   assert(reduced_size <= desired_eden_size, "Inconsistent result");
@@ -966,7 +966,7 @@ uint PSAdaptiveSizePolicy::compute_survivor_space_size_and_threshold(
   log_debug(gc, ergo)("avg_survived_padded_avg: %f", _avg_survived->padded_average());
 
   log_trace(gc, ergo)("avg_promoted_avg: %f  avg_promoted_dev: %f", avg_promoted()->average(), avg_promoted()->deviation());
-  log_debug(gc, ergo)("avg_promoted_padded_avg: %f  avg_pretenured_padded_avg: %f  tenuring_thresh: %d  target_size: " SIZE_FORMAT,
+  log_debug(gc, ergo)("avg_promoted_padded_avg: %f  avg_pretenured_padded_avg: %f  tenuring_thresh: %d  target_size: %zu",
                       avg_promoted()->padded_average(),
                       _avg_pretenured->padded_average(),
                       tenuring_threshold, target_size);
@@ -989,7 +989,7 @@ void PSAdaptiveSizePolicy::update_averages(bool is_survivor_overflow,
   }
   avg_promoted()->sample(promoted);
 
-  log_trace(gc, ergo)("AdaptiveSizePolicy::update_averages:  survived: "  SIZE_FORMAT "  promoted: "  SIZE_FORMAT "  overflow: %s",
+  log_trace(gc, ergo)("AdaptiveSizePolicy::update_averages:  survived: %zu  promoted: %zu  overflow: %s",
                       survived, promoted, is_survivor_overflow ? "true" : "false");
 }
 

--- a/src/hotspot/share/gc/parallel/psClosure.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psClosure.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public:
       oop new_obj = o->forwardee();
       if (log_develop_is_enabled(Trace, gc, scavenge)) {
         ResourceMark rm; // required by internal_name()
-        log_develop_trace(gc, scavenge)("{%s %s " PTR_FORMAT " -> " PTR_FORMAT " (" SIZE_FORMAT ")}",
+        log_develop_trace(gc, scavenge)("{%s %s " PTR_FORMAT " -> " PTR_FORMAT " (%zu)}",
                                         "forwarding",
                                         new_obj->klass()->internal_name(), p2i((void *)o), p2i((void *)new_obj), new_obj->size());
       }

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -251,7 +251,7 @@ bool PSOldGen::expand_by(size_t bytes) {
   if (result) {
     size_t new_mem_size = virtual_space()->committed_size();
     size_t old_mem_size = new_mem_size - bytes;
-    log_debug(gc)("Expanding %s from " SIZE_FORMAT "K by " SIZE_FORMAT "K to " SIZE_FORMAT "K",
+    log_debug(gc)("Expanding %s from %zuK by %zuK to %zuK",
                   name(), old_mem_size/K, bytes/K, new_mem_size/K);
   }
 
@@ -279,7 +279,7 @@ void PSOldGen::shrink(size_t bytes) {
 
     size_t new_mem_size = virtual_space()->committed_size();
     size_t old_mem_size = new_mem_size + bytes;
-    log_debug(gc)("Shrinking %s from " SIZE_FORMAT "K by " SIZE_FORMAT "K to " SIZE_FORMAT "K",
+    log_debug(gc)("Shrinking %s from %zuK by %zuK to %zuK",
                   name(), old_mem_size/K, bytes/K, new_mem_size/K);
   }
 }
@@ -309,9 +309,9 @@ void PSOldGen::resize(size_t desired_free_space) {
   const size_t current_size = capacity_in_bytes();
 
   log_trace(gc, ergo)("AdaptiveSizePolicy::old generation size: "
-    "desired free: " SIZE_FORMAT " used: " SIZE_FORMAT
-    " new size: " SIZE_FORMAT " current size " SIZE_FORMAT
-    " gen limits: " SIZE_FORMAT " / " SIZE_FORMAT,
+    "desired free: %zu used: %zu"
+    " new size: %zu current size %zu"
+    " gen limits: %zu / %zu",
     desired_free_space, used_in_bytes(), new_size, current_size,
     max_gen_size(), min_gen_size());
 
@@ -329,7 +329,7 @@ void PSOldGen::resize(size_t desired_free_space) {
     shrink(change_bytes);
   }
 
-  log_trace(gc, ergo)("AdaptiveSizePolicy::old generation size: collection: %d (" SIZE_FORMAT ") -> (" SIZE_FORMAT ") ",
+  log_trace(gc, ergo)("AdaptiveSizePolicy::old generation size: collection: %d (%zu) -> (%zu) ",
                       ParallelScavengeHeap::heap()->total_collections(),
                       size_before,
                       virtual_space()->committed_size());
@@ -367,7 +367,7 @@ void PSOldGen::post_resize() {
 void PSOldGen::print() const { print_on(tty);}
 void PSOldGen::print_on(outputStream* st) const {
   st->print(" %-15s", name());
-  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+  st->print(" total %zuK, used %zuK",
               capacity_in_bytes()/K, used_in_bytes()/K);
   st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
                 p2i(virtual_space()->low_boundary()),

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -584,16 +584,16 @@ bool PSParallelCompact::initialize_aux_data() {
 
   if (!_mark_bitmap.initialize(mr)) {
     vm_shutdown_during_initialization(
-      err_msg("Unable to allocate " SIZE_FORMAT "KB bitmaps for parallel "
-      "garbage collection for the requested " SIZE_FORMAT "KB heap.",
+      err_msg("Unable to allocate %zuKB bitmaps for parallel "
+      "garbage collection for the requested %zuKB heap.",
       _mark_bitmap.reserved_byte_size()/K, mr.byte_size()/K));
     return false;
   }
 
   if (!_summary_data.initialize(mr)) {
     vm_shutdown_during_initialization(
-      err_msg("Unable to allocate " SIZE_FORMAT "KB card tables for parallel "
-      "garbage collection for the requested " SIZE_FORMAT "KB heap.",
+      err_msg("Unable to allocate %zuKB card tables for parallel "
+      "garbage collection for the requested %zuKB heap.",
       _summary_data.reserved_byte_size()/K, mr.byte_size()/K));
     return false;
   }
@@ -1075,7 +1075,7 @@ bool PSParallelCompact::invoke_no_policy(bool clear_all_soft_refs) {
 
     if (UseAdaptiveSizePolicy) {
       log_debug(gc, ergo)("AdaptiveSizeStart: collection: %d ", heap->total_collections());
-      log_trace(gc, ergo)("old_gen_capacity: " SIZE_FORMAT " young_gen_capacity: " SIZE_FORMAT,
+      log_trace(gc, ergo)("old_gen_capacity: %zu young_gen_capacity: %zu",
                           old_gen->capacity_in_bytes(), young_gen->capacity_in_bytes());
 
       // Don't check if the size_policy is ready here.  Let
@@ -1688,7 +1688,7 @@ private:
 public:
   FillableRegionLogger() : _next_index(0), _enabled(log_develop_is_enabled(Trace, gc, compaction)), _total_regions(0) { }
   ~FillableRegionLogger() {
-    log.trace(SIZE_FORMAT " initially fillable regions", _total_regions);
+    log.trace("%zu initially fillable regions", _total_regions);
   }
 
   void print_line() {
@@ -1697,7 +1697,7 @@ public:
     }
     FormatBuffer<> line("Fillable: ");
     for (int i = 0; i < _next_index; i++) {
-      line.append(" " SIZE_FORMAT_W(7), _regions[i]);
+      line.append(" %7zu", _regions[i]);
     }
     log.trace("%s", line.buffer());
     _next_index = 0;

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -460,7 +460,7 @@ bool PSScavenge::invoke(bool clear_soft_refs) {
         // Calculate the new survivor size and tenuring threshold
 
         log_debug(gc, ergo)("AdaptiveSizeStart:  collection: %d ", heap->total_collections());
-        log_trace(gc, ergo)("old_gen_capacity: " SIZE_FORMAT " young_gen_capacity: " SIZE_FORMAT,
+        log_trace(gc, ergo)("old_gen_capacity: %zu young_gen_capacity: %zu",
                             old_gen->capacity_in_bytes(), young_gen->capacity_in_bytes());
 
         if (UsePerfData) {
@@ -628,7 +628,7 @@ bool PSScavenge::should_attempt_scavenge() {
   size_t free_in_old_gen = old_gen->max_gen_size() - old_gen->used_in_bytes();
   bool result = promotion_estimate < free_in_old_gen;
 
-  log_trace(ergo)("%s scavenge: average_promoted " SIZE_FORMAT " padded_average_promoted " SIZE_FORMAT " free in old gen " SIZE_FORMAT,
+  log_trace(ergo)("%s scavenge: average_promoted %zu padded_average_promoted %zu free in old gen %zu",
                 result ? "Do" : "Skip", (size_t) policy->average_promoted_in_bytes(),
                 (size_t) policy->padded_average_promoted_in_bytes(),
                 free_in_old_gen);

--- a/src/hotspot/share/gc/parallel/psYoungGen.cpp
+++ b/src/hotspot/share/gc/parallel/psYoungGen.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -256,9 +256,9 @@ void PSYoungGen::resize(size_t eden_size, size_t survivor_size) {
     space_invariants();
 
     log_trace(gc, ergo)("Young generation size: "
-                        "desired eden: " SIZE_FORMAT " survivor: " SIZE_FORMAT
-                        " used: " SIZE_FORMAT " capacity: " SIZE_FORMAT
-                        " gen limits: " SIZE_FORMAT " / " SIZE_FORMAT,
+                        "desired eden: %zu survivor: %zu"
+                        " used: %zu capacity: %zu"
+                        " gen limits: %zu / %zu",
                         eden_size, survivor_size, used_in_bytes(), capacity_in_bytes(),
                         max_gen_size(), min_gen_size());
   }
@@ -315,15 +315,15 @@ bool PSYoungGen::resize_generation(size_t eden_size, size_t survivor_size) {
     }
   } else {
     if (orig_size == max_gen_size()) {
-      log_trace(gc)("PSYoung generation size at maximum: " SIZE_FORMAT "K", orig_size/K);
+      log_trace(gc)("PSYoung generation size at maximum: %zuK", orig_size/K);
     } else if (orig_size == min_gen_size()) {
-      log_trace(gc)("PSYoung generation size at minimum: " SIZE_FORMAT "K", orig_size/K);
+      log_trace(gc)("PSYoung generation size at minimum: %zuK", orig_size/K);
     }
   }
 
   if (size_changed) {
     post_resize();
-    log_trace(gc)("PSYoung generation size changed: " SIZE_FORMAT "K->" SIZE_FORMAT "K",
+    log_trace(gc)("PSYoung generation size changed: %zuK->%zuK",
                   orig_size/K, virtual_space()->committed_size()/K);
   }
 
@@ -420,21 +420,21 @@ void PSYoungGen::resize_spaces(size_t requested_eden_size,
     return;
   }
 
-  log_trace(gc, ergo)("PSYoungGen::resize_spaces(requested_eden_size: " SIZE_FORMAT ", requested_survivor_size: " SIZE_FORMAT ")",
+  log_trace(gc, ergo)("PSYoungGen::resize_spaces(requested_eden_size: %zu, requested_survivor_size: %zu)",
                       requested_eden_size, requested_survivor_size);
-  log_trace(gc, ergo)("    eden: [" PTR_FORMAT ".." PTR_FORMAT ") " SIZE_FORMAT,
+  log_trace(gc, ergo)("    eden: [" PTR_FORMAT ".." PTR_FORMAT ") %zu",
                       p2i(eden_space()->bottom()),
                       p2i(eden_space()->end()),
                       pointer_delta(eden_space()->end(),
                                     eden_space()->bottom(),
                                     sizeof(char)));
-  log_trace(gc, ergo)("    from: [" PTR_FORMAT ".." PTR_FORMAT ") " SIZE_FORMAT,
+  log_trace(gc, ergo)("    from: [" PTR_FORMAT ".." PTR_FORMAT ") %zu",
                       p2i(from_space()->bottom()),
                       p2i(from_space()->end()),
                       pointer_delta(from_space()->end(),
                                     from_space()->bottom(),
                                     sizeof(char)));
-  log_trace(gc, ergo)("      to: [" PTR_FORMAT ".." PTR_FORMAT ") " SIZE_FORMAT,
+  log_trace(gc, ergo)("      to: [" PTR_FORMAT ".." PTR_FORMAT ") %zu",
                       p2i(to_space()->bottom()),
                       p2i(to_space()->end()),
                       pointer_delta(  to_space()->end(),
@@ -525,15 +525,15 @@ void PSYoungGen::resize_spaces(size_t requested_eden_size,
 
     guarantee(to_start != to_end, "to space is zero sized");
 
-    log_trace(gc, ergo)("    [eden_start .. eden_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [eden_start .. eden_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(eden_start),
                         p2i(eden_end),
                         pointer_delta(eden_end, eden_start, sizeof(char)));
-    log_trace(gc, ergo)("    [from_start .. from_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [from_start .. from_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(from_start),
                         p2i(from_end),
                         pointer_delta(from_end, from_start, sizeof(char)));
-    log_trace(gc, ergo)("    [  to_start ..   to_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [  to_start ..   to_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(to_start),
                         p2i(to_end),
                         pointer_delta(  to_end,   to_start, sizeof(char)));
@@ -575,15 +575,15 @@ void PSYoungGen::resize_spaces(size_t requested_eden_size,
     eden_end = MAX2(eden_end, eden_start + SpaceAlignment);
     to_start = MAX2(to_start, eden_end);
 
-    log_trace(gc, ergo)("    [eden_start .. eden_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [eden_start .. eden_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(eden_start),
                         p2i(eden_end),
                         pointer_delta(eden_end, eden_start, sizeof(char)));
-    log_trace(gc, ergo)("    [  to_start ..   to_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [  to_start ..   to_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(to_start),
                         p2i(to_end),
                         pointer_delta(  to_end,   to_start, sizeof(char)));
-    log_trace(gc, ergo)("    [from_start .. from_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [from_start .. from_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(from_start),
                         p2i(from_end),
                         pointer_delta(from_end, from_start, sizeof(char)));
@@ -646,7 +646,7 @@ void PSYoungGen::resize_spaces(size_t requested_eden_size,
 
   assert(from_space()->top() == old_from_top, "from top changed!");
 
-  log_trace(gc, ergo)("AdaptiveSizePolicy::survivor space sizes: collection: %d (" SIZE_FORMAT ", " SIZE_FORMAT ") -> (" SIZE_FORMAT ", " SIZE_FORMAT ") ",
+  log_trace(gc, ergo)("AdaptiveSizePolicy::survivor space sizes: collection: %d (%zu, %zu) -> (%zu, %zu) ",
                       ParallelScavengeHeap::heap()->total_collections(),
                       old_from, old_to,
                       from_space()->capacity_in_bytes(),
@@ -702,7 +702,7 @@ void PSYoungGen::object_iterate(ObjectClosure* blk) {
 void PSYoungGen::print() const { print_on(tty); }
 void PSYoungGen::print_on(outputStream* st) const {
   st->print(" %-15s", "PSYoungGen");
-  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+  st->print(" total %zuK, used %zuK",
              capacity_in_bytes()/K, used_in_bytes()/K);
   virtual_space()->print_space_boundaries_on(st);
   st->print("  eden"); eden_space()->print_on(st);

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -480,11 +480,11 @@ void DefNewGeneration::compute_new_size() {
     gch->rem_set()->resize_covered_region(cmr);
 
     log_debug(gc, ergo, heap)(
-        "New generation size " SIZE_FORMAT "K->" SIZE_FORMAT "K [eden=" SIZE_FORMAT "K,survivor=" SIZE_FORMAT "K]",
+        "New generation size %zuK->%zuK [eden=%zuK,survivor=%zuK]",
         new_size_before/K, _virtual_space.committed_size()/K,
         eden()->capacity()/K, from()->capacity()/K);
     log_trace(gc, ergo, heap)(
-        "  [allowed " SIZE_FORMAT "K extra for %d threads]",
+        "  [allowed %zuK extra for %d threads]",
           thread_increase_size/K, threads_count);
       }
 }
@@ -715,7 +715,7 @@ void DefNewGeneration::remove_forwarding_pointers() {
 }
 
 void DefNewGeneration::handle_promotion_failure(oop old) {
-  log_debug(gc, promotion)("Promotion failure size = " SIZE_FORMAT ") ", old->size());
+  log_debug(gc, promotion)("Promotion failure size = %zu) ", old->size());
 
   _promotion_failed = true;
   _promotion_failed_info.register_copy_failure(old->size());
@@ -840,7 +840,7 @@ void DefNewGeneration::verify() {
 void DefNewGeneration::print_on(outputStream* st) const {
   st->print(" %-10s", name());
 
-  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+  st->print(" total %zuK, used %zuK",
             capacity()/K, used()/K);
   st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
                p2i(_virtual_space.low_boundary()),

--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,7 +133,7 @@ public:
       // obj->set_mark(obj->mark().set_marked());
 
       assert(dead_length == obj->size(), "bad filler object size");
-      log_develop_trace(gc, compaction)("Inserting object to dead space: " PTR_FORMAT ", " PTR_FORMAT ", " SIZE_FORMAT "b",
+      log_develop_trace(gc, compaction)("Inserting object to dead space: " PTR_FORMAT ", " PTR_FORMAT ", %zub",
                                         p2i(dead_start), p2i(dead_end), dead_length * HeapWordSize);
 
       return true;
@@ -651,7 +651,7 @@ void SerialFullGC::adjust_marks() {
 }
 
 void SerialFullGC::restore_marks() {
-  log_trace(gc)("Restoring " SIZE_FORMAT " marks", _preserved_count + _preserved_overflow_stack_set.get()->size());
+  log_trace(gc)("Restoring %zu marks", _preserved_count + _preserved_overflow_stack_set.get()->size());
 
   // restore the marks we saved earlier
   for (size_t i = 0; i < _preserved_count; i++) {

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -219,8 +219,7 @@ ReservedHeapSpace SerialHeap::allocate(size_t alignment) {
                                   "the maximum representable size");
   }
   assert(total_reserved % alignment == 0,
-         "Gen size; total_reserved=" SIZE_FORMAT ", alignment="
-         SIZE_FORMAT, total_reserved, alignment);
+         "Gen size; total_reserved=%zu, alignment=%zu", total_reserved, alignment);
 
   ReservedHeapSpace heap_rs = Universe::reserve_heap(total_reserved, alignment);
   size_t used_page_size = heap_rs.page_size();
@@ -400,7 +399,7 @@ HeapWord* SerialHeap::mem_allocate_work(size_t size,
     if ((QueuedAllocationWarningCount > 0) &&
         (try_count % QueuedAllocationWarningCount == 0)) {
           log_warning(gc, ergo)("SerialHeap::mem_allocate_work retries %d times,"
-                                " size=" SIZE_FORMAT " %s", try_count, size, is_tlab ? "(TLAB)" : "");
+                                " size=%zu %s", try_count, size, is_tlab ? "(TLAB)" : "");
     }
   }
 }

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ bool TenuredGeneration::grow_by(size_t bytes) {
 
     size_t new_mem_size = _virtual_space.committed_size();
     size_t old_mem_size = new_mem_size - bytes;
-    log_trace(gc, heap)("Expanding %s from " SIZE_FORMAT "K by " SIZE_FORMAT "K to " SIZE_FORMAT "K",
+    log_trace(gc, heap)("Expanding %s from %zuK by %zuK to %zuK",
                     name(), old_mem_size/K, bytes/K, new_mem_size/K);
   }
   return result;
@@ -140,7 +140,7 @@ void TenuredGeneration::shrink(size_t bytes) {
 
   size_t new_mem_size = _virtual_space.committed_size();
   size_t old_mem_size = new_mem_size + size;
-  log_trace(gc, heap)("Shrinking %s from " SIZE_FORMAT "K to " SIZE_FORMAT "K",
+  log_trace(gc, heap)("Shrinking %s from %zuK to %zuK",
                       name(), old_mem_size/K, new_mem_size/K);
 }
 
@@ -236,7 +236,7 @@ void TenuredGeneration::compute_new_size_inner() {
       assert(shrink_bytes <= max_shrink_bytes, "invalid shrink size");
       log_trace(gc, heap)("    shrinking:  initSize: %.1fK  maximum_desired_capacity: %.1fK",
                                OldSize / (double) K, maximum_desired_capacity / (double) K);
-      log_trace(gc, heap)("    shrink_bytes: %.1fK  current_shrink_factor: " SIZE_FORMAT "  new shrink factor: " SIZE_FORMAT "  _min_heap_delta_bytes: %.1fK",
+      log_trace(gc, heap)("    shrink_bytes: %.1fK  current_shrink_factor: %zu  new shrink factor: %zu  _min_heap_delta_bytes: %.1fK",
                                shrink_bytes / (double) K,
                                current_shrink_factor,
                                _shrink_factor,
@@ -354,8 +354,8 @@ void TenuredGeneration::compute_new_size() {
   compute_new_size_inner();
 
   assert(used() == used_after_gc && used_after_gc <= capacity(),
-         "used: " SIZE_FORMAT " used_after_gc: " SIZE_FORMAT
-         " capacity: " SIZE_FORMAT, used(), used_after_gc, capacity());
+         "used: %zu used_after_gc: %zu"
+         " capacity: %zu", used(), used_after_gc, capacity());
 }
 
 void TenuredGeneration::update_promote_stats() {
@@ -384,7 +384,7 @@ bool TenuredGeneration::promotion_attempt_is_safe(size_t max_promotion_in_bytes)
 
   bool res = (promotion_estimate <= available);
 
-  log_trace(gc)("Tenured: promo attempt is%s safe: available(" SIZE_FORMAT ") %s av_promo(" SIZE_FORMAT "), max_promo(" SIZE_FORMAT ")",
+  log_trace(gc)("Tenured: promo attempt is%s safe: available(%zu) %s av_promo(%zu), max_promo(%zu)",
     res? "":" not", available, res? ">=":"<", avg_promoted, max_promotion_in_bytes);
 
   return res;
@@ -445,7 +445,7 @@ void TenuredGeneration::verify() {
 void TenuredGeneration::print_on(outputStream* st)  const {
   st->print(" %-10s", name());
 
-  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+  st->print(" total %zuK, used %zuK",
             capacity()/K, used()/K);
   st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
                p2i(_virtual_space.low_boundary()),


### PR DESCRIPTION
Please review this change to replace SIZE_FORMAT with %zu in the parallel and serial gc directories. The only hand edit that I did for this one was SIZE_FORMAT_W(7) because my sed script had problems with it.  The %zu is a lot less noisy but it does look funny as %zums.  I verified that this format specifier does print <the number>ms and doesn't get confused.

Tested all the GC changes together (other PRs coming) with tier1-4 on x86 and aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347729](https://bugs.openjdk.org/browse/JDK-8347729): Replace SIZE_FORMAT in parallel and serial gc (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23113/head:pull/23113` \
`$ git checkout pull/23113`

Update a local copy of the PR: \
`$ git checkout pull/23113` \
`$ git pull https://git.openjdk.org/jdk.git pull/23113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23113`

View PR using the GUI difftool: \
`$ git pr show -t 23113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23113.diff">https://git.openjdk.org/jdk/pull/23113.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23113#issuecomment-2590787669)
</details>
