### PR TITLE
8348182: Remove DONT_USE_PRECOMPILED_HEADER

### DIFF
--- a/make/hotspot/lib/JvmFlags.gmk
+++ b/make/hotspot/lib/JvmFlags.gmk
@@ -92,11 +92,6 @@ JVM_CFLAGS += \
     $(EXTRA_CFLAGS) \
     #
 
-# -DDONT_USE_PRECOMPILED_HEADER will exclude all includes in precompiled.hpp.
-ifeq ($(USE_PRECOMPILED_HEADER), false)
-  JVM_CFLAGS += -DDONT_USE_PRECOMPILED_HEADER
-endif
-
 ifneq ($(HOTSPOT_OVERRIDE_LIBPATH), )
   JVM_CFLAGS += -DOVERRIDE_LIBPATH='"$(HOTSPOT_OVERRIDE_LIBPATH)"'
 endif

--- a/src/hotspot/share/precompiled/precompiled.hpp
+++ b/src/hotspot/share/precompiled/precompiled.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@
 
 // Precompiled headers are turned off if the user passes
 // --disable-precompiled-headers to configure.
-
-#ifndef DONT_USE_PRECOMPILED_HEADER
 
 // These header files are included in at least 130 C++ files, as of
 // measurements made in November 2018. This list excludes files named
@@ -77,5 +75,3 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #endif // TARGET_COMPILER_visCPP
-
-#endif // !DONT_USE_PRECOMPILED_HEADER


### PR DESCRIPTION
Before [JDK-8347909](https://bugs.openjdk.org/browse/JDK-8347909) we had to remove the include lines in precompiled.hpp when precompiled headers were turned off. This was done by defining DONT_USE_PRECOMPILED_HEADER.

After [JDK-8347909](https://bugs.openjdk.org/browse/JDK-8347909) we simply don't include precompiled.hpp if precompiled headers are turned off and therefore we don't need to removed the include lines.

I propose that we get rid of DONT_USE_PRECOMPILED_HEADER.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348182](https://bugs.openjdk.org/browse/JDK-8348182): Remove DONT_USE_PRECOMPILED_HEADER (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23211/head:pull/23211` \
`$ git checkout pull/23211`

Update a local copy of the PR: \
`$ git checkout pull/23211` \
`$ git pull https://git.openjdk.org/jdk.git pull/23211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23211`

View PR using the GUI difftool: \
`$ git pr show -t 23211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23211.diff">https://git.openjdk.org/jdk/pull/23211.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23211#issuecomment-2604642287)
</details>
