### PR TITLE
8347987: Bad ifdef in 8330851

### DIFF
--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -250,10 +250,10 @@ const TypeFunc* OptoRuntime::_updateBytesCRC32C_Type              = nullptr;
 const TypeFunc* OptoRuntime::_updateBytesAdler32_Type             = nullptr;
 const TypeFunc* OptoRuntime::_osr_end_Type                        = nullptr;
 const TypeFunc* OptoRuntime::_register_finalizer_Type             = nullptr;
-#ifdef INCLUDE_JFR
+#if INCLUDE_JFR
 const TypeFunc* OptoRuntime::_class_id_load_barrier_Type          = nullptr;
 #endif // INCLUDE_JFR
-#ifdef INCLUDE_JVMTI
+#if INCLUDE_JVMTI
 const TypeFunc* OptoRuntime::_notify_jvmti_vthread_Type           = nullptr;
 #endif // INCLUDE_JVMTI
 const TypeFunc* OptoRuntime::_dtrace_method_entry_exit_Type       = nullptr;
@@ -2002,7 +2002,7 @@ void OptoRuntime::initialize_types() {
   JFR_ONLY(
     _class_id_load_barrier_Type       = make_class_id_load_barrier_Type();
   )
-#ifdef INCLUDE_JVMTI
+#if INCLUDE_JVMTI
   _notify_jvmti_vthread_Type          = make_notify_jvmti_vthread_Type();
 #endif // INCLUDE_JVMTI
   _dtrace_method_entry_exit_Type      = make_dtrace_method_entry_exit_Type();

--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -190,10 +190,10 @@ class OptoRuntime : public AllStatic {
   static const TypeFunc* _updateBytesAdler32_Type;
   static const TypeFunc* _osr_end_Type;
   static const TypeFunc* _register_finalizer_Type;
-#ifdef INCLUDE_JFR
+#if INCLUDE_JFR
   static const TypeFunc* _class_id_load_barrier_Type;
 #endif // INCLUDE_JFR
-#ifdef INCLUDE_JVMTI
+#if INCLUDE_JVMTI
   static const TypeFunc* _notify_jvmti_vthread_Type;
 #endif // INCLUDE_JVMTI
   static const TypeFunc* _dtrace_method_entry_exit_Type;
@@ -645,7 +645,7 @@ private:
     return _register_finalizer_Type;
   }
 
-#ifdef INCLUDE_JFR
+#if INCLUDE_JFR
   static inline const TypeFunc* class_id_load_barrier_Type() {
     assert(_class_id_load_barrier_Type != nullptr, "should be initialized");
     return _class_id_load_barrier_Type;


### PR DESCRIPTION
Hi, please consider.

We use "#if INCLUDE_xxx" everywhere else.
Currently I get this compilation error:
```
src/hotspot/share/opto/runtime.cpp:2006:41: error: ‘make_notify_jvmti_vthread_Type’ was not declared in this scope; did you mean ‘_notify_jvmti_vthread_Type’?
 2006 |   _notify_jvmti_vthread_Type          = make_notify_jvmti_vthread_Type();
```

Only compiled tested, thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347987](https://bugs.openjdk.org/browse/JDK-8347987): Bad ifdef in 8330851 (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23172/head:pull/23172` \
`$ git checkout pull/23172`

Update a local copy of the PR: \
`$ git checkout pull/23172` \
`$ git pull https://git.openjdk.org/jdk.git pull/23172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23172`

View PR using the GUI difftool: \
`$ git pr show -t 23172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23172.diff">https://git.openjdk.org/jdk/pull/23172.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23172#issuecomment-2598126205)
</details>
