### PR TITLE
8347779: sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java fails with Unable to deduce type of thread from address

### DIFF
--- a/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
+++ b/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
@@ -53,6 +53,7 @@ public class JShellHeapDumpTest {
     static Process jShellProcess;
     static boolean doSleep = true; // By default do a short sleep when app starts up
 
+    // Returns false if the attempt should be retried.
     public static boolean launch(String expectedMessage, List<String> toolArgs, boolean allowRetry)
         throws IOException {
 
@@ -102,6 +103,8 @@ public class JShellHeapDumpTest {
         throws IOException {
 
         boolean res = launch(expectedMessage, Arrays.asList(toolArgs), true);
+        // Allow a retry for !doSleep, because the sleep allows the debuggee to stabilize,
+        // making it very unlikely that jmap will fail.
         if (!res && !doSleep) {
             launch(expectedMessage, Arrays.asList(toolArgs), false);
         }

--- a/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
+++ b/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class JShellHeapDumpTest {
     static Process jShellProcess;
     static boolean doSleep = true; // By default do a short sleep when app starts up
 
-    public static void launch(String expectedMessage, List<String> toolArgs)
+    public static boolean launch(String expectedMessage, List<String> toolArgs, boolean allowRetry)
         throws IOException {
 
         try {
@@ -81,6 +81,7 @@ public class JShellHeapDumpTest {
             System.out.println("###### End of all output which took " + elapsedTime + "ms");
             output.shouldHaveExitValue(0);
         } catch (Exception ex) {
+            if (allowRetry) return false;
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {
             if (jShellProcess.isAlive()) {
@@ -91,12 +92,16 @@ public class JShellHeapDumpTest {
                 System.out.println("Jshell not alive");
             }
         }
+        return true;
     }
 
     public static void launch(String expectedMessage, String... toolArgs)
         throws IOException {
 
-        launch(expectedMessage, Arrays.asList(toolArgs));
+        boolean res = launch(expectedMessage, Arrays.asList(toolArgs), true);
+        if (!res) { // try once more
+            launch(expectedMessage, Arrays.asList(toolArgs), false);
+        }
     }
 
     /* Returns false if the attempt should be retried. */

--- a/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
+++ b/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
@@ -102,7 +102,7 @@ public class JShellHeapDumpTest {
         throws IOException {
 
         boolean res = launch(expectedMessage, Arrays.asList(toolArgs), true);
-        if (!res) { // try once more
+        if (!res && !doSleep) {
             launch(expectedMessage, Arrays.asList(toolArgs), false);
         }
     }

--- a/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
+++ b/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
@@ -81,7 +81,10 @@ public class JShellHeapDumpTest {
             System.out.println("###### End of all output which took " + elapsedTime + "ms");
             output.shouldHaveExitValue(0);
         } catch (Exception ex) {
-            if (allowRetry) return false;
+            if (allowRetry) {
+                System.out.println("Exception " + ex + " in 'launch' occured. Allow one retry.");
+                return false;
+            }
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {
             if (jShellProcess.isAlive()) {


### PR DESCRIPTION
We were running into this error :
sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java on Linux aarch64, jdk25

stderr: [java.lang.RuntimeException: Unable to deduce type of thread from address 0x0000ffff34144e30 (expected type JavaThread, CompilerThread, MonitorDeflationThread, AttachListenerThread, StringDedupThread, NotificationThread, ServiceThread or JvmtiAgentThread)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.Threads.createJavaThreadWrapper(Threads.java:196)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.Threads.getJavaThreadAt(Threads.java:178)
at jdk.hotspot.agent/sun.jvm.hotspot.utilities.HeapHprofBinWriter.dumpStackTraces(HeapHprofBinWriter.java:828)
at jdk.hotspot.agent/sun.jvm.hotspot.utilities.HeapHprofBinWriter.write(HeapHprofBinWriter.java:460)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.JMap.writeHeapHprofBin(JMap.java:216)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.JMap.run(JMap.java:103)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.startInternal(Tool.java:278)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.start(Tool.java:241)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.execute(Tool.java:134)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.JMap.main(JMap.java:202)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.runJMAP(SALauncher.java:344)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.main(SALauncher.java:507)
Caused by: sun.jvm.hotspot.types.WrongTypeException: No suitable match for type of address 0x0000ffff34144e30
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.InstanceConstructor.newWrongTypeException(InstanceConstructor.java:62)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.VirtualConstructor.instantiateWrapperFor(VirtualConstructor.java:80)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.Threads.createJavaThreadWrapper(Threads.java:192)
... 11 more

In the discussion in the JBS bug it was found that a retry option in` launch `should be added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347779](https://bugs.openjdk.org/browse/JDK-8347779): sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java fails with Unable to deduce type of thread from address (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23213/head:pull/23213` \
`$ git checkout pull/23213`

Update a local copy of the PR: \
`$ git checkout pull/23213` \
`$ git pull https://git.openjdk.org/jdk.git pull/23213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23213`

View PR using the GUI difftool: \
`$ git pr show -t 23213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23213.diff">https://git.openjdk.org/jdk/pull/23213.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23213#issuecomment-2604743557)
</details>
