### PR TITLE
8332857: Test vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/TestDescription.java failed

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/thrcputime002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/thrcputime002.cpp
@@ -33,7 +33,7 @@ extern "C" {
 /* ============================================================================= */
 
 static jlong timeout = 0;
-static jrawMonitorID monitor;
+static jrawMonitorID monitor; // a monitor to serialize event callbacks and checkCpuTime calls
 
 #define TESTED_THREAD_NAME      "thrcputime002Thread"
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/thrcputime002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/thrcputime002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ extern "C" {
 /* ============================================================================= */
 
 static jlong timeout = 0;
+static jrawMonitorID monitor;
 
 #define TESTED_THREAD_NAME      "thrcputime002Thread"
 
@@ -150,6 +151,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     NSK_DISPLAY0(">>> Testcase #2: Check initial cpu time in agent thread\n");
     {
+        RawMonitorLocker rml(jvmti, jni, monitor);
         if (!checkCpuTime(jvmti, testAgentThread, &prevAgentThreadTime, nullptr, "agent thread")) {
             nsk_jvmti_setFailStatus();
         }
@@ -173,6 +175,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
         NSK_DISPLAY0(">>> Testcase #5: Check middle cpu time from agent thread\n");
         {
+            RawMonitorLocker rml(jvmti, jni, monitor);
             julong time = 0;
             runIterations(iterations);
             if (!checkCpuTime(jvmti, testAgentThread, &time, &prevAgentThreadTime, "agent thread")) {
@@ -183,6 +186,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         if (testedThread != nullptr) {
             NSK_DISPLAY0(">>> Testcase #6: Check tested thread cpu time from agent thread\n");
             {
+                RawMonitorLocker rml(jvmti, jni, monitor);
                 julong time = 0;
                 runIterations(iterations);
                 if (!checkCpuTime(jvmti, testedThread, &time, &prevTestedThreadTime, "agent thread")) {
@@ -224,6 +228,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
  */
 JNIEXPORT void JNICALL
 callbackVMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
+    RawMonitorLocker rml(jvmti, jni, monitor);
 
     NSK_DISPLAY0(">>> Testcase #1: Check initial cpu time in VM_INIT callback\n");
     {
@@ -239,6 +244,8 @@ callbackVMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
  */
 JNIEXPORT void JNICALL
 callbackVMDeath(jvmtiEnv* jvmti, JNIEnv* jni) {
+    RawMonitorLocker rml(jvmti, jni, monitor);
+
     int success = NSK_TRUE;
 
     NSK_DISPLAY1("Disable events: %d events\n", EVENTS_COUNT);
@@ -261,6 +268,7 @@ callbackVMDeath(jvmtiEnv* jvmti, JNIEnv* jni) {
  */
 JNIEXPORT void JNICALL
 callbackThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
+    RawMonitorLocker rml(jvmti, jni, monitor);
 
     jvmtiThreadInfo threadInfo;
     {
@@ -296,6 +304,7 @@ callbackThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
  */
 JNIEXPORT void JNICALL
 callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
+    RawMonitorLocker rml(jvmti, jni, monitor);
 
     jvmtiThreadInfo threadInfo;
     {
@@ -389,6 +398,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (nsk_jvmti_enableEvents(JVMTI_ENABLE, EVENTS_COUNT, events, nullptr)) {
         NSK_DISPLAY0("  ... enabled\n");
     }
+    monitor = create_raw_monitor(jvmti, "Raw monitor for synchronization");
 
     return JNI_OK;
 }


### PR DESCRIPTION
The test lacks a synchronization, so it is added by this fix.

Testing:
 - Ran the failing test `vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002`
 - TBD: submit mach5 tiers 1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332857](https://bugs.openjdk.org/browse/JDK-8332857): Test vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/TestDescription.java failed (**Bug** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) Review applies to [ec07eda1](https://git.openjdk.org/jdk/pull/23144/files/ec07eda1a132c8ff4f844d0de4fafe937452095d)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23144/head:pull/23144` \
`$ git checkout pull/23144`

Update a local copy of the PR: \
`$ git checkout pull/23144` \
`$ git pull https://git.openjdk.org/jdk.git pull/23144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23144`

View PR using the GUI difftool: \
`$ git pr show -t 23144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23144.diff">https://git.openjdk.org/jdk/pull/23144.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23144#issuecomment-2594980938)
</details>
