### PR TITLE
6899304 : java.awt.Toolkit.getScreenInsets(GraphicsConfiguration) returns incorrect values

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -1936,7 +1936,6 @@ JNIEnv* AwtToolkit::GetEnv() {
 
 BOOL AwtToolkit::GetScreenInsets(int screenNum, RECT * rect)
 {
-
     MONITORINFO *miInfo = AwtWin32GraphicsDevice::GetMonitorInfo(screenNum);
     if (miInfo) {
         rect->top = miInfo->rcWork.top    - miInfo->rcMonitor.top;
@@ -1944,8 +1943,7 @@ BOOL AwtToolkit::GetScreenInsets(int screenNum, RECT * rect)
         rect->bottom = miInfo->rcMonitor.bottom - miInfo->rcWork.bottom;
         rect->right = miInfo->rcMonitor.right - miInfo->rcWork.right;
         return TRUE;
-    }
-    
+    }    
     return FALSE;
 }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -1938,12 +1938,12 @@ BOOL AwtToolkit::GetScreenInsets(int screenNum, RECT * rect)
 {
     MONITORINFO *miInfo = AwtWin32GraphicsDevice::GetMonitorInfo(screenNum);
     if (miInfo) {
-        rect->top = miInfo->rcWork.top    - miInfo->rcMonitor.top;
-        rect->left = miInfo->rcWork.left   - miInfo->rcMonitor.left;
+        rect->top = miInfo->rcWork.top - miInfo->rcMonitor.top;
+        rect->left = miInfo->rcWork.left - miInfo->rcMonitor.left;
         rect->bottom = miInfo->rcMonitor.bottom - miInfo->rcWork.bottom;
         rect->right = miInfo->rcMonitor.right - miInfo->rcWork.right;
         return TRUE;
-    }    
+    }
     return FALSE;
 }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -1937,8 +1937,7 @@ JNIEnv* AwtToolkit::GetEnv() {
 BOOL AwtToolkit::GetScreenInsets(int screenNum, RECT * rect)
 {
 
-    MONITORINFO *miInfo;
-    miInfo = AwtWin32GraphicsDevice::GetMonitorInfo(screenNum);
+    MONITORINFO *miInfo = AwtWin32GraphicsDevice::GetMonitorInfo(screenNum);
     if (miInfo) {
         rect->top = miInfo->rcWork.top    - miInfo->rcMonitor.top;
         rect->left = miInfo->rcWork.left   - miInfo->rcMonitor.left;

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -1936,29 +1936,17 @@ JNIEnv* AwtToolkit::GetEnv() {
 
 BOOL AwtToolkit::GetScreenInsets(int screenNum, RECT * rect)
 {
-    /* if primary display */
-    if (screenNum == 0) {
-        RECT rRW;
-        if (::SystemParametersInfo(SPI_GETWORKAREA,0,(void *) &rRW,0) == TRUE) {
-            rect->top = rRW.top;
-            rect->left = rRW.left;
-            rect->bottom = ::GetSystemMetrics(SM_CYSCREEN) - rRW.bottom;
-            rect->right = ::GetSystemMetrics(SM_CXSCREEN) - rRW.right;
-            return TRUE;
-        }
+
+    MONITORINFO *miInfo;
+    miInfo = AwtWin32GraphicsDevice::GetMonitorInfo(screenNum);
+    if (miInfo) {
+        rect->top = miInfo->rcWork.top    - miInfo->rcMonitor.top;
+        rect->left = miInfo->rcWork.left   - miInfo->rcMonitor.left;
+        rect->bottom = miInfo->rcMonitor.bottom - miInfo->rcWork.bottom;
+        rect->right = miInfo->rcMonitor.right - miInfo->rcWork.right;
+        return TRUE;
     }
-    /* if additional display */
-    else {
-        MONITORINFO *miInfo;
-        miInfo = AwtWin32GraphicsDevice::GetMonitorInfo(screenNum);
-        if (miInfo) {
-            rect->top = miInfo->rcWork.top    - miInfo->rcMonitor.top;
-            rect->left = miInfo->rcWork.left   - miInfo->rcMonitor.left;
-            rect->bottom = miInfo->rcMonitor.bottom - miInfo->rcWork.bottom;
-            rect->right = miInfo->rcMonitor.right - miInfo->rcWork.right;
-            return TRUE;
-        }
-    }
+    
     return FALSE;
 }
 

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -25,7 +25,7 @@
   @test
   @key headful
   @bug 8020443 6899304
-  @summary Test to check if the frame is created on the specified GraphicsDevice 
+  @summary Test to check if the frame is created on the specified GraphicsDevice
   and if getScreenInsets()returns the correct values across multiple monitors.
   @author Oleg Pekhovskiy
   @library /test/lib
@@ -47,7 +47,7 @@ public class MultiScreenInsetsTest {
     private static final int SIZE = 100;
 
     public static void main(String[] args) throws InterruptedException {
-  
+
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
         GraphicsDevice[] gds = ge.getScreenDevices();
         if (gds.length < 2) {
@@ -66,8 +66,8 @@ public class MultiScreenInsetsTest {
                               bounds.y + (bounds.height - SIZE) / 2);
             frame.setSize(SIZE, SIZE);
 
-            /* 
-             * On Windows, undecorated maximized frames are placed over the taskbar. 
+            /*
+             * On Windows, undecorated maximized frames are placed over the taskbar.
              * Use a decorated frame instead.
              */
             if(Platform.isWindows()) {
@@ -75,7 +75,7 @@ public class MultiScreenInsetsTest {
             } else {
                 frame.setUndecorated(true);
             }
- 
+
             frame.setVisible(true);
 
             // Maximize Frame to reach the struts
@@ -85,13 +85,13 @@ public class MultiScreenInsetsTest {
             Rectangle frameBounds = frame.getBounds();
             frame.dispose();
 
-            /* 
+            /*
              * On Windows, the top-left corner of an undecorated maximized frame may have negative coordinates (x, y).
              * Adjust the frame bounds accordingly.
              */
             if (frameBounds.x < bounds.x)
             {
-                frameBounds.width -= (bounds.x - frameBounds.x) * 2; 
+                frameBounds.width -= (bounds.x - frameBounds.x) * 2;
                 frameBounds.x = bounds.x;
             }
             if (frameBounds.y < bounds.y)
@@ -99,8 +99,8 @@ public class MultiScreenInsetsTest {
                 frameBounds.height -= (bounds.y - frameBounds.y) * 2;
                 frameBounds.y = bounds.y;
             }
-             
-             // Add a margin to compensate for the lost fractional parts when casting to an integer.       
+
+            // Add a margin to compensate for the lost fractional parts when casting to an integer.
             int marginX = getMarginForScaleX(gc);
             int marginY = getMarginForScaleY(gc);
 

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
   @test
   @key headful
-  @bug 8020443
-  @summary Frame is not created on the specified GraphicsDevice with two
-monitors
+  @bug 8020443 6899304
+  @summary Test to check if the frame is created on the specified GraphicsDevice 
+  and if getScreenInsets()returns the correct values across multiple monitors.
   @author Oleg Pekhovskiy
   @library /test/lib
   @build jdk.test.lib.Platform
@@ -47,12 +47,7 @@ public class MultiScreenInsetsTest {
     private static final int SIZE = 100;
 
     public static void main(String[] args) throws InterruptedException {
-        if (!Platform.isLinux()) {
-            System.out.println("This test is for Linux only..." +
-                               "skipping!");
-            return;
-        }
-
+  
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
         GraphicsDevice[] gds = ge.getScreenDevices();
         if (gds.length < 2) {
@@ -70,7 +65,17 @@ public class MultiScreenInsetsTest {
             frame.setLocation(bounds.x + (bounds.width - SIZE) / 2,
                               bounds.y + (bounds.height - SIZE) / 2);
             frame.setSize(SIZE, SIZE);
-            frame.setUndecorated(true);
+
+            /* 
+             * On Windows, undecorated maximized frames are placed over the taskbar. 
+             * Use a decorated frame instead.
+             */
+            if(Platform.isWindows()) {
+                frame.setUndecorated(false);
+            } else {
+                frame.setUndecorated(true);
+            }
+ 
             frame.setVisible(true);
 
             // Maximize Frame to reach the struts
@@ -79,14 +84,42 @@ public class MultiScreenInsetsTest {
 
             Rectangle frameBounds = frame.getBounds();
             frame.dispose();
+
+            /* 
+             * On Windows, the top-left corner of an undecorated maximized frame may have negative coordinates (x, y).
+             * Adjust the frame bounds accordingly.
+             */
+            if (frameBounds.x < bounds.x)
+            {
+                frameBounds.width -= (bounds.x - frameBounds.x) * 2; 
+                frameBounds.x = bounds.x;
+            }
+            if (frameBounds.y < bounds.y)
+            {
+                frameBounds.height -= (bounds.y - frameBounds.y) * 2;
+                frameBounds.y = bounds.y;
+            }
+             
+             // Add a margin to compensate for the lost fractional parts when casting to an integer.       
+            int marginX = getMarginForScaleX(gc);
+            int marginY = getMarginForScaleY(gc);
+
             if (bounds.x + insets.left != frameBounds.x
                 || bounds.y + insets.top != frameBounds.y
-                || bounds.width - insets.right - insets.left != frameBounds.width
-                || bounds.height - insets.bottom - insets.top != frameBounds.height) {
+                || bounds.width - insets.right - insets.left + marginX!= frameBounds.width
+                || bounds.height - insets.bottom - insets.top + marginY!= frameBounds.height) {
                 throw new RuntimeException("Test FAILED! Wrong screen #" +
                                            screen + " insets: " + insets);
             }
         }
         System.out.println("Test PASSED!");
+    }
+    static int getMarginForScaleX(GraphicsConfiguration gc) {
+        float scaleFactorX = (float) gc.getDefaultTransform().getScaleX();
+        return (scaleFactorX % 1 == 0.5) ? 1 : 0;
+    }
+    static int getMarginForScaleY(GraphicsConfiguration gc) {
+        float scaleFactorY = (float) gc.getDefaultTransform().getScaleY();
+        return (scaleFactorY % 1 == 0.5) ? 1 : 0;
     }
 }

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -84,7 +84,8 @@ public class MultiScreenInsetsTest {
             frame.dispose();
 
             /*
-             * On Windows, the top-left corner of an undecorated maximized frame may have negative coordinates (x, y).
+             * On Windows, the top-left corner of an undecorated maximized frame
+             * may have negative coordinates (x, y).
              * Adjust the frame bounds accordingly.
              */
             if (frameBounds.x < bounds.x) {

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -60,6 +60,9 @@ public class MultiScreenInsetsTest {
             GraphicsConfiguration gc = gd.getDefaultConfiguration();
             Rectangle bounds = gc.getBounds();
             Insets insets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
+            System.out.println("Screen #" + screen);
+            System.out.println("Screen Bounds: " + bounds);
+            System.out.println("Insets: " + insets);
 
             Frame frame = new Frame(gc);
             frame.setLocation(bounds.x + (bounds.width - SIZE) / 2,
@@ -83,6 +86,8 @@ public class MultiScreenInsetsTest {
             Thread.sleep(2000);
 
             Rectangle frameBounds = frame.getBounds();
+            System.out.println("Frame bounds: " + frameBounds);
+
             frame.dispose();
 
             /*
@@ -98,6 +103,7 @@ public class MultiScreenInsetsTest {
                 frameBounds.height -= (bounds.y - frameBounds.y) * 2;
                 frameBounds.y = bounds.y;
             }
+            System.out.println("Adjusted Frame bounds: " + frameBounds);
 
             if (bounds.x + insets.left != frameBounds.x
                 || bounds.y + insets.top != frameBounds.y

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -69,7 +69,7 @@ public class MultiScreenInsetsTest {
              * On Windows, undecorated maximized frames are placed over the taskbar.
              * Use a decorated frame instead.
              */
-            if(Platform.isWindows()) {
+            if (Platform.isWindows()) {
                 frame.setUndecorated(false);
             } else {
                 frame.setUndecorated(true);

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -28,7 +28,7 @@
   @summary Test to check if the frame is created on the specified GraphicsDevice
   and if getScreenInsets()returns the correct values across multiple monitors.
   @library /test/lib
-  @build jdk.test.lib.Platform
+  @build jdk.test.lib.Platform jtreg.SkippedException
   @run main MultiScreenInsetsTest
  */
 

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -41,17 +41,16 @@ import java.awt.Rectangle;
 import java.awt.Toolkit;
 
 import jdk.test.lib.Platform;
+import jtreg.SkippedException;
 
 public class MultiScreenInsetsTest {
     private static final int SIZE = 100;
 
     public static void main(String[] args) throws InterruptedException {
-
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
         GraphicsDevice[] gds = ge.getScreenDevices();
         if (gds.length < 2) {
-            System.out.println("It's a multi-screen test... skipping!");
-            return;
+            throw new SkippedException("It's a multi-screen test... skipping!");
         }
 
         for (int screen = 0; screen < gds.length; ++screen) {
@@ -92,8 +91,7 @@ public class MultiScreenInsetsTest {
                 frameBounds.width -= (bounds.x - frameBounds.x) * 2;
                 frameBounds.x = bounds.x;
             }
-            if (frameBounds.y < bounds.y)
-            {
+            if (frameBounds.y < bounds.y) {
                 frameBounds.height -= (bounds.y - frameBounds.y) * 2;
                 frameBounds.y = bounds.y;
             }
@@ -112,11 +110,13 @@ public class MultiScreenInsetsTest {
         }
         System.out.println("Test PASSED!");
     }
-    static int getMarginForScaleX(GraphicsConfiguration gc) {
+
+    private static int getMarginForScaleX(GraphicsConfiguration gc) {
         float scaleFactorX = (float) gc.getDefaultTransform().getScaleX();
         return (scaleFactorX % 1 == 0.5) ? 1 : 0;
     }
-    static int getMarginForScaleY(GraphicsConfiguration gc) {
+
+    private static int getMarginForScaleY(GraphicsConfiguration gc) {
         float scaleFactorY = (float) gc.getDefaultTransform().getScaleY();
         return (scaleFactorY % 1 == 0.5) ? 1 : 0;
     }

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -45,6 +45,8 @@ import jtreg.SkippedException;
 
 public class MultiScreenInsetsTest {
     private static final int SIZE = 100;
+    // Allow a margin tolerance of 1 pixel due to scaling
+    private static final int MARGIN_TOLERANCE = 1;
 
     public static void main(String[] args) throws InterruptedException {
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
@@ -97,29 +99,14 @@ public class MultiScreenInsetsTest {
                 frameBounds.y = bounds.y;
             }
 
-            // Add a margin to compensate for the lost fractional parts
-            // when casting to an integer.
-            int marginX = getMarginForScaleX(gc);
-            int marginY = getMarginForScaleY(gc);
-
             if (bounds.x + insets.left != frameBounds.x
                 || bounds.y + insets.top != frameBounds.y
-                || bounds.width - insets.right - insets.left + marginX != frameBounds.width
-                || bounds.height - insets.bottom - insets.top + marginY != frameBounds.height) {
+                || Math.abs((bounds.width - insets.right - insets.left) - frameBounds.width) > MARGIN_TOLERANCE
+                || Math.abs((bounds.height - insets.bottom - insets.top) - frameBounds.height) > MARGIN_TOLERANCE) {
                 throw new RuntimeException("Test FAILED! Wrong screen #" +
                                            screen + " insets: " + insets);
             }
         }
         System.out.println("Test PASSED!");
-    }
-
-    private static int getMarginForScaleX(GraphicsConfiguration gc) {
-        float scaleFactorX = (float) gc.getDefaultTransform().getScaleX();
-        return (scaleFactorX % 1 == 0.5) ? 1 : 0;
-    }
-
-    private static int getMarginForScaleY(GraphicsConfiguration gc) {
-        float scaleFactorY = (float) gc.getDefaultTransform().getScaleY();
-        return (scaleFactorY % 1 == 0.5) ? 1 : 0;
     }
 }

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -88,8 +88,7 @@ public class MultiScreenInsetsTest {
              * On Windows, the top-left corner of an undecorated maximized frame may have negative coordinates (x, y).
              * Adjust the frame bounds accordingly.
              */
-            if (frameBounds.x < bounds.x)
-            {
+            if (frameBounds.x < bounds.x) {
                 frameBounds.width -= (bounds.x - frameBounds.x) * 2;
                 frameBounds.x = bounds.x;
             }

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -97,7 +97,8 @@ public class MultiScreenInsetsTest {
                 frameBounds.y = bounds.y;
             }
 
-            // Add a margin to compensate for the lost fractional parts when casting to an integer.
+            // Add a margin to compensate for the lost fractional parts
+            // when casting to an integer.
             int marginX = getMarginForScaleX(gc);
             int marginY = getMarginForScaleY(gc);
 

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -106,8 +106,8 @@ public class MultiScreenInsetsTest {
 
             if (bounds.x + insets.left != frameBounds.x
                 || bounds.y + insets.top != frameBounds.y
-                || bounds.width - insets.right - insets.left + marginX!= frameBounds.width
-                || bounds.height - insets.bottom - insets.top + marginY!= frameBounds.height) {
+                || bounds.width - insets.right - insets.left + marginX != frameBounds.width
+                || bounds.height - insets.bottom - insets.top + marginY != frameBounds.height) {
                 throw new RuntimeException("Test FAILED! Wrong screen #" +
                                            screen + " insets: " + insets);
             }

--- a/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/test/jdk/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -27,7 +27,6 @@
   @bug 8020443 6899304
   @summary Test to check if the frame is created on the specified GraphicsDevice
   and if getScreenInsets()returns the correct values across multiple monitors.
-  @author Oleg Pekhovskiy
   @library /test/lib
   @build jdk.test.lib.Platform
   @run main MultiScreenInsetsTest


### PR DESCRIPTION
Screen number 0 is not always the primary screen, so we’ve removed the code that assumes it is.

We used an existing test and took the following considerations into account for Windows:

- On Windows, undecorated maximized frames are placed over the taskbar.
- On Windows, the top-left corner of an undecorated maximized frame may have negative coordinates (x, y).
- Consider the fractional part after scaling.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-6899304](https://bugs.openjdk.org/browse/JDK-6899304): java.awt.Toolkit.getScreenInsets(GraphicsConfiguration) returns incorrect values (**Bug** - P3)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [ec467e34](https://git.openjdk.org/jdk/pull/23183/files/ec467e341c216af493943ac64a319e3c145fd8d4)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) Review applies to [ec145d3d](https://git.openjdk.org/jdk/pull/23183/files/ec145d3d91ea6c5f78a2f4ee3c9de134da6d248f)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23183/head:pull/23183` \
`$ git checkout pull/23183`

Update a local copy of the PR: \
`$ git checkout pull/23183` \
`$ git pull https://git.openjdk.org/jdk.git pull/23183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23183`

View PR using the GUI difftool: \
`$ git pr show -t 23183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23183.diff">https://git.openjdk.org/jdk/pull/23183.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23183#issuecomment-2611120766)
</details>
