### PR TITLE
8348029: Make gtest death tests work with real crash signals

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2024 SAP SE. All rights reserved.
- * Copyright (c) 2023, Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2023, 2025, Red Hat, Inc. and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1545,6 +1545,12 @@ void VMError::report_and_die(Thread* thread, const void* context, const char* fi
 
 void VMError::report_and_die(Thread* thread, unsigned int sig, address pc, const void* siginfo, const void* context)
 {
+  if (ExecutingUnitTests) {
+    // See TEST_VM_CRASH_SIGNAL gtest macro
+    char tmp[64];
+    fprintf(stderr, "signaled: %s", os::exception_name(sig, tmp, sizeof(tmp)));
+  }
+
   report_and_die(thread, sig, pc, siginfo, context, "%s", "");
 }
 

--- a/test/hotspot/gtest/unittest.hpp
+++ b/test/hotspot/gtest/unittest.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,5 +158,23 @@ extern void gtest_exit_from_child_vm(int num);
   }                                                                 \
                                                                     \
   void test_ ## category ## _ ## name ## _()
+
+#define TEST_VM_CRASH_SIGNAL(category, name, signame)               \
+  static void test_  ## category ## _ ## name ## _();               \
+                                                                    \
+  static void child_ ## category ## _ ## name ## _() {              \
+    ::testing::GTEST_FLAG(throw_on_failure) = true;                 \
+    test_ ## category ## _ ## name ## _();                          \
+    gtest_exit_from_child_vm(0);                                    \
+  }                                                                 \
+                                                                    \
+  TEST(category, CONCAT(name, _vm_assert)) {                        \
+    ASSERT_EXIT(child_ ## category ## _ ## name ## _(),             \
+                ::testing::ExitedWithCode(1),                       \
+                "signaled: " signame);                              \
+  }                                                                 \
+                                                                    \
+  void test_ ## category ## _ ## name ## _()
+
 
 #endif // UNITTEST_HPP


### PR DESCRIPTION
Small change adds a new macro to the gtest TEST macro zoo: `TEST_VM_CRASH_SIGNAL`. This one is a companion to `TEST_VM_FATAL_ERROR_MSG` and `TEST_VM_ASSERT_MSG` and allows to write gtest that test expected crashes to happen. I will need that for a regression test for https://bugs.openjdk.org/browse/JDK-8330174 , among other things.

You use it like this:

```
TEST_VM_CRASH_SIGNAL(Testtest, test, "SIGSEGV") {
  ... do something that you expect should result in a specific crash ...
}
```
Note that the string provided is platform dependent (signal names on Posix, SEH names on Windows).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348029](https://bugs.openjdk.org/browse/JDK-8348029): Make gtest death tests work with real crash signals (**Enhancement** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Sonia Zaldana Calles](https://openjdk.org/census#szaldana) (@SoniaZaldana - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23191/head:pull/23191` \
`$ git checkout pull/23191`

Update a local copy of the PR: \
`$ git checkout pull/23191` \
`$ git pull https://git.openjdk.org/jdk.git pull/23191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23191`

View PR using the GUI difftool: \
`$ git pr show -t 23191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23191.diff">https://git.openjdk.org/jdk/pull/23191.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23191#issuecomment-2600746085)
</details>
