### PR TITLE
8229012: When single stepping, the debug agent can cause the thread to remain in interpreter mode after single stepping completes

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/stepControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/stepControl.c
@@ -888,15 +888,12 @@ clearStep(jthread thread, StepRequest *step)
             (void)eventHandler_free(step->methodEnterHandlerNode);
             step->methodEnterHandlerNode = NULL;
         }
-
         /*
          * Warning: Do not clear step->method, step->lineEntryCount,
          *          or step->lineEntries here, they will likely
          *          be needed on the next step.
          */
-    }
 
-    if (step->pending) {
         jvmtiError error;
         jboolean needsSuspending; // true if we needed to suspend this thread
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/stepControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/stepControl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -858,6 +858,17 @@ stepControl_beginStep(JNIEnv *env, jthread thread, jint size, jint depth,
     return error;
 }
 
+static jint
+getThreadState(jthread thread)
+{
+    jint state = 0;
+    jvmtiError error = JVMTI_FUNC_PTR(gdata->jvmti,GetThreadState)
+        (gdata->jvmti, thread, &state);
+    if (error != JVMTI_ERROR_NONE) {
+        EXIT_ERROR(error, "getting thread state");
+    }
+    return state;
+}
 
 static void
 clearStep(jthread thread, StepRequest *step)
@@ -877,15 +888,65 @@ clearStep(jthread thread, StepRequest *step)
             (void)eventHandler_free(step->methodEnterHandlerNode);
             step->methodEnterHandlerNode = NULL;
         }
-        step->pending = JNI_FALSE;
 
         /*
          * Warning: Do not clear step->method, step->lineEntryCount,
          *          or step->lineEntries here, they will likely
          *          be needed on the next step.
          */
-
     }
+
+    if (step->pending) {
+        jvmtiError error;
+        jboolean needsSuspending; // true if we needed to suspend this thread
+
+        // The thread needs suspending if it is not the current thread and is
+        // not already suspended.
+        if (isSameObject(getEnv(), threadControl_currentThread(), thread)) {
+            needsSuspending = JNI_FALSE;
+        } else {
+            jint state = getThreadState(thread);
+            needsSuspending = ((state & JVMTI_THREAD_STATE_SUSPENDED) == 0);
+        }
+
+        if (needsSuspending) {
+            tty_message("clearStep: suspending thread");
+            // Don't use threadControl_suspendThread() here. It does a lot of
+            // locking, increasing the risk of deadlock issues. None of that
+            // locking is needed here.
+            error = JVMTI_FUNC_PTR(gdata->jvmti,SuspendThread)
+                (gdata->jvmti, thread);
+            if (error != JVMTI_ERROR_NONE) {
+                EXIT_ERROR(error, "suspending thread");
+            }
+        }
+
+        error = JVMTI_FUNC_PTR(gdata->jvmti,ClearAllFramePops)
+            (gdata->jvmti, thread);
+        if (error != JVMTI_ERROR_NONE) {
+#ifdef DEBUG
+            jint currentDepth = getFrameCount(thread);
+            jint state = getThreadState(thread);
+            tty_message("JVMTI ERROR(%d): ClearAllFramePops (state=0x%x fromDepth=%d currentDepth=%d)",
+                        error, state, step->fromStackDepth, currentDepth);
+            printThreadInfo(thread);
+            printStackTrace(thread);
+            threadControl_dumpThread(thread);
+#endif
+            EXIT_ERROR(error, "clearing all frame pops");
+        }
+
+        if (needsSuspending) {
+            tty_message("clearStep: resuming thread");
+            error = JVMTI_FUNC_PTR(gdata->jvmti,ResumeThread)
+                (gdata->jvmti, thread);
+            if (error != JVMTI_ERROR_NONE) {
+                EXIT_ERROR(error, "resuming thread");
+            }
+        }
+    }
+
+    step->pending = JNI_FALSE;
 }
 
 jvmtiError

--- a/src/jdk.jdwp.agent/share/native/libjdwp/stepControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/stepControl.c
@@ -910,7 +910,6 @@ clearStep(jthread thread, StepRequest *step)
         }
 
         if (needsSuspending) {
-            tty_message("clearStep: suspending thread");
             // Don't use threadControl_suspendThread() here. It does a lot of
             // locking, increasing the risk of deadlock issues. None of that
             // locking is needed here.

--- a/src/jdk.jdwp.agent/share/native/libjdwp/stepControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/stepControl.c
@@ -937,7 +937,6 @@ clearStep(jthread thread, StepRequest *step)
         }
 
         if (needsSuspending) {
-            tty_message("clearStep: resuming thread");
             error = JVMTI_FUNC_PTR(gdata->jvmti,ResumeThread)
                 (gdata->jvmti, thread);
             if (error != JVMTI_ERROR_NONE) {

--- a/test/jdk/com/sun/jdi/SingleStepCompilationTest.java
+++ b/test/jdk/com/sun/jdi/SingleStepCompilationTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+//  THIS TEST IS LINE NUMBER SENSITIVE
+
+/**
+ * @test
+ * @bug 8229012
+ * @summary Verify that during single stepping a method is not compiled and
+ *          after single stepping it is compiled..
+ * @requires vm.compMode == "Xmixed"
+ * @library /test/lib /
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run build TestScaffold VMConnection TargetListener TargetAdapter
+ * @run compile -g SingleStepCompilationTest.java
+ * @run driver SingleStepCompilationTest
+ */
+
+import com.sun.jdi.*;
+import com.sun.jdi.event.*;
+import com.sun.jdi.request.*;
+
+import java.util.*;
+import java.lang.reflect.Method;
+
+import jdk.test.whitebox.WhiteBox;
+
+class TestTarg {
+    public final static int BKPT_LINE = 66;
+
+    public static void main(String[] args) {
+        // Call buswork() and verify that is get compiled.
+        busyWork("Warmup");
+        if (!isCompiled()) {
+            throw new RuntimeException("busywork() did not get compiled after warmup");
+        }
+
+        // We need to force deopt the method now. Although we are about to force interp_only
+        // mode by enabling single stepping, this does not result in the method being
+        // deopt right away. It just causes the compiled method not to be used.
+        deoptimizeMethod();
+
+        // Call busywork() again. This time the debugger will have single stepping
+        // enabled. After calling, verify that busywork() is not compiled.
+        busyWork("StepOver"); // BKPT_LINE: We do a STEP_OVER here
+        if (isCompiled()) {
+            throw new RuntimeException("busywork() compiled during single stepping");
+        }
+
+        // Call busywork a 3rd time. This time the debugger will not have single stepping
+        // enabled. After calling, verify that busywork is compiled.
+        busyWork("AfterStep");
+        if (!isCompiled()) {
+            throw new RuntimeException("busywork() not compiled after single stepping completes");
+        }
+    }
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    private static Method busyWorkMethod;
+    static {
+        try {
+            busyWorkMethod = TestTarg.class.getDeclaredMethod("busyWork", String.class);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean isCompiled() {
+        return  WB.isMethodCompiled(busyWorkMethod, true) || WB.isMethodCompiled(busyWorkMethod, false);
+    }
+
+    private static void deoptimizeMethod() {
+        System.out.println("Decompile count before: " + WB.getMethodDecompileCount(busyWorkMethod));
+        WB.deoptimizeMethod(busyWorkMethod, true);
+        WB.deoptimizeMethod(busyWorkMethod, false);
+        System.out.println("Decompile count after: " + WB.getMethodDecompileCount(busyWorkMethod));
+    }
+
+    // We put the array and the result variables in static volatiles just to make sure
+    // the compiler doesn't optimize them away.
+    public static final int ARRAY_SIZE = 1000*1024;
+    public static volatile int[] a = new int[ARRAY_SIZE];
+    public static volatile long result = 0;
+
+    // Do something compute intensive to trigger compilation.
+    public static void busyWork(String phase) {
+        // Although timing is not necessary for this test, it is useful to have in the
+        // log output for troubleshooting. The timing when step over is enabled should
+        // be sigficantly slower than when not.
+        long start = System.currentTimeMillis();
+
+        // Burn some CPU time and trigger OSR compilation.
+        for (int j = 0; j < 500; j++) {
+            for (int i = 0; i < ARRAY_SIZE; i++) {
+                a[i] = j*i + i << 5 + j;
+            }
+        }
+        for (int i = 0; i < ARRAY_SIZE; i++) {
+            result += a[i];
+        }
+
+        long end = System.currentTimeMillis();
+        long totalTime = end - start;
+        System.out.println(phase + " time: " + totalTime);
+    }
+}
+
+/********** test program **********/
+
+public class SingleStepCompilationTest extends TestScaffold {
+    ClassType targetClass;
+    ThreadReference mainThread;
+
+    SingleStepCompilationTest (String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args)   throws Exception {
+        /*
+         * We need to pass some extra args to the debuggee for WhiteBox support and
+         * for more consistent compilation behavior.
+         */
+        String[] newArgs = new String[5];
+        if (args.length != 0) {
+            throw new RuntimeException("Unexpected arguments passed to test");
+        }
+
+        // These are all needed for WhiteBoxAPI
+        newArgs[0] = "-Xbootclasspath/a:.";
+        newArgs[1] = "-XX:+UnlockDiagnosticVMOptions";
+        newArgs[2] = "-XX:+WhiteBoxAPI";
+
+        // In order to make sure the compilation is complete before we exit busyWork(),
+        // we don't allow background compilations.
+        newArgs[3] = "-XX:-BackgroundCompilation";
+
+        // Disabled tiered compilations so a new compilation doesn't start in the middle
+        // of executing busyWork(). (Might not really be needed)
+        newArgs[4] = "-XX:-TieredCompilation";
+
+        new SingleStepCompilationTest(newArgs).startTests();
+    }
+
+    /********** event handlers **********/
+
+    EventRequestManager erm;
+    BreakpointRequest bkptRequest;
+    StepRequest stepRequest;
+
+    // When we get a bkpt we want to disable the request and enable single stepping.
+    public void breakpointReached(BreakpointEvent event) {
+        System.out.println("Got BreakpointEvent: " + event);
+        EventRequest req = event.request();
+        req.disable();
+        stepRequest = erm.createStepRequest(mainThread,
+                                            StepRequest.STEP_LINE,
+                                            StepRequest.STEP_OVER);
+        stepRequest.enable();
+    }
+
+    public void stepCompleted(StepEvent event) {
+        System.out.println("Got StepEvent: " + event);
+        EventRequest req = event.request();
+        req.disable();
+    }
+
+    public void eventSetComplete(EventSet set) {
+        set.resume();
+    }
+
+    public void vmDisconnected(VMDisconnectEvent event) {
+        System.out.println("Got VMDisconnectEvent");
+    }
+
+    /********** test core **********/
+
+    protected void runTests() throws Exception {
+        /*
+         * Get to the top of main() to determine targetClass and mainThread
+         */
+        BreakpointEvent bpe = startToMain("TestTarg");
+        targetClass = (ClassType)bpe.location().declaringType();
+        mainThread = bpe.thread();
+        erm = vm().eventRequestManager();
+        
+        // The BKPT_LINE is the line we will STEP_OVER
+        Location loc1 = findLocation(targetClass, TestTarg.BKPT_LINE);
+        bkptRequest = erm.createBreakpointRequest(loc1);
+        bkptRequest.enable();
+
+        try {
+            addListener(this);
+        } catch (Exception ex){
+            ex.printStackTrace();
+            failure("failure: Could not add listener");
+            throw new RuntimeException("SingleStepCompilationTest: failed", ex);
+        }
+
+        vm().resume();
+        waitForVMDisconnect();
+
+        System.out.println("done with loop");
+        removeListener(this);
+
+        /*
+         * Deal with results of test. If anything has called failure("foo")
+         * then testFailed will be true
+         */
+        if (!testFailed) {
+            System.out.println("SingleStepCompilationTest: passed");
+        } else {
+            throw new Exception("SingleStepCompilationTest: failed");
+        }
+    }
+}

--- a/test/jdk/com/sun/jdi/SingleStepCompilationTest.java
+++ b/test/jdk/com/sun/jdi/SingleStepCompilationTest.java
@@ -87,7 +87,7 @@ class TestTarg {
     }
 
     private static boolean isCompiled() {
-        return  WB.isMethodCompiled(busyWorkMethod, true) || WB.isMethodCompiled(busyWorkMethod, false);
+        return WB.isMethodCompiled(busyWorkMethod, true) || WB.isMethodCompiled(busyWorkMethod, false);
     }
 
     private static void deoptimizeMethod() {
@@ -136,7 +136,7 @@ public class SingleStepCompilationTest extends TestScaffold {
         super(args);
     }
 
-    public static void main(String[] args)   throws Exception {
+    public static void main(String[] args) throws Exception {
         /*
          * We need to pass some extra args to the debuggee for WhiteBox support and
          * for more consistent compilation behavior.
@@ -211,7 +211,7 @@ public class SingleStepCompilationTest extends TestScaffold {
 
         try {
             addListener(this);
-        } catch (Exception ex){
+        } catch (Exception ex) {
             ex.printStackTrace();
             failure("failure: Could not add listener");
             throw new RuntimeException("SingleStepCompilationTest: failed", ex);

--- a/test/jdk/com/sun/jdi/SingleStepCompilationTest.java
+++ b/test/jdk/com/sun/jdi/SingleStepCompilationTest.java
@@ -203,7 +203,7 @@ public class SingleStepCompilationTest extends TestScaffold {
         targetClass = (ClassType)bpe.location().declaringType();
         mainThread = bpe.thread();
         erm = vm().eventRequestManager();
-        
+
         // The BKPT_LINE is the line we will STEP_OVER
         Location loc1 = findLocation(targetClass, TestTarg.BKPT_LINE);
         bkptRequest = erm.createBreakpointRequest(loc1);

--- a/test/jdk/com/sun/jdi/SingleStepCompilationTest.java
+++ b/test/jdk/com/sun/jdi/SingleStepCompilationTest.java
@@ -27,9 +27,9 @@
  * @test
  * @bug 8229012
  * @summary Verify that during single stepping a method is not compiled and
- *          after single stepping it is compiled..
+ *          after single stepping it is compiled.
  * @requires vm.compMode == "Xmixed"
- * @library /test/lib /
+ * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
@@ -197,14 +197,14 @@ public class SingleStepCompilationTest extends TestScaffold {
 
     protected void runTests() throws Exception {
         /*
-         * Get to the top of main() to determine targetClass and mainThread
+         * Get to the top of main() to determine targetClass and mainThread.
          */
         BreakpointEvent bpe = startToMain("TestTarg");
         targetClass = (ClassType)bpe.location().declaringType();
         mainThread = bpe.thread();
         erm = vm().eventRequestManager();
 
-        // The BKPT_LINE is the line we will STEP_OVER
+        // The BKPT_LINE is the line we will STEP_OVER.
         Location loc1 = findLocation(targetClass, TestTarg.BKPT_LINE);
         bkptRequest = erm.createBreakpointRequest(loc1);
         bkptRequest.enable();
@@ -225,7 +225,7 @@ public class SingleStepCompilationTest extends TestScaffold {
 
         /*
          * Deal with results of test. If anything has called failure("foo")
-         * then testFailed will be true
+         * then testFailed will be true.
          */
         if (!testFailed) {
             System.out.println("SingleStepCompilationTest: passed");


### PR DESCRIPTION
When doing a  STEP_OVER, the debug agent does a NotifyFramePop() on the current frame as a safety net. After the STEP_OVER completes, the NotifyFramePop() is usually still in place. This keeps the thread in interp_only mode, which hurts performance. JVMTI has added a new ClearAllFramePops() API to allow clearing of the NotifyFramePop() and normal performance to resume.

Testing:

- [x] Tier1 CI
- [x] Tier2 CI svc testing
- [x] Tier3 CI svc testing
- [x] Tier5 CI svc testing
- [x] ran all svc test 10 times each on all supported platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8229012](https://bugs.openjdk.org/browse/JDK-8229012): When single stepping, the debug agent can cause the thread to remain in interpreter mode after single stepping completes (**Bug** - P3)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) Review applies to [bbd778fc](https://git.openjdk.org/jdk/pull/23182/files/bbd778fc2399efc029b3519d9917ad6ad6be49b1)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23182/head:pull/23182` \
`$ git checkout pull/23182`

Update a local copy of the PR: \
`$ git checkout pull/23182` \
`$ git pull https://git.openjdk.org/jdk.git pull/23182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23182`

View PR using the GUI difftool: \
`$ git pr show -t 23182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23182.diff">https://git.openjdk.org/jdk/pull/23182.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23182#issuecomment-2599233751)
</details>
