### PR TITLE
8348169: Destruct values on free in Treap

### DIFF
--- a/src/hotspot/share/nmt/nmtTreap.hpp
+++ b/src/hotspot/share/nmt/nmtTreap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -230,7 +230,7 @@ public:
     _root(nullptr),
     _prng_seed(_initial_seed),
     _node_count(0) {
-    static_assert(std::is_trivially_destructible<K>, "must be");
+    static_assert(std::is_trivially_destructible<K>::value, "must be");
   }
 
   ~Treap() {

--- a/src/hotspot/share/nmt/nmtTreap.hpp
+++ b/src/hotspot/share/nmt/nmtTreap.hpp
@@ -31,6 +31,7 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/powerOfTwo.hpp"
+#include <type_traits>
 
 // A Treap is a self-balanced binary tree where each node is equipped with a
 // priority. It adds the invariant that the priority of a parent P is strictly larger
@@ -228,7 +229,9 @@ public:
   : _allocator(),
     _root(nullptr),
     _prng_seed(_initial_seed),
-    _node_count(0) {}
+    _node_count(0) {
+    static_assert(std::is_trivially_destructible<K>, "must be");
+  }
 
   ~Treap() {
     this->remove_all();
@@ -266,6 +269,7 @@ public:
     if (second_split.right != nullptr) {
       // The key k existed, we delete it.
       _node_count--;
+      second_split.right->_value.~V();
       _allocator.free(second_split.right);
     }
     // Merge together everything
@@ -283,6 +287,7 @@ public:
       if (head == nullptr) continue;
       to_delete.push(head->_left);
       to_delete.push(head->_right);
+      head->_value.~V();
       _allocator.free(head);
     }
     _root = nullptr;

--- a/test/hotspot/gtest/nmt/test_nmt_treap.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_treap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/nmt/test_nmt_treap.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_treap.cpp
@@ -326,5 +326,28 @@ TEST_VM_F(NMTTreapTest, VerifyItThroughStressTest) {
     verify_it(treap);
   }
 }
+struct NTD {
+  static bool has_run_destructor;
+  ~NTD() {
+    has_run_destructor = true;
+  }
+};
+
+bool NTD::has_run_destructor = false;
+
+TEST_VM_F(NMTTreapTest, ValueDestructorsAreRun) {
+  TreapCHeap<int, NTD, Cmp> treap;
+  NTD ntd;
+  treap.upsert(0, ntd);
+  treap.remove(0);
+  EXPECT_TRUE(NTD::has_run_destructor);
+  NTD::has_run_destructor = false;
+  {
+    TreapCHeap<int, NTD, Cmp> treap;
+    NTD ntd;
+    treap.upsert(0, ntd);
+  }
+  EXPECT_TRUE(NTD::has_run_destructor);
+}
 
 #endif // ASSERT


### PR DESCRIPTION
Hi,

Since the RBTree's integration is taking a while, could we add this change to the Treap? We want to integrate https://github.com/openjdk/jdk/pull/21899 which is using the Treap and non-trivially destructible values.

This is hopefully the last change that we make to the Treap before replacing it entirely with the RBTree.

Running GithubActions as testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348169](https://bugs.openjdk.org/browse/JDK-8348169): Destruct values on free in Treap (**Enhancement** - P4)


### Reviewers
 * [Casper Norrbin](https://openjdk.org/census#cnorrbin) (@caspernorrbin - Author)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23208/head:pull/23208` \
`$ git checkout pull/23208`

Update a local copy of the PR: \
`$ git checkout pull/23208` \
`$ git pull https://git.openjdk.org/jdk.git pull/23208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23208`

View PR using the GUI difftool: \
`$ git pr show -t 23208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23208.diff">https://git.openjdk.org/jdk/pull/23208.diff</a>

</details>
