### PR TITLE
JDK-8348286: [AIX] clang 17 introduces new warning Wtentative-Definitions which produces Build errors

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -520,6 +520,12 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     # clang compiler on aix needs -ffunction-sections
     TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -ffunction-sections -ftls-model -fno-math-errno -fstack-protector"
     TOOLCHAIN_CFLAGS_JDK="-ffunction-sections -fsigned-char -fstack-protector"
+    # clang 17 compiler on aix needs -Wno-tentative-definitions,
+    # otherwise variable definitions in headers are forbidden (only extern declaration is allowed)
+    if test "x$CC_VERSION_NUMBER" = "x17.0.6"; then
+      TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -Wno-tentative-definitions"
+      TOOLCHAIN_CFLAGS_JDK="$TOOLCHAIN_CFLAGS_JDK -Wno-tentative-definitions"
+    fi
   fi
 
   if test "x$TOOLCHAIN_TYPE" = xgcc; then


### PR DESCRIPTION
We (SAP) try to introduce the ‘IBM Open XL C/C++ for AIX 17.1.2’ (based on clang 17) as a feasible compiler for jdk25, because in combination with the 17.1.3 runtime this would enable the support for ubsan.
Unfortunately, the new compiler comes along with a new set of compiler warnings turned into errors by -Werror.
One of the warnings is -Wtentative-definitions. It is fired when a variable definition in a header is found:
/jdk/src/java.desktop/share/native/libawt/awt/image/imageInitIDs.h:36:20: error: possible missing 'extern' on global variable definition in header [-Werror,-Wtentative-definitions]
   36 | IMGEXTERN jfieldID g_BImgRasterID;
      | ^
From now on headers allow only extern declarations of variables. The definition must take place in a c/cpp file. This means e.g.
imageInitIDs.h:36:20
   36 extern jfieldID g_BImgRasterID;
and the corresponding c-File
   jfieldID g_BImgRasterID;

The other possible solution would be to compile everything with
-Wno-tentative-definitions
which could be set in flags-cflags.m4, if compiling with clang 17.