### PR TITLE
8347841: Test fixes that use deprecated time zone IDs

### DIFF
--- a/test/jdk/java/io/File/TimeZoneLastModified.java
+++ b/test/jdk/java/io/File/TimeZoneLastModified.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,14 @@
 
 /*
  * @test
- * @bug 6212869
+ * @bug 6212869 8347841
  * @summary Determine if lastModified() works after TimeZone.setDefault()
  * @run main/othervm TimeZoneLastModified
  */
 
 import java.io.File;
-import java.util.Date;
+import java.time.ZoneId;
 import java.util.TimeZone;
-import java.text.SimpleDateFormat;
 
 public class TimeZoneLastModified {
     // Tue, 04 Jun 2002 13:56:50.002 GMT
@@ -40,6 +39,9 @@ public class TimeZoneLastModified {
     public static void main(String[] args) throws Throwable {
         int failures = test(null);
         for (String timeZoneID : TimeZone.getAvailableIDs()) {
+            if (ZoneId.SHORT_IDS.containsKey(timeZoneID)) {
+                continue;
+            }
             failures += test(timeZoneID);
         }
         if (failures != 0) {

--- a/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @bug 4029195 4052408 4056591 4059917 4060212 4061287 4065240 4071441 4073003
  * 4089106 4100302 4101483 4103340 4103341 4104136 4104522 4106807 4108407
  * 4134203 4138203 4148168 4151631 4151706 4153860 4162071 4182066 4209272 4210209
- * 4213086 4250359 4253490 4266432 4406615 4413980 8008577 8305853 8174269
+ * 4213086 4250359 4253490 4266432 4406615 4413980 8008577 8305853 8174269 8347841
  * @library /java/text/testlib
  * @run junit DateFormatRegression
  */
@@ -274,7 +274,7 @@ public class DateFormatRegression {
         try {
             Locale curLocale = Locale.GERMANY;
             Locale.setDefault(curLocale);
-            TimeZone.setDefault(TimeZone.getTimeZone("EST"));
+            TimeZone.setDefault(TimeZone.getTimeZone("America/Panama"));
             curDate = new Date(98, 0, 1);
             shortdate = DateFormat.getDateInstance(DateFormat.SHORT);
             fulldate = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG
@@ -453,7 +453,7 @@ public class DateFormatRegression {
         TimeZone savedTimeZone = TimeZone.getDefault();
         try {
             boolean pass = true;
-            String[] IDs = new String[] {"Undefined", "PST", "US/Pacific",
+            String[] IDs = new String[] {"Undefined", "America/Los_Angeles", "US/Pacific",
                                          "GMT+3:00", "GMT-01:30"};
             for (int i = 0; i < IDs.length; i++) {
                 TimeZone tz = TimeZone.getTimeZone(IDs[i]);
@@ -543,7 +543,7 @@ public class DateFormatRegression {
     public void Test4103341() {
         TimeZone saveZone  =TimeZone.getDefault();
         try {
-            TimeZone.setDefault(TimeZone.getTimeZone("CST"));
+            TimeZone.setDefault(TimeZone.getTimeZone("America/Chicago"));
             SimpleDateFormat simple = new SimpleDateFormat("MM/dd/yyyy HH:mm");
             if (!simple.getTimeZone().equals(TimeZone.getDefault()))
                 fail("Fail: SimpleDateFormat not using default zone");
@@ -794,7 +794,7 @@ public class DateFormatRegression {
       Locale savedLocale = Locale.getDefault();
       TimeZone savedTimeZone = TimeZone.getDefault();
       Locale.setDefault(Locale.US);
-      TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+      TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
 
       Date d1, d2;
       String dt = "Mon, 1 Jan 2001 00:00:00";
@@ -1096,7 +1096,7 @@ public class DateFormatRegression {
 
         // XXX: Test assumes "PST" is not TimeZoneNames_ja. Need to
         // pick up another time zone when L10N is done to that file.
-        TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
         SimpleDateFormat fmt = new SimpleDateFormat("yy/MM/dd hh:ss zzz", Locale.JAPAN);
         @SuppressWarnings("deprecation")
         String result = fmt.format(new Date(1999 - 1900, 0, 1));

--- a/test/jdk/java/text/Format/DateFormat/DateFormatTest.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,14 +24,16 @@
 /**
  * @test
  * @bug 4052223 4089987 4469904 4326988 4486735 8008577 8045998 8140571
- *      8190748 8216969 8174269
+ *      8190748 8216969 8174269 8347841
  * @summary test DateFormat and SimpleDateFormat.
  * @modules jdk.localedata
  * @run junit DateFormatTest
  */
 
-import java.util.*;
+import java.time.ZoneId;
 import java.text.*;
+import java.util.*;
+import java.util.function.Predicate;
 import static java.util.GregorianCalendar.*;
 
 import org.junit.jupiter.api.Test;
@@ -89,7 +91,9 @@ public class DateFormatTest
         /*
          * A String array for the time zone ids.
          */
-        String[] ids = TimeZone.getAvailableIDs();
+        String[] ids = Arrays.stream(TimeZone.getAvailableIDs())
+                .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+                .toArray(String[]::new);
         /*
          * How many ids do we have?
          */
@@ -183,7 +187,7 @@ public class DateFormatTest
         //logln(fmt.format(date)); // This shows what the current locale format is
         //logln(((SimpleDateFormat)fmt).toPattern());
         TimeZone save = TimeZone.getDefault();
-        TimeZone PST  = TimeZone.getTimeZone("PST");
+        TimeZone PST  = TimeZone.getTimeZone("America/Los_Angeles");
         String s = "03-Apr-04 2:20:47 o'clock AM PST";
         int hour = 2;
         try {
@@ -275,7 +279,7 @@ public class DateFormatTest
             "0034", "0012", "0513", "Pacific Daylight Time",
         };
         Date someDate = new Date(871508052513L);
-        TimeZone PST = TimeZone.getTimeZone("PST");
+        TimeZone PST  = TimeZone.getTimeZone("America/Los_Angeles");
         for (int j = 0, exp = 0; j < dateFormats.length; ++j) {
             DateFormat df = dateFormats[j];
             if (!(df instanceof SimpleDateFormat)) {

--- a/test/jdk/java/text/Format/DateFormat/DateFormatTest.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatTest.java
@@ -187,7 +187,7 @@ public class DateFormatTest
         //logln(fmt.format(date)); // This shows what the current locale format is
         //logln(((SimpleDateFormat)fmt).toPattern());
         TimeZone save = TimeZone.getDefault();
-        TimeZone PST  = TimeZone.getTimeZone("America/Los_Angeles");
+        TimeZone PST = TimeZone.getTimeZone("America/Los_Angeles");
         String s = "03-Apr-04 2:20:47 o'clock AM PST";
         int hour = 2;
         try {
@@ -279,7 +279,7 @@ public class DateFormatTest
             "0034", "0012", "0513", "Pacific Daylight Time",
         };
         Date someDate = new Date(871508052513L);
-        TimeZone PST  = TimeZone.getTimeZone("America/Los_Angeles");
+        TimeZone PST = TimeZone.getTimeZone("America/Los_Angeles");
         for (int j = 0, exp = 0; j < dateFormats.length; ++j) {
             DateFormat df = dateFormats[j];
             if (!(df instanceof SimpleDateFormat)) {

--- a/test/jdk/java/text/Format/DateFormat/SDFTCKZoneNamesTest.java
+++ b/test/jdk/java/text/Format/DateFormat/SDFTCKZoneNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,13 @@
 
 /**
  * @test
- * @bug 8218948
+ * @bug 8218948 8347841
  * @summary TCK tests that check the time zone names between DFS.getZoneStrings()
  *      and SDF.format("z*")
  * @run main SDFTCKZoneNamesTest
  */
 import java.text.*;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -325,6 +326,9 @@ public class SDFTCKZoneNamesTest {
         SimpleDateFormat sdf = new SimpleDateFormat();
         Date date = new Date(1234567890);
         for (String[] tz : sdf.getDateFormatSymbols().getZoneStrings()) {
+            if (ZoneId.SHORT_IDS.containsKey(tz[0])) {
+                continue;
+            }
             sdf.setTimeZone(TimeZone.getTimeZone(tz[0]));
             for (int i = 0; i < patterns.length && passed; i++) {
                 StringBuffer result = new StringBuffer("qwerty");

--- a/test/jdk/java/text/Format/DateFormat/bug4358730.java
+++ b/test/jdk/java/text/Format/DateFormat/bug4358730.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @test
- * @bug 4358730
+ * @bug 4358730 8347841
  * @summary test that confirms Zero-Padding on year.
  * @run junit bug4358730
  */
@@ -56,7 +56,7 @@ public class bug4358730 {
         Locale saveLocale = Locale.getDefault();
 
         try {
-            TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+            TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
             Locale.setDefault(Locale.US);
             SimpleDateFormat sdf = new SimpleDateFormat();
 

--- a/test/jdk/java/util/Calendar/CalendarRegression.java
+++ b/test/jdk/java/util/Calendar/CalendarRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  * 4174361 4177484 4197699 4209071 4288792 4328747 4413980 4546637 4623997
  * 4685354 4655637 4683492 4080631 4080631 4167995 4340146 4639407
  * 4652815 4652830 4740554 4936355 4738710 4633646 4846659 4822110 4960642
- * 4973919 4980088 4965624 5013094 5006864 8152077
+ * 4973919 4980088 4965624 5013094 5006864 8152077 8347841
  * @library /java/text/testlib
  * @run junit CalendarRegression
  */
@@ -42,6 +42,8 @@ import java.io.ObjectOutputStream;
 import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -50,6 +52,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
+import java.util.function.Predicate;
 
 import static java.util.Calendar.*;
 
@@ -75,7 +78,9 @@ public class CalendarRegression {
     public void Test4031502() {
         // This bug actually occurs on Windows NT as well, and doesn't
         // require the host zone to be set; it can be set in Java.
-        String[] ids = TimeZone.getAvailableIDs();
+        String[] ids = Arrays.stream(TimeZone.getAvailableIDs())
+                .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+                .toArray(String[]::new);
         boolean bad = false;
         for (int i = 0; i < ids.length; ++i) {
             TimeZone zone = TimeZone.getTimeZone(ids[i]);
@@ -489,7 +494,7 @@ public class CalendarRegression {
     @Test
     public void Test4096231() {
         TimeZone GMT = TimeZone.getTimeZone("GMT");
-        TimeZone PST = TimeZone.getTimeZone("PST");
+        TimeZone PST = TimeZone.getTimeZone("America/Los_Angeles");
         int sec = 0, min = 0, hr = 0, day = 1, month = 10, year = 1997;
 
         Calendar cal1 = new GregorianCalendar(PST);
@@ -838,7 +843,7 @@ public class CalendarRegression {
         TimeZone saveZone = TimeZone.getDefault();
         boolean fail = false;
         try {
-            TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+            TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
             Calendar cal = Calendar.getInstance();
             long onset = new Date(98, APRIL, 5, 1, 0).getTime() + ONE_HOUR;
             long cease = new Date(98, OCTOBER, 25, 0, 0).getTime() + 2 * ONE_HOUR;
@@ -1163,8 +1168,8 @@ public class CalendarRegression {
     @Test
     public void Test4149677() {
         TimeZone[] zones = {TimeZone.getTimeZone("GMT"),
-            TimeZone.getTimeZone("PST"),
-            TimeZone.getTimeZone("EAT")};
+            TimeZone.getTimeZone("America/Los_Angeles"),
+            TimeZone.getTimeZone("Africa/Addis_Ababa")};
         for (int i = 0; i < zones.length; ++i) {
             GregorianCalendar calendar = new GregorianCalendar(zones[i]);
 
@@ -1197,7 +1202,7 @@ public class CalendarRegression {
     @Test
     public void Test4162587() {
         TimeZone savedTz = TimeZone.getDefault();
-        TimeZone tz = TimeZone.getTimeZone("PST");
+        TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
         TimeZone.setDefault(tz);
         GregorianCalendar cal = new GregorianCalendar(tz);
         Date d;
@@ -1511,8 +1516,8 @@ public class CalendarRegression {
      */
     @Test
     public void Test4177484() {
-        TimeZone PST = TimeZone.getTimeZone("PST");
-        TimeZone EST = TimeZone.getTimeZone("EST");
+        TimeZone PST = TimeZone.getTimeZone("America/Los_Angeles");
+        TimeZone EST = TimeZone.getTimeZone("America/Panama");
 
         Calendar cal = Calendar.getInstance(PST, Locale.US);
         cal.clear();
@@ -1770,7 +1775,7 @@ public class CalendarRegression {
         TimeZone savedTimeZone = TimeZone.getDefault();
         try {
             boolean pass = true;
-            String[] IDs = new String[]{"Undefined", "PST", "US/Pacific",
+            String[] IDs = new String[]{"Undefined", "America/Los_Angeles", "US/Pacific",
                 "GMT+3:00", "GMT-01:30"};
             for (int i = 0; i < IDs.length; i++) {
                 TimeZone tz = TimeZone.getTimeZone(IDs[i]);

--- a/test/jdk/java/util/Calendar/JavatimeTest.java
+++ b/test/jdk/java/util/Calendar/JavatimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  *@test
- *@bug 8007520 8008254
+ *@bug 8007520 8008254 8347841
  *@summary Test those bridge methods to/from java.time date/time classes
  * @key randomness
  */
@@ -107,23 +107,22 @@ public class JavatimeTest {
 
         ///////////// java.util.TimeZone /////////////////////////
         for (String zidStr : TimeZone.getAvailableIDs()) {
-            // TBD: tzdt intergration
-            if (zidStr.startsWith("SystemV")
-                    || zidStr.contains("Riyadh8")
-                    || zidStr.equals("US/Pacific-New")
-                    || zidStr.equals("EST")
-                    || zidStr.equals("HST")
-                    || zidStr.equals("MST")) {
+            if (ZoneId.SHORT_IDS.containsKey(zidStr)) {
                 continue;
             }
-            ZoneId zid = ZoneId.of(zidStr, ZoneId.SHORT_IDS);
+            // TBD: tzdt integration
+            if (zidStr.startsWith("SystemV")
+                    || zidStr.contains("Riyadh8")
+                    || zidStr.equals("US/Pacific-New")) {
+                continue;
+            }
+            ZoneId zid = ZoneId.of(zidStr);
             if (!zid.equals(TimeZone.getTimeZone(zid).toZoneId())) {
                 throw new RuntimeException("FAILED: zid -> tz -> zid :" + zidStr);
             }
             TimeZone tz = TimeZone.getTimeZone(zidStr);
             // no round-trip for alias and "GMT"
             if (!tz.equals(TimeZone.getTimeZone(tz.toZoneId()))
-                    && !ZoneId.SHORT_IDS.containsKey(zidStr)
                     && !zidStr.startsWith("GMT")) {
                 throw new RuntimeException("FAILED: tz -> zid -> tz :" + zidStr);
             }

--- a/test/jdk/java/util/Calendar/bug4316678.java
+++ b/test/jdk/java/util/Calendar/bug4316678.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4316678
+ * @bug 4316678 8347841
  * @summary test that Calendar's Serialization works correctly.
  * @run junit bug4316678
  */
@@ -53,7 +53,7 @@ public class bug4316678 {
     // Set custom JVM default TimeZone
     @BeforeAll
     static void initAll() {
-        TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
     }
 
     // Restore JVM default Locale and TimeZone

--- a/test/jdk/java/util/Calendar/bug4372743.java
+++ b/test/jdk/java/util/Calendar/bug4372743.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4372743
+ * @bug 4372743 8347841
  * @summary test that checks transitions of ERA and YEAR which are caused by add(MONTH).
  * @run junit bug4372743
  */
@@ -67,7 +67,7 @@ public class bug4372743 {
     // Set custom JVM default timezone
     @BeforeAll
     static void initAll() {
-        TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
     }
 
     // Restore JVM default timezone

--- a/test/jdk/java/util/Date/Bug4955000.java
+++ b/test/jdk/java/util/Date/Bug4955000.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4955000
+ * @bug 4955000 8347841
  * @summary Make sure that a Date and a GregorianCalendar produce the
  * same date/time. Both are new implementations in 1.5.
  */
@@ -42,7 +42,7 @@ public class Bug4955000 {
     public static void main(String[] args) {
         TimeZone defaultTZ = TimeZone.getDefault();
         try {
-            TimeZone.setDefault(TimeZone.getTimeZone("NST"));
+            TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Auckland"));
             GregorianCalendar gc = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
             // Date1025
             int[] years1 = {

--- a/test/jdk/java/util/Date/DateRegression.java
+++ b/test/jdk/java/util/Date/DateRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @bug 4023247 4027685 4032037 4072029 4073003 4118010 4120606 4133833 4136916 6274757 6314387
+ * @bug 4023247 4027685 4032037 4072029 4073003 4118010 4120606 4133833
+ *      4136916 6274757 6314387 8347841
  * @run junit DateRegression
  */
 
@@ -106,7 +107,7 @@ public class DateRegression {
         TimeZone saveZone = TimeZone.getDefault();
 
         try {
-            TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+            TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
             Date now = new Date();
             String s = now.toString();
             Date now2 = new Date(now.toString());

--- a/test/jdk/java/util/Date/DateTest.java
+++ b/test/jdk/java/util/Date/DateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4143459
+ * @bug 4143459 8347841
  * @summary test Date
  * @run junit DateTest
  */
@@ -56,7 +56,7 @@ public class DateTest
             d.setMonth(Calendar.JANUARY);
             d.setDate(1);
             d.setHours(6);
-            TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+            TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
             if (d.getHours() != 22) {
                 fail("Fail: Date.setHours()/getHours() ignoring default zone");
             }
@@ -79,7 +79,7 @@ public class DateTest
             Date ref = new Date(883634400000L); // This is Thu Jan 1 1998 6:00 am GMT
             String refstr = "Jan 1 1998 6:00";
             TimeZone GMT = TimeZone.getTimeZone("GMT");
-            TimeZone PST = TimeZone.getTimeZone("PST");
+            TimeZone PST = TimeZone.getTimeZone("America/Los_Angeles");
 
             String[] names = { "year", "month", "date", "day of week", "hour", "offset" };
             int[] GMT_EXP = { 98, Calendar.JANUARY, 1, Calendar.THURSDAY - Calendar.SUNDAY, 6, 0 };
@@ -207,7 +207,7 @@ public class DateTest
     {
       TimeZone save = TimeZone.getDefault();
       try {
-        TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
         Date d1=new java.util.Date(97,8,13,10,8,13);
         System.out.println("d       = "+d1);
         Date d2=new java.util.Date(97,8,13,30,8,13); // 20 hours later

--- a/test/jdk/java/util/Properties/StoreDeadlock.java
+++ b/test/jdk/java/util/Properties/StoreDeadlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6199320
+ * @bug 6199320 8347841
  * @summary Properties.store() causes deadlock when concurrently calling TimeZone apis
  * @run main/timeout=20 StoreDeadlock
  * @author Xueming Shen
@@ -59,7 +59,7 @@ public class StoreDeadlock {
     }
     class Thread2 extends Thread {
         public void run() {
-            System.out.println("tz=" + TimeZone.getTimeZone("PST"));
+            System.out.println("tz=" + TimeZone.getTimeZone("America/Los_Angeles"));
         }
     }
 }

--- a/test/jdk/java/util/TimeZone/Bug5097350.java
+++ b/test/jdk/java/util/TimeZone/Bug5097350.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,16 +23,19 @@
 
 /*
  * @test
- * @bug 5097350
+ * @bug 5097350 8347841
  * @summary Make sure that TimeZone.getTimeZone returns a clone of a cached TimeZone instance.
  */
 
+import java.time.ZoneId;
 import java.util.*;
-import java.text.*;
+import java.util.function.Predicate;
 
 public class Bug5097350 {
     public static void main(String[] args) {
-        String[] tzids = TimeZone.getAvailableIDs();
+        String[] tzids = Arrays.stream(TimeZone.getAvailableIDs())
+                .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+                .toArray(String[]::new);
         List<String> ids = new ArrayList<>(tzids.length + 10);
         ids.addAll(Arrays.asList(tzids));
         // add some custom ids

--- a/test/jdk/java/util/TimeZone/Bug6329116.java
+++ b/test/jdk/java/util/TimeZone/Bug6329116.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,15 @@
  * @test
  * @bug 6329116 6756569 6757131 6758988 6764308 6796489 6834474 6609737 6507067
  *      7039469 7090843 7103108 7103405 7158483 8008577 8059206 8064560 8072042
- *      8077685 8151876 8166875 8169191 8170316 8176044 8174269
+ *      8077685 8151876 8166875 8169191 8170316 8176044 8174269 8347841
  * @summary Make sure that timezone short display names are identical to Olson's data.
  * @run junit Bug6329116
  */
 
 import java.io.*;
+import java.time.ZoneId;
 import java.util.*;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +46,9 @@ public class Bug6329116 {
 
     // static Locale[] locales = Locale.getAvailableLocales();
     static Locale[] locales = {Locale.US};
-    static String[] timezones = TimeZone.getAvailableIDs();
+    static String[] timezones = Arrays.stream(TimeZone.getAvailableIDs())
+            .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+            .toArray(String[]::new);
 
     @Test
     public void bug6329116() throws IOException {
@@ -101,6 +105,9 @@ public class Bug6329116 {
                 tzs[0] = timezoneID;
 
                 for (int j = 0; j < tzs.length; j++) {
+                    if (ZoneId.SHORT_IDS.containsKey(tzs[j])) {
+                        continue;
+                    }
                     tz = TimeZone.getTimeZone(tzs[j]);
 
                     if (!tzs[j].equals(tz.getID())) {

--- a/test/jdk/java/util/TimeZone/Bug6772689.java
+++ b/test/jdk/java/util/TimeZone/Bug6772689.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,18 @@
 
 /*
  * @test
- * @bug 6772689
+ * @bug 6772689 8347841
  * @summary Test for standard-to-daylight transitions at midnight:
  * date stays on the given day.
  */
 
+import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
+import java.util.function.Predicate;
 import static java.util.GregorianCalendar.*;
 
 public class Bug6772689 {
@@ -43,7 +46,9 @@ public class Bug6772689 {
         int errors = 0;
 
         Calendar cal = new GregorianCalendar(BEGIN_YEAR, MARCH, 1);
-        String[] tzids = TimeZone.getAvailableIDs();
+        String[] tzids = Arrays.stream(TimeZone.getAvailableIDs())
+                .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+                .toArray(String[]::new);
         try {
             for (String id : tzids) {
                 TimeZone tz = TimeZone.getTimeZone(id);

--- a/test/jdk/java/util/TimeZone/DaylightTimeTest.java
+++ b/test/jdk/java/util/TimeZone/DaylightTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,17 +23,21 @@
 
 /*
  * @test
- * @bug 6936350
+ * @bug 6936350 8347841
  * @summary Test case for TimeZone.observesDaylightTime()
  */
 
+import java.time.ZoneId;
 import java.util.*;
+import java.util.function.Predicate;
 import static java.util.GregorianCalendar.*;
 
 public class DaylightTimeTest {
     private static final int ONE_HOUR = 60 * 60 * 1000; // one hour
     private static final int INTERVAL = 24 * ONE_HOUR;  // one day
-    private static final String[] ZONES = TimeZone.getAvailableIDs();
+    private static final String[] ZONES = Arrays.stream(TimeZone.getAvailableIDs())
+            .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+            .toArray(String[]::new);
     private static int errors = 0;
 
     public static void main(String[] args) {

--- a/test/jdk/java/util/TimeZone/IDTest.java
+++ b/test/jdk/java/util/TimeZone/IDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,24 +23,30 @@
 
 /*
  * @test
- * @bug 4509255 5055567 6176318 7090844
+ * @bug 4509255 5055567 6176318 7090844 8347841
  * @summary Tests consistencies of time zone IDs.
  */
 
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 
 public class IDTest {
     public static void main(String[] args) {
         Set<String> ids = new HashSet<>();
         Map<Integer, Set<String>> tree = new TreeMap<>();
 
-        String[] tzs = TimeZone.getAvailableIDs();
-        String[] tzs2 = TimeZone.getAvailableIDs();
+        String[] tzs = Arrays.stream(TimeZone.getAvailableIDs())
+                .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+                .toArray(String[]::new);
+        String[] tzs2 = Arrays.stream(TimeZone.getAvailableIDs())
+                .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+                .toArray(String[]::new);
         if (tzs.length != tzs2.length) {
             throw new RuntimeException("tzs.length(" + tzs.length
                                        + ") != tzs2.length(" + tzs2.length + ")");
@@ -83,8 +89,12 @@ public class IDTest {
             // Check the getAvailableIDs(int) call to return the same
             // set of IDs
             int offset = key.intValue();
-            tzs = TimeZone.getAvailableIDs(offset);
-            tzs2 = TimeZone.getAvailableIDs(offset);
+            tzs = Arrays.stream(TimeZone.getAvailableIDs(offset))
+                    .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+                    .toArray(String[]::new);
+            tzs2 = Arrays.stream(TimeZone.getAvailableIDs(offset))
+                    .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+                    .toArray(String[]::new);
             if (!Arrays.equals(tzs, tzs2)) {
                 throw new RuntimeException("inconsistent tzs from getAvailableIDs("+offset+")");
             }

--- a/test/jdk/java/util/TimeZone/ListTimeZones.java
+++ b/test/jdk/java/util/TimeZone/ListTimeZones.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,17 +23,21 @@
 
 /**
  * @test
- * @bug 6851214
+ * @bug 6851214 8347841
  * @summary Allow 24:00 as a valid end/start DST time stamp
  * @run main ListTimeZones
  */
 
+import java.time.ZoneId;
 import java.util.*;
+import java.util.function.Predicate;
 
 public class ListTimeZones{
   public static void main(String[] args){
     Date date = new Date();
-    String TimeZoneIds[] = TimeZone.getAvailableIDs();
+    String[] TimeZoneIds = Arrays.stream(TimeZone.getAvailableIDs())
+            .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+            .toArray(String[]::new);
     for(int i = 0; i < TimeZoneIds.length; i++){
       TimeZone tz = TimeZone.getTimeZone(TimeZoneIds[i]);
       Calendar calendar = new GregorianCalendar(tz);

--- a/test/jdk/java/util/TimeZone/TimeZoneBoundaryTest.java
+++ b/test/jdk/java/util/TimeZone/TimeZoneBoundaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8347841
  * @summary test Time Zone Boundary
  * @run junit TimeZoneBoundaryTest
  */
@@ -251,7 +252,7 @@ public class TimeZoneBoundaryTest
     @Test
     public void TestBoundaries()
     {
-        TimeZone pst = TimeZone.getTimeZone("PST");
+        TimeZone pst = TimeZone.getTimeZone("America/Los_Angeles");
         TimeZone save = TimeZone.getDefault();
         try {
             TimeZone.setDefault(pst);
@@ -410,11 +411,8 @@ public class TimeZoneBoundaryTest
     @Test
     public void TestStepwise()
     {
-        findBoundariesStepwise(1997, ONE_DAY, TimeZone.getTimeZone("ACT"), 0);
-        // "EST" is disabled because its behavior depends on the mapping property. (6466476).
-        //findBoundariesStepwise(1997, ONE_DAY, TimeZone.getTimeZone("EST"), 2);
-        findBoundariesStepwise(1997, ONE_DAY, TimeZone.getTimeZone("HST"), 0);
-        findBoundariesStepwise(1997, ONE_DAY, TimeZone.getTimeZone("PST"), 2);
+        findBoundariesStepwise(1997, ONE_DAY, TimeZone.getTimeZone("Australia/Darwin"), 0);
+        findBoundariesStepwise(1997, ONE_DAY, TimeZone.getTimeZone("Pacific/Honolulu"), 0);
         findBoundariesStepwise(1997, ONE_DAY, TimeZone.getTimeZone("PST8PDT"), 2);
         findBoundariesStepwise(1997, ONE_DAY, TimeZone.getTimeZone("SystemV/PST"), 0);
         findBoundariesStepwise(1997, ONE_DAY, TimeZone.getTimeZone("SystemV/PST8PDT"), 2);

--- a/test/jdk/java/util/TimeZone/TimeZoneRegression.java
+++ b/test/jdk/java/util/TimeZone/TimeZoneRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 4052967 4073209 4073215 4084933 4096952 4109314 4126678 4151406 4151429
  * 4154525 4154537 4154542 4154650 4159922 4162593 4173604 4176686 4184229 4208960
- * 4966229 6433179 6851214 8007520 8008577 8174269
+ * 4966229 6433179 6851214 8007520 8008577 8174269 8347841
  * @library /java/text/testlib
  * @run junit TimeZoneRegression
  */
@@ -42,8 +42,8 @@ public class TimeZoneRegression {
 
     @Test
     public void Test4073209() {
-        TimeZone z1 = TimeZone.getTimeZone("PST");
-        TimeZone z2 = TimeZone.getTimeZone("PST");
+        TimeZone z1 = TimeZone.getTimeZone("America/Los_Angeles");
+        TimeZone z2 = TimeZone.getTimeZone("America/Los_Angeles");
         if (z1 == z2) {
             fail("Fail: TimeZone should return clones");
         }
@@ -81,7 +81,7 @@ public class TimeZoneRegression {
         // test both SimpleTimeZone and ZoneInfo objects.
         // @since 1.4
         sub4084933(getPST());
-        sub4084933(TimeZone.getTimeZone("PST"));
+        sub4084933(TimeZone.getTimeZone("America/Los_Angeles"));
     }
 
     private void sub4084933(TimeZone tz) {
@@ -122,7 +122,7 @@ public class TimeZoneRegression {
 
     @Test
     public void Test4096952() {
-        String[] ZONES = { "GMT", "MET", "IST" };
+        String[] ZONES = { "GMT", "MET", "Asia/Kolkata" };
         boolean pass = true;
         try {
             for (int i=0; i<ZONES.length; ++i) {
@@ -172,7 +172,7 @@ public class TimeZoneRegression {
         // test both SimpleTimeZone and ZoneInfo objects.
         // @since 1.4
         sub4109314(getPST());
-        sub4109314(TimeZone.getTimeZone("PST"));
+        sub4109314(TimeZone.getTimeZone("America/Los_Angeles"));
     }
 
 
@@ -303,7 +303,7 @@ public class TimeZoneRegression {
         // test both SimpleTimeZone and ZoneInfo objects.
         // @since 1.4
         sub4126678(getPST());
-        sub4126678(TimeZone.getTimeZone("PST"));
+        sub4126678(TimeZone.getTimeZone("America/Los_Angeles"));
 
         // restore the initial time zone so that this test case
         // doesn't affect the others.
@@ -755,7 +755,7 @@ public class TimeZoneRegression {
         // test both SimpleTimeZone and ZoneInfo objects.
         // @since 1.4
         sub4173604(getPST());
-        sub4173604(TimeZone.getTimeZone("PST"));
+        sub4173604(TimeZone.getTimeZone("America/Los_Angeles"));
     }
 
     private void sub4173604(TimeZone pst) {
@@ -915,7 +915,7 @@ public class TimeZoneRegression {
         // test both SimpleTimeZone and ZoneInfo objects.
         // @since 1.4
         sub4208960(getPST());
-        sub4208960(TimeZone.getTimeZone("PST"));
+        sub4208960(TimeZone.getTimeZone("America/Los_Angeles"));
     }
 
     private void sub4208960(TimeZone tz) {

--- a/test/jdk/java/util/TimeZone/bug4096952.java
+++ b/test/jdk/java/util/TimeZone/bug4096952.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4096952
+ * @bug 4096952 8347841
  * @summary simple serialization/deserialization test
  */
 
@@ -38,7 +38,7 @@ public class bug4096952 {
 
     public static void main(String[] args) {
         int errors = 0;
-        String[] ZONES = { "GMT", "MET", "IST" };
+        String[] ZONES = { "GMT", "MET", "Asia/Kolkata" };
         for (String id : ZONES) {
             TimeZone zone = TimeZone.getTimeZone(id);
             try {

--- a/test/jdk/sun/security/x509/X509CertImpl/V3Certificate.java
+++ b/test/jdk/sun/security/x509/X509CertImpl/V3Certificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8049237 8242151
+ * @bug 8049237 8242151 8347841
  * @modules java.base/sun.security.x509
  *          java.base/sun.security.util
  *          jdk.crypto.ec
@@ -114,7 +114,7 @@ public class V3Certificate {
 
         // Validity interval
         Date firstDate = new Date();
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("PST"));
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("America/Los_Angeles"));
         cal.set(2014, 03, 10, 12, 30, 30);
         Date lastDate = cal.getTime();
         CertificateValidity interval = new CertificateValidity(firstDate,

--- a/test/jdk/sun/util/resources/TimeZone/Bug4640234.java
+++ b/test/jdk/sun/util/resources/TimeZone/Bug4640234.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 4640234 4946057 4938151 4873691 5023181
+ * @bug 4640234 4946057 4938151 4873691 5023181 8347841
  * @summary Verifies the translation of time zone names, this test will catch
  *          presence of country name for english and selected locales for all
  *          ISO country codes.
@@ -42,6 +42,8 @@
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 
+import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Enumeration;
@@ -49,6 +51,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.TimeZone;
+import java.util.function.Predicate;
 
 import sun.util.resources.LocaleData;
 
@@ -83,7 +86,9 @@ public class Bug4640234  {
             StringBuffer errors = new StringBuffer("");
             StringBuffer warnings = new StringBuffer("");
 
-            String[] timezones = TimeZone.getAvailableIDs();
+            String[] timezones = Arrays.stream(TimeZone.getAvailableIDs())
+                    .filter(Predicate.not(ZoneId.SHORT_IDS::containsKey))
+                    .toArray(String[]::new);
             String[] countries = locEn.getISOCountries();
             String[] languages = locEn.getISOLanguages();
 

--- a/test/jdk/sun/util/resources/cldr/Bug8134384.java
+++ b/test/jdk/sun/util/resources/cldr/Bug8134384.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8134384 8234347 8236548
+ * @bug 8134384 8234347 8236548 8347841
  * @summary Tests CLDR TimeZoneNames has English names for all tzids
  * @run main/othervm -Djava.locale.providers=CLDR Bug8134384
  */
@@ -38,6 +38,9 @@ public class Bug8134384 {
 
         try {
             for (String tz : TimeZone.getAvailableIDs() ) {
+                if (ZoneId.SHORT_IDS.containsKey(tz)) {
+                    continue;
+                }
                 TimeZone.setDefault(TimeZone.getTimeZone(tz));
                 // Summer solstice
                 String date1 = Date.from(Instant.parse("2015-06-21T00:00:00.00Z")).toString();

--- a/test/jdk/sun/util/resources/cldr/Bug8202764.java
+++ b/test/jdk/sun/util/resources/cldr/Bug8202764.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
  /*
  * @test
- * @bug 8202764
+ * @bug 8202764 8347841
  * @modules jdk.localedata
  * @summary Checks time zone names are consistent with aliased ids,
  *      between DateFormatSymbols.getZoneStrings() and getDisplayName()
@@ -49,6 +49,7 @@ public class Bug8202764 {
     public void testAliasedTZs() {
         Set<String> zoneIds = ZoneId.getAvailableZoneIds();
         Arrays.stream(DateFormatSymbols.getInstance(Locale.US).getZoneStrings())
+            .filter(zone -> !ZoneId.SHORT_IDS.containsKey(zone[0]))
             .forEach(zone -> {
                 System.out.println(zone[0]);
                 TimeZone tz = TimeZone.getTimeZone(zone[0]);


### PR DESCRIPTION
This fix is a follow on for [JDK-8342550](https://bugs.openjdk.org/browse/JDK-8342550). Replaces/Removes usages of those deprecated time zone ids in tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347841](https://bugs.openjdk.org/browse/JDK-8347841): Test fixes that use deprecated time zone IDs (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23166/head:pull/23166` \
`$ git checkout pull/23166`

Update a local copy of the PR: \
`$ git checkout pull/23166` \
`$ git pull https://git.openjdk.org/jdk.git pull/23166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23166`

View PR using the GUI difftool: \
`$ git pr show -t 23166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23166.diff">https://git.openjdk.org/jdk/pull/23166.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23166#issuecomment-2597132635)
</details>
