### PR TITLE
8347730: Replace SIZE_FORMAT in g1

### DIFF
--- a/src/hotspot/share/gc/g1/g1AllocRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1AllocRegion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -225,10 +225,10 @@ void G1AllocRegion::trace(const char* str, size_t min_word_size, size_t desired_
 
     if (detailed_info) {
       if (result != nullptr) {
-        out->print(" min " SIZE_FORMAT " desired " SIZE_FORMAT " actual " SIZE_FORMAT " " PTR_FORMAT,
+        out->print(" min %zu desired %zu actual %zu " PTR_FORMAT,
                    min_word_size, desired_word_size, actual_word_size, p2i(result));
       } else if (min_word_size != 0) {
-        out->print(" min " SIZE_FORMAT " desired " SIZE_FORMAT, min_word_size, desired_word_size);
+        out->print(" min %zu desired %zu", min_word_size, desired_word_size);
       }
     }
     out->cr();
@@ -319,7 +319,7 @@ G1HeapRegion* MutatorAllocRegion::release() {
     _wasted_bytes += retire_internal(_retained_alloc_region, false);
     _retained_alloc_region = nullptr;
   }
-  log_debug(gc, alloc, region)("Mutator Allocation stats, regions: %u, wasted size: " SIZE_FORMAT "%s (%4.1f%%)",
+  log_debug(gc, alloc, region)("Mutator Allocation stats, regions: %u, wasted size: %zu%s (%4.1f%%)",
                                count(),
                                byte_size_in_proper_unit(_wasted_bytes),
                                proper_unit_for_byte_size(_wasted_bytes),

--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -218,7 +218,7 @@ HeapWord* G1Allocator::par_allocate_during_gc(G1HeapRegionAttr dest,
   size_t temp = 0;
   HeapWord* result = par_allocate_during_gc(dest, word_size, word_size, &temp, node_index);
   assert(result == nullptr || temp == word_size,
-         "Requested " SIZE_FORMAT " words, but got " SIZE_FORMAT " at " PTR_FORMAT,
+         "Requested %zu words, but got %zu at " PTR_FORMAT,
          word_size, temp, p2i(result));
   return result;
 }

--- a/src/hotspot/share/gc/g1/g1BiasedArray.cpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,20 +48,20 @@ address G1BiasedMappedArrayBase::create_new_base_array(size_t length, size_t ele
 #ifndef PRODUCT
 void G1BiasedMappedArrayBase::verify_index(idx_t index) const {
   guarantee(_base != nullptr, "Array not initialized");
-  guarantee(index < length(), "Index out of bounds index: " SIZE_FORMAT " length: " SIZE_FORMAT, index, length());
+  guarantee(index < length(), "Index out of bounds index: %zu length: %zu", index, length());
 }
 
 void G1BiasedMappedArrayBase::verify_biased_index(idx_t biased_index) const {
   guarantee(_biased_base != nullptr, "Array not initialized");
   guarantee(biased_index >= bias() && biased_index < (bias() + length()),
-            "Biased index out of bounds, index: " SIZE_FORMAT " bias: " SIZE_FORMAT " length: " SIZE_FORMAT,
+            "Biased index out of bounds, index: %zu bias: %zu length: %zu",
             biased_index, bias(), length());
 }
 
 void G1BiasedMappedArrayBase::verify_biased_index_inclusive_end(idx_t biased_index) const {
   guarantee(_biased_base != nullptr, "Array not initialized");
   guarantee(biased_index >= bias() && biased_index <= (bias() + length()),
-            "Biased index out of inclusive bounds, index: " SIZE_FORMAT " bias: " SIZE_FORMAT " length: " SIZE_FORMAT,
+            "Biased index out of inclusive bounds, index: %zu bias: %zu length: %zu",
             biased_index, bias(), length());
 }
 

--- a/src/hotspot/share/gc/g1/g1BiasedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,12 +72,12 @@ protected:
   void initialize(HeapWord* bottom, HeapWord* end, size_t target_elem_size_in_bytes, size_t mapping_granularity_in_bytes) {
     assert(mapping_granularity_in_bytes > 0, "just checking");
     assert(is_power_of_2(mapping_granularity_in_bytes),
-           "mapping granularity must be power of 2, is " SIZE_FORMAT, mapping_granularity_in_bytes);
+           "mapping granularity must be power of 2, is %zu", mapping_granularity_in_bytes);
     assert((uintptr_t)bottom % mapping_granularity_in_bytes == 0,
-           "bottom mapping area address must be a multiple of mapping granularity " SIZE_FORMAT ", is  " PTR_FORMAT,
+           "bottom mapping area address must be a multiple of mapping granularity %zu, is  " PTR_FORMAT,
            mapping_granularity_in_bytes, p2i(bottom));
     assert((uintptr_t)end % mapping_granularity_in_bytes == 0,
-           "end mapping area address must be a multiple of mapping granularity " SIZE_FORMAT ", is " PTR_FORMAT,
+           "end mapping area address must be a multiple of mapping granularity %zu, is " PTR_FORMAT,
            mapping_granularity_in_bytes, p2i(end));
     size_t num_target_elems = pointer_delta(end, bottom, mapping_granularity_in_bytes);
     idx_t bias = (uintptr_t)bottom / mapping_granularity_in_bytes;

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ G1BlockOffsetTable::G1BlockOffsetTable(MemRegion heap, G1RegionToSpaceMapper* st
   _offset_base = ((uint8_t*)bot_reserved.start() - (uintptr_t(_reserved.start()) >> CardTable::card_shift()));
 
   log_trace(gc, bot)("G1BlockOffsetTable::G1BlockOffsetTable: ");
-  log_trace(gc, bot)("    rs.base(): " PTR_FORMAT "  rs.size(): " SIZE_FORMAT "  rs end(): " PTR_FORMAT,
+  log_trace(gc, bot)("    rs.base(): " PTR_FORMAT "  rs.size(): %zu  rs end(): " PTR_FORMAT,
                      p2i(bot_reserved.start()), bot_reserved.byte_size(), p2i(bot_reserved.end()));
 }
 

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ private:
 
   void check_offset(size_t offset, const char* msg) const {
     assert(offset < CardTable::card_size_in_words(),
-           "%s - offset: " SIZE_FORMAT ", N_words: %u",
+           "%s - offset: %zu, N_words: %u",
            msg, offset, CardTable::card_size_in_words());
   }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -179,11 +179,11 @@ G1HeapRegion* G1CollectedHeap::new_region(size_t word_size,
     // safepoint.
     assert(SafepointSynchronize::is_at_safepoint(), "invariant");
 
-    log_debug(gc, ergo, heap)("Attempt heap expansion (region allocation request failed). Allocation request: " SIZE_FORMAT "B",
+    log_debug(gc, ergo, heap)("Attempt heap expansion (region allocation request failed). Allocation request: %zuB",
                               word_size * HeapWordSize);
 
     assert(word_size * HeapWordSize < G1HeapRegion::GrainBytes,
-           "This kind of expansion should never be more than one region. Size: " SIZE_FORMAT,
+           "This kind of expansion should never be more than one region. Size: %zu",
            word_size * HeapWordSize);
     if (expand_single_region(node_index)) {
       // Given that expand_single_region() succeeded in expanding the heap, and we
@@ -335,7 +335,7 @@ G1CollectedHeap::humongous_obj_allocate_initialize_regions(G1HeapRegion* first_h
 }
 
 size_t G1CollectedHeap::humongous_obj_size_in_regions(size_t word_size) {
-  assert(is_humongous(word_size), "Object of size " SIZE_FORMAT " must be humongous here", word_size);
+  assert(is_humongous(word_size), "Object of size %zu must be humongous here", word_size);
   return align_up(word_size, G1HeapRegion::GrainWords) / G1HeapRegion::GrainWords;
 }
 
@@ -358,7 +358,7 @@ HeapWord* G1CollectedHeap::humongous_obj_allocate(size_t word_size) {
     humongous_start = _hrm.expand_and_allocate_humongous(obj_regions);
     if (humongous_start != nullptr) {
       // We managed to find a region by expanding the heap.
-      log_debug(gc, ergo, heap)("Heap expansion (humongous allocation request). Allocation request: " SIZE_FORMAT "B",
+      log_debug(gc, ergo, heap)("Heap expansion (humongous allocation request). Allocation request: %zuB",
                                 word_size * HeapWordSize);
       policy()->record_new_heap_size(num_regions());
     } else {
@@ -444,7 +444,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
       return result;
     }
 
-    log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating " SIZE_FORMAT " words",
+    log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating %zu words",
                          Thread::current()->name(), word_size);
 
     // We can reach here if we were unsuccessful in scheduling a collection (because
@@ -462,7 +462,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
     // Give a warning if we seem to be looping forever.
     if ((QueuedAllocationWarningCount > 0) &&
         (try_count % QueuedAllocationWarningCount == 0)) {
-      log_warning(gc, alloc)("%s:  Retried allocation %u times for " SIZE_FORMAT " words",
+      log_warning(gc, alloc)("%s:  Retried allocation %u times for %zu words",
                              Thread::current()->name(), try_count, word_size);
     }
   }
@@ -495,8 +495,8 @@ HeapWord* G1CollectedHeap::alloc_archive_region(size_t word_size, HeapWord* pref
   MemRegion reserved = _hrm.reserved();
 
   if (reserved.word_size() <= word_size) {
-    log_info(gc, heap)("Unable to allocate regions as archive heap is too large; size requested = " SIZE_FORMAT
-                       " bytes, heap = " SIZE_FORMAT " bytes", word_size, reserved.word_size());
+    log_info(gc, heap)("Unable to allocate regions as archive heap is too large; size requested = %zu"
+                       " bytes, heap = %zu bytes", word_size, reserved.word_size());
     return nullptr;
   }
 
@@ -514,7 +514,7 @@ HeapWord* G1CollectedHeap::alloc_archive_region(size_t word_size, HeapWord* pref
   }
   increase_used(word_size * HeapWordSize);
   if (commits != 0) {
-    log_debug(gc, ergo, heap)("Attempt heap expansion (allocate archive regions). Total size: " SIZE_FORMAT "B",
+    log_debug(gc, ergo, heap)("Attempt heap expansion (allocate archive regions). Total size: %zuB",
                               G1HeapRegion::GrainWords * HeapWordSize * commits);
   }
 
@@ -573,7 +573,7 @@ void G1CollectedHeap::dealloc_archive_regions(MemRegion range) {
   iterate_regions_in_range(range, dealloc_archive_region);
 
   if (shrink_count != 0) {
-    log_debug(gc, ergo, heap)("Attempt heap shrinking (CDS archive regions). Total size: " SIZE_FORMAT "B",
+    log_debug(gc, ergo, heap)("Attempt heap shrinking (CDS archive regions). Total size: %zuB",
                               G1HeapRegion::GrainWords * HeapWordSize * shrink_count);
     // Explicit uncommit.
     uncommit_regions(shrink_count);
@@ -673,7 +673,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
       return result;
     }
 
-    log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating " SIZE_FORMAT "",
+    log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating %zu",
                          Thread::current()->name(), word_size);
 
     // We can reach here if we were unsuccessful in scheduling a collection (because
@@ -978,7 +978,7 @@ HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
   _verifier->verify_region_sets_optional();
 
   size_t expand_bytes = MAX2(word_size * HeapWordSize, MinHeapDeltaBytes);
-  log_debug(gc, ergo, heap)("Attempt heap expansion (allocation request failed). Allocation request: " SIZE_FORMAT "B",
+  log_debug(gc, ergo, heap)("Attempt heap expansion (allocation request failed). Allocation request: %zuB",
                             word_size * HeapWordSize);
 
 
@@ -995,7 +995,7 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_worker
   size_t aligned_expand_bytes = os::align_up_vm_page_size(expand_bytes);
   aligned_expand_bytes = align_up(aligned_expand_bytes, G1HeapRegion::GrainBytes);
 
-  log_debug(gc, ergo, heap)("Expand the heap. requested expansion amount: " SIZE_FORMAT "B expansion amount: " SIZE_FORMAT "B",
+  log_debug(gc, ergo, heap)("Expand the heap. requested expansion amount: %zuB expansion amount: %zuB",
                             expand_bytes, aligned_expand_bytes);
 
   if (is_maximal_no_gc()) {
@@ -1042,7 +1042,7 @@ void G1CollectedHeap::shrink_helper(size_t shrink_bytes) {
   uint num_regions_removed = _hrm.shrink_by(num_regions_to_remove);
   size_t shrunk_bytes = num_regions_removed * G1HeapRegion::GrainBytes;
 
-  log_debug(gc, ergo, heap)("Shrink the heap. requested shrinking amount: " SIZE_FORMAT "B aligned shrinking amount: " SIZE_FORMAT "B actual amount shrunk: " SIZE_FORMAT "B",
+  log_debug(gc, ergo, heap)("Shrink the heap. requested shrinking amount: %zuB aligned shrinking amount: %zuB actual amount shrunk: %zuB",
                             shrink_bytes, aligned_shrink_bytes, shrunk_bytes);
   if (num_regions_removed > 0) {
     log_debug(gc, heap)("Uncommittable regions after shrink: %u", num_regions_removed);
@@ -2117,12 +2117,12 @@ void G1CollectedHeap::print_on(outputStream* st) const {
             p2i(_hrm.reserved().start()),
             p2i(_hrm.reserved().end()));
   st->cr();
-  st->print("  region size " SIZE_FORMAT "K, ", G1HeapRegion::GrainBytes / K);
+  st->print("  region size %zuK, ", G1HeapRegion::GrainBytes / K);
   uint young_regions = young_regions_count();
-  st->print("%u young (" SIZE_FORMAT "K), ", young_regions,
+  st->print("%u young (%zuK), ", young_regions,
             (size_t) young_regions * G1HeapRegion::GrainBytes / K);
   uint survivor_regions = survivor_regions_count();
-  st->print("%u survivors (" SIZE_FORMAT "K)", survivor_regions,
+  st->print("%u survivors (%zuK)", survivor_regions,
             (size_t) survivor_regions * G1HeapRegion::GrainBytes / K);
   st->cr();
   if (_numa->is_enabled()) {
@@ -2774,7 +2774,7 @@ void G1CollectedHeap::increase_used(size_t bytes) {
 
 void G1CollectedHeap::decrease_used(size_t bytes) {
   assert(_summary_bytes_used >= bytes,
-         "invariant: _summary_bytes_used: " SIZE_FORMAT " should be >= bytes: " SIZE_FORMAT,
+         "invariant: _summary_bytes_used: %zu should be >= bytes: %zu",
          _summary_bytes_used, bytes);
   _summary_bytes_used -= bytes;
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -361,8 +361,8 @@ private:
   do {                                                                        \
     size_t cur_used_bytes = g1h->used();                                      \
     size_t recal_used_bytes = g1h->recalculate_used();                        \
-    assert(cur_used_bytes == recal_used_bytes, "Used(" SIZE_FORMAT ") is not" \
-           " same as recalculated used(" SIZE_FORMAT ").",                    \
+    assert(cur_used_bytes == recal_used_bytes, "Used(%zu) is not" \
+           " same as recalculated used(%zu).",                    \
            cur_used_bytes, recal_used_bytes);                                 \
   } while (0)
 #else

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -284,7 +284,7 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
 
   size_t pending_cards = _policy->pending_cards_at_gc_start();
 
-  log_trace(gc, ergo, cset)("Start choosing CSet. Pending cards: " SIZE_FORMAT " target pause time: %1.2fms",
+  log_trace(gc, ergo, cset)("Start choosing CSet. Pending cards: %zu target pause time: %1.2fms",
                             pending_cards, target_pause_time_ms);
 
   // The young list is laid with the survivor regions from the previous

--- a/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,7 +224,7 @@ class G1BuildCandidateRegionsTask : public WorkerTask {
       num_pruned++;
     }
 
-    log_debug(gc, ergo, cset)("Pruned %u regions out of %u, leaving " SIZE_FORMAT " bytes waste (allowed " SIZE_FORMAT ")",
+    log_debug(gc, ergo, cset)("Pruned %u regions out of %u, leaving %zu bytes waste (allowed %zu)",
                               num_pruned,
                               num_candidates,
                               wasted_bytes,

--- a/src/hotspot/share/gc/g1/g1CommittedRegionMap.cpp
+++ b/src/hotspot/share/gc/g1/g1CommittedRegionMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,7 +233,7 @@ void G1CommittedRegionMap::verify_free_range(uint start, uint end) const {
 
 void G1CommittedRegionMap::verify_no_inactive_regons() const {
   BitMap::idx_t first_inactive = _inactive.find_first_set_bit(0);
-  assert(first_inactive == _inactive.size(), "Should be no inactive regions, but was at index: " SIZE_FORMAT, first_inactive);
+  assert(first_inactive == _inactive.size(), "Should be no inactive regions, but was at index: %zu", first_inactive);
 }
 
 void G1CommittedRegionMap::verify_active_count(uint start, uint end, uint expected) const {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,7 +140,7 @@ bool G1CMMarkStack::initialize() {
 
   log_trace(gc)("MarkStackSize: %uk  MarkStackSizeMax: %uk", (uint)(MarkStackSize / K), (uint)(MarkStackSizeMax / K));
 
-  log_debug(gc)("Initialize mark stack with " SIZE_FORMAT " chunks, maximum " SIZE_FORMAT,
+  log_debug(gc)("Initialize mark stack with %zu chunks, maximum %zu",
                 initial_num_chunks, max_capacity);
 
   return _chunk_allocator.initialize(initial_num_chunks, max_num_chunks);
@@ -205,7 +205,7 @@ bool G1CMMarkStack::ChunkAllocator::initialize(size_t initial_capacity, size_t m
   size_t new_capacity = bucket_size(0);
 
   if (!reserve(new_capacity)) {
-    log_warning(gc)("Failed to reserve memory for new overflow mark stack with " SIZE_FORMAT " chunks and size " SIZE_FORMAT "B.", new_capacity, new_capacity * sizeof(TaskQueueEntryChunk));
+    log_warning(gc)("Failed to reserve memory for new overflow mark stack with %zu chunks and size %zuB.", new_capacity, new_capacity * sizeof(TaskQueueEntryChunk));
     return false;
   }
   return true;
@@ -213,7 +213,7 @@ bool G1CMMarkStack::ChunkAllocator::initialize(size_t initial_capacity, size_t m
 
 bool G1CMMarkStack::ChunkAllocator::try_expand_to(size_t desired_capacity) {
   if (_capacity == _max_capacity) {
-    log_debug(gc)("Can not expand overflow mark stack further, already at maximum capacity of " SIZE_FORMAT " chunks.", _capacity);
+    log_debug(gc)("Can not expand overflow mark stack further, already at maximum capacity of %zu chunks.", _capacity);
     return false;
   }
 
@@ -221,7 +221,7 @@ bool G1CMMarkStack::ChunkAllocator::try_expand_to(size_t desired_capacity) {
   desired_capacity = MIN2(desired_capacity, _max_capacity);
 
   if (reserve(desired_capacity)) {
-    log_debug(gc)("Expanded the mark stack capacity from " SIZE_FORMAT " to " SIZE_FORMAT " chunks",
+    log_debug(gc)("Expanded the mark stack capacity from %zu to %zu chunks",
                   old_capacity, desired_capacity);
     return true;
   }
@@ -249,7 +249,7 @@ G1CMMarkStack::ChunkAllocator::~ChunkAllocator() {
 }
 
 bool G1CMMarkStack::ChunkAllocator::reserve(size_t new_capacity) {
-  assert(new_capacity <= _max_capacity, "Cannot expand overflow mark stack beyond the max_capacity" SIZE_FORMAT " chunks.", _max_capacity);
+  assert(new_capacity <= _max_capacity, "Cannot expand overflow mark stack beyond the max_capacity%zu chunks.", _max_capacity);
 
   size_t highest_bucket = get_bucket(new_capacity - 1);
   size_t i = get_bucket(_capacity);
@@ -273,7 +273,7 @@ bool G1CMMarkStack::ChunkAllocator::reserve(size_t new_capacity) {
     TaskQueueEntryChunk* bucket_base = MmapArrayAllocator<TaskQueueEntryChunk>::allocate_or_null(bucket_capacity, mtGC);
 
     if (bucket_base == nullptr) {
-      log_warning(gc)("Failed to reserve memory for increasing the overflow mark stack capacity with " SIZE_FORMAT " chunks and size " SIZE_FORMAT "B.",
+      log_warning(gc)("Failed to reserve memory for increasing the overflow mark stack capacity with %zu chunks and size %zuB.",
                       bucket_capacity, bucket_capacity * sizeof(TaskQueueEntryChunk));
       return false;
     }
@@ -384,7 +384,7 @@ void G1CMRootMemRegions::reset() {
 void G1CMRootMemRegions::add(HeapWord* start, HeapWord* end) {
   assert_at_safepoint();
   size_t idx = Atomic::fetch_then_add(&_num_root_regions, 1u);
-  assert(idx < _max_regions, "Trying to add more root MemRegions than there is space " SIZE_FORMAT, _max_regions);
+  assert(idx < _max_regions, "Trying to add more root MemRegions than there is space %zu", _max_regions);
   assert(start != nullptr && end != nullptr && start <= end, "Start (" PTR_FORMAT ") should be less or equal to "
          "end (" PTR_FORMAT ")", p2i(start), p2i(end));
   _root_regions[idx].set_start(start);
@@ -446,7 +446,7 @@ void G1CMRootMemRegions::scan_finished() {
 
   if (!_should_abort) {
     assert(_claimed_root_regions >= num_root_regions(),
-           "we should have claimed all root regions, claimed " SIZE_FORMAT ", length = %u",
+           "we should have claimed all root regions, claimed %zu, length = %u",
            _claimed_root_regions, num_root_regions());
   }
 
@@ -790,7 +790,7 @@ void G1ConcurrentMark::clear_bitmap(WorkerThreads* workers, bool may_yield) {
 
   G1ClearBitMapTask cl(this, num_workers, may_yield);
 
-  log_debug(gc, ergo)("Running %s with %u workers for " SIZE_FORMAT " work units.", cl.name(), num_workers, num_chunks);
+  log_debug(gc, ergo)("Running %s with %u workers for %zu work units.", cl.name(), num_workers, num_chunks);
   workers->run_task(&cl, num_workers);
   guarantee(may_yield || cl.is_complete(), "Must have completed iteration when not yielding.");
 }
@@ -1737,7 +1737,7 @@ void G1ConcurrentMark::weak_refs_work() {
     // We can not trust g1_is_alive and the contents of the heap if the marking stack
     // overflowed while processing references. Exit the VM.
     fatal("Overflow during reference processing, can not continue. Current mark stack depth: "
-          SIZE_FORMAT ", MarkStackSize: " SIZE_FORMAT ", MarkStackSizeMax: " SIZE_FORMAT ". "
+          "%zu, MarkStackSize: %zu, MarkStackSizeMax: %zu. "
           "Please increase MarkStackSize and/or MarkStackSizeMax and restart.",
           _global_mark_stack.size(), MarkStackSize, MarkStackSizeMax);
     return;
@@ -1882,7 +1882,7 @@ void G1ConcurrentMark::finalize_marking() {
   SATBMarkQueueSet& satb_mq_set = G1BarrierSet::satb_mark_queue_set();
   guarantee(has_overflown() ||
             satb_mq_set.completed_buffers_num() == 0,
-            "Invariant: has_overflown = %s, num buffers = " SIZE_FORMAT,
+            "Invariant: has_overflown = %s, num buffers = %zu",
             BOOL_TO_STR(has_overflown()),
             satb_mq_set.completed_buffers_num());
 
@@ -1898,7 +1898,7 @@ void G1ConcurrentMark::flush_all_task_caches() {
     misses += stats.second;
   }
   size_t sum = hits + misses;
-  log_debug(gc, stats)("Mark stats cache hits " SIZE_FORMAT " misses " SIZE_FORMAT " ratio %1.3lf",
+  log_debug(gc, stats)("Mark stats cache hits %zu misses %zu ratio %1.3lf",
                        hits, misses, percent_of(hits, sum));
 }
 
@@ -2475,7 +2475,7 @@ void G1CMTask::print_stats() {
                        _step_times_ms.sum());
   size_t const hits = _mark_stats_cache.hits();
   size_t const misses = _mark_stats_cache.misses();
-  log_debug(gc, stats)("  Mark Stats Cache: hits " SIZE_FORMAT " misses " SIZE_FORMAT " ratio %.3f",
+  log_debug(gc, stats)("  Mark Stats Cache: hits %zu misses %zu ratio %.3f",
                        hits, misses, percent_of(hits, hits + misses));
 }
 
@@ -2976,7 +2976,7 @@ G1CMTask::G1CMTask(uint worker_id,
 #define G1PPRL_TYPE_H_FORMAT          "   %4s"
 #define G1PPRL_STATE_FORMAT           "   %-5s"
 #define G1PPRL_STATE_H_FORMAT         "   %5s"
-#define G1PPRL_BYTE_FORMAT            "  " SIZE_FORMAT_W(9)
+#define G1PPRL_BYTE_FORMAT            "  %9zu"
 #define G1PPRL_BYTE_H_FORMAT          "  %9s"
 #define G1PPRL_DOUBLE_FORMAT          "%14.1f"
 #define G1PPRL_GCEFF_FORMAT           "  %14s"
@@ -2984,7 +2984,7 @@ G1CMTask::G1CMTask(uint worker_id,
 
 // For summary info
 #define G1PPRL_SUM_ADDR_FORMAT(tag)    "  " tag ":" G1PPRL_ADDR_BASE_FORMAT
-#define G1PPRL_SUM_BYTE_FORMAT(tag)    "  " tag ": " SIZE_FORMAT
+#define G1PPRL_SUM_BYTE_FORMAT(tag)    "  " tag ": %zu"
 #define G1PPRL_SUM_MB_FORMAT(tag)      "  " tag ": %1.2f MB"
 #define G1PPRL_SUM_MB_PERC_FORMAT(tag) G1PPRL_SUM_MB_FORMAT(tag) " / %1.2f %%"
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -249,7 +249,7 @@ G1CMMarkStack::ChunkAllocator::~ChunkAllocator() {
 }
 
 bool G1CMMarkStack::ChunkAllocator::reserve(size_t new_capacity) {
-  assert(new_capacity <= _max_capacity, "Cannot expand overflow mark stack beyond the max_capacity%zu chunks.", _max_capacity);
+  assert(new_capacity <= _max_capacity, "Cannot expand overflow mark stack beyond the max_capacity of %zu chunks.", _max_capacity);
 
   size_t highest_bucket = get_bucket(new_capacity - 1);
   size_t i = get_bucket(_capacity);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,7 +92,7 @@ inline void G1CMMarkStack::iterate(Fn fn) const {
 
   TaskQueueEntryChunk* cur = _chunk_list;
   while (cur != nullptr) {
-    guarantee(num_chunks <= _chunks_in_chunk_list, "Found " SIZE_FORMAT " oop chunks which is more than there should be", num_chunks);
+    guarantee(num_chunks <= _chunks_in_chunk_list, "Found %zu oop chunks which is more than there should be", num_chunks);
 
     for (size_t i = 0; i < EntriesPerChunk; ++i) {
       if (cur->data[i].is_null()) {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkObjArrayProcessor.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkObjArrayProcessor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ size_t G1CMObjArrayProcessor::process_array_slice(objArrayOop obj, HeapWord* sta
 }
 
 size_t G1CMObjArrayProcessor::process_obj(oop obj) {
-  assert(should_be_sliced(obj), "Must be an array object %d and large " SIZE_FORMAT, obj->is_objArray(), obj->size());
+  assert(should_be_sliced(obj), "Must be an array object %d and large %zu", obj->is_objArray(), obj->size());
 
   return process_array_slice(objArrayOop(obj), cast_from_oop<HeapWord*>(obj), objArrayOop(obj)->size());
 }

--- a/src/hotspot/share/gc/g1/g1DirtyCardQueue.cpp
+++ b/src/hotspot/share/gc/g1/g1DirtyCardQueue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,7 +174,7 @@ void G1DirtyCardQueueSet::verify_num_cards() const {
     actual += cur->size();
   }
   assert(actual == Atomic::load(&_num_cards),
-         "Num entries in completed buffers should be " SIZE_FORMAT " but are " SIZE_FORMAT,
+         "Num entries in completed buffers should be %zu but are %zu",
          Atomic::load(&_num_cards), actual);
 }
 #endif // ASSERT

--- a/src/hotspot/share/gc/g1/g1FromCardCache.cpp
+++ b/src/hotspot/share/gc/g1/g1FromCardCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ void G1FromCardCache::initialize(uint max_reserved_regions) {
 
 void G1FromCardCache::invalidate(uint start_idx, size_t new_num_regions) {
   guarantee((size_t)start_idx + new_num_regions <= max_uintx,
-            "Trying to invalidate beyond maximum region, from %u size " SIZE_FORMAT,
+            "Trying to invalidate beyond maximum region, from %u size %zu",
             start_idx, new_num_regions);
   uint end_idx = (start_idx + (uint)new_num_regions);
   assert(end_idx <= _max_reserved_regions, "Must be within max.");
@@ -73,7 +73,7 @@ void G1FromCardCache::invalidate(uint start_idx, size_t new_num_regions) {
 void G1FromCardCache::print(outputStream* out) {
   for (uint i = 0; i < num_par_rem_sets(); i++) {
     for (uint j = 0; j < _max_reserved_regions; j++) {
-      out->print_cr("_from_card_cache[%u][%u] = " SIZE_FORMAT ".",
+      out->print_cr("_from_card_cache[%u][%u] = %zu.",
                     i, j, at(i, j));
     }
   }

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ inline bool G1DetermineCompactionQueueClosure::do_heap_region(G1HeapRegion* hr) 
 
     // Too many live objects in the region; skip compacting it.
     _collector->update_from_compacting_to_skip_compacting(hr->hrm_index());
-    log_trace(gc, phases)("Phase 2: skip compaction region index: %u, live words: " SIZE_FORMAT,
+    log_trace(gc, phases)("Phase 2: skip compaction region index: %u, live words: %zu",
                             hr->hrm_index(), _collector->live_words(hr->hrm_index()));
   }
 

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -405,7 +405,7 @@ void G1GCPhaseTimes::trace_time(const char* name, double value) const {
 }
 
 void G1GCPhaseTimes::trace_count(const char* name, size_t value) const {
-  log_trace(gc, phases)("      %s: " SIZE_FORMAT, name, value);
+  log_trace(gc, phases)("      %s: %zu", name, value);
 }
 
 double G1GCPhaseTimes::print_pre_evacuate_collection_set() const {

--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -389,7 +389,7 @@ bool G1HeapRegion::verify_code_roots(VerifyOption vo) const {
   if (is_empty()) {
     bool has_code_roots = code_roots_length > 0;
     if (has_code_roots) {
-      log_error(gc, verify)("region " HR_FORMAT " is empty but has " SIZE_FORMAT " code root entries",
+      log_error(gc, verify)("region " HR_FORMAT " is empty but has %zu code root entries",
                             HR_FORMAT_PARAMS(this), code_roots_length);
     }
     return has_code_roots;
@@ -398,7 +398,7 @@ bool G1HeapRegion::verify_code_roots(VerifyOption vo) const {
   if (is_continues_humongous()) {
     bool has_code_roots = code_roots_length > 0;
     if (has_code_roots) {
-      log_error(gc, verify)("region " HR_FORMAT " is a continuation of a humongous region but has " SIZE_FORMAT " code root entries",
+      log_error(gc, verify)("region " HR_FORMAT " is a continuation of a humongous region but has %zu code root entries",
                             HR_FORMAT_PARAMS(this), code_roots_length);
     }
     return has_code_roots;

--- a/src/hotspot/share/gc/g1/g1HeapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionRemSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,7 +98,7 @@ G1MonotonicArenaMemoryStats G1HeapRegionRemSet::card_set_memory_stats() const {
 }
 
 void G1HeapRegionRemSet::print_static_mem_size(outputStream* out) {
-  out->print_cr("  Static structures = " SIZE_FORMAT, G1HeapRegionRemSet::static_mem_size());
+  out->print_cr("  Static structures = %zu", G1HeapRegionRemSet::static_mem_size());
 }
 
 // Code roots support

--- a/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
@@ -74,7 +74,7 @@ static void log_expansion(double short_term_pause_time_ratio,
   log_debug(gc, ergo, heap)("Heap expansion: "
                             "short term pause time ratio %1.2f%% long term pause time ratio %1.2f%% "
                             "threshold %1.2f%% pause time ratio %1.2f%% fully expanded %s "
-                            "resize by " SIZE_FORMAT "B",
+                            "resize by %zuB",
                             short_term_pause_time_ratio * 100.0,
                             long_term_pause_time_ratio * 100.0,
                             threshold * 100.0,
@@ -240,8 +240,8 @@ size_t G1HeapSizingPolicy::full_collection_resize_amount(bool& expand) {
   // This assert only makes sense here, before we adjust them
   // with respect to the min and max heap size.
   assert(minimum_desired_capacity <= maximum_desired_capacity,
-         "minimum_desired_capacity = " SIZE_FORMAT ", "
-         "maximum_desired_capacity = " SIZE_FORMAT,
+         "minimum_desired_capacity = %zu, "
+         "maximum_desired_capacity = %zu",
          minimum_desired_capacity, maximum_desired_capacity);
 
   // Should not be greater than the heap max size. No need to adjust
@@ -258,8 +258,8 @@ size_t G1HeapSizingPolicy::full_collection_resize_amount(bool& expand) {
     size_t expand_bytes = minimum_desired_capacity - capacity_after_gc;
 
     log_debug(gc, ergo, heap)("Attempt heap expansion (capacity lower than min desired capacity). "
-                              "Capacity: " SIZE_FORMAT "B occupancy: " SIZE_FORMAT "B live: " SIZE_FORMAT "B "
-                              "min_desired_capacity: " SIZE_FORMAT "B (%zu %%)",
+                              "Capacity: %zuB occupancy: %zuB live: %zuB "
+                              "min_desired_capacity: %zuB (%zu %%)",
                               capacity_after_gc, used_after_gc, _g1h->used(), minimum_desired_capacity, MinHeapFreeRatio);
 
     expand = true;
@@ -270,8 +270,8 @@ size_t G1HeapSizingPolicy::full_collection_resize_amount(bool& expand) {
     size_t shrink_bytes = capacity_after_gc - maximum_desired_capacity;
 
     log_debug(gc, ergo, heap)("Attempt heap shrinking (capacity higher than max desired capacity). "
-                              "Capacity: " SIZE_FORMAT "B occupancy: " SIZE_FORMAT "B live: " SIZE_FORMAT "B "
-                              "maximum_desired_capacity: " SIZE_FORMAT "B (%zu %%)",
+                              "Capacity: %zuB occupancy: %zuB live: %zuB "
+                              "maximum_desired_capacity: %zuB (%zu %%)",
                               capacity_after_gc, used_after_gc, _g1h->used(), maximum_desired_capacity, MaxHeapFreeRatio);
 
     expand = false;

--- a/src/hotspot/share/gc/g1/g1HeapTransition.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapTransition.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ public:
       _usage._humongous_used += r->used();
       _usage._humongous_region_count++;
     } else {
-      assert(r->used() == 0, "Expected used to be 0 but it was " SIZE_FORMAT, r->used());
+      assert(r->used() == 0, "Expected used to be 0 but it was %zu", r->used());
     }
     return false;
   }
@@ -109,7 +109,7 @@ static void log_regions(const char* msg, size_t before_length, size_t after_leng
   if (lt.is_enabled()) {
     LogStream ls(lt);
 
-    ls.print("%s regions: " SIZE_FORMAT "->" SIZE_FORMAT "("  SIZE_FORMAT ")",
+    ls.print("%s regions: %zu->%zu(%zu)",
              msg, before_length, after_length, capacity);
     // Not null only if gc+heap+numa at Debug level is enabled.
     if (before_per_node_length != nullptr && after_per_node_length != nullptr) {
@@ -141,12 +141,12 @@ void G1HeapTransition::print() {
     DetailedUsageClosure blk;
     _g1_heap->heap_region_iterate(&blk);
     usage = blk._usage;
-    assert(usage._eden_region_count == 0, "Expected no eden regions, but got " SIZE_FORMAT, usage._eden_region_count);
-    assert(usage._survivor_region_count == after._survivor_length, "Expected survivors to be " SIZE_FORMAT " but was " SIZE_FORMAT,
+    assert(usage._eden_region_count == 0, "Expected no eden regions, but got %zu", usage._eden_region_count);
+    assert(usage._survivor_region_count == after._survivor_length, "Expected survivors to be %zu but was %zu",
            after._survivor_length, usage._survivor_region_count);
-    assert(usage._old_region_count == after._old_length, "Expected old to be " SIZE_FORMAT " but was " SIZE_FORMAT,
+    assert(usage._old_region_count == after._old_length, "Expected old to be %zu but was %zu",
            after._old_length, usage._old_region_count);
-    assert(usage._humongous_region_count == after._humongous_length, "Expected humongous to be " SIZE_FORMAT " but was " SIZE_FORMAT,
+    assert(usage._humongous_region_count == after._humongous_length, "Expected humongous to be %zu but was %zu",
            after._humongous_length, usage._humongous_region_count);
   }
 
@@ -156,17 +156,17 @@ void G1HeapTransition::print() {
 
   log_regions("Survivor", _before._survivor_length, after._survivor_length, survivor_capacity_length_before_gc,
               _before._survivor_length_per_node, after._survivor_length_per_node);
-  log_trace(gc, heap)(" Used: " SIZE_FORMAT "K, Waste: " SIZE_FORMAT "K",
+  log_trace(gc, heap)(" Used: %zuK, Waste: %zuK",
                       usage._survivor_used / K, ((after._survivor_length * G1HeapRegion::GrainBytes) - usage._survivor_used) / K);
 
-  log_info(gc, heap)("Old regions: " SIZE_FORMAT "->" SIZE_FORMAT,
+  log_info(gc, heap)("Old regions: %zu->%zu",
                      _before._old_length, after._old_length);
-  log_trace(gc, heap)(" Used: " SIZE_FORMAT "K, Waste: " SIZE_FORMAT "K",
+  log_trace(gc, heap)(" Used: %zuK, Waste: %zuK",
                       usage._old_used / K, ((after._old_length * G1HeapRegion::GrainBytes) - usage._old_used) / K);
 
-  log_info(gc, heap)("Humongous regions: " SIZE_FORMAT "->" SIZE_FORMAT,
+  log_info(gc, heap)("Humongous regions: %zu->%zu",
                      _before._humongous_length, after._humongous_length);
-  log_trace(gc, heap)(" Used: " SIZE_FORMAT "K, Waste: " SIZE_FORMAT "K",
+  log_trace(gc, heap)(" Used: %zuK, Waste: %zuK",
                       usage._humongous_used / K, ((after._humongous_length * G1HeapRegion::GrainBytes) - usage._humongous_used) / K);
 
   MetaspaceUtils::print_metaspace_change(_before._meta_sizes);

--- a/src/hotspot/share/gc/g1/g1IHOPControl.cpp
+++ b/src/hotspot/share/gc/g1/g1IHOPControl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ G1IHOPControl::G1IHOPControl(double initial_ihop_percent,
 }
 
 void G1IHOPControl::update_target_occupancy(size_t new_target_occupancy) {
-  log_debug(gc, ihop)("Target occupancy update: old: " SIZE_FORMAT "B, new: " SIZE_FORMAT "B",
+  log_debug(gc, ihop)("Target occupancy update: old: %zuB, new: %zuB",
                       _target_occupancy, new_target_occupancy);
   _target_occupancy = new_target_occupancy;
 }
@@ -54,8 +54,8 @@ void G1IHOPControl::update_allocation_info(double allocation_time_s, size_t addi
 void G1IHOPControl::print() {
   assert(_target_occupancy > 0, "Target occupancy still not updated yet.");
   size_t cur_conc_mark_start_threshold = get_conc_mark_start_threshold();
-  log_debug(gc, ihop)("Basic information (value update), threshold: " SIZE_FORMAT "B (%1.2f), target occupancy: " SIZE_FORMAT "B, current occupancy: " SIZE_FORMAT "B, "
-                      "recent allocation size: " SIZE_FORMAT "B, recent allocation duration: %1.2fms, recent old gen allocation rate: %1.2fB/s, recent marking phase length: %1.2fms",
+  log_debug(gc, ihop)("Basic information (value update), threshold: %zuB (%1.2f), target occupancy: %zuB, current occupancy: %zuB, "
+                      "recent allocation size: %zuB, recent allocation duration: %1.2fms, recent old gen allocation rate: %1.2fB/s, recent marking phase length: %1.2fms",
                       cur_conc_mark_start_threshold,
                       percent_of(cur_conc_mark_start_threshold, _target_occupancy),
                       _target_occupancy,
@@ -169,8 +169,8 @@ void G1AdaptiveIHOPControl::update_marking_length(double marking_length_s) {
 void G1AdaptiveIHOPControl::print() {
   G1IHOPControl::print();
   size_t actual_target = actual_target_threshold();
-  log_debug(gc, ihop)("Adaptive IHOP information (value update), threshold: " SIZE_FORMAT "B (%1.2f), internal target occupancy: " SIZE_FORMAT "B, "
-                      "occupancy: " SIZE_FORMAT "B, additional buffer size: " SIZE_FORMAT "B, predicted old gen allocation rate: %1.2fB/s, "
+  log_debug(gc, ihop)("Adaptive IHOP information (value update), threshold: %zuB (%1.2f), internal target occupancy: %zuB, "
+                      "occupancy: %zuB, additional buffer size: %zuB, predicted old gen allocation rate: %1.2fB/s, "
                       "predicted marking phase length: %1.2fms, prediction active: %s",
                       get_conc_mark_start_threshold(),
                       percent_of(get_conc_mark_start_threshold(), actual_target),

--- a/src/hotspot/share/gc/g1/g1InitLogger.cpp
+++ b/src/hotspot/share/gc/g1/g1InitLogger.cpp
@@ -30,7 +30,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 void G1InitLogger::print_heap() {
-  log_info_p(gc, init)("Heap Region Size: " SIZE_FORMAT "M", G1HeapRegionSize / M);
+  log_info_p(gc, init)("Heap Region Size: %zuM", G1HeapRegionSize / M);
   GCInitLogger::print_heap();
 }
 

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -285,12 +285,12 @@ void G1MonitoringSupport::recalculate_sizes() {
   _eden_space_used = MIN2(_eden_space_used, _eden_space_committed);
   // _survivor_space_used is calculated during a safepoint and _survivor_space_committed
   // is calculated from survivor region count * heap region size.
-  assert(_survivor_space_used <= _survivor_space_committed, "Survivor used bytes(" SIZE_FORMAT
-         ") should be less than or equal to survivor committed(" SIZE_FORMAT ")",
+  assert(_survivor_space_used <= _survivor_space_committed, "Survivor used bytes(%zu"
+         ") should be less than or equal to survivor committed(%zu)",
          _survivor_space_used, _survivor_space_committed);
   // _old_gen_committed is calculated in terms of _old_gen_used value.
-  assert(_old_gen_used <= _old_gen_committed, "Old gen used bytes(" SIZE_FORMAT
-         ") should be less than or equal to old gen committed(" SIZE_FORMAT ")",
+  assert(_old_gen_used <= _old_gen_committed, "Old gen used bytes(%zu"
+         ") should be less than or equal to old gen committed(%zu)",
          _old_gen_used, _old_gen_committed);
 }
 

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -285,12 +285,12 @@ void G1MonitoringSupport::recalculate_sizes() {
   _eden_space_used = MIN2(_eden_space_used, _eden_space_committed);
   // _survivor_space_used is calculated during a safepoint and _survivor_space_committed
   // is calculated from survivor region count * heap region size.
-  assert(_survivor_space_used <= _survivor_space_committed, "Survivor used bytes(%zu"
-         ") should be less than or equal to survivor committed(%zu)",
+  assert(_survivor_space_used <= _survivor_space_committed, "Survivor used bytes(%zu)"
+         " should be less than or equal to survivor committed(%zu)",
          _survivor_space_used, _survivor_space_committed);
   // _old_gen_committed is calculated in terms of _old_gen_used value.
-  assert(_old_gen_used <= _old_gen_committed, "Old gen used bytes(%zu"
-         ") should be less than or equal to old gen committed(%zu)",
+  assert(_old_gen_used <= _old_gen_committed, "Old gen used bytes(%zu)"
+         " should be less than or equal to old gen committed(%zu)",
          _old_gen_used, _old_gen_committed);
 }
 

--- a/src/hotspot/share/gc/g1/g1NUMA.cpp
+++ b/src/hotspot/share/gc/g1/g1NUMA.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,7 +215,7 @@ void G1NUMA::request_memory_on_node(void* aligned_address, size_t size_in_bytes,
   uint node_index = preferred_node_index_for_index(region_index);
 
   assert(is_aligned(aligned_address, page_size()), "Given address (" PTR_FORMAT ") should be aligned.", p2i(aligned_address));
-  assert(is_aligned(size_in_bytes, page_size()), "Given size (" SIZE_FORMAT ") should be aligned.", size_in_bytes);
+  assert(is_aligned(size_in_bytes, page_size()), "Given size (%zu) should be aligned.", size_in_bytes);
 
   log_trace(gc, heap, numa)("Request memory [" PTR_FORMAT ", " PTR_FORMAT ") to be NUMA id (%u)",
                             p2i(aligned_address), p2i((char*)aligned_address + size_in_bytes), _node_ids[node_index]);

--- a/src/hotspot/share/gc/g1/g1NUMAStats.cpp
+++ b/src/hotspot/share/gc/g1/g1NUMAStats.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,7 +162,7 @@ static const char* phase_to_explanatory_string(G1NUMAStats::NodeDataItems phase)
   }
 }
 
-#define RATE_TOTAL_FORMAT "%0.0f%% " SIZE_FORMAT "/" SIZE_FORMAT
+#define RATE_TOTAL_FORMAT "%0.0f%% %zu/%zu"
 
 void G1NUMAStats::print_info(G1NUMAStats::NodeDataItems phase) {
   LogTarget(Info, gc, heap, numa) lt;
@@ -206,18 +206,18 @@ void G1NUMAStats::print_mutator_alloc_stat_debug() {
     for (uint req = 0; req < array_width; req++) {
       ls.print("%3d ", _node_ids[req]);
       for (uint alloc = 0; alloc < array_width; alloc++) {
-        ls.print(SIZE_FORMAT_W(8), _node_data[NewRegionAlloc]->get(req, alloc));
+        ls.print("%8zu", _node_data[NewRegionAlloc]->get(req, alloc));
       }
-      ls.print(SIZE_FORMAT_W(8), _node_data[NewRegionAlloc]->sum(req));
+      ls.print("%8zu",  _node_data[NewRegionAlloc]->sum(req));
       ls.print_cr("");
       // Add padding to align with the string 'Requested NUMA id'.
       ls.print("                  ");
     }
     ls.print("Any ");
     for (uint alloc = 0; alloc < array_width; alloc++) {
-      ls.print(SIZE_FORMAT_W(8), _node_data[NewRegionAlloc]->get(array_width, alloc));
+      ls.print("%8zu", _node_data[NewRegionAlloc]->get(array_width, alloc));
     }
-    ls.print(SIZE_FORMAT_W(8), _node_data[NewRegionAlloc]->sum(array_width));
+    ls.print("%8zu", _node_data[NewRegionAlloc]->sum(array_width));
     ls.print_cr("");
   }
 }

--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,13 +48,13 @@ void G1PageBasedVirtualSpace::initialize_with_page_size(ReservedSpace rs, size_t
   vmassert(page_size > 0, "Page size must be non-zero.");
 
   guarantee(is_aligned(rs.base(), page_size),
-            "Reserved space base " PTR_FORMAT " is not aligned to requested page size " SIZE_FORMAT, p2i(rs.base()), page_size);
+            "Reserved space base " PTR_FORMAT " is not aligned to requested page size %zu", p2i(rs.base()), page_size);
   guarantee(is_aligned(used_size, os::vm_page_size()),
-            "Given used reserved space size needs to be OS page size aligned (" SIZE_FORMAT " bytes) but is " SIZE_FORMAT, os::vm_page_size(), used_size);
+            "Given used reserved space size needs to be OS page size aligned (%zu bytes) but is %zu", os::vm_page_size(), used_size);
   guarantee(used_size <= rs.size(),
-            "Used size of reserved space " SIZE_FORMAT " bytes is smaller than reservation at " SIZE_FORMAT " bytes", used_size, rs.size());
+            "Used size of reserved space %zu bytes is smaller than reservation at %zu bytes", used_size, rs.size());
   guarantee(is_aligned(rs.size(), page_size),
-            "Expected that the virtual space is size aligned, but " SIZE_FORMAT " is not aligned to page size " SIZE_FORMAT, rs.size(), page_size);
+            "Expected that the virtual space is size aligned, but %zu is not aligned to page size %zu", rs.size(), page_size);
 
   _low_boundary  = rs.base();
   _high_boundary = _low_boundary + used_size;
@@ -121,15 +121,15 @@ size_t G1PageBasedVirtualSpace::page_size() const {
 
 bool G1PageBasedVirtualSpace::is_after_last_page(size_t index) const {
   guarantee(index <= _committed.size(),
-            "Given boundary page " SIZE_FORMAT " is beyond managed page count " SIZE_FORMAT, index, _committed.size());
+            "Given boundary page %zu is beyond managed page count %zu", index, _committed.size());
   return index == _committed.size();
 }
 
 void G1PageBasedVirtualSpace::commit_preferred_pages(size_t start, size_t num_pages) {
   vmassert(num_pages > 0, "No full pages to commit");
   vmassert(start + num_pages <= _committed.size(),
-           "Tried to commit area from page " SIZE_FORMAT " to page " SIZE_FORMAT " "
-           "that is outside of managed space of " SIZE_FORMAT " pages",
+           "Tried to commit area from page %zu to page %zu "
+           "that is outside of managed space of %zu pages",
            start, start + num_pages, _committed.size());
 
   char* start_addr = page_start(start);
@@ -147,9 +147,9 @@ void G1PageBasedVirtualSpace::commit_tail() {
 
 void G1PageBasedVirtualSpace::commit_internal(size_t start_page, size_t end_page) {
   guarantee(start_page < end_page,
-            "Given start page " SIZE_FORMAT " is larger or equal to end page " SIZE_FORMAT, start_page, end_page);
+            "Given start page %zu is larger or equal to end page %zu", start_page, end_page);
   guarantee(end_page <= _committed.size(),
-            "Given end page " SIZE_FORMAT " is beyond end of managed page amount of " SIZE_FORMAT, end_page, _committed.size());
+            "Given end page %zu is beyond end of managed page amount of %zu", end_page, _committed.size());
 
   size_t pages = end_page - start_page;
   bool need_to_commit_tail = is_after_last_page(end_page) && is_last_page_partial();
@@ -176,7 +176,7 @@ char* G1PageBasedVirtualSpace::bounded_end_addr(size_t end_page) const {
 bool G1PageBasedVirtualSpace::commit(size_t start_page, size_t size_in_pages) {
   // We need to make sure to commit all pages covered by the given area.
   guarantee(is_area_uncommitted(start_page, size_in_pages),
-            "Specified area is not uncommitted, start page: " SIZE_FORMAT ", page count: " SIZE_FORMAT,
+            "Specified area is not uncommitted, start page: %zu, page count: %zu",
             start_page, size_in_pages);
 
   bool zero_filled = true;
@@ -198,7 +198,7 @@ bool G1PageBasedVirtualSpace::commit(size_t start_page, size_t size_in_pages) {
 
 void G1PageBasedVirtualSpace::uncommit_internal(size_t start_page, size_t end_page) {
   guarantee(start_page < end_page,
-            "Given start page " SIZE_FORMAT " is larger or equal to end page " SIZE_FORMAT, start_page, end_page);
+            "Given start page %zu is larger or equal to end page %zu", start_page, end_page);
 
   char* start_addr = page_start(start_page);
   os::uncommit_memory(start_addr, pointer_delta(bounded_end_addr(end_page), start_addr, sizeof(char)));
@@ -206,7 +206,7 @@ void G1PageBasedVirtualSpace::uncommit_internal(size_t start_page, size_t end_pa
 
 void G1PageBasedVirtualSpace::uncommit(size_t start_page, size_t size_in_pages) {
   guarantee(is_area_committed(start_page, size_in_pages),
-            "Specified area is not committed, start page: " SIZE_FORMAT ", page count: " SIZE_FORMAT,
+            "Specified area is not committed, start page: %zu, page count: %zu",
             start_page, size_in_pages);
 
   size_t end_page = start_page + size_in_pages;
@@ -236,9 +236,9 @@ void G1PageBasedVirtualSpace::print_on(outputStream* out) {
   out->print   ("Virtual space:");
   if (_special) out->print(" (pinned in memory)");
   out->cr();
-  out->print_cr(" - committed: " SIZE_FORMAT, committed_size());
-  out->print_cr(" - reserved:  " SIZE_FORMAT, reserved_size());
-  out->print_cr(" - preferred page size: " SIZE_FORMAT, _page_size);
+  out->print_cr(" - committed: %zu", committed_size());
+  out->print_cr(" - reserved:  %zu", reserved_size());
+  out->print_cr(" - preferred page size: %zu", _page_size);
   out->print_cr(" - [low_b, high_b]: [" PTR_FORMAT ", " PTR_FORMAT "]",  p2i(_low_boundary), p2i(_high_boundary));
 }
 

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ inline void G1ParScanThreadState::remember_root_into_optional_region(T* p) {
   oop o = RawAccess<IS_NOT_NULL>::oop_load(p);
   uint index = _g1h->heap_region_containing(o)->index_in_opt_cset();
   assert(index < _max_num_optional_regions,
-         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _max_num_optional_regions);
+         "Trying to access optional region idx %u beyond %zu", index, _max_num_optional_regions);
   _oops_into_optional_regions[index].push_root(p);
 }
 
@@ -84,14 +84,14 @@ inline void G1ParScanThreadState::remember_reference_into_optional_region(T* p) 
   oop o = RawAccess<IS_NOT_NULL>::oop_load(p);
   uint index = _g1h->heap_region_containing(o)->index_in_opt_cset();
   assert(index < _max_num_optional_regions,
-         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _max_num_optional_regions);
+         "Trying to access optional region idx %u beyond %zu", index, _max_num_optional_regions);
   _oops_into_optional_regions[index].push_oop(p);
   verify_task(p);
 }
 
 G1OopStarChunkedList* G1ParScanThreadState::oops_into_optional_region(const G1HeapRegion* hr) {
   assert(hr->index_in_opt_cset() < _max_num_optional_regions,
-         "Trying to access optional region idx %u beyond " SIZE_FORMAT " " HR_FORMAT,
+         "Trying to access optional region idx %u beyond %zu " HR_FORMAT,
          hr->index_in_opt_cset(), _max_num_optional_regions, HR_FORMAT_PARAMS(hr));
   return &_oops_into_optional_regions[hr->index_in_opt_cset()];
 }

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -606,8 +606,8 @@ void G1Policy::record_full_collection_end() {
 
 static void log_refinement_stats(const char* kind, const G1ConcurrentRefineStats& stats) {
   log_debug(gc, refine, stats)
-           ("%s refinement: %.2fms, refined: " SIZE_FORMAT
-            ", precleaned: " SIZE_FORMAT ", dirtied: " SIZE_FORMAT,
+           ("%s refinement: %.2fms, refined: %zu"
+            ", precleaned: %zu, dirtied: %zu",
             kind,
             stats.refinement_time().seconds() * MILLIUNITS,
             stats.refined_cards(),
@@ -757,7 +757,7 @@ bool G1Policy::need_to_start_conc_mark(const char* source, size_t alloc_word_siz
   bool result = false;
   if (marking_request_bytes > marking_initiating_used_threshold) {
     result = collector_state()->in_young_only_phase();
-    log_debug(gc, ergo, ihop)("%s occupancy: " SIZE_FORMAT "B allocation request: " SIZE_FORMAT "B threshold: " SIZE_FORMAT "B (%1.2f) source: %s",
+    log_debug(gc, ergo, ihop)("%s occupancy: %zuB allocation request: %zuB threshold: %zuB (%1.2f) source: %s",
                               result ? "Request concurrent cycle initiation (occupancy higher than threshold)" : "Do not request concurrent cycle initiation (still doing mixed collections)",
                               cur_used_bytes, alloc_byte_size, marking_initiating_used_threshold, (double) marking_initiating_used_threshold / _g1h->capacity() * 100, source);
   }

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,7 @@ class G1RegionsLargerThanCommitSizeMapper : public G1RegionToSpaceMapper {
 
   virtual void commit_regions(uint start_idx, size_t num_regions, WorkerThreads* pretouch_workers) {
     guarantee(is_range_uncommitted(start_idx, num_regions),
-              "Range not uncommitted, start: %u, num_regions: " SIZE_FORMAT,
+              "Range not uncommitted, start: %u, num_regions: %zu",
               start_idx, num_regions);
 
     const size_t start_page = (size_t)start_idx * _pages_per_region;
@@ -113,7 +113,7 @@ class G1RegionsLargerThanCommitSizeMapper : public G1RegionToSpaceMapper {
 
   virtual void uncommit_regions(uint start_idx, size_t num_regions) {
     guarantee(is_range_committed(start_idx, num_regions),
-             "Range not committed, start: %u, num_regions: " SIZE_FORMAT,
+             "Range not committed, start: %u, num_regions: %zu",
               start_idx, num_regions);
 
     _storage.uncommit((size_t)start_idx * _pages_per_region, num_regions * _pages_per_region);

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public:
   // dirty card, i.e. actually needs scanning.
   bool chunk_needs_scan(uint const region_idx, uint const card_in_region) const {
     size_t const idx = ((size_t)region_idx << _log_scan_chunks_per_region) + (card_in_region >> _scan_chunks_shift);
-    assert(idx < _num_total_scan_chunks, "Index " SIZE_FORMAT " out of bounds " SIZE_FORMAT,
+    assert(idx < _num_total_scan_chunks, "Index %zu out of bounds %zu",
            idx, _num_total_scan_chunks);
     return _region_scan_chunks[idx];
   }
@@ -347,7 +347,7 @@ public:
 
   void set_chunk_dirty(size_t const card_idx) {
     assert((card_idx >> _scan_chunks_shift) < _num_total_scan_chunks,
-           "Trying to access index " SIZE_FORMAT " out of bounds " SIZE_FORMAT,
+           "Trying to access index %zu out of bounds %zu",
            card_idx >> _scan_chunks_shift, _num_total_scan_chunks);
     size_t const chunk_idx = card_idx >> _scan_chunks_shift;
     _region_scan_chunks[chunk_idx] = true;
@@ -1438,7 +1438,7 @@ void G1RemSet::print_merge_heap_roots_stats() {
     size_t total_old_region_cards =
       (g1h->num_regions() - (g1h->num_free_regions() - g1h->collection_set()->cur_length())) * G1HeapRegion::CardsPerRegion;
 
-    ls.print_cr("Visited cards " SIZE_FORMAT " Total dirty " SIZE_FORMAT " (%.2lf%%) Total old " SIZE_FORMAT " (%.2lf%%)",
+    ls.print_cr("Visited cards %zu Total dirty %zu (%.2lf%%) Total old %zu (%.2lf%%)",
                 num_visited_cards,
                 total_dirty_region_cards,
                 percent_of(num_visited_cards, total_dirty_region_cards),
@@ -1471,7 +1471,7 @@ void G1RemSet::merge_heap_roots(bool initial_evacuation) {
 
   {
     G1MergeHeapRootsTask cl(_scan_state, num_workers, initial_evacuation);
-    log_debug(gc, ergo)("Running %s using %u workers for " SIZE_FORMAT " regions",
+    log_debug(gc, ergo)("Running %s using %u workers for %zu regions",
                         cl.name(), num_workers, increment_length);
     workers->run_task(&cl, num_workers);
   }
@@ -1504,7 +1504,7 @@ inline void check_card_ptr(CardTable::CardValue* card_ptr, G1CardTable* ct) {
 #ifdef ASSERT
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   assert(g1h->is_in(ct->addr_for(card_ptr)),
-         "Card at " PTR_FORMAT " index " SIZE_FORMAT " representing heap at " PTR_FORMAT " (%u) must be in committed heap",
+         "Card at " PTR_FORMAT " index %zu representing heap at " PTR_FORMAT " (%u) must be in committed heap",
          p2i(card_ptr),
          ct->index_for(ct->addr_for(card_ptr)),
          p2i(ct->addr_for(card_ptr)),

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,29 +153,29 @@ public:
   size_t code_root_elems() const { return _code_root_elems; }
 
   void print_rs_mem_info_on(outputStream * out, size_t total) {
-    out->print_cr("    " SIZE_FORMAT_W(8) " (%5.1f%%) by " SIZE_FORMAT " "
-                  "(" SIZE_FORMAT ") %s regions unused " SIZE_FORMAT,
+    out->print_cr("    %8zu (%5.1f%%) by %zu "
+                  "(%zu) %s regions unused %zu",
                   rs_mem_size(), rs_mem_size_percent_of(total),
                   amount_tracked(), amount(),
                   _name, rs_unused_mem_size());
   }
 
   void print_cards_occupied_info_on(outputStream * out, size_t total) {
-    out->print_cr("     " SIZE_FORMAT_W(8) " (%5.1f%%) entries by " SIZE_FORMAT " "
-                  "(" SIZE_FORMAT ") %s regions",
+    out->print_cr("     %8zu (%5.1f%%) entries by %zu "
+                  "(%zu) %s regions",
                   cards_occupied(), cards_occupied_percent_of(total),
                   amount_tracked(), amount(), _name);
   }
 
   void print_code_root_mem_info_on(outputStream * out, size_t total) {
-    out->print_cr("    " SIZE_FORMAT_W(8) "%s (%5.1f%%) by " SIZE_FORMAT " %s regions",
+    out->print_cr("    %8zu%s (%5.1f%%) by %zu %s regions",
         byte_size_in_proper_unit(code_root_mem_size()),
         proper_unit_for_byte_size(code_root_mem_size()),
         code_root_mem_size_percent_of(total), amount(), _name);
   }
 
   void print_code_root_elems_info_on(outputStream * out, size_t total) {
-    out->print_cr("     " SIZE_FORMAT_W(8) " (%5.1f%%) elements by " SIZE_FORMAT " %s regions",
+    out->print_cr("     %8zu (%5.1f%%) elements by %zu %s regions",
         code_root_elems(), code_root_elems_percent_of(total), amount(), _name);
   }
 };
@@ -267,8 +267,8 @@ public:
     RegionTypeCounter* counters[] = { &_young, &_humongous, &_free, &_old, nullptr };
 
     out->print_cr(" Current rem set statistics");
-    out->print_cr("  Total per region rem sets sizes = " SIZE_FORMAT
-                  " Max = " SIZE_FORMAT " unused = " SIZE_FORMAT,
+    out->print_cr("  Total per region rem sets sizes = %zu"
+                  " Max = %zu unused = %zu",
                   total_rs_mem_sz(),
                   max_rs_mem_sz(),
                   total_rs_unused_mem_sz());
@@ -276,7 +276,7 @@ public:
       (*current)->print_rs_mem_info_on(out, total_rs_mem_sz());
     }
 
-    out->print_cr("    " SIZE_FORMAT " occupied cards represented.",
+    out->print_cr("    %zu occupied cards represented.",
                   total_cards_occupied());
     for (RegionTypeCounter** current = &counters[0]; *current != nullptr; current++) {
       (*current)->print_cards_occupied_info_on(out, total_cards_occupied());
@@ -285,7 +285,7 @@ public:
     // Largest sized rem set region statistics
     G1HeapRegionRemSet* rem_set = max_rs_mem_sz_region()->rem_set();
     out->print_cr("    Region with largest rem set = " HR_FORMAT ", "
-                  "size = " SIZE_FORMAT " occupied = " SIZE_FORMAT,
+                  "size = %zu occupied = %zu",
                   HR_FORMAT_PARAMS(max_rs_mem_sz_region()),
                   rem_set->mem_size(),
                   rem_set->occupied());
@@ -296,8 +296,8 @@ public:
 
     // Code root statistics
     G1HeapRegionRemSet* max_code_root_rem_set = max_code_root_mem_sz_region()->rem_set();
-    out->print_cr("  Total heap region code root sets sizes = " SIZE_FORMAT "%s."
-                  "  Max = " SIZE_FORMAT "%s.",
+    out->print_cr("  Total heap region code root sets sizes = %zu%s."
+                  "  Max = %zu%s.",
                   byte_size_in_proper_unit(total_code_root_mem_sz()),
                   proper_unit_for_byte_size(total_code_root_mem_sz()),
                   byte_size_in_proper_unit(max_code_root_rem_set->code_roots_mem_size()),
@@ -306,14 +306,14 @@ public:
       (*current)->print_code_root_mem_info_on(out, total_code_root_mem_sz());
     }
 
-    out->print_cr("    " SIZE_FORMAT " code roots represented.",
+    out->print_cr("    %zu code roots represented.",
                   total_code_root_elems());
     for (RegionTypeCounter** current = &counters[0]; *current != nullptr; current++) {
       (*current)->print_code_root_elems_info_on(out, total_code_root_elems());
     }
 
     out->print_cr("    Region with largest amount of code roots = " HR_FORMAT ", "
-                  "size = " SIZE_FORMAT "%s, num_slots = " SIZE_FORMAT ".",
+                  "size = %zu%s, num_slots = %zu.",
                   HR_FORMAT_PARAMS(max_code_root_mem_sz_region()),
                   byte_size_in_proper_unit(max_code_root_rem_set->code_roots_mem_size()),
                   proper_unit_for_byte_size(max_code_root_rem_set->code_roots_mem_size()),

--- a/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
+++ b/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ void G1UncommitRegionTask::report_execution(Tickspan time, uint regions) {
   _summary_region_count += regions;
   _summary_duration += time;
 
-  log_trace(gc, heap)("Concurrent Uncommit: " SIZE_FORMAT "%s, %u regions, %1.3fms",
+  log_trace(gc, heap)("Concurrent Uncommit: %zu%s, %u regions, %1.3fms",
                       byte_size_in_proper_unit(regions * G1HeapRegion::GrainBytes),
                       proper_unit_for_byte_size(regions * G1HeapRegion::GrainBytes),
                       regions,
@@ -90,7 +90,7 @@ void G1UncommitRegionTask::report_execution(Tickspan time, uint regions) {
 }
 
 void G1UncommitRegionTask::report_summary() {
-  log_debug(gc, heap)("Concurrent Uncommit Summary: " SIZE_FORMAT "%s, %u regions, %1.3fms",
+  log_debug(gc, heap)("Concurrent Uncommit Summary: %zu%s, %u regions, %1.3fms",
                       byte_size_in_proper_unit(_summary_region_count * G1HeapRegion::GrainBytes),
                       proper_unit_for_byte_size(_summary_region_count * G1HeapRegion::GrainBytes),
                       _summary_region_count,

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -394,7 +394,7 @@ public:
               "Only eagerly reclaiming type arrays is supported, but the object "
               PTR_FORMAT " is not.", p2i(r->bottom()));
 
-    log_debug(gc, humongous)("Reclaimed humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ")",
+    log_debug(gc, humongous)("Reclaimed humongous region %u (object size %zu @ " PTR_FORMAT ")",
                              region_index,
                              obj->size() * HeapWordSize,
                              p2i(r->bottom())

--- a/src/hotspot/share/gc/g1/g1YoungGenSizer.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGenSizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,8 @@ G1YoungGenSizer::G1YoungGenSizer() : _sizer_kind(SizerDefaults),
 
   if (NewSize > MaxNewSize) {
     if (FLAG_IS_CMDLINE(MaxNewSize)) {
-      log_warning(gc, ergo)("NewSize (" SIZE_FORMAT "k) is greater than the MaxNewSize (" SIZE_FORMAT "k). "
-                            "A new max generation size of " SIZE_FORMAT "k will be used.",
+      log_warning(gc, ergo)("NewSize (%zuk) is greater than the MaxNewSize (%zuk). "
+                            "A new max generation size of %zuk will be used.",
                             NewSize/K, MaxNewSize/K, NewSize/K);
     }
     FLAG_SET_ERGO(MaxNewSize, NewSize);

--- a/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
+++ b/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
@@ -83,7 +83,7 @@ JVMFlag::Error G1HeapRegionSizeConstraintFunc(size_t value, bool verbose) {
   // Default value of G1HeapRegionSize=0 means will be set ergonomically.
   if (FLAG_IS_CMDLINE(G1HeapRegionSize) && (value < G1HeapRegionBounds::min_size())) {
     JVMFlag::printError(verbose,
-                        "G1HeapRegionSize (" SIZE_FORMAT ") must be "
+                        "G1HeapRegionSize (%zu) must be "
                         "greater than or equal to ergonomic heap region minimum size\n",
                         value);
     return JVMFlag::VIOLATES_CONSTRAINT;
@@ -171,7 +171,7 @@ JVMFlag::Error NewSizeConstraintFuncG1(size_t value, bool verbose) {
   // So maximum of NewSize should be 'max_juint * 1M'
   if (UseG1GC && (value > (max_juint * 1 * M))) {
     JVMFlag::printError(verbose,
-                        "NewSize (" SIZE_FORMAT ") must be less than ergonomic maximum value\n",
+                        "NewSize (%zu) must be less than ergonomic maximum value\n",
                         value);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }


### PR DESCRIPTION
Please review this change to replace SIZE_FORMAT with %zu in the g1 directory.  Most edits were by script but SIZE_FORMAT_W(n) was done sort of by hand.  Also fixed one place where preexisting formatting was bad.

Tested all the GC changes together (other PRs coming) with tier1-4 on x86 and aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347730](https://bugs.openjdk.org/browse/JDK-8347730): Replace SIZE_FORMAT in g1 (**Sub-task** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) Review applies to [504ca4c7](https://git.openjdk.org/jdk/pull/23114/files/504ca4c75d13bc4071029aa1f533c27892f20b24)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23114/head:pull/23114` \
`$ git checkout pull/23114`

Update a local copy of the PR: \
`$ git checkout pull/23114` \
`$ git pull https://git.openjdk.org/jdk.git pull/23114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23114`

View PR using the GUI difftool: \
`$ git pr show -t 23114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23114.diff">https://git.openjdk.org/jdk/pull/23114.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23114#issuecomment-2590850739)
</details>
