### PR TITLE
8344976: Remove the jmx.invoke.getters compatibility property

### DIFF
--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/PerInterface.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/PerInterface.java
@@ -108,8 +108,7 @@ final class PerInterface<M> {
         final List<MethodAndSig> list = ops.get(operation);
         if (list == null) {
             final String msg = "No such operation: " + operation;
-            return noSuchMethod(msg, resource, operation, params, signature,
-                                cookie);
+            throw new ReflectionException(new NoSuchMethodException(operation + sigString(signature)), msg);
         }
         if (signature == null)
             signature = new String[0];
@@ -131,27 +130,9 @@ final class PerInterface<M> {
                 msg = "Operation " + operation + " exists but not with " +
                         "this signature: " + badSig;
             }
-            return noSuchMethod(msg, resource, operation, params, signature,
-                                cookie);
+            throw new ReflectionException(new NoSuchMethodException(operation + badSig), msg);
         }
         return introspector.invokeM(found.method, resource, params, cookie);
-    }
-
-    /*
-     * This method is called to throw an Exception when invoke doesn't find the named method.
-     */
-    private Object noSuchMethod(String msg, Object resource, String operation,
-                                Object[] params, String[] signature,
-                                Object cookie)
-            throws MBeanException, ReflectionException {
-
-        // Construct the exception that we will throw
-        final NoSuchMethodException nsme =
-            new NoSuchMethodException(operation + sigString(signature));
-        final ReflectionException exception =
-            new ReflectionException(nsme, msg);
-
-        throw exception;
     }
 
     private String sigString(String[] signature) {

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/PerInterface.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/PerInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,25 +138,7 @@ final class PerInterface<M> {
     }
 
     /*
-     * This method is called when invoke doesn't find the named method.
-     * Before throwing an exception, we check to see whether the
-     * jmx.invoke.getters property is set, and if so whether the method
-     * being invoked might be a getter or a setter.  If so we invoke it
-     * and return the result.  This is for compatibility
-     * with code based on JMX RI 1.0 or 1.1 which allowed invoking getters
-     * and setters.  It is *not* recommended that new code use this feature.
-     *
-     * Since this method is either going to throw an exception or use
-     * functionality that is strongly discouraged, we consider that its
-     * performance is not very important.
-     *
-     * A simpler way to implement the functionality would be to add the getters
-     * and setters to the operations map when jmx.invoke.getters is set.
-     * However, that means that the property is consulted when an MBean
-     * interface is being introspected and not thereafter.  Previously,
-     * the property was consulted on every invocation.  So this simpler
-     * implementation could potentially break code that sets and unsets
-     * the property at different times.
+     * This method is called to throw an Exception when invoke doesn't find the named method.
      */
     @SuppressWarnings("removal")
     private Object noSuchMethod(String msg, Object resource, String operation,
@@ -164,46 +146,11 @@ final class PerInterface<M> {
                                 Object cookie)
             throws MBeanException, ReflectionException {
 
-        // Construct the exception that we will probably throw
+        // Construct the exception that we will throw
         final NoSuchMethodException nsme =
             new NoSuchMethodException(operation + sigString(signature));
         final ReflectionException exception =
             new ReflectionException(nsme, msg);
-
-        if (introspector.isMXBean())
-            throw exception; // No compatibility requirement here
-
-        // Is the compatibility property set?
-        String invokeGettersS = System.getProperty("jmx.invoke.getters");
-        if (invokeGettersS == null)
-            throw exception;
-
-        int rest = 0;
-        Map<String, M> methods = null;
-        if (signature == null || signature.length == 0) {
-            if (operation.startsWith("get"))
-                rest = 3;
-            else if (operation.startsWith("is"))
-                rest = 2;
-            if (rest != 0)
-                methods = getters;
-        } else if (signature.length == 1 &&
-                   operation.startsWith("set")) {
-            rest = 3;
-            methods = setters;
-        }
-
-        if (rest != 0) {
-            String attrName = operation.substring(rest);
-            M method = methods.get(attrName);
-            if (method != null && introspector.getName(method).equals(operation)) {
-                String[] msig = introspector.getSignature(method);
-                if ((signature == null && msig.length == 0) ||
-                        Arrays.equals(signature, msig)) {
-                    return introspector.invokeM(method, resource, params, cookie);
-                }
-            }
-        }
 
         throw exception;
     }

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/PerInterface.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/PerInterface.java
@@ -140,7 +140,6 @@ final class PerInterface<M> {
     /*
      * This method is called to throw an Exception when invoke doesn't find the named method.
      */
-    @SuppressWarnings("removal")
     private Object noSuchMethod(String msg, Object resource, String operation,
                                 Object[] params, String[] signature,
                                 Object cookie)

--- a/test/jdk/javax/management/Introspector/InvokeGettersTest.java
+++ b/test/jdk/javax/management/Introspector/InvokeGettersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/management/Introspector/InvokeGettersTest.java
+++ b/test/jdk/javax/management/Introspector/InvokeGettersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,8 @@
 
 /*
  * @test
- * @bug 6317101
- * @summary Test that the jmx.invoke.getters system property works
+ * @bug 6317101 8344976
+ * @summary Test invocation after removal of the jmx.invoke.getters system property
  * @author Eamonn McManus
  *
  * @run clean InvokeGettersTest
@@ -63,10 +63,7 @@ public class InvokeGettersTest {
         ObjectName on = new ObjectName("a:b=c");
         mbs.registerMBean(new Thing(), on);
         if (test(mbs, on, false))
-            System.out.println("OK: invoke without jmx.invoke.getters");
-        System.setProperty("jmx.invoke.getters", "true");
-        if (test(mbs, on, true))
-            System.out.println("OK: invoke with jmx.invoke.getters");
+            System.out.println("OK");
         if (failure == null)
             System.out.println("TEST PASSED");
         else
@@ -117,7 +114,7 @@ public class InvokeGettersTest {
                 System.out.println("isTrue got expected exception: " + e);
         }
 
-        // Following cases should fail whether or not jmx.invoke.getters is set
+        // Following cases should fail
         final Object[][] badInvokes = {
             {"isWhatsit", null, null},
             {"getWhatsit", new Object[] {5}, new String[] {"int"}},


### PR DESCRIPTION
The System Property "jmx.invoke.getters" was added in [JDK-4949203](https://bugs.openjdk.org/browse/JDK-4949203) to optionally be compatible with a time before JDK-6, when calling invoke on getters and setters was permitted.

It should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8347823](https://bugs.openjdk.org/browse/JDK-8347823) to be approved

### Issues
 * [JDK-8344976](https://bugs.openjdk.org/browse/JDK-8344976): Remove the jmx.invoke.getters compatibility property (**Enhancement** - P4)
 * [JDK-8347823](https://bugs.openjdk.org/browse/JDK-8347823): Remove the jmx.invoke.getters compatibility property (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) Review applies to [99ff70d2](https://git.openjdk.org/jdk/pull/23132/files/99ff70d2dc8fa3631c2228c3b860398a1a67b413)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) Review applies to [99ff70d2](https://git.openjdk.org/jdk/pull/23132/files/99ff70d2dc8fa3631c2228c3b860398a1a67b413)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23132/head:pull/23132` \
`$ git checkout pull/23132`

Update a local copy of the PR: \
`$ git checkout pull/23132` \
`$ git pull https://git.openjdk.org/jdk.git pull/23132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23132`

View PR using the GUI difftool: \
`$ git pr show -t 23132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23132.diff">https://git.openjdk.org/jdk/pull/23132.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23132#issuecomment-2593094134)
</details>
