### PR TITLE
8346927: serviceability/dcmd/vm/[SystemMapTest.java|SystemDumpMapTest.java] fail at jmx

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
@@ -157,7 +157,7 @@ public class SystemMapTestBase {
 
         static final String macow = "cow";
         static final String macprivate = "pvt";
-        static final String macprivate_or_shared = "(pvt|tsh)";
+        static final String macprivate_or_shared = "(pvt|tsh|cow|p/a)";
         static final String macprivatealiased = "p/a";
 
         static final String macOSbase = range + space + someSize + space + macprot + space;


### PR DESCRIPTION
This fix widens the regex used to determine if a JAVAHEAP line is correct in the output of System.map/System.dump_map.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346927](https://bugs.openjdk.org/browse/JDK-8346927): serviceability/dcmd/vm/[SystemMapTest.java|SystemDumpMapTest.java] fail at jmx (**Bug** - P3)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23205/head:pull/23205` \
`$ git checkout pull/23205`

Update a local copy of the PR: \
`$ git checkout pull/23205` \
`$ git pull https://git.openjdk.org/jdk.git pull/23205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23205`

View PR using the GUI difftool: \
`$ git pr show -t 23205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23205.diff">https://git.openjdk.org/jdk/pull/23205.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23205#issuecomment-2604879834)
</details>
