### PR TITLE
8348180: Remove mention of include of precompiled.hpp from the HotSpot Style Guide

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -217,8 +217,6 @@ file as the first include line. Declarations needed by other files
 should be put in the .hpp file, and not in the .inline.hpp file. This
 rule exists to resolve problems with circular dependencies between
 .inline.hpp files.</p></li>
-<li><p>All .cpp files include precompiled.hpp as the first include
-line.</p></li>
 <li><p>precompiled.hpp is just a build time optimization, so don't rely
 on it to resolve include problems.</p></li>
 <li><p>Keep the include lines alphabetically sorted.</p></li>

--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -217,8 +217,10 @@ file as the first include line. Declarations needed by other files
 should be put in the .hpp file, and not in the .inline.hpp file. This
 rule exists to resolve problems with circular dependencies between
 .inline.hpp files.</p></li>
-<li><p>precompiled.hpp is just a build time optimization, so don't rely
-on it to resolve include problems.</p></li>
+<li><p>Some build configurations use precompiled headers to speed up the
+build times. The precompiled headers are included in the precompiled.hpp
+file. Note that precompiled.hpp is just a build time optimization, so
+don't rely on it to resolve include problems.</p></li>
 <li><p>Keep the include lines alphabetically sorted.</p></li>
 <li><p>Put conditional inclusions (<code>#if ...</code>) at the end of
 the include list.</p></li>

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -150,8 +150,6 @@ the first include line. Declarations needed by other files should be put
 in the .hpp file, and not in the .inline.hpp file. This rule exists to
 resolve problems with circular dependencies between .inline.hpp files.
 
-* All .cpp files include precompiled.hpp as the first include line.
-
 * precompiled.hpp is just a build time optimization, so don't rely on
 it to resolve include problems.
 

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -150,8 +150,10 @@ the first include line. Declarations needed by other files should be put
 in the .hpp file, and not in the .inline.hpp file. This rule exists to
 resolve problems with circular dependencies between .inline.hpp files.
 
-* precompiled.hpp is just a build time optimization, so don't rely on
-it to resolve include problems.
+* Some build configurations use precompiled headers to speed up the
+build times. The precompiled headers are included in the precompiled.hpp
+file. Note that precompiled.hpp is just a build time optimization, so
+don't rely on it to resolve include problems.
 
 * Keep the include lines alphabetically sorted.
 


### PR DESCRIPTION
[JDK-8347909](https://bugs.openjdk.org/browse/JDK-8347909) removed the need for HotSpot devs to include the precompiled.hpp. This is the PR to reflect that.

I know that there is some process around updating the style guide, but I can't find it, so I'm starting with a plain PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348180](https://bugs.openjdk.org/browse/JDK-8348180): Remove mention of include of precompiled.hpp from the HotSpot Style Guide (**Enhancement** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) Review applies to [09c88c4f](https://git.openjdk.org/jdk/pull/23210/files/09c88c4fdb04449ae869c5ac3a79730f7c5f4719)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23210/head:pull/23210` \
`$ git checkout pull/23210`

Update a local copy of the PR: \
`$ git checkout pull/23210` \
`$ git pull https://git.openjdk.org/jdk.git pull/23210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23210`

View PR using the GUI difftool: \
`$ git pr show -t 23210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23210.diff">https://git.openjdk.org/jdk/pull/23210.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23210#issuecomment-2604617297)
</details>
