### PR TITLE
8347761: Test tools/jimage/JImageExtractTest.java fails after JDK-8303884

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jimage/resources/jimage.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jimage/resources/jimage.properties
@@ -93,6 +93,7 @@ main.opt.footer=\
 
 err.not.a.task=task must be one of <extract | info | list | verify>: {0}
 err.missing.arg=no value given for {0}
+err.ambiguous.arg=value for option {0} starts with \"--\" should use {0}=<value> format
 err.not.a.dir=not a directory: {0}
 err.not.a.jimage=not a jimage file: {0}
 err.invalid.jimage=Unable to open {0}: {1}


### PR DESCRIPTION
jimage use the same code to parse command line options, the resource bundle for jimage also need update.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347761](https://bugs.openjdk.org/browse/JDK-8347761): Test tools/jimage/JImageExtractTest.java fails after JDK-8303884 (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23123/head:pull/23123` \
`$ git checkout pull/23123`

Update a local copy of the PR: \
`$ git checkout pull/23123` \
`$ git pull https://git.openjdk.org/jdk.git pull/23123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23123`

View PR using the GUI difftool: \
`$ git pr show -t 23123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23123.diff">https://git.openjdk.org/jdk/pull/23123.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23123#issuecomment-2591674028)
</details>
