### PR TITLE
8347917: AArch64: Enable upper GPR registers in C1

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_Defs_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_Defs_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -41,16 +41,17 @@ enum {
 
 // registers
 enum {
+  pd_nof_available_regs = 32,
   pd_nof_cpu_regs_frame_map = Register::number_of_registers,       // number of GP registers used during code emission
   pd_nof_fpu_regs_frame_map = FloatRegister::number_of_registers,  // number of FP registers used during code emission
 
-  pd_nof_caller_save_cpu_regs_frame_map = 19 - 2 /* rscratch1 and rscratch2 */ R18_RESERVED_ONLY(- 1),  // number of registers killed by calls
+  pd_nof_caller_save_cpu_regs_frame_map = pd_nof_available_regs,  // number of registers killed by calls
   pd_nof_caller_save_fpu_regs_frame_map = 32,  // number of registers killed by calls
 
-  pd_first_callee_saved_reg = 19 - 2 /* rscratch1 and rscratch2 */ R18_RESERVED_ONLY(- 1),
-  pd_last_callee_saved_reg = 26 - 2 /* rscratch1 and rscratch2 */ R18_RESERVED_ONLY(- 1),
+  pd_first_callee_saved_reg = pd_nof_available_regs - 1,
+  pd_last_callee_saved_reg = pd_first_callee_saved_reg - 1, // in fact, no callee saved regs
 
-  pd_last_allocatable_cpu_reg = 16 R18_RESERVED_ONLY(- 1),
+  pd_last_allocatable_cpu_reg = pd_nof_available_regs - 1,
 
   pd_nof_cpu_regs_reg_alloc
     = pd_last_allocatable_cpu_reg + 1,  // number of registers that are visible to register allocator
@@ -60,9 +61,9 @@ enum {
   pd_nof_fpu_regs_linearscan = pd_nof_fpu_regs_frame_map, // number of registers visible to linear scan
   pd_nof_xmm_regs_linearscan = 0,  // don't have vector registers
   pd_first_cpu_reg = 0,
-  pd_last_cpu_reg = 16 R18_RESERVED_ONLY(- 1),
+  pd_last_cpu_reg = pd_nof_available_regs - 1,
   pd_first_byte_reg = 0,
-  pd_last_byte_reg = 16 R18_RESERVED_ONLY(- 1),
+  pd_last_byte_reg = pd_last_cpu_reg,
   pd_first_fpu_reg = pd_nof_cpu_regs_frame_map,
   pd_last_fpu_reg =  pd_first_fpu_reg + 31,
 

--- a/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.cpp
@@ -194,16 +194,22 @@ void FrameMap::initialize() {
   map_register(i, r25); r25_opr = LIR_OprFact::single_cpu(i); i++;
   map_register(i, r26); r26_opr = LIR_OprFact::single_cpu(i); i++;
 
+  // r27 is allocated conditionally. With compressed oops it holds
+  // the heapbase value and is not visible to the allocator.
+  bool preserve_rheapbase = i >= nof_caller_save_cpu_regs();
+  if (!preserve_rheapbase) {
+    map_register(i, r27); r27_opr = LIR_OprFact::single_cpu(i); i++; // rheapbase
+  }
+
   if(!PreserveFramePointer) {
     map_register(i, r29); r29_opr = LIR_OprFact::single_cpu(i); i++;
   }
 
-  // r27 is allocated conditionally. With compressed oops it holds
-  // the heapbase value and is not visible to the allocator.
-  map_register(i, r27); r27_opr = LIR_OprFact::single_cpu(i); i++; // rheapbase
-
   // The unallocatable registers are at the end
 
+  if (preserve_rheapbase) {
+    map_register(i, r27); r27_opr = LIR_OprFact::single_cpu(i); i++; // rheapbase
+  }
   map_register(i, r28); r28_opr = LIR_OprFact::single_cpu(i); i++; // rthread
   if(PreserveFramePointer) {
     map_register(i, r29); r29_opr = LIR_OprFact::single_cpu(i); i++; // rfp

--- a/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.cpp
@@ -260,15 +260,8 @@ void FrameMap::initialize() {
   _caller_save_cpu_regs[23 R18_RESERVED_ONLY(-1)] = r25_opr;
   _caller_save_cpu_regs[24 R18_RESERVED_ONLY(-1)] = r26_opr;
 
-  if (PreserveFramePointer) {
-    if (nof_caller_save_cpu_regs() >= 26 R18_RESERVED_ONLY(-1)) {
-      _caller_save_cpu_regs[25 R18_RESERVED_ONLY(-1)] = r27_opr;
-    }
-  } else {
-    _caller_save_cpu_regs[25 R18_RESERVED_ONLY(-1)] = r29_opr;
-    if (nof_caller_save_cpu_regs() >= 27 R18_RESERVED_ONLY(-1)) {
-      _caller_save_cpu_regs[26 R18_RESERVED_ONLY(-1)] = r27_opr;
-    }
+  if (nof_caller_save_cpu_regs() > 25 R18_RESERVED_ONLY(-1)) {
+    _caller_save_cpu_regs[25 R18_RESERVED_ONLY(-1)] = r27_opr;
   }
 
   for (int i = 0; i < 8; i++) {

--- a/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -194,9 +194,20 @@ void FrameMap::initialize() {
   map_register(i, r25); r25_opr = LIR_OprFact::single_cpu(i); i++;
   map_register(i, r26); r26_opr = LIR_OprFact::single_cpu(i); i++;
 
+  if(!PreserveFramePointer) {
+    map_register(i, r29); r29_opr = LIR_OprFact::single_cpu(i); i++;
+  }
+
+  // r27 is allocated conditionally. With compressed oops it holds
+  // the heapbase value and is not visible to the allocator.
   map_register(i, r27); r27_opr = LIR_OprFact::single_cpu(i); i++; // rheapbase
+
+  // The unallocatable registers are at the end
+
   map_register(i, r28); r28_opr = LIR_OprFact::single_cpu(i); i++; // rthread
-  map_register(i, r29); r29_opr = LIR_OprFact::single_cpu(i); i++; // rfp
+  if(PreserveFramePointer) {
+    map_register(i, r29); r29_opr = LIR_OprFact::single_cpu(i); i++; // rfp
+  }
   map_register(i, r30); r30_opr = LIR_OprFact::single_cpu(i); i++; // lr
   map_register(i, r31_sp); sp_opr = LIR_OprFact::single_cpu(i); i++; // sp
   map_register(i, r8); r8_opr = LIR_OprFact::single_cpu(i); i++;   // rscratch1
@@ -239,6 +250,26 @@ void FrameMap::initialize() {
   // See comment in register_aarch64.hpp
   _caller_save_cpu_regs[16] = r18_opr;
 #endif
+
+  _caller_save_cpu_regs[17 R18_RESERVED_ONLY(-1)] = r19_opr;
+  _caller_save_cpu_regs[18 R18_RESERVED_ONLY(-1)] = r20_opr;
+  _caller_save_cpu_regs[19 R18_RESERVED_ONLY(-1)] = r21_opr;
+  _caller_save_cpu_regs[20 R18_RESERVED_ONLY(-1)] = r22_opr;
+  _caller_save_cpu_regs[21 R18_RESERVED_ONLY(-1)] = r23_opr;
+  _caller_save_cpu_regs[22 R18_RESERVED_ONLY(-1)] = r24_opr;
+  _caller_save_cpu_regs[23 R18_RESERVED_ONLY(-1)] = r25_opr;
+  _caller_save_cpu_regs[24 R18_RESERVED_ONLY(-1)] = r26_opr;
+
+  if (PreserveFramePointer) {
+    if (nof_caller_save_cpu_regs() >= 26 R18_RESERVED_ONLY(-1)) {
+      _caller_save_cpu_regs[25 R18_RESERVED_ONLY(-1)] = r27_opr;
+    }
+  } else {
+    _caller_save_cpu_regs[25 R18_RESERVED_ONLY(-1)] = r29_opr;
+    if (nof_caller_save_cpu_regs() >= 27 R18_RESERVED_ONLY(-1)) {
+      _caller_save_cpu_regs[26 R18_RESERVED_ONLY(-1)] = r27_opr;
+    }
+  }
 
   for (int i = 0; i < 8; i++) {
     _caller_save_fpu_regs[i] = LIR_OprFact::single_fpu(i);

--- a/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -140,8 +140,26 @@
   static bool is_caller_save_register (LIR_Opr opr) { return true; }
   static bool is_caller_save_register (Register r) { return true; }
 
-  static int nof_caller_save_cpu_regs() { return pd_nof_caller_save_cpu_regs_frame_map; }
-  static int last_cpu_reg()             { return pd_last_cpu_reg;  }
-  static int last_byte_reg()            { return pd_last_byte_reg; }
+  static int adjust_reg_range(int range) {
+    // r27 is not allocatable when compressed oops is on and heapbase is not
+    // zero, compressed klass pointers doesn't use r27 after JDK-8234794
+    if (UseCompressedOops && (CompressedOops::base() != nullptr)) {
+      range -= 1;
+    }
+
+    // r29 is not allocatable when PreserveFramePointer is on
+    if (PreserveFramePointer) {
+      range -= 1;
+    }
+
+    // rscratch registers r8, r9
+    // r28=rthread, r30=lr, r31=sp
+    // r18 on masOS/Windows
+    return range - 5 R18_RESERVED_ONLY(-1);
+  }
+
+  static int nof_caller_save_cpu_regs() { return adjust_reg_range(pd_nof_caller_save_cpu_regs_frame_map); }
+  static int last_cpu_reg()             { return adjust_reg_range(pd_last_cpu_reg);  }
+  static int last_byte_reg()            { return adjust_reg_range(pd_last_byte_reg); }
 
 #endif // CPU_AARCH64_C1_FRAMEMAP_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.hpp
@@ -140,15 +140,16 @@
   static bool is_caller_save_register (LIR_Opr opr) { return true; }
   static bool is_caller_save_register (Register r) { return true; }
 
-  static int adjust_reg_range(int range) {
+  static int adjust_reg_range(int range, bool exclude_fp = true) {
     // r27 is not allocatable when compressed oops is on and heapbase is not
     // zero, compressed klass pointers doesn't use r27 after JDK-8234794
     if (UseCompressedOops && (CompressedOops::base() != nullptr)) {
       range -= 1;
     }
 
-    // r29 is not allocatable when PreserveFramePointer is on
-    if (PreserveFramePointer) {
+    // r29 is not allocatable when PreserveFramePointer is on,
+    // but fp saving is handled in MacroAssembler::build_frame()/remove_frame()
+    if (exclude_fp) {
       range -= 1;
     }
 
@@ -158,8 +159,8 @@
     return range - 5 R18_RESERVED_ONLY(-1);
   }
 
-  static int nof_caller_save_cpu_regs() { return adjust_reg_range(pd_nof_caller_save_cpu_regs_frame_map); }
-  static int last_cpu_reg()             { return adjust_reg_range(pd_last_cpu_reg);  }
-  static int last_byte_reg()            { return adjust_reg_range(pd_last_byte_reg); }
+  static int nof_caller_save_cpu_regs() { return adjust_reg_range(pd_nof_caller_save_cpu_regs_frame_map);  }
+  static int last_cpu_reg()             { return adjust_reg_range(pd_last_cpu_reg, PreserveFramePointer);  }
+  static int last_byte_reg()            { return adjust_reg_range(pd_last_byte_reg, PreserveFramePointer); }
 
 #endif // CPU_AARCH64_C1_FRAMEMAP_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/c1_LinearScan_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_LinearScan_aarch64.hpp
@@ -41,9 +41,9 @@ inline bool LinearScan::requires_adjacent_regs(BasicType type) {
 
 inline bool LinearScan::is_caller_save(int assigned_reg) {
   assert(assigned_reg >= 0 && assigned_reg < nof_regs, "should call this only for registers");
-  if (assigned_reg < pd_first_callee_saved_reg)
+  if (assigned_reg < FrameMap::nof_caller_save_cpu_regs())
     return true;
-  if (assigned_reg > pd_last_callee_saved_reg && assigned_reg < pd_first_callee_saved_fpu_reg)
+  if (assigned_reg >= pd_first_fpu_reg && assigned_reg < pd_first_callee_saved_fpu_reg)
     return true;
   if (assigned_reg > pd_last_callee_saved_fpu_reg && assigned_reg < pd_last_fpu_reg)
     return true;

--- a/src/hotspot/cpu/aarch64/c1_LinearScan_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_LinearScan_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -66,7 +66,7 @@ inline bool LinearScanWalker::pd_init_regs_for_alloc(Interval* cur) {
     return true;
   } else if (cur->type() == T_INT || cur->type() == T_LONG || cur->type() == T_OBJECT || cur->type() == T_ADDRESS || cur->type() == T_METADATA) {
     _first_reg = pd_first_cpu_reg;
-    _last_reg = pd_last_allocatable_cpu_reg;
+    _last_reg = FrameMap::last_cpu_reg();
     return true;
   }
   return false;

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -258,14 +258,17 @@ static OopMap* generate_oop_map(StubAssembler* sasm, bool save_fpu_registers) {
   int frame_size_in_slots = frame_size_in_bytes / sizeof(jint);
   OopMap* oop_map = new OopMap(frame_size_in_slots, 0);
 
-  for (int i = 0; i < FrameMap::nof_cpu_regs; i++) {
-    Register r = as_Register(i);
-    if (r == rthread || (i < 28 && i != rscratch1->encoding() && i != rscratch2->encoding())) {
-      int sp_offset = cpu_reg_save_offsets[i];
-      oop_map->set_callee_saved(VMRegImpl::stack2reg(sp_offset),
-                                r->as_VMReg());
-    }
+  for (int i = 0; i < FrameMap::nof_caller_save_cpu_regs(); i++) {
+    LIR_Opr opr = FrameMap::caller_save_cpu_reg_at(i);
+    Register r = opr->as_register();
+    int reg_num = r->encoding();
+    int sp_offset = cpu_reg_save_offsets[reg_num];
+    oop_map->set_callee_saved(VMRegImpl::stack2reg(cpu_reg_save_offsets[reg_num]), r->as_VMReg());
   }
+
+  Register r = rthread;
+  int reg_num = r->encoding();
+  oop_map->set_callee_saved(VMRegImpl::stack2reg(cpu_reg_save_offsets[reg_num]), r->as_VMReg());
 
   if (save_fpu_registers) {
     for (int i = 0; i < FrameMap::nof_fpu_regs; i++) {

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -260,7 +260,7 @@ static OopMap* generate_oop_map(StubAssembler* sasm, bool save_fpu_registers) {
 
   for (int i = 0; i < FrameMap::nof_cpu_regs; i++) {
     Register r = as_Register(i);
-    if (r == rthread || (i <= 18 && i != rscratch1->encoding() && i != rscratch2->encoding())) {
+    if (r == rthread || (i <= 29 && i != rscratch1->encoding() && i != rscratch2->encoding())) {
       int sp_offset = cpu_reg_save_offsets[i];
       oop_map->set_callee_saved(VMRegImpl::stack2reg(sp_offset),
                                 r->as_VMReg());

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -260,7 +260,7 @@ static OopMap* generate_oop_map(StubAssembler* sasm, bool save_fpu_registers) {
 
   for (int i = 0; i < FrameMap::nof_cpu_regs; i++) {
     Register r = as_Register(i);
-    if (r == rthread || (i <= 29 && i != rscratch1->encoding() && i != rscratch2->encoding())) {
+    if (r == rthread || (i < 28 && i != rscratch1->encoding() && i != rscratch2->encoding())) {
       int sp_offset = cpu_reg_save_offsets[i];
       oop_map->set_callee_saved(VMRegImpl::stack2reg(sp_offset),
                                 r->as_VMReg());

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ Compiler::Compiler() : AbstractCompiler(compiler_c1) {
 
 void Compiler::init_c1_runtime() {
   BufferBlob* buffer_blob = CompilerThread::current()->get_buffer_blob();
-  Runtime1::initialize(buffer_blob);
   FrameMap::initialize();
+  Runtime1::initialize(buffer_blob);
   // initialize data structures
   ValueType::initialize();
   GraphBuilder::initialize();

--- a/src/hotspot/share/c1/c1_FrameMap.hpp
+++ b/src/hotspot/share/c1/c1_FrameMap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
 #include "runtime/frame.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
+#include "oops/compressedOops.hpp"
 
 class ciMethod;
 class CallingConvention;


### PR DESCRIPTION
This small change enables upper GPR registers in C1 so they are used, and used similar to C2. r19-r26 are declared as caller-saved and enabled, r27 (rheapbase) is declared caller-saved, r27 (rheapbase) and r29 (fp) are enabled conditionally similar to C2. r29 is already handled in MacroAssembler::build_frame()/remove_frame().

r18 is excluded on masOS and Windows as before. r27 is excluded when `UseCompressedOops` is on and `CompressedOops::base() != nullptr,` r29 is excluded when `PreserveFramePointer` is on.

Registers are declared caller-saved in c1_FrameMap_aarch64.cpp, conditionally enabled ones are in the tail of enabled range which is adjusted in c1_FrameMap_aarch64.hpp, the code there was made similar to x86 (JDK-6985015).

Register ranges are also updated in the linear scan itself and in OOP map generation.

Having more allocatable registers help to avoid spills in register hungry code and thus improve performance and code density and simplify compilation. In practice the code that operates so many values is not too frequent and upper registers are used less frequently than first ones. To perform testing it turned to be useful to run C1 in a special mode when registers are allocated from upper to lower in LinearScanWalker::find_free_reg():

```
-  for (int i = _first_reg; i <= _last_reg; i++) {
+  for (int i = _last_reg; i >= _first_reg; i--) {
```

It was also useful to run the JVM with C1 compilation only and with different GCs and small heaps like `-XX:TieredStopAtLevel=1 -Xmx256m -XX:+UseSerialGC`.

Tier1-3 jtreg tests showed no regression on linux-aarch64 (release, slowdebug, Xcomp) with either direct or reversed register allocation order. Windows and macOS were also tested to check r18 handling, +-CompressedOops and +-PreserveFramePointer combinations were tested.

SHA3 Java implementation is as an example of register hungry code. Throughput results greatly depend on the actual CPU being used. On Graviton 2 the improvement in the dedicated micro-benchmark is ~**19%** for longer arrays (`-XX:TieredStopAtLevel=1 -XX:+UnlockDiagnosticVMOptions -XX:-UseSHA3Intrinsics -jar ../benchmarks.jar -f 1 -wi 2 -i 3 -p digesterName=SHA3-256 -p length=16384 -jvmArgsAppend="-XX:-UseCompressedOops -XX:-PreserveFramePointer -Xmx31g -Xlog:gc+heap+coops=debug" MessageDigests.digest$`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347917](https://bugs.openjdk.org/browse/JDK-8347917): AArch64: Enable upper GPR registers in C1 (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23152/head:pull/23152` \
`$ git checkout pull/23152`

Update a local copy of the PR: \
`$ git checkout pull/23152` \
`$ git pull https://git.openjdk.org/jdk.git pull/23152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23152`

View PR using the GUI difftool: \
`$ git pr show -t 23152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23152.diff">https://git.openjdk.org/jdk/pull/23152.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23152#issuecomment-2595472840)
</details>
