### PR TITLE
8348648: Unnecessary Hashtable usage in javax.swing.text.html.CSS.LengthUnit

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3005,25 +3005,23 @@ public class CSS implements Serializable {
      */
     @SuppressWarnings("serial") // Same-version serialization only
     static class LengthUnit implements Serializable {
-        static Hashtable<String, Float> lengthMapping = new Hashtable<String, Float>(6);
-        static Hashtable<String, Float> w3cLengthMapping = new Hashtable<String, Float>(6);
-        static {
-            lengthMapping.put("pt", 1f);
-            // Not sure about 1.3, determined by experimentation.
-            lengthMapping.put("px", 1.3f);
-            lengthMapping.put("mm", 2.83464f);
-            lengthMapping.put("cm", 28.3464f);
-            lengthMapping.put("pc", 12f);
-            lengthMapping.put("in", 72f);
-            // Mapping according to the CSS2.2 spec
-            // https://www.w3.org/TR/CSS22/syndata.html#x39
-            w3cLengthMapping.put("pt", 96f / 72f);         // 1/72 of 1in
-            w3cLengthMapping.put("px", 1f);                // 1/96 of 1in
-            w3cLengthMapping.put("mm", 96f / 2.54f / 10f); // 1/10 of 1cm
-            w3cLengthMapping.put("cm", 96f / 2.54f);       // 96px/2.54
-            w3cLengthMapping.put("pc", 96f / 6f);          // 1/6 of 1in
-            w3cLengthMapping.put("in", 96f);               // 96px
-        }
+        private static final Map<String, Float> lengthMapping = Map.of(
+                "pt", 1f,
+                // Not sure about 1.3, determined by experimentation.
+                "px", 1.3f,
+                "mm", 2.83464f,
+                "cm", 28.3464f,
+                "pc", 12f,
+                "in", 72f);
+        // Mapping according to the CSS2.2 spec
+        // https://www.w3.org/TR/CSS22/syndata.html#x39
+        private static final Map<String, Float> w3cLengthMapping = Map.of(
+                "pt", 96f / 72f,         // 1/72 of 1in
+                "px", 1f,                // 1/96 of 1in
+                "mm", 96f / 2.54f / 10f, // 1/10 of 1cm
+                "cm", 96f / 2.54f,       // 96px/2.54
+                "pc", 96f / 6f,          // 1/6 of 1in
+                "in", 96f);              // 96px
 
         LengthUnit(String value, short defaultType, float defaultValue) {
             parse(value, defaultType, defaultValue);
@@ -3095,7 +3093,7 @@ public class CSS implements Serializable {
             if (units == null) {
                 return value;
             }
-            Hashtable<String, Float> mapping = (w3cLengthUnits) ? w3cLengthMapping : lengthMapping;
+            Map<String, Float> mapping = (w3cLengthUnits) ? w3cLengthMapping : lengthMapping;
             float scale = mapping.getOrDefault(units, 1f);
             return value * scale;
         }


### PR DESCRIPTION
Two `Hashtable`'s in `javax.swing.text.html.CSS.LengthUnit` class are modified only within `<clinit>` block:
1. lengthMapping
2. w3cLengthMapping

We can replace them with immutable maps to avoid Hashtable synchronization overhead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348648](https://bugs.openjdk.org/browse/JDK-8348648): Unnecessary Hashtable usage in javax.swing.text.html.CSS.LengthUnit (**Enhancement** - P5)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23198/head:pull/23198` \
`$ git checkout pull/23198`

Update a local copy of the PR: \
`$ git checkout pull/23198` \
`$ git pull https://git.openjdk.org/jdk.git pull/23198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23198`

View PR using the GUI difftool: \
`$ git pr show -t 23198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23198.diff">https://git.openjdk.org/jdk/pull/23198.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23198#issuecomment-2615223237)
</details>
