### PR TITLE
8344969: Remove the jmx.mxbean.multiname compatibility property

### DIFF
--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/MXBeanLookup.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/MXBeanLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,11 +144,8 @@ public class MXBeanLookup {
     throws InstanceAlreadyExistsException {
         ObjectName existing = mxbeanToObjectName.get(mxbean);
         if (existing != null) {
-            String multiname = System.getProperty("jmx.mxbean.multiname");
-            if (!"true".equalsIgnoreCase(multiname)) {
-                throw new InstanceAlreadyExistsException(
+            throw new InstanceAlreadyExistsException(
                         "MXBean already registered with name " + existing);
-            }
         }
         mxbeanToObjectName.put(mxbean, name);
     }

--- a/test/jdk/javax/management/mxbean/SameObjectTwoNamesTest.java
+++ b/test/jdk/javax/management/mxbean/SameObjectTwoNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  * @author Eamonn McManus
  *
  * @run main SameObjectTwoNamesTest
- * @run main/othervm -Djmx.mxbean.multiname=true SameObjectTwoNamesTest
  */
 
 import javax.management.InstanceAlreadyExistsException;
@@ -41,8 +40,7 @@ import javax.management.ObjectName;
 public class SameObjectTwoNamesTest {
 
     public static void main(String[] args) throws Exception {
-        boolean expectException =
-                (System.getProperty("jmx.mxbean.multiname") == null);
+        boolean expectException = true;
         try {
             ObjectName objectName1 = new ObjectName("test:index=1");
             ObjectName objectName2 = new ObjectName("test:index=2");

--- a/test/jdk/javax/management/mxbean/SameObjectTwoNamesTest.java
+++ b/test/jdk/javax/management/mxbean/SameObjectTwoNamesTest.java
@@ -40,7 +40,6 @@ import javax.management.ObjectName;
 public class SameObjectTwoNamesTest {
 
     public static void main(String[] args) throws Exception {
-        boolean expectException = true;
         try {
             ObjectName objectName1 = new ObjectName("test:index=1");
             ObjectName objectName2 = new ObjectName("test:index=2");
@@ -51,19 +50,10 @@ public class SameObjectTwoNamesTest {
 
             mbs.registerMBean(mxBeanObject, objectName2);
 
-            if (expectException) {
-                throw new Exception("TEST FAILED: " +
-                        "InstanceAlreadyExistsException was not thrown");
-            } else
-                System.out.println("Correctly got no exception with compat property");
+            throw new Exception("TEST FAILED: InstanceAlreadyExistsException was not thrown");
         } catch (InstanceAlreadyExistsException e) {
-            if (expectException) {
-                System.out.println("Got expected InstanceAlreadyExistsException:");
-                e.printStackTrace(System.out);
-            } else {
-                throw new Exception(
-                        "TEST FAILED: Got exception even though compat property set", e);
-            }
+            System.out.println("Got expected InstanceAlreadyExistsException:");
+            e.printStackTrace(System.out);
         }
         System.out.println("TEST PASSED");
     }


### PR DESCRIPTION
Remove the System Property "jmx.mxbean.multiname" which was introduced in JDK-7 for compatibility with code which may have depended on previous incorrect behaviour.  Removal is long overdue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8347805](https://bugs.openjdk.org/browse/JDK-8347805) to be approved

### Issues
 * [JDK-8344969](https://bugs.openjdk.org/browse/JDK-8344969): Remove the jmx.mxbean.multiname compatibility property (**Enhancement** - P4)
 * [JDK-8347805](https://bugs.openjdk.org/browse/JDK-8347805): Remove the jmx.mxbean.multiname compatibility property (**CSR**)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23131/head:pull/23131` \
`$ git checkout pull/23131`

Update a local copy of the PR: \
`$ git checkout pull/23131` \
`$ git pull https://git.openjdk.org/jdk.git pull/23131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23131`

View PR using the GUI difftool: \
`$ git pr show -t 23131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23131.diff">https://git.openjdk.org/jdk/pull/23131.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23131#issuecomment-2592399396)
</details>
