### PR TITLE
8347989: Trees.getScope may crash for not-yet attributed source

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -546,7 +546,7 @@ public class Enter extends JCTree.Visitor {
 
 //        Assert.checkNonNull(c.modle, c.sourcefile.toString());
 
-        result = c.type;
+        result = tree.type = c.type;
     }
     //where
         /** Does class have the same name as the file it appears in?


### PR DESCRIPTION
Consider code like this:
```
class Test {
    private int test(boolean b) {
        int v = b ? test(!b) : 0;
        return v;
    }
}
```

and consider `Trees.getScope` being called for a `TreePath` corresponding to "return" after the "enter" phase, but before `Attr`. E.g. from an annotation processor. This will lead to an exception like:

```
Caused by: java.lang.NullPointerException: Cannot invoke "com.sun.tools.javac.code.Type.accept(com.sun.tools.javac.code.Type$Visitor, Object)" because "t" is null
at jdk.compiler/com.sun.tools.javac.code.Types$DefaultTypeVisitor.visit(Types.java:4936)
at jdk.compiler/com.sun.tools.javac.code.Types.memberType(Types.java:2306)
at jdk.compiler/com.sun.tools.javac.comp.Attr.isBooleanOrNumeric(Attr.java:2133)
at jdk.compiler/com.sun.tools.javac.comp.Attr.isBooleanOrNumeric(Attr.java:2122)
at jdk.compiler/com.sun.tools.javac.comp.Attr.visitConditional(Attr.java:2060)
at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCConditional.accept(JCTree.java:1580)
at jdk.compiler/com.sun.tools.javac.comp.Attr.attribTree(Attr.java:677)
at jdk.compiler/com.sun.tools.javac.comp.Attr.attribExpr(Attr.java:723)
at jdk.compiler/com.sun.tools.javac.comp.Attr.visitVarDef(Attr.java:1320)
at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCVariableDecl.accept(JCTree.java:1066)
at jdk.compiler/com.sun.tools.javac.comp.Attr.attribTree(Attr.java:677)
at jdk.compiler/com.sun.tools.javac.comp.Attr.attribStat(Attr.java:751)
at jdk.compiler/com.sun.tools.javac.comp.Attr.attribStats(Attr.java:770)
at jdk.compiler/com.sun.tools.javac.comp.Attr.visitBlock(Attr.java:1454)
at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCBlock.accept(JCTree.java:1136)
at jdk.compiler/com.sun.tools.javac.comp.Attr.attribTree(Attr.java:677)
at jdk.compiler/com.sun.tools.javac.comp.DeferredAttr.attribSpeculative(DeferredAttr.java:515)
at jdk.compiler/com.sun.tools.javac.comp.Attr.attribToTree(Attr.java:428)
at jdk.compiler/com.sun.tools.javac.comp.Attr.attribStatToTree(Attr.java:421)
at jdk.compiler/com.sun.tools.javac.api.JavacTrees.attribStatToTree(JavacTrees.java:882)
at jdk.compiler/com.sun.tools.javac.api.JavacTrees.getAttrContext(JavacTrees.java:857)
at jdk.compiler/com.sun.tools.javac.api.JavacTrees.getScope(JavacTrees.java:723)
at jdk.compiler/com.sun.tools.javac.api.JavacTrees.getScope(JavacTrees.java:159)
```

The reason is that the `Attr.isBooleanOrNumeric` in this case will refer to `env.encClass.type`, but the type of the enclosing class is filled at the end of `Attr.visitClassDef`. So, the `Trees.getScope` running before `Attr` cannot use it.

The proposal in this PR is to set the `JCClassDecl`'s type (also) in `Enter`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347989](https://bugs.openjdk.org/browse/JDK-8347989): Trees.getScope may crash for not-yet attributed source (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23179/head:pull/23179` \
`$ git checkout pull/23179`

Update a local copy of the PR: \
`$ git checkout pull/23179` \
`$ git pull https://git.openjdk.org/jdk.git pull/23179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23179`

View PR using the GUI difftool: \
`$ git pr show -t 23179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23179.diff">https://git.openjdk.org/jdk/pull/23179.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23179#issuecomment-2598955337)
</details>
