### PR TITLE
8347825: Make IDEA ide support use proper build system mechanisms

### DIFF
--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,7 @@ if [ "$VERBOSE" = "true" ] ; then
   echo "idea template dir: $IDEA_TEMPLATE"
 fi
 
-cd $TOP ; make -f "$IDEA_MAKE/idea.gmk" -I $MAKE_DIR/.. idea MAKEOVERRIDES= OUT=$IDEA_OUTPUT/env.cfg MODULES="$*" $CONF_ARG || exit 1
+cd $TOP ; make idea-gen-config IDEA_OUTPUT=$IDEA_OUTPUT MODULES="$*" $CONF_ARG || exit 1
 cd $SCRIPT_DIR
 
 . $IDEA_OUTPUT/env.cfg

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -361,7 +361,7 @@ $(eval $(call SetupTarget, vscode-project-ccls, \
 
 $(eval $(call SetupTarget, idea-gen-config, \
     MAKEFILE := ide/idea/jdk/IdeaGenConfig, \
-    ARGS := IDEA_OUTPUT=$(IDEA_OUTPUT) MODULES=$(MODULES), \
+    ARGS := IDEA_OUTPUT="$(IDEA_OUTPUT)" MODULES="$(MODULES)", \
 ))
 
 ################################################################################

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -354,6 +354,14 @@ $(eval $(call SetupTarget, vscode-project-ccls, \
     MAKEFILE := ide/vscode/hotspot/CreateVSCodeProject, \
     ARGS := VSCODE_INDEXER=ccls, \
     DEPS := compile-commands, \
+))
+
+################################################################################
+# IDEA IntelliJ projects
+
+$(eval $(call SetupTarget, idea-gen-config, \
+    MAKEFILE := ide/idea/jdk/IdeaGenConfig, \
+    ARGS := IDEA_OUTPUT=$(IDEA_OUTPUT) MODULES=$(MODULES), \
 ))
 
 ################################################################################

--- a/make/ide/idea/jdk/IdeaGenConfig.gmk
+++ b/make/ide/idea/jdk/IdeaGenConfig.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,36 +23,35 @@
 # questions.
 #
 
-include Makefile
-include make/MainSupport.gmk
+default: all
 
-.PHONY: idea
+include $(SPEC)
+include MakeBase.gmk
 
-ifeq ($(SPEC), )
-  ifneq ($(words $(SPECS)), 1)
-	@echo "Error: Multiple build specification files found. Please select one explicitly."
-	@exit 2
-  endif
-  idea:
-	@cd $(topdir)
-	@$(MAKE) $(MFLAGS) $(MAKE_LOG_FLAGS) -r -R -j 1 -f $(topdir)/make/ide/idea/jdk/idea.gmk SPEC=$(SPECS) HAS_SPEC=true ACTUAL_TOPDIR=$(topdir) MODULES="$(MODULES)" idea
-else #with SPEC
-  include make/common/Modules.gmk
+include Modules.gmk
 
-  ifeq ($(MODULES), )
-    SEL_MODULES := $(call FindAllModules)
-  else
-    SEL_MODULES := $(MODULES)
-  endif
+# MODULES and IDEA_OUTPUT is passed on the command line
+ifeq ($(MODULES), )
+  override MODULES := $(call FindAllModules)
+endif
 
-  idea:
+ifeq ($(IDEA_OUTPUT), )
+  override IDEA_OUTPUT := $(WORKSPACE_ROOT)/.idea
+endif
+
+OUT := $(IDEA_OUTPUT)/env.cfg
+
+idea:
+	$(RM) $(OUT)
 	$(ECHO) "SUPPORT=$(SUPPORT_OUTPUTDIR)" >> $(OUT)
-	$(ECHO) "MODULE_ROOTS=\"$(foreach mod, $(SEL_MODULES), $(call FindModuleSrcDirs, $(mod)))\"" >> $(OUT)
-	$(ECHO) "MODULE_NAMES=\"$(strip $(foreach mod, $(SEL_MODULES), $(mod)))\"" >> $(OUT)
-	$(ECHO) "SEL_MODULES=\"$(SEL_MODULES)\"" >> $(OUT)
+	$(ECHO) "MODULE_ROOTS=\"$(foreach mod, $(MODULES), $(call FindModuleSrcDirs, $(mod)))\"" >> $(OUT)
+	$(ECHO) "MODULE_NAMES=\"$(strip $(foreach mod, $(MODULES), $(mod)))\"" >> $(OUT)
+	$(ECHO) "SEL_MODULES=\"$(MODULES)\"" >> $(OUT)
 	$(ECHO) "BOOT_JDK=\"$(BOOT_JDK)\"" >> $(OUT)
 	$(ECHO) "CYGPATH=\"$(PATHTOOL)\"" >> $(OUT)
 	$(ECHO) "SPEC=\"$(SPEC)\"" >> $(OUT)
 	$(ECHO) "JT_HOME=\"$(JT_HOME)\"" >> $(OUT)
 
-endif
+all: idea
+
+.PHONY: default all idea

--- a/test/make/TestIdea.gmk
+++ b/test/make/TestIdea.gmk
@@ -33,9 +33,9 @@ clean-idea:
 
 verify-idea:
 	$(MKDIR) -p $(IDEA_OUTPUT_DIR)
-	MAKEFLAGS= MFLAGS= $(BASH) $(TOPDIR)/bin/idea.sh -o $(IDEA_OUTPUT_DIR)/idea1
-	MAKEFLAGS= MFLAGS= $(BASH) $(TOPDIR)/bin/idea.sh -o $(IDEA_OUTPUT_DIR)/idea2 java.base
-	MAKEFLAGS= MFLAGS= $(BASH) $(TOPDIR)/bin/idea.sh -o $(IDEA_OUTPUT_DIR)/idea3 java.base jdk.compiler
+	cd $(WORKSPACE_ROOT) && HAS_SPEC= MAKEFLAGS= MFLAGS= $(BASH) $(TOPDIR)/bin/idea.sh -o $(IDEA_OUTPUT_DIR)/idea1
+	cd $(WORKSPACE_ROOT) && HAS_SPEC= MAKEFLAGS= MFLAGS= $(BASH) $(TOPDIR)/bin/idea.sh -o $(IDEA_OUTPUT_DIR)/idea2 java.base
+	cd $(WORKSPACE_ROOT) && HAS_SPEC= MAKEFLAGS= MFLAGS= $(BASH) $(TOPDIR)/bin/idea.sh -o $(IDEA_OUTPUT_DIR)/idea3 java.base jdk.compiler
 
 TEST_TARGETS += verify-idea
 


### PR DESCRIPTION
The idea.sh script which creates a configuration for IDEA does at some point call a makefile, to extract information from the build system. However, this is done in an ad-hoc manner that does not fit properly in the build system.

I ran into this as a problem when trying to implement another change, so this needs to be fixed, and should be fixed separately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347825](https://bugs.openjdk.org/browse/JDK-8347825): Make IDEA ide support use proper build system mechanisms (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23140/head:pull/23140` \
`$ git checkout pull/23140`

Update a local copy of the PR: \
`$ git checkout pull/23140` \
`$ git pull https://git.openjdk.org/jdk.git pull/23140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23140`

View PR using the GUI difftool: \
`$ git pr show -t 23140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23140.diff">https://git.openjdk.org/jdk/pull/23140.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23140#issuecomment-2593256946)
</details>
