### PR TITLE
8327240: Obsolete Tier2CompileThreshold/Tier2BackEdgeThreshold product flags

### DIFF
--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,14 +166,6 @@
           "C1 with MDO profiling (tier 3) invocation notification "         \
           "frequency")                                                      \
           range(0, 30)                                                      \
-                                                                            \
-  product(intx, Tier2CompileThreshold, 0,                                   \
-          "threshold at which tier 2 compilation is invoked")               \
-          range(0, max_jint)                                                \
-                                                                            \
-  product(intx, Tier2BackEdgeThreshold, 0,                                  \
-          "Back edge threshold at which tier 2 compilation is invoked")     \
-          range(0, max_jint)                                                \
                                                                             \
   product(intx, Tier3InvocationThreshold, 200,                              \
           "Compile if number of method invocations crosses this "           \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -534,6 +534,8 @@ static SpecialFlag const special_jvm_flags[] = {
 
   { "MetaspaceReclaimPolicy",       JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
   { "ZGenerational",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::undefined() },
+  { "Tier2CompileThreshold",        JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::jdk(26) },
+  { "Tier2BackEdgeThreshold",       JDK_Version::undefined(), JDK_Version::jdk(25), JDK_Version::jdk(26) },
 
 #ifdef ASSERT
   { "DummyObsoleteTestFlag",        JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::undefined() },

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm -XX:-OmitStackTraceInFastThrow jit.t.t105.t105
- * @run main/othervm -XX:-OmitStackTraceInFastThrow -Xbatch -XX:Tier0BackedgeNotifyFreqLog=0 -XX:Tier2BackedgeNotifyFreqLog=0 -XX:Tier3BackedgeNotifyFreqLog=0 -XX:Tier2BackEdgeThreshold=1 -XX:Tier3BackEdgeThreshold=1 -XX:Tier4BackEdgeThreshold=1 jit.t.t105.t105
+ * @run main/othervm -XX:-OmitStackTraceInFastThrow -Xbatch -XX:Tier0BackedgeNotifyFreqLog=0 -XX:Tier2BackedgeNotifyFreqLog=0 -XX:Tier3BackedgeNotifyFreqLog=0 -XX:Tier3BackEdgeThreshold=1 -XX:Tier4BackEdgeThreshold=1 jit.t.t105.t105
  *
  * This test must be run with OmitStackTraceInFastThrow disabled to avoid preallocated
  * exceptions. They don't have the detailed message that this test relies on.


### PR DESCRIPTION
Hi folks,

This PR obsoletes the options Tier2CompileThreshold and Tier2BackEdgeThreshold.

Please note the comments in a previous PR denoting when these flags were removed. https://github.com/openjdk/jdk/pull/18904#issuecomment-2074223780


Thanks,
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change requires CSR request [JDK-8331082](https://bugs.openjdk.org/browse/JDK-8331082) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8327240](https://bugs.openjdk.org/browse/JDK-8327240): Obsolete Tier2CompileThreshold/Tier2BackEdgeThreshold product flags (**Enhancement** - P4)
 * [JDK-8331082](https://bugs.openjdk.org/browse/JDK-8331082): Obsolete Tier2CompileThreshold/Tier2BackEdgeThreshold product flags (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23139/head:pull/23139` \
`$ git checkout pull/23139`

Update a local copy of the PR: \
`$ git checkout pull/23139` \
`$ git pull https://git.openjdk.org/jdk.git pull/23139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23139`

View PR using the GUI difftool: \
`$ git pr show -t 23139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23139.diff">https://git.openjdk.org/jdk/pull/23139.diff</a>

</details>
