### PR TITLE
JDK-8330174: Protection zone for easier detection of accidental zero-nKlass use

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -365,9 +365,9 @@ address ArchiveBuilder::reserve_buffer() {
   }
 
   if (CDSConfig::is_dumping_static_archive()) {
-    // We don't want any valid object to be at the very bottom of the archive.
-    // See ArchivePtrMarker::mark_pointer().
-    rw_region()->allocate(16);
+    // The region that will be located at the bottom of the encoding range at runtime shall have
+    // space for a protection zone.
+    MetaspaceShared::allocate_and_mark_protection_zone(rw_region());
   }
 
   return buffer_bottom;

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1337,6 +1337,13 @@ MapArchiveResult MetaspaceShared::map_archives(FileMapInfo* static_mapinfo, File
               cds_base, ccs_end - cds_base // Klass range
               );
           }
+
+          // After narrowKlass encoding scheme is decided: if encoding base points to archive start (can happen
+          // for both cases above), establish protection zone.
+          if (CompressedKlassPointers::base() == cds_base) {
+            MetaspaceShared::check_and_establish_protection_zone(cds_base);
+          }
+
           // map_or_load_heap_region() compares the current narrow oop and klass encodings
           // with the archived ones, so it must be done after all encodings are determined.
           static_mapinfo->map_or_load_heap_region();
@@ -1353,6 +1360,50 @@ MapArchiveResult MetaspaceShared::map_archives(FileMapInfo* static_mapinfo, File
   return result;
 }
 
+// Protection zone handling.
+//
+// A Klass structure must never be located at the encoding base since that would encode to an
+// invalid nKlass of zero. At runtime, we set the encoding base to the start of the mapped
+// archive. In order to catch accidental accesses via a zero nKlass, we will establis a no-access
+// zone there, similar to how the heap does it. Space for that page must be prepared when dumping
+// the archive.
+static constexpr uint64_t protzone_tag       = 0x50524F545A4F4E45ULL; // "PROTZONE"
+static constexpr uint64_t protzone_tag_start = 0x2D3E2D3E50524F54ULL; // "->->PROT"
+static constexpr uint64_t protzone_tag_end   = 0x50524F543C2D3C2DULL; // "PROT<-<-"
+
+// Dumptime
+void MetaspaceShared::allocate_and_mark_protection_zone(DumpRegion* region) {
+
+  assert(region->used() == 0, "Should not have allocations yet");
+
+  // Note: not page size but core region alignment! Page size can differ at runtime.
+  const size_t protzone_size = MetaspaceShared::core_region_alignment();
+  uint64_t* const protzone = (uint64_t*) region->allocate(protzone_size);
+  const size_t len = protzone_size/sizeof(uint64_t);
+  protzone[0] = protzone_tag_start;
+  protzone[len - 1] = protzone_tag_end;
+
+  for (size_t i = 1; i < len - 1; i++) {
+    protzone[i] = protzone_tag;
+  }
+}
+
+// Runtime
+bool MetaspaceShared::check_and_establish_protection_zone(address addr) {
+  const size_t protzone_size = MetaspaceShared::core_region_alignment();
+  const uint64_t* const protzone = (const uint64_t*) addr;
+  const size_t len = protzone_size/sizeof(uint64_t);
+  if (protzone[0] != protzone_tag_start || protzone[len - 1] != protzone_tag_end) {
+    return false;
+  }
+#ifdef ASSERT
+  for (size_t i = 1; i < len - 1; i++) {
+    assert(protzone[i] == protzone_tag, "Corrupted CDS protection zone");
+  }
+#endif
+  CompressedKlassPointers::establish_protection_zone((address)protzone, protzone_size);
+  return true;
+}
 
 // This will reserve two address spaces suitable to house Klass structures, one
 //  for the cds archives (static archive and optionally dynamic archive) and

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -34,6 +34,7 @@
 
 class ArchiveBuilder;
 class ArchiveHeapInfo;
+class DumpRegion;
 class FileMapInfo;
 class Method;
 class outputStream;
@@ -162,6 +163,14 @@ public:
   static char* requested_base_address() {
     return _requested_base_address;
   }
+
+  // Given a dump region (that should not yet have allocations), allocate and prepare a protection
+  // at the start of the region.
+  static void allocate_and_mark_protection_zone(DumpRegion* region);
+
+  // Given an address that should point to a mapped protection zone, check markers, then protect
+  // the zone. Will return false if markers don't match up (misshapen/tempered archive)
+  static bool check_and_establish_protection_zone(address address);
 
   // Non-zero if the archive(s) need to be mapped a non-default location due to ASLR.
   static intx relocation_delta() { return _relocation_delta; }

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -38,6 +38,7 @@
 #include "memory/metaspace/chunkManager.hpp"
 #include "memory/metaspace/commitLimiter.hpp"
 #include "memory/metaspace/internalStats.hpp"
+#include "memory/metaspace/metachunk.hpp"
 #include "memory/metaspace/metaspaceCommon.hpp"
 #include "memory/metaspace/metaspaceContext.hpp"
 #include "memory/metaspace/metaspaceReporter.hpp"
@@ -806,6 +807,19 @@ void Metaspace::global_initialize() {
     // Set up compressed class pointer encoding.
     // In CDS=off mode, we give the JVM some leeway to choose a favorable base/shift combination.
     CompressedKlassPointers::initialize((address)rs.base(), rs.size());
+
+    // After narrowKlass encoding scheme is decided: if the encoding base points to class space start,
+    // establish a protection zone.
+    if (CompressedKlassPointers::base() == (address)rs.base()) {
+      const size_t protzone_size = os::vm_page_size();
+      const size_t protzone_wordsize = protzone_size / BytesPerWord;
+      const metaspace::chunklevel_t lvl = metaspace::chunklevel::level_fitting_word_size(protzone_wordsize);
+      metaspace::Metachunk* const chunk = MetaspaceContext::context_class()->cm()->get_chunk(lvl);
+      const address protzone = (address) chunk->base();
+      assert(protzone == (address)rs.base(), "The very first chunk should be located at the class space start?");
+      assert(chunk->word_size() == protzone_wordsize, "Weird chunk size");
+      CompressedKlassPointers::establish_protection_zone(protzone, protzone_size);
+    }
   }
 
 #endif
@@ -814,20 +828,6 @@ void Metaspace::global_initialize() {
   MetaspaceContext::initialize_nonclass_space_context();
 
   _tracer = new MetaspaceTracer();
-
-  // We must prevent the very first address of the ccs from being used to store
-  // metadata, since that address would translate to a narrow pointer of 0, and the
-  // VM does not distinguish between "narrow 0 as in null" and "narrow 0 as in start
-  //  of ccs".
-  // Before Elastic Metaspace that did not happen due to the fact that every Metachunk
-  // had a header and therefore could not allocate anything at offset 0.
-#ifdef _LP64
-  if (using_class_space()) {
-    // The simplest way to fix this is to allocate a tiny dummy chunk right at the
-    // start of ccs and do not use it for anything.
-    MetaspaceContext::context_class()->cm()->get_chunk(metaspace::chunklevel::HIGHEST_CHUNK_LEVEL);
-  }
-#endif
 
 #ifdef _LP64
   if (UseCompressedClassPointers) {

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -43,6 +43,7 @@ address CompressedKlassPointers::_klass_range_start = nullptr;
 address CompressedKlassPointers::_klass_range_end = nullptr;
 narrowKlass CompressedKlassPointers::_lowest_valid_narrow_klass_id = (narrowKlass)-1;
 narrowKlass CompressedKlassPointers::_highest_valid_narrow_klass_id = (narrowKlass)-1;
+size_t CompressedKlassPointers::_protection_zone_size = 0;
 
 #ifdef _LP64
 
@@ -305,9 +306,30 @@ void CompressedKlassPointers::print_mode(outputStream* st) {
     st->print_cr("Klass Range:    " RANGE2FMT, RANGE2FMTARGS(_klass_range_start, _klass_range_end));
     st->print_cr("Klass ID Range:  [%u - %u) (%u)", _lowest_valid_narrow_klass_id, _highest_valid_narrow_klass_id + 1,
                  _highest_valid_narrow_klass_id + 1 - _lowest_valid_narrow_klass_id);
+    if (_protection_zone_size > 0) {
+      st->print_cr("Protection zone: " RANGEFMT, RANGEFMTARGS(_base, _protection_zone_size));
+    } else {
+      st->print_cr("No protection zone.");
+    }
   } else {
     st->print_cr("UseCompressedClassPointers off");
   }
+}
+
+// Protect a zone a the start of the encoding range
+void CompressedKlassPointers::establish_protection_zone(address addr, size_t size) {
+  assert(_protection_zone_size == 0, "just once");
+  assert(addr == base(), "Protection zone not at start of encoding range?");
+  assert(size > 0 && is_aligned(size, os::vm_page_size()), "Protection zone not page sized");
+  const bool rc = os::protect_memory((char*)addr, size, os::MEM_PROT_NONE, true);
+  assert(rc, "Failed to protect the Class space protection zone");
+  log_info(metaspace)("Established Narrow Klass Protection zone " RANGEFMT, RANGEFMTARGS(addr, size));
+  _protection_zone_size = size;
+}
+
+bool CompressedKlassPointers::is_in_protection_zone(address addr) {
+  return _protection_zone_size > 0 ?
+      (addr >= base() && addr < base() + _protection_zone_size) : false;
 }
 
 #endif // _LP64

--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -134,6 +134,8 @@ class CompressedKlassPointers : public AllStatic {
   static narrowKlass _lowest_valid_narrow_klass_id;
   static narrowKlass _highest_valid_narrow_klass_id;
 
+  // Protection zone size (0 if not set up)
+  static size_t _protection_zone_size;
 
   // Helper function for common cases.
   static char* reserve_address_space_X(uintptr_t from, uintptr_t to, size_t size, size_t alignment, bool aslr);
@@ -150,8 +152,6 @@ class CompressedKlassPointers : public AllStatic {
   static inline void check_init(T var) {
     assert(var != (T)-1, "Not yet initialized");
   }
-
-  static inline Klass* decode_not_null_without_asserts(narrowKlass v, address base, int shift);
 
 public:
 
@@ -231,6 +231,7 @@ public:
   static bool is_null(narrowKlass v) { return v == 0; }
 
   // Versions without asserts
+  static inline Klass* decode_not_null_without_asserts(narrowKlass v, address base, int shift);
   static inline Klass* decode_without_asserts(narrowKlass v);
   static inline Klass* decode_not_null(narrowKlass v);
   static inline Klass* decode(narrowKlass v);
@@ -257,6 +258,12 @@ public:
     return (address)addr >= _klass_range_start && (address)addr < _klass_range_end &&
         is_aligned(addr, klass_alignment_in_bytes());
   }
+
+  // Protect a zone a the start of the encoding range
+  static void establish_protection_zone(address addr, size_t size);
+
+  // Returns true if address points into protection zone (for error reporting)
+  static bool is_in_protection_zone(address addr);
 
 #if defined(AARCH64) && !defined(ZERO)
   // Check that with the given base, shift and range, aarch64 code can encode and decode the klass pointer.

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1293,6 +1293,12 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
 
   bool accessible = is_readable_pointer(addr);
 
+  // Check if addr points into the narrow Klass protection zone
+  if (UseCompressedClassPointers && CompressedKlassPointers::is_in_protection_zone(addr)) {
+    st->print_cr(PTR_FORMAT " points into nKlass protection zone", p2i(addr));
+    return;
+  }
+
   // Check if addr is a JNI handle.
   if (align_down((intptr_t)addr, sizeof(intptr_t)) != 0 && accessible) {
     if (JNIHandles::is_global_handle((jobject) addr)) {

--- a/test/hotspot/gtest/oops/test_compressedKlass.cpp
+++ b/test/hotspot/gtest/oops/test_compressedKlass.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "oops/compressedKlass.inline.hpp"
+#include "oops/klass.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 #include "unittest.hpp"
@@ -107,4 +108,34 @@ TEST_VM(CompressedKlass, test_good_address) {
   ASSERT_TRUE(CompressedKlassPointers::is_encodable(addr));
   addr = CompressedKlassPointers::klass_range_end() - alignment;
   ASSERT_TRUE(CompressedKlassPointers::is_encodable(addr));
+}
+
+// This tests the protection zone mechanism. If the encoding base is not zero, VM should have
+// established a protection zone. Decoding an nKlass==0 should result in a Klass* that, upon
+// access, causes a SIGSEGV
+static bool test_nklass_protection_zone() {
+  if (!UseCompressedClassPointers) {
+    tty->print_cr("UseCompressedClassPointers is off, test not possible");
+    return true; // skipped
+  } else if (CompressedKlassPointers::base() == nullptr) {
+    tty->print_cr("Zero-based encoding; test not needed");
+    return true; // skipped
+  } else {
+    constexpr narrowKlass nk = 0;
+    Klass* const k = CompressedKlassPointers::decode_not_null_without_asserts(nk, CompressedKlassPointers::base(), CompressedKlassPointers::shift());
+    assert(k == (Klass*) CompressedKlassPointers::base(), "Sanity? (" PTR_FORMAT " vs " PTR_FORMAT ")",
+           p2i(k), p2i(CompressedKlassPointers::base()));
+    // Now call a virtual function on that klass.
+    k->print_on(tty); // << loading vtable ptr from protected page, crash expected here
+    return false;
+  }
+}
+
+// This does not work yet, since gtest death tests don't work with real signals. That needs to be fixed first (see JDK-8348028).
+TEST_VM_FATAL_ERROR_MSG(CompressedKlass, DISABLED_test_nklass_protection_zone_death_test, ".*SIGSEGV.*") {
+  if (test_nklass_protection_zone()) {
+    // Still alive but returned true, so we skipped the test.
+    // Do a fake assert that matches the regex above to satisfy the death test
+    guarantee(false, "fake message ignore this - SIGSEGV");
+  }
 }


### PR DESCRIPTION
After having reserved an address range for the Klass encoding range, we either:
a) Place CDS, then class space, into that address range
b) Place only class space in that range (if CDS is off).

In both cases, we might end up with the encoding base pointing to the start of the archive (unless we are allowed to and manage to run zero-based).

If we wrongly decode an nKlass-id of 0, and the encoding base is not NULL, the resulting pointer points to the start of the class range. That area is readable, albeit unused in both cases (a) and (b). Both metaspace and CDS make sure to pre-allocate a buffer there that is not used.

Still, that buffer is then zero-initialized, and since reading is still possible, analysis of crashes (especially in release builds) needs some work until one figures out the cause. To make this a bit easier, and akin to how the OS protects the zero page and how the java heap protects its base page, we should protect the first page in the narrow Klass encoding range, too.

This patch does that.

It also provides a helpful output to `os::print_location` for cases like this, eg:

```
RDI=0x0000000800000000 points into nKlass protection zone
```
Testing: GHAs. I tested the patch manually on x64 Linux for both CDS on, CDS off and zero-based encoding, CDS off and non-zero-based encoding. I also prepared a automatic gtest, but that needs some preparatory work on the gtest suite first to work (see https://bugs.openjdk.org/browse/JDK-8348028 )




