### PR TITLE
8345049: Remove the jmx.tabular.data.hash.map compatibility property

### DIFF
--- a/src/java.management/share/classes/javax/management/openmbean/TabularDataSupport.java
+++ b/src/java.management/share/classes/javax/management/openmbean/TabularDataSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,16 +143,9 @@ public class TabularDataSupport
         List<String> tmpNames = tabularType.getIndexNames();
         this.indexNamesArray = tmpNames.toArray(new String[tmpNames.size()]);
 
-        // Since LinkedHashMap was introduced in SE 1.4, it's conceivable even
-        // if very unlikely that we might be the server of a 1.3 client.  In
-        // that case you'll need to set this property.  See CR 6334663.
-        boolean useHashMap = Boolean.getBoolean("jmx.tabular.data.hash.map");
-
         // Construct the empty contents HashMap
         //
-        this.dataMap = useHashMap ?
-            new HashMap<>(initialCapacity, loadFactor) :
-            new LinkedHashMap<>(initialCapacity, loadFactor);
+        this.dataMap = new LinkedHashMap<>(initialCapacity, loadFactor);
     }
 
 

--- a/test/jdk/javax/management/openmbean/TabularDataOrderTest.java
+++ b/test/jdk/javax/management/openmbean/TabularDataOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,8 +56,6 @@ import javax.management.openmbean.TabularType;
 
 public class TabularDataOrderTest {
     private static String failure;
-
-    private static final String COMPAT_PROP_NAME = "jmx.tabular.data.hash.map";
 
     private static final String[] intNames = {
         "unus", "duo", "tres", "quatuor", "quinque", "sex", "septem",
@@ -128,44 +126,6 @@ public class TabularDataOrderTest {
         }
         if (!ordered)
             fail("Order not preserved");
-
-        // Now test the undocumented property that causes HashMap to be used
-        // instead of LinkedHashMap, in case serializing to a 1.3 client.
-        // We serialize and deserialize in case the implementation handles
-        // this at serialization time.  Then we look at object fields; that's
-        // not guaranteed to work but at worst it will fail spuriously and
-        // we'll have to update the test.
-        System.out.println("Testing compatible behaviour");
-        System.setProperty(COMPAT_PROP_NAME, "true");
-        td = makeTable();
-        System.out.println(td);
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        ObjectOutputStream oout = new ObjectOutputStream(bout);
-        oout.writeObject(td);
-        oout.close();
-        byte[] bytes = bout.toByteArray();
-        ByteArrayInputStream bin = new ByteArrayInputStream(bytes);
-        ObjectInputStream oin = new ObjectInputStream(bin);
-        td = (TabularData) oin.readObject();
-        boolean found = false;
-        for (Field f : td.getClass().getDeclaredFields()) {
-            if (Modifier.isStatic(f.getModifiers()))
-                continue;
-            f.setAccessible(true);
-            Object x = f.get(td);
-            if (x != null && x.getClass() == HashMap.class) {
-                found = true;
-                System.out.println(
-                        x.getClass().getName() + " TabularDataSupport." +
-                        f.getName() + " = " + x);
-                break;
-            }
-        }
-        if (!found) {
-            fail("TabularDataSupport does not contain HashMap though " +
-                    COMPAT_PROP_NAME + "=true");
-        }
-        System.clearProperty(COMPAT_PROP_NAME);
 
         System.out.println("Testing MXBean behaviour");
         MBeanServer mbs = MBeanServerFactory.newMBeanServer();


### PR DESCRIPTION
Remove the System Property "jmx.tabular.data.hash.map" which was introduced historically for JMX compatibility with JDK 1.3 clients.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8347920](https://bugs.openjdk.org/browse/JDK-8347920) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8345049](https://bugs.openjdk.org/browse/JDK-8345049): Remove the jmx.tabular.data.hash.map compatibility property (**Enhancement** - P4)
 * [JDK-8347920](https://bugs.openjdk.org/browse/JDK-8347920): Remove the jmx.tabular.data.hash.map compatibility property (**CSR**)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23153/head:pull/23153` \
`$ git checkout pull/23153`

Update a local copy of the PR: \
`$ git checkout pull/23153` \
`$ git pull https://git.openjdk.org/jdk.git pull/23153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23153`

View PR using the GUI difftool: \
`$ git pr show -t 23153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23153.diff">https://git.openjdk.org/jdk/pull/23153.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23153#issuecomment-2595608819)
</details>
