### PR TITLE
8345048: Remove the jmx.extend.open.types compatibility property

### DIFF
--- a/src/java.management/share/classes/javax/management/openmbean/OpenType.java
+++ b/src/java.management/share/classes/javax/management/openmbean/OpenType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -194,10 +194,7 @@ public abstract class OpenType<T> implements Serializable {
         if (this.getClass().getClassLoader() == null)
             return;  // We trust bootstrap classes.
         if (overridesGetClassName(this.getClass())) {
-            if (System.getProperty("jmx.extend.open.types") == null) {
-                throw new SecurityException("Cannot override getClassName() " +
-                        "unless -Djmx.extend.open.types");
-            }
+            throw new SecurityException("Cannot override getClassName()");
         }
     }
 


### PR DESCRIPTION
Classes should not override javax.management.openmbean.OpenType.getClassName(), and this was made illegal (caused an Exception) in JDK6.  A System Property jmx.extend.open.types was introduced to allow such an override, for compatibility reasons.

This was not documented but was mentioned in the Exception message.

This compatibility convenience flag should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8347918](https://bugs.openjdk.org/browse/JDK-8347918) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8345048](https://bugs.openjdk.org/browse/JDK-8345048): Remove the jmx.extend.open.types compatibility property (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).
 * [JDK-8347918](https://bugs.openjdk.org/browse/JDK-8347918): Remove the jmx.extend.open.types compatibility property (**CSR**)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23151/head:pull/23151` \
`$ git checkout pull/23151`

Update a local copy of the PR: \
`$ git checkout pull/23151` \
`$ git pull https://git.openjdk.org/jdk.git pull/23151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23151`

View PR using the GUI difftool: \
`$ git pr show -t 23151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23151.diff">https://git.openjdk.org/jdk/pull/23151.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23151#issuecomment-2595494056)
</details>
