### PR TITLE
8347758: modules.cpp leaks string returned from get_numbered_property_as_sorted_string()

### DIFF
--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -631,6 +631,7 @@ void Modules::dump_native_access_flag() {
   const char* native_access_names = get_native_access_flags_as_sorted_string();
   if (native_access_names != nullptr) {
     _archived_native_access_flags = ArchiveBuilder::current()->ro_strdup(native_access_names);
+    os::free((void*)native_access_names);
   }
 }
 
@@ -641,10 +642,12 @@ const char* Modules::get_native_access_flags_as_sorted_string() {
 void Modules::serialize_native_access_flags(SerializeClosure* soc) {
   soc->do_ptr(&_archived_native_access_flags);
   if (soc->reading()) {
-    check_archived_flag_consistency(_archived_native_access_flags, get_native_access_flags_as_sorted_string(), "jdk.module.enable.native.access");
+    const char* native_access_names = get_native_access_flags_as_sorted_string();
+    check_archived_flag_consistency(_archived_native_access_flags, native_access_names, "jdk.module.enable.native.access");
 
     // Don't hold onto the pointer, in case we might decide to unmap the archive.
     _archived_native_access_flags = nullptr;
+    os::free((void*)native_access_names);
   }
 }
 
@@ -652,6 +655,7 @@ void Modules::dump_addmods_names() {
   const char* addmods_names = get_addmods_names_as_sorted_string();
   if (addmods_names != nullptr) {
     _archived_addmods_names = ArchiveBuilder::current()->ro_strdup(addmods_names);
+    os::free((void*)addmods_names);
   }
 }
 
@@ -662,10 +666,12 @@ const char* Modules::get_addmods_names_as_sorted_string() {
 void Modules::serialize_addmods_names(SerializeClosure* soc) {
   soc->do_ptr(&_archived_addmods_names);
   if (soc->reading()) {
-    check_archived_flag_consistency(_archived_addmods_names, get_addmods_names_as_sorted_string(), "jdk.module.addmods");
+    const char* addmods_names = get_addmods_names_as_sorted_string();
+    check_archived_flag_consistency(_archived_addmods_names, addmods_names, "jdk.module.addmods");
 
     // Don't hold onto the pointer, in case we might decide to unmap the archive.
     _archived_addmods_names = nullptr;
+    os::free((void*)addmods_names);
   }
 }
 

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -637,7 +637,6 @@ void Modules::dump_native_access_flag() {
 
 // Caller needs ResourceMark
 const char* Modules::get_native_access_flags_as_sorted_string() {
-  assert(Thread::current()->current_resource_mark() != nullptr, "Setup by caller");
   return get_numbered_property_as_sorted_string("jdk.module.enable.native.access");
 }
 
@@ -662,7 +661,6 @@ void Modules::dump_addmods_names() {
 
 // Caller needs ResourceMark
 const char* Modules::get_addmods_names_as_sorted_string() {
-  assert(Thread::current()->current_resource_mark() != nullptr, "Setup by caller");
   return get_numbered_property_as_sorted_string("jdk.module.addmods");
 }
 
@@ -679,7 +677,6 @@ void Modules::serialize_addmods_names(SerializeClosure* soc) {
 
 // Caller needs ResourceMark
 const char* Modules::get_numbered_property_as_sorted_string(const char* property) {
-  assert(Thread::current()->current_resource_mark() != nullptr, "Setup by caller");
   // theoretical string size limit for decimal int, but the following loop will end much sooner due to
   // OS command-line size limit.
   const int max_digits = 10;

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -642,9 +642,9 @@ const char* Modules::get_native_access_flags_as_sorted_string() {
 }
 
 void Modules::serialize_native_access_flags(SerializeClosure* soc) {
-  ResourceMark rm;
   soc->do_ptr(&_archived_native_access_flags);
   if (soc->reading()) {
+    ResourceMark rm;
     check_archived_flag_consistency(_archived_native_access_flags, get_native_access_flags_as_sorted_string(), "jdk.module.enable.native.access");
 
     // Don't hold onto the pointer, in case we might decide to unmap the archive.
@@ -667,9 +667,9 @@ const char* Modules::get_addmods_names_as_sorted_string() {
 }
 
 void Modules::serialize_addmods_names(SerializeClosure* soc) {
-  ResourceMark rm;
   soc->do_ptr(&_archived_addmods_names);
   if (soc->reading()) {
+    ResourceMark rm;
     check_archived_flag_consistency(_archived_addmods_names, get_addmods_names_as_sorted_string(), "jdk.module.addmods");
 
     // Don't hold onto the pointer, in case we might decide to unmap the archive.

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -572,7 +572,6 @@ void Modules::dump_main_module_name() {
 }
 
 void Modules::check_archived_flag_consistency(char* archived_flag, const char* runtime_flag, const char* property) {
-  assert(Thread::current()->current_resource_mark() != nullptr, "Setup by caller");
   log_info(cds)("%s %s", property,
     archived_flag != nullptr ? archived_flag : "(null)");
   bool disable = false;
@@ -615,7 +614,6 @@ void Modules::serialize_archived_module_info(SerializeClosure* soc) {
 }
 
 void Modules::serialize(SerializeClosure* soc) {
-  ResourceMark rm;
   soc->do_ptr(&_archived_main_module_name);
   if (soc->reading()) {
     const char* runtime_main_module = Arguments::get_property("jdk.module.main");
@@ -662,6 +660,7 @@ void Modules::dump_addmods_names() {
 }
 
 const char* Modules::get_addmods_names_as_sorted_string() {
+  assert(Thread::current()->current_resource_mark() != nullptr, "Setup by caller");
   return get_numbered_property_as_sorted_string("jdk.module.addmods");
 }
 

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -635,6 +635,7 @@ void Modules::dump_native_access_flag() {
   }
 }
 
+// Caller needs ResourceMark
 const char* Modules::get_native_access_flags_as_sorted_string() {
   assert(Thread::current()->current_resource_mark() != nullptr, "Setup by caller");
   return get_numbered_property_as_sorted_string("jdk.module.enable.native.access");
@@ -659,6 +660,7 @@ void Modules::dump_addmods_names() {
   }
 }
 
+// Caller needs ResourceMark
 const char* Modules::get_addmods_names_as_sorted_string() {
   assert(Thread::current()->current_resource_mark() != nullptr, "Setup by caller");
   return get_numbered_property_as_sorted_string("jdk.module.addmods");
@@ -675,6 +677,7 @@ void Modules::serialize_addmods_names(SerializeClosure* soc) {
   }
 }
 
+// Caller needs ResourceMark
 const char* Modules::get_numbered_property_as_sorted_string(const char* property) {
   assert(Thread::current()->current_resource_mark() != nullptr, "Setup by caller");
   // theoretical string size limit for decimal int, but the following loop will end much sooner due to

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -669,8 +669,7 @@ void Modules::serialize_addmods_names(SerializeClosure* soc) {
   ResourceMark rm;
   soc->do_ptr(&_archived_addmods_names);
   if (soc->reading()) {
-    const char* addmods_names = get_addmods_names_as_sorted_string();
-    check_archived_flag_consistency(_archived_addmods_names, addmods_names, "jdk.module.addmods");
+    check_archived_flag_consistency(_archived_addmods_names, get_addmods_names_as_sorted_string(), "jdk.module.addmods");
 
     // Don't hold onto the pointer, in case we might decide to unmap the archive.
     _archived_addmods_names = nullptr;


### PR DESCRIPTION
Modules::get_numbered_property_as_sorted_string() returns strings created from os::strdup(), callers should free them after uses.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347758](https://bugs.openjdk.org/browse/JDK-8347758): modules.cpp leaks string returned from get_numbered_property_as_sorted_string() (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**) Review applies to [01ffa015](https://git.openjdk.org/jdk/pull/23121/files/01ffa01536a5c05f9e25674a91eca116d61fc525)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23121/head:pull/23121` \
`$ git checkout pull/23121`

Update a local copy of the PR: \
`$ git checkout pull/23121` \
`$ git pull https://git.openjdk.org/jdk.git pull/23121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23121`

View PR using the GUI difftool: \
`$ git pr show -t 23121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23121.diff">https://git.openjdk.org/jdk/pull/23121.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23121#issuecomment-2591555430)
</details>
