### PR TITLE
8354789: Unnecessary null check in sun.awt.windows.WToolkit.getFontPeer

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
@@ -600,6 +600,7 @@ public final class WToolkit extends SunToolkit implements Runnable {
                 return cachedVal;
             }
         }
+
         FontPeer retval = new WFontPeer(name, style);
         if (null == cacheFontPeer) {
             cacheFontPeer = new Hashtable<>(5, 0.9f);

--- a/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
@@ -593,15 +593,14 @@ public final class WToolkit extends SunToolkit implements Runnable {
 
     @Override
     public FontPeer getFontPeer(String name, int style) {
-        FontPeer retval;
         String lcName = name.toLowerCase();
         if (null != cacheFontPeer) {
-            retval = cacheFontPeer.get(lcName + style);
-            if (null != retval) {
-                return retval;
+            FontPeer cachedVal = cacheFontPeer.get(lcName + style);
+            if (null != cachedVal) {
+                return cachedVal;
             }
         }
-        retval = new WFontPeer(name, style);
+        FontPeer retval = new WFontPeer(name, style);
         if (null == cacheFontPeer) {
             cacheFontPeer = new Hashtable<>(5, 0.9f);
         }

--- a/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -593,7 +593,7 @@ public final class WToolkit extends SunToolkit implements Runnable {
 
     @Override
     public FontPeer getFontPeer(String name, int style) {
-        FontPeer retval = null;
+        FontPeer retval;
         String lcName = name.toLowerCase();
         if (null != cacheFontPeer) {
             retval = cacheFontPeer.get(lcName + style);
@@ -602,13 +602,11 @@ public final class WToolkit extends SunToolkit implements Runnable {
             }
         }
         retval = new WFontPeer(name, style);
-        if (retval != null) {
-            if (null == cacheFontPeer) {
-                cacheFontPeer = new Hashtable<>(5, 0.9f);
-            }
-            if (null != cacheFontPeer) {
-                cacheFontPeer.put(lcName + style, retval);
-            }
+        if (null == cacheFontPeer) {
+            cacheFontPeer = new Hashtable<>(5, 0.9f);
+        }
+        if (null != cacheFontPeer) {
+            cacheFontPeer.put(lcName + style, retval);
         }
         return retval;
     }


### PR DESCRIPTION
There is redundant `null` comparison in `sun.awt.windows.WToolkit.getFontPeer`
Local variable `retval` can't be null after new object assignment.
https://github.com/openjdk/jdk/blob/24de9dee80738fe6ab1fc726b071546c85bbf79a/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java#L604-L605

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354789](https://bugs.openjdk.org/browse/JDK-8354789): Unnecessary null check in sun.awt.windows.WToolkit.getFontPeer (**Enhancement** - P5)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**) Review applies to [ebb84a5d](https://git.openjdk.org/jdk/pull/23150/files/ebb84a5d9bc5c86eac5e1cf9b78317a5262d91d4)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23150/head:pull/23150` \
`$ git checkout pull/23150`

Update a local copy of the PR: \
`$ git checkout pull/23150` \
`$ git pull https://git.openjdk.org/jdk.git pull/23150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23150`

View PR using the GUI difftool: \
`$ git pr show -t 23150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23150.diff">https://git.openjdk.org/jdk/pull/23150.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23150#issuecomment-2808787860)
</details>
