### PR TITLE
8345045: Remove the jmx.remote.x.buffer.size JMX notification property

### DIFF
--- a/src/java.management/share/classes/com/sun/jmx/remote/util/EnvHelp.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/util/EnvHelp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -262,21 +262,11 @@ public class EnvHelp {
     public static int getNotifBufferSize(Map<String, ?> env) {
         int defaultQueueSize = 1000; // default value
 
-        // keep it for the compatibility for the fix:
-        // 6174229: Environment parameter should be notification.buffer.size
-        // instead of buffer.size
-        final String oldP = "jmx.remote.x.buffer.size";
-
         // the default value re-specified in the system
         try {
             String s = System.getProperty(BUFFER_SIZE_PROPERTY);
             if (s != null) {
                 defaultQueueSize = Integer.parseInt(s);
-            } else { // try the old one
-                s = System.getProperty(oldP);
-                if (s != null) {
-                    defaultQueueSize = Integer.parseInt(s);
-                }
             }
         } catch (RuntimeException e) {
             logger.warning("getNotifBufferSize",
@@ -290,10 +280,6 @@ public class EnvHelp {
         try {
             if (env.containsKey(BUFFER_SIZE_PROPERTY)) {
                 queueSize = (int)EnvHelp.getIntegerAttribute(env,BUFFER_SIZE_PROPERTY,
-                                            defaultQueueSize,0,
-                                            Integer.MAX_VALUE);
-            } else { // try the old one
-                queueSize = (int)EnvHelp.getIntegerAttribute(env,oldP,
                                             defaultQueueSize,0,
                                             Integer.MAX_VALUE);
             }

--- a/test/jdk/javax/management/remote/mandatory/notif/NotifBufferSizePropertyNameTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/NotifBufferSizePropertyNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test NotifBufferSizePropertyNameTest
- * @bug 6174229
+ * @bug 6174229 8345045
  * @summary Verify the property name specifying server notification buffer size.
  * @author Shanliang JIANG
  *
@@ -52,35 +52,25 @@ public class NotifBufferSizePropertyNameTest {
             };
 
     public static void main(String[] args) throws Exception {
-        System.out.println(
-           "Verify the property name specifying the server notification buffer size.");
+        System.out.println("Verify the property name specifying the server notification buffer size.");
 
         oname = new ObjectName ("Default:name=NotificationEmitter");
         url = new JMXServiceURL("rmi", null, 0);
         Map env = new HashMap(2);
 
-        System.out.println("Test the new property name.");
+        System.out.println("Test the property name.");
         env.put("jmx.remote.x.notification.buffer.size", String.valueOf(bufferSize));
         test(env);
 
-        System.out.println("Test the old property name.");
-        env.remove("jmx.remote.x.notification.buffer.size");
-        env.put("jmx.remote.x.buffer.size", String.valueOf(bufferSize));
-        test(env);
-
+        // Recognition of the old, incorrect property "jmx.remote.x.buffer.size" has been dropped.
+        // Do not test old name is recognised, but do test it does not interfere with correct name:
         System.out.println("Test that the new property name overwrite the old one.");
         env.put("jmx.remote.x.notification.buffer.size", String.valueOf(bufferSize));
         env.put("jmx.remote.x.buffer.size", String.valueOf(bufferSize*6));
         test(env);
 
-        System.out.println("Test the old property name on system.");
-        System.setProperty("jmx.remote.x.buffer.size", String.valueOf(bufferSize));
-        test(null);
-
-        System.out.println(
-             "Test that the new property name overwrite the old one on system.");
-        System.setProperty("jmx.remote.x.notification.buffer.size",
-                           String.valueOf(bufferSize));
+        System.out.println("Test that the new property name overwrite the old one on system.");
+        System.setProperty("jmx.remote.x.notification.buffer.size", String.valueOf(bufferSize));
         System.setProperty("jmx.remote.x.buffer.size", String.valueOf(bufferSize*6));
         test(null);
     }


### PR DESCRIPTION
jmx.remote.x.buffer.size was a previous and incorrect name for the jmx.remote.x.notification.buffer.size property.  

The old name was still recognised to aid compatibility.
That was 2004.  We should only recognise the correct name at this point.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8347905](https://bugs.openjdk.org/browse/JDK-8347905) to be approved

### Issues
 * [JDK-8345045](https://bugs.openjdk.org/browse/JDK-8345045): Remove the jmx.remote.x.buffer.size JMX notification property (**Enhancement** - P4)
 * [JDK-8347905](https://bugs.openjdk.org/browse/JDK-8347905): Remove the jmx.remote.x.buffer.size JMX notification property (**CSR**)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23145/head:pull/23145` \
`$ git checkout pull/23145`

Update a local copy of the PR: \
`$ git checkout pull/23145` \
`$ git pull https://git.openjdk.org/jdk.git pull/23145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23145`

View PR using the GUI difftool: \
`$ git pr show -t 23145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23145.diff">https://git.openjdk.org/jdk/pull/23145.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23145#issuecomment-2595165202)
</details>
