### PR TITLE
8344361: Restore null return for invalid services from legacy providers

### DIFF
--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1147,6 +1147,7 @@ public abstract class Provider extends Properties {
             s = legacyMap.get(key);
             if (s != null && !s.isValid()) {
                 legacyMap.remove(key, s);
+                return null;
             }
         }
 

--- a/test/jdk/java/security/Provider/InvalidServiceTest.java
+++ b/test/jdk/java/security/Provider/InvalidServiceTest.java
@@ -24,17 +24,17 @@
 /*
  * @test
  * @bug 8344361
- * @summary Restore null return for invalid services from legacy providers
+ * @summary Restore null return for invalid services
  */
 
 import java.security.Provider;
 
-public class LegacyProviderTest {
+public class InvalidServiceTest {
 
     public static void main(String[] args) throws Exception {
         Provider p1 = new LProvider("LegacyFormat");
-	// this builds a service with null class name. Helps exercise the code path
-	Provider.Service s1 = p1.getService("MessageDigest", "SHA-1");
+        // this returns a service with null class name. Helps exercise the code path
+        Provider.Service s1 = p1.getService("MessageDigest", "SHA-1");
         if (s1 != null)
             throw new RuntimeException("expecting null service");
     }
@@ -43,7 +43,7 @@ public class LegacyProviderTest {
         LProvider(String name) {
             super(name, "1.0", null);
             put("Signature.MD5withRSA", "com.foo.Sig");
-	    put("MessageDigest.SHA-1 ImplementedIn", "Software");
+            put("MessageDigest.SHA-1 ImplementedIn", "Software");
         }
     }
 }

--- a/test/jdk/java/security/Provider/LegacyProviderTest.java
+++ b/test/jdk/java/security/Provider/LegacyProviderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8344361
+ * @summary Restore null return for invalid services from legacy providers
+ */
+
+import java.security.Provider;
+
+public class LegacyProviderTest {
+
+    public static void main(String[] args) throws Exception {
+        Provider p1 = new LProvider("LegacyFormat");
+	// this builds a service with null class name. Helps exercise the code path
+	Provider.Service s1 = p1.getService("MessageDigest", "SHA-1");
+        if (s1 != null)
+            throw new RuntimeException("expecting null service");
+    }
+
+    private static class LProvider extends Provider {
+        LProvider(String name) {
+            super(name, "1.0", null);
+            put("Signature.MD5withRSA", "com.foo.Sig");
+	    put("MessageDigest.SHA-1 ImplementedIn", "Software");
+        }
+    }
+}


### PR DESCRIPTION
Correct a corner case where null should be returned if a service from the legacyMap is marked invalid. 

New test case added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344361](https://bugs.openjdk.org/browse/JDK-8344361): Restore null return for invalid services from legacy providers (**Bug** - P3)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23201/head:pull/23201` \
`$ git checkout pull/23201`

Update a local copy of the PR: \
`$ git checkout pull/23201` \
`$ git pull https://git.openjdk.org/jdk.git pull/23201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23201`

View PR using the GUI difftool: \
`$ git pr show -t 23201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23201.diff">https://git.openjdk.org/jdk/pull/23201.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23201#issuecomment-2602808650)
</details>
