### PR TITLE
8348013: [doc] fix typo in java.md caused by JDK-8347763

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -3978,12 +3978,12 @@ The values for these options (if specified), should be identical when creating a
 CDS archive. Otherwise, if there is a mismatch of any of these options, the CDS archive may be
 partially or completely disabled, leading to lower performance.
 
-- If the -XX:+AOTClassLoading options *was* used during CDS archive creation, the CDS archive
+- If the -XX:+AOTClassLinking options *was* used during CDS archive creation, the CDS archive
   cannot be used, and the following error message is printed:
 
   `CDS archive has aot-linked classes. It cannot be used when archived full module graph is not used`
 
-- If the -XX:+AOTClassLoading options *was not* used during CDS archive creation, the CDS archive
+- If the -XX:+AOTClassLinking options *was not* used during CDS archive creation, the CDS archive
   can be used, but the "archived module graph" feature will be disabled. This can lead to increased
   start-up time.
 


### PR DESCRIPTION
A trivial typo fix: s/AOTClassLoading/AOTClassLinking

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348013](https://bugs.openjdk.org/browse/JDK-8348013): [doc] fix typo in java.md caused by JDK-8347763 (**Bug** - P4)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23187/head:pull/23187` \
`$ git checkout pull/23187`

Update a local copy of the PR: \
`$ git checkout pull/23187` \
`$ git pull https://git.openjdk.org/jdk.git pull/23187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23187`

View PR using the GUI difftool: \
`$ git pr show -t 23187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23187.diff">https://git.openjdk.org/jdk/pull/23187.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23187#issuecomment-2599383863)
</details>
