### PR TITLE
8347817: Timeouts running test/jdk/java/lang/String/concat/HiddenClassUnloading.java with fastdebug builds

### DIFF
--- a/test/jdk/java/lang/String/concat/HiddenClassUnloading.java
+++ b/test/jdk/java/lang/String/concat/HiddenClassUnloading.java
@@ -26,13 +26,20 @@ import java.lang.StringBuilder;
 import java.lang.invoke.*;
 import java.lang.management.ManagementFactory;
 
+import jdk.test.whitebox.WhiteBox;
+
 /**
  * @test
  * @summary Test whether the hidden class unloading of StringConcatFactory works
  *
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @requires vm.flagless
- * @run main/othervm -Xmx8M -Xms8M -Xverify:all HiddenClassUnloading
- * @run main/othervm -Xmx8M -Xms8M -Xverify:all -XX:-CompactStrings HiddenClassUnloading
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -Xverify:all HiddenClassUnloading
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -Xverify:all -XX:-CompactStrings HiddenClassUnloading
  */
 public class HiddenClassUnloading {
     public static void main(String[] args) throws Throwable {
@@ -43,7 +50,7 @@ public class HiddenClassUnloading {
 
         long initUnloadedClassCount = ManagementFactory.getClassLoadingMXBean().getUnloadedClassCount();
 
-        for (int i = 0; i < 12000; i++) {
+        for (int i = 0; i < 2000; i++) {
             int radix = types.length;
             String str = Integer.toString(i, radix);
             int length = str.length();
@@ -60,6 +67,9 @@ public class HiddenClassUnloading {
                     new Object[0]
             );
         }
+
+        // Request GC which performs class unloading
+        WhiteBox.getWhiteBox().fullGC();
 
         long unloadedClassCount = ManagementFactory.getClassLoadingMXBean().getUnloadedClassCount();
         if (initUnloadedClassCount == unloadedClassCount) {


### PR DESCRIPTION
Hi all,

I would like to backport the test-fix from  commit [15d6469e](https://github.com/openjdk/jdk/commit/15d6469e8da635364c0ba83e425fd149c2d69495) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The backport will help prevent frequent tier1 test timeouts in our CI testing.

The commit being backported was authored by Richard Reingruber on 22 Jan 2025 and was reviewed by Christoph Langer, Matthias Baesken and Martin Doerr.

Thanks, Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347817](https://bugs.openjdk.org/browse/JDK-8347817): Timeouts running test/jdk/java/lang/String/concat/HiddenClassUnloading.java with fastdebug builds (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23228/head:pull/23228` \
`$ git checkout pull/23228`

Update a local copy of the PR: \
`$ git checkout pull/23228` \
`$ git pull https://git.openjdk.org/jdk.git pull/23228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23228`

View PR using the GUI difftool: \
`$ git pr show -t 23228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23228.diff">https://git.openjdk.org/jdk/pull/23228.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23228#issuecomment-2606598184)
</details>
