### PR TITLE
8347008: beancontext package spec does not clearly explain why the API is deprecated

### DIFF
--- a/src/java.desktop/share/classes/java/beans/beancontext/package-info.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/package-info.java
@@ -31,7 +31,7 @@
  * contains events and listener interface for beans being added and removed from
  * a bean context.
  * <p>
- * These APIs are now both obsolete and express an "anti-pattern" of component
+ * These APIs are now both obsolete and express an <em>anti-pattern</em> of component
  * assembly and interaction.
  * <p>
  * This package has been deprecated and may be removed in a future version of

--- a/src/java.desktop/share/classes/java/beans/beancontext/package-info.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,12 +30,15 @@
  * context can be nested within another bean context. This package also
  * contains events and listener interface for beans being added and removed from
  * a bean context.
- *
- * This package has been deprecated and may be removed in a future version of the Java Platform
- * There is no replacement.
- *
+ * <p>
+ * These APIs are now both obsolete and express an "anti-pattern" of component
+ * assembly and interaction.
+ * <p>
+ * This package has been deprecated and may be removed in a future version of
+ * the Java Platform. There is no replacement.
+ * <p>
  * All of the classes and interfaces in this package have been terminally deprecated.
- *
+ * <p>
  * Users are advised to migrate their applications to other technologies.
  *
  * @since 1.2


### PR DESCRIPTION
The beancontext package description or the deprecation text in the classes doesn't say anything about why the API is deprecated.
A few more words have been added in this regard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8348188](https://bugs.openjdk.org/browse/JDK-8348188) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8347008: beancontext package spec does not clearly explain why the API is deprecated`

### Issues
 * [JDK-8347008](https://bugs.openjdk.org/browse/JDK-8347008): beancontext package spec does not clearly explain why the API is deprecated (**Bug** - P4)
 * [JDK-8348188](https://bugs.openjdk.org/browse/JDK-8348188): beancontext package spec does not clearly explain why the API is deprecated (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [6d6ae98c](https://git.openjdk.org/jdk/pull/23216/files/6d6ae98c5db899ab0f8ab6a85a698f2336eda759)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23216/head:pull/23216` \
`$ git checkout pull/23216`

Update a local copy of the PR: \
`$ git checkout pull/23216` \
`$ git pull https://git.openjdk.org/jdk.git pull/23216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23216`

View PR using the GUI difftool: \
`$ git pr show -t 23216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23216.diff">https://git.openjdk.org/jdk/pull/23216.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23216#issuecomment-2604901931)
</details>
