### PR TITLE
8225739: sun/security/pkcs11/tls/tls12/FipsModeTLS12.java is not reliable

### DIFF
--- a/test/jdk/sun/security/pkcs11/tls/tls12/FipsModeTLS12.java
+++ b/test/jdk/sun/security/pkcs11/tls/tls12/FipsModeTLS12.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Red Hat, Inc.
+ * Copyright (c) 2019, 2025, Red Hat, Inc.
  * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -65,6 +65,7 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManagerFactory;
 
 import jdk.test.lib.security.SecurityUtils;
+import jtreg.SkippedException;
 import sun.security.internal.spec.TlsMasterSecretParameterSpec;
 import sun.security.internal.spec.TlsPrfParameterSpec;
 import sun.security.internal.spec.TlsRsaPremasterSecretParameterSpec;
@@ -88,12 +89,11 @@ public final class FipsModeTLS12 extends SecmodTest {
         try {
             initialize();
         } catch (Exception e) {
-            System.out.println("Test skipped: failure during" +
-                    " initialization");
             if (enableDebug) {
                 System.out.println(e);
             }
-            return;
+            throw new SkippedException("Test skipped: failure during " +
+                    "initialization.");
         }
 
         if (shouldRun()) {
@@ -105,7 +105,7 @@ public final class FipsModeTLS12 extends SecmodTest {
 
             System.out.println("Test PASS - OK");
         } else {
-            System.out.println("Test skipped: TLS 1.2 mechanisms" +
+            throw new SkippedException("Test skipped: TLS 1.2 mechanisms" +
                     " not supported by current SunPKCS11 back-end");
         }
     }


### PR DESCRIPTION
Hello,

I would like to propose a solution for this test that makes it more clear when it's skipped.

Regards,
Martin.-

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8225739](https://bugs.openjdk.org/browse/JDK-8225739): sun/security/pkcs11/tls/tls12/FipsModeTLS12.java is not reliable (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23177/head:pull/23177` \
`$ git checkout pull/23177`

Update a local copy of the PR: \
`$ git checkout pull/23177` \
`$ git pull https://git.openjdk.org/jdk.git pull/23177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23177`

View PR using the GUI difftool: \
`$ git pr show -t 23177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23177.diff">https://git.openjdk.org/jdk/pull/23177.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23177#issuecomment-2598853194)
</details>
