### PR TITLE
8347996: JavaCompilation.gmk should not include ZipArchive.gmk

### DIFF
--- a/make/CompileDemos.gmk
+++ b/make/CompileDemos.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -132,12 +132,19 @@ define SetupBuildDemoBody
         JARMAIN := $$($1_MAIN_CLASS), \
         MANIFEST := $(DEMO_MANIFEST), \
         EXTRA_MANIFEST_ATTR := $$($1_EXTRA_MANIFEST_ATTR), \
-        SRCZIP := $(SUPPORT_OUTPUTDIR)/demos/image/$$($1_DEMO_SUBDIR)/$1/src.zip, \
         EXCLUDE_FILES := $$($1_EXCLUDE_FILES), \
         DISABLED_WARNINGS := $$($1_DISABLED_WARNINGS), \
     ))
 
     $1 += $$(BUILD_DEMO_$1)
+
+    $$(eval $$(call SetupZipArchive, ZIP_SRC_DEMO_$1, \
+        SRC := $$($1_MAIN_SRC) $$($1_EXTRA_SRC_DIR), \
+        ZIP := $(SUPPORT_OUTPUTDIR)/demos/image/$$($1_DEMO_SUBDIR)/$1/src.zip, \
+        EXCLUDE_FILES := $$($1_EXCLUDE_FILES), \
+    ))
+
+    $1 += $$(ZIP_SRC_DEMO_$1)
   endif
 
   # Copy files. Sort is needed to remove duplicates.

--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -32,10 +32,8 @@ endif
 
 include MakeIO.gmk
 
-# Java compilation needs SetupJarArchive and/or SetupZipArchive, if we're
-# generating a jar file or a source zip.
+# Java compilation needs SetupJarArchive if we're generating a jar file
 include JarArchive.gmk
-include ZipArchive.gmk
 
 ###
 ### Definitions for common release targets
@@ -156,7 +154,6 @@ endef
 #   COPY_FILES myapp/foo/setting.txt means copy this file over to the package myapp/foo
 #   CLEAN .properties means copy and clean all properties file to the corresponding package in BIN.
 #   CLEAN_FILES myapp/foo/setting.txt means clean this file over to the package myapp/foo
-#   SRCZIP Create a src.zip based on the found sources and copied files.
 #   INCLUDE_FILES "com/sun/SolarisFoobar.java" means only compile this file!
 #   EXCLUDE_FILES "com/sun/SolarisFoobar.java" means do not compile this particular file!
 #       "SolarisFoobar.java" means do not compile SolarisFoobar, wherever it is found.
@@ -528,19 +525,6 @@ define SetupJavaCompilationBody
 
       # Add jar to target list
       $1 += $$($1_JAR)
-    endif
-
-    # Check if a srczip was specified, then setup the rules for the srczip.
-    ifneq ($$($1_SRCZIP), )
-      $$(eval $$(call SetupZipArchive, ZIP_ARCHIVE_$1, \
-          SRC := $$($1_SRC), \
-          ZIP := $$($1_SRCZIP), \
-          INCLUDES := $$($1_INCLUDES), \
-          EXCLUDES := $$($1_EXCLUDES), \
-          EXCLUDE_FILES := $$($1_EXCLUDE_FILES)))
-
-      # Add zip to target list
-      $1 += $$($1_SRCZIP)
     endif
   endif # Source files found
 endef


### PR DESCRIPTION
JavaCompilation.gmk includes ZipArchive.gmk, which includes ToolsJdk.gmk, which in turns includes JavaCompilation.gmk. This causes a circular dependency, which is not ideal. Make handles this anyway, but when I was developing new functionality to the build system, I discovered that this became a blocker.

Fortunately, the solution is simple. We include ZipArchive.gmk to support the convenience argument SRCZIP. It is used only in a single place, when compiling demos, and we can just as well (and arguably even better) call SetupZipArchive directly there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347996](https://bugs.openjdk.org/browse/JDK-8347996): JavaCompilation.gmk should not include ZipArchive.gmk (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23175/head:pull/23175` \
`$ git checkout pull/23175`

Update a local copy of the PR: \
`$ git checkout pull/23175` \
`$ git pull https://git.openjdk.org/jdk.git pull/23175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23175`

View PR using the GUI difftool: \
`$ git pr show -t 23175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23175.diff">https://git.openjdk.org/jdk/pull/23175.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23175#issuecomment-2598631044)
</details>
