### PR TITLE
8348241: ZGC: Unnecessarily reinitialize ZFragmentationLimit's default value

### DIFF
--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -141,10 +141,6 @@ void ZArguments::initialize() {
     FLAG_SET_ERGO_IF_DEFAULT(ZCollectionIntervalMajor, ZCollectionInterval);
   }
 
-  if (FLAG_IS_DEFAULT(ZFragmentationLimit)) {
-    FLAG_SET_DEFAULT(ZFragmentationLimit, 5.0);
-  }
-
   // Set medium page size here because MaxTenuringThreshold may use it.
   ZHeuristics::set_medium_page_size();
 


### PR DESCRIPTION
Please review this trivial change to remove unnecessary reinitializing  ZFragmentationLimit's default value. Looks like a leftover from [JDK-8341692](https://bugs.openjdk.org/browse/JDK-8341692)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348241](https://bugs.openjdk.org/browse/JDK-8348241): ZGC: Unnecessarily reinitialize ZFragmentationLimit's default value (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23225/head:pull/23225` \
`$ git checkout pull/23225`

Update a local copy of the PR: \
`$ git checkout pull/23225` \
`$ git pull https://git.openjdk.org/jdk.git pull/23225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23225`

View PR using the GUI difftool: \
`$ git pr show -t 23225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23225.diff">https://git.openjdk.org/jdk/pull/23225.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23225#issuecomment-2606144493)
</details>
