### PR TITLE
8347347: Build fails undefined symbol: __asan_init by clang17

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -446,6 +446,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
           fi
           if test "x$TOOLCHAIN_TYPE" = "xclang"; then
             ASAN_CFLAGS="$ASAN_CFLAGS -fsanitize-address-use-after-return=never"
+            ASAN_LDFLAGS="$ASAN_LDFLAGS -shared-libasan"
           fi
         elif test "x$TOOLCHAIN_TYPE" = "xmicrosoft"; then
           # -Oy- is equivalent to -fno-omit-frame-pointer in GCC/Clang.


### PR DESCRIPTION
Hi all,
This PR fix the bugs which build fails "undefined symbol: __asan_init" by clang17 with configure parameter "--enable-asan".
With clang, [-static-libsan is the default](https://github.com/google/sanitizers/issues/1086#issuecomment-509775957), -shared-libsan forces the linker to use the shared asan run-time. And with [gcc there is no this issue](https://github.com/google/sanitizers/issues/1169#issuecomment-558947352).
This PR append `-shared-libasan` link flags to `ASAN_LDFLAGS` will fix the make failure. The change has been verified locally, risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347347](https://bugs.openjdk.org/browse/JDK-8347347): Build fails undefined symbol: __asan_init by clang17 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23124/head:pull/23124` \
`$ git checkout pull/23124`

Update a local copy of the PR: \
`$ git checkout pull/23124` \
`$ git pull https://git.openjdk.org/jdk.git pull/23124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23124`

View PR using the GUI difftool: \
`$ git pr show -t 23124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23124.diff">https://git.openjdk.org/jdk/pull/23124.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23124#issuecomment-2591868387)
</details>
