### PR TITLE
8348265: RMIConnectionImpl: Remove Subject.callAs on MarshalledObject

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java
@@ -122,7 +122,7 @@ public class RMIConnectionImpl implements RMIConnection, Unreferenced {
     }
 
     public String getConnectionId() throws IOException {
-        // We should call reqIncomming() here... shouldn't we?
+        // reqIncoming()/rspOutgoing() could be here, but never have been.
         return connectionId;
     }
 
@@ -1495,20 +1495,7 @@ public class RMIConnectionImpl implements RMIConnection, Unreferenced {
         try {
             ClassLoader old = setCcl(cl);
             try {
-                if (subject != null) {
-                    try {
-                        return Subject.callAs(subject, () -> wrappedClass.cast(mo.get()));
-                    } catch (CompletionException ce) {
-                        Throwable thr = ce.getCause();
-                        if (thr instanceof Exception e) {
-                            throw e;
-                        } else {
-                            throw new RuntimeException(thr);
-                        }
-                    }
-                } else {
-                    return wrappedClass.cast(mo.get());
-                }
+                return wrappedClass.cast(mo.get());
             } finally {
                 setCcl(old);
             }


### PR DESCRIPTION
Redundant after Security Manager removal, remove the Subject.callAs() call on a MashalledObject.cast().
Previously, a Policy could possibly have restricted permissable classes available to the cast().

Nothing in our tests fails if we remove the callAs.

Also fixing a comment typo ("reqIncomming") and rewording that comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348265](https://bugs.openjdk.org/browse/JDK-8348265): RMIConnectionImpl: Remove Subject.callAs on MarshalledObject (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23230/head:pull/23230` \
`$ git checkout pull/23230`

Update a local copy of the PR: \
`$ git checkout pull/23230` \
`$ git pull https://git.openjdk.org/jdk.git pull/23230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23230`

View PR using the GUI difftool: \
`$ git pr show -t 23230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23230.diff">https://git.openjdk.org/jdk/pull/23230.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23230#issuecomment-2606829369)
</details>
