### PR TITLE
8346230: [perf] scalability issue for the specjvm2008::xml.transform workload

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/XMLReaderManager.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/XMLReaderManager.java
@@ -125,13 +125,13 @@ public class XMLReaderManager {
                 m_readers.set(new ReaderWrapper(reader, m_overrideDefaultParser));
             }
 
-            //reader is cached, but this property might have been reset
-            JdkXmlUtils.setXMLReaderPropertyIfSupport(reader, XMLConstants.ACCESS_EXTERNAL_DTD,
-                    _accessExternalDTD, true);
-
-            JdkXmlUtils.setXMLReaderPropertyIfSupport(reader, JdkConstants.CDATA_CHUNK_SIZE,
-                    _cdataChunkSize, false);
         }
+        //reader is cached, but this property might have been reset
+        JdkXmlUtils.setXMLReaderPropertyIfSupport(reader, XMLConstants.ACCESS_EXTERNAL_DTD,
+                _accessExternalDTD, true);
+
+        JdkXmlUtils.setXMLReaderPropertyIfSupport(reader, JdkConstants.CDATA_CHUNK_SIZE,
+                _cdataChunkSize, false);
 
         return reader;
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/XMLReaderManager.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/XMLReaderManager.java
@@ -50,7 +50,7 @@ public class XMLReaderManager {
     /**
      * Cache of XMLReader objects
      */
-    private volatile ThreadLocal<ReaderWrapper> m_readers;
+    private ThreadLocal<ReaderWrapper> m_readers;
 
     /**
      * Keeps track of whether an XMLReader object is in use.
@@ -141,14 +141,14 @@ public class XMLReaderManager {
                     m_inUse.put(reader, Boolean.TRUE);
                 }
             }
+
+            //reader is cached, but this property might have been reset
+                JdkXmlUtils.setXMLReaderPropertyIfSupport(reader, XMLConstants.ACCESS_EXTERNAL_DTD,
+                        _accessExternalDTD, true);
+
+                JdkXmlUtils.setXMLReaderPropertyIfSupport(reader, JdkConstants.CDATA_CHUNK_SIZE,
+                        _cdataChunkSize, false);
         }
-
-        //reader is cached, but this property might have been reset
-        JdkXmlUtils.setXMLReaderPropertyIfSupport(reader, XMLConstants.ACCESS_EXTERNAL_DTD,
-                _accessExternalDTD, true);
-
-        JdkXmlUtils.setXMLReaderPropertyIfSupport(reader, JdkConstants.CDATA_CHUNK_SIZE,
-                _cdataChunkSize, false);
 
         return reader;
     }


### PR DESCRIPTION
The HashMap for caching was deleted. Now it use only ThreadLocal variable without synchronization.
According to the specjvm2008::xml.transform workload the performance for low threads counts was not affected and improved for high threads counts. 
For the 2 socket server based on Xeon 6780E reported scores are (average for 3 runs):
2x6780E | 1C | 32C | 64C | 96C | 128C | 160C | 192C | 224C | 256C | 288C
orig        | 138.9567 | 4127.567 | 8203.907 | 12252.07 | 15496.65 | 16222.91 | 15846.48 | 14758.43 | 14612.34 | 13969.25
patched | 139.7067 | 4118.763 | 8352.657 | 12491.14 | 16085.63 | 18101.67 | 21001.52 | 23847.33 | 26481.25 | 28273.93

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346230](https://bugs.openjdk.org/browse/JDK-8346230): [perf] scalability issue for the specjvm2008::xml.transform workload (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23185/head:pull/23185` \
`$ git checkout pull/23185`

Update a local copy of the PR: \
`$ git checkout pull/23185` \
`$ git pull https://git.openjdk.org/jdk.git pull/23185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23185`

View PR using the GUI difftool: \
`$ git pr show -t 23185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23185.diff">https://git.openjdk.org/jdk/pull/23185.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23185#issuecomment-2599356651)
</details>
