### PR TITLE
8347740: java/io/File/createTempFile/SpecialTempFile.java failing

### DIFF
--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -108,16 +108,17 @@ public class SpecialTempFile {
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
-        System.out.println("OS name:    " + StaticProperty.osName() + "\n" +
-                           "OS version: " + OSVersion.current());
-
         String osName = StaticProperty.osName();
+        OSVersion osVersion = OSVersion.current();
+        System.out.println("OS name:    " + osName + "\n" +
+                           "OS version: " + osVersion);
+
         String[] nameElements = osName.split(" ");
         int nameVers = Integer.valueOf(nameElements[nameElements.length - 1]);
         System.out.println("OS version from name: " + nameVers);
 
         boolean exceptionExpected =
-            !(new OSVersion(10, 0).compareTo(OSVersion.current()) > 0 ||
+            !(new OSVersion(10, 0).compareTo(osVersion) > 0 ||
               osName.contains("Server") ? nameVers > 2022 : nameVers > 10);
 
         test("ReservedName", resvPre, resvSuf, exceptionExpected);

--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -108,9 +108,18 @@ public class SpecialTempFile {
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
+        System.out.println("OS name:    " + StaticProperty.osName() + "\n" +
+                           "OS version: " + OSVersion.current());
+
+        String osName = StaticProperty.osName();
+        String[] nameElements = osName.split(" ");
+        int nameVers = Integer.valueOf(nameElements[nameElements.length - 1]);
+        System.out.println("OS version from name: " + nameVers);
+
         boolean exceptionExpected =
-            !(StaticProperty.osName().matches("^.*[11|2025]$") ||
-              new OSVersion(10, 0).compareTo(OSVersion.current()) > 0);
+            !(new OSVersion(10, 0).compareTo(OSVersion.current()) > 0 ||
+              osName.contains("Server") ? nameVers > 2022 : nameVers > 10);
+
         test("ReservedName", resvPre, resvSuf, exceptionExpected);
     }
 }

--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -39,8 +39,6 @@ import jdk.internal.util.OSVersion;
 import jdk.internal.util.StaticProperty;
 
 public class SpecialTempFile {
-    private static final int WINDOWS_11_MINIMUM_BUILD = 22000;
-
     //
     // If exceptionExpected == null, then any IOException thrown by
     // File.createTempFile is ignored.


### PR DESCRIPTION
Fix the means of determining whether an exception is to be expected in the Windows test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347740](https://bugs.openjdk.org/browse/JDK-8347740): java/io/File/createTempFile/SpecialTempFile.java failing (**Bug** - P3)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23117/head:pull/23117` \
`$ git checkout pull/23117`

Update a local copy of the PR: \
`$ git checkout pull/23117` \
`$ git pull https://git.openjdk.org/jdk.git pull/23117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23117`

View PR using the GUI difftool: \
`$ git pr show -t 23117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23117.diff">https://git.openjdk.org/jdk/pull/23117.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23117#issuecomment-2591179623)
</details>
