### PR TITLE
8346875: Test jdk/jdk/jfr/event/os/TestCPULoad.java fails on macOS

### DIFF
--- a/test/jdk/jdk/jfr/event/os/TestCPULoad.java
+++ b/test/jdk/jdk/jfr/event/os/TestCPULoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class TestCPULoad {
         recording.enable(EVENT_NAME);
         recording.start();
         // Need to sleep so a time delta can be calculated
-        Thread.sleep(100);
+        Thread.sleep(600);
         recording.stop();
 
         List<RecordedEvent> events = Events.fromRecording(recording);

--- a/test/jdk/jdk/jfr/event/os/TestCPULoad.java
+++ b/test/jdk/jdk/jfr/event/os/TestCPULoad.java
@@ -30,7 +30,6 @@ import jdk.jfr.consumer.RecordedEvent;
 import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
-
 /**
  * @test
  * @key jfr
@@ -41,13 +40,32 @@ import jdk.test.lib.jfr.Events;
 public class TestCPULoad {
     private final static String EVENT_NAME = EventNames.CPULoad;
 
+    public static boolean isPrime(int num) {
+        if (num <= 1) return false;
+        for (int i = 2; i <= Math.sqrt(num); i++) {
+            if (num % i == 0) return false;
+        }
+        return true;
+    }
+
+    public static int burnCpuCycles(int limit) {
+        int primeCount = 0;
+        for (int i = 2; i < limit; i++) {
+            if (isPrime(i)) {
+                primeCount++;
+            }
+        }
+        return primeCount;
+    }
+
     public static void main(String[] args) throws Throwable {
         Recording recording = new Recording();
         recording.enable(EVENT_NAME);
         recording.start();
-        // Need to sleep so a time delta can be calculated
-        Thread.sleep(600);
+        // burn some cycles to check increase of CPU related counters
+        int pn = burnCpuCycles(2500000);
         recording.stop();
+        System.out.println("Found " + pn + " primes while burning cycles");
 
         List<RecordedEvent> events = Events.fromRecording(recording);
         if (events.isEmpty()) {


### PR DESCRIPTION
The test fails on some new Mac instances (macOS 14.5 (macOS aarch64) , CPU Apple M2) with :
java.lang.AssertionError: Expected at least one event
at jdk.jfr.event.os.TestCPULoad.main(TestCPULoad.java:62)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:565)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1447)

The current sleep value seems to be a bit too slow for those machines.  The issues occured (mostly) with fastdebug binaries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346875](https://bugs.openjdk.org/browse/JDK-8346875): Test jdk/jdk/jfr/event/os/TestCPULoad.java fails on macOS (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23136/head:pull/23136` \
`$ git checkout pull/23136`

Update a local copy of the PR: \
`$ git checkout pull/23136` \
`$ git pull https://git.openjdk.org/jdk.git pull/23136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23136`

View PR using the GUI difftool: \
`$ git pr show -t 23136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23136.diff">https://git.openjdk.org/jdk/pull/23136.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23136#issuecomment-2592953949)
</details>
