### PR TITLE
8347617: Shenandoah: Use consistent name for update references phase

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -420,7 +420,7 @@ void ShenandoahBarrierSet::arraycopy_barrier(T* src, T* dst, size_t count) {
   char gc_state = ShenandoahThreadLocalData::gc_state(Thread::current());
   if ((gc_state & ShenandoahHeap::EVACUATION) != 0) {
     arraycopy_evacuation(src, count);
-  } else if ((gc_state & ShenandoahHeap::UPDATEREFS) != 0) {
+  } else if ((gc_state & ShenandoahHeap::UPDATE_REFS) != 0) {
     arraycopy_update(src, count);
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -67,16 +67,16 @@ protected:
   // call the entry method below
   void vmop_entry_init_mark();
   void vmop_entry_final_mark();
-  void vmop_entry_init_updaterefs();
-  void vmop_entry_final_updaterefs();
+  void vmop_entry_init_update_refs();
+  void vmop_entry_final_update_refs();
   void vmop_entry_final_roots();
 
   // Entry methods to normally STW GC operations. These set up logging, monitoring
   // and workers for net VM operation
   void entry_init_mark();
   void entry_final_mark();
-  void entry_init_updaterefs();
-  void entry_final_updaterefs();
+  void entry_init_update_refs();
+  void entry_final_update_refs();
   void entry_final_roots();
 
   // Entry methods to normally concurrent GC operations. These set up logging, monitoring
@@ -93,7 +93,7 @@ protected:
   void entry_cleanup_early();
   void entry_evacuate();
   void entry_update_thread_roots();
-  void entry_updaterefs();
+  void entry_update_refs();
   void entry_cleanup_complete();
 
   // Called when the collection set is empty, but the generational mode has regions to promote in place
@@ -112,10 +112,10 @@ protected:
   void op_strong_roots();
   void op_cleanup_early();
   void op_evacuate();
-  void op_init_updaterefs();
-  void op_updaterefs();
+  void op_init_update_refs();
+  void op_update_refs();
   void op_update_thread_roots();
-  void op_final_updaterefs();
+  void op_final_update_refs();
   void op_final_roots();
   void op_cleanup_complete();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -264,15 +264,15 @@ void ShenandoahDegenGC::op_degenerated() {
       // If heuristics thinks we should do the cycle, this flag would be set,
       // and we need to do update-refs. Otherwise, it would be the shortcut cycle.
       if (heap->has_forwarded_objects()) {
-        op_init_updaterefs();
+        op_init_update_refs();
         assert(!heap->cancelled_gc(), "STW reference update can not OOM");
       } else {
         _abbreviated = true;
       }
 
-    case _degenerated_updaterefs:
+    case _degenerated_update_refs:
       if (heap->has_forwarded_objects()) {
-        op_updaterefs();
+        op_update_refs();
         op_update_roots();
         assert(!heap->cancelled_gc(), "STW reference update can not OOM");
       }
@@ -387,16 +387,16 @@ void ShenandoahDegenGC::op_evacuate() {
   ShenandoahHeap::heap()->evacuate_collection_set(false /* concurrent*/);
 }
 
-void ShenandoahDegenGC::op_init_updaterefs() {
+void ShenandoahDegenGC::op_init_update_refs() {
   // Evacuation has completed
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   heap->prepare_update_heap_references(false /*concurrent*/);
   heap->set_update_refs_in_progress(true);
 }
 
-void ShenandoahDegenGC::op_updaterefs() {
+void ShenandoahDegenGC::op_update_refs() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_updaterefs);
+  ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_update_refs);
   // Handed over from concurrent update references phase
   heap->update_heap_references(false /*concurrent*/);
 
@@ -412,7 +412,7 @@ void ShenandoahDegenGC::op_update_roots() {
   heap->update_heap_region_states(false /*concurrent*/);
 
   if (ShenandoahVerify) {
-    heap->verifier()->verify_after_updaterefs();
+    heap->verifier()->verify_after_update_refs();
   }
 
   if (VerifyAfterGC) {
@@ -447,7 +447,7 @@ const char* ShenandoahDegenGC::degen_event_message(ShenandoahDegenPoint point) c
       SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Mark)");
     case _degenerated_evac:
       SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Evacuation)");
-    case _degenerated_updaterefs:
+    case _degenerated_update_refs:
       SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Update Refs)");
     default:
       ShouldNotReachHere();

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -53,8 +53,8 @@ private:
   void op_cleanup_early();
 
   void op_evacuate();
-  void op_init_updaterefs();
-  void op_updaterefs();
+  void op_init_update_refs();
+  void op_update_refs();
   void op_update_roots();
   void op_cleanup_complete();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGC.cpp
@@ -45,7 +45,7 @@ const char* ShenandoahGC::degen_point_to_string(ShenandoahDegenPoint point) {
       return "Mark";
     case _degenerated_evac:
       return "Evacuation";
-    case _degenerated_updaterefs:
+    case _degenerated_update_refs:
       return "Update References";
     default:
       ShouldNotReachHere();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGC.hpp
@@ -53,7 +53,7 @@ public:
     _degenerated_roots,
     _degenerated_mark,
     _degenerated_evac,
-    _degenerated_updaterefs,
+    _degenerated_update_refs,
     _DEGENERATED_LIMIT
   };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -852,7 +852,7 @@ private:
       }
 
       if (region_progress && ShenandoahPacing) {
-        _heap->pacer()->report_updaterefs(pointer_delta(update_watermark, r->bottom()));
+        _heap->pacer()->report_update_refs(pointer_delta(update_watermark, r->bottom()));
       }
 
       if (_heap->check_cancelled_gc_and_yield(CONCURRENT)) {
@@ -912,7 +912,7 @@ private:
         }
 
         if (ShenandoahPacing) {
-          _heap->pacer()->report_updaterefs(pointer_delta(end_of_range, start_of_range));
+          _heap->pacer()->report_update_refs(pointer_delta(end_of_range, start_of_range));
         }
       }
     }
@@ -1072,7 +1072,7 @@ void ShenandoahGenerationalHeap::complete_degenerated_cycle() {
   shenandoah_assert_heaplocked_or_safepoint();
   if (is_concurrent_old_mark_in_progress()) {
     // This is still necessary for degenerated cycles because the degeneration point may occur
-    // after final mark of the young generation. See ShenandoahConcurrentGC::op_final_updaterefs for
+    // after final mark of the young generation. See ShenandoahConcurrentGC::op_final_update_refs for
     // a more detailed explanation.
     old_generation()->transfer_pointers_from_satb();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -329,7 +329,7 @@ public:
     EVACUATION_BITPOS = 2,
 
     // Heap is under updating: needs no additional barriers.
-    UPDATEREFS_BITPOS = 3,
+    UPDATE_REFS_BITPOS = 3,
 
     // Heap is under weak-reference/roots processing: needs weak-LRB barriers.
     WEAK_ROOTS_BITPOS  = 4,
@@ -346,7 +346,7 @@ public:
     HAS_FORWARDED = 1 << HAS_FORWARDED_BITPOS,
     MARKING       = 1 << MARKING_BITPOS,
     EVACUATION    = 1 << EVACUATION_BITPOS,
-    UPDATEREFS    = 1 << UPDATEREFS_BITPOS,
+    UPDATE_REFS   = 1 << UPDATE_REFS_BITPOS,
     WEAK_ROOTS    = 1 << WEAK_ROOTS_BITPOS,
     YOUNG_MARKING = 1 << YOUNG_MARKING_BITPOS,
     OLD_MARKING   = 1 << OLD_MARKING_BITPOS

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -472,7 +472,7 @@ inline bool ShenandoahHeap::is_evacuation_in_progress() const {
 }
 
 inline bool ShenandoahHeap::is_update_refs_in_progress() const {
-  return is_gc_state(UPDATEREFS);
+  return is_gc_state(UPDATE_REFS);
 }
 
 inline bool ShenandoahHeap::is_concurrent_weak_root_in_progress() const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -107,7 +107,7 @@ void ShenandoahPacer::setup_for_evac() {
                      tax);
 }
 
-void ShenandoahPacer::setup_for_updaterefs() {
+void ShenandoahPacer::setup_for_update_refs() {
   assert(ShenandoahPacing, "Only be here when pacing is enabled");
 
   size_t used = _heap->used();

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.hpp
@@ -97,13 +97,13 @@ public:
   void setup_for_idle();
   void setup_for_mark();
   void setup_for_evac();
-  void setup_for_updaterefs();
+  void setup_for_update_refs();
 
   void setup_for_reset();
 
   inline void report_mark(size_t words);
   inline void report_evac(size_t words);
-  inline void report_updaterefs(size_t words);
+  inline void report_update_refs(size_t words);
 
   inline void report_alloc(size_t words);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.inline.hpp
@@ -38,7 +38,7 @@ inline void ShenandoahPacer::report_evac(size_t words) {
   report_internal(words);
 }
 
-inline void ShenandoahPacer::report_updaterefs(size_t words) {
+inline void ShenandoahPacer::report_update_refs(size_t words) {
   report_internal(words);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -146,7 +146,7 @@ class outputStream;
   f(degen_gc_final_rebuild_freeset,                 "  Rebuild Free Set")              \
   f(degen_gc_stw_evac,                              "  Evacuation")                    \
   f(degen_gc_init_update_refs_manage_gclabs,        "  Manage GCLABs")                 \
-  f(degen_gc_updaterefs,                            "  Update References")             \
+  f(degen_gc_update_refs,                           "  Update References")             \
   f(degen_gc_final_update_refs_finish_work,         "  Finish Work")                   \
   f(degen_gc_final_update_refs_update_region_states,"  Update Region States")          \
   f(degen_gc_final_update_refs_trash_cset,          "  Trash Collection Set")          \

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
@@ -109,14 +109,14 @@ void VM_ShenandoahDegeneratedGC::doit() {
 void VM_ShenandoahInitUpdateRefs::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Init Update Refs", SvcGCMarker::CONCURRENT);
   set_active_generation();
-  _gc->entry_init_updaterefs();
+  _gc->entry_init_update_refs();
   ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 }
 
 void VM_ShenandoahFinalUpdateRefs::doit() {
   ShenandoahGCPauseMark mark(_gc_id, "Final Update Refs", SvcGCMarker::CONCURRENT);
   set_active_generation();
-  _gc->entry_final_updaterefs();
+  _gc->entry_final_update_refs();
   ShenandoahHeap::heap()->propagate_gc_state_to_all_threads();
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -818,7 +818,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
         break;
       case _verify_gcstate_updating:
         enabled = true;
-        expected = ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::UPDATEREFS;
+        expected = ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::UPDATE_REFS;
         break;
       case _verify_gcstate_stable:
         enabled = true;
@@ -1114,7 +1114,7 @@ void ShenandoahVerifier::verify_before_evacuation() {
   );
 }
 
-void ShenandoahVerifier::verify_before_updaterefs() {
+void ShenandoahVerifier::verify_before_update_refs() {
   verify_at_safepoint(
           "Before Updating References",
           _verify_remembered_before_updating_references,  // verify read-write remembered set
@@ -1129,7 +1129,7 @@ void ShenandoahVerifier::verify_before_updaterefs() {
 }
 
 // We have not yet cleanup (reclaimed) the collection set
-void ShenandoahVerifier::verify_after_updaterefs() {
+void ShenandoahVerifier::verify_after_update_refs() {
   verify_at_safepoint(
           "After Updating References",
           _verify_remembered_disable,  // do not verify remembered set

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
@@ -214,8 +214,8 @@ public:
   void verify_after_concmark();
   void verify_after_concmark_with_promotions();
   void verify_before_evacuation();
-  void verify_before_updaterefs();
-  void verify_after_updaterefs();
+  void verify_before_update_refs();
+  void verify_after_update_refs();
   void verify_before_fullgc();
   void verify_after_fullgc();
   void verify_after_degenerated();


### PR DESCRIPTION
During the review of https://github.com/openjdk/jdk/pull/22688, we discovered that some methods and variables used `updaterefs`, while most used `update_refs` (or `UpdateRefs`). This PR changes all of the `updaterefs` names to `update_refs` for consistency.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347617](https://bugs.openjdk.org/browse/JDK-8347617): Shenandoah: Use consistent name for update references phase (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23164/head:pull/23164` \
`$ git checkout pull/23164`

Update a local copy of the PR: \
`$ git checkout pull/23164` \
`$ git pull https://git.openjdk.org/jdk.git pull/23164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23164`

View PR using the GUI difftool: \
`$ git pr show -t 23164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23164.diff">https://git.openjdk.org/jdk/pull/23164.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23164#issuecomment-2596757779)
</details>
