### PR TITLE
8347763: [doc] Add documentation of module options for JEP 483

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -3969,6 +3969,35 @@ archive, you should make sure that the archive is created by at least version
 -   The CDS archive cannot be loaded if any JAR files in the class path or
     module path are modified after the archive is generated.
 
+### Module related options
+
+The following module related options are supported by CDS: `--module-path`, `--module`,
+`--add-modules`, and `--enable-native-access`.
+
+The values for these options (if specified), should be identical when creating and using the
+CDS archive. Otherwise, if there is a mismatch of any of these options, the CDS archive may be
+partially or completely disabled, leading to lower performance.
+
+- If the -XX:+AOTClassLoading options *was* used during CDS archive creation, the CDS archive
+  cannot be used, and the following error message is printed:
+
+  `CDS archive has aot-linked classes. It cannot be used when archived full module graph is not used`
+
+- If the -XX:+AOTClassLoading options *was not* used during CDS archive creation, the CDS archive
+  can be used, but the "archived module graph" feature will be disabled. This can lead to increased
+  start-up time.
+
+To diagnose problems with the above options, you can add `-Xlog:cds` to the application's VM
+arguments. For example, if `--add-modules jdk.jconcole` was specified during archive creation
+and `--add-modules jdk.incubator.vector` is specified during runtime, the following messages will
+be logged:
+
+ `Mismatched values for property jdk.module.addmods`
+
+ `runtime jdk.incubator.vector dump time jdk.jconsole`
+
+ `subgraph jdk.internal.module.ArchivedBootLayer cannot be used because full module graph is disabled`
+
 -   If any of the VM options `--upgrade-module-path`, `--patch-module` or
     `--limit-modules` are specified, CDS is disabled. This means that the
     JVM will execute without loading any CDS archives. In addition, if

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -3998,11 +3998,11 @@ be logged:
 
  `subgraph jdk.internal.module.ArchivedBootLayer cannot be used because full module graph is disabled`
 
--   If any of the VM options `--upgrade-module-path`, `--patch-module` or
-    `--limit-modules` are specified, CDS is disabled. This means that the
-    JVM will execute without loading any CDS archives. In addition, if
-    you try to create a CDS archive with any of these 3 options specified,
-    the JVM will report an error.
+If any of the VM options `--upgrade-module-path`, `--patch-module` or
+`--limit-modules` are specified, CDS is disabled. This means that the
+JVM will execute without loading any CDS archives. In addition, if
+you try to create a CDS archive with any of these 3 options specified,
+the JVM will report an error.
 
 ## Performance Tuning Examples
 


### PR DESCRIPTION
Document the module related options for CDS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347763](https://bugs.openjdk.org/browse/JDK-8347763): [doc] Add documentation of module options for JEP 483 (**Bug** - P4)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23120/head:pull/23120` \
`$ git checkout pull/23120`

Update a local copy of the PR: \
`$ git checkout pull/23120` \
`$ git pull https://git.openjdk.org/jdk.git pull/23120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23120`

View PR using the GUI difftool: \
`$ git pr show -t 23120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23120.diff">https://git.openjdk.org/jdk/pull/23120.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23120#issuecomment-2593563492)
</details>
