### PR TITLE
8347924: Replace SIZE_FORMAT in memory and metaspace

### DIFF
--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -142,8 +142,7 @@ Chunk* ChunkPool::allocate_chunk(size_t length, AllocFailType alloc_failmode) {
   // - the payload size (length) must be aligned to 64-bit, which takes care of 64-bit
   //   aligning (D)
 
-  assert(is_aligned(length, ARENA_AMALLOC_ALIGNMENT), "chunk payload length misaligned: "
-         "%zu.", length);
+  assert(is_aligned(length, ARENA_AMALLOC_ALIGNMENT), "chunk payload length misaligned: %zu.", length);
   // Try to reuse a freed chunk from the pool
   ChunkPool* pool = ChunkPool::get_pool_for_size(length);
   Chunk* chunk = nullptr;

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -143,7 +143,7 @@ Chunk* ChunkPool::allocate_chunk(size_t length, AllocFailType alloc_failmode) {
   //   aligning (D)
 
   assert(is_aligned(length, ARENA_AMALLOC_ALIGNMENT), "chunk payload length misaligned: "
-         SIZE_FORMAT ".", length);
+         "%zu.", length);
   // Try to reuse a freed chunk from the pool
   ChunkPool* pool = ChunkPool::get_pool_for_size(length);
   Chunk* chunk = nullptr;

--- a/src/hotspot/share/memory/classLoaderMetaspace.cpp
+++ b/src/hotspot/share/memory/classLoaderMetaspace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -148,8 +148,8 @@ MetaWord* ClassLoaderMetaspace::expand_and_allocate(size_t word_size, Metaspace:
     Metaspace::tracer()->report_gc_threshold(before, after,
                                   MetaspaceGCThresholdUpdater::ExpandAndAllocate);
     // Keeping both for now until I am sure the old variant (gc + metaspace) is not needed anymore
-    log_trace(gc, metaspace)("Increase capacity to GC from " SIZE_FORMAT " to " SIZE_FORMAT, before, after);
-    UL2(info, "GC threshold increased: " SIZE_FORMAT "->" SIZE_FORMAT ".", before, after);
+    log_trace(gc, metaspace)("Increase capacity to GC from %zu to %zu", before, after);
+    UL2(info, "GC threshold increased: %zu->%zu.", before, after);
   }
 
   return res;

--- a/src/hotspot/share/memory/guardedMemory.cpp
+++ b/src/hotspot/share/memory/guardedMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ void GuardedMemory::print_on(outputStream* st) const {
     return;
   }
   st->print_cr("GuardedMemory(" PTR_FORMAT ") base_addr=" PTR_FORMAT
-      " tag=" PTR_FORMAT " user_size=" SIZE_FORMAT " user_data=" PTR_FORMAT,
+      " tag=" PTR_FORMAT " user_size=%zu user_data=" PTR_FORMAT,
       p2i(this), p2i(_base_addr), p2i(get_tag()), get_user_size(), p2i(get_user_ptr()));
 
   Guard* guard = get_head_guard();

--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -131,8 +131,7 @@ ReservedSpace MemoryReserver::reserve_memory_special(char* requested_address,
                                                      size_t alignment,
                                                      size_t page_size,
                                                      bool exec) {
-  log_trace(pagesize)("Attempt special mapping: size: %zu%s, "
-                      "alignment: %zu%s",
+  log_trace(pagesize)("Attempt special mapping: size: %zu%s, alignment: %zu%s",
                       byte_size_in_exact_unit(size), exact_unit_for_byte_size(size),
                       byte_size_in_exact_unit(alignment), exact_unit_for_byte_size(alignment));
 

--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -68,7 +68,7 @@ static void log_on_large_pages_failure(char* req_addr, size_t bytes) {
     // JVM style warning that we did not succeed in using large pages.
     char msg[128];
     jio_snprintf(msg, sizeof(msg), "Failed to reserve and commit memory using large pages. "
-                                   "req_addr: " PTR_FORMAT " bytes: " SIZE_FORMAT,
+                                   "req_addr: " PTR_FORMAT " bytes: %zu",
                                    req_addr, bytes);
     warning("%s", msg);
   }
@@ -89,7 +89,7 @@ static char* reserve_memory_inner(char* requested_address,
   // important.  If the reservation fails, return null.
   if (requested_address != nullptr) {
     assert(is_aligned(requested_address, alignment),
-           "Requested address " PTR_FORMAT " must be aligned to " SIZE_FORMAT,
+           "Requested address " PTR_FORMAT " must be aligned to %zu",
            p2i(requested_address), alignment);
     return os::attempt_reserve_memory_at(requested_address, size, exec, mem_tag);
   }
@@ -131,8 +131,8 @@ ReservedSpace MemoryReserver::reserve_memory_special(char* requested_address,
                                                      size_t alignment,
                                                      size_t page_size,
                                                      bool exec) {
-  log_trace(pagesize)("Attempt special mapping: size: " SIZE_FORMAT "%s, "
-                      "alignment: " SIZE_FORMAT "%s",
+  log_trace(pagesize)("Attempt special mapping: size: %zu%s, "
+                      "alignment: %zu%s",
                       byte_size_in_exact_unit(size), exact_unit_for_byte_size(size),
                       byte_size_in_exact_unit(alignment), exact_unit_for_byte_size(alignment));
 
@@ -141,7 +141,7 @@ ReservedSpace MemoryReserver::reserve_memory_special(char* requested_address,
   if (base != nullptr) {
     assert(is_aligned(base, alignment),
            "reserve_memory_special() returned an unaligned address, "
-           "base: " PTR_FORMAT " alignment: " SIZE_FORMAT_X,
+           "base: " PTR_FORMAT " alignment: 0x%zx",
            p2i(base), alignment);
 
     return ReservedSpace(base, size, alignment, page_size, exec, true /* special */);
@@ -255,7 +255,7 @@ static char* map_memory_to_file(char* requested_address,
   // important.  If the reservation fails, return null.
   if (requested_address != nullptr) {
     assert(is_aligned(requested_address, alignment),
-           "Requested address " PTR_FORMAT " must be aligned to " SIZE_FORMAT,
+           "Requested address " PTR_FORMAT " must be aligned to %zu",
            p2i(requested_address), alignment);
     return os::attempt_map_memory_to_file_at(requested_address, size, fd, mem_tag);
   }
@@ -401,7 +401,7 @@ ReservedSpace HeapReserver::Instance::try_reserve_memory(size_t size,
                                                          char* requested_address) {
   // Try to reserve the memory for the heap.
   log_trace(gc, heap, coops)("Trying to allocate at address " PTR_FORMAT
-                             " heap of size " SIZE_FORMAT_X,
+                             " heap of size 0x%zx",
                              p2i(requested_address),
                              size);
 
@@ -639,7 +639,7 @@ ReservedHeapSpace HeapReserver::Instance::reserve_compressed_oops_heap(const siz
 
     // Last, desperate try without any placement.
     if (!reserved.is_reserved()) {
-      log_trace(gc, heap, coops)("Trying to allocate at address null heap of size " SIZE_FORMAT_X, size + noaccess_prefix);
+      log_trace(gc, heap, coops)("Trying to allocate at address null heap of size 0x%zx", size + noaccess_prefix);
       assert(alignment >= os::vm_page_size(), "Unexpected");
       reserved = reserve_memory(size + noaccess_prefix, alignment, page_size);
     }

--- a/src/hotspot/share/memory/metaspace/binList.hpp
+++ b/src/hotspot/share/memory/metaspace/binList.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * Copyright (c) 2023 Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -78,7 +78,7 @@ class BinListImpl {
     Block(Block* next) : _next(next) {}
   };
 
-#define BLOCK_FORMAT              "Block @" PTR_FORMAT ": size: " SIZE_FORMAT ", next: " PTR_FORMAT
+#define BLOCK_FORMAT              "Block @" PTR_FORMAT ": size: %zu, next: " PTR_FORMAT
 #define BLOCK_FORMAT_ARGS(b, sz)  p2i(b), (sz), p2i((b)->_next)
 
   // Block size must be exactly one word size.
@@ -161,7 +161,7 @@ public:
   // Block may be larger.
   MetaBlock remove_block(size_t word_size) {
     assert(word_size >= MinWordSize &&
-           word_size <= MaxWordSize, "bad block size " SIZE_FORMAT ".", word_size);
+           word_size <= MaxWordSize, "bad block size %zu.", word_size);
     MetaBlock result;
     int index = index_for_word_size(word_size);
     index = index_for_next_non_empty_list(index);

--- a/src/hotspot/share/memory/metaspace/blockTree.cpp
+++ b/src/hotspot/share/memory/metaspace/blockTree.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -44,7 +44,7 @@ const size_t BlockTree::MinWordSize;
   ", left " PTR_FORMAT \
   ", right " PTR_FORMAT \
   ", next " PTR_FORMAT \
-  ", size " SIZE_FORMAT
+  ", size %zu"
 
 #define NODE_FORMAT_ARGS(n) \
   p2i(n), \

--- a/src/hotspot/share/memory/metaspace/blockTree.hpp
+++ b/src/hotspot/share/memory/metaspace/blockTree.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -348,7 +348,7 @@ public:
   void add_block(MetaBlock block) {
     DEBUG_ONLY(zap_block(block);)
     const size_t word_size = block.word_size();
-    assert(word_size >= MinWordSize, "invalid block size " SIZE_FORMAT, word_size);
+    assert(word_size >= MinWordSize, "invalid block size %zu", word_size);
     Node* n = new(block.base()) Node(word_size);
     if (_root == nullptr) {
       _root = n;
@@ -361,7 +361,7 @@ public:
   // Given a word_size, search and return the smallest block that is equal or
   //  larger than that size.
   MetaBlock remove_block(size_t word_size) {
-    assert(word_size >= MinWordSize, "invalid block size " SIZE_FORMAT, word_size);
+    assert(word_size >= MinWordSize, "invalid block size %zu", word_size);
 
     MetaBlock result;
     Node* n = find_closest_fit(word_size);

--- a/src/hotspot/share/memory/metaspace/chunkManager.cpp
+++ b/src/hotspot/share/memory/metaspace/chunkManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -141,7 +141,7 @@ Metachunk* ChunkManager::get_chunk_locked(chunklevel_t preferred_level, chunklev
   DEBUG_ONLY(chunklevel::check_valid_level(preferred_level);)
 
   UL2(debug, "requested chunk: pref_level: " CHKLVL_FORMAT
-     ", max_level: " CHKLVL_FORMAT ", min committed size: " SIZE_FORMAT ".",
+     ", max_level: " CHKLVL_FORMAT ", min committed size: %zu.",
      preferred_level, max_level, min_committed_words);
 
   // First, optimistically look for a chunk which is already committed far enough to hold min_word_size.
@@ -212,7 +212,7 @@ Metachunk* ChunkManager::get_chunk_locked(chunklevel_t preferred_level, chunklev
     const size_t to_commit = min_committed_words;
     if (c->committed_words() < to_commit) {
       if (c->ensure_committed_locked(to_commit) == false) {
-        UL2(info, "failed to commit " SIZE_FORMAT " words on chunk " METACHUNK_FORMAT ".",
+        UL2(info, "failed to commit %zu words on chunk " METACHUNK_FORMAT ".",
             to_commit,  METACHUNK_FORMAT_ARGS(c));
         return_chunk_locked(c);
         c = nullptr;
@@ -434,7 +434,7 @@ void ChunkManager::print_on(outputStream* st) const {
 
 void ChunkManager::print_on_locked(outputStream* st) const {
   assert_lock_strong(Metaspace_lock);
-  st->print_cr("cm %s: %d chunks, total word size: " SIZE_FORMAT ".", _name,
+  st->print_cr("cm %s: %d chunks, total word size: %zu.", _name,
                total_num_chunks(), total_word_size());
   _chunks.print_on(st);
 }

--- a/src/hotspot/share/memory/metaspace/chunklevel.cpp
+++ b/src/hotspot/share/memory/metaspace/chunklevel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,7 +36,7 @@ using namespace chunklevel;
 
 chunklevel_t chunklevel::level_fitting_word_size(size_t word_size) {
   assert(MAX_CHUNK_WORD_SIZE >= word_size,
-         SIZE_FORMAT " - too large allocation size.", word_size * BytesPerWord);
+         "%zu - too large allocation size.", word_size * BytesPerWord);
   if (word_size <= MIN_CHUNK_WORD_SIZE) {
     return HIGHEST_CHUNK_LEVEL;
   }

--- a/src/hotspot/share/memory/metaspace/commitMask.cpp
+++ b/src/hotspot/share/memory/metaspace/commitMask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -61,7 +61,7 @@ void CommitMask::check_pointer(const MetaWord* p) const {
 void CommitMask::check_pointer_aligned(const MetaWord* p) const {
   check_pointer(p);
   assert(is_aligned(p, _words_per_bit * BytesPerWord),
-         "Pointer " PTR_FORMAT " should be aligned to commit granule size " SIZE_FORMAT ".",
+         "Pointer " PTR_FORMAT " should be aligned to commit granule size %zu.",
          p2i(p), _words_per_bit * BytesPerWord);
 }
 // Given a range, check if it points into the range this bitmap covers,
@@ -69,7 +69,7 @@ void CommitMask::check_pointer_aligned(const MetaWord* p) const {
 void CommitMask::check_range(const MetaWord* start, size_t word_size) const {
   check_pointer_aligned(start);
   assert(is_aligned(word_size, _words_per_bit),
-         "Range " SIZE_FORMAT " should be aligned to commit granule size " SIZE_FORMAT ".",
+         "Range %zu should be aligned to commit granule size %zu.",
          word_size, _words_per_bit);
   check_pointer(start + word_size - 1);
 }

--- a/src/hotspot/share/memory/metaspace/freeChunkList.cpp
+++ b/src/hotspot/share/memory/metaspace/freeChunkList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -155,7 +155,7 @@ void FreeChunkListVector::print_on(outputStream* st) const {
     list_for_level(l)->print_on(st);
     st->cr();
   }
-  st->print_cr("total chunks: %d, total word size: " SIZE_FORMAT ".",
+  st->print_cr("total chunks: %d, total word size: %zu.",
                num_chunks(), word_size());
 }
 

--- a/src/hotspot/share/memory/metaspace/metablock.hpp
+++ b/src/hotspot/share/memory/metaspace/metablock.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023 Red Hat, Inc. All rights reserved.
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public:
   void print_on(outputStream* st) const;
 };
 
-#define METABLOCKFORMAT                 "block (@" PTR_FORMAT " word size " SIZE_FORMAT ")"
+#define METABLOCKFORMAT                 "block (@" PTR_FORMAT " word size %zu)"
 #define METABLOCKFORMATARGS(__block__)  p2i((__block__).base()), (__block__).word_size()
 
 } // namespace metaspace

--- a/src/hotspot/share/memory/metaspace/metachunk.cpp
+++ b/src/hotspot/share/memory/metaspace/metachunk.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -102,7 +102,7 @@ bool Metachunk::commit_up_to(size_t new_committed_words) {
   assert(commit_to <= word_size(), "Sanity");
   if (commit_to > commit_from) {
     log_debug(metaspace)("Chunk " METACHUNK_FORMAT ": attempting to move commit line to "
-                         SIZE_FORMAT " words.", METACHUNK_FORMAT_ARGS(this), commit_to);
+                         "%zu words.", METACHUNK_FORMAT_ARGS(this), commit_to);
     if (!_vsnode->ensure_range_is_committed(base() + commit_from, commit_to - commit_from)) {
       DEBUG_ONLY(verify();)
       return false;
@@ -271,10 +271,10 @@ void Metachunk::verify() const {
 
   assert(base() != nullptr, "No base ptr");
   assert(committed_words() >= used_words(),
-         "mismatch: committed: " SIZE_FORMAT ", used: " SIZE_FORMAT ".",
+         "mismatch: committed: %zu, used: %zu.",
          committed_words(), used_words());
   assert(word_size() >= committed_words(),
-         "mismatch: word_size: " SIZE_FORMAT ", committed: " SIZE_FORMAT ".",
+         "mismatch: word_size: %zu, committed: %zu.",
          word_size(), committed_words());
 
   // Test base pointer
@@ -304,8 +304,8 @@ void Metachunk::verify() const {
 void Metachunk::print_on(outputStream* st) const {
   // Note: must also work with invalid/random data. (e.g. do not call word_size())
   st->print("Chunk @" PTR_FORMAT ", state %c, base " PTR_FORMAT ", "
-            "level " CHKLVL_FORMAT " (" SIZE_FORMAT " words), "
-            "used " SIZE_FORMAT " words, committed " SIZE_FORMAT " words.",
+            "level " CHKLVL_FORMAT " (%zu words), "
+            "used %zu words, committed %zu words.",
             p2i(this), get_state_char(), p2i(base()), level(),
             (chunklevel::is_valid_level(level()) ? chunklevel::word_size_for_level(level()) : SIZE_MAX),
             used_words(), committed_words());

--- a/src/hotspot/share/memory/metaspace/metachunk.hpp
+++ b/src/hotspot/share/memory/metaspace/metachunk.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -362,7 +362,7 @@ public:
 #define METACHUNK_FORMAT                "@" PTR_FORMAT ", %c, base " PTR_FORMAT ", level " CHKLVL_FORMAT
 #define METACHUNK_FORMAT_ARGS(chunk)    p2i(chunk), chunk->get_state_char(), p2i(chunk->base()), chunk->level()
 
-#define METACHUNK_FULL_FORMAT                "@" PTR_FORMAT ", %c, base " PTR_FORMAT ", level " CHKLVL_FORMAT " (" SIZE_FORMAT "), used: " SIZE_FORMAT ", committed: " SIZE_FORMAT ", committed-free: " SIZE_FORMAT
+#define METACHUNK_FULL_FORMAT                "@" PTR_FORMAT ", %c, base " PTR_FORMAT ", level " CHKLVL_FORMAT " (%zu), used: %zu, committed: %zu, committed-free: %zu"
 #define METACHUNK_FULL_FORMAT_ARGS(chunk)    p2i(chunk), chunk->get_state_char(), p2i(chunk->base()), chunk->level(), chunk->word_size(), chunk->used_words(), chunk->committed_words(), chunk->free_below_committed_words()
 
 } // namespace metaspace

--- a/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp
@@ -98,9 +98,9 @@ void print_human_readable_size(outputStream* st, size_t byte_size, size_t scale,
 
   if (width == -1) {
     if (scale == 1) {
-      st->print(SIZE_FORMAT " bytes", byte_size);
+      st->print("%zu bytes", byte_size);
     } else if (scale == BytesPerWord) {
-      st->print(SIZE_FORMAT " words", byte_size / BytesPerWord);
+      st->print("%zu words", byte_size / BytesPerWord);
     } else {
       const char* display_unit = display_unit_for_scale(scale);
       float display_value = (float) byte_size / (float)scale;

--- a/src/hotspot/share/memory/metaspace/metaspaceCommon.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceCommon.hpp
@@ -80,8 +80,8 @@ void print_percentage(outputStream* st, size_t total, size_t part);
 #ifdef ASSERT
 #define assert_is_aligned(value, alignment)                  \
   assert(is_aligned((value), (alignment)),                   \
-"0x%zx is not aligned to "                 \
-         SIZE_FORMAT_X, (size_t)(uintptr_t)value, (size_t)(alignment))
+         "0x%zx is not aligned to 0x%zx",                    \
+         (size_t)(uintptr_t)value, (size_t)(alignment))
 #define assert_is_aligned_metaspace_pointer(p) \
   assert_is_aligned((p), metaspace::AllocationAlignmentByteSize)
 #else

--- a/src/hotspot/share/memory/metaspace/metaspaceCommon.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceCommon.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -80,7 +80,7 @@ void print_percentage(outputStream* st, size_t total, size_t part);
 #ifdef ASSERT
 #define assert_is_aligned(value, alignment)                  \
   assert(is_aligned((value), (alignment)),                   \
-         SIZE_FORMAT_X " is not aligned to "                 \
+"0x%zx is not aligned to "                 \
          SIZE_FORMAT_X, (size_t)(uintptr_t)value, (size_t)(alignment))
 #define assert_is_aligned_metaspace_pointer(p) \
   assert_is_aligned((p), metaspace::AllocationAlignmentByteSize)

--- a/src/hotspot/share/memory/metaspace/metaspaceSettings.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceSettings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -49,9 +49,9 @@ void Settings::ergo_initialize() {
 }
 
 void Settings::print_on(outputStream* st) {
-  st->print_cr(" - commit_granule_bytes: " SIZE_FORMAT ".", commit_granule_bytes());
-  st->print_cr(" - commit_granule_words: " SIZE_FORMAT ".", commit_granule_words());
-  st->print_cr(" - virtual_space_node_default_size: " SIZE_FORMAT ".", virtual_space_node_default_word_size());
+  st->print_cr(" - commit_granule_bytes: %zu.", commit_granule_bytes());
+  st->print_cr(" - commit_granule_words: %zu.", commit_granule_words());
+  st->print_cr(" - virtual_space_node_default_size: %zu.", virtual_space_node_default_word_size());
   st->print_cr(" - enlarge_chunks_in_place: %d.", (int)enlarge_chunks_in_place());
 }
 

--- a/src/hotspot/share/memory/metaspace/metaspaceStatistics.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceStatistics.cpp
@@ -128,7 +128,7 @@ void InUseChunkStats::print_on(outputStream* st, size_t scale) const {
 void InUseChunkStats::verify() const {
   assert(_word_size >= _committed_words &&
       _committed_words == _used_words + _free_words + _waste_words,
-         "Sanity: cap " SIZE_FORMAT ", committed " SIZE_FORMAT ", used " SIZE_FORMAT ", free " SIZE_FORMAT ", waste " SIZE_FORMAT ".",
+         "Sanity: cap %zu, committed %zu, used %zu, free %zu, waste %zu.",
          _word_size, _committed_words, _used_words, _free_words, _waste_words);
 }
 #endif

--- a/src/hotspot/share/memory/metaspace/testHelpers.cpp
+++ b/src/hotspot/share/memory/metaspace/testHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -78,8 +78,8 @@ MetaspaceTestContext::MetaspaceTestContext(const char* name, size_t commit_limit
   _commit_limiter(commit_limit == 0 ? max_uintx : commit_limit), // commit_limit == 0 -> no limit
   _rs()
 {
-  assert(is_aligned(reserve_limit, Metaspace::reserve_alignment_words()), "reserve_limit (" SIZE_FORMAT ") "
-                    "not aligned to metaspace reserve alignment (" SIZE_FORMAT ")",
+  assert(is_aligned(reserve_limit, Metaspace::reserve_alignment_words()), "reserve_limit (%zu) "
+                    "not aligned to metaspace reserve alignment (%zu)",
                     reserve_limit, Metaspace::reserve_alignment_words());
   if (reserve_limit > 0) {
     // have reserve limit -> non-expandable context

--- a/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -150,7 +150,7 @@ void VirtualSpaceList::print_on(outputStream* st) const {
     vsn = vsn->next();
     n++;
   }
-  st->print_cr("- total %d nodes, " SIZE_FORMAT " reserved words, " SIZE_FORMAT " committed words.",
+  st->print_cr("- total %d nodes, %zu reserved words, %zu committed words.",
                n, reserved_words(), committed_words());
 }
 

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -65,7 +65,7 @@ static void check_pointer_is_aligned_to_commit_granule(const MetaWord* p) {
 }
 static void check_word_size_is_aligned_to_commit_granule(size_t word_size) {
   assert(is_aligned(word_size, Settings::commit_granule_words()),
-         "Not aligned to commit granule size: " SIZE_FORMAT ".", word_size);
+         "Not aligned to commit granule size: %zu.", word_size);
 }
 #endif
 
@@ -95,7 +95,7 @@ bool VirtualSpaceNode::commit_range(MetaWord* p, size_t word_size) {
   //  were we to commit the given address range completely.
   const size_t commit_increase_words = word_size - committed_words_in_range;
 
-  UL2(debug, "committing range " PTR_FORMAT ".." PTR_FORMAT "(" SIZE_FORMAT " words)",
+  UL2(debug, "committing range " PTR_FORMAT ".." PTR_FORMAT "(%zu words)",
       p2i(p), p2i(p + word_size), word_size);
 
   if (commit_increase_words == 0) {
@@ -118,7 +118,7 @@ bool VirtualSpaceNode::commit_range(MetaWord* p, size_t word_size) {
     os::pretouch_memory(p, p + word_size);
   }
 
-  UL2(debug, "... committed " SIZE_FORMAT " additional words.", commit_increase_words);
+  UL2(debug, "... committed %zu additional words.", commit_increase_words);
 
   // ... tell commit limiter...
   _commit_limiter->increase_committed(commit_increase_words);
@@ -180,7 +180,7 @@ void VirtualSpaceNode::uncommit_range(MetaWord* p, size_t word_size) {
   const size_t committed_words_in_range = _commit_mask.get_committed_size_in_range(p, word_size);
   DEBUG_ONLY(check_word_size_is_aligned_to_commit_granule(committed_words_in_range);)
 
-  UL2(debug, "uncommitting range " PTR_FORMAT ".." PTR_FORMAT "(" SIZE_FORMAT " words)",
+  UL2(debug, "uncommitting range " PTR_FORMAT ".." PTR_FORMAT "(%zu words)",
       p2i(p), p2i(p + word_size), word_size);
 
   if (committed_words_in_range == 0) {
@@ -194,7 +194,7 @@ void VirtualSpaceNode::uncommit_range(MetaWord* p, size_t word_size) {
     fatal("Failed to uncommit metaspace.");
   }
 
-  UL2(debug, "... uncommitted " SIZE_FORMAT " words.", committed_words_in_range);
+  UL2(debug, "... uncommitted %zu words.", committed_words_in_range);
 
   // ... tell commit limiter...
   _commit_limiter->decrease_committed(committed_words_in_range);
@@ -231,7 +231,7 @@ VirtualSpaceNode::VirtualSpaceNode(ReservedSpace rs, bool owns_rs, CommitLimiter
   _total_reserved_words_counter(reserve_counter),
   _total_committed_words_counter(commit_counter)
 {
-  UL2(debug, "born (word_size " SIZE_FORMAT ").", _word_size);
+  UL2(debug, "born (word_size %zu).", _word_size);
 
   // Update reserved counter in vslist
   _total_reserved_words_counter->increment_by(_word_size);

--- a/src/hotspot/share/memory/resourceArea.hpp
+++ b/src/hotspot/share/memory/resourceArea.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public:
       // Reset size before deleting chunks.  Otherwise, the total
       // size could exceed the total chunk size.
       assert(size_in_bytes() > state._size_in_bytes,
-             "size: " SIZE_FORMAT ", saved size: " SIZE_FORMAT,
+             "size: %zu, saved size: %zu",
              size_in_bytes(), state._size_in_bytes);
       set_size_in_bytes(state._size_in_bytes);
       Chunk::next_chop(state._chunk);

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -940,7 +940,7 @@ void Universe::initialize_tlab() {
 ReservedHeapSpace Universe::reserve_heap(size_t heap_size, size_t alignment) {
 
   assert(alignment <= Arguments::conservative_max_heap_alignment(),
-         "actual alignment " SIZE_FORMAT " must be within maximum heap alignment " SIZE_FORMAT,
+         "actual alignment %zu must be within maximum heap alignment %zu",
          alignment, Arguments::conservative_max_heap_alignment());
 
   size_t total_reserved = align_up(heap_size, alignment);
@@ -985,7 +985,7 @@ ReservedHeapSpace Universe::reserve_heap(size_t heap_size, size_t alignment) {
   }
 
   vm_exit_during_initialization(
-    err_msg("Could not reserve enough space for " SIZE_FORMAT "KB object heap",
+    err_msg("Could not reserve enough space for %zuKB object heap",
             total_reserved/K));
 
   // satisfy compiler

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,7 +203,7 @@ static bool commit_expanded(char* start, size_t size, size_t alignment, bool pre
 
   debug_only(warning(
       "INFO: os::commit_memory(" PTR_FORMAT ", " PTR_FORMAT
-      " size=" SIZE_FORMAT ", executable=%d) failed",
+      " size=%zu, executable=%d) failed",
       p2i(start), p2i(start + size), size, executable);)
 
   return false;
@@ -426,8 +426,8 @@ void VirtualSpace::print_on(outputStream* out) const {
   out->print   ("Virtual space:");
   if (special()) out->print(" (pinned in memory)");
   out->cr();
-  out->print_cr(" - committed: " SIZE_FORMAT, committed_size());
-  out->print_cr(" - reserved:  " SIZE_FORMAT, reserved_size());
+  out->print_cr(" - committed: %zu", committed_size());
+  out->print_cr(" - reserved:  %zu", reserved_size());
   out->print_cr(" - [low, high]:     [" PTR_FORMAT ", " PTR_FORMAT "]",  p2i(low()), p2i(high()));
   out->print_cr(" - [low_b, high_b]: [" PTR_FORMAT ", " PTR_FORMAT "]",  p2i(low_boundary()), p2i(high_boundary()));
 }


### PR DESCRIPTION
Please review this change to replace SIZE_FORMAT with %zu in the memory and metaspace directories.  This code prints a lot of numbers so splitting this out.  Most done by script but a couple of hand-edited commits.
Testing with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347924](https://bugs.openjdk.org/browse/JDK-8347924): Replace SIZE_FORMAT in memory and metaspace (**Sub-task** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23157/head:pull/23157` \
`$ git checkout pull/23157`

Update a local copy of the PR: \
`$ git checkout pull/23157` \
`$ git pull https://git.openjdk.org/jdk.git pull/23157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23157`

View PR using the GUI difftool: \
`$ git pr show -t 23157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23157.diff">https://git.openjdk.org/jdk/pull/23157.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23157#issuecomment-2595758019)
</details>
