### PR TITLE
8348240: Remove SystemDictionaryShared::lookup_super_for_unregistered_class()

### DIFF
--- a/src/hotspot/share/cds/classListParser.hpp
+++ b/src/hotspot/share/cds/classListParser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,12 +137,10 @@ private:
   void print_diagnostic_info(outputStream* st, const char* msg, ...) ATTRIBUTE_PRINTF(3, 0);
   void constant_pool_resolution_warning(const char* msg, ...) ATTRIBUTE_PRINTF(2, 0);
   void error(const char* msg, ...) ATTRIBUTE_PRINTF(2, 0);
+  objArrayOop get_specified_interfaces(TRAPS);
 
 public:
-  static void parse_classlist(const char* classlist_path, ParseMode parse_mode, TRAPS) {
-    ClassListParser parser(classlist_path, parse_mode);
-    parser.parse(THREAD);
-  }
+  static void parse_classlist(const char* classlist_path, ParseMode parse_mode, TRAPS);
 
   static bool is_parsing_thread();
   static ClassListParser* instance() {
@@ -201,12 +199,6 @@ public:
   }
 
   bool is_loading_from_source();
-
-  // Look up the super or interface of the current class being loaded
-  // (in this->load_current_class()).
-  InstanceKlass* lookup_super_for_current_class(Symbol* super_name);
-  InstanceKlass* lookup_interface_for_current_class(Symbol* interface_name);
-
   static void populate_cds_indy_info(const constantPoolHandle &pool, int cp_index, CDSIndyInfo* cii, TRAPS);
 };
 #endif // SHARE_CDS_CLASSLISTPARSER_HPP

--- a/src/hotspot/share/cds/unregisteredClasses.cpp
+++ b/src/hotspot/share/cds/unregisteredClasses.cpp
@@ -28,7 +28,7 @@
 #include "classfile/classLoaderExt.hpp"
 #include "classfile/javaClasses.inline.hpp"
 #include "classfile/symbolTable.hpp"
-#include "classfile/systemDictionaryShared.hpp"
+#include "classfile/systemDictionary.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "memory/oopFactory.hpp"
 #include "memory/resourceArea.hpp"
@@ -38,10 +38,22 @@
 #include "runtime/javaCalls.hpp"
 #include "services/threadService.hpp"
 
+InstanceKlass* UnregisteredClasses::_UnregisteredClassLoader_klass = nullptr;
+
+void UnregisteredClasses::initialize(TRAPS) {
+  if (_UnregisteredClassLoader_klass == nullptr) {
+    // no need for synchronization as this function is called single-threaded.
+    Symbol* klass_name = SymbolTable::new_symbol("jdk/internal/misc/CDS$UnregisteredClassLoader");
+    Klass* k = SystemDictionary::resolve_or_fail(klass_name, true, CHECK);
+    _UnregisteredClassLoader_klass = InstanceKlass::cast(k);
+  }
+}
+
 // Load the class of the given name from the location given by path. The path is specified by
 // the "source:" in the class list file (see classListParser.cpp), and can be a directory or
 // a JAR file.
-InstanceKlass* UnregisteredClasses::load_class(Symbol* name, const char* path, TRAPS) {
+InstanceKlass* UnregisteredClasses::load_class(Symbol* name, const char* path,
+                                               Handle super_class, objArrayHandle interfaces, TRAPS) {
   assert(name != nullptr, "invariant");
   assert(CDSConfig::is_dumping_static_archive(), "this function is only used with -Xshare:dump");
 
@@ -49,19 +61,23 @@ InstanceKlass* UnregisteredClasses::load_class(Symbol* name, const char* path, T
                              THREAD->get_thread_stat()->perf_timers_addr(),
                              PerfClassTraceTime::CLASS_LOAD);
 
+  // Call CDS$UnregisteredClassLoader::load(String name, Class<?> superClass, Class<?>[] interfaces)
+  Symbol* methodName = SymbolTable::new_symbol("load");
+  Symbol* methodSignature = SymbolTable::new_symbol("(Ljava/lang/String;Ljava/lang/Class;[Ljava/lang/Class;)Ljava/lang/Class;");
   Symbol* path_symbol = SymbolTable::new_symbol(path);
-  Symbol* findClass = SymbolTable::new_symbol("findClass");
-  Handle url_classloader = get_url_classloader(path_symbol, CHECK_NULL);
+  Handle classloader = get_classloader(path_symbol, CHECK_NULL);
   Handle ext_class_name = java_lang_String::externalize_classname(name, CHECK_NULL);
 
   JavaValue result(T_OBJECT);
   JavaCallArguments args(2);
-  args.set_receiver(url_classloader);
+  args.set_receiver(classloader);
   args.push_oop(ext_class_name);
+  args.push_oop(super_class);
+  args.push_oop(interfaces);
   JavaCalls::call_virtual(&result,
-                          vmClasses::URLClassLoader_klass(),
-                          findClass,
-                          vmSymbols::string_class_signature(),
+                          UnregisteredClassLoader_klass(),
+                          methodName,
+                          methodSignature,
                           &args,
                           CHECK_NULL);
   assert(result.get_type() == T_OBJECT, "just checking");
@@ -69,45 +85,35 @@ InstanceKlass* UnregisteredClasses::load_class(Symbol* name, const char* path, T
   return InstanceKlass::cast(java_lang_Class::as_Klass(obj));
 }
 
-class URLClassLoaderTable : public ResourceHashtable<
+class UnregisteredClasses::ClassLoaderTable : public ResourceHashtable<
   Symbol*, OopHandle,
   137, // prime number
   AnyObj::C_HEAP> {};
 
-static URLClassLoaderTable* _url_classloader_table = nullptr;
+static UnregisteredClasses::ClassLoaderTable* _classloader_table = nullptr;
 
-Handle UnregisteredClasses::create_url_classloader(Symbol* path, TRAPS) {
+Handle UnregisteredClasses::create_classloader(Symbol* path, TRAPS) {
   ResourceMark rm(THREAD);
   JavaValue result(T_OBJECT);
   Handle path_string = java_lang_String::create_from_str(path->as_C_string(), CHECK_NH);
-  JavaCalls::call_static(&result,
-                         vmClasses::jdk_internal_loader_ClassLoaders_klass(),
-                         vmSymbols::toFileURL_name(),
-                         vmSymbols::toFileURL_signature(),
-                         path_string, CHECK_NH);
-  assert(result.get_type() == T_OBJECT, "just checking");
-  oop url_h = result.get_oop();
-  objArrayHandle urls = oopFactory::new_objArray_handle(vmClasses::URL_klass(), 1, CHECK_NH);
-  urls->obj_at_put(0, url_h);
-
-  Handle url_classloader = JavaCalls::construct_new_instance(
-                             vmClasses::URLClassLoader_klass(),
-                             vmSymbols::url_array_classloader_void_signature(),
-                             urls, Handle(), CHECK_NH);
-  return url_classloader;
+  Handle classloader = JavaCalls::construct_new_instance(
+                           UnregisteredClassLoader_klass(),
+                           vmSymbols::string_void_signature(),
+                           path_string, CHECK_NH);
+  return classloader;
 }
 
-Handle UnregisteredClasses::get_url_classloader(Symbol* path, TRAPS) {
-  if (_url_classloader_table == nullptr) {
-    _url_classloader_table = new (mtClass)URLClassLoaderTable();
+Handle UnregisteredClasses::get_classloader(Symbol* path, TRAPS) {
+  if (_classloader_table == nullptr) {
+    _classloader_table = new (mtClass)ClassLoaderTable();
   }
-  OopHandle* url_classloader_ptr = _url_classloader_table->get(path);
-  if (url_classloader_ptr != nullptr) {
-    return Handle(THREAD, (*url_classloader_ptr).resolve());
+  OopHandle* classloader_ptr = _classloader_table->get(path);
+  if (classloader_ptr != nullptr) {
+    return Handle(THREAD, (*classloader_ptr).resolve());
   } else {
-    Handle url_classloader = create_url_classloader(path, CHECK_NH);
-    _url_classloader_table->put(path, OopHandle(Universe::vm_global(), url_classloader()));
+    Handle classloader = create_classloader(path, CHECK_NH);
+    _classloader_table->put(path, OopHandle(Universe::vm_global(), classloader()));
     path->increment_refcount();
-    return url_classloader;
+    return classloader;
   }
 }

--- a/src/hotspot/share/cds/unregisteredClasses.cpp
+++ b/src/hotspot/share/cds/unregisteredClasses.cpp
@@ -69,7 +69,7 @@ InstanceKlass* UnregisteredClasses::load_class(Symbol* name, const char* path,
   Handle ext_class_name = java_lang_String::externalize_classname(name, CHECK_NULL);
 
   JavaValue result(T_OBJECT);
-  JavaCallArguments args(2);
+  JavaCallArguments args(3);
   args.set_receiver(classloader);
   args.push_oop(ext_class_name);
   args.push_oop(super_class);

--- a/src/hotspot/share/cds/unregisteredClasses.hpp
+++ b/src/hotspot/share/cds/unregisteredClasses.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,30 @@
 #ifndef SHARE_CDS_UNREGISTEREDCLASSES_HPP
 #define SHARE_CDS_UNREGISTEREDCLASSES_HPP
 
+#include "memory/allStatic.hpp"
 #include "runtime/handles.hpp"
+
+class InstanceKlass;
+class Symbol;
 
 class UnregisteredClasses: AllStatic {
 public:
-  static InstanceKlass* load_class(Symbol* h_name, const char* path, TRAPS);
+  static InstanceKlass* load_class(Symbol* h_name, const char* path,
+                                   Handle super_class, objArrayHandle interfaces,
+                                   TRAPS);
+  static void initialize(TRAPS);
+  static InstanceKlass* UnregisteredClassLoader_klass() {
+    return _UnregisteredClassLoader_klass;
+  }
+
+  class ClassLoaderTable;
 
 private:
-  static Handle create_url_classloader(Symbol* path, TRAPS);
-  static Handle get_url_classloader(Symbol* path, TRAPS);
+  // Don't put this in vmClasses as it's used only with CDS dumping.
+  static InstanceKlass* _UnregisteredClassLoader_klass;
+
+  static Handle create_classloader(Symbol* path, TRAPS);
+  static Handle get_classloader(Symbol* path, TRAPS);
 };
 
 #endif // SHARE_CDS_UNREGISTEREDCLASSES_HPP

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -423,16 +423,6 @@ InstanceKlass* SystemDictionary::resolve_with_circularity_detection(Symbol* clas
 
   assert(next_name != nullptr, "null superclass for resolving");
   assert(!Signature::is_array(next_name), "invalid superclass name");
-#if INCLUDE_CDS
-  if (CDSConfig::is_dumping_static_archive()) {
-    // Special processing for handling UNREGISTERED shared classes.
-    InstanceKlass* k = SystemDictionaryShared::lookup_super_for_unregistered_class(class_name,
-                           next_name, is_superclass);
-    if (k) {
-      return k;
-    }
-  }
-#endif // INCLUDE_CDS
 
   // If class_name is already loaded, just return the superclass or superinterface.
   // Make sure there's a placeholder for the class_name before resolving.

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -35,6 +35,7 @@
 #include "cds/heapShared.hpp"
 #include "cds/metaspaceShared.hpp"
 #include "cds/runTimeClassInfo.hpp"
+#include "cds/unregisteredClasses.hpp"
 #include "classfile/classFileStream.hpp"
 #include "classfile/classLoader.hpp"
 #include "classfile/classLoaderData.inline.hpp"
@@ -352,6 +353,12 @@ bool SystemDictionaryShared::check_for_exclusion_impl(InstanceKlass* k) {
     }
   }
 
+  if (k == UnregisteredClasses::UnregisteredClassLoader_klass()) {
+    ResourceMark rm;
+    log_info(cds)("Skipping %s: used only when dumping CDS archive", k->name()->as_C_string());
+    return true;
+  }
+
   return false; // false == k should NOT be excluded
 }
 
@@ -468,45 +475,6 @@ bool SystemDictionaryShared::add_unregistered_class(Thread* current, InstanceKla
     name->increment_refcount();
   }
   return (klass == *v);
-}
-
-// This function is called to lookup the super/interfaces of shared classes for
-// unregistered loaders. E.g., SharedClass in the below example
-// where "super:" (and optionally "interface:") have been specified.
-//
-// java/lang/Object id: 0
-// Interface    id: 2 super: 0 source: cust.jar
-// SharedClass  id: 4 super: 0 interfaces: 2 source: cust.jar
-InstanceKlass* SystemDictionaryShared::lookup_super_for_unregistered_class(
-    Symbol* class_name, Symbol* super_name, bool is_superclass) {
-
-  assert(CDSConfig::is_dumping_static_archive(), "only when static dumping");
-
-  if (!ClassListParser::is_parsing_thread()) {
-    // Unregistered classes can be created only by ClassListParser::_parsing_thread.
-
-    return nullptr;
-  }
-
-  ClassListParser* parser = ClassListParser::instance();
-  if (parser == nullptr) {
-    // We're still loading the well-known classes, before the ClassListParser is created.
-    return nullptr;
-  }
-  if (class_name->equals(parser->current_class_name())) {
-    // When this function is called, all the numbered super and interface types
-    // must have already been loaded. Hence this function is never recursively called.
-    if (is_superclass) {
-      return parser->lookup_super_for_current_class(super_name);
-    } else {
-      return parser->lookup_interface_for_current_class(super_name);
-    }
-  } else {
-    // The VM is not trying to resolve a super type of parser->current_class_name().
-    // Instead, it's resolving an error class (because parser->current_class_name() has
-    // failed parsing or verification). Don't do anything here.
-    return nullptr;
-  }
 }
 
 void SystemDictionaryShared::set_shared_class_misc_info(InstanceKlass* k, ClassFileStream* cfs) {

--- a/src/hotspot/share/classfile/vmClassMacros.hpp
+++ b/src/hotspot/share/classfile/vmClassMacros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,7 +138,6 @@
   /* support for CDS */                                                                                         \
   do_klass(ByteArrayInputStream_klass,                  java_io_ByteArrayInputStream                          ) \
   do_klass(URL_klass,                                   java_net_URL                                          ) \
-  do_klass(URLClassLoader_klass,                        java_net_URLClassLoader                               ) \
   do_klass(Enum_klass,                                  java_lang_Enum                                        ) \
   do_klass(Jar_Manifest_klass,                          java_util_jar_Manifest                                ) \
   do_klass(jdk_internal_loader_BuiltinClassLoader_klass,jdk_internal_loader_BuiltinClassLoader                ) \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -739,7 +739,6 @@ class SerializeClosure;
   template(runtimeSetup,                                    "runtimeSetup")                                       \
   template(toFileURL_name,                                  "toFileURL")                                          \
   template(toFileURL_signature,                             "(Ljava/lang/String;)Ljava/net/URL;")                 \
-  template(url_array_classloader_void_signature,            "([Ljava/net/URL;Ljava/lang/ClassLoader;)V")          \
                                                                                                                   \
   /* jcmd Thread.dump_to_file */                                                                                  \
   template(jdk_internal_vm_ThreadDumper,           "jdk/internal/vm/ThreadDumper")                                \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -124,7 +124,6 @@ class SerializeClosure;
   template(java_security_ProtectionDomain,            "java/security/ProtectionDomain")           \
   template(java_security_SecureClassLoader,           "java/security/SecureClassLoader")          \
   template(java_net_URL,                              "java/net/URL")                             \
-  template(java_net_URLClassLoader,                   "java/net/URLClassLoader")                  \
   template(java_util_jar_Manifest,                    "java/util/jar/Manifest")                   \
   template(java_io_ByteArrayInputStream,              "java/io/ByteArrayInputStream")             \
   template(java_io_Serializable,                      "java/io/Serializable")                     \

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ClassListFormatE.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ClassListFormatE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,14 +49,15 @@ public class ClassListFormatE extends ClassListFormatBase {
         //----------------------------------------------------------------------
         // TESTGROUP E: super class and interfaces
         //----------------------------------------------------------------------
-        dumpShouldFail(
+        dumpShouldPass(
             "TESTCASE E1: missing interfaces: keyword",
             appJar, classlist(
                 "Hello",
                 "java/lang/Object id: 1",
                 "CustomLoadee2 id: 1 super: 1 source: " + customJarPath
             ),
-            "Class CustomLoadee2 implements the interface CustomInterface2_ia, but no interface has been specified in the input line");
+            "java.lang.NoClassDefFoundError: CustomInterface2_ia",
+            "Cannot find CustomLoadee2");
 
         dumpShouldFail(
             "TESTCASE E2: missing one interface",
@@ -67,7 +68,7 @@ public class ClassListFormatE extends ClassListFormatBase {
                 "CustomInterface2_ib id: 3 super: 1 source: " + customJarPath,
                 "CustomLoadee2 id: 4 super: 1 interfaces: 2 source: " + customJarPath
             ),
-            "The interface CustomInterface2_ib implemented by class CustomLoadee2 does not match any of the specified interface IDs");
+            "The number of interfaces (1) specified in class list does not match the class file (2)");
 
         dumpShouldFail(
             "TESTCASE E3: specifying an interface that's not implemented by the class",
@@ -101,5 +102,15 @@ public class ClassListFormatE extends ClassListFormatBase {
                 "CustomLoadee2 id: 5 super: 4 interfaces: 2 3 source: " + customJarPath
             ),
             "The specified super class CustomLoadee (id 4) does not match actual super class java.lang.Object");
+
+        dumpShouldPass(
+            "TESTCASE E6: JAR file doesn't exist",
+            appJar, classlist(
+                "Hello",
+                "java/lang/Object id: 1",
+                "NoSuchClass id: 2 super: 1 source: no_such_file.jar"
+            ),
+            "Cannot find NoSuchClass",
+            "java.io.IOException: No such file: no_such_file.jar");
     }
 }


### PR DESCRIPTION
I reimplemented `SystemDictionaryShared::lookup_super_for_unregistered_class()` with Java code. This removes hacks in `SystemDictionary::resolve_with_circularity_detection()` to facilitate future clean-ups there that are planned by @coleenp. Please see the [JBS issue](https://bugs.openjdk.org/browse/JDK-8348240) for a discussion of why the hack was there.

The new Java code is in the `jdk/internal/misc/CDS$UnregisteredClassLoader` class. I also simplified `UnregisteredClasses::create_classloader()` by moving some unwieldy C++ `JavaCalls` code into Java.

### How this works:

For example, let's assume you have the following classfiles in foo.jar:

```
interface MyInterface1 {}
interface MyInterface2 {}
class MyClass extends Object implements MyInterface1, MyInterface2 {}
```

The CDS classlist file can look like this:

```
java/lang/Object id: 1
MyInterface1: id: 2 super: 1 source: foo.jar
MyInterface2: id: 3 super: 1 source: foo.jar
MyClass: id: 4 super: 1 interfaces: 2 3 source: foo.jar
```

When CDS handles the `MyClass: id: 4` line, it calls `CDS$UnregisteredClassLoader::load()` with the following parameters:

- `name` = "MyClass"
- `superClass` = java.lang.Object
- `interfaces` = {MyInterface1, MyInterface2} 

`CDS$UnregisteredClassLoader::load()` will start parsing MyClass.class from foo.jar. The ClassFileParser will see symbolic references to the supertypes of `MyClass`. These supertypes will be resolved by `CDS$UnregisteredClassLoader::findClass()`, using the classes provided by `superClass` and `interfaces`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348240](https://bugs.openjdk.org/browse/JDK-8348240): Remove SystemDictionaryShared::lookup_super_for_unregistered_class() (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) Review applies to [ca801052](https://git.openjdk.org/jdk/pull/23226/files/ca801052e7a64869ef8cf563882d64e6778d2c24)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23226/head:pull/23226` \
`$ git checkout pull/23226`

Update a local copy of the PR: \
`$ git checkout pull/23226` \
`$ git pull https://git.openjdk.org/jdk.git pull/23226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23226`

View PR using the GUI difftool: \
`$ git pr show -t 23226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23226.diff">https://git.openjdk.org/jdk/pull/23226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23226#issuecomment-2606213271)
</details>
