### PR TITLE
8348186: C1: Purge fpu_stack_size infrastructure

### DIFF
--- a/src/hotspot/cpu/x86/c1_LinearScan_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LinearScan_x86.cpp
@@ -649,7 +649,6 @@ void FpuStackAllocator::handle_op1(LIR_Op1* op1) {
       new_in = to_fpu_stack_top(res);
       new_res = new_in;
 
-      op1->set_fpu_stack_size(sim()->stack_size());
       break;
     }
 

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -1599,8 +1599,6 @@ public:
 class LIR_Op2: public LIR_Op {
  friend class LIR_OpVisitState;
 
-  int  _fpu_stack_size; // for sin/cos implementation on Intel
-
  protected:
   LIR_Opr   _opr1;
   LIR_Opr   _opr2;
@@ -1617,7 +1615,6 @@ class LIR_Op2: public LIR_Op {
  public:
   LIR_Op2(LIR_Code code, LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, CodeEmitInfo* info = nullptr, BasicType type = T_ILLEGAL)
     : LIR_Op(code, LIR_OprFact::illegalOpr, info)
-    , _fpu_stack_size(0)
     , _opr1(opr1)
     , _opr2(opr2)
     , _tmp1(LIR_OprFact::illegalOpr)
@@ -1632,7 +1629,6 @@ class LIR_Op2: public LIR_Op {
 
   LIR_Op2(LIR_Code code, LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr result, BasicType type)
     : LIR_Op(code, result, nullptr)
-    , _fpu_stack_size(0)
     , _opr1(opr1)
     , _opr2(opr2)
     , _tmp1(LIR_OprFact::illegalOpr)
@@ -1649,7 +1645,6 @@ class LIR_Op2: public LIR_Op {
   LIR_Op2(LIR_Code code, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr result = LIR_OprFact::illegalOpr,
           CodeEmitInfo* info = nullptr, BasicType type = T_ILLEGAL)
     : LIR_Op(code, result, info)
-    , _fpu_stack_size(0)
     , _opr1(opr1)
     , _opr2(opr2)
     , _tmp1(LIR_OprFact::illegalOpr)
@@ -1665,7 +1660,6 @@ class LIR_Op2: public LIR_Op {
   LIR_Op2(LIR_Code code, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr result, LIR_Opr tmp1, LIR_Opr tmp2 = LIR_OprFact::illegalOpr,
           LIR_Opr tmp3 = LIR_OprFact::illegalOpr, LIR_Opr tmp4 = LIR_OprFact::illegalOpr, LIR_Opr tmp5 = LIR_OprFact::illegalOpr)
     : LIR_Op(code, result, nullptr)
-    , _fpu_stack_size(0)
     , _opr1(opr1)
     , _opr2(opr2)
     , _tmp1(tmp1)
@@ -1692,9 +1686,6 @@ class LIR_Op2: public LIR_Op {
   void set_condition(LIR_Condition condition) {
     assert(code() == lir_cmp || code() == lir_branch || code() == lir_cond_float_branch, "only valid for branch"); _condition = condition;
   }
-
-  void set_fpu_stack_size(int size)              { _fpu_stack_size = size; }
-  int  fpu_stack_size() const                    { return _fpu_stack_size; }
 
   void set_in_opr1(LIR_Opr opr)                  { _opr1 = opr; }
   void set_in_opr2(LIR_Opr opr)                  { _opr2 = opr; }


### PR DESCRIPTION
There is currently a build failure for x86_32 in mainline due to [JDK-8346038](https://bugs.openjdk.org/browse/JDK-8346038) moving things around. The failure looks like this:

```
* For target hotspot_variant-server_libjvm_objs_c1_LinearScan_x86.o:
src/hotspot/cpu/x86/c1_LinearScan_x86.cpp: In member function 'void FpuStackAllocator::handle_op1(LIR_Op1*)':
src/hotspot/cpu/x86/c1_LinearScan_x86.cpp:652:12: error: 'class LIR_Op1' has no member named 'set_fpu_stack_size'
  652 | op1->set_fpu_stack_size(sim()->stack_size());
      | ^~~~~~~~~~~~~~~~~~
```

This does not warrant a fix, given the code is in deprecated x86_32 parts. But we do not need the whole `set_fpu_stack_size` infra to begin with: the last uses were removed by [JDK-8143353](https://bugs.openjdk.org/browse/JDK-8143353) and [JDK-8152907](https://bugs.openjdk.org/browse/JDK-8152907). So we can clean up this part for both x86_64 and x86_32 at once, and fix an easy build failure meanwhile.

Additional testing:
 - [x] linux-x86-server-fastdebug build
 - [x] linux-x86_64-server-fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348186](https://bugs.openjdk.org/browse/JDK-8348186): C1: Purge fpu_stack_size infrastructure (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23215/head:pull/23215` \
`$ git checkout pull/23215`

Update a local copy of the PR: \
`$ git checkout pull/23215` \
`$ git pull https://git.openjdk.org/jdk.git pull/23215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23215`

View PR using the GUI difftool: \
`$ git pr show -t 23215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23215.diff">https://git.openjdk.org/jdk/pull/23215.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23215#issuecomment-2604856456)
</details>
