### PR TITLE
8347762: ClassFile attribute specification refers to non-SE modules

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/attribute/CharacterRangeTableAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CharacterRangeTableAttribute.java
@@ -62,15 +62,14 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * attribute instance in the built {@code Code} attribute.
  * <p>
  * This attribute is not predefined in the Java SE Platform.  This is a
- * JDK-specific nonstandard attribute produced by the {@linkplain jdk.compiler/
- * implementation of the system Java compiler}.
+ * JDK-specific nonstandard attribute produced by the reference implementation
+ * of the system Java compiler, defined by the {@code jdk.compiler} module.
  *
  * @see Attributes#characterRangeTable()
  * @see CompilationIDAttribute
  * @see SourceIDAttribute
  * @since 24
  */
-@SuppressWarnings("doclint:reference")
 public sealed interface CharacterRangeTableAttribute
         extends Attribute<CharacterRangeTableAttribute>
         permits BoundAttribute.BoundCharacterRangeTableAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/CompilationIDAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CompilationIDAttribute.java
@@ -45,15 +45,14 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * data dependency on the {@linkplain AttributeStability#CP_REFS constant pool}.
  * <p>
  * This attribute is not predefined in the Java SE Platform.  This is a
- * JDK-specific nonstandard attribute produced by the {@linkplain jdk.compiler/
- * implementation of the system Java compiler}.
+ * JDK-specific nonstandard attribute produced by the reference implementation
+ * of the system Java compiler, defined by the {@code jdk.compiler} module.
  *
  * @see Attributes#compilationId()
  * @see CharacterRangeTableAttribute
  * @see SourceIDAttribute
  * @since 24
  */
-@SuppressWarnings("doclint:reference")
 public sealed interface CompilationIDAttribute
         extends Attribute<CompilationIDAttribute>, ClassElement
         permits BoundAttribute.BoundCompilationIDAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/DeprecatedAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/DeprecatedAttribute.java
@@ -45,16 +45,15 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * When this attribute is present, the {@link Deprecated} annotation should
  * also be present in the {@link RuntimeVisibleAnnotationsAttribute
  * RuntimeVisibleAnnotations} attribute to provide more obvious alerts.
- * The {@linkplain jdk.compiler/ implementation of the system Java compiler}
- * emits this attribute without the annotation when a {@code @deprecated} tag
- * is present in the documentation comments without the annotation.
+ * The reference implementation of the system Java compiler emits this attribute
+ * without the annotation when a {@code @deprecated} tag is present in the
+ * documentation comments without the annotation.
  *
  * @see Attributes#deprecated()
  * @see Deprecated
  * @jvms 4.7.15 The {@code Deprecated} Attribute
  * @since 24
  */
-@SuppressWarnings("doclint:reference")
 public sealed interface DeprecatedAttribute
         extends Attribute<DeprecatedAttribute>,
                 ClassElement, MethodElement, FieldElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleHashesAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleHashesAttribute.java
@@ -70,15 +70,14 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * data dependency on the {@linkplain AttributeStability#CP_REFS constant pool}.
  * <p>
  * This attribute is not predefined in the Java SE Platform.  This is a
- * JDK-specific nonstandard attribute produced by the {@linkplain jdk.jlink/
- * jlink and jmod tools} and used by the implementation.
+ * JDK-specific nonstandard attribute produced by the {@code jdk.jlink} module,
+ * which defines the {@code jlink} and {@code jmod} tools.
  *
  * @see Attributes#moduleHashes()
  * @see ModuleResolutionAttribute
  * @see ModuleTargetAttribute
  * @since 24
  */
-@SuppressWarnings("doclint:reference")
 public sealed interface ModuleHashesAttribute
         extends Attribute<ModuleHashesAttribute>, ClassElement
         permits BoundAttribute.BoundModuleHashesAttribute, UnboundAttribute.UnboundModuleHashesAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleResolutionAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleResolutionAttribute.java
@@ -65,15 +65,14 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * {@linkplain AttributeStability#STATELESS no data dependency}.
  * <p>
  * This attribute is not predefined in the Java SE Platform.  This is a
- * JDK-specific nonstandard attribute produced by the {@linkplain jdk.jlink/
- * jlink and jmod tools} and used by the implementation.
+ * JDK-specific nonstandard attribute produced by the {@code jdk.jlink} module,
+ * which defines the {@code jlink} and {@code jmod} tools.
  *
  * @see Attributes#moduleResolution()
  * @see ModuleHashesAttribute
  * @see ModuleTargetAttribute
  * @since 24
  */
-@SuppressWarnings("doclint:reference")
 public sealed interface ModuleResolutionAttribute
         extends Attribute<ModuleResolutionAttribute>, ClassElement
         permits BoundAttribute.BoundModuleResolutionAttribute, UnboundAttribute.UnboundModuleResolutionAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleTargetAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleTargetAttribute.java
@@ -60,15 +60,14 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * data dependency on the {@linkplain AttributeStability#CP_REFS constant pool}.
  * <p>
  * This attribute is not predefined in the Java SE Platform.  This is a
- * JDK-specific nonstandard attribute produced by the {@linkplain jdk.jlink/
- * jlink and jmod tools} and used by the implementation.
+ * JDK-specific nonstandard attribute produced by the {@code jdk.jlink} module,
+ * which defines the {@code jlink} and {@code jmod} tools.
  *
  * @see Attributes#moduleTarget()
  * @see ModuleHashesAttribute
  * @see ModuleResolutionAttribute
  * @since 24
  */
-@SuppressWarnings("doclint:reference")
 public sealed interface ModuleTargetAttribute
         extends Attribute<ModuleTargetAttribute>, ClassElement
         permits BoundAttribute.BoundModuleTargetAttribute, UnboundAttribute.UnboundModuleTargetAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SourceIDAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SourceIDAttribute.java
@@ -46,15 +46,14 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * data dependency on the {@linkplain AttributeStability#CP_REFS constant pool}.
  * <p>
  * This attribute is not predefined in the Java SE Platform.  This is a
- * JDK-specific nonstandard attribute produced by the {@linkplain jdk.compiler/
- * implementation of the system Java compiler}.
+ * JDK-specific nonstandard attribute produced bythe reference implementation
+ * of the system Java compiler, defined by the {@code jdk.compiler} module.
  *
  * @see Attributes#sourceId()
  * @see CompilationIDAttribute
  * @see CharacterRangeTableAttribute
  * @since 24
  */
-@SuppressWarnings("doclint:reference")
 public sealed interface SourceIDAttribute
         extends Attribute<SourceIDAttribute>, ClassElement
         permits BoundAttribute.BoundSourceIDAttribute, UnboundAttribute.UnboundSourceIDAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SourceIDAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SourceIDAttribute.java
@@ -46,7 +46,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * data dependency on the {@linkplain AttributeStability#CP_REFS constant pool}.
  * <p>
  * This attribute is not predefined in the Java SE Platform.  This is a
- * JDK-specific nonstandard attribute produced bythe reference implementation
+ * JDK-specific nonstandard attribute produced by the reference implementation
  * of the system Java compiler, defined by the {@code jdk.compiler} module.
  *
  * @see Attributes#sourceId()


### PR DESCRIPTION
The new API specification for class file attributes link to non-SE modules of jdk.compiler and jdk.jlink, which caused docs build failure for SE docs. This patch removes those links and replace them with plain module name references.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347762](https://bugs.openjdk.org/browse/JDK-8347762): ClassFile attribute specification refers to non-SE modules (**Bug** - P2)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23122/head:pull/23122` \
`$ git checkout pull/23122`

Update a local copy of the PR: \
`$ git checkout pull/23122` \
`$ git pull https://git.openjdk.org/jdk.git pull/23122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23122`

View PR using the GUI difftool: \
`$ git pr show -t 23122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23122.diff">https://git.openjdk.org/jdk/pull/23122.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23122#issuecomment-2591628459)
</details>
