### PR TITLE
8347923: Parallel: Simplify compute_survivor_space_size_and_threshold

### DIFF
--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -947,12 +947,10 @@ uint PSAdaptiveSizePolicy::compute_survivor_space_size_and_threshold(
   // Finally, increment or decrement the tenuring threshold, as decided above.
   // We test for decrementing first, as we might have hit the target size
   // limit.
-  if (decr_tenuring_threshold && !(AlwaysTenure || NeverTenure)) {
-    if (tenuring_threshold > 1) {
+  if (!(AlwaysTenure || NeverTenure)) {
+    if (decr_tenuring_threshold && tenuring_threshold > 1) {
       tenuring_threshold--;
-    }
-  } else if (incr_tenuring_threshold && !(AlwaysTenure || NeverTenure)) {
-    if (tenuring_threshold < MaxTenuringThreshold) {
+    } else if (incr_tenuring_threshold && tenuring_threshold < MaxTenuringThreshold) {
       tenuring_threshold++;
     }
   }


### PR DESCRIPTION
Trivial extracting out the common subexpression from both if-else branches.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347923](https://bugs.openjdk.org/browse/JDK-8347923): Parallel: Simplify compute_survivor_space_size_and_threshold (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23155/head:pull/23155` \
`$ git checkout pull/23155`

Update a local copy of the PR: \
`$ git checkout pull/23155` \
`$ git pull https://git.openjdk.org/jdk.git pull/23155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23155`

View PR using the GUI difftool: \
`$ git pr show -t 23155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23155.diff">https://git.openjdk.org/jdk/pull/23155.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23155#issuecomment-2595728196)
</details>
