### PR TITLE
8334320: Replace vmTestbase/metaspace/share/TriggerUnloadingWithWhiteBox.java with ClassUnloadCommon from testlibrary

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/metaspace/share/TriggerUnloadingWithFullGC.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/share/TriggerUnloadingWithFullGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,19 +20,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package metaspace.share;
 
-
-import jdk.test.whitebox.WhiteBox;
+import jdk.test.lib.classloader.ClassUnloadCommon;
 import nsk.share.test.ExecutionController;
 
-public class TriggerUnloadingWithWhiteBox implements TriggerUnloadingHelper {
-
-        private final static WhiteBox wb = WhiteBox.getWhiteBox();
+public class TriggerUnloadingWithFullGC implements TriggerUnloadingHelper {
 
         @Override
         public void triggerUnloading(ExecutionController stresser) {
-                wb.fullGC();
+                ClassUnloadCommon.triggerUnloading();
         }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/metaspace/staticReferences/StaticReferences.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/staticReferences/StaticReferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ import java.util.Map;
 import java.util.Random;
 
 import metaspace.share.TriggerUnloadingHelper;
-import metaspace.share.TriggerUnloadingWithWhiteBox;
+import metaspace.share.TriggerUnloadingWithFullGC;
 import nsk.share.gc.GCTestBase;
 import nsk.share.test.ExecutionController;
 import nsk.share.test.Stresser;
@@ -86,7 +86,7 @@ public class StaticReferences extends GCTestBase {
 
     private Random random;
 
-    private TriggerUnloadingHelper triggerUnloadingHelper = new TriggerUnloadingWithWhiteBox();
+    private TriggerUnloadingHelper triggerUnloadingHelper = new TriggerUnloadingWithFullGC();
 
     private String[] typesArray = new String[] {"Object object", "boolean boolean", "byte byte", "char char", "double double", "float float", "int int", "long long", "short short"};
 

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/common/StressHierarchyBaseClass.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/common/StressHierarchyBaseClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ import java.net.MalformedURLException;
 import metaspace.share.HeapOOMEException;
 import metaspace.share.TriggerUnloadingByFillingMetaspace;
 import metaspace.share.TriggerUnloadingHelper;
-import metaspace.share.TriggerUnloadingWithWhiteBox;
+import metaspace.share.TriggerUnloadingWithFullGC;
 import metaspace.stressHierarchy.common.classloader.tree.Node;
 import metaspace.stressHierarchy.common.classloader.tree.Tree;
 import metaspace.stressHierarchy.common.exceptions.TimeIsOverException;
@@ -48,7 +48,7 @@ abstract public class StressHierarchyBaseClass extends TestBase {
 
     protected static String[] args;
 
-    protected TriggerUnloadingHelper triggerUnloadingHelper = new TriggerUnloadingWithWhiteBox(); //default helper
+    protected TriggerUnloadingHelper triggerUnloadingHelper = new TriggerUnloadingWithFullGC(); //default helper
 
     protected PerformChecksHelper performChecksHelper = null;
 


### PR DESCRIPTION
Rename and make TriggerUnloadingWithWhiteBox call ClassUnloadCommon.triggerUnloading() instead of WB.fullGC().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334320](https://bugs.openjdk.org/browse/JDK-8334320): Replace vmTestbase/metaspace/share/TriggerUnloadingWithWhiteBox.java with ClassUnloadCommon from testlibrary (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23174/head:pull/23174` \
`$ git checkout pull/23174`

Update a local copy of the PR: \
`$ git checkout pull/23174` \
`$ git pull https://git.openjdk.org/jdk.git pull/23174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23174`

View PR using the GUI difftool: \
`$ git pr show -t 23174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23174.diff">https://git.openjdk.org/jdk/pull/23174.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23174#issuecomment-2607294698)
</details>
