### PR TITLE
8345618: javax/swing/text/Caret/8163124/CaretFloatingPointAPITest.java leaves Caret is not complete

### DIFF
--- a/test/jdk/javax/swing/text/Caret/8163124/CaretFloatingPointAPITest.java
+++ b/test/jdk/javax/swing/text/Caret/8163124/CaretFloatingPointAPITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -222,11 +222,11 @@ public class CaretFloatingPointAPITest {
 
             Graphics2D g2d = (Graphics2D) g;
             g2d.draw(new Line2D.Float(c, cy, c, cy + ch));
-            g2d.draw(new Line2D.Float(cx, cy, cx + cw, cy));
-            g2d.draw(new Line2D.Float(cx, cy + ch, cx + cw, cy + ch));
         }
 
         void repaint(Rectangle r) {
+            r.width += 1;
+            r.height += 1;
             component.repaint(r);
         }
 
@@ -424,6 +424,8 @@ public class CaretFloatingPointAPITest {
 
         protected synchronized void damage(Rectangle r) {
             if (r != null && component != null) {
+                r.width += 1;
+                r.height += 1;
                 component.repaint(r);
             }
         }


### PR DESCRIPTION
This manual test draws a "custom" Caret which is to be placed in the same position between characters but it is seen the movement of caret leaves artifacts. Custom caret is rendering 2 horizontal and 1 vertical line to render "capital I" but horizontal lines repainting is not done properly.
If the test is made to use Swing DefaultCaret implementation, no artifacts is seen. Since the test is about placing of caret at same position between characters, a plain vertical caret is sufficient to test so removed the horizontal line rendering.  Also, added 1 extra pixel in repainting logic to tackle caretWidth,height.
Tested against windows, linux and mac where it renders ok and movement of caret does not leave any artifacts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345618](https://bugs.openjdk.org/browse/JDK-8345618): javax/swing/text/Caret/8163124/CaretFloatingPointAPITest.java leaves Caret is not complete (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23129/head:pull/23129` \
`$ git checkout pull/23129`

Update a local copy of the PR: \
`$ git checkout pull/23129` \
`$ git pull https://git.openjdk.org/jdk.git pull/23129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23129`

View PR using the GUI difftool: \
`$ git pr show -t 23129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23129.diff">https://git.openjdk.org/jdk/pull/23129.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23129#issuecomment-2592161870)
</details>
