### PR TITLE
8345493: JFR: JVM.flush hangs intermittently

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -679,4 +679,8 @@ public final class PlatformRecorder {
     public RepositoryChunk getCurrentChunk() {
         return currentChunk;
     }
+
+    public synchronized void flush() {
+        MetadataRepository.getInstance().flush();
+    }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/FlushTask.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/FlushTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@ package jdk.jfr.internal.periodic;
 
 import jdk.jfr.internal.JVM;
 import jdk.jfr.internal.MetadataRepository;
+import jdk.jfr.internal.PlatformRecorder;
+import jdk.jfr.internal.PrivateAccess;
 import jdk.jfr.internal.util.Utils;
 
 /**
@@ -44,7 +46,8 @@ final class FlushTask extends PeriodicTask {
 
     @Override
     public void execute(long timestamp, PeriodicType periodicType) {
-        MetadataRepository.getInstance().flush();
+        PlatformRecorder recorder = PrivateAccess.getInstance().getPlatformRecorder();
+        recorder.flush();
         Utils.notifyFlush();
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345493](https://bugs.openjdk.org/browse/JDK-8345493): JFR: JVM.flush hangs intermittently (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23141/head:pull/23141` \
`$ git checkout pull/23141`

Update a local copy of the PR: \
`$ git checkout pull/23141` \
`$ git pull https://git.openjdk.org/jdk.git pull/23141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23141`

View PR using the GUI difftool: \
`$ git pr show -t 23141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23141.diff">https://git.openjdk.org/jdk/pull/23141.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23141#issuecomment-2593383550)
</details>
