### PR TITLE
8348170: Unnecessary Hashtable usage in CSS.styleConstantToCssMap

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1097,7 +1097,7 @@ public class CSS implements Serializable {
      * up a translation from StyleConstants (i.e. the <em>well known</em>
      * attributes) to the associated CSS attributes.
      */
-    private static final Hashtable<Object, Attribute> styleConstantToCssMap = new Hashtable<Object, Attribute>(17);
+    private static final Map<Object, Attribute> styleConstantToCssMap;
     /** Maps from HTML value to a CSS value. Used in internal mapping. */
     private static final Hashtable<String, CSS.Value> htmlValueToCssValueMap = new Hashtable<String, CSS.Value>(8);
     /** Maps from CSS value (string) to internal value. */
@@ -1167,38 +1167,40 @@ public class CSS implements Serializable {
         );
 
         // initialize StyleConstants mapping
-        styleConstantToCssMap.put(StyleConstants.FontFamily,
-                                  CSS.Attribute.FONT_FAMILY);
-        styleConstantToCssMap.put(StyleConstants.FontSize,
-                                  CSS.Attribute.FONT_SIZE);
-        styleConstantToCssMap.put(StyleConstants.Bold,
-                                  CSS.Attribute.FONT_WEIGHT);
-        styleConstantToCssMap.put(StyleConstants.Italic,
-                                  CSS.Attribute.FONT_STYLE);
-        styleConstantToCssMap.put(StyleConstants.Underline,
-                                  CSS.Attribute.TEXT_DECORATION);
-        styleConstantToCssMap.put(StyleConstants.StrikeThrough,
-                                  CSS.Attribute.TEXT_DECORATION);
-        styleConstantToCssMap.put(StyleConstants.Superscript,
-                                  CSS.Attribute.VERTICAL_ALIGN);
-        styleConstantToCssMap.put(StyleConstants.Subscript,
-                                  CSS.Attribute.VERTICAL_ALIGN);
-        styleConstantToCssMap.put(StyleConstants.Foreground,
-                                  CSS.Attribute.COLOR);
-        styleConstantToCssMap.put(StyleConstants.Background,
-                                  CSS.Attribute.BACKGROUND_COLOR);
-        styleConstantToCssMap.put(StyleConstants.FirstLineIndent,
-                                  CSS.Attribute.TEXT_INDENT);
-        styleConstantToCssMap.put(StyleConstants.LeftIndent,
-                                  CSS.Attribute.MARGIN_LEFT);
-        styleConstantToCssMap.put(StyleConstants.RightIndent,
-                                  CSS.Attribute.MARGIN_RIGHT);
-        styleConstantToCssMap.put(StyleConstants.SpaceAbove,
-                                  CSS.Attribute.MARGIN_TOP);
-        styleConstantToCssMap.put(StyleConstants.SpaceBelow,
-                                  CSS.Attribute.MARGIN_BOTTOM);
-        styleConstantToCssMap.put(StyleConstants.Alignment,
-                                  CSS.Attribute.TEXT_ALIGN);
+        styleConstantToCssMap = Map.ofEntries(
+                Map.entry(StyleConstants.FontFamily,
+                          CSS.Attribute.FONT_FAMILY),
+                Map.entry(StyleConstants.FontSize,
+                          CSS.Attribute.FONT_SIZE),
+                Map.entry(StyleConstants.Bold,
+                          CSS.Attribute.FONT_WEIGHT),
+                Map.entry(StyleConstants.Italic,
+                          CSS.Attribute.FONT_STYLE),
+                Map.entry(StyleConstants.Underline,
+                          CSS.Attribute.TEXT_DECORATION),
+                Map.entry(StyleConstants.StrikeThrough,
+                          CSS.Attribute.TEXT_DECORATION),
+                Map.entry(StyleConstants.Superscript,
+                          CSS.Attribute.VERTICAL_ALIGN),
+                Map.entry(StyleConstants.Subscript,
+                          CSS.Attribute.VERTICAL_ALIGN),
+                Map.entry(StyleConstants.Foreground,
+                          CSS.Attribute.COLOR),
+                Map.entry(StyleConstants.Background,
+                          CSS.Attribute.BACKGROUND_COLOR),
+                Map.entry(StyleConstants.FirstLineIndent,
+                          CSS.Attribute.TEXT_INDENT),
+                Map.entry(StyleConstants.LeftIndent,
+                          CSS.Attribute.MARGIN_LEFT),
+                Map.entry(StyleConstants.RightIndent,
+                          CSS.Attribute.MARGIN_RIGHT),
+                Map.entry(StyleConstants.SpaceAbove,
+                          CSS.Attribute.MARGIN_TOP),
+                Map.entry(StyleConstants.SpaceBelow,
+                          CSS.Attribute.MARGIN_BOTTOM),
+                Map.entry(StyleConstants.Alignment,
+                          CSS.Attribute.TEXT_ALIGN)
+        );
 
         // HTML->CSS
         htmlValueToCssValueMap.put("disc", CSS.Value.DISC);


### PR DESCRIPTION
There is a field `javax.swing.text.html.CSS#styleConstantToCssMap` which uses legacy `Hashtable` class.
As this map is read-only and all its content is initialized in `<clinit>` we can safely use immutable `Map` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348170](https://bugs.openjdk.org/browse/JDK-8348170): Unnecessary Hashtable usage in CSS.styleConstantToCssMap (**Enhancement** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23149/head:pull/23149` \
`$ git checkout pull/23149`

Update a local copy of the PR: \
`$ git checkout pull/23149` \
`$ git pull https://git.openjdk.org/jdk.git pull/23149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23149`

View PR using the GUI difftool: \
`$ git pr show -t 23149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23149.diff">https://git.openjdk.org/jdk/pull/23149.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23149#issuecomment-2604147636)
</details>
