### PR TITLE
8347990: Remove SIZE_FORMAT macros and replace remaining uses

### DIFF
--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -217,7 +217,7 @@ void MetaspaceUtils::print_on(outputStream* out) {
   // Used from all GCs. It first prints out totals, then, separately, the class space portion.
   MetaspaceCombinedStats stats = get_combined_statistics();
   out->print_cr(" Metaspace       "
-                "used "      SIZE_FORMAT "K, "
+                "used %zuK, "
                 "committed %zuK, "
                 "reserved %zuK",
                 stats.used()/K,
@@ -226,7 +226,7 @@ void MetaspaceUtils::print_on(outputStream* out) {
 
   if (Metaspace::using_class_space()) {
     out->print_cr("  class space    "
-                  "used "      SIZE_FORMAT "K, "
+                  "used %zuK, "
                   "committed %zuK, "
                   "reserved %zuK",
                   stats.class_space_stats().used()/K,
@@ -566,7 +566,7 @@ void Metaspace::initialize_class_space(ReservedSpace rs) {
          "%zu != %zu", rs.size(), CompressedClassSpaceSize);
   assert(using_class_space(), "Must be using class space");
 
-  assert(rs.size() == CompressedClassSpaceSize, SIZE_FORMAT " != %zu",
+  assert(rs.size() == CompressedClassSpaceSize, "%zu != %zu",
          rs.size(), CompressedClassSpaceSize);
   assert(is_aligned(rs.base(), Metaspace::reserve_alignment()) &&
          is_aligned(rs.size(), Metaspace::reserve_alignment()),

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -134,12 +134,6 @@ class oopDesc;
 #define UINT64_FORMAT_W(width)   "%"   #width PRIu64
 #define UINT64_FORMAT_0          "%016"       PRIx64
 
-
-// Format integers which change size between 32- and 64-bit.
-#define SIZE_FORMAT              "%"          PRIuPTR
-#define SIZE_FORMAT_X            "0x%"        PRIxPTR
-#define SIZE_FORMAT_W(width)     "%"   #width PRIuPTR
-
 // Format jlong, if necessary
 #ifndef JLONG_FORMAT
 #define JLONG_FORMAT             INT64_FORMAT
@@ -373,15 +367,15 @@ inline T byte_size_in_proper_unit(T s) {
   }
 }
 
-#define PROPERFMT             SIZE_FORMAT "%s"
+#define PROPERFMT             "%zu%s"
 #define PROPERFMTARGS(s)      byte_size_in_proper_unit(s), proper_unit_for_byte_size(s)
 
 // Printing a range, with start and bytes given
-#define RANGEFMT              "[" PTR_FORMAT " - " PTR_FORMAT "), (" SIZE_FORMAT " bytes)"
+#define RANGEFMT              "[" PTR_FORMAT " - " PTR_FORMAT "), (%zu bytes)"
 #define RANGEFMTARGS(p1, size) p2i(p1), p2i(p1 + size), size
 
 // Printing a range, with start and end given
-#define RANGE2FMT             "[" PTR_FORMAT " - " PTR_FORMAT "), (" SIZE_FORMAT " bytes)"
+#define RANGE2FMT             "[" PTR_FORMAT " - " PTR_FORMAT "), (%zu bytes)"
 #define RANGE2FMTARGS(p1, p2) p2i(p1), p2i(p2), ((uintptr_t)p2 - (uintptr_t)p1)
 
 inline const char* exact_unit_for_byte_size(size_t s) {
@@ -414,12 +408,12 @@ inline size_t byte_size_in_exact_unit(size_t s) {
   return s;
 }
 
-#define EXACTFMT            SIZE_FORMAT "%s"
+#define EXACTFMT            "%zu%s"
 #define EXACTFMTARGS(s)     byte_size_in_exact_unit(s), exact_unit_for_byte_size(s)
 
 // Memory size transition formatting.
 
-#define HEAP_CHANGE_FORMAT "%s: " SIZE_FORMAT "K(" SIZE_FORMAT "K)->" SIZE_FORMAT "K(" SIZE_FORMAT "K)"
+#define HEAP_CHANGE_FORMAT "%s: %zuK(%zuK)->%zuK(%zuK)"
 
 #define HEAP_CHANGE_FORMAT_ARGS(_name_, _prev_used_, _prev_capacity_, _used_, _capacity_) \
   (_name_), (_prev_used_) / K, (_prev_capacity_) / K, (_used_) / K, (_capacity_) / K

--- a/test/hotspot/gtest/gc/g1/test_g1FreeIdSet.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1FreeIdSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ public:
       ++_allocations;
       ThreadBlockInVM tbiv(this); // Safepoint check.
     }
-    tty->print_cr("%u allocations: " SIZE_FORMAT, _thread_number, _allocations);
+    tty->print_cr("%u allocations: %zu", _thread_number, _allocations);
     Atomic::add(_total_allocations, _allocations);
   }
 };
@@ -151,7 +151,7 @@ TEST_VM(G1FreeIdSetTest, stress) {
     ThreadInVMfromNative invm(this_thread);
     post.wait_with_safepoint_check(this_thread);
   }
-  tty->print_cr("total allocations: " SIZE_FORMAT, total_allocations);
+  tty->print_cr("total allocations: %zu", total_allocations);
   tty->print_cr("final free list: ");
   uint ids[size] = {};
   for (uint i = 0; i < size; ++i) {

--- a/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
+++ b/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,7 +142,7 @@ public:
       ++_allocations;
       ThreadBlockInVM tbiv(this); // Safepoint check.
     }
-    tty->print_cr("allocations: " SIZE_FORMAT, _allocations);
+    tty->print_cr("allocations: %zu", _allocations);
     Atomic::add(_total_allocations, _allocations);
   }
 };
@@ -234,8 +234,8 @@ static void run_test(BufferNode::Allocator* allocator, CompletedList* cbl) {
     post.wait_with_safepoint_check(this_thread);
   }
   ASSERT_TRUE(BufferNode::TestSupport::try_transfer_pending(allocator));
-  tty->print_cr("total allocations: " SIZE_FORMAT, total_allocations);
-  tty->print_cr("allocator free count: " SIZE_FORMAT, allocator->free_count());
+  tty->print_cr("total allocations: %zu", total_allocations);
+  tty->print_cr("allocator free count: %zu", allocator->free_count());
 }
 
 TEST_VM(BufferNodeAllocatorTest, stress_free_list_allocator) {

--- a/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1136,9 +1136,9 @@ TEST_VM_F(OopStorageTestWithAllocation, print_storage) {
   {
     ResourceMark rm;
     stringStream expected_st;
-    expected_st.print("Test Storage: " SIZE_FORMAT
-                      " entries in " SIZE_FORMAT
-                      " blocks (%.F%%), " SIZE_FORMAT " bytes",
+    expected_st.print("Test Storage: %zu"
+                      " entries in %zu"
+                      " blocks (%.F%%), %zu bytes",
                       expected_entries,
                       expected_blocks,
                       expected_usage,

--- a/test/hotspot/gtest/gc/shared/test_workerDataArray.cpp
+++ b/test/hotspot/gtest/gc/shared/test_workerDataArray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,10 +89,10 @@ const char* WorkerDataArrayTest<size_t>::format_summary(
   size_t min, double avg, size_t max, size_t diff, size_t sum, size_t workers) {
 
   stringStream out;
-  out.print(" Min: " SIZE_FORMAT
-            ", Avg: %4.1lf, Max: " SIZE_FORMAT
-            ", Diff: " SIZE_FORMAT ", Sum: " SIZE_FORMAT
-            ", Workers: " SIZE_FORMAT "\n",
+  out.print(" Min: %zu"
+            ", Avg: %4.1lf, Max: %zu"
+            ", Diff: %zu, Sum: %zu"
+            ", Workers: %zu\n",
             min, avg, max, diff, sum, workers);
   return out.as_string();
 }
@@ -105,7 +105,7 @@ const char* WorkerDataArrayTest<double>::format_summary(
   out.print(" Min: %4.2lf"
             ", Avg: %4.2lf, Max: %4.2lf"
             ", Diff: %4.2lf, Sum: %4.2lf"
-            ", Workers: " SIZE_FORMAT "\n",
+            ", Workers: %zu\n",
             min, avg, max, diff, sum, workers);
   return out.as_string();
 }

--- a/test/hotspot/gtest/logging/test_logFileOutput.cpp
+++ b/test/hotspot/gtest/logging/test_logFileOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,7 @@ TEST_VM(LogFileOutput, parse_invalid) {
 // Test for overflows with filesize
 TEST_VM(LogFileOutput, filesize_overflow) {
   char buf[256];
-  int ret = jio_snprintf(buf, sizeof(buf), "filesize=" SIZE_FORMAT "K", SIZE_MAX);
+  int ret = jio_snprintf(buf, sizeof(buf), "filesize=%zuK", SIZE_MAX);
   ASSERT_GT(ret, 0) << "Buffer too small";
 
   ResourceMark rm;
@@ -108,7 +108,7 @@ TEST_VM(LogFileOutput, startup_rotation) {
   for (size_t i = 0; i < rotations; i++) {
     size_t len = strlen(filename) + 3;
     rotated_file[i] = NEW_RESOURCE_ARRAY(char, len);
-    int ret = jio_snprintf(rotated_file[i], len, "%s." SIZE_FORMAT, filename, i);
+    int ret = jio_snprintf(rotated_file[i], len, "%s.%zu", filename, i);
     ASSERT_NE(-1, ret);
     delete_file(rotated_file[i]);
   }

--- a/test/hotspot/gtest/logging/test_logMessageTest.cpp
+++ b/test/hotspot/gtest/logging/test_logMessageTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,14 +168,14 @@ TEST_VM_F(LogMessageTest, message_with_many_lines) {
 
   LogMessageBuffer msg;
   for (size_t i = 0; i < lines; i++) {
-    msg.info("Line #" SIZE_FORMAT, i);
+    msg.info("Line #%zu", i);
   }
   _log.write(msg);
 
   char expected_lines_data[lines][line_length];
   const char* expected_lines[lines + 1];
   for (size_t i = 0; i < lines; i++) {
-    jio_snprintf(&expected_lines_data[i][0], line_length, "Line #" SIZE_FORMAT, i);
+    jio_snprintf(&expected_lines_data[i][0], line_length, "Line #%zu", i);
     expected_lines[i] = expected_lines_data[i];
   }
   expected_lines[lines] = nullptr;

--- a/test/hotspot/gtest/memory/test_arena.cpp
+++ b/test/hotspot/gtest/memory/test_arena.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 SAP SE. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -249,7 +249,7 @@ TEST_VM(Arena, random_allocs) {
       p = ar.AmallocWords(size);
       alignment = BytesPerWord;
     }
-    LOG(("[%d]: " PTR_FORMAT ", size " SIZE_FORMAT ", aligned " SIZE_FORMAT,
+    LOG(("[%d]: " PTR_FORMAT ", size %zu, aligned %zu",
          i, p2i(p), size, alignment));
     ASSERT_NOT_NULL(p);
     ASSERT_ALIGN(p, alignment);
@@ -280,7 +280,7 @@ TEST_VM(Arena, random_allocs) {
       ASSERT_NULL(p2);
     }
     ptrs[i] = p2; sizes[i] = new_size;
-    LOG(("[%d]: realloc " PTR_FORMAT ", size " SIZE_FORMAT ", aligned " SIZE_FORMAT,
+    LOG(("[%d]: realloc " PTR_FORMAT ", size %zu, aligned %zu",
          i, p2i(p2), new_size, alignments[i]));
   }
 

--- a/test/hotspot/gtest/metaspace/test_blocktree.cpp
+++ b/test/hotspot/gtest/metaspace/test_blocktree.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -144,7 +144,7 @@ static void test_find_nearest_fit_with_tree(const size_t sizes[], size_t request
     EXPECT_0(real_size);
   }
 
-  LOG(SIZE_FORMAT ": " SIZE_FORMAT ".", request_size, real_size);
+  LOG(SIZE_FORMAT ": %zu.", request_size, real_size);
 
 }
 
@@ -398,13 +398,13 @@ class BlockTreeTest {
 
     feed_all(feeding_pattern);
 
-    LOG("Blocks in circulation: bt1=%d:" SIZE_FORMAT ", bt2=%d:" SIZE_FORMAT ".",
+    LOG("Blocks in circulation: bt1=%d:%zu, bt2=%d:%zu.",
         _bt[0].count(), _bt[0].total_size(),
         _bt[1].count(), _bt[1].total_size());
 
     ping_pong_loop(5000);
 
-    LOG("After Pingpong: bt1=%d:" SIZE_FORMAT ", bt2=%d:" SIZE_FORMAT ".",
+    LOG("After Pingpong: bt1=%d:%zu, bt2=%d:%zu.",
         _bt[0].count(), _bt[0].total_size(),
         _bt[1].count(), _bt[1].total_size());
 

--- a/test/hotspot/gtest/metaspace/test_chunkheaderpool.cpp
+++ b/test/hotspot/gtest/metaspace/test_chunkheaderpool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -46,7 +46,7 @@ class ChunkHeaderPoolTest {
 
   void attempt_free_at(size_t index) {
 
-    LOG("attempt_free_at " SIZE_FORMAT ".", index);
+    LOG("attempt_free_at %zu.", index);
 
     if (_elems[index] == nullptr) {
       return;
@@ -64,7 +64,7 @@ class ChunkHeaderPoolTest {
 
   void attempt_allocate_at(size_t index) {
 
-    LOG("attempt_allocate_at " SIZE_FORMAT ".", index);
+    LOG("attempt_allocate_at %zu.", index);
 
     if (_elems[index] != nullptr) {
       return;

--- a/test/hotspot/gtest/metaspace/test_commitmask.cpp
+++ b/test/hotspot/gtest/metaspace/test_commitmask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -252,7 +252,7 @@ public:
 
   void test() {
     LOG("mask range: " PTR_FORMAT "-" PTR_FORMAT
-         " (" SIZE_FORMAT " words).",
+         " (%zu words).",
          p2i(_base), p2i(_base + _word_size), _word_size);
     for (int i = 0; i < 5; i++) {
       test1(); test2(); test3();

--- a/test/hotspot/gtest/metaspace/test_metachunk.cpp
+++ b/test/hotspot/gtest/metaspace/test_metachunk.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2023 SAP SE. All rights reserved.
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ TEST_VM(metaspace, get_chunk_with_commit_limit) {
           // When should commit work? As long as min_committed_words is smaller than commit_limit_words.
           bool commit_should_work = min_committed_words <= commit_limit_words;
 
-          // printf("commit_limit: " SIZE_FORMAT ", min_committed_words: " SIZE_FORMAT
+          // printf("commit_limit: %zu, min_committed_words: %zu"
           //       ", max chunk level: " CHKLVL_FORMAT ", preferred chunk level: " CHKLVL_FORMAT ", should work: %d\n",
           //       commit_limit_words, min_committed_words, max_lvl, pref_lvl, commit_should_work);
           // fflush(stdout);

--- a/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2023 SAP SE. All rights reserved.
  * Copyright (c) 2023 Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -640,7 +640,7 @@ static void test_controlled_growth(Metaspace::MetaspaceType type, bool is_class,
     ASSERT_GE(capacity2, capacity);
     const size_t capacity_jump = capacity2 - capacity;
     if (capacity_jump > 0) {
-      LOG(">" SIZE_FORMAT "->" SIZE_FORMAT "(+" SIZE_FORMAT ")", capacity, capacity2, capacity_jump)
+      LOG(">%zu->%zu(+%zu)", capacity, capacity2, capacity_jump)
       if (capacity_jump > highest_capacity_jump) {
         /* Disabled for now since this is rather shaky. The way it is tested makes it too dependent
          * on allocation history. Need to rethink this.

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -376,7 +376,7 @@ public:
       const bool do_commit = IntRange(100).random_value() >= 50;
       if (do_commit) {
 
-        //LOG("c " SIZE_FORMAT "," SIZE_FORMAT, r.start(), r.end());
+        //LOG("c %zu,%zu", r.start(), r.end());
 
         bool rc = false;
         {
@@ -396,7 +396,7 @@ public:
 
       } else {
 
-        //LOG("u " SIZE_FORMAT "," SIZE_FORMAT, r.start(), r.end());
+        //LOG("u %zu,%zu", r.start(), r.end());
 
         {
           MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);

--- a/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, 2023 SAP SE. All rights reserved.
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,7 +138,7 @@ TEST_VM(NMT, random_reallocs) {
 
   for (int n = 0; n < 100; n ++) {
     size_t new_size = (size_t)(os::random() % 512) + 1;
-    // LOG_HERE("reallocating " SIZE_FORMAT "->" SIZE_FORMAT, size, new_size);
+    // LOG_HERE("reallocating %zu->%zu", size, new_size);
     p = do_realloc(p, size, new_size, content, nmt_enabled);
     size = new_size;
     content = (n % 26) + 'A';

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc. and/or its affiliates.
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ static void test_pointer(const void* p, bool expected_return_code, const char* e
 
 static void test_for_live_c_heap_block(size_t sz, ssize_t offset) {
   char* c = NEW_C_HEAP_ARRAY(char, sz, mtTest);
-  LOG_HERE("C-block starts " PTR_FORMAT ", size " SIZE_FORMAT ".", p2i(c), sz);
+  LOG_HERE("C-block starts " PTR_FORMAT ", size %zu.", p2i(c), sz);
   memset(c, 0, sz);
   if (MemTracker::enabled()) {
     const char* expected_string = "into live malloced block";
@@ -73,7 +73,7 @@ static void test_for_dead_c_heap_block(size_t sz, ssize_t offset) {
     return;
   }
   char* c = NEW_C_HEAP_ARRAY(char, sz, mtTest);
-  LOG_HERE("C-block starts " PTR_FORMAT ", size " SIZE_FORMAT ".", p2i(c), sz);
+  LOG_HERE("C-block starts " PTR_FORMAT ", size %zu.", p2i(c), sz);
   memset(c, 0, sz);
   // We cannot just free the allocation to try dead block printing, since the memory
   // may be immediately reused by concurrent code. Instead, we mark the block as dead

--- a/test/hotspot/gtest/nmt/test_nmt_totals.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_totals.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022 SAP SE. All rights reserved.
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ TEST_VM(NMTNumbers, totals) {
 
   const totals_t t1 = get_totals();
 
-  LOG("t1: " SIZE_FORMAT " - " SIZE_FORMAT " - " SIZE_FORMAT, t1.n, t1.s, t1.ovrh);
+  LOG("t1: %zu - %zu - %zu", t1.n, t1.s, t1.ovrh);
 
   static const int NUM_ALLOCS = 1024 * 16;
   static const int ALLOC_SIZE = 1024;
@@ -94,14 +94,14 @@ TEST_VM(NMTNumbers, totals) {
   }
 
   const totals_t t2 = get_totals();
-  LOG("t2: " SIZE_FORMAT " - " SIZE_FORMAT " - " SIZE_FORMAT, t2.n, t2.s, t2.ovrh);
+  LOG("t2: %zu - %zu - %zu", t2.n, t2.s, t2.ovrh);
 
   totals_t t2_expected;
   t2_expected.n = t1.n + NUM_ALLOCS;
   t2_expected.s = t1.s + ALLOC_SIZE * NUM_ALLOCS;
   t2_expected.ovrh = (t1.n + NUM_ALLOCS) * sizeof(MallocHeader);
 
-  LOG("t2 expected: " SIZE_FORMAT " - " SIZE_FORMAT " - " SIZE_FORMAT, t2_expected.n, t2_expected.s, t2_expected.ovrh);
+  LOG("t2 expected: %zu - %zu - %zu", t2_expected.n, t2_expected.s, t2_expected.ovrh);
 
   compare_totals(t2, t2_expected);
 
@@ -110,7 +110,7 @@ TEST_VM(NMTNumbers, totals) {
   }
 
   const totals_t t3 = get_totals();
-  LOG("t3: " SIZE_FORMAT " - " SIZE_FORMAT " - " SIZE_FORMAT, t3.n, t3.s, t3.ovrh);
+  LOG("t3: %zu - %zu - %zu", t3.n, t3.s, t3.ovrh);
 
   compare_totals(t3, t1);
 

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -328,7 +328,7 @@ static void test_snprintf(PrintFn pf, bool expect_count) {
     size_t test_size = sizes_to_test[i];
     ResourceMark rm;
     stringStream s;
-    s.print("test_size: " SIZE_FORMAT, test_size);
+    s.print("test_size: %zu", test_size);
     SCOPED_TRACE(s.as_string());
     size_t prefix_size = padding_size;
     guarantee(test_size <= (sizeof(buffer) - prefix_size), "invariant");
@@ -1031,7 +1031,7 @@ TEST_VM(os, trim_native_heap) {
   os::size_change_t sc;
   sc.before = sc.after = (size_t)-1;
   EXPECT_TRUE(os::trim_native_heap(&sc));
-  tty->print_cr(SIZE_FORMAT "->" SIZE_FORMAT, sc.before, sc.after);
+  tty->print_cr("%zu->%zu", sc.before, sc.after);
   // Regardless of whether we freed memory, both before and after
   // should be somewhat believable numbers (RSS).
   const size_t min = 5 * M;

--- a/test/hotspot/gtest/utilities/test_align.cpp
+++ b/test/hotspot/gtest/utilities/test_align.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ static void static_test_alignments() {
 
 template <typename T, typename A>
 static void test_alignments() {
-  log("### Test: %c" SIZE_FORMAT " " UINT64_FORMAT " : %c" SIZE_FORMAT " " UINT64_FORMAT " ###\n",
+  log("### Test: %c%zu " UINT64_FORMAT " : %c%zu " UINT64_FORMAT " ###\n",
       std::numeric_limits<T>::is_signed ? 's' : 'u', sizeof(T), (uint64_t)std::numeric_limits<T>::max(),
       std::numeric_limits<A>::is_signed ? 's' : 'u', sizeof(A), (uint64_t)std::numeric_limits<A>::max());
 

--- a/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
+++ b/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
@@ -271,11 +271,11 @@ TEST(globalDefinitions, format_specifiers) {
   check_format("%+zd",                 (ssize_t)-2147483647, "-2147483647");
   check_format("%5zd",                 (ssize_t)123,      "  123");
   check_format("%-5zd",                (ssize_t)123,      "123  ");
-  check_format(SIZE_FORMAT,            (size_t)123u,      "123");
-  check_format(SIZE_FORMAT_X,          (size_t)0x123u,    "0x123");
+  check_format("%zu",                  (size_t)123u,      "123");
+  check_format("0x%zx",                (size_t)0x123u,    "0x123");
+  check_format("%5zu",                 (size_t)123u,      "  123");
+  check_format("%-5zu",                (size_t)123u,      "123  ");
   check_format(SIZE_FORMAT_X_0,        (size_t)0x123u,    "0x" LP64_ONLY("00000000") "00000123");
-  check_format(SIZE_FORMAT_W(5),       (size_t)123u,      "  123");
-  check_format(SIZE_FORMAT_W(-5),      (size_t)123u,      "123  ");
 
   check_format("%zd",                  (intx)123,         "123");
   check_format("%#zx",                 (intx)0x123,       "0x123");

--- a/test/hotspot/gtest/utilities/test_lockFreeStack.cpp
+++ b/test/hotspot/gtest/utilities/test_lockFreeStack.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -234,7 +234,7 @@ public:
         Atomic::inc(_processed);
         ++_local_processed;
       } else if (Atomic::load_acquire(_processed) == _process_limit) {
-        tty->print_cr("thread %u processed " SIZE_FORMAT, _id, _local_processed);
+        tty->print_cr("thread %u processed %zu", _id, _local_processed);
         return;
       }
     }

--- a/test/hotspot/gtest/utilities/test_nonblockingQueue.cpp
+++ b/test/hotspot/gtest/utilities/test_nonblockingQueue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -211,7 +211,7 @@ public:
         Atomic::inc(_processed);
         ++_local_processed;
       } else if (Atomic::load_acquire(_processed) == _process_limit) {
-        tty->print_cr("thread %u processed " SIZE_FORMAT, _id, _local_processed);
+        tty->print_cr("thread %u processed %zu", _id, _local_processed);
         return;
       }
     }

--- a/test/hotspot/gtest/utilities/test_singleWriterSynchronizer.cpp
+++ b/test/hotspot/gtest/utilities/test_singleWriterSynchronizer.cpp
@@ -75,7 +75,7 @@ public:
         ++values_changed;
       }
     }
-    tty->print_cr("reader iterations: " SIZE_FORMAT ", changes: " SIZE_FORMAT,
+    tty->print_cr("reader iterations: %zu, changes: %zu",
                   iterations, values_changed);
   }
 };

--- a/test/hotspot/gtest/utilities/test_vmerror.cpp
+++ b/test/hotspot/gtest/utilities/test_vmerror.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ TEST_VM_ASSERT_MSG(vmErrorTest, assert1, "assert.str == nullptr. failed: expecte
 
 TEST_VM_ASSERT_MSG(vmErrorTest, assert2, "assert.num == 1023 && .str == 'X'. failed: num=500 str=\"hello\"") {
   vmassert(num == 1023 && *str == 'X',
-           "num=" SIZE_FORMAT " str=\"%s\"", num, str);
+           "num=%zu str=\"%s\"", num, str);
 }
 
 TEST_VM_ASSERT_MSG(vmErrorTest, guarantee1, "guarantee.str == nullptr. failed: expected null") {
@@ -58,7 +58,7 @@ TEST_VM_ASSERT_MSG(vmErrorTest, guarantee1, "guarantee.str == nullptr. failed: e
 
 TEST_VM_ASSERT_MSG(vmErrorTest, guarantee2, "guarantee.num == 1023 && .str == 'X'. failed: num=500 str=\"hello\"") {
   guarantee(num == 1023 && *str == 'X',
-            "num=" SIZE_FORMAT " str=\"%s\"", num, str);
+            "num=%zu str=\"%s\"", num, str);
 }
 
 TEST_VM_ASSERT_MSG(vmErrorTest, fatal1, "fatal error: expected null") {
@@ -66,7 +66,7 @@ TEST_VM_ASSERT_MSG(vmErrorTest, fatal1, "fatal error: expected null") {
 }
 
 TEST_VM_ASSERT_MSG(vmErrorTest, fatal2, "fatal error: num=500 str=\"hello\"") {
-  fatal("num=" SIZE_FORMAT " str=\"%s\"", num, str);
+  fatal("num=%zu str=\"%s\"", num, str);
 }
 
 TEST_VM_ASSERT_MSG(vmErrorTest, fatal3, "fatal error: this message should be truncated during formatting") {


### PR DESCRIPTION
Please review this patch that removes the SIZE_FORMAT macros and the remaining uses I missed in metaspace and the gtests.
Tested with tier1-4, and cross-compiled other platforms (except they fail for other reasons).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347990](https://bugs.openjdk.org/browse/JDK-8347990): Remove SIZE_FORMAT macros and replace remaining uses (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23180/head:pull/23180` \
`$ git checkout pull/23180`

Update a local copy of the PR: \
`$ git checkout pull/23180` \
`$ git pull https://git.openjdk.org/jdk.git pull/23180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23180`

View PR using the GUI difftool: \
`$ git pr show -t 23180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23180.diff">https://git.openjdk.org/jdk/pull/23180.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23180#issuecomment-2599179133)
</details>
