### PR TITLE
8346830: Simplify adlc build config for aix

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -37,13 +37,8 @@ ifeq ($(call check-jvm-feature, compiler2), true)
   ifeq ($(call isBuildOs, linux), true)
     ADLC_CFLAGS := -fno-exceptions -DLINUX
   else ifeq ($(call isBuildOs, aix), true)
-    ifeq ($(TOOLCHAIN_TYPE), clang)
-      ADLC_LDFLAGS += -m64
-      ADLC_CFLAGS := -fno-rtti -fexceptions -ffunction-sections -m64 -DAIX -mcpu=pwr8
-    else
-      ADLC_LDFLAGS += -q64
-      ADLC_CFLAGS := -qnortti -qeh -q64 -DAIX
-    endif
+    ADLC_LDFLAGS += -m64
+    ADLC_CFLAGS := -fno-rtti -fexceptions -ffunction-sections -m64 -DAIX -mcpu=pwr8
   else ifeq ($(call isBuildOs, windows), true)
     ADLC_CFLAGS := -nologo -EHsc
     ADLC_CFLAGS_WARNINGS := -W3 -D_CRT_SECURE_NO_WARNINGS


### PR DESCRIPTION
In GensrcAdlc.gmk

This bit of code in GensrcAdlc.gmk is conditionalized on whether we're
building with clang or not.

https://github.com/openjdk/jdk/blob/1a32654faf6f6f0256fd7f42e6351adf914d8337/make/hotspot/gensrc/GensrcAdlc.gmk#L39-L46

It can be simplified, since for aix we always build with clang now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346830](https://bugs.openjdk.org/browse/JDK-8346830): Simplify adlc build config for aix (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23214/head:pull/23214` \
`$ git checkout pull/23214`

Update a local copy of the PR: \
`$ git checkout pull/23214` \
`$ git pull https://git.openjdk.org/jdk.git pull/23214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23214`

View PR using the GUI difftool: \
`$ git pr show -t 23214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23214.diff">https://git.openjdk.org/jdk/pull/23214.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23214#issuecomment-2604835154)
</details>
