### PR TITLE
8345500: Timeout in jdk.jfr.api.consumer.streaming.TestJVMCrash

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/streaming/TestProcess.java
+++ b/test/jdk/jdk/jfr/api/consumer/streaming/TestProcess.java
@@ -68,6 +68,9 @@ public final class TestProcess implements AutoCloseable {
             };
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(args);
         process = ProcessTools.startProcess(name, pb);
+
+        // give the process a chance to awake (and to be seen from other threads)
+        takeLongNap();
     }
 
     public static void main(String... args) throws Exception {
@@ -97,6 +100,14 @@ public final class TestProcess implements AutoCloseable {
 
     public Path getRepository() throws Exception {
         return StreamingUtils.getJfrRepository(process);
+    }
+
+    private static void takeLongNap() {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ie) {
+            // ignore
+        }
     }
 
     private static void takeNap() {


### PR DESCRIPTION
In this fix we add 1 second delay after we create a process.

On macOS we seem to be creating a process so quickly, that other threads need time to see it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345500](https://bugs.openjdk.org/browse/JDK-8345500): Timeout in jdk.jfr.api.consumer.streaming.TestJVMCrash (**Bug** - P3) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23163/head:pull/23163` \
`$ git checkout pull/23163`

Update a local copy of the PR: \
`$ git checkout pull/23163` \
`$ git pull https://git.openjdk.org/jdk.git pull/23163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23163`

View PR using the GUI difftool: \
`$ git pr show -t 23163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23163.diff">https://git.openjdk.org/jdk/pull/23163.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23163#issuecomment-2596750570)
</details>
