### PR TITLE
8331723: Serial: Remove the unused parameter of the method SerialHeap::gc_prologue

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -460,7 +460,7 @@ bool SerialHeap::do_young_collection(bool clear_soft_refs) {
     prepare_for_verify();
     Universe::verify("Before GC");
   }
-  gc_prologue(false);
+  gc_prologue();
   COMPILER2_OR_JVMCI_PRESENT(DerivedPointerTable::clear());
 
   save_marks();
@@ -728,7 +728,7 @@ void SerialHeap::do_full_collection_no_gc_locker(bool clear_all_soft_refs) {
     Universe::verify("Before GC");
   }
 
-  gc_prologue(true);
+  gc_prologue();
   COMPILER2_OR_JVMCI_PRESENT(DerivedPointerTable::clear());
   CodeCache::on_gc_marking_cycle_start();
   ClassUnloadingContext ctx(1 /* num_nmethod_unlink_workers */,
@@ -934,7 +934,7 @@ void SerialHeap::print_heap_change(const PreGenGCValues& pre_gc_values) const {
   MetaspaceUtils::print_metaspace_change(pre_gc_values.metaspace_sizes());
 }
 
-void SerialHeap::gc_prologue(bool full) {
+void SerialHeap::gc_prologue() {
   // Fill TLAB's and such
   ensure_parsability(true);   // retire TLABs
 

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -111,7 +111,7 @@ private:
 
   bool is_young_gc_safe() const;
 
-  void gc_prologue(bool full);
+  void gc_prologue();
   void gc_epilogue(bool full);
 
 public:


### PR DESCRIPTION
Hi all,

This patch removes the unnecessary parameter `full` in `SerialHeap::gc_prologue`. The previous patch is at https://github.com/openjdk/jdk/pull/19207 .

Thanks for the review.

Best Regards,
-- Gouxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331723](https://bugs.openjdk.org/browse/JDK-8331723): Serial: Remove the unused parameter of the method SerialHeap::gc_prologue (**Enhancement** - P5)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Contributors
 * nanxiaotao `<nxtchongchong@163.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23218/head:pull/23218` \
`$ git checkout pull/23218`

Update a local copy of the PR: \
`$ git checkout pull/23218` \
`$ git pull https://git.openjdk.org/jdk.git pull/23218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23218`

View PR using the GUI difftool: \
`$ git pr show -t 23218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23218.diff">https://git.openjdk.org/jdk/pull/23218.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23218#issuecomment-2605243064)
</details>
