### PR TITLE
8345285: [s390x] test failures: foreign/normalize/TestNormalize.java with C2

### DIFF
--- a/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
+++ b/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -190,6 +190,9 @@ void AbstractInterpreter::layout_activation(Method* method,
     // Note: the unextended_sp is required by nmethod::orig_pc_addr().
     assert(is_bottom_frame && (sender_sp == caller->unextended_sp()),
            "must initialize sender_sp of bottom skeleton frame when pushing it");
+  } else if (caller->is_upcall_stub_frame()) {
+    // deoptimization case, sender_sp as unextended_sp, see frame::sender_for_interpreter_frame()
+    sender_sp = caller->unextended_sp();
   } else {
     assert(caller->is_entry_frame(), "is there a new frame type??");
     sender_sp = caller->sp(); // Call_stub only uses it's fp.

--- a/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
+++ b/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
@@ -190,11 +190,8 @@ void AbstractInterpreter::layout_activation(Method* method,
     // Note: the unextended_sp is required by nmethod::orig_pc_addr().
     assert(is_bottom_frame && (sender_sp == caller->unextended_sp()),
            "must initialize sender_sp of bottom skeleton frame when pushing it");
-  } else if (caller->is_upcall_stub_frame()) {
-    // deoptimization case, sender_sp as unextended_sp, see frame::sender_for_interpreter_frame()
-    sender_sp = caller->unextended_sp();
   } else {
-    assert(caller->is_entry_frame(), "is there a new frame type??");
+    assert(caller->is_entry_frame() || caller->is_upcall_stub_frame(), "is there a new frame type??");
     sender_sp = caller->sp(); // Call_stub only uses it's fp.
   }
 
@@ -204,6 +201,8 @@ void AbstractInterpreter::layout_activation(Method* method,
   interpreter_frame->interpreter_frame_set_monitor_end((BasicObjectLock *)monitor);
   *interpreter_frame->interpreter_frame_cache_addr() = method->constants()->cache();
   interpreter_frame->interpreter_frame_set_tos_address(tos);
-  interpreter_frame->interpreter_frame_set_sender_sp(sender_sp);
+  if (!is_bottom_frame) {
+    interpreter_frame->interpreter_frame_set_sender_sp(sender_sp);
+  }
   interpreter_frame->interpreter_frame_set_top_frame_sp(top_frame_sp);
 }


### PR DESCRIPTION
Fixes `foreign/normalize/TestNormalize.java` failure on s390x.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345285](https://bugs.openjdk.org/browse/JDK-8345285): [s390x] test failures: foreign/normalize/TestNormalize.java with C2 (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23197/head:pull/23197` \
`$ git checkout pull/23197`

Update a local copy of the PR: \
`$ git checkout pull/23197` \
`$ git pull https://git.openjdk.org/jdk.git pull/23197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23197`

View PR using the GUI difftool: \
`$ git pr show -t 23197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23197.diff">https://git.openjdk.org/jdk/pull/23197.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23197#issuecomment-2602174652)
</details>
