### PR TITLE
8347756: Re-evaluate the java/net/DatagramSocket/InterruptibleDatagramSocket.java test

### DIFF
--- a/test/jdk/java/net/DatagramSocket/InterruptibleDatagramSocket.java
+++ b/test/jdk/java/net/DatagramSocket/InterruptibleDatagramSocket.java
@@ -80,16 +80,11 @@ public class InterruptibleDatagramSocket {
             if (interruptible)
                 throw e;
             System.out.println("Got expected SocketTimeoutException: " + e);
-        } catch (SocketException e) {
-            if ((e.getCause() instanceof ClosedByInterruptException) && interruptible) {
-                System.out.println("Got expected ClosedByInterruptException: " + e);
-            } else {
+        } catch (SocketException | ClosedByInterruptException e) {
+            if (!interruptible) {
                 throw e;
             }
-        } catch (ClosedByInterruptException e) {
-            if (!interruptible)
-                throw e;
-            System.out.println("Got expected ClosedByInterruptException: " + e);
+            System.out.println("Got expected: " + e);
         }
         if (s.isClosed() && !interruptible)
             throw new RuntimeException("DatagramSocket should not be closed");
@@ -98,23 +93,29 @@ public class InterruptibleDatagramSocket {
     }
 
     public static void main(String[] args) throws Exception {
-        if (Thread.currentThread().isVirtual()) {
-            throw new jtreg.SkippedException(
-                    "skipping test execution - main thread is a virtual thread");
-        }
+        final boolean isVirtualThread = Thread.currentThread().isVirtual();
         try (DatagramSocket s = new DatagramSocket()) {
-            System.out.println("Testing interrupt of DatagramSocket receive " +
-                    "on endpoint " + s.getLocalSocketAddress());
-            test(s, false);
+            System.out.println(
+                    (isVirtualThread ? "(virtual thread) " : "")
+                            + "Testing interrupt of DatagramSocket receive "
+                            + "on endpoint " + s.getLocalSocketAddress()
+            );
+            test(s, isVirtualThread);
         }
         try (DatagramSocket s = new MulticastSocket()) {
-            System.out.println("Testing interrupt of MulticastSocket receive" +
-                    " on endpoint " + s.getLocalSocketAddress());
-            test(s, false);
+            System.out.println(
+                    (isVirtualThread ? "(virtual thread) " : "")
+                            + "Testing interrupt of MulticastSocket receive "
+                            + "on endpoint " + s.getLocalSocketAddress()
+            );
+            test(s, isVirtualThread);
         }
         try (DatagramSocket s = DatagramChannel.open().bind(null).socket()) {
-            System.out.println("Testing interrupt of DatagramChannel socket " +
-                    "receive on endpoint " + s.getLocalSocketAddress());
+            System.out.println(
+                    (isVirtualThread ? "(virtual thread) " : "")
+                            + "Testing interrupt of DatagramChannel socket "
+                            + "receive on endpoint " + s.getLocalSocketAddress()
+            );
             test(s, true);
         }
     }


### PR DESCRIPTION
Can I please get a review of this test-only change which updates the `test/jdk/java/net/DatagramSocket/InterruptibleDatagramSocket.java` to match the specified behaviour of `DatagramSocket.receive()` method?

This test was introduced in Java 14 (https://bugs.openjdk.org/browse/JDK-8233018) and that version of Java through Java 18, behave differently when a DatagramSocket associated with a DatagramChannel, when blocked in a receive() is interrupted. In those versions, a `SocketException` gets thrown with `ClosedByInterruptException` as the cause of that `SocketException`. 

Starting Java 19, the specification of DatagramSocket.receive() has been updated to clarify the expectations of this scenario. Given those updates, the DatagramSocket.receive() is expected to throw a (top level) `ClosedByInterruptException` when associated with a `DatagramChannel`.

The change in this PR updates the test code to no longer expect a `SocketException` to contain the `ClosedByInterruptException`. With this change the test continues to pass both with platform threads as well as virtual threads. The test will no longer be skipped when the main() is launched through a virtual thread.

