### PR TITLE
8347817: Timeouts running test/jdk/java/lang/String/concat/HiddenClassUnloading.java with fastdebug builds

### DIFF
--- a/test/jdk/java/lang/String/concat/HiddenClassUnloading.java
+++ b/test/jdk/java/lang/String/concat/HiddenClassUnloading.java
@@ -26,13 +26,20 @@ import java.lang.StringBuilder;
 import java.lang.invoke.*;
 import java.lang.management.ManagementFactory;
 
+import jdk.test.whitebox.WhiteBox;
+
 /**
  * @test
  * @summary Test whether the hidden class unloading of StringConcatFactory works
  *
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @requires vm.flagless
- * @run main/othervm -Xmx8M -Xms8M -Xverify:all HiddenClassUnloading
- * @run main/othervm -Xmx8M -Xms8M -Xverify:all -XX:-CompactStrings HiddenClassUnloading
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -Xverify:all HiddenClassUnloading
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -Xverify:all -XX:-CompactStrings HiddenClassUnloading
  */
 public class HiddenClassUnloading {
     public static void main(String[] args) throws Throwable {
@@ -60,6 +67,9 @@ public class HiddenClassUnloading {
                     new Object[0]
             );
         }
+
+        // Request GC which performs class unloading
+        WhiteBox.getWhiteBox().fullGC();
 
         long unloadedClassCount = ManagementFactory.getClassLoadingMXBean().getUnloadedClassCount();
         if (initUnloadedClassCount == unloadedClassCount) {

--- a/test/jdk/java/lang/String/concat/HiddenClassUnloading.java
+++ b/test/jdk/java/lang/String/concat/HiddenClassUnloading.java
@@ -43,7 +43,7 @@ public class HiddenClassUnloading {
 
         long initUnloadedClassCount = ManagementFactory.getClassLoadingMXBean().getUnloadedClassCount();
 
-        for (int i = 0; i < 12000; i++) {
+        for (int i = 0; i < 2000; i++) {
             int radix = types.length;
             String str = Integer.toString(i, radix);
             int length = str.length();


### PR DESCRIPTION
This PR reverts the fix from [JDK-8339166](https://bugs.openjdk.org/browse/JDK-8339166) because it increases the runtime of the test a lot.
Instead a full gc is requested via the whitebox api. This solves the issues (see bug description) and it is also clearer and more reliable then allocating objects and classes expecting a gc because of the small heap.
The heap setting is also removed since it is not needed anymore.

#### Testing: Duration Running HiddenClassUnloading with fastdebug Builds

I'm giving the minimum of a few runs because durations vary by +/- 10s.

```
Linux / x86_64:
After JDK-8339166:    3m15s
JDK-8339166 reverted:   50s
PR:                     50s

macOS / M1:
After JDK-8339166:    2m30s
JDK-8339166 reverted:   30s
PR:                     30s

Linux / ppc64le
After JDK-8339166:    12m30s
JDK-8339166 reverted:  2m30s  (failure: no classes unloaded)
PR:                    2m30s  (success)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347817](https://bugs.openjdk.org/browse/JDK-8347817): Timeouts running test/jdk/java/lang/String/concat/HiddenClassUnloading.java with fastdebug builds (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23137/head:pull/23137` \
`$ git checkout pull/23137`

Update a local copy of the PR: \
`$ git checkout pull/23137` \
`$ git pull https://git.openjdk.org/jdk.git pull/23137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23137`

View PR using the GUI difftool: \
`$ git pr show -t 23137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23137.diff">https://git.openjdk.org/jdk/pull/23137.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23137#issuecomment-2592980579)
</details>
