### PR TITLE
8345543: Test serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java failed: expected JVMTI_ERROR_OPAQUE_FRAME instead of: 0

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -492,9 +492,6 @@ void ObjectMonitor::enter_with_contention_mark(JavaThread *current, ObjectMonito
 
   freeze_result result;
 
-  assert(current->current_pending_monitor() == nullptr, "invariant");
-  current->set_current_pending_monitor(this);
-
   DTRACE_MONITOR_PROBE(contended__enter, this, object(), current);
   if (JvmtiExport::should_post_monitor_contended_enter()) {
     JvmtiExport::post_monitor_contended_enter(current, this);
@@ -533,6 +530,9 @@ void ObjectMonitor::enter_with_contention_mark(JavaThread *current, ObjectMonito
   {
     // Change java thread status to indicate blocked on monitor enter.
     JavaThreadBlockedOnMonitorEnterState jtbmes(current, this);
+
+    assert(current->current_pending_monitor() == nullptr, "invariant");
+    current->set_current_pending_monitor(this);
 
     OSThreadContendState osts(current->osthread());
 

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -473,6 +473,21 @@ bool ObjectMonitor::enter(JavaThread* current) {
   return true;
 }
 
+void ObjectMonitor::notify_contended_enter(JavaThread *current) {
+  current->set_current_pending_monitor(this);
+
+  DTRACE_MONITOR_PROBE(contended__enter, this, object(), current);
+  if (JvmtiExport::should_post_monitor_contended_enter()) {
+    JvmtiExport::post_monitor_contended_enter(current, this);
+
+    // The current thread does not yet own the monitor and does not
+    // yet appear on any queues that would get it made the successor.
+    // This means that the JVMTI_EVENT_MONITOR_CONTENDED_ENTER event
+    // handler cannot accidentally consume an unpark() meant for the
+    // ParkEvent associated with this ObjectMonitor.
+  }
+}
+
 void ObjectMonitor::enter_with_contention_mark(JavaThread *current, ObjectMonitorContentionMark &cm) {
   assert(current == JavaThread::current(), "must be");
   assert(!has_owner(current), "must be");
@@ -493,21 +508,11 @@ void ObjectMonitor::enter_with_contention_mark(JavaThread *current, ObjectMonito
   freeze_result result;
 
   assert(current->current_pending_monitor() == nullptr, "invariant");
-  current->set_current_pending_monitor(this);
-
-  DTRACE_MONITOR_PROBE(contended__enter, this, object(), current);
-  if (JvmtiExport::should_post_monitor_contended_enter()) {
-    JvmtiExport::post_monitor_contended_enter(current, this);
-
-    // The current thread does not yet own the monitor and does not
-    // yet appear on any queues that would get it made the successor.
-    // This means that the JVMTI_EVENT_MONITOR_CONTENDED_ENTER event
-    // handler cannot accidentally consume an unpark() meant for the
-    // ParkEvent associated with this ObjectMonitor.
-  }
 
   ContinuationEntry* ce = current->last_continuation();
-  if (ce != nullptr && ce->is_virtual_thread()) {
+  bool is_virtual = ce != nullptr && ce->is_virtual_thread();
+  if (is_virtual) {
+    notify_contended_enter(current);
     result = Continuation::try_preempt(current, ce->cont_oop(current));
     if (result == freeze_ok) {
       bool acquired = VThreadMonitorEnter(current);
@@ -534,6 +539,9 @@ void ObjectMonitor::enter_with_contention_mark(JavaThread *current, ObjectMonito
     // Change java thread status to indicate blocked on monitor enter.
     JavaThreadBlockedOnMonitorEnterState jtbmes(current, this);
 
+    if (!is_virtual) { // already notified contended_enter for virtual
+      notify_contended_enter(current);
+    }
     OSThreadContendState osts(current->osthread());
 
     assert(current->thread_state() == _thread_in_vm, "invariant");

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -492,6 +492,9 @@ void ObjectMonitor::enter_with_contention_mark(JavaThread *current, ObjectMonito
 
   freeze_result result;
 
+  assert(current->current_pending_monitor() == nullptr, "invariant");
+  current->set_current_pending_monitor(this);
+
   DTRACE_MONITOR_PROBE(contended__enter, this, object(), current);
   if (JvmtiExport::should_post_monitor_contended_enter()) {
     JvmtiExport::post_monitor_contended_enter(current, this);
@@ -530,9 +533,6 @@ void ObjectMonitor::enter_with_contention_mark(JavaThread *current, ObjectMonito
   {
     // Change java thread status to indicate blocked on monitor enter.
     JavaThreadBlockedOnMonitorEnterState jtbmes(current, this);
-
-    assert(current->current_pending_monitor() == nullptr, "invariant");
-    current->set_current_pending_monitor(this);
 
     OSThreadContendState osts(current->osthread());
 

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -492,9 +492,7 @@ void ObjectMonitor::enter_with_contention_mark(JavaThread *current, ObjectMonito
 
   freeze_result result;
 
-  { // Change java thread status to indicate blocked on monitor enter.
-    JavaThreadBlockedOnMonitorEnterState jtbmes(current, this);
-
+  {
     assert(current->current_pending_monitor() == nullptr, "invariant");
     current->set_current_pending_monitor(this);
 
@@ -532,6 +530,9 @@ void ObjectMonitor::enter_with_contention_mark(JavaThread *current, ObjectMonito
         return;
       }
     }
+
+    // Change java thread status to indicate blocked on monitor enter.
+    JavaThreadBlockedOnMonitorEnterState jtbmes(current, this);
 
     OSThreadContendState osts(current->osthread());
 

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -390,6 +390,7 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   bool      enter(JavaThread* current);
   bool      try_enter(JavaThread* current, bool check_for_recursion = true);
   bool      spin_enter(JavaThread* current);
+  void      notify_contended_enter(JavaThread *current);
   void      enter_with_contention_mark(JavaThread* current, ObjectMonitorContentionMark& contention_mark);
   void      exit(JavaThread* current, bool not_suspended = true);
   bool      resume_operation(JavaThread* current, ObjectWaiter* node, ContinuationWrapper& cont);

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -384,13 +384,13 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   };
 
   bool      enter_is_async_deflating();
+  void      notify_contended_enter(JavaThread *current);
  public:
   void      enter_for_with_contention_mark(JavaThread* locking_thread, ObjectMonitorContentionMark& contention_mark);
   bool      enter_for(JavaThread* locking_thread);
   bool      enter(JavaThread* current);
   bool      try_enter(JavaThread* current, bool check_for_recursion = true);
   bool      spin_enter(JavaThread* current);
-  void      notify_contended_enter(JavaThread *current);
   void      enter_with_contention_mark(JavaThread* current, ObjectMonitorContentionMark& contention_mark);
   void      exit(JavaThread* current, bool not_suspended = true);
   bool      resume_operation(JavaThread* current, ObjectWaiter* node, ContinuationWrapper& cont);


### PR DESCRIPTION
The problem is that the state of the target `vthread` is changed to `BLOCKED` too early. It is done in a constructor of helper object `JavaThreadBlockedOnMonitorEnterState` which sets the state of `vthread` to `JavaThreadStatus::BLOCKED_ON_MONITOR_ENTER`. The `vthread` is getting suspended in `try_preempt()` while calling `JvmtiVTMSTransitionDisabler::start_VTMS_transition()`, so does not become unmounted as it is expected by the failing test. Also, it seems that the base class of the `JavaThreadBlockedOnMonitorEnterState` is supporting just HotSpot  `JavaThread`'s and so, it is changing the carrier thread state only.

The fix is to move the definition of the `JavaThreadBlockedOnMonitorEnterState` object after block where `try_preempt()` is called.

Testing:
 - Checked the failed test does not fail with the fix: `serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java`
 - Ran mach5 tiers 1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345543](https://bugs.openjdk.org/browse/JDK-8345543): Test serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java failed: expected JVMTI_ERROR_OPAQUE_FRAME instead of: 0 (**Bug** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [7312011e](https://git.openjdk.org/jdk/pull/23125/files/7312011e5bed2d9a46530dd4c192192908a6ab04)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23125/head:pull/23125` \
`$ git checkout pull/23125`

Update a local copy of the PR: \
`$ git checkout pull/23125` \
`$ git pull https://git.openjdk.org/jdk.git pull/23125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23125`

View PR using the GUI difftool: \
`$ git pr show -t 23125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23125.diff">https://git.openjdk.org/jdk/pull/23125.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23125#issuecomment-2591868287)
</details>
