### PR TITLE
8339889: Several compiler tests ignore vm flags and not marked as flagless

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class TestReduceAllocationAndHeapDump {
                 HeapDumper.class.getName()
             };
 
-            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(dumperArgs);
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(dumperArgs);
             Process p = pb.start();
             OutputAnalyzer out = new OutputAnalyzer(p);
 

--- a/test/hotspot/jtreg/compiler/calls/NativeCalls.java
+++ b/test/hotspot/jtreg/compiler/calls/NativeCalls.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -104,7 +105,7 @@ public class NativeCalls {
             ArrayList<String> command = new ArrayList<String>(v.options);
             command.addAll(baseOptions);
             command.add(v.compile);
-            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command);
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(command);
             OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
             analyzer.shouldHaveExitValue(0);
             System.out.println(analyzer.getOutput());

--- a/test/hotspot/jtreg/compiler/debug/TestStress.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import jdk.test.lib.Asserts;
  * @key stress randomness
  * @bug 8252219 8256535 8317349
  * @requires vm.debug == true & vm.compiler2.enabled
+ * @requires vm.flagless
  * @summary Tests that stress compilations with the same seed yield the same
  *          IGVN, CCP, and macro expansion traces.
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/inlining/TestDuplicatedLateInliningOutput.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestDuplicatedLateInliningOutput.java
@@ -28,8 +28,7 @@
  * @summary late inlining output shouldn't produce both failure and success messages
  * @library /test/lib
  * @requires vm.compiler2.enabled
- * @requires vm.compMode != "Xcomp"
- * @requires vm.opt.PerMethodSpecTrapLimit!=0 & vm.opt.PerMethodTrapLimit!=0
+ * @requires vm.flagless
  * @run driver compiler.inlining.TestDuplicatedLateInliningOutput
  */
 
@@ -59,7 +58,7 @@ public class TestDuplicatedLateInliningOutput {
     }
 
     private static void test(Class<?> launcher, String pattern1, String pattern2) throws Exception {
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:+PrintInlining",
                 "-XX:CICompilerCount=1",

--- a/test/hotspot/jtreg/compiler/inlining/TestDuplicatedLateInliningOutput.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestDuplicatedLateInliningOutput.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Red Hat and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,6 +28,8 @@
  * @summary late inlining output shouldn't produce both failure and success messages
  * @library /test/lib
  * @requires vm.compiler2.enabled
+ * @requires vm.compMode != "Xcomp"
+ * @requires vm.opt.PerMethodSpecTrapLimit!=0 & vm.opt.PerMethodTrapLimit!=0
  * @run driver compiler.inlining.TestDuplicatedLateInliningOutput
  */
 
@@ -56,7 +59,7 @@ public class TestDuplicatedLateInliningOutput {
     }
 
     private static void test(Class<?> launcher, String pattern1, String pattern2) throws Exception {
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:+PrintInlining",
                 "-XX:CICompilerCount=1",


### PR DESCRIPTION
Tests
compiler/c2/TestReduceAllocationAndHeapDump.java
compiler/calls/NativeCalls.java
compiler/debug/TestStress.java
compiler/inlining/TestDuplicatedLateInliningOutput.java
ignore vm flags using limited process builder and not marked as flagless.

Please note that test
compiler/inlining/TestDuplicatedLateInliningOutput.java
is failing with some VM flags. See
https://bugs.openjdk.org/browse/JDK-8348214

I haven't excluded test, since it fail with certain non-common flags only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339889](https://bugs.openjdk.org/browse/JDK-8339889): Several compiler tests ignore vm flags and not marked as flagless (**Sub-task** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23224/head:pull/23224` \
`$ git checkout pull/23224`

Update a local copy of the PR: \
`$ git checkout pull/23224` \
`$ git pull https://git.openjdk.org/jdk.git pull/23224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23224`

View PR using the GUI difftool: \
`$ git pr show -t 23224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23224.diff">https://git.openjdk.org/jdk/pull/23224.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23224#issuecomment-2606072672)
</details>
