### PR TITLE
8346987: [lto] gtest build fails

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -174,7 +174,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     EXCLUDE_FILES := $(JVM_EXCLUDE_FILES), \
     EXCLUDE_PATTERNS := $(JVM_EXCLUDE_PATTERNS), \
     DEFAULT_CFLAGS := false, \
-    CFLAGS := $(JVM_CFLAGS), \
+    CFLAGS := $(JVM_CFLAGS) $(JVM_CFLAGS_FEATURES_LTO), \
     abstract_vm_version.cpp_CXXFLAGS := $(CFLAGS_VM_VERSION), \
     arguments.cpp_CXXFLAGS := $(CFLAGS_VM_VERSION), \
     DISABLED_WARNINGS_gcc := $(DISABLED_WARNINGS_gcc), \
@@ -221,7 +221,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     ASFLAGS := $(JVM_ASFLAGS), \
     LD_SET_ORIGIN := false, \
     DEFAULT_LDFLAGS := false, \
-    LDFLAGS := $(JVM_LDFLAGS), \
+    LDFLAGS := $(JVM_LDFLAGS) $(JVM_LDFLAGS_FEATURES_LTO), \
     LIBS := $(JVM_LIBS), \
     OPTIMIZATION := $(JVM_OPTIMIZATION), \
     OBJECT_DIR := $(JVM_OUTPUTDIR)/objs, \

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -170,23 +170,23 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
   # later on if desired
   JVM_OPTIMIZATION := HIGHEST_JVM
   ifeq ($(call isCompiler, gcc), true)
-    JVM_CFLAGS_FEATURES += -flto=auto -fuse-linker-plugin -fno-strict-aliasing \
+    JVM_CFLAGS_FEATURES_LTO += -flto=auto -fuse-linker-plugin -fno-strict-aliasing \
         -fno-fat-lto-objects
-    JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto=auto \
+    JVM_LDFLAGS_FEATURES_LTO += $(CXX_O_FLAG_HIGHEST_JVM) -flto=auto \
         -fuse-linker-plugin -fno-strict-aliasing
   else ifeq ($(call isCompiler, clang), true)
-    JVM_CFLAGS_FEATURES += -flto -fno-strict-aliasing
+    JVM_CFLAGS_FEATURES_LTO += -flto -fno-strict-aliasing
     ifeq ($(call isBuildOs, aix), true)
-      JVM_CFLAGS_FEATURES += -ffat-lto-objects
+      JVM_CFLAGS_FEATURES_LTO += -ffat-lto-objects
     endif
-    JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto -fno-strict-aliasing
+    JVM_LDFLAGS_FEATURES_LTO += $(CXX_O_FLAG_HIGHEST_JVM) -flto -fno-strict-aliasing
   else ifeq ($(call isCompiler, microsoft), true)
-    JVM_CFLAGS_FEATURES += -GL
-    JVM_LDFLAGS_FEATURES += -LTCG:INCREMENTAL
+    JVM_CFLAGS_FEATURES_LTO += -GL
+    JVM_LDFLAGS_FEATURES_LTO += -LTCG:INCREMENTAL
   endif
 else
   ifeq ($(call isCompiler, gcc), true)
-    JVM_LDFLAGS_FEATURES += -O1
+    JVM_LDFLAGS_FEATURES_LTO += -O1
   endif
 endif
 


### PR DESCRIPTION
When building with link time optimization (lto) , configure flag is --enable-jvm-feature-link-time-opt , we run in the gtest build into a lot of errors.
One workaround is just to configure without gtest ; this one changes the make to NOT use the lto build flags for gtest , just for the "normal" libjvm.so .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346987](https://bugs.openjdk.org/browse/JDK-8346987): [lto] gtest build fails (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23173/head:pull/23173` \
`$ git checkout pull/23173`

Update a local copy of the PR: \
`$ git checkout pull/23173` \
`$ git pull https://git.openjdk.org/jdk.git pull/23173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23173`

View PR using the GUI difftool: \
`$ git pr show -t 23173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23173.diff">https://git.openjdk.org/jdk/pull/23173.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23173#issuecomment-2598187947)
</details>
