### PR TITLE
8347733: Replace SIZE_FORMAT in runtime code

### DIFF
--- a/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
+++ b/src/hotspot/share/cds/aotLinkedClassBulkLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ void AOTLinkedClassBulkLoader::exit_on_exception(JavaThread* current) {
   ResourceMark rm(current);
   if (current->pending_exception()->is_a(vmClasses::OutOfMemoryError_klass())) {
     log_error(cds)("Out of memory. Please run with a larger Java heap, current MaxHeapSize = "
-                   SIZE_FORMAT "M", MaxHeapSize/M);
+                   "%zuM", MaxHeapSize/M);
   } else {
     log_error(cds)("%s: %s", current->pending_exception()->klass()->external_name(),
                    java_lang_String::as_utf8_string(java_lang_Throwable::message(current->pending_exception())));

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1204,7 +1204,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
     size_t size = top - base;
     base = requested_base;
     top = requested_base + size;
-    log_info(cds, map)("[%-18s " PTR_FORMAT " - " PTR_FORMAT " " SIZE_FORMAT_W(9) " bytes]",
+    log_info(cds, map)("[%-18s " PTR_FORMAT " - " PTR_FORMAT " %9zu bytes]",
                        name, p2i(base), p2i(top), size);
   }
 
@@ -1573,12 +1573,12 @@ void ArchiveBuilder::print_region_stats(FileMapInfo *mapinfo, ArchiveHeapInfo* h
     print_heap_region_stats(heap_info, total_reserved);
   }
 
-  log_debug(cds)("total   : " SIZE_FORMAT_W(9) " [100.0%% of total] out of " SIZE_FORMAT_W(9) " bytes [%5.1f%% used]",
+  log_debug(cds)("total   : %9zu [100.0%% of total] out of %9zu bytes [%5.1f%% used]",
                  total_bytes, total_reserved, total_u_perc);
 }
 
 void ArchiveBuilder::print_bitmap_region_stats(size_t size, size_t total_size) {
-  log_debug(cds)("bm space: " SIZE_FORMAT_W(9) " [ %4.1f%% of total] out of " SIZE_FORMAT_W(9) " bytes [100.0%% used]",
+  log_debug(cds)("bm space: %9zu [ %4.1f%% of total] out of %9zu bytes [100.0%% used]",
                  size, size/double(total_size)*100.0, size);
 }
 
@@ -1586,7 +1586,7 @@ void ArchiveBuilder::print_heap_region_stats(ArchiveHeapInfo *info, size_t total
   char* start = info->buffer_start();
   size_t size = info->buffer_byte_size();
   char* top = start + size;
-  log_debug(cds)("hp space: " SIZE_FORMAT_W(9) " [ %4.1f%% of total] out of " SIZE_FORMAT_W(9) " bytes [100.0%% used] at " INTPTR_FORMAT,
+  log_debug(cds)("hp space: %9zu [ %4.1f%% of total] out of %9zu bytes [100.0%% used] at " INTPTR_FORMAT,
                      size, size/double(total_size)*100.0, size, p2i(start));
 }
 

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -312,14 +312,14 @@ address ArchiveBuilder::reserve_buffer() {
                                              MetaspaceShared::core_region_alignment(),
                                              os::vm_page_size());
   if (!rs.is_reserved()) {
-    log_error(cds)("Failed to reserve " SIZE_FORMAT " bytes of output buffer.", buffer_size);
+    log_error(cds)("Failed to reserve %zu bytes of output buffer.", buffer_size);
     MetaspaceShared::unrecoverable_writing_error();
   }
 
   // buffer_bottom is the lowest address of the 2 core regions (rw, ro) when
   // we are copying the class metadata into the buffer.
   address buffer_bottom = (address)rs.base();
-  log_info(cds)("Reserved output buffer space at " PTR_FORMAT " [" SIZE_FORMAT " bytes]",
+  log_info(cds)("Reserved output buffer space at " PTR_FORMAT " [%zu bytes]",
                 p2i(buffer_bottom), buffer_size);
   _shared_rs = rs;
 
@@ -1184,7 +1184,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
 
     log_as_hex(last_obj_base, last_obj_end, last_obj_base + buffer_to_runtime_delta());
     if (last_obj_end < region_end) {
-      log_debug(cds, map)(PTR_FORMAT ": @@ Misc data " SIZE_FORMAT " bytes",
+      log_debug(cds, map)(PTR_FORMAT ": @@ Misc data %zu bytes",
                           p2i(last_obj_end + buffer_to_runtime_delta()),
                           size_t(region_end - last_obj_end));
       log_as_hex(last_obj_end, region_end, last_obj_end + buffer_to_runtime_delta());
@@ -1245,7 +1245,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
         // We have a filler oop, which also does not exist in BufferOffsetToSourceObjectTable.
         // Example:
         // 0x00000007ffc3ffd8: @@ Object filler 40 bytes
-        st.print_cr("filler " SIZE_FORMAT " bytes", byte_size);
+        st.print_cr("filler %zu bytes", byte_size);
       } else {
         ShouldNotReachHere();
       }
@@ -1348,7 +1348,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
           print_oop_info_cr(&st, obj);
         }
       } else {
-        st.print_cr(" - fields (" SIZE_FORMAT " words):", source_oop->size());
+        st.print_cr(" - fields (%zu words):", source_oop->size());
         ArchivedFieldPrinter print_field(heap_info, &st, source_oop, buffered_addr);
         InstanceKlass::cast(source_klass)->print_nonstatic_fields(&print_field);
 

--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -308,7 +308,7 @@ bool ArchiveHeapLoader::load_heap_region_impl(FileMapInfo* mapinfo, LoadedArchiv
   }
   assert(r->mapped_base() == (char*)load_address, "sanity");
   log_info(cds)("Loaded heap    region #%d at base " INTPTR_FORMAT " top " INTPTR_FORMAT
-                " size " SIZE_FORMAT_W(6) " delta %zd",
+                " size %6zu delta %zd",
                 loaded_region->_region_index, load_address, load_address + loaded_region->_region_size,
                 loaded_region->_region_size, loaded_region->_runtime_offset);
 

--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -218,7 +218,7 @@ void ArchiveHeapWriter::copy_roots_to_buffer(GrowableArrayCHeap<oop, mtClassShar
   // after the roots.
 
   assert((_buffer_used % MIN_GC_REGION_ALIGNMENT) == 0,
-         "Pre-condition: Roots start at aligned boundary: " SIZE_FORMAT, _buffer_used);
+         "Pre-condition: Roots start at aligned boundary: %zu", _buffer_used);
 
   int max_elem_count = ((MIN_GC_REGION_ALIGNMENT - arrayOopDesc::header_size_in_bytes()) / heapOopSize);
   assert(objArrayOopDesc::object_size(max_elem_count)*HeapWordSize == MIN_GC_REGION_ALIGNMENT,
@@ -239,7 +239,7 @@ void ArchiveHeapWriter::copy_roots_to_buffer(GrowableArrayCHeap<oop, mtClassShar
     ensure_buffer_space(_buffer_used);
 
     assert((oop_offset % MIN_GC_REGION_ALIGNMENT) == 0,
-           "Roots segment " SIZE_FORMAT " start is not aligned: " SIZE_FORMAT,
+           "Roots segment %zu start is not aligned: %zu",
            segments.count(), oop_offset);
 
     objArrayOop seg_oop = allocate_root_segment(oop_offset, size_elems);
@@ -247,7 +247,7 @@ void ArchiveHeapWriter::copy_roots_to_buffer(GrowableArrayCHeap<oop, mtClassShar
       root_segment_at_put(seg_oop, i, roots->at(root_index++));
     }
 
-    log_info(cds, heap)("archived obj root segment [%d] = " SIZE_FORMAT " bytes, obj = " PTR_FORMAT,
+    log_info(cds, heap)("archived obj root segment [%d] = %zu bytes, obj = " PTR_FORMAT,
                         size_elems, size_bytes, p2i(seg_oop));
   }
 
@@ -330,7 +330,7 @@ void ArchiveHeapWriter::copy_source_objs_to_buffer(GrowableArrayCHeap<oop, mtCla
     }
   }
 
-  log_info(cds)("Size of heap region = " SIZE_FORMAT " bytes, %d objects, %d roots, %d native ptrs",
+  log_info(cds)("Size of heap region = %zu bytes, %d objects, %d roots, %d native ptrs",
                 _buffer_used, _source_objs->length() + 1, roots->length(), _num_native_ptrs);
 }
 
@@ -396,7 +396,7 @@ void ArchiveHeapWriter::maybe_fill_gc_region_gap(size_t required_byte_size) {
     ensure_buffer_space(filler_end);
 
     int array_length = filler_array_length(fill_bytes);
-    log_info(cds, heap)("Inserting filler obj array of %d elements (" SIZE_FORMAT " bytes total) @ buffer offset " SIZE_FORMAT,
+    log_info(cds, heap)("Inserting filler obj array of %d elements (%zu bytes total) @ buffer offset %zu",
                         array_length, fill_bytes, _buffer_used);
     HeapWord* filler = init_filler_array_at_buffer_top(array_length, fill_bytes);
     _buffer_used = filler_end;
@@ -754,7 +754,7 @@ void ArchiveHeapWriter::compute_ptrmap(ArchiveHeapInfo* heap_info) {
   }
 
   heap_info->ptrmap()->resize(max_idx + 1);
-  log_info(cds, heap)("calculate_ptrmap: marked %d non-null native pointers for heap region (" SIZE_FORMAT " bits)",
+  log_info(cds, heap)("calculate_ptrmap: marked %d non-null native pointers for heap region (%zu bits)",
                       num_non_null_ptrs, size_t(heap_info->ptrmap()->size()));
 }
 

--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -627,7 +627,7 @@ static void log_bitmap_usage(const char* which, BitMap* bitmap, size_t total_bit
   // The whole heap is covered by total_bits, but there are only non-zero bits within [start ... end).
   size_t start = bitmap->find_first_set_bit(0);
   size_t end = bitmap->size();
-  log_info(cds)("%s = " SIZE_FORMAT_W(7) " ... " SIZE_FORMAT_W(7) " (%3zu%% ... %3zu%% = %3zu%%)", which,
+  log_info(cds)("%s = %7zu ... %7zu (%3zu%% ... %3zu%% = %3zu%%)", which,
                 start, end,
                 start * 100 / total_bits,
                 end * 100 / total_bits,

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -228,7 +228,7 @@ void DumpRegion::commit_to(char* newtop) {
   assert(commit <= uncommitted, "sanity");
 
   if (!_vs->expand_by(commit, false)) {
-    log_error(cds)("Failed to expand shared space to " SIZE_FORMAT " bytes",
+    log_error(cds)("Failed to expand shared space to %zu bytes",
                     need_committed_size);
     MetaspaceShared::unrecoverable_writing_error();
   }

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -124,7 +124,7 @@ void ArchivePtrMarker::mark_pointer(address* ptr_loc) {
       }
       assert(idx < _ptrmap->size(), "must be");
       _ptrmap->set_bit(idx);
-      //tty->print_cr("Marking pointer [" PTR_FORMAT "] -> " PTR_FORMAT " @ " SIZE_FORMAT_W(5), p2i(ptr_loc), p2i(*ptr_loc), idx);
+      //tty->print_cr("Marking pointer [" PTR_FORMAT "] -> " PTR_FORMAT " @ %5zu", p2i(ptr_loc), p2i(*ptr_loc), idx);
     }
   }
 }
@@ -138,7 +138,7 @@ void ArchivePtrMarker::clear_pointer(address* ptr_loc) {
   size_t idx = ptr_loc - ptr_base();
   assert(idx < _ptrmap->size(), "cannot clear pointers that have not been marked");
   _ptrmap->clear_bit(idx);
-  //tty->print_cr("Clearing pointer [" PTR_FORMAT "] -> " PTR_FORMAT " @ " SIZE_FORMAT_W(5), p2i(ptr_loc), p2i(*ptr_loc), idx);
+  //tty->print_cr("Clearing pointer [" PTR_FORMAT "] -> " PTR_FORMAT " @ %5zu", p2i(ptr_loc), p2i(*ptr_loc), idx);
 }
 
 class ArchivePtrBitmapCleaner: public BitMapClosure {
@@ -163,7 +163,7 @@ public:
       }
     } else {
       _ptrmap->clear_bit(offset);
-      DEBUG_ONLY(log_trace(cds, reloc)("Clearing pointer [" PTR_FORMAT  "] -> null @ " SIZE_FORMAT_W(9), p2i(ptr_loc), offset));
+      DEBUG_ONLY(log_trace(cds, reloc)("Clearing pointer [" PTR_FORMAT  "] -> null @ %9zu", p2i(ptr_loc), offset));
     }
 
     return true;
@@ -239,7 +239,7 @@ void DumpRegion::commit_to(char* newtop) {
   } else {
     which = "shared";
   }
-  log_debug(cds)("Expanding %s spaces by " SIZE_FORMAT_W(7) " bytes [total " SIZE_FORMAT_W(9)  " bytes ending at %p]",
+  log_debug(cds)("Expanding %s spaces by %7zu bytes [total %9zu bytes ending at %p]",
                  which, commit, _vs->actual_committed_size(), _vs->high());
 }
 
@@ -265,7 +265,7 @@ void DumpRegion::append_intptr_t(intptr_t n, bool need_to_mark) {
 }
 
 void DumpRegion::print(size_t total_bytes) const {
-  log_debug(cds)("%s space: " SIZE_FORMAT_W(9) " [ %4.1f%% of total] out of " SIZE_FORMAT_W(9) " bytes [%5.1f%% used] at " INTPTR_FORMAT,
+  log_debug(cds)("%s space: %9zu [ %4.1f%% of total] out of %9zu bytes [%5.1f%% used] at " INTPTR_FORMAT,
                  _name, used(), percent_of(used(), total_bytes), reserved(), percent_of(used(), reserved()),
                  p2i(ArchiveBuilder::current()->to_requested(_base)));
 }

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -352,7 +352,7 @@ void DynamicArchiveBuilder::write_archive(char* serialized_data) {
   size_t file_size = pointer_delta(top, base, sizeof(char));
 
   log_info(cds, dynamic)("Written dynamic archive " PTR_FORMAT " - " PTR_FORMAT
-                         " [" UINT32_FORMAT " bytes header, " SIZE_FORMAT " bytes total]",
+                         " [" UINT32_FORMAT " bytes header, %zu bytes total]",
                          p2i(base), p2i(top), _header->header_size(), file_size);
 
   log_info(cds, dynamic)("%d klasses; %d symbols", klasses()->length(), symbols()->length());

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -279,7 +279,7 @@ void FileMapHeader::print(outputStream* st) {
   }
   st->print_cr("============ end regions ======== ");
 
-  st->print_cr("- core_region_alignment:          " SIZE_FORMAT, _core_region_alignment);
+  st->print_cr("- core_region_alignment:          %zu", _core_region_alignment);
   st->print_cr("- obj_alignment:                  %d", _obj_alignment);
   st->print_cr("- narrow_oop_base:                " INTPTR_FORMAT, p2i(_narrow_oop_base));
   st->print_cr("- narrow_oop_shift                %d", _narrow_oop_shift);
@@ -291,11 +291,11 @@ void FileMapHeader::print(outputStream* st) {
   st->print_cr("- compressed_class_ptrs:          %d", _compressed_class_ptrs);
   st->print_cr("- narrow_klass_pointer_bits:      %d", _narrow_klass_pointer_bits);
   st->print_cr("- narrow_klass_shift:             %d", _narrow_klass_shift);
-  st->print_cr("- cloned_vtables_offset:          " SIZE_FORMAT_X, _cloned_vtables_offset);
-  st->print_cr("- early_serialized_data_offset:   " SIZE_FORMAT_X, _early_serialized_data_offset);
-  st->print_cr("- serialized_data_offset:         " SIZE_FORMAT_X, _serialized_data_offset);
+  st->print_cr("- cloned_vtables_offset:          0x%zx", _cloned_vtables_offset);
+  st->print_cr("- early_serialized_data_offset:   0x%zx", _early_serialized_data_offset);
+  st->print_cr("- serialized_data_offset:         0x%zx", _serialized_data_offset);
   st->print_cr("- jvm_ident:                      %s", _jvm_ident);
-  st->print_cr("- shared_path_table_offset:       " SIZE_FORMAT_X, _shared_path_table_offset);
+  st->print_cr("- shared_path_table_offset:       0x%zx", _shared_path_table_offset);
   st->print_cr("- app_class_paths_start_index:    %d", _app_class_paths_start_index);
   st->print_cr("- app_module_paths_start_index:   %d", _app_module_paths_start_index);
   st->print_cr("- num_module_paths:               %d", _num_module_paths);
@@ -307,14 +307,14 @@ void FileMapHeader::print(outputStream* st) {
   st->print_cr("- requested_base_address:         " INTPTR_FORMAT, p2i(_requested_base_address));
   st->print_cr("- mapped_base_address:            " INTPTR_FORMAT, p2i(_mapped_base_address));
   st->print_cr("- heap_root_segments.roots_count: %d" , _heap_root_segments.roots_count());
-  st->print_cr("- heap_root_segments.base_offset: " SIZE_FORMAT_X, _heap_root_segments.base_offset());
-  st->print_cr("- heap_root_segments.count:       " SIZE_FORMAT, _heap_root_segments.count());
+  st->print_cr("- heap_root_segments.base_offset: 0x%zx", _heap_root_segments.base_offset());
+  st->print_cr("- heap_root_segments.count:       %zu", _heap_root_segments.count());
   st->print_cr("- heap_root_segments.max_size_elems: %d", _heap_root_segments.max_size_in_elems());
   st->print_cr("- heap_root_segments.max_size_bytes: %d", _heap_root_segments.max_size_in_bytes());
-  st->print_cr("- _heap_oopmap_start_pos:         " SIZE_FORMAT, _heap_oopmap_start_pos);
-  st->print_cr("- _heap_ptrmap_start_pos:         " SIZE_FORMAT, _heap_ptrmap_start_pos);
-  st->print_cr("- _rw_ptrmap_start_pos:           " SIZE_FORMAT, _rw_ptrmap_start_pos);
-  st->print_cr("- _ro_ptrmap_start_pos:           " SIZE_FORMAT, _ro_ptrmap_start_pos);
+  st->print_cr("- _heap_oopmap_start_pos:         %zu", _heap_oopmap_start_pos);
+  st->print_cr("- _heap_ptrmap_start_pos:         %zu", _heap_ptrmap_start_pos);
+  st->print_cr("- _rw_ptrmap_start_pos:           %zu", _rw_ptrmap_start_pos);
+  st->print_cr("- _ro_ptrmap_start_pos:           %zu", _ro_ptrmap_start_pos);
   st->print_cr("- allow_archiving_with_java_agent:%d", _allow_archiving_with_java_agent);
   st->print_cr("- use_optimized_module_handling:  %d", _use_optimized_module_handling);
   st->print_cr("- has_full_module_graph           %d", _has_full_module_graph);
@@ -1420,7 +1420,7 @@ bool FileMapInfo::init_from_file(int fd) {
 
 void FileMapInfo::seek_to_position(size_t pos) {
   if (os::lseek(_fd, (long)pos, SEEK_SET) < 0) {
-    log_error(cds)("Unable to seek to position " SIZE_FORMAT, pos);
+    log_error(cds)("Unable to seek to position %zu", pos);
     MetaspaceShared::unrecoverable_loading_error();
   }
 }
@@ -1555,7 +1555,7 @@ BitMapView FileMapInfo::bitmap_view(int region_index, bool is_oopmap) {
   bitmap_base += is_oopmap ? r->oopmap_offset() : r->ptrmap_offset();
   size_t size_in_bits = is_oopmap ? r->oopmap_size_in_bits() : r->ptrmap_size_in_bits();
 
-  log_debug(cds, reloc)("mapped %s relocation %smap @ " INTPTR_FORMAT " (" SIZE_FORMAT " bits)",
+  log_debug(cds, reloc)("mapped %s relocation %smap @ " INTPTR_FORMAT " (%zu bits)",
                         region_name(region_index), is_oopmap ? "oop" : "ptr",
                         p2i(bitmap_base), size_in_bits);
 
@@ -1578,13 +1578,13 @@ void FileMapRegion::print(outputStream* st, int region_index) {
   st->print_cr("- is_heap_region:                 %d", _is_heap_region);
   st->print_cr("- is_bitmap_region:               %d", _is_bitmap_region);
   st->print_cr("- mapped_from_file:               %d", _mapped_from_file);
-  st->print_cr("- file_offset:                    " SIZE_FORMAT_X, _file_offset);
-  st->print_cr("- mapping_offset:                 " SIZE_FORMAT_X, _mapping_offset);
-  st->print_cr("- used:                           " SIZE_FORMAT, _used);
-  st->print_cr("- oopmap_offset:                  " SIZE_FORMAT_X, _oopmap_offset);
-  st->print_cr("- oopmap_size_in_bits:            " SIZE_FORMAT, _oopmap_size_in_bits);
-  st->print_cr("- ptrmap_offset:                  " SIZE_FORMAT_X, _ptrmap_offset);
-  st->print_cr("- ptrmap_size_in_bits:            " SIZE_FORMAT, _ptrmap_size_in_bits);
+  st->print_cr("- file_offset:                    0x%zx", _file_offset);
+  st->print_cr("- mapping_offset:                 0x%zx", _mapping_offset);
+  st->print_cr("- used:                           %zu", _used);
+  st->print_cr("- oopmap_offset:                  0x%zx", _oopmap_offset);
+  st->print_cr("- oopmap_size_in_bits:            %zu", _oopmap_size_in_bits);
+  st->print_cr("- ptrmap_offset:                  0x%zx", _ptrmap_offset);
+  st->print_cr("- ptrmap_size_in_bits:            %zu", _ptrmap_size_in_bits);
   st->print_cr("- mapped_base:                    " INTPTR_FORMAT, p2i(_mapped_base));
 }
 
@@ -2171,13 +2171,13 @@ bool FileMapInfo::can_use_heap_region() {
   const int archive_narrow_klass_pointer_bits = header()->narrow_klass_pointer_bits();
   const int archive_narrow_klass_shift = header()->narrow_klass_shift();
 
-  log_info(cds)("CDS archive was created with max heap size = " SIZE_FORMAT "M, and the following configuration:",
+  log_info(cds)("CDS archive was created with max heap size = %zuM, and the following configuration:",
                 max_heap_size()/M);
   log_info(cds)("    narrow_klass_base at mapping start address, narrow_klass_pointer_bits = %d, narrow_klass_shift = %d",
                 archive_narrow_klass_pointer_bits, archive_narrow_klass_shift);
   log_info(cds)("    narrow_oop_mode = %d, narrow_oop_base = " PTR_FORMAT ", narrow_oop_shift = %d",
                 narrow_oop_mode(), p2i(narrow_oop_base()), narrow_oop_shift());
-  log_info(cds)("The current max heap size = " SIZE_FORMAT "M, G1HeapRegion::GrainBytes = " SIZE_FORMAT,
+  log_info(cds)("The current max heap size = %zuM, G1HeapRegion::GrainBytes = %zu",
                 MaxHeapSize/M, G1HeapRegion::GrainBytes);
   log_info(cds)("    narrow_klass_base = " PTR_FORMAT ", arrow_klass_pointer_bits = %d, narrow_klass_shift = %d",
                 p2i(CompressedKlassPointers::base()), CompressedKlassPointers::narrow_klass_pointer_bits(), CompressedKlassPointers::shift());
@@ -2334,7 +2334,7 @@ bool FileMapInfo::map_heap_region_impl() {
     if (base == nullptr || base != addr) {
       dealloc_heap_region();
       log_info(cds)("UseSharedSpaces: Unable to map at required address in java heap. "
-                    INTPTR_FORMAT ", size = " SIZE_FORMAT " bytes",
+                    INTPTR_FORMAT ", size = %zu bytes",
                     p2i(addr), _mapped_heap_memregion.byte_size());
       return false;
     }

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1623,7 +1623,7 @@ void FileMapInfo::write_region(int region, char* base, size_t size,
   r->set_file_offset(_file_offset);
   int crc = ClassLoader::crc32(0, base, (jint)size);
   if (size > 0) {
-    log_info(cds)("Shared file region (%s) %d: " SIZE_FORMAT_W(8)
+    log_info(cds)("Shared file region (%s) %d: %8zu"
                    " bytes, addr " INTPTR_FORMAT " file offset 0x%08" PRIxPTR
                    " crc 0x%08x",
                    region_name(region), region, size, p2i(requested_base), _file_offset, crc);
@@ -2109,7 +2109,7 @@ MemRegion FileMapInfo::get_heap_region_requested_range() {
 
   address start = heap_region_requested_address();
   address end = start + size;
-  log_info(cds)("Requested heap region [" INTPTR_FORMAT " - " INTPTR_FORMAT "] = "  SIZE_FORMAT_W(8) " bytes",
+  log_info(cds)("Requested heap region [" INTPTR_FORMAT " - " INTPTR_FORMAT "] = %8zu bytes",
                 p2i(start), p2i(end), size);
 
   return MemRegion((HeapWord*)start, (HeapWord*)end);
@@ -2371,7 +2371,7 @@ bool FileMapInfo::map_heap_region_impl() {
       return false;
     }
   }
-  log_info(cds)("Heap data mapped at " INTPTR_FORMAT ", size = " SIZE_FORMAT_W(8) " bytes",
+  log_info(cds)("Heap data mapped at " INTPTR_FORMAT ", size = %8zu bytes",
                 p2i(mapped_start), _mapped_heap_memregion.byte_size());
   log_info(cds)("CDS heap data relocation delta = %zd bytes", delta);
   return true;

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -302,7 +302,7 @@ bool HeapShared::archive_object(oop obj, KlassSubGraphInfo* subgraph_info) {
   }
 
   if (ArchiveHeapWriter::is_too_large_to_archive(obj->size())) {
-    log_debug(cds, heap)("Cannot archive, object (" PTR_FORMAT ") is too large: " SIZE_FORMAT,
+    log_debug(cds, heap)("Cannot archive, object (" PTR_FORMAT ") is too large: %zu",
                          p2i(obj), obj->size());
     debug_trace();
     return false;
@@ -1388,7 +1388,7 @@ class WalkOopAndArchiveClosure: public BasicOopIterateClosure {
 
       if (!_record_klasses_only && log_is_enabled(Debug, cds, heap)) {
         ResourceMark rm;
-        log_debug(cds, heap)("(%d) %s[" SIZE_FORMAT "] ==> " PTR_FORMAT " size " SIZE_FORMAT " %s", _level,
+        log_debug(cds, heap)("(%d) %s[%zu] ==> " PTR_FORMAT " size %zu %s", _level,
                              _referencing_obj->klass()->external_name(), field_delta,
                              p2i(obj), obj->size() * HeapWordSize, obj->klass()->external_name());
         if (log_is_enabled(Trace, cds, heap)) {
@@ -1531,7 +1531,7 @@ bool HeapShared::archive_reachable_objects_from(int level,
       ResourceMark rm;
       log_error(cds, heap)(
         "Cannot archive the sub-graph referenced from %s object ("
-        PTR_FORMAT ") size " SIZE_FORMAT ", skipped.",
+        PTR_FORMAT ") size %zu, skipped.",
         orig_obj->klass()->external_name(), p2i(orig_obj), orig_obj->size() * HeapWordSize);
       if (level == 1) {
         // Don't archive a subgraph root that's too big. For archives static fields, that's OK

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -2119,18 +2119,18 @@ void HeapShared::print_stats() {
     size_t byte_size_limit = (size_t(1) << i) * HeapWordSize;
     size_t count = _alloc_count[i];
     size_t size = _alloc_size[i];
-    log_info(cds, heap)(SIZE_FORMAT_W(8) " objects are <= " SIZE_FORMAT_W(-6)
-                        " bytes (total " SIZE_FORMAT_W(8) " bytes, avg %8.1f bytes)",
+    log_info(cds, heap)("%8zu objects are <= %-6zu"
+                        " bytes (total %8zu bytes, avg %8.1f bytes)",
                         count, byte_size_limit, size * HeapWordSize, avg_size(size, count));
     huge_count -= count;
     huge_size -= size;
   }
 
-  log_info(cds, heap)(SIZE_FORMAT_W(8) " huge  objects               (total "  SIZE_FORMAT_W(8) " bytes"
+  log_info(cds, heap)("%8zu huge  objects               (total %8zu bytes"
                       ", avg %8.1f bytes)",
                       huge_count, huge_size * HeapWordSize,
                       avg_size(huge_size, huge_count));
-  log_info(cds, heap)(SIZE_FORMAT_W(8) " total objects               (total "  SIZE_FORMAT_W(8) " bytes"
+  log_info(cds, heap)("%8zu total objects               (total %8zu bytes"
                       ", avg %8.1f bytes)",
                       _total_obj_count, _total_obj_size * HeapWordSize,
                       avg_size(_total_obj_size, _total_obj_count));

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1467,8 +1467,7 @@ char* MetaspaceShared::reserve_address_space_for_archives(FileMapInfo* static_ma
   size_t class_space_size = CompressedClassSpaceSize;
   assert(CompressedClassSpaceSize > 0 &&
          is_aligned(CompressedClassSpaceSize, class_space_alignment),
-         "CompressedClassSpaceSize malformed: "
-         SIZE_FORMAT, CompressedClassSpaceSize);
+         "CompressedClassSpaceSize malformed: %zu", CompressedClassSpaceSize);
 
   const size_t ccs_begin_offset = align_up(archive_space_size, class_space_alignment);
   const size_t gap_size = ccs_begin_offset - archive_space_size;

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -265,7 +265,7 @@ static char* compute_shared_base(size_t cds_max) {
 
 void MetaspaceShared::initialize_for_static_dump() {
   assert(CDSConfig::is_dumping_static_archive(), "sanity");
-  log_info(cds)("Core region alignment: " SIZE_FORMAT, core_region_alignment());
+  log_info(cds)("Core region alignment: %zu", core_region_alignment());
   // The max allowed size for CDS archive. We use this to limit SharedBaseAddress
   // to avoid address space wrap around.
   size_t cds_max;
@@ -286,7 +286,7 @@ void MetaspaceShared::initialize_for_static_dump() {
   size_t symbol_rs_size = LP64_ONLY(3 * G) NOT_LP64(128 * M);
   _symbol_rs = MemoryReserver::reserve(symbol_rs_size, mtClassShared);
   if (!_symbol_rs.is_reserved()) {
-    log_error(cds)("Unable to reserve memory for symbols: " SIZE_FORMAT " bytes.", symbol_rs_size);
+    log_error(cds)("Unable to reserve memory for symbols: %zu bytes.", symbol_rs_size);
     MetaspaceShared::unrecoverable_writing_error();
   }
   _symbol_region.init(&_symbol_rs, &_symbol_vs);
@@ -769,7 +769,7 @@ void MetaspaceShared::preload_and_dump(TRAPS) {
   if (HAS_PENDING_EXCEPTION) {
     if (PENDING_EXCEPTION->is_a(vmClasses::OutOfMemoryError_klass())) {
       log_error(cds)("Out of memory. Please run with a larger Java heap, current MaxHeapSize = "
-                     SIZE_FORMAT "M", MaxHeapSize/M);
+                     "%zuM", MaxHeapSize/M);
       MetaspaceShared::writing_error();
     } else {
       log_error(cds)("%s: %s", PENDING_EXCEPTION->klass()->external_name(),
@@ -798,15 +798,15 @@ void MetaspaceShared::adjust_heap_sizes_for_dumping() {
   julong max_heap_size = (julong)(4 * G);
 
   if (MinHeapSize > max_heap_size) {
-    log_debug(cds)("Setting MinHeapSize to 4G for CDS dumping, original size = " SIZE_FORMAT "M", MinHeapSize/M);
+    log_debug(cds)("Setting MinHeapSize to 4G for CDS dumping, original size = %zuM", MinHeapSize/M);
     FLAG_SET_ERGO(MinHeapSize, max_heap_size);
   }
   if (InitialHeapSize > max_heap_size) {
-    log_debug(cds)("Setting InitialHeapSize to 4G for CDS dumping, original size = " SIZE_FORMAT "M", InitialHeapSize/M);
+    log_debug(cds)("Setting InitialHeapSize to 4G for CDS dumping, original size = %zuM", InitialHeapSize/M);
     FLAG_SET_ERGO(InitialHeapSize, max_heap_size);
   }
   if (MaxHeapSize > max_heap_size) {
-    log_debug(cds)("Setting MaxHeapSize to 4G for CDS dumping, original size = " SIZE_FORMAT "M", MaxHeapSize/M);
+    log_debug(cds)("Setting MaxHeapSize to 4G for CDS dumping, original size = %zuM", MaxHeapSize/M);
     FLAG_SET_ERGO(MaxHeapSize, max_heap_size);
   }
 }
@@ -1082,7 +1082,7 @@ void MetaspaceShared::initialize_runtime_shared_and_meta_spaces() {
   FileMapInfo* dynamic_mapinfo = nullptr;
 
   if (static_mapinfo != nullptr) {
-    log_info(cds)("Core region alignment: " SIZE_FORMAT, static_mapinfo->core_region_alignment());
+    log_info(cds)("Core region alignment: %zu", static_mapinfo->core_region_alignment());
     dynamic_mapinfo = open_dynamic_archive();
 
     // First try to map at the requested address
@@ -1236,9 +1236,9 @@ MapArchiveResult MetaspaceShared::map_archives(FileMapInfo* static_mapinfo, File
     }
 #endif // ASSERT
 
-    log_info(cds)("Reserved archive_space_rs [" INTPTR_FORMAT " - " INTPTR_FORMAT "] (" SIZE_FORMAT ") bytes",
+    log_info(cds)("Reserved archive_space_rs [" INTPTR_FORMAT " - " INTPTR_FORMAT "] (%zu) bytes",
                    p2i(archive_space_rs.base()), p2i(archive_space_rs.end()), archive_space_rs.size());
-    log_info(cds)("Reserved class_space_rs   [" INTPTR_FORMAT " - " INTPTR_FORMAT "] (" SIZE_FORMAT ") bytes",
+    log_info(cds)("Reserved class_space_rs   [" INTPTR_FORMAT " - " INTPTR_FORMAT "] (%zu) bytes",
                    p2i(class_space_rs.base()), p2i(class_space_rs.end()), class_space_rs.size());
 
     if (MetaspaceShared::use_windows_memory_mapping()) {
@@ -1478,7 +1478,7 @@ char* MetaspaceShared::reserve_address_space_for_archives(FileMapInfo* static_ma
   guarantee(archive_space_size < max_encoding_range_size - class_space_alignment, "Archive too large");
   if ((archive_space_size + gap_size + class_space_size) > max_encoding_range_size) {
     class_space_size = align_down(max_encoding_range_size - archive_space_size - gap_size, class_space_alignment);
-    log_info(metaspace)("CDS initialization: reducing class space size from " SIZE_FORMAT " to " SIZE_FORMAT,
+    log_info(metaspace)("CDS initialization: reducing class space size from %zu to %zu",
         CompressedClassSpaceSize, class_space_size);
     FLAG_SET_ERGO(CompressedClassSpaceSize, class_space_size);
   }
@@ -1600,8 +1600,8 @@ MapArchiveResult MetaspaceShared::map_archive(FileMapInfo* mapinfo, char* mapped
 
   mapinfo->set_is_mapped(false);
   if (mapinfo->core_region_alignment() != (size_t)core_region_alignment()) {
-    log_info(cds)("Unable to map CDS archive -- core_region_alignment() expected: " SIZE_FORMAT
-                  " actual: " SIZE_FORMAT, mapinfo->core_region_alignment(), core_region_alignment());
+    log_info(cds)("Unable to map CDS archive -- core_region_alignment() expected: %zu"
+                  " actual: %zu", mapinfo->core_region_alignment(), core_region_alignment());
     return MAP_ARCHIVE_OTHER_FAILURE;
   }
 
@@ -1770,7 +1770,7 @@ void MetaspaceShared::print_on(outputStream* st) {
     address static_top = (address)_shared_metaspace_static_top;
     address top = (address)MetaspaceObj::shared_metaspace_top();
     st->print("[" PTR_FORMAT "-" PTR_FORMAT "-" PTR_FORMAT "), ", p2i(base), p2i(static_top), p2i(top));
-    st->print("size " SIZE_FORMAT ", ", top - base);
+    st->print("size %zu, ", top - base);
     st->print("SharedBaseAddress: " PTR_FORMAT ", ArchiveRelocationMode: %d.", SharedBaseAddress, ArchiveRelocationMode);
   } else {
     st->print("CDS archive(s) not mapped");

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5663,7 +5663,7 @@ void ClassFileParser::mangle_hidden_class_name(InstanceKlass* const ik) {
     static volatile size_t counter = 0;
     Atomic::cmpxchg(&counter, (size_t)0, Arguments::default_SharedBaseAddress()); // initialize it
     size_t new_id = Atomic::add(&counter, (size_t)1);
-    jio_snprintf(addr_buf, 20, SIZE_FORMAT_X, new_id);
+    jio_snprintf(addr_buf, 20, "0x%zx", new_id);
   } else {
     jio_snprintf(addr_buf, 20, INTPTR_FORMAT, p2i(ik));
   }

--- a/src/hotspot/share/classfile/classLoaderStats.cpp
+++ b/src/hotspot/share/classfile/classLoaderStats.cpp
@@ -112,7 +112,7 @@ bool ClassLoaderStatsClosure::do_entry(oop const& key, ClassLoaderStats const& c
   Klass* class_loader_klass = (cls._class_loader == nullptr ? nullptr : cls._class_loader->klass());
   Klass* parent_klass = (cls._parent == nullptr ? nullptr : cls._parent->klass());
 
-  _out->print(INTPTR_FORMAT "  " INTPTR_FORMAT "  " INTPTR_FORMAT "  %6zu  " SIZE_FORMAT_W(8) "  " SIZE_FORMAT_W(8) "  ",
+  _out->print(INTPTR_FORMAT "  " INTPTR_FORMAT "  " INTPTR_FORMAT "  %6zu  %8zu  %8zu  ",
       p2i(class_loader_klass), p2i(parent_klass), p2i(cls._cld),
       cls._classes_count,
       cls._chunk_sz, cls._block_sz);
@@ -123,7 +123,7 @@ bool ClassLoaderStatsClosure::do_entry(oop const& key, ClassLoaderStats const& c
   }
   _out->cr();
   if (cls._hidden_classes_count > 0) {
-    _out->print_cr(SPACE SPACE SPACE "                                    %6zu  " SIZE_FORMAT_W(8) "  " SIZE_FORMAT_W(8) "   + hidden classes",
+    _out->print_cr(SPACE SPACE SPACE "                                    %6zu  %8zu  %8zu   + hidden classes",
         "", "", "",
         cls._hidden_classes_count,
         cls._hidden_chunk_sz, cls._hidden_block_sz);
@@ -137,7 +137,7 @@ void ClassLoaderStatsClosure::print() {
   _stats->iterate(this);
   _out->print("Total = %-6zu", _total_loaders);
   _out->print(SPACE SPACE SPACE "                      ", "", "", "");
-  _out->print_cr("%6zu  " SIZE_FORMAT_W(8) "  " SIZE_FORMAT_W(8) "  ",
+  _out->print_cr("%6zu  %8zu  %8zu  ",
       _total_classes,
       _total_chunk_sz,
       _total_block_sz);

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ Dictionary::Dictionary(ClassLoaderData* loader_data, size_t table_size)
 
   size_t start_size_log_2 = MAX2(log2i_ceil(table_size), 2); // 2 is minimum size even though some dictionaries only have one entry
   size_t current_size = ((size_t)1) << start_size_log_2;
-  log_info(class, loader, data)("Dictionary start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
+  log_info(class, loader, data)("Dictionary start size: %zu (%zu)",
                                 current_size, start_size_log_2);
   _table = new ConcurrentTable(start_size_log_2, END_SIZE, REHASH_LEN);
 }

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1242,8 +1242,8 @@ void java_lang_Class::fixup_module_field(Klass* k, Handle module) {
 
 void java_lang_Class::set_oop_size(HeapWord* java_class, size_t size) {
   assert(_oop_size_offset != 0, "must be set");
-  assert(size > 0, "Oop size must be greater than zero, not " SIZE_FORMAT, size);
-  assert(size <= INT_MAX, "Lossy conversion: " SIZE_FORMAT, size);
+  assert(size > 0, "Oop size must be greater than zero, not %zu", size);
+  assert(size <= INT_MAX, "Lossy conversion: %zu", size);
   *(int*)(((char*)java_class) + _oop_size_offset) = (int)size;
 }
 

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -311,7 +311,7 @@ public:
 void StringTable::create_table() {
   size_t start_size_log_2 = log2i_ceil(StringTableSize);
   _current_size = ((size_t)1) << start_size_log_2;
-  log_trace(stringtable)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
+  log_trace(stringtable)("Start size: %zu (%zu)",
                          _current_size, start_size_log_2);
   _local_table = new StringTableHash(start_size_log_2, END_SIZE, REHASH_LEN, true);
   _oop_storage = OopStorageSet::create_weak("StringTable Weak", mtSymbol);
@@ -582,7 +582,7 @@ void StringTable::grow(JavaThread* jt) {
   }
   gt.done(jt);
   _current_size = table_size();
-  log_debug(stringtable)("Grown to size:" SIZE_FORMAT, _current_size);
+  log_debug(stringtable)("Grown to size:%zu", _current_size);
 }
 
 struct StringTableDoDelete : StackObj {
@@ -631,7 +631,7 @@ void StringTable::clean_dead_entries(JavaThread* jt) {
 }
 
 void StringTable::gc_notification(size_t num_dead) {
-  log_trace(stringtable)("Uncleaned items:" SIZE_FORMAT, num_dead);
+  log_trace(stringtable)("Uncleaned items:%zu", num_dead);
 
   if (has_work()) {
     return;

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -931,29 +931,29 @@ void SymbolTable::print_histogram() {
   HistogramIterator hi;
   _local_table->do_scan(Thread::current(), hi);
   tty->print_cr("Symbol Table Histogram:");
-  tty->print_cr("  Total number of symbols  " SIZE_FORMAT_W(7), hi.total_count);
-  tty->print_cr("  Total size in memory     " SIZE_FORMAT_W(7) "K", (hi.total_size * wordSize) / K);
-  tty->print_cr("  Total counted            " SIZE_FORMAT_W(7), _symbols_counted);
-  tty->print_cr("  Total removed            " SIZE_FORMAT_W(7), _symbols_removed);
+  tty->print_cr("  Total number of symbols  %7zu", hi.total_count);
+  tty->print_cr("  Total size in memory     %7zuK", (hi.total_size * wordSize) / K);
+  tty->print_cr("  Total counted            %7zu", _symbols_counted);
+  tty->print_cr("  Total removed            %7zu", _symbols_removed);
   if (_symbols_counted > 0) {
     tty->print_cr("  Percent removed          %3.2f",
           ((double)_symbols_removed / (double)_symbols_counted) * 100);
   }
-  tty->print_cr("  Reference counts         " SIZE_FORMAT_W(7), Symbol::_total_count);
-  tty->print_cr("  Symbol arena used        " SIZE_FORMAT_W(7) "K", arena()->used() / K);
-  tty->print_cr("  Symbol arena size        " SIZE_FORMAT_W(7) "K", arena()->size_in_bytes() / K);
-  tty->print_cr("  Total symbol length      " SIZE_FORMAT_W(7), hi.total_length);
-  tty->print_cr("  Maximum symbol length    " SIZE_FORMAT_W(7), hi.max_length);
+  tty->print_cr("  Reference counts         %7zu", Symbol::_total_count);
+  tty->print_cr("  Symbol arena used        %7zuK", arena()->used() / K);
+  tty->print_cr("  Symbol arena size        %7zuK", arena()->size_in_bytes() / K);
+  tty->print_cr("  Total symbol length      %7zu", hi.total_length);
+  tty->print_cr("  Maximum symbol length    %7zu", hi.max_length);
   tty->print_cr("  Average symbol length    %7.2f", ((double)hi.total_length / (double)hi.total_count));
   tty->print_cr("  Symbol length histogram:");
   tty->print_cr("    %6s %10s %10s", "Length", "#Symbols", "Size");
   for (size_t i = 0; i < hi.results_length; i++) {
     if (hi.counts[i] > 0) {
-      tty->print_cr("    " SIZE_FORMAT_W(6) " " SIZE_FORMAT_W(10) " " SIZE_FORMAT_W(10) "K",
+      tty->print_cr("    %6zu %10zu %10zuK",
                     i, hi.counts[i], (hi.sizes[i] * wordSize) / K);
     }
   }
-  tty->print_cr("  >=" SIZE_FORMAT_W(6) " " SIZE_FORMAT_W(10) " " SIZE_FORMAT_W(10) "K\n",
+  tty->print_cr("  >= %6zu %10zu %10zuK\n",
                 hi.results_length, hi.out_of_range_count, (hi.out_of_range_size*wordSize) / K);
 }
 #endif // PRODUCT

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -214,7 +214,7 @@ private:
 void SymbolTable::create_table ()  {
   size_t start_size_log_2 = log2i_ceil(SymbolTableSize);
   _current_size = ((size_t)1) << start_size_log_2;
-  log_trace(symboltable)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
+  log_trace(symboltable)("Start size: %zu (%zu)",
                          _current_size, start_size_log_2);
   _local_table = new SymbolTableHash(start_size_log_2, END_SIZE, REHASH_LEN, true);
 
@@ -749,7 +749,7 @@ void SymbolTable::grow(JavaThread* jt) {
   }
   gt.done(jt);
   _current_size = table_size();
-  log_debug(symboltable)("Grown to size:" SIZE_FORMAT, _current_size);
+  log_debug(symboltable)("Grown to size:%zu", _current_size);
 }
 
 struct SymbolTableDoDelete : StackObj {
@@ -798,7 +798,7 @@ void SymbolTable::clean_dead_entries(JavaThread* jt) {
 
   Atomic::add(&_symbols_counted, stdc._processed);
 
-  log_debug(symboltable)("Cleaned " SIZE_FORMAT " of " SIZE_FORMAT,
+  log_debug(symboltable)("Cleaned %zu of %zu",
                          stdd._deleted, stdc._processed);
 }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -181,7 +181,7 @@ static void check_min_size(const char* codeheap, size_t size, size_t required_si
     log_debug(codecache)("Code heap (%s) size %zuK below required minimal size %zuK",
                          codeheap, size/K, required_size/K);
     err_msg title("Not enough space in %s to run VM", codeheap);
-    err_msg message(SIZE_FORMAT "K < %zuK", size/K, required_size/K);
+    err_msg message("%zuK < %zuK", size/K, required_size/K);
     vm_exit_during_initialization(title, message);
   }
 }

--- a/src/hotspot/share/code/codeHeapState.cpp
+++ b/src/hotspot/share/code/codeHeapState.cpp
@@ -1042,19 +1042,19 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
       // interspersed with print data from other threads. We take this risk intentionally.
       // Getting stalled waiting for tty_lock while holding the CodeCache_lock is not desirable.
       printBox(ast, '-', "Global CodeHeap statistics for segment ", heapName);
-      ast->print_cr("freeSpace        = " SIZE_FORMAT_W(8) "k, nBlocks_free     = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", freeSpace/(size_t)K,     nBlocks_free,     (100.0*freeSpace)/size,     (100.0*freeSpace)/res_size);
-      ast->print_cr("usedSpace        = " SIZE_FORMAT_W(8) "k, nBlocks_used     = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", usedSpace/(size_t)K,     nBlocks_used,     (100.0*usedSpace)/size,     (100.0*usedSpace)/res_size);
-      ast->print_cr("  Tier1 Space    = " SIZE_FORMAT_W(8) "k, nBlocks_t1       = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", t1Space/(size_t)K,       nBlocks_t1,       (100.0*t1Space)/size,       (100.0*t1Space)/res_size);
-      ast->print_cr("  Tier2 Space    = " SIZE_FORMAT_W(8) "k, nBlocks_t2       = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", t2Space/(size_t)K,       nBlocks_t2,       (100.0*t2Space)/size,       (100.0*t2Space)/res_size);
-      ast->print_cr("  Alive Space    = " SIZE_FORMAT_W(8) "k, nBlocks_alive    = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", aliveSpace/(size_t)K,    nBlocks_alive,    (100.0*aliveSpace)/size,    (100.0*aliveSpace)/res_size);
-      ast->print_cr("    disconnected = " SIZE_FORMAT_W(8) "k, nBlocks_disconn  = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", disconnSpace/(size_t)K,  nBlocks_disconn,  (100.0*disconnSpace)/size,  (100.0*disconnSpace)/res_size);
-      ast->print_cr("    not entrant  = " SIZE_FORMAT_W(8) "k, nBlocks_notentr  = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", notentrSpace/(size_t)K,  nBlocks_notentr,  (100.0*notentrSpace)/size,  (100.0*notentrSpace)/res_size);
-      ast->print_cr("  stubSpace      = " SIZE_FORMAT_W(8) "k, nBlocks_stub     = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", stubSpace/(size_t)K,     nBlocks_stub,     (100.0*stubSpace)/size,     (100.0*stubSpace)/res_size);
+      ast->print_cr("freeSpace        = %8zuk, nBlocks_free     = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", freeSpace/(size_t)K,     nBlocks_free,     (100.0*freeSpace)/size,     (100.0*freeSpace)/res_size);
+      ast->print_cr("usedSpace        = %8zuk, nBlocks_used     = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", usedSpace/(size_t)K,     nBlocks_used,     (100.0*usedSpace)/size,     (100.0*usedSpace)/res_size);
+      ast->print_cr("  Tier1 Space    = %8zuk, nBlocks_t1       = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", t1Space/(size_t)K,       nBlocks_t1,       (100.0*t1Space)/size,       (100.0*t1Space)/res_size);
+      ast->print_cr("  Tier2 Space    = %8zuk, nBlocks_t2       = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", t2Space/(size_t)K,       nBlocks_t2,       (100.0*t2Space)/size,       (100.0*t2Space)/res_size);
+      ast->print_cr("  Alive Space    = %8zuk, nBlocks_alive    = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", aliveSpace/(size_t)K,    nBlocks_alive,    (100.0*aliveSpace)/size,    (100.0*aliveSpace)/res_size);
+      ast->print_cr("    disconnected = %8zuk, nBlocks_disconn  = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", disconnSpace/(size_t)K,  nBlocks_disconn,  (100.0*disconnSpace)/size,  (100.0*disconnSpace)/res_size);
+      ast->print_cr("    not entrant  = %8zuk, nBlocks_notentr  = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", notentrSpace/(size_t)K,  nBlocks_notentr,  (100.0*notentrSpace)/size,  (100.0*notentrSpace)/res_size);
+      ast->print_cr("  stubSpace      = %8zuk, nBlocks_stub     = %6d, %10.3f%% of capacity, %10.3f%% of max_capacity", stubSpace/(size_t)K,     nBlocks_stub,     (100.0*stubSpace)/size,     (100.0*stubSpace)/res_size);
       ast->print_cr("ZombieBlocks     = %8d. These are HeapBlocks which could not be identified as CodeBlobs.", nBlocks_zomb);
       ast->cr();
-      ast->print_cr("Segment start          = " INTPTR_FORMAT ", used space      = " SIZE_FORMAT_W(8)"k", p2i(low_bound), size/K);
-      ast->print_cr("Segment end (used)     = " INTPTR_FORMAT ", remaining space = " SIZE_FORMAT_W(8)"k", p2i(low_bound) + size, (res_size - size)/K);
-      ast->print_cr("Segment end (reserved) = " INTPTR_FORMAT ", reserved space  = " SIZE_FORMAT_W(8)"k", p2i(low_bound) + res_size, res_size/K);
+      ast->print_cr("Segment start          = " INTPTR_FORMAT ", used space      = %8zuk", p2i(low_bound), size/K);
+      ast->print_cr("Segment end (used)     = " INTPTR_FORMAT ", remaining space = %8zuk", p2i(low_bound) + size, (res_size - size)/K);
+      ast->print_cr("Segment end (reserved) = " INTPTR_FORMAT ", reserved space  = %8zuk", p2i(low_bound) + res_size, res_size/K);
       ast->cr();
       ast->print_cr("latest allocated compilation id = %d", latest_compilation_id);
       ast->print_cr("highest observed compilation id = %d", highest_compilation_id);
@@ -1303,7 +1303,7 @@ void CodeHeapState::print_usedSpace(outputStream* out, CodeHeap* heap) {
         if (is_nmethod) {
           //---<  nMethod size in hex  >---
           ast->print(UINT32_FORMAT_X_0, TopSizeArray[i].nm_size);
-          ast->print("(" SIZE_FORMAT_W(4) "K)", TopSizeArray[i].nm_size/K);
+          ast->print("(%4zuK)", TopSizeArray[i].nm_size/K);
           ast->fill_to(51);
           ast->print("  %c", blobTypeChar[TopSizeArray[i].type]);
           //---<  compiler information  >---
@@ -1315,7 +1315,7 @@ void CodeHeapState::print_usedSpace(outputStream* out, CodeHeap* heap) {
         } else {
           //---<  block size in hex  >---
           ast->print(UINT32_FORMAT_X_0, (unsigned int)(TopSizeArray[i].len<<log2_seg_size));
-          ast->print("(" SIZE_FORMAT_W(4) "K)", (TopSizeArray[i].len<<log2_seg_size)/K);
+          ast->print("(%4zuK)", (TopSizeArray[i].len<<log2_seg_size)/K);
           //---<  no compiler information  >---
           ast->fill_to(56);
           //---<  name and signature  >---
@@ -1362,17 +1362,17 @@ void CodeHeapState::print_usedSpace(outputStream* out, CodeHeap* heap) {
       ast->print_cr("[Size Range)------avg.-size-+----count-+");
       for (unsigned int i = 0; i < nSizeDistElements; i++) {
         if (SizeDistributionArray[i].rangeStart<<log2_seg_size < K) {
-          ast->print("[" SIZE_FORMAT_W(5) " .." SIZE_FORMAT_W(5) " ): "
+          ast->print("[%5zu ..%5zu ): "
                     ,(size_t)(SizeDistributionArray[i].rangeStart<<log2_seg_size)
                     ,(size_t)(SizeDistributionArray[i].rangeEnd<<log2_seg_size)
                     );
         } else if (SizeDistributionArray[i].rangeStart<<log2_seg_size < M) {
-          ast->print("[" SIZE_FORMAT_W(5) "K.." SIZE_FORMAT_W(5) "K): "
+          ast->print("[%5zuK..%5zuK): "
                     ,(SizeDistributionArray[i].rangeStart<<log2_seg_size)/K
                     ,(SizeDistributionArray[i].rangeEnd<<log2_seg_size)/K
                     );
         } else {
-          ast->print("[" SIZE_FORMAT_W(5) "M.." SIZE_FORMAT_W(5) "M): "
+          ast->print("[%5zuM..%5zuM): "
                     ,(SizeDistributionArray[i].rangeStart<<log2_seg_size)/M
                     ,(SizeDistributionArray[i].rangeEnd<<log2_seg_size)/M
                     );
@@ -1402,17 +1402,17 @@ void CodeHeapState::print_usedSpace(outputStream* out, CodeHeap* heap) {
       ast->print_cr("[Size Range)------avg.-size-+----count-+");
       for (unsigned int i = 0; i < nSizeDistElements; i++) {
         if (SizeDistributionArray[i].rangeStart<<log2_seg_size < K) {
-          ast->print("[" SIZE_FORMAT_W(5) " .." SIZE_FORMAT_W(5) " ): "
+          ast->print("[%5zu ..%5zu ): "
                     ,(size_t)(SizeDistributionArray[i].rangeStart<<log2_seg_size)
                     ,(size_t)(SizeDistributionArray[i].rangeEnd<<log2_seg_size)
                     );
         } else if (SizeDistributionArray[i].rangeStart<<log2_seg_size < M) {
-          ast->print("[" SIZE_FORMAT_W(5) "K.." SIZE_FORMAT_W(5) "K): "
+          ast->print("[%5zuK..%5zuK): "
                     ,(SizeDistributionArray[i].rangeStart<<log2_seg_size)/K
                     ,(SizeDistributionArray[i].rangeEnd<<log2_seg_size)/K
                     );
         } else {
-          ast->print("[" SIZE_FORMAT_W(5) "M.." SIZE_FORMAT_W(5) "M): "
+          ast->print("[%5zuM..%5zuM): "
                     ,(SizeDistributionArray[i].rangeStart<<log2_seg_size)/M
                     ,(SizeDistributionArray[i].rangeEnd<<log2_seg_size)/M
                     );
@@ -2170,7 +2170,7 @@ void CodeHeapState::print_names(outputStream* out, CodeHeap* heap) {
           bool         get_name   = (cbType == nMethod_inuse) || (cbType == nMethod_notused);
           //---<  nMethod size in hex  >---
           ast->print(UINT32_FORMAT_X_0, total_size);
-          ast->print("(" SIZE_FORMAT_W(4) "K)", total_size/K);
+          ast->print("(%4zuK)", total_size/K);
           //---<  compiler information  >---
           ast->fill_to(51);
           ast->print("%5s %3d", compTypeName[StatArray[ix].compiler], StatArray[ix].level);

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2778,9 +2778,9 @@ void CompileBroker::print_info(outputStream *out) {
   out->print_cr("CodeCache overview");
   out->print_cr("--------------------------------------------------------");
   out->cr();
-  out->print_cr("         Reserved size : " SIZE_FORMAT_W(7) " KB", CodeCache::max_capacity() / K);
-  out->print_cr("        Committed size : " SIZE_FORMAT_W(7) " KB", CodeCache::capacity() / K);
-  out->print_cr("  Unallocated capacity : " SIZE_FORMAT_W(7) " KB", CodeCache::unallocated_capacity() / K);
+  out->print_cr("         Reserved size : %7zu KB", CodeCache::max_capacity() / K);
+  out->print_cr("        Committed size : %7zu KB", CodeCache::capacity() / K);
+  out->print_cr("  Unallocated capacity : %7zu KB", CodeCache::unallocated_capacity() / K);
   out->cr();
 }
 

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ AsyncLogWriter::AsyncLogWriter()
   size_t size = AsyncLogBufferSize / 2;
   _buffer = new Buffer(size);
   _buffer_staging = new Buffer(size);
-  log_info(logging)("AsyncLogBuffer estimates memory use: " SIZE_FORMAT " bytes", size * 2);
+  log_info(logging)("AsyncLogBuffer estimates memory use: %zu bytes", size * 2);
   if (os::create_thread(this, os::asynclog_thread)) {
     _initialized = true;
   } else {

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -214,8 +214,8 @@ size_t LogConfiguration::add_output(LogOutput* output) {
 
 void LogConfiguration::delete_output(size_t idx) {
   assert(idx > 1 && idx < _n_outputs,
-         "idx must be in range 1 < idx < _n_outputs, but idx = " SIZE_FORMAT
-         " and _n_outputs = " SIZE_FORMAT, idx, _n_outputs);
+         "idx must be in range 1 < idx < _n_outputs, but idx = %zu"
+         " and _n_outputs = %zu", idx, _n_outputs);
   LogOutput* output = _outputs[idx];
   // Swap places with the last output and shrink the array
   _outputs[idx] = _outputs[--_n_outputs];
@@ -240,7 +240,7 @@ void LogConfiguration::delete_output(size_t idx) {
 //
 void LogConfiguration::configure_output(size_t idx, const LogSelectionList& selections, const LogDecorators& decorators) {
   assert(ConfigurationLock::current_thread_has_lock(), "Must hold configuration lock to call this function.");
-  assert(idx < _n_outputs, "Invalid index, idx = " SIZE_FORMAT " and _n_outputs = " SIZE_FORMAT, idx, _n_outputs);
+  assert(idx < _n_outputs, "Invalid index, idx = %zu and _n_outputs = %zu", idx, _n_outputs);
   LogOutput* output = _outputs[idx];
 
   output->_reconfigured = true;
@@ -351,7 +351,7 @@ void LogConfiguration::configure_stdout(LogLevelType level, int exact_match, ...
     }
   }
   assert(i < LogTag::MaxTags || static_cast<LogTagType>(va_arg(ap, int)) == LogTag::__NO_TAG,
-         "Too many tags specified! Can only have up to " SIZE_FORMAT " tags in a tag set.", LogTag::MaxTags);
+         "Too many tags specified! Can only have up to %zu tags in a tag set.", LogTag::MaxTags);
   va_end(ap);
 
   LogSelection selection(tags, !exact_match, level);
@@ -566,7 +566,7 @@ void LogConfiguration::describe_available(outputStream* out) {
 void LogConfiguration::describe_current_configuration(outputStream* out) {
   out->print_cr("Log output configuration:");
   for (size_t i = 0; i < _n_outputs; i++) {
-    out->print(" #" SIZE_FORMAT ": ", i);
+    out->print(" #%zu: ", i);
     _outputs[i]->describe(out);
     if (_outputs[i]->is_reconfigured()) {
       out->print(" (reconfigured)");

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -500,7 +500,7 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
   size_t idx;
   bool added = false;
   if (outputstr[0] == '#') { // Output specified using index
-    int ret = sscanf(outputstr + 1, SIZE_FORMAT, &idx);
+    int ret = sscanf(outputstr + 1, "%zu", &idx);
     if (ret != 1 || idx >= _n_outputs) {
       errstream->print_cr("Invalid output index '%s'", outputstr);
       return false;

--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -185,7 +185,7 @@ bool LogFileOutput::set_option(const char* key, const char* value, outputStream*
       success = Arguments::atojulong(value, &longval);
       if (!success || (longval > SIZE_MAX)) {
         errstream->print_cr("Invalid option: %s must be in range [0, "
-                            SIZE_FORMAT "]", FileSizeOptionKey, (size_t)SIZE_MAX);
+                            "%zu]", FileSizeOptionKey, (size_t)SIZE_MAX);
         success = false;
       } else {
         _rotate_size = static_cast<size_t>(longval);
@@ -215,7 +215,7 @@ bool LogFileOutput::initialize(const char* options, outputStream* errstream) {
   }
 
   log_trace(logging)("Initializing logging to file '%s' (filecount: %u"
-                     ", filesize: " SIZE_FORMAT " KiB).",
+                     ", filesize: %zu KiB).",
                      _file_name, _file_count, _rotate_size / K);
 
   if (_file_count > 0 && file_exist) {
@@ -461,7 +461,7 @@ char* LogFileOutput::make_file_name(const char* file_name,
 
 void LogFileOutput::describe(outputStream *out) {
   LogFileStreamOutput::describe(out);
-  out->print(",filecount=%u,filesize=" SIZE_FORMAT "%s,async=%s", _file_count,
+  out->print(",filecount=%u,filesize=%zu%s,async=%s", _file_count,
              byte_size_in_proper_unit(_rotate_size),
              proper_unit_for_byte_size(_rotate_size),
              LogConfiguration::is_async_mode() ? "true" : "false");

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -145,7 +145,7 @@ static LogSelection parse_internal(char *str, outputStream* errstream) {
     }
     if (ntags == LogTag::MaxTags) {
       if (errstream != nullptr) {
-        errstream->print_cr("Too many tags in log selection '%s' (can only have up to " SIZE_FORMAT " tags).",
+        errstream->print_cr("Too many tags in log selection '%s' (can only have up to %zu tags).",
                                str, LogTag::MaxTags);
       }
       return LogSelection::Invalid;

--- a/src/hotspot/share/logging/logSelectionList.cpp
+++ b/src/hotspot/share/logging/logSelectionList.cpp
@@ -72,7 +72,7 @@ bool LogSelectionList::parse(const char* str, outputStream* errstream) {
   for (char *comma_pos = copy, *cur = copy; success; cur = comma_pos + 1) {
     if (_nselections == MaxSelections) {
       if (errstream != nullptr) {
-        errstream->print_cr("Can not have more than " SIZE_FORMAT " log selections in a single configuration.",
+        errstream->print_cr("Can not have more than %zu log selections in a single configuration.",
                             MaxSelections);
       }
       success = false;

--- a/src/hotspot/share/nmt/mallocTracker.cpp
+++ b/src/hotspot/share/nmt/mallocTracker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, 2023 SAP SE. All rights reserved.
  * Copyright (c) 2023, 2024, Red Hat, Inc. and/or its affiliates.
  *
@@ -292,7 +292,7 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
     } else {
       where = "just outside of";
     }
-    st->print_cr(PTR_FORMAT " %s %s malloced block starting at " PTR_FORMAT ", size " SIZE_FORMAT ", tag %s",
+    st->print_cr(PTR_FORMAT " %s %s malloced block starting at " PTR_FORMAT ", size %zu, tag %s",
                  p2i(p), where,
                  (block->is_dead() ? "dead" : "live"),
                  p2i(block + 1), // lets print the payload start, not the header

--- a/src/hotspot/share/nmt/memReporter.cpp
+++ b/src/hotspot/share/nmt/memReporter.cpp
@@ -42,8 +42,8 @@
 
 // Diff two counters, express them as signed, with range checks
 static ssize_t counter_diff(size_t c1, size_t c2) {
-  assert(c1 <= SSIZE_MAX, "counter out of range: " SIZE_FORMAT ".", c1);
-  assert(c2 <= SSIZE_MAX, "counter out of range: " SIZE_FORMAT ".", c2);
+  assert(c1 <= SSIZE_MAX, "counter out of range: %zu.", c1);
+  assert(c2 <= SSIZE_MAX, "counter out of range: %zu.", c2);
   if (c1 > SSIZE_MAX || c2 > SSIZE_MAX) {
     return 0;
   }
@@ -63,10 +63,10 @@ size_t MemReporterBase::committed_total(const MallocMemory* malloc, const Virtua
 
 void MemReporterBase::print_total(size_t reserved, size_t committed, size_t peak) const {
   const char* scale = current_scale();
-  output()->print("reserved=" SIZE_FORMAT "%s, committed=" SIZE_FORMAT "%s",
+  output()->print("reserved=%zu%s, committed=%zu%s",
     amount_in_current_scale(reserved), scale, amount_in_current_scale(committed), scale);
   if (peak != 0) {
-    output()->print(", peak=" SIZE_FORMAT "%s", amount_in_current_scale(peak), scale);
+    output()->print(", peak=%zu%s", amount_in_current_scale(peak), scale);
   }
 }
 
@@ -79,16 +79,16 @@ void MemReporterBase::print_malloc(const MemoryCounter* c, MemTag mem_tag) const
   const size_t count = c->count();
 
   if (mem_tag != mtNone) {
-    out->print("(%s" SIZE_FORMAT "%s type=%s", alloc_type,
+    out->print("(%s%zu%s type=%s", alloc_type,
       amount_in_current_scale(amount), scale, NMTUtil::tag_to_name(mem_tag));
   } else {
-    out->print("(%s" SIZE_FORMAT "%s", alloc_type,
+    out->print("(%s%zu%s", alloc_type,
       amount_in_current_scale(amount), scale);
   }
 
   // blends out mtChunk count number
   if (count > 0) {
-    out->print(" #" SIZE_FORMAT "", count);
+    out->print(" #%zu", count);
   }
 
   out->print(")");
@@ -98,7 +98,7 @@ void MemReporterBase::print_malloc(const MemoryCounter* c, MemTag mem_tag) const
     out->print_raw(" (at peak)");
   } else if (pk_amount > amount) {
     size_t pk_count = c->peak_count();
-    out->print(" (peak=" SIZE_FORMAT "%s #" SIZE_FORMAT ")",
+    out->print(" (peak=%zu%s #%zu)",
         amount_in_current_scale(pk_amount), scale, pk_count);
   }
 }
@@ -106,12 +106,12 @@ void MemReporterBase::print_malloc(const MemoryCounter* c, MemTag mem_tag) const
 void MemReporterBase::print_virtual_memory(size_t reserved, size_t committed, size_t peak) const {
   outputStream* out = output();
   const char* scale = current_scale();
-  out->print("(mmap: reserved=" SIZE_FORMAT "%s, committed=" SIZE_FORMAT "%s, ",
+  out->print("(mmap: reserved=%zu%s, committed=%zu%s, ",
     amount_in_current_scale(reserved), scale, amount_in_current_scale(committed), scale);
   if (peak == committed) {
     out->print_raw("at peak)");
   } else {
-    out->print("peak=" SIZE_FORMAT "%s)", amount_in_current_scale(peak), scale);
+    out->print("peak=%zu%s)", amount_in_current_scale(peak), scale);
   }
 }
 
@@ -122,7 +122,7 @@ void MemReporterBase::print_arena(const MemoryCounter* c) const {
   const size_t amount = c->size();
   const size_t count = c->count();
 
-  out->print("(arena=" SIZE_FORMAT "%s #" SIZE_FORMAT ")",
+  out->print("(arena=%zu%s #%zu)",
              amount_in_current_scale(amount), scale, count);
 
   size_t pk_amount = c->peak_size();
@@ -130,14 +130,14 @@ void MemReporterBase::print_arena(const MemoryCounter* c) const {
     out->print_raw(" (at peak)");
   } else if (pk_amount > amount) {
     size_t pk_count = c->peak_count();
-    out->print(" (peak=" SIZE_FORMAT "%s #" SIZE_FORMAT ")",
+    out->print(" (peak=%zu%s #%zu)",
         amount_in_current_scale(pk_amount), scale, pk_count);
   }
 }
 
 void MemReporterBase::print_virtual_memory_region(const char* type, address base, size_t size) const {
   const char* scale = current_scale();
-  output()->print("[" PTR_FORMAT " - " PTR_FORMAT "] %s " SIZE_FORMAT "%s",
+  output()->print("[" PTR_FORMAT " - " PTR_FORMAT "] %s %zu%s",
     p2i(base), p2i(base + size), type, amount_in_current_scale(size), scale);
 }
 
@@ -165,7 +165,7 @@ void MemSummaryReporter::report() {
   print_total(total_reserved_amount, total_committed_amount);
   out->cr();
   INDENT_BY(7,
-    out->print_cr("malloc: " SIZE_FORMAT "%s #" SIZE_FORMAT ", peak=" SIZE_FORMAT "%s #" SIZE_FORMAT,
+    out->print_cr("malloc: %zu%s #%zu, peak=%zu%s #%zu",
                   amount_in_current_scale(total_malloced_bytes), current_scale(),
                   _malloc_snapshot->total_count(),
                   amount_in_current_scale(_malloc_snapshot->total_peak()),
@@ -224,7 +224,7 @@ void MemSummaryReporter::report_summary_of_type(MemTag mem_tag,
 #if INCLUDE_CDS
   if (mem_tag == mtClassShared) {
       size_t read_only_bytes = FileMapInfo::readonly_total();
-    output()->print(", readonly=" SIZE_FORMAT "%s",
+    output()->print(", readonly=%zu%s",
                     amount_in_current_scale(read_only_bytes), scale);
   }
 #endif
@@ -234,14 +234,14 @@ void MemSummaryReporter::report_summary_of_type(MemTag mem_tag,
 
   if (mem_tag == mtClass) {
     // report class count
-    out->print_cr("(classes #" SIZE_FORMAT ")", (_instance_class_count + _array_class_count));
-    out->print_cr("(  instance classes #" SIZE_FORMAT ", array classes #" SIZE_FORMAT ")",
+    out->print_cr("(classes #%zu)", (_instance_class_count + _array_class_count));
+    out->print_cr("(  instance classes #%zu, array classes #%zu)",
                   _instance_class_count, _array_class_count);
   } else if (mem_tag == mtThread) {
     const VirtualMemory* thread_stack_usage =
      _vm_snapshot->by_type(mtThreadStack);
     // report thread count
-    out->print_cr("(threads #" SIZE_FORMAT ")", ThreadStackTracker::thread_count());
+    out->print_cr("(threads #%zu)", ThreadStackTracker::thread_count());
     out->print("(stack: ");
     print_total(thread_stack_usage->reserved(), thread_stack_usage->committed(), thread_stack_usage->peak_size());
     out->print_cr(")");
@@ -265,7 +265,7 @@ void MemSummaryReporter::report_summary_of_type(MemTag mem_tag,
 
   if (mem_tag == mtNMT &&
     amount_in_current_scale(_malloc_snapshot->malloc_overhead()) > 0) {
-    out->print_cr("(tracking overhead=" SIZE_FORMAT "%s)",
+    out->print_cr("(tracking overhead=%zu%s)",
                    amount_in_current_scale(_malloc_snapshot->malloc_overhead()), scale);
   } else if (mem_tag == mtClass) {
     // Metadata information
@@ -301,8 +301,8 @@ void MemSummaryReporter::report_metadata(Metaspace::MetadataType type) const {
   out->print("(    ");
   print_total(stats.reserved(), stats.committed());
   out->print_cr(")");
-  out->print_cr("(    used=" SIZE_FORMAT "%s)", amount_in_current_scale(stats.used()), scale);
-  out->print_cr("(    waste=" SIZE_FORMAT "%s =%2.2f%%)", amount_in_current_scale(waste),
+  out->print_cr("(    used=%zu%s)", amount_in_current_scale(stats.used()), scale);
+  out->print_cr("(    waste=%zu%s =%2.2f%%)", amount_in_current_scale(waste),
                 scale, waste_percentage);
 }
 
@@ -540,7 +540,7 @@ void MemSummaryDiffReporter::print_malloc_diff(size_t current_amount, size_t cur
   outputStream* out = output();
   const char* alloc_tag = (mem_tag == mtThread) ? "" : "malloc=";
 
-  out->print("%s" SIZE_FORMAT "%s", alloc_tag, amount_in_current_scale(current_amount), scale);
+  out->print("%s%zu%s", alloc_tag, amount_in_current_scale(current_amount), scale);
   // Report type only if it is valid and not under "thread" category
   if (mem_tag != mtNone && mem_tag != mtThread) {
     out->print(" type=%s", NMTUtil::tag_to_name(mem_tag));
@@ -551,7 +551,7 @@ void MemSummaryDiffReporter::print_malloc_diff(size_t current_amount, size_t cur
     out->print(" " INT64_PLUS_FORMAT "%s", amount_diff, scale);
   }
   if (current_count > 0) {
-    out->print(" #" SIZE_FORMAT "", current_count);
+    out->print(" #%zu", current_count);
     const ssize_t delta_count = counter_diff(current_count, early_count);
     if (delta_count != 0) {
       out->print(" %+zd", delta_count);
@@ -563,13 +563,13 @@ void MemSummaryDiffReporter::print_arena_diff(size_t current_amount, size_t curr
   size_t early_amount, size_t early_count) const {
   const char* scale = current_scale();
   outputStream* out = output();
-  out->print("arena=" SIZE_FORMAT "%s", amount_in_current_scale(current_amount), scale);
+  out->print("arena=%zu%s", amount_in_current_scale(current_amount), scale);
   int64_t amount_diff = diff_in_current_scale(current_amount, early_amount);
   if (amount_diff != 0) {
     out->print(" " INT64_PLUS_FORMAT "%s", amount_diff, scale);
   }
 
-  out->print(" #" SIZE_FORMAT "", current_count);
+  out->print(" #%zu", current_count);
   const ssize_t delta_count = counter_diff(current_count, early_count);
   if (delta_count != 0) {
     out->print(" %+zd", delta_count);
@@ -580,13 +580,13 @@ void MemSummaryDiffReporter::print_virtual_memory_diff(size_t current_reserved, 
     size_t early_reserved, size_t early_committed) const {
   const char* scale = current_scale();
   outputStream* out = output();
-  out->print("reserved=" SIZE_FORMAT "%s", amount_in_current_scale(current_reserved), scale);
+  out->print("reserved=%zu%s", amount_in_current_scale(current_reserved), scale);
   int64_t reserved_diff = diff_in_current_scale(current_reserved, early_reserved);
   if (reserved_diff != 0) {
     out->print(" " INT64_PLUS_FORMAT "%s", reserved_diff, scale);
   }
 
-  out->print(", committed=" SIZE_FORMAT "%s", amount_in_current_scale(current_committed), scale);
+  out->print(", committed=%zu%s", amount_in_current_scale(current_committed), scale);
   int64_t committed_diff = diff_in_current_scale(current_committed, early_committed);
   if (committed_diff != 0) {
     out->print(" " INT64_PLUS_FORMAT "%s", committed_diff, scale);
@@ -646,7 +646,7 @@ void MemSummaryDiffReporter::diff_summary_of_type(MemTag mem_tag,
     // detail lines
     if (mem_tag == mtClass) {
       // report class count
-      out->print("(classes #" SIZE_FORMAT, _current_baseline.class_count());
+      out->print("(classes #%zu", _current_baseline.class_count());
       const ssize_t class_count_diff =
           counter_diff(_current_baseline.class_count(), _early_baseline.class_count());
       if (class_count_diff != 0) {
@@ -654,13 +654,13 @@ void MemSummaryDiffReporter::diff_summary_of_type(MemTag mem_tag,
       }
       out->print_cr(")");
 
-      out->print("(  instance classes #" SIZE_FORMAT, _current_baseline.instance_class_count());
+      out->print("(  instance classes #%zu", _current_baseline.instance_class_count());
       const ssize_t instance_class_count_diff =
           counter_diff(_current_baseline.instance_class_count(), _early_baseline.instance_class_count());
       if (instance_class_count_diff != 0) {
         out->print(" %+zd", instance_class_count_diff);
       }
-      out->print(", array classes #" SIZE_FORMAT, _current_baseline.array_class_count());
+      out->print(", array classes #%zu", _current_baseline.array_class_count());
       const ssize_t array_class_count_diff =
           counter_diff(_current_baseline.array_class_count(), _early_baseline.array_class_count());
       if (array_class_count_diff != 0) {
@@ -670,7 +670,7 @@ void MemSummaryDiffReporter::diff_summary_of_type(MemTag mem_tag,
 
     } else if (mem_tag == mtThread) {
       // report thread count
-      out->print("(threads #" SIZE_FORMAT, _current_baseline.thread_count());
+      out->print("(threads #%zu", _current_baseline.thread_count());
       const ssize_t thread_count_diff = counter_diff(_current_baseline.thread_count(), _early_baseline.thread_count());
       if (thread_count_diff != 0) {
         out->print(" %+zd", thread_count_diff);
@@ -724,7 +724,7 @@ void MemSummaryDiffReporter::diff_summary_of_type(MemTag mem_tag,
       size_t current_tracking_overhead = amount_in_current_scale(_current_baseline.malloc_tracking_overhead());
       size_t early_tracking_overhead   = amount_in_current_scale(_early_baseline.malloc_tracking_overhead());
 
-      out->print("(tracking overhead=" SIZE_FORMAT "%s",
+      out->print("(tracking overhead=%zu%s",
                  amount_in_current_scale(_current_baseline.malloc_tracking_overhead()), scale);
 
       int64_t overhead_diff = diff_in_current_scale(_current_baseline.malloc_tracking_overhead(),
@@ -770,7 +770,7 @@ void MemSummaryDiffReporter::print_metaspace_diff(const char* header,
   int64_t diff_waste = diff_in_current_scale(current_waste, early_waste);
 
   // Diff used
-  out->print("(    used=" SIZE_FORMAT "%s",
+  out->print("(    used=%zu%s",
              amount_in_current_scale(current_stats.used()), scale);
   if (diff_used != 0) {
     out->print(" " INT64_PLUS_FORMAT "%s", diff_used, scale);
@@ -780,7 +780,7 @@ void MemSummaryDiffReporter::print_metaspace_diff(const char* header,
   // Diff waste
   const float waste_percentage = current_stats.committed() == 0 ? 0.0f :
                                  ((float)current_waste * 100.0f) / (float)current_stats.committed();
-  out->print("(    waste=" SIZE_FORMAT "%s =%2.2f%%",
+  out->print("(    waste=%zu%s =%2.2f%%",
              amount_in_current_scale(current_waste), scale, waste_percentage);
   if (diff_waste != 0) {
     out->print(" " INT64_PLUS_FORMAT "%s", diff_waste, scale);

--- a/src/hotspot/share/nmt/memoryFileTracker.cpp
+++ b/src/hotspot/share/nmt/memoryFileTracker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ void MemoryFileTracker::print_report_on(const MemoryFile* file, outputStream* st
     if (prev->val().out.type() == VMATree::StateType::Committed) {
       const VMATree::position& start_addr = prev->key();
       const VMATree::position& end_addr = current->key();
-      stream->print_cr("[" PTR_FORMAT " - " PTR_FORMAT "] allocated " SIZE_FORMAT "%s" " for %s from",
+      stream->print_cr("[" PTR_FORMAT " - " PTR_FORMAT "] allocated %zu%s" " for %s from",
                        start_addr, end_addr,
                        NMTUtil::amount_in_scale(end_addr - start_addr, scale),
                        NMTUtil::scale_name(scale),

--- a/src/hotspot/share/nmt/nmtPreInit.cpp
+++ b/src/hotspot/share/nmt/nmtPreInit.cpp
@@ -132,7 +132,7 @@ void NMTPreInitAllocationTable::print_state(outputStream* st) const {
     num_entries += chain_len;
     longest_chain = MAX2(chain_len, longest_chain);
   }
-  st->print("entries: %d (primary: %d, empties: %d), sum bytes: " SIZE_FORMAT
+  st->print("entries: %d (primary: %d, empties: %d), sum bytes: %zu"
             ", longest chain length: %d",
             num_entries, num_primary_entries, table_size - num_primary_entries,
             sum_bytes, longest_chain);
@@ -143,7 +143,7 @@ void NMTPreInitAllocationTable::print_map(outputStream* st) const {
   for (int i = 0; i < table_size; i++) {
     st->print("[%d]: ", i);
     for (NMTPreInitAllocation* a = _entries[i]; a != nullptr; a = a->next) {
-      st->print( PTR_FORMAT "(" SIZE_FORMAT ") ", p2i(a->payload), a->size);
+      st->print( PTR_FORMAT "(%zu) ", p2i(a->payload), a->size);
     }
     st->cr();
   }

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -341,7 +341,7 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
   ReservedMemoryRegion  rgn(base_addr, size, stack, mem_tag);
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
 
-  log_debug(nmt)("Add reserved region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+  log_debug(nmt)("Add reserved region \'%s\' (" INTPTR_FORMAT ", %zu)",
                 rgn.mem_tag_name(), p2i(rgn.base()), rgn.size());
   if (reserved_rgn == nullptr) {
     VirtualMemorySummary::record_reserved_memory(size, mem_tag);
@@ -381,7 +381,7 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
       // CDS reserves the whole region for mapping CDS archive, then maps each section into the region.
       // NMT reports CDS as a whole.
       if (reserved_rgn->mem_tag() == mtClassShared) {
-        log_debug(nmt)("CDS reserved region \'%s\' as a whole (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+        log_debug(nmt)("CDS reserved region \'%s\' as a whole (" INTPTR_FORMAT ", %zu)",
                       reserved_rgn->mem_tag_name(), p2i(reserved_rgn->base()), reserved_rgn->size());
         assert(reserved_rgn->contain_region(base_addr, size), "Reserved CDS region should contain this mapping region");
         return true;
@@ -390,7 +390,7 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
       // Mapped CDS string region.
       // The string region(s) is part of the java heap.
       if (reserved_rgn->mem_tag() == mtJavaHeap) {
-        log_debug(nmt)("CDS reserved region \'%s\' as a whole (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+        log_debug(nmt)("CDS reserved region \'%s\' as a whole (" INTPTR_FORMAT ", %zu)",
                       reserved_rgn->mem_tag_name(), p2i(reserved_rgn->base()), reserved_rgn->size());
         assert(reserved_rgn->contain_region(base_addr, size), "Reserved heap region should contain this mapping region");
         return true;
@@ -439,13 +439,13 @@ bool VirtualMemoryTracker::add_committed_region(address addr, size_t size,
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
 
   if (reserved_rgn == nullptr) {
-    log_debug(nmt)("Add committed region \'%s\', No reserved region found for  (" INTPTR_FORMAT ", " SIZE_FORMAT ")",
+    log_debug(nmt)("Add committed region \'%s\', No reserved region found for  (" INTPTR_FORMAT ", %zu)",
                   rgn.mem_tag_name(),  p2i(rgn.base()), rgn.size());
   }
   assert(reserved_rgn != nullptr, "Add committed region, No reserved region found");
   assert(reserved_rgn->contain_region(addr, size), "Not completely contained");
   bool result = reserved_rgn->add_committed_region(addr, size, stack);
-  log_debug(nmt)("Add committed region \'%s\'(" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
+  log_debug(nmt)("Add committed region \'%s\'(" INTPTR_FORMAT ", %zu) %s",
                 reserved_rgn->mem_tag_name(),  p2i(rgn.base()), rgn.size(), (result ? "Succeeded" : "Failed"));
   return result;
 }
@@ -457,11 +457,11 @@ bool VirtualMemoryTracker::remove_uncommitted_region(address addr, size_t size) 
 
   ReservedMemoryRegion  rgn(addr, size);
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
-  assert(reserved_rgn != nullptr, "No reserved region (" INTPTR_FORMAT ", " SIZE_FORMAT ")", p2i(addr), size);
+  assert(reserved_rgn != nullptr, "No reserved region (" INTPTR_FORMAT ", %zu)", p2i(addr), size);
   assert(reserved_rgn->contain_region(addr, size), "Not completely contained");
   const char* type_name = reserved_rgn->mem_tag_name();  // after remove, info is not complete
   bool result = reserved_rgn->remove_uncommitted_region(addr, size);
-  log_debug(nmt)("Removed uncommitted region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
+  log_debug(nmt)("Removed uncommitted region \'%s\' (" INTPTR_FORMAT ", %zu) %s",
                  type_name,  p2i(addr), size, (result ? " Succeeded" : "Failed"));
   return result;
 }
@@ -473,7 +473,7 @@ bool VirtualMemoryTracker::remove_released_region(ReservedMemoryRegion* rgn) {
   // uncommit regions within the released region
   ReservedMemoryRegion backup(*rgn);
   bool result = rgn->remove_uncommitted_region(rgn->base(), rgn->size());
-  log_debug(nmt)("Remove uncommitted region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") %s",
+  log_debug(nmt)("Remove uncommitted region \'%s\' (" INTPTR_FORMAT ", %zu) %s",
                 backup.mem_tag_name(), p2i(backup.base()), backup.size(), (result ? "Succeeded" : "Failed"));
   if (!result) {
     return false;
@@ -481,7 +481,7 @@ bool VirtualMemoryTracker::remove_released_region(ReservedMemoryRegion* rgn) {
 
   VirtualMemorySummary::record_released_memory(rgn->size(), rgn->mem_tag());
   result =  _reserved_regions->remove(*rgn);
-  log_debug(nmt)("Removed region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ") from _reserved_regions %s" ,
+  log_debug(nmt)("Removed region \'%s\' (" INTPTR_FORMAT ", %zu) from _reserved_regions %s" ,
                 backup.mem_tag_name(), p2i(backup.base()), backup.size(), (result ? "Succeeded" : "Failed"));
   return result;
 }
@@ -495,7 +495,7 @@ bool VirtualMemoryTracker::remove_released_region(address addr, size_t size) {
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
 
   if (reserved_rgn == nullptr) {
-    log_debug(nmt)("No reserved region found for (" INTPTR_FORMAT ", " SIZE_FORMAT ")!",
+    log_debug(nmt)("No reserved region found for (" INTPTR_FORMAT ", %zu)!",
                   p2i(rgn.base()), rgn.size());
   }
   assert(reserved_rgn != nullptr, "No reserved region");
@@ -571,7 +571,7 @@ bool VirtualMemoryTracker::split_reserved_region(address addr, size_t size, size
 
   const char* name = reserved_rgn->mem_tag_name();
   remove_released_region(reserved_rgn);
-  log_debug(nmt)("Split region \'%s\' (" INTPTR_FORMAT ", " SIZE_FORMAT ")  with size " SIZE_FORMAT,
+  log_debug(nmt)("Split region \'%s\' (" INTPTR_FORMAT ", %zu)  with size %zu",
                 name, p2i(rgn.base()), rgn.size(), split);
   // Now, create two new regions.
   add_reserved_region(addr, split, original_stack, mem_tag);

--- a/src/hotspot/share/nmt/vmatree.cpp
+++ b/src/hotspot/share/nmt/vmatree.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -220,7 +220,7 @@ VMATree::SummaryDiff VMATree::register_mapping(position A, position B, StateType
 #ifdef ASSERT
 void VMATree::print_on(outputStream* out) {
   visit_in_order([&](TreapNode* current) {
-    out->print(SIZE_FORMAT " (%s) - %s - ", current->key(), NMTUtil::tag_to_name(out_state(current).mem_tag()),
+    out->print("%zu (%s) - %s - ", current->key(), NMTUtil::tag_to_name(out_state(current).mem_tag()),
                statetype_to_string(out_state(current).type()));
   });
   out->cr();

--- a/src/hotspot/share/oops/array.hpp
+++ b/src/hotspot/share/oops/array.hpp
@@ -74,7 +74,7 @@ protected:
     assert(is_aligned(left, sizeof(T)), "Must be");
 
     size_t elements = left / sizeof(T);
-    assert(elements <= (size_t)INT_MAX, "number of elements %zudoesn't fit into an int.", elements);
+    assert(elements <= (size_t)INT_MAX, "number of elements %zu doesn't fit into an int.", elements);
 
     int length = (int)elements;
 

--- a/src/hotspot/share/oops/array.hpp
+++ b/src/hotspot/share/oops/array.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,12 +74,12 @@ protected:
     assert(is_aligned(left, sizeof(T)), "Must be");
 
     size_t elements = left / sizeof(T);
-    assert(elements <= (size_t)INT_MAX, "number of elements " SIZE_FORMAT "doesn't fit into an int.", elements);
+    assert(elements <= (size_t)INT_MAX, "number of elements %zudoesn't fit into an int.", elements);
 
     int length = (int)elements;
 
     assert((size_t)size(length) * BytesPerWord == (size_t)bytes,
-           "Expected: " SIZE_FORMAT " got: " SIZE_FORMAT,
+           "Expected: %zu got: %zu",
            bytes, (size_t)size(length) * BytesPerWord);
 
     return length;
@@ -135,7 +135,7 @@ protected:
     size_t bytes = align_up(byte_sizeof(length), BytesPerWord);
     size_t words = bytes / BytesPerWord;
 
-    assert(words <= INT_MAX, "Overflow: " SIZE_FORMAT, words);
+    assert(words <= INT_MAX, "Overflow: %zu", words);
 
     return (int)words;
   }

--- a/src/hotspot/share/oops/compressedOops.cpp
+++ b/src/hotspot/share/oops/compressedOops.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,7 +161,7 @@ bool CompressedOops::base_overlaps() {
 }
 
 void CompressedOops::print_mode(outputStream* st) {
-  st->print("Heap address: " PTR_FORMAT ", size: " SIZE_FORMAT " MB",
+  st->print("Heap address: " PTR_FORMAT ", size: %zu MB",
             p2i(_heap_address_range.start()), _heap_address_range.byte_size()/M);
 
   st->print(", Compressed Oops mode: %s", mode_to_string(mode()));

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3806,7 +3806,7 @@ void InstanceKlass::oop_print_on(oop obj, outputStream* st) {
     }
   }
 
-  st->print_cr(BULLET"---- fields (total size " SIZE_FORMAT " words):", oop_size(obj));
+  st->print_cr(BULLET"---- fields (total size %zu words):", oop_size(obj));
   FieldPrinter print_field(st, obj);
   print_nonstatic_fields(&print_field);
 

--- a/src/hotspot/share/oops/instanceMirrorKlass.cpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ size_t InstanceMirrorKlass::instance_size(Klass* k) {
 instanceOop InstanceMirrorKlass::allocate_instance(Klass* k, TRAPS) {
   // Query before forming handle.
   size_t size = instance_size(k);
-  assert(size > 0, "total object size must be non-zero: " SIZE_FORMAT, size);
+  assert(size > 0, "total object size must be non-zero: %zu", size);
 
   // Since mirrors can be variable sized because of the static fields, store
   // the size in the mirror itself.

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -220,8 +220,8 @@ size_t oopDesc::size_given_klass(Klass* klass)  {
     }
   }
 
-  assert(s > 0, "Oop size must be greater than zero, not " SIZE_FORMAT, s);
-  assert(is_object_aligned(s), "Oop size is not properly aligned: " SIZE_FORMAT, s);
+  assert(s > 0, "Oop size must be greater than zero, not %zu", s);
+  assert(is_object_aligned(s), "Oop size is not properly aligned: %zu", s);
   return s;
 }
 

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -497,7 +497,7 @@ public:
     assert(obj == nullptr || dbg_is_good_oop(obj), "p: " PTR_FORMAT " obj: " PTR_FORMAT, p2i(p), p2i(obj));
     if (_chunk->has_bitmap()) {
       BitMap::idx_t index = _chunk->bit_index_for(p);
-      assert(_chunk->bitmap().at(index), "Bit not set at index " SIZE_FORMAT " corresponding to " PTR_FORMAT, index, p2i(p));
+      assert(_chunk->bitmap().at(index), "Bit not set at index %zu corresponding to " PTR_FORMAT, index, p2i(p));
     }
   }
 
@@ -582,7 +582,7 @@ public:
 
     oop obj = _chunk->load_oop(p);
     assert(obj == nullptr || dbg_is_good_oop(obj),
-           "p: " PTR_FORMAT " obj: " PTR_FORMAT " index: " SIZE_FORMAT,
+           "p: " PTR_FORMAT " obj: " PTR_FORMAT " index: %zu",
            p2i(p), p2i((oopDesc*)obj), index);
 
     return true; // continue processing

--- a/src/hotspot/share/prims/jvmtiEnter.xsl
+++ b/src/hotspot/share/prims/jvmtiEnter.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -1244,7 +1244,7 @@ static jvmtiError JNICALL
   <xsl:param name="name"/>
   <xsl:text> </xsl:text>
   <xsl:value-of select="$name"/>
-  <xsl:text>=" SIZE_FORMAT_X "</xsl:text>
+  <xsl:text>=0x%zx</xsl:text>
 </xsl:template>
 
 <xsl:template match="jfloat|jdouble" mode="traceInFormat">

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,7 @@ volatile size_t          _items_count           = 0;
 
 void ResolvedMethodTable::create_table() {
   _local_table  = new ResolvedMethodTableHash(ResolvedMethodTableSizeLog, END_SIZE, GROW_HINT);
-  log_trace(membername, table)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
+  log_trace(membername, table)("Start size: %zu (%zu)",
                                _current_size, ResolvedMethodTableSizeLog);
   _oop_storage = OopStorageSet::create_weak("ResolvedMethodTable Weak", mtClass);
   _oop_storage->register_num_dead_callback(&gc_notification);
@@ -231,7 +231,7 @@ static const double PREF_AVG_LIST_LEN = 2.0;
 static const double CLEAN_DEAD_HIGH_WATER_MARK = 0.5;
 
 void ResolvedMethodTable::gc_notification(size_t num_dead) {
-  log_trace(membername, table)("Uncleaned items:" SIZE_FORMAT, num_dead);
+  log_trace(membername, table)("Uncleaned items:%zu", num_dead);
 
   if (has_work()) {
     return;
@@ -291,7 +291,7 @@ void ResolvedMethodTable::grow(JavaThread* jt) {
   }
   gt.done(jt);
   _current_size = table_size();
-  log_info(membername, table)("Grown to size:" SIZE_FORMAT, _current_size);
+  log_info(membername, table)("Grown to size:%zu", _current_size);
 }
 
 struct ResolvedMethodTableDoDelete : StackObj {

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -288,8 +288,8 @@ WB_ENTRY(jlong, WB_GetCompressedOopsMaxHeapSize(JNIEnv* env, jobject o)) {
 WB_END
 
 WB_ENTRY(void, WB_PrintHeapSizes(JNIEnv* env, jobject o)) {
-  tty->print_cr("Minimum heap " SIZE_FORMAT " Initial heap " SIZE_FORMAT " "
-                "Maximum heap " SIZE_FORMAT " Space alignment " SIZE_FORMAT " Heap alignment " SIZE_FORMAT,
+  tty->print_cr("Minimum heap %zu Initial heap %zu "
+                "Maximum heap %zu Space alignment %zu Heap alignment %zu",
                 MinHeapSize,
                 InitialHeapSize,
                 MaxHeapSize,

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1532,8 +1532,8 @@ void Arguments::set_heap_size() {
       if (!FLAG_IS_DEFAULT(HeapBaseMinAddress)) {
         if (HeapBaseMinAddress < DefaultHeapBaseMinAddress) {
           // matches compressed oops printing flags
-          log_debug(gc, heap, coops)("HeapBaseMinAddress must be at least " SIZE_FORMAT
-                                     " (" SIZE_FORMAT "G) which is greater than value given " SIZE_FORMAT,
+          log_debug(gc, heap, coops)("HeapBaseMinAddress must be at least %zu"
+                                     " (%zuG) which is greater than value given %zu",
                                      DefaultHeapBaseMinAddress,
                                      DefaultHeapBaseMinAddress/G,
                                      HeapBaseMinAddress);
@@ -1558,7 +1558,7 @@ void Arguments::set_heap_size() {
       if (reasonable_max > max_coop_heap) {
         if (FLAG_IS_ERGO(UseCompressedOops) && override_coop_limit) {
           log_info(cds)("UseCompressedOops and UseCompressedClassPointers have been disabled due to"
-            " max heap " SIZE_FORMAT " > compressed oop heap " SIZE_FORMAT ". "
+            " max heap %zu > compressed oop heap %zu. "
             "Please check the setting of MaxRAMPercentage %5.2f."
             ,(size_t)reasonable_max, (size_t)max_coop_heap, MaxRAMPercentage);
           FLAG_SET_ERGO(UseCompressedOops, false);
@@ -1569,7 +1569,7 @@ void Arguments::set_heap_size() {
     }
 #endif // _LP64
 
-    log_trace(gc, heap)("  Maximum heap size " SIZE_FORMAT, (size_t) reasonable_max);
+    log_trace(gc, heap)("  Maximum heap size %zu", (size_t) reasonable_max);
     FLAG_SET_ERGO(MaxHeapSize, (size_t)reasonable_max);
   }
 
@@ -1590,13 +1590,13 @@ void Arguments::set_heap_size() {
       reasonable_initial = MIN2(reasonable_initial, (julong)MaxHeapSize);
 
       FLAG_SET_ERGO(InitialHeapSize, (size_t)reasonable_initial);
-      log_trace(gc, heap)("  Initial heap size " SIZE_FORMAT, InitialHeapSize);
+      log_trace(gc, heap)("  Initial heap size %zu", InitialHeapSize);
     }
     // If the minimum heap size has not been set (via -Xms or -XX:MinHeapSize),
     // synchronize with InitialHeapSize to avoid errors with the default value.
     if (MinHeapSize == 0) {
       FLAG_SET_ERGO(MinHeapSize, MIN2((size_t)reasonable_minimum, InitialHeapSize));
-      log_trace(gc, heap)("  Minimum heap size " SIZE_FORMAT, MinHeapSize);
+      log_trace(gc, heap)("  Minimum heap size %zu", MinHeapSize);
     }
   }
 }
@@ -1785,7 +1785,7 @@ bool Arguments::check_vm_args_consistency() {
   if (TLABRefillWasteFraction == 0) {
     jio_fprintf(defaultStream::error_stream(),
                 "TLABRefillWasteFraction should be a denominator, "
-                "not " SIZE_FORMAT "\n",
+                "not %zu\n",
                 TLABRefillWasteFraction);
     status = false;
   }

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -320,7 +320,7 @@ static void print_objects(JavaThread* deoptee_thread,
 
     st.print("     object <" INTPTR_FORMAT "> of type ", p2i(sv->value()()));
     k->print_value_on(&st);
-    st.print_cr(" allocated (" SIZE_FORMAT " bytes)", obj->size() * HeapWordSize);
+    st.print_cr(" allocated (%zu bytes)", obj->size() * HeapWordSize);
 
     if (Verbose && k != nullptr) {
       k->oop_print_on(obj(), &st);

--- a/src/hotspot/share/runtime/flags/jvmFlag.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlag.cpp
@@ -215,7 +215,7 @@ void JVMFlag::print_on(outputStream* st, bool withComments, bool printRanges) co
     } else if (is_uint64_t()) {
       st->print(UINT64_FORMAT, get_uint64_t());
     } else if (is_size_t()) {
-      st->print(SIZE_FORMAT, get_size_t());
+      st->print("%zu", get_size_t());
     } else if (is_double()) {
       st->print("%f", get_double());
     } else if (is_ccstr()) {

--- a/src/hotspot/share/runtime/flags/jvmFlag.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlag.cpp
@@ -417,7 +417,7 @@ void JVMFlag::print_as_flag(outputStream* st) const {
   } else if (is_uint64_t()) {
     st->print("-XX:%s=" UINT64_FORMAT, _name, get_uint64_t());
   } else if (is_size_t()) {
-    st->print("-XX:%s=" SIZE_FORMAT, _name, get_size_t());
+    st->print("-XX:%s=%zu", _name, get_size_t());
   } else if (is_double()) {
     st->print("-XX:%s=%f", _name, get_double());
   } else if (is_ccstr()) {

--- a/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
@@ -244,8 +244,8 @@ class FlagAccessImpl_size_t : public RangedFlagAccessImpl<size_t, EventUnsignedL
 public:
   void range_error(const char* name, size_t value, size_t min, size_t max, bool verbose) const {
     JVMFlag::printError(verbose,
-                        "size_t %s=" SIZE_FORMAT " is outside the allowed range "
-                        "[ " SIZE_FORMAT " ... " SIZE_FORMAT " ]\n",
+                        "size_t %s=%zu is outside the allowed range "
+                        "[ %zu ... %zu ]\n",
                         name, value, min, max);
   }
   JVMFlag::Error typed_check_constraint(void* func, size_t value, bool verbose) const {

--- a/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
@@ -252,10 +252,10 @@ public:
     return ((JVMFlagConstraintFunc_size_t)func)(value, verbose);
   }
   void print_range_impl(outputStream* st, size_t min, size_t max) const {
-    st->print("[ " SIZE_FORMAT_W(-25) " ... " SIZE_FORMAT_W(25) " ]", min, max);
+    st->print("[ %-25zu ... %25zu ]", min, max);
   }
   void print_default_range(outputStream* st) const {
-    st->print("[ " SIZE_FORMAT_W(-25) " ... " SIZE_FORMAT_W(25) " ]", size_t(0), size_t(SIZE_MAX));
+    st->print("[ %-25zu ... %25zu ]", size_t(0), size_t(SIZE_MAX));
   }
 };
 

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -169,7 +169,7 @@ JVMFlag::Error CodeCacheSegmentSizeConstraintFunc(uintx value, bool verbose) {
   if (CodeCacheSegmentSize < sizeof(jdouble)) {
     JVMFlag::printError(verbose,
                         "CodeCacheSegmentSize  (%zu) must be "
-                        "at least " SIZE_FORMAT " to align constants\n",
+                        "at least %zu to align constants\n",
                         CodeCacheSegmentSize, sizeof(jdouble));
     return JVMFlag::VIOLATES_CONSTRAINT;
   }

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
@@ -59,7 +59,7 @@ JVMFlag::Error ObjectAlignmentInBytesConstraintFunc(int value, bool verbose) {
   if (value >= (intx)os::vm_page_size()) {
     JVMFlag::printError(verbose,
                         "ObjectAlignmentInBytes (%d) must be "
-                        "less than page size (" SIZE_FORMAT ")\n",
+                        "less than page size (%zu)\n",
                         value, os::vm_page_size());
     return JVMFlag::VIOLATES_CONSTRAINT;
   }

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -519,7 +519,7 @@ void before_exit(JavaThread* thread, bool halt) {
   if (VerifyStringTableAtExit) {
     size_t fail_cnt = StringTable::verify_and_compare_entries();
     if (fail_cnt != 0) {
-      tty->print_cr("ERROR: fail_cnt=" SIZE_FORMAT, fail_cnt);
+      tty->print_cr("ERROR: fail_cnt=%zu", fail_cnt);
       guarantee(fail_cnt == 0, "unexpected StringTable verification failures");
     }
   }

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -251,7 +251,7 @@ bool JNIHandles::is_weak_global_handle(jobject handle) {
 void JNIHandles::print_on(outputStream* st) {
   assert(SafepointSynchronize::is_at_safepoint(), "must be at safepoint");
 
-  st->print_cr("JNI global refs: " SIZE_FORMAT ", weak refs: " SIZE_FORMAT,
+  st->print_cr("JNI global refs: %zu, weak refs: %zu",
                global_handles()->allocation_count(),
                weak_global_handles()->allocation_count());
   st->cr();

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1185,9 +1185,9 @@ void os::print_summary_info(outputStream* st, char* buf, size_t buflen) {
   size_t mem = physical_memory()/G;
   if (mem == 0) {  // for low memory systems
     mem = physical_memory()/M;
-    st->print("%d cores, " SIZE_FORMAT "M, ", processor_count(), mem);
+    st->print("%d cores, %zuM, ", processor_count(), mem);
   } else {
-    st->print("%d cores, " SIZE_FORMAT "G, ", processor_count(), mem);
+    st->print("%d cores, %zuG, ", processor_count(), mem);
   }
   get_summary_os_info(buf, buflen);
   st->print_raw(buf);
@@ -1822,11 +1822,11 @@ void os::trace_page_sizes(const char* str,
                           const size_t page_size) {
 
   log_info(pagesize)("%s: "
-                     " min=" SIZE_FORMAT "%s"
-                     " max=" SIZE_FORMAT "%s"
+                     " min=%zu%s"
+                     " max=%zu%s"
                      " base=" PTR_FORMAT
-                     " size=" SIZE_FORMAT "%s"
-                     " page_size=" SIZE_FORMAT "%s",
+                     " size=%zu%s"
+                     " page_size=%zu%s",
                      str,
                      trace_page_size_params(region_min_size),
                      trace_page_size_params(region_max_size),
@@ -1843,11 +1843,11 @@ void os::trace_page_sizes_for_requested_size(const char* str,
                                              const size_t page_size) {
 
   log_info(pagesize)("%s:"
-                     " req_size=" SIZE_FORMAT "%s"
-                     " req_page_size=" SIZE_FORMAT "%s"
+                     " req_size=%zu%s"
+                     " req_page_size=%zu%s"
                      " base=" PTR_FORMAT
-                     " size=" SIZE_FORMAT "%s"
-                     " page_size=" SIZE_FORMAT "%s",
+                     " size=%zu%s"
+                     " page_size=%zu%s",
                      str,
                      trace_page_size_params(requested_size),
                      trace_page_size_params(requested_page_size),
@@ -1989,7 +1989,7 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
   // we attempt to minimize fragmentation.
   constexpr unsigned total_shuffle_threshold = 1024;
 
-#define ARGSFMT "range [" PTR_FORMAT "-" PTR_FORMAT "), size " SIZE_FORMAT_X ", alignment " SIZE_FORMAT_X ", randomize: %d"
+#define ARGSFMT "range [" PTR_FORMAT "-" PTR_FORMAT "), size 0x%zx, alignment 0x%zx, randomize: %d"
 #define ARGSFMTARGS p2i(min), p2i(max), bytes, alignment, randomize
 
   log_debug(os, map) ("reserve_between (" ARGSFMT ")", ARGSFMTARGS);
@@ -2376,17 +2376,17 @@ void os::naked_sleep(jlong millis) {
 ////// Implementation of PageSizes
 
 void os::PageSizes::add(size_t page_size) {
-  assert(is_power_of_2(page_size), "page_size must be a power of 2: " SIZE_FORMAT_X, page_size);
+  assert(is_power_of_2(page_size), "page_size must be a power of 2: 0x%zx", page_size);
   _v |= page_size;
 }
 
 bool os::PageSizes::contains(size_t page_size) const {
-  assert(is_power_of_2(page_size), "page_size must be a power of 2: " SIZE_FORMAT_X, page_size);
+  assert(is_power_of_2(page_size), "page_size must be a power of 2: 0x%zx", page_size);
   return (_v & page_size) != 0;
 }
 
 size_t os::PageSizes::next_smaller(size_t page_size) const {
-  assert(is_power_of_2(page_size), "page_size must be a power of 2: " SIZE_FORMAT_X, page_size);
+  assert(is_power_of_2(page_size), "page_size must be a power of 2: 0x%zx", page_size);
   size_t v2 = _v & (page_size - 1);
   if (v2 == 0) {
     return 0;
@@ -2395,7 +2395,7 @@ size_t os::PageSizes::next_smaller(size_t page_size) const {
 }
 
 size_t os::PageSizes::next_larger(size_t page_size) const {
-  assert(is_power_of_2(page_size), "page_size must be a power of 2: " SIZE_FORMAT_X, page_size);
+  assert(is_power_of_2(page_size), "page_size must be a power of 2: 0x%zx", page_size);
   if (page_size == max_power_of_2<size_t>()) { // Shift by 32/64 would be UB
     return 0;
   }
@@ -2430,11 +2430,11 @@ void os::PageSizes::print_on(outputStream* st) const {
       st->print_raw(", ");
     }
     if (sz < M) {
-      st->print(SIZE_FORMAT "k", sz / K);
+      st->print("%zuk", sz / K);
     } else if (sz < G) {
-      st->print(SIZE_FORMAT "M", sz / M);
+      st->print("%zuM", sz / M);
     } else {
-      st->print(SIZE_FORMAT "G", sz / G);
+      st->print("%zuG", sz / G);
     }
   }
   if (first) {
@@ -2468,7 +2468,7 @@ jint os::set_minimum_stack_sizes() {
     // ThreadStackSize so we go with "Java thread stack size" instead
     // of "ThreadStackSize" to be more friendly.
     tty->print_cr("\nThe Java thread stack size specified is too small. "
-                  "Specify at least " SIZE_FORMAT "k",
+                  "Specify at least %zuk",
                   _java_thread_min_stack_allowed / K);
     return JNI_ERR;
   }
@@ -2489,7 +2489,7 @@ jint os::set_minimum_stack_sizes() {
   if (stack_size_in_bytes != 0 &&
       stack_size_in_bytes < _compiler_thread_min_stack_allowed) {
     tty->print_cr("\nThe CompilerThreadStackSize specified is too small. "
-                  "Specify at least " SIZE_FORMAT "k",
+                  "Specify at least %zuk",
                   _compiler_thread_min_stack_allowed / K);
     return JNI_ERR;
   }
@@ -2501,7 +2501,7 @@ jint os::set_minimum_stack_sizes() {
   if (stack_size_in_bytes != 0 &&
       stack_size_in_bytes < _vm_internal_thread_min_stack_allowed) {
     tty->print_cr("\nThe VMThreadStackSize specified is too small. "
-                  "Specify at least " SIZE_FORMAT "k",
+                  "Specify at least %zuk",
                   _vm_internal_thread_min_stack_allowed / K);
     return JNI_ERR;
   }

--- a/src/hotspot/share/runtime/perfData.cpp
+++ b/src/hotspot/share/runtime/perfData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,8 +171,8 @@ void PerfData::create_entry(BasicType dtype, size_t dsize, size_t vlen) {
   pdep->data_offset = (jint) data_start;
 
   log_debug(perf, datacreation)("name = %s, dtype = %d, variability = %d,"
-                                " units = %d, dsize = " SIZE_FORMAT ", vlen = " SIZE_FORMAT ","
-                                " pad_length = " SIZE_FORMAT ", size = " SIZE_FORMAT ", on_c_heap = %s,"
+                                " units = %d, dsize = %zu, vlen = %zu,"
+                                " pad_length = %zu, size = %zu, on_c_heap = %s,"
                                 " address = " INTPTR_FORMAT ","
                                 " data address = " INTPTR_FORMAT,
                                 cname, dtype, variability(),

--- a/src/hotspot/share/runtime/perfMemory.cpp
+++ b/src/hotspot/share/runtime/perfMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,8 +97,8 @@ void PerfMemory::initialize() {
                              os::vm_allocation_granularity());
 
   log_debug(perf, memops)("PerfDataMemorySize = %d,"
-                          " os::vm_allocation_granularity = " SIZE_FORMAT
-                          ", adjusted size = " SIZE_FORMAT,
+                          " os::vm_allocation_granularity = %zu"
+                          ", adjusted size = %zu",
                           PerfDataMemorySize,
                           os::vm_allocation_granularity(),
                           capacity);
@@ -127,7 +127,7 @@ void PerfMemory::initialize() {
     // the PerfMemory region was created as expected.
 
     log_debug(perf, memops)("PerfMemory created: address = " INTPTR_FORMAT ","
-                            " size = " SIZE_FORMAT,
+                            " size = %zu",
                             p2i(_start),
                             _capacity);
 
@@ -178,8 +178,8 @@ void PerfMemory::destroy() {
     //
     if (PrintMiscellaneous && Verbose) {
       warning("PerfMemory Overflow Occurred.\n"
-              "\tCapacity = " SIZE_FORMAT " bytes"
-              "  Used = " SIZE_FORMAT " bytes"
+              "\tCapacity = %zu bytes"
+              "  Used = %zu bytes"
               "  Overflow = " INT32_FORMAT " bytes"
               "\n\tUse -XX:PerfDataMemorySize=<size> to specify larger size.",
               PerfMemory::capacity(),

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -549,7 +549,7 @@ char* Reflection::verify_class_access_msg(const Klass* current_class,
           strlen(new_class_name) + 2*sizeof(uintx);
         msg = NEW_RESOURCE_ARRAY(char, len);
         jio_snprintf(msg, len - 1,
-          "class %s (in module %s) cannot access class %s (in unnamed module @" SIZE_FORMAT_X ") because module %s does not read unnamed module @" SIZE_FORMAT_X,
+          "class %s (in module %s) cannot access class %s (in unnamed module @0x%zx) because module %s does not read unnamed module @0x%zx",
           current_class_name, module_from_name, new_class_name, uintx(identity_hash),
           module_from_name, uintx(identity_hash));
       }
@@ -576,7 +576,7 @@ char* Reflection::verify_class_access_msg(const Klass* current_class,
           2*strlen(module_to_name) + strlen(package_name) + 2*sizeof(uintx);
         msg = NEW_RESOURCE_ARRAY(char, len);
         jio_snprintf(msg, len - 1,
-          "class %s (in unnamed module @" SIZE_FORMAT_X ") cannot access class %s (in module %s) because module %s does not export %s to unnamed module @" SIZE_FORMAT_X,
+          "class %s (in unnamed module @0x%zx) cannot access class %s (in module %s) because module %s does not export %s to unnamed module @0x%zx",
           current_class_name, uintx(identity_hash), new_class_name, module_to_name,
           module_to_name, package_name, uintx(identity_hash));
       }

--- a/src/hotspot/share/runtime/stackOverflow.cpp
+++ b/src/hotspot/share/runtime/stackOverflow.cpp
@@ -91,7 +91,7 @@ void StackOverflow::create_stack_guard_pages() {
   assert(is_aligned(len, os::vm_page_size()), "Stack size should be a multiple of page size");
 
   int must_commit = os::must_commit_stack_guard_pages();
-  // warning("Guarding at " PTR_FORMAT " for len " SIZE_FORMAT "\n", low_addr, len);
+  // warning("Guarding at " PTR_FORMAT " for len %zu\n", low_addr, len);
 
   if (must_commit && !os::create_stack_guard_pages((char *) low_addr, len)) {
     log_warning(os, thread)("Attempt to allocate stack guard pages failed.");

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -2013,8 +2013,8 @@ void ObjectSynchronizer::chk_in_use_list(outputStream* out, int *error_cnt_p) {
   }
 
   if (l_in_use_count == ck_in_use_count) {
-    out->print_cr("in_use_count=%zu equals ck_in_use_count="
-                  SIZE_FORMAT, l_in_use_count, ck_in_use_count);
+    out->print_cr("in_use_count=%zu equals ck_in_use_count=%zu",
+                  l_in_use_count, ck_in_use_count);
   } else {
     out->print_cr("WARNING: in_use_count=%zu is not equal to "
                   "ck_in_use_count=%zu", l_in_use_count,
@@ -2023,8 +2023,8 @@ void ObjectSynchronizer::chk_in_use_list(outputStream* out, int *error_cnt_p) {
 
   size_t ck_in_use_max = _in_use_list.max();
   if (l_in_use_max == ck_in_use_max) {
-    out->print_cr("in_use_max=%zu equals ck_in_use_max="
-                  SIZE_FORMAT, l_in_use_max, ck_in_use_max);
+    out->print_cr("in_use_max=%zu equals ck_in_use_max=%zu",
+                  l_in_use_max, ck_in_use_max);
   } else {
     out->print_cr("WARNING: in_use_max=%zu is not equal to "
                   "ck_in_use_max=%zu", l_in_use_max, ck_in_use_max);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1294,8 +1294,8 @@ static bool monitors_used_above_threshold(MonitorList* list) {
 
       ObjectSynchronizer::set_in_use_list_ceiling(new_ceiling);
       log_info(monitorinflation)("Too many deflations without progress; "
-                                 "bumping in_use_list_ceiling from " SIZE_FORMAT
-                                 " to " SIZE_FORMAT, old_ceiling, new_ceiling);
+                                 "bumping in_use_list_ceiling from %zu"
+                                 " to %zu", old_ceiling, new_ceiling);
       _no_progress_cnt = 0;
       ceiling = new_ceiling;
 
@@ -1303,8 +1303,8 @@ static bool monitors_used_above_threshold(MonitorList* list) {
       monitor_usage = (monitors_used * 100LL) / ceiling;
       is_above_threshold = int(monitor_usage) > MonitorUsedDeflationThreshold;
     }
-    log_info(monitorinflation)("monitors_used=" SIZE_FORMAT ", ceiling=" SIZE_FORMAT
-                               ", monitor_usage=" SIZE_FORMAT ", threshold=%d",
+    log_info(monitorinflation)("monitors_used=%zu, ceiling=%zu"
+                               ", monitor_usage=%zu, threshold=%d",
                                monitors_used, ceiling, monitor_usage, MonitorUsedDeflationThreshold);
     return is_above_threshold;
   }
@@ -1725,7 +1725,7 @@ public:
 
   void begin() {
     if (_stream != nullptr) {
-      _stream->print_cr("begin deflating: in_use_list stats: ceiling=" SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
+      _stream->print_cr("begin deflating: in_use_list stats: ceiling=%zu, count=%zu, max=%zu",
                         ceiling(), count(), max());
       _timer.start();
     }
@@ -1734,9 +1734,9 @@ public:
   void before_handshake(size_t unlinked_count) {
     if (_stream != nullptr) {
       _timer.stop();
-      _stream->print_cr("before handshaking: unlinked_count=" SIZE_FORMAT
-                        ", in_use_list stats: ceiling=" SIZE_FORMAT ", count="
-                        SIZE_FORMAT ", max=" SIZE_FORMAT,
+      _stream->print_cr("before handshaking: unlinked_count=%zu"
+                        ", in_use_list stats: ceiling=%zu, count="
+                        "%zu, max=%zu",
                         unlinked_count, ceiling(), count(), max());
     }
   }
@@ -1744,7 +1744,7 @@ public:
   void after_handshake() {
     if (_stream != nullptr) {
       _stream->print_cr("after handshaking: in_use_list stats: ceiling="
-                        SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
+                        "%zu, count=%zu, max=%zu",
                         ceiling(), count(), max());
       _timer.start();
     }
@@ -1754,10 +1754,10 @@ public:
     if (_stream != nullptr) {
       _timer.stop();
       if (deflated_count != 0 || unlinked_count != 0 || _debug.is_enabled()) {
-        _stream->print_cr("deflated_count=" SIZE_FORMAT ", {unlinked,deleted}_count=" SIZE_FORMAT " monitors in %3.7f secs",
+        _stream->print_cr("deflated_count=%zu, {unlinked,deleted}_count=%zu monitors in %3.7f secs",
                           deflated_count, unlinked_count, _timer.seconds());
       }
-      _stream->print_cr("end deflating: in_use_list stats: ceiling=" SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
+      _stream->print_cr("end deflating: in_use_list stats: ceiling=%zu, count=%zu, max=%zu",
                         ceiling(), count(), max());
     }
   }
@@ -1765,16 +1765,16 @@ public:
   void before_block_for_safepoint(const char* op_name, const char* cnt_name, size_t cnt) {
     if (_stream != nullptr) {
       _timer.stop();
-      _stream->print_cr("pausing %s: %s=" SIZE_FORMAT ", in_use_list stats: ceiling="
-                        SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
+      _stream->print_cr("pausing %s: %s=%zu, in_use_list stats: ceiling="
+                        "%zu, count=%zu, max=%zu",
                         op_name, cnt_name, cnt, ceiling(), count(), max());
     }
   }
 
   void after_block_for_safepoint(const char* op_name) {
     if (_stream != nullptr) {
-      _stream->print_cr("resuming %s: in_use_list stats: ceiling=" SIZE_FORMAT
-                        ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT, op_name,
+      _stream->print_cr("resuming %s: in_use_list stats: ceiling=%zu"
+                        ", count=%zu, max=%zu", op_name,
                         ceiling(), count(), max());
       _timer.start();
     }
@@ -2001,7 +2001,7 @@ void ObjectSynchronizer::audit_and_print_stats(outputStream* ls, bool on_exit) {
 void ObjectSynchronizer::chk_in_use_list(outputStream* out, int *error_cnt_p) {
   size_t l_in_use_count = _in_use_list.count();
   size_t l_in_use_max = _in_use_list.max();
-  out->print_cr("count=" SIZE_FORMAT ", max=" SIZE_FORMAT, l_in_use_count,
+  out->print_cr("count=%zu, max=%zu", l_in_use_count,
                 l_in_use_max);
 
   size_t ck_in_use_count = 0;
@@ -2013,21 +2013,21 @@ void ObjectSynchronizer::chk_in_use_list(outputStream* out, int *error_cnt_p) {
   }
 
   if (l_in_use_count == ck_in_use_count) {
-    out->print_cr("in_use_count=" SIZE_FORMAT " equals ck_in_use_count="
+    out->print_cr("in_use_count=%zu equals ck_in_use_count="
                   SIZE_FORMAT, l_in_use_count, ck_in_use_count);
   } else {
-    out->print_cr("WARNING: in_use_count=" SIZE_FORMAT " is not equal to "
-                  "ck_in_use_count=" SIZE_FORMAT, l_in_use_count,
+    out->print_cr("WARNING: in_use_count=%zu is not equal to "
+                  "ck_in_use_count=%zu", l_in_use_count,
                   ck_in_use_count);
   }
 
   size_t ck_in_use_max = _in_use_list.max();
   if (l_in_use_max == ck_in_use_max) {
-    out->print_cr("in_use_max=" SIZE_FORMAT " equals ck_in_use_max="
+    out->print_cr("in_use_max=%zu equals ck_in_use_max="
                   SIZE_FORMAT, l_in_use_max, ck_in_use_max);
   } else {
-    out->print_cr("WARNING: in_use_max=" SIZE_FORMAT " is not equal to "
-                  "ck_in_use_max=" SIZE_FORMAT, l_in_use_max, ck_in_use_max);
+    out->print_cr("WARNING: in_use_max=%zu is not equal to "
+                  "ck_in_use_max=%zu", l_in_use_max, ck_in_use_max);
   }
 }
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -219,7 +219,7 @@ void Thread::call_run() {
   JFR_ONLY(Jfr::on_thread_start(this);)
 
   log_debug(os, thread)("Thread %zu stack dimensions: "
-    PTR_FORMAT "-" PTR_FORMAT " (" SIZE_FORMAT "k).",
+    PTR_FORMAT "-" PTR_FORMAT " (%zuk).",
     os::current_thread_id(), p2i(stack_end()),
     p2i(stack_base()), stack_size()/1024);
 
@@ -475,7 +475,7 @@ void Thread::print_on(outputStream* st, bool print_extended_info) const {
               );
     if (is_Java_thread() && (PrintExtendedThreadInfo || print_extended_info)) {
       size_t allocated_bytes = (size_t) const_cast<Thread*>(this)->cooked_allocated_bytes();
-      st->print("allocated=" SIZE_FORMAT "%s ",
+      st->print("allocated=%zu%s ",
                 byte_size_in_proper_unit(allocated_bytes),
                 proper_unit_for_byte_size(allocated_bytes)
                 );

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -317,7 +317,7 @@ void JVMTIAgentLoadDCmd::execute(DCmdSource source, TRAPS) {
       char *opt = (char *)os::malloc(opt_len, mtInternal);
       if (opt == nullptr) {
         output()->print_cr("JVMTI agent attach failed: "
-                           "Could not allocate " SIZE_FORMAT " bytes for argument.",
+                           "Could not allocate %zu bytes for argument.",
                            opt_len);
         return;
       }

--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -77,7 +77,7 @@ char const* GZipCompressor::compress(char* in, size_t in_size, char* out, size_t
     char buf[128];
     // Write the block size used as a comment in the first gzip chunk, so the
     // code used to read it later can make a good choice of the buffer sizes it uses.
-    jio_snprintf(buf, sizeof(buf), "HPROF BLOCKSIZE=" SIZE_FORMAT, _block_size);
+    jio_snprintf(buf, sizeof(buf), "HPROF BLOCKSIZE=%zu", _block_size);
     *compressed_size = ZipLibrary::compress(in, in_size, out, out_size, tmp, tmp_size, _level, buf, &msg);
     _is_first = false;
   } else {

--- a/src/hotspot/share/services/lowMemoryDetector.cpp
+++ b/src/hotspot/share/services/lowMemoryDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -379,7 +379,7 @@ void SensorInfo::clear(int count, TRAPS) {
 
 #ifndef PRODUCT
 void SensorInfo::print() {
-  tty->print_cr("%s count = " SIZE_FORMAT " pending_triggers = %d pending_clears = %d",
+  tty->print_cr("%s count = %zu pending_triggers = %d pending_clears = %d",
                 (_sensor_on ? "on" : "off"),
                 _sensor_count, _pending_trigger_count, _pending_clear_count);
 }

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -1,6 +1,6 @@
 
 /*
-* Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -174,7 +174,7 @@ void ThreadIdTable::grow(JavaThread* jt) {
   }
   gt.done(jt);
   _current_size = table_size();
-  log_info(thread, table)("Grown to size:" SIZE_FORMAT, _current_size);
+  log_info(thread, table)("Grown to size:%zu", _current_size);
 }
 
 class ThreadIdTableLookup : public StackObj {

--- a/src/hotspot/share/services/writeableFlags.cpp
+++ b/src/hotspot/share/services/writeableFlags.cpp
@@ -175,7 +175,7 @@ JVMFlag::Error WriteableFlags::set_uint64_t_flag(const char* name, const char* a
 JVMFlag::Error WriteableFlags::set_size_t_flag(const char* name, const char* arg, JVMFlagOrigin origin, FormatBuffer<80>& err_msg) {
   size_t value;
 
-  if (sscanf(arg, SIZE_FORMAT, &value) == 1) {
+  if (sscanf(arg, "%zu", &value) == 1) {
     return set_flag_impl<JVM_FLAG_TYPE(size_t)>(name, value, origin, err_msg);
   }
   err_msg.print("flag value must be an unsigned integer");

--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,19 +199,19 @@ bm_word_t* CHeapBitMap::reallocate(bm_word_t* map, size_t old_size_in_words, siz
 #ifdef ASSERT
 void BitMap::verify_index(idx_t bit) const {
   assert(bit < _size,
-         "BitMap index out of bounds: " SIZE_FORMAT " >= " SIZE_FORMAT,
+         "BitMap index out of bounds: %zu >= %zu",
          bit, _size);
 }
 
 void BitMap::verify_limit(idx_t bit) const {
   assert(bit <= _size,
-         "BitMap limit out of bounds: " SIZE_FORMAT " > " SIZE_FORMAT,
+         "BitMap limit out of bounds: %zu > %zu",
          bit, _size);
 }
 
 void BitMap::verify_range(idx_t beg, idx_t end) const {
   assert(beg <= end,
-         "BitMap range error: " SIZE_FORMAT " > " SIZE_FORMAT, beg, end);
+         "BitMap range error: %zu > %zu", beg, end);
   verify_limit(end);
 }
 #endif // #ifdef ASSERT
@@ -706,7 +706,7 @@ void BitMap::IteratorImpl::assert_not_empty() const {
 #endif
 
 void BitMap::print_on(outputStream* st) const {
-  st->print("Bitmap (" SIZE_FORMAT " bits):", size());
+  st->print("Bitmap (%zu bits):", size());
   for (idx_t index = 0; index < size(); index++) {
     if ((index % 64) == 0) {
       st->cr();

--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -710,7 +710,7 @@ void BitMap::print_on(outputStream* st) const {
   for (idx_t index = 0; index < size(); index++) {
     if ((index % 64) == 0) {
       st->cr();
-      st->print(SIZE_FORMAT_W(5) ":", index);
+      st->print("%5zu:", index);
     }
     if ((index % 8) == 0) {
       st->print(" ");

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -260,7 +260,7 @@ class BitMap {
   constexpr static void verify_size(idx_t size_in_bits) {
 #ifdef ASSERT
     assert(size_in_bits <= max_size_in_bits(),
-           "out of bounds: " SIZE_FORMAT, size_in_bits);
+           "out of bounds: %zu", size_in_bits);
 #endif
   }
 

--- a/src/hotspot/share/utilities/chunkedList.hpp
+++ b/src/hotspot/share/utilities/chunkedList.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ template <class T, MemTag MT> class ChunkedList : public CHeapObj<MT> {
   }
 
   T at(size_t i) {
-    assert(i < size(), "IOOBE i: " SIZE_FORMAT " size(): " SIZE_FORMAT, i, size());
+    assert(i < size(), "IOOBE i: %zu size(): %zu", i, size());
     return _values[i];
   }
 };

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -680,7 +680,7 @@ inline bool ConcurrentHashTable<CONFIG, MT>::
         odd = aux->next_ptr();
       } else {
         const char* msg = "Cannot resize table: Node hash code has changed possibly due to corruption of the contents.";
-        DEBUG_ONLY(fatal("%s Node hash code changed from " SIZE_FORMAT " to " SIZE_FORMAT, msg, aux->saved_hash(), aux_hash);)
+        DEBUG_ONLY(fatal("%s Node hash code changed from %zu to %zu", msg, aux->saved_hash(), aux_hash);)
         NOT_DEBUG(fatal("%s", msg);)
       }
     }

--- a/src/hotspot/share/utilities/copy.cpp
+++ b/src/hotspot/share/utilities/copy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,9 +71,9 @@ public:
     assert(src != nullptr, "address must not be null");
     assert(dst != nullptr, "address must not be null");
     assert(elem_size == 2 || elem_size == 4 || elem_size == 8,
-           "incorrect element size: " SIZE_FORMAT, elem_size);
+           "incorrect element size: %zu", elem_size);
     assert(is_aligned(byte_count, elem_size),
-           "byte_count " SIZE_FORMAT " must be multiple of element size " SIZE_FORMAT, byte_count, elem_size);
+           "byte_count %zu must be multiple of element size %zu", byte_count, elem_size);
 
     address src_end = (address)src + byte_count;
 
@@ -196,7 +196,7 @@ private:
     case 2: do_conjoint_swap<uint16_t,D,swap>(src, dst, byte_count); break;
     case 4: do_conjoint_swap<uint32_t,D,swap>(src, dst, byte_count); break;
     case 8: do_conjoint_swap<uint64_t,D,swap>(src, dst, byte_count); break;
-    default: guarantee(false, "do_conjoint_swap: Invalid elem_size " SIZE_FORMAT "\n", elem_size);
+    default: guarantee(false, "do_conjoint_swap: Invalid elem_size %zu\n", elem_size);
     }
   }
 };

--- a/src/hotspot/share/utilities/elfFile.cpp
+++ b/src/hotspot/share/utilities/elfFile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1862,7 +1862,7 @@ bool DwarfFile::MarkedDwarfFileReader::read_string(char* result, const size_t re
     if (next_byte == 0) {
       if (exceeded_buffer) {
         result[result_len - 1] = '\0'; // Mark end of string.
-        DWARF_LOG_ERROR("Tried to read " SIZE_FORMAT " bytes but exceeded buffer size of " SIZE_FORMAT ". Truncating string.",
+        DWARF_LOG_ERROR("Tried to read %zu bytes but exceeded buffer size of %zu. Truncating string.",
                         char_index, result_len);
       }
       return true;

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -134,14 +134,10 @@ class oopDesc;
 #define UINT64_FORMAT_W(width)   "%"   #width PRIu64
 #define UINT64_FORMAT_0          "%016"       PRIx64
 
+
 // Format integers which change size between 32- and 64-bit.
 #define SIZE_FORMAT              "%"          PRIuPTR
 #define SIZE_FORMAT_X            "0x%"        PRIxPTR
-#ifdef _LP64
-#define SIZE_FORMAT_X_0          "0x%016"     PRIxPTR
-#else
-#define SIZE_FORMAT_X_0          "0x%08"      PRIxPTR
-#endif
 #define SIZE_FORMAT_W(width)     "%"   #width PRIuPTR
 
 // Format jlong, if necessary
@@ -163,10 +159,12 @@ class oopDesc;
 #define INTPTR_FORMAT            "0x%016"     PRIxPTR
 #define PTR_FORMAT               "0x%016"     PRIxPTR
 #define UINTX_FORMAT_X_0         "0x%016"     PRIxPTR
+#define SIZE_FORMAT_X_0          "0x%016"     PRIxPTR
 #else   // !_LP64
 #define INTPTR_FORMAT            "0x%08"      PRIxPTR
 #define PTR_FORMAT               "0x%08"      PRIxPTR
 #define UINTX_FORMAT_X_0         "0x%08"      PRIxPTR
+#define SIZE_FORMAT_X_0          "0x%08"      PRIxPTR
 #endif  // _LP64
 
 // Convert pointer to intptr_t, for use in printing pointers.

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -130,8 +130,8 @@ const char* outputStream::do_vsnprintf(char* buffer, size_t buflen,
   }
 #ifdef ASSERT
   if (required_len > result_len) {
-    warning("outputStream::do_vsnprintf output truncated -- buffer length is " SIZE_FORMAT
-            " bytes but " SIZE_FORMAT " bytes are needed.",
+    warning("outputStream::do_vsnprintf output truncated -- buffer length is %zu"
+            " bytes but %zu bytes are needed.",
             add_cr ? buflen + 1 : buflen, required_len + 1);
   }
 #endif
@@ -387,7 +387,7 @@ void stringStream::write(const char* s, size_t len) {
   }
   const size_t reasonable_max_len = 1 * G;
   if (len >= reasonable_max_len) {
-    assert(false, "bad length? (" SIZE_FORMAT ")", len);
+    assert(false, "bad length? (%zu)", len);
     return;
   }
   size_t write_len = 0;

--- a/src/hotspot/share/utilities/tableStatistics.cpp
+++ b/src/hotspot/share/utilities/tableStatistics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,10 +134,10 @@ TableStatistics::~TableStatistics() { }
 void TableStatistics::print(outputStream* st, const char *table_name) {
   st->print_cr("%s statistics:", table_name);
   st->print_cr("Number of buckets       : %9" PRIuPTR " = %9" PRIuPTR
-               " bytes, each " SIZE_FORMAT,
+               " bytes, each %zu",
               _number_of_buckets, _bucket_bytes, _bucket_size);
   st->print_cr("Number of entries       : %9" PRIuPTR " = %9" PRIuPTR
-               " bytes, each " SIZE_FORMAT,
+               " bytes, each %zu",
                _number_of_entries, _entry_bytes, _entry_size);
   if (_literal_bytes != 0) {
     float literal_avg = (_number_of_entries <= 0) ? 0.0f : (float)(_literal_bytes / _number_of_entries);

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -216,8 +216,8 @@ void VMError::reattempt_test_hit_stack_limit(outputStream* st) {
     const size_t available_headroom   = stack_pointer - unguarded_stack_end;
     const size_t allocation_size      = available_headroom - _reattempt_required_stack_headroom + K;
 
-    st->print_cr("Current Stack Pointer: " PTR_FORMAT " alloca " SIZE_FORMAT
-                 " of " SIZE_FORMAT " bytes available unguarded stack space",
+    st->print_cr("Current Stack Pointer: " PTR_FORMAT " alloca %zu"
+                 " of %zu bytes available unguarded stack space",
                  p2i(stack_pointer), allocation_size, available_headroom);
 
     // Allocate byte blob on the stack. Make pointer volatile to avoid having
@@ -934,7 +934,7 @@ void VMError::report(outputStream* st, bool _verbose) {
     if (fr.sp()) {
       st->print(",  sp=" PTR_FORMAT, p2i(fr.sp()));
       size_t free_stack_size = pointer_delta(fr.sp(), stack_bottom, 1024);
-      st->print(",  free space=" SIZE_FORMAT "k", free_stack_size);
+      st->print(",  free space=%zuk", free_stack_size);
     }
 
     st->cr();

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -768,7 +768,7 @@ void VMError::report(outputStream* st, bool _verbose) {
           st->print((_id == (int)OOM_MALLOC_ERROR) ? "(malloc) failed to allocate " :
                     (_id == (int)OOM_MMAP_ERROR)   ? "(mmap) failed to map " :
                                                     "(mprotect) failed to protect ");
-          jio_snprintf(buf, sizeof(buf), SIZE_FORMAT, _size);
+          jio_snprintf(buf, sizeof(buf), "%zu", _size);
           st->print("%s", buf);
           st->print(" bytes.");
           if (strlen(_detail_msg) > 0) {


### PR DESCRIPTION
Please review this change to replace SIZE_FORMAT with %zu in the runtime code.  The second and third commits are hand editing for fixing up formats of the code, not the output.  After this, there'll be a separate change to remove SIZE_FORMAT.  Note that SIZE_FORMAT_X_0 depends on LP64 so that macro will be retained.  There were a couple of compiler files that I missed.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347733](https://bugs.openjdk.org/browse/JDK-8347733): Replace SIZE_FORMAT in runtime code (**Sub-task** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) Review applies to [87fdb72f](https://git.openjdk.org/jdk/pull/23160/files/87fdb72f626a53afee1fba02f364766096ee4166)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [87fdb72f](https://git.openjdk.org/jdk/pull/23160/files/87fdb72f626a53afee1fba02f364766096ee4166)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23160/head:pull/23160` \
`$ git checkout pull/23160`

Update a local copy of the PR: \
`$ git checkout pull/23160` \
`$ git pull https://git.openjdk.org/jdk.git pull/23160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23160`

View PR using the GUI difftool: \
`$ git pr show -t 23160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23160.diff">https://git.openjdk.org/jdk/pull/23160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23160#issuecomment-2596807278)
</details>
