### PR TITLE
8347781: Problemlist serviceability/sa/TestJhsdbJstackMixed.java on linux-riscv64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -146,6 +146,7 @@ serviceability/sa/ClhsdbPmap.java#core            8267433,8318754 macosx-x64,mac
 serviceability/sa/ClhsdbPstack.java#core          8267433,8318754 macosx-x64,macosx-aarch64
 serviceability/sa/TestJmapCore.java               8267433,8318754 macosx-x64,macosx-aarch64
 serviceability/sa/TestJmapCoreMetaspace.java      8267433,8318754 macosx-x64,macosx-aarch64
+serviceability/sa/TestJhsdbJstackMixed.java       8248675 linux-riscv64
 
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java 8315980 linux-all,windows-x64
 


### PR DESCRIPTION
Hi all,
We observed the test serviceability/sa/TestJhsdbJstackMixed.java intermittent fails on linux-riscv64. Should we problemlist this test before the root cause has been fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347781](https://bugs.openjdk.org/browse/JDK-8347781): Problemlist serviceability/sa/TestJhsdbJstackMixed.java on linux-riscv64 (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23127/head:pull/23127` \
`$ git checkout pull/23127`

Update a local copy of the PR: \
`$ git checkout pull/23127` \
`$ git pull https://git.openjdk.org/jdk.git pull/23127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23127`

View PR using the GUI difftool: \
`$ git pr show -t 23127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23127.diff">https://git.openjdk.org/jdk/pull/23127.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23127#issuecomment-2591942361)
</details>
