### PR TITLE
8348135: Fix couple of problem listing entries in test/hotspot/jtreg/ProblemList-Virtual.txt

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -104,9 +104,9 @@ gc/g1/TestMixedGCLiveThreshold.java#25percent 8334759 windows-x64
 
 gc/arguments/TestNewSizeThreadIncrease.java 0000000 generic-all
 gc/g1/TestSkipRebuildRemsetPhase.java 0000000 generic-all
-runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java JDK-8346442 generic-all
+runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java 8346442 generic-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 0000000 generic-all
-runtime/logging/LoaderConstraintsTest.java JDK-8346442 generic-all
+runtime/logging/LoaderConstraintsTest.java 8346442 generic-all
 runtime/Thread/AsyncExceptionOnMonitorEnter.java 0000000 generic-all
 runtime/Thread/StopAtExit.java 0000000 generic-all
 runtime/handshake/HandshakeWalkStackTest.java 0000000 generic-all


### PR DESCRIPTION
Can I please get a review of this trivial change which fixes two entries in the `test/hotspot/jtreg/ProblemList-Virtual.txt` problem listing file?

As noted in https://bugs.openjdk.org/browse/JDK-8348135, these two entries currently are considered malformed due to the `JDK-` prefix to the bug ids. The commit in this PR removes that prefix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348135](https://bugs.openjdk.org/browse/JDK-8348135): Fix couple of problem listing entries in test/hotspot/jtreg/ProblemList-Virtual.txt (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23206/head:pull/23206` \
`$ git checkout pull/23206`

Update a local copy of the PR: \
`$ git checkout pull/23206` \
`$ git pull https://git.openjdk.org/jdk.git pull/23206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23206`

View PR using the GUI difftool: \
`$ git pr show -t 23206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23206.diff">https://git.openjdk.org/jdk/pull/23206.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23206#issuecomment-2603945848)
</details>
