### PR TITLE
8348117: The two-argument overload of SignatureHandlerLibrary::add is not used

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -607,7 +607,6 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
 
   // Properties
   const char* name() const                  { return _name; }
-  void set_name(const char* name)           { _name = name; }
   CodeBuffer* before_expand() const         { return _before_expand; }
   BufferBlob* blob() const                  { return _blob; }
   void    set_blob(BufferBlob* blob);

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -97,7 +97,6 @@ class JavaFrameAnchor; // for UpcallStub::jfa_for_frame
 class CodeBlob {
   friend class VMStructs;
   friend class JVMCIVMStructs;
-  friend class CodeCacheDumper;
 
 protected:
   // order fields from large to small to minimize padding between fields

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -90,7 +90,6 @@ class CodeCache : AllStatic {
   friend class JVMCIVMStructs;
   template <class T, class Filter, bool is_relaxed> friend class CodeBlobIterator;
   friend class WhiteBox;
-  friend class CodeCacheLoader;
   friend class ShenandoahParallelCodeHeapIterator;
  private:
   // CodeHeaps of the cache

--- a/src/hotspot/share/interpreter/interpreter.hpp
+++ b/src/hotspot/share/interpreter/interpreter.hpp
@@ -44,7 +44,6 @@ class InterpreterMacroAssembler;
 
 class InterpreterCodelet: public Stub {
   friend class VMStructs;
-  friend class CodeCacheDumper; // possible extension [do not remove]
  private:
   NOT_PRODUCT(AsmRemarks _asm_remarks;)   // Comments for annotating assembler output.
   NOT_PRODUCT(DbgStrings _dbg_strings;)   // Debug strings used in generated code.

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1431,38 +1431,6 @@ void SignatureHandlerLibrary::add(const methodHandle& method) {
 #endif // ASSERT
 }
 
-void SignatureHandlerLibrary::add(uint64_t fingerprint, address handler) {
-  int handler_index = -1;
-  // use customized signature handler
-  MutexLocker mu(SignatureHandlerLibrary_lock);
-  // make sure data structure is initialized
-  initialize();
-  fingerprint = InterpreterRuntime::normalize_fast_native_fingerprint(fingerprint);
-  handler_index = _fingerprints->find(fingerprint);
-  // create handler if necessary
-  if (handler_index < 0) {
-    if (PrintSignatureHandlers && (handler != Interpreter::slow_signature_handler())) {
-      tty->cr();
-      tty->print_cr("argument handler #%d at " PTR_FORMAT " for fingerprint " UINT64_FORMAT,
-                    _handlers->length(),
-                    p2i(handler),
-                    fingerprint);
-    }
-    _fingerprints->append(fingerprint);
-    _handlers->append(handler);
-  } else {
-    if (PrintSignatureHandlers) {
-      tty->cr();
-      tty->print_cr("duplicate argument handler #%d for fingerprint " UINT64_FORMAT "(old: " PTR_FORMAT ", new : " PTR_FORMAT ")",
-                    _handlers->length(),
-                    fingerprint,
-                    p2i(_handlers->at(handler_index)),
-                    p2i(handler));
-    }
-  }
-}
-
-
 BufferBlob*              SignatureHandlerLibrary::_handler_blob = nullptr;
 address                  SignatureHandlerLibrary::_handler      = nullptr;
 GrowableArray<uint64_t>* SignatureHandlerLibrary::_fingerprints = nullptr;

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -192,7 +192,6 @@ class SignatureHandlerLibrary: public AllStatic {
 
  public:
   static void add(const methodHandle& method);
-  static void add(uint64_t fingerprint, address handler);
 };
 
 #endif // SHARE_INTERPRETER_INTERPRETERRUNTIME_HPP

--- a/src/hotspot/share/interpreter/templateInterpreter.hpp
+++ b/src/hotspot/share/interpreter/templateInterpreter.hpp
@@ -88,7 +88,6 @@ class TemplateInterpreter: public AbstractInterpreter {
   friend class InterpreterMacroAssembler;
   friend class TemplateInterpreterGenerator;
   friend class TemplateTable;
-  friend class CodeCacheExtensions;
   // friend class Interpreter;
  public:
 

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
@@ -244,7 +244,6 @@ void TemplateInterpreterGenerator::generate_all() {
   set_entry_points_for_all_bytes();
 
   // installation of code in other places in the runtime
-  // (ExcutableCodeManager calls not needed to copy the entries)
   set_safepoints_for_all_bytes();
 
   { CodeletMark cm(_masm, "deoptimization entry points");

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -151,7 +151,6 @@ class ScopedVMInitArgs;
 class Arguments : AllStatic {
   friend class VMStructs;
   friend class JvmtiExport;
-  friend class CodeCacheExtensions;
   friend class ArgumentsTest;
   friend class LargeOptionsTest;
  public:


### PR DESCRIPTION
The  `SignatureHandlerLibrary::add` two-arg API was added to support closed code under [JDK-8087333](https://bugs.openjdk.org/browse/JDK-8087333) in JDK 9. That closed code was removed again, still in JDK 9, as part of JEP 297 ([JDK-8168503](https://bugs.openjdk.org/browse/JDK-8168503)) which unified the closed and open ARM ports - leaving the API unused.

There were other leftovers from the same set of changes so they are cleaned up as well - nothing significant, just unnecessary friend declarations, comments, and one other method.

Testing:
 - all builds in tiers 1-5

Thanks.