### PR TITLE
8347475: GTK: javax/swing/JColorChooser/Test8152419.java there are no swatches or RGB tab in JColorChooser

### DIFF
--- a/test/jdk/javax/swing/JColorChooser/Test8152419.java
+++ b/test/jdk/javax/swing/JColorChooser/Test8152419.java
@@ -21,12 +21,12 @@
  * questions.
  */
 
- /*
-* @test
-* @bug 8152419
-* @library /test/lib
-* @summary To Verify JColorChooser tab selection
-* @run main/manual Test8152419
+/*
+ * @test
+ * @bug 8152419
+ * @library /test/lib
+ * @summary To Verify JColorChooser tab selection
+ * @run main/manual Test8152419
  */
 
 import java.awt.Color;
@@ -49,7 +49,6 @@ import jtreg.SkippedException;
 public class Test8152419 {
 
     public static void main(String args[]) throws Exception {
-
         // ColorChooser UI design is different for GTK L&F.
         // There are no tabs available for GTK L&F, skip the testing.
         if (UIManager.getLookAndFeel().getName().contains("GTK")) {

--- a/test/jdk/javax/swing/JColorChooser/Test8152419.java
+++ b/test/jdk/javax/swing/JColorChooser/Test8152419.java
@@ -24,6 +24,7 @@
  /*
 * @test
 * @bug 8152419
+* @library /test/lib
 * @summary To Verify JColorChooser tab selection
 * @run main/manual Test8152419
  */

--- a/test/jdk/javax/swing/JColorChooser/Test8152419.java
+++ b/test/jdk/javax/swing/JColorChooser/Test8152419.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,9 +43,18 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
 
+import jtreg.SkippedException;
+
 public class Test8152419 {
 
     public static void main(String args[]) throws Exception {
+
+        // ColorChooser UI design is different for GTK L&F.
+        // There are no tabs available for GTK L&F, skip the testing.
+        if (UIManager.getLookAndFeel().getName().contains("GTK")) {
+            throw new SkippedException("Test not applicable for GTK L&F");
+        }
+
         final CountDownLatch latch = new CountDownLatch(1);
 
         JColorChooserTest test = new JColorChooserTest(latch);


### PR DESCRIPTION
There are no tabs available for GTK Look and Feel due to the different ColorChooser UI design. Updated the test to skip testing for GTK L&F.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347475](https://bugs.openjdk.org/browse/JDK-8347475): GTK: javax/swing/JColorChooser/Test8152419.java there are no swatches or RGB tab in JColorChooser (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) Review applies to [f5f7df45](https://git.openjdk.org/jdk/pull/23128/files/f5f7df4567df20843640f60bed94b42a7c3acb6e)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23128/head:pull/23128` \
`$ git checkout pull/23128`

Update a local copy of the PR: \
`$ git checkout pull/23128` \
`$ git pull https://git.openjdk.org/jdk.git pull/23128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23128`

View PR using the GUI difftool: \
`$ git pr show -t 23128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23128.diff">https://git.openjdk.org/jdk/pull/23128.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23128#issuecomment-2592124810)
</details>
