### PR TITLE
8348299: Update List/ItemEventTest/ItemEventTest.java

### DIFF
--- a/test/jdk/java/awt/List/ItemEventTest/ItemEventTest.java
+++ b/test/jdk/java/awt/List/ItemEventTest/ItemEventTest.java
@@ -112,9 +112,7 @@ public final class ItemEventTest extends Frame {
     }
 
     private void performTest() {
-        synchronized (actualSelectionOrder) {
-            actualSelectionOrder.delete(0, actualSelectionOrder.length());
-        }
+        actualSelectionOrder.setLength(0);
 
         final Rectangle rect = getListBoundsOnScreen();
         final int dY = rect.height / list.getItemCount();

--- a/test/jdk/java/awt/List/ItemEventTest/ItemEventTest.java
+++ b/test/jdk/java/awt/List/ItemEventTest/ItemEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,12 @@
  * @bug 8033936 8172510
  * @summary Verify that correct ItemEvent is received while selection &
  *          deselection of multi select List items.
+ * @library /test/lib
+ * @build jdk.test.lib.Platform
+ * @run main ItemEventTest
  */
+
+// Pass -save to the test to enable screenshots at each select/deselect
 
 import java.awt.AWTException;
 import java.awt.Event;
@@ -37,26 +42,30 @@ import java.awt.List;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
-import java.awt.event.KeyEvent;
 import java.awt.event.InputEvent;
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
+import java.awt.event.KeyEvent;
+import java.awt.image.RenderedImage;
+import java.io.File;
+import java.io.IOException;
 
-public class ItemEventTest extends Frame
-{
-    List list;
-    final String expectedSelectionOrder;
-    StringBuilder actualSelectionOrder;
-    Robot robot;
+import javax.imageio.ImageIO;
 
-    public ItemEventTest()
-    {
-        try {
-            robot = new Robot();
-        } catch(AWTException e) {
-            throw new RuntimeException(e.getMessage());
-        }
-        expectedSelectionOrder = "01230123";
+import jdk.test.lib.Platform;
+
+public final class ItemEventTest extends Frame {
+    private static final String expectedSelectionOrder = "01230123";
+
+    private static boolean saveScreenshots;
+
+    private final StringBuffer actualSelectionOrder
+            = new StringBuffer(expectedSelectionOrder.length());
+
+    private final List list;
+    private final Robot robot;
+
+    private ItemEventTest() throws AWTException {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
 
         list = new List(4, true);
         list.add("0");
@@ -65,71 +74,78 @@ public class ItemEventTest extends Frame
         list.add("3");
 
         add(list);
+
         setSize(400,400);
         setLayout(new FlowLayout());
         pack();
+        setLocationRelativeTo(null);
         setVisible(true);
         robot.waitForIdle();
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public boolean handleEvent(Event e) {
-        if (e.target instanceof List) {
-            if (e.id == Event.LIST_DESELECT || e.id == Event.LIST_SELECT) {
-                actualSelectionOrder.append(e.arg);
-            }
+        if ((e.target instanceof List)
+            && (e.id == Event.LIST_DESELECT
+                || e.id == Event.LIST_SELECT)) {
+            logEvent("handleEvent: ", e.arg);
         }
         return true;
     }
 
-    void testHandleEvent() {
+    private void logEvent(String method, Object listItem) {
+        actualSelectionOrder.append(listItem);
+        System.out.println(method + listItem);
+    }
+
+    private void testHandleEvent() {
         // When no ItemListener is added to List, parent's handleEvent is
         // called with ItemEvent.
         performTest();
     }
 
-    void testItemListener() {
-        list.addItemListener(new ItemListener() {
-            @Override
-            public void itemStateChanged(ItemEvent ie) {
-                actualSelectionOrder.append(ie.getItem());
-            }
-        });
+    private void testItemListener() {
+        list.addItemListener(ie
+                -> logEvent("testItemListener: ", ie.getItem()));
         performTest();
     }
 
-    void performTest() {
-        actualSelectionOrder = new StringBuilder();
-        Point loc = list.getLocationOnScreen();
-        Rectangle rect = list.getBounds();
-        int dY = rect.height / list.getItemCount();
-        loc = new Point(loc.x + 10, loc.y + 5);
+    private void performTest() {
+        synchronized (actualSelectionOrder) {
+            actualSelectionOrder.delete(0, actualSelectionOrder.length());
+        }
 
-        String osName = System.getProperty("os.name");
-        boolean isMac = osName.contains("Mac") || osName.contains("mac");
-        if(isMac) {
+        final Rectangle rect = getListBoundsOnScreen();
+        final int dY = rect.height / list.getItemCount();
+        final Point loc = new Point(rect.x + rect.width / 2,
+                                    rect.y + dY / 2);
+
+        if (Platform.isOSX()) {
             robot.keyPress(KeyEvent.VK_META);
-            robot.waitForIdle();
         }
 
         // First loop to select & Second loop to deselect the list items.
         for (int j = 0; j < 2; ++j) {
             for (int i = 0; i < list.getItemCount(); ++i) {
                 robot.mouseMove(loc.x, loc.y + i * dY);
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
                 robot.waitForIdle();
-                robot.mousePress(InputEvent.BUTTON1_MASK);
-                robot.waitForIdle();
-                robot.mouseRelease(InputEvent.BUTTON1_MASK);
-                robot.waitForIdle();
+
+                if (saveScreenshots) {
+                    saveImage(robot.createScreenCapture(rect));
+                }
             }
         }
 
-        if(isMac) {
+        if (Platform.isOSX()) {
             robot.keyRelease(KeyEvent.VK_META);
         }
 
-        if (!expectedSelectionOrder.equals(actualSelectionOrder.toString())) {
-            dispose();
+        if (!expectedSelectionOrder.contentEquals(actualSelectionOrder)) {
+            saveImage(robot.createScreenCapture(rect));
+
             throw new RuntimeException("ItemEvent for selection & deselection"
                 + " of multi select List's item is not correct"
                 + " Expected : " + expectedSelectionOrder
@@ -137,10 +153,32 @@ public class ItemEventTest extends Frame
         }
     }
 
-    public static void main(String args[]) {
-       ItemEventTest test = new ItemEventTest();
-       test.testHandleEvent();
-       test.testItemListener();
-       test.dispose();
+    private Rectangle getListBoundsOnScreen() {
+        return new Rectangle(list.getLocationOnScreen(),
+                             list.getSize());
+    }
+
+    private static int imageNo = 0;
+
+    private static void saveImage(RenderedImage image) {
+        try {
+            ImageIO.write(image,
+                          "png",
+                          new File(String.format("image-%02d.png",
+                                                 ++imageNo)));
+        } catch (IOException ignored) {
+        }
+    }
+
+    public static void main(String[] args) throws AWTException {
+        saveScreenshots = args.length > 0 && "-save".equals(args[0]);
+
+        ItemEventTest test = new ItemEventTest();
+        try {
+            test.testHandleEvent();
+            test.testItemListener();
+        } finally {
+            test.dispose();
+        }
     }
 }


### PR DESCRIPTION
With this changeset, I update the `java/awt/List/ItemEventTest/ItemEventTest.java` test to improve its stability and analysis of failures of the test.

1. Use thread-safe `StringBuffer` for `actualSelectionOrder` to track selecting/deselecting items in the list.
2. Enable `robot.setAutoWaitForIdle(true)` and remove `robot.waitForIdle()` from the test code.
3. Log `handleEvent` and `ItemListener` which helps to identify test failures.  
    (In case of [JDK-8204221](https://bugs.openjdk.org/browse/JDK-8204221), `handleEvent` is never logged.)
5. Take screenshot of the list on failure;  
    Optionally take screenshot after each mouse press+release if `-save` is passed as a parameter to the test.

The updated test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348299](https://bugs.openjdk.org/browse/JDK-8348299): Update List/ItemEventTest/ItemEventTest.java (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [5a54dcff](https://git.openjdk.org/jdk/pull/23238/files/5a54dcff1c3f7f4a34e71405b62805a92a580a8e)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) Review applies to [5a54dcff](https://git.openjdk.org/jdk/pull/23238/files/5a54dcff1c3f7f4a34e71405b62805a92a580a8e)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23238/head:pull/23238` \
`$ git checkout pull/23238`

Update a local copy of the PR: \
`$ git checkout pull/23238` \
`$ git pull https://git.openjdk.org/jdk.git pull/23238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23238`

View PR using the GUI difftool: \
`$ git pr show -t 23238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23238.diff">https://git.openjdk.org/jdk/pull/23238.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23238#issuecomment-2607762546)
</details>
