### PR TITLE
8348038: Docs build failing in Options.notifyListeners with AssertionError

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/BaseFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/BaseFileManager.java
@@ -94,6 +94,12 @@ public abstract class BaseFileManager implements JavaFileManager {
         // Initialize locations
         locations.update(log, lint, FSInfo.instance(context));
 
+        // Apply options
+        options.whenReady(this::applyOptions);
+    }
+
+    protected void applyOptions(Options options) {
+
         // Setting this option is an indication that close() should defer actually closing
         // the file manager until after a specified period of inactivity.
         // This is to accommodate clients which save references to Symbols created for use
@@ -106,16 +112,14 @@ public abstract class BaseFileManager implements JavaFileManager {
         // in seconds, of the period of inactivity to wait for, before the file manager
         // is actually closed.
         // See also deferredClose().
-        options.whenReady(options -> {
-            String s = options.get("fileManager.deferClose");
-            if (s != null) {
-                try {
-                    deferredCloseTimeout = (int) (Float.parseFloat(s) * 1000);
-                } catch (NumberFormatException e) {
-                    deferredCloseTimeout = 60 * 1000;  // default: one minute, in millis
-                }
+        String s = options.get("fileManager.deferClose");
+        if (s != null) {
+            try {
+                deferredCloseTimeout = (int) (Float.parseFloat(s) * 1000);
+            } catch (NumberFormatException e) {
+                deferredCloseTimeout = 60 * 1000;  // default: one minute, in millis
             }
-        });
+        }
     }
 
     protected Locations createLocations() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -80,6 +80,7 @@ import com.sun.tools.javac.util.DefinedBy;
 import com.sun.tools.javac.util.DefinedBy.Api;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.ListBuffer;
+import com.sun.tools.javac.util.Options;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
@@ -109,7 +110,7 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
     private static final Set<JavaFileObject.Kind> SOURCE_OR_CLASS =
         Set.of(JavaFileObject.Kind.SOURCE, JavaFileObject.Kind.CLASS);
 
-    protected boolean symbolFileEnabled;
+    protected boolean symbolFileEnabled = true;
 
     private PathFactory pathFactory = Paths::get;
 
@@ -169,8 +170,12 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
     @Override
     public void setContext(Context context) {
         super.setContext(context);
-
         fsInfo = FSInfo.instance(context);
+    }
+
+    @Override
+    protected void applyOptions(Options options) {
+        super.applyOptions(options);
 
         symbolFileEnabled = !options.isSet("ignore.symbol.file");
 

--- a/test/langtools/tools/javac/options/JavadocIgnoreSymbolFile.java
+++ b/test/langtools/tools/javac/options/JavadocIgnoreSymbolFile.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8348038
+ * @summary Verify use of "-XDignore.symbol.file=true" doesn't cause assertion failure
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ */
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class JavadocIgnoreSymbolFile {
+
+    public static void main(String[] args) {
+        String[] javadocArgs = new String[] {
+            "-XDignore.symbol.file=true"
+        };
+        StringWriter buf = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(buf)) {
+            jdk.javadoc.internal.tool.Main.execute(javadocArgs, pw);
+        }
+        String expected = "error: No modules, packages or classes specified. 1 error";
+        String actual = buf.toString().trim().replaceAll("\\s+", " ");
+        if (!actual.equals(expected))
+            throw new AssertionError("unexpected output:\n" + actual);
+    }
+}

--- a/test/langtools/tools/javac/options/OptionsOrderingTest.java
+++ b/test/langtools/tools/javac/options/OptionsOrderingTest.java
@@ -31,7 +31,6 @@
  *  jdk.compiler/com.sun.tools.javac.file
  *  jdk.compiler/com.sun.tools.javac.main
  *  jdk.compiler/com.sun.tools.javac.util:+open
- *  jdk.javadoc/jdk.javadoc.internal.tool
  */
 
 import java.io.PrintWriter;
@@ -89,17 +88,7 @@ public class OptionsOrderingTest extends TestRunner {
         }
     }
 
-    // JDK-8348038
-    public void testJavadocIgnoreSymbolsFile() throws Exception {
-        jdk.javadoc.internal.tool.Main.execute(
-          "-XDignore.symbol.file=true",
-          "dummy.java"
-        );
-    }
-
     public static void main(String... args) throws Exception {
-        OptionsOrderingTest test = new OptionsOrderingTest();
-        test.testJavacMessagesDiagFormatter();
-        test.testJavadocIgnoreSymbolsFile();
+        new OptionsOrderingTest().testJavacMessagesDiagFormatter();
     }
 }

--- a/test/langtools/tools/javac/options/OptionsOrderingTest.java
+++ b/test/langtools/tools/javac/options/OptionsOrderingTest.java
@@ -31,6 +31,7 @@
  *  jdk.compiler/com.sun.tools.javac.file
  *  jdk.compiler/com.sun.tools.javac.main
  *  jdk.compiler/com.sun.tools.javac.util:+open
+ *  jdk.javadoc/jdk.javadoc.internal.tool
  */
 
 import java.io.PrintWriter;
@@ -88,7 +89,17 @@ public class OptionsOrderingTest extends TestRunner {
         }
     }
 
+    // JDK-8348038
+    public void testJavadocIgnoreSymbolsFile() throws Exception {
+        jdk.javadoc.internal.tool.Main.execute(
+          "-XDignore.symbol.file=true",
+          "dummy.java"
+        );
+    }
+
     public static void main(String... args) throws Exception {
-        new OptionsOrderingTest().testJavacMessagesDiagFormatter();
+        OptionsOrderingTest test = new OptionsOrderingTest();
+        test.testJavacMessagesDiagFormatter();
+        test.testJavadocIgnoreSymbolsFile();
     }
 }


### PR DESCRIPTION
The change in [JDK-8347474](https://bugs.openjdk.org/browse/JDK-8347474) caused `make all-docs-bundles` to start failing. This PR includes a fix for that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348038](https://bugs.openjdk.org/browse/JDK-8348038): Docs build failing in Options.notifyListeners with AssertionError (**Bug** - P1)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23192/head:pull/23192` \
`$ git checkout pull/23192`

Update a local copy of the PR: \
`$ git checkout pull/23192` \
`$ git pull https://git.openjdk.org/jdk.git pull/23192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23192`

View PR using the GUI difftool: \
`$ git pr show -t 23192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23192.diff">https://git.openjdk.org/jdk/pull/23192.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23192#issuecomment-2600976633)
</details>
