### PR TITLE
8348212: Need to add warn() step to JavacTaskImpl after JDK-8344148

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
@@ -401,12 +401,12 @@ public class JavacTaskImpl extends BasicJavacTask {
         final ListBuffer<Element> results = new ListBuffer<>();
         try {
             if (classes == null) {
-                handleFlowResults(compiler.flow(compiler.attribute(compiler.todo)), results);
+                handleFlowResults(compiler.warn(compiler.flow(compiler.attribute(compiler.todo))), results);
             } else {
                 Filter f = new Filter() {
                     @Override
                     public void process(Env<AttrContext> env) {
-                        handleFlowResults(compiler.flow(compiler.attribute(env)), results);
+                        handleFlowResults(compiler.warn(compiler.flow(compiler.attribute(env))), results);
                     }
                 };
                 f.run(compiler.todo, classes);

--- a/test/langtools/tools/javac/api/TestJavacTaskWithWarning.java
+++ b/test/langtools/tools/javac/api/TestJavacTaskWithWarning.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8348212
+ * @summary Ensure the warn() phase executes when the compiler is invoked via the API
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ * @compile TestJavacTask.java TestJavacTaskWithWarning.java
+ * @run main TestJavacTaskWithWarning
+ */
+
+import com.sun.tools.javac.api.JavacTaskImpl;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import javax.tools.JavaFileObject;
+import javax.tools.ToolProvider;
+
+public class TestJavacTaskWithWarning extends TestJavacTask {
+
+    public static void warningTest() throws IOException {
+
+        // Create a source file that will generate a warning
+        String srcdir = System.getProperty("test.src");
+        File file = new File(srcdir, "GeneratesWarning.java");
+        try (PrintStream out = new PrintStream(new FileOutputStream(file))) {
+            out.print(
+                """
+                public class GeneratesWarning {
+                    public GeneratesWarning() {
+                        hashCode();     // generates a "this-escape" warning
+                    }
+                }
+                """);
+        }
+
+        // Compile it using API
+        Iterable<? extends JavaFileObject> files = fm.getJavaFileObjectsFromFiles(List.of(file));
+        StringWriter buf = new StringWriter();
+        List<String> options = List.of(
+          "-Xlint:this-escape",
+          "-XDrawDiagnostics"
+        );
+        JavacTaskImpl task = (JavacTaskImpl)compiler.getTask(new PrintWriter(buf), fm, null, options, null, files);
+        task.analyze();
+
+        // Verify warning was generated
+        if (!buf.toString().contains("compiler.warn.possible.this.escape"))
+            throw new AssertionError("warning not found in:\n" + buf);
+    }
+
+    public static void main(String[] args) throws IOException {
+        try {
+            warningTest();
+        } finally {
+            fm.close();
+        }
+    }
+}

--- a/test/langtools/tools/javac/api/TestJavacTaskWithWarning.java
+++ b/test/langtools/tools/javac/api/TestJavacTaskWithWarning.java
@@ -26,25 +26,28 @@
  * @bug     8348212
  * @summary Ensure the warn() phase executes when the compiler is invoked via the API
  * @modules jdk.compiler/com.sun.tools.javac.api
- * @compile TestJavacTask.java TestJavacTaskWithWarning.java
- * @run main TestJavacTaskWithWarning
  */
 
 import com.sun.tools.javac.api.JavacTaskImpl;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
+
+import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 
-public class TestJavacTaskWithWarning extends TestJavacTask {
+public class TestJavacTaskWithWarning {
 
-    public static void warningTest() throws IOException {
+    static final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    static final StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null);
+
+    public static void warningTest() throws Exception {
 
         // Create a source file that will generate a warning
         String srcdir = System.getProperty("test.src");
@@ -75,7 +78,7 @@ public class TestJavacTaskWithWarning extends TestJavacTask {
             throw new AssertionError("warning not found in:\n" + buf);
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         try {
             warningTest();
         } finally {


### PR DESCRIPTION
In [JDK-8344148](https://bugs.openjdk.org/browse/JDK-8344148) a new `warn()` compiler phase was added and `JavaCompiler.java` was updated accordingly.

However, the class `JavacTaskImpl` also walks through the compiler phases step-by-step, but the new `warn()` step was never added there. This will cause some warnings to not be emitted when that API is used.

This PR adds the missing `warn()` calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348212](https://bugs.openjdk.org/browse/JDK-8348212): Need to add warn() step to JavacTaskImpl after JDK-8344148 (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23223/head:pull/23223` \
`$ git checkout pull/23223`

Update a local copy of the PR: \
`$ git checkout pull/23223` \
`$ git pull https://git.openjdk.org/jdk.git pull/23223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23223`

View PR using the GUI difftool: \
`$ git pr show -t 23223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23223.diff">https://git.openjdk.org/jdk/pull/23223.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23223#issuecomment-2606194684)
</details>
