### PR TITLE
8337997: MallocHeader description refers to non-existent NMT state "minimal"

### DIFF
--- a/src/hotspot/share/nmt/mallocHeader.hpp
+++ b/src/hotspot/share/nmt/mallocHeader.hpp
@@ -36,7 +36,7 @@ class outputStream;
 /*
  * Malloc tracking header.
  *
- * If NMT is active (state >= minimal), we need to track allocations. A simple and cheap way to
+ * If NMT is active (state >= summary), we need to track allocations. A simple and cheap way to
  * do this is by using malloc headers.
  *
  * The user allocation is preceded by a header and is immediately followed by a (possibly unaligned)


### PR DESCRIPTION
Hi everyone,

Small fix to a comment in `mallocHeader.hpp`, which referenced a non-existant NMT state. This has been changed to the correct (existing) state.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337997](https://bugs.openjdk.org/browse/JDK-8337997): MallocHeader description refers to non-existent NMT state "minimal" (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23199/head:pull/23199` \
`$ git checkout pull/23199`

Update a local copy of the PR: \
`$ git checkout pull/23199` \
`$ git pull https://git.openjdk.org/jdk.git pull/23199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23199`

View PR using the GUI difftool: \
`$ git pr show -t 23199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23199.diff">https://git.openjdk.org/jdk/pull/23199.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23199#issuecomment-2602708091)
</details>
