### PR TITLE
8348301: Remove unused Reference.waitForReferenceProcessing break-ins in tests

### DIFF
--- a/test/jdk/sun/security/provider/FileInputStreamPool/FileInputStreamPoolTest.java
+++ b/test/jdk/sun/security/provider/FileInputStreamPool/FileInputStreamPoolTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8047769
  * @modules java.base/java.io:open
- *          java.base/java.lang.ref:open
  *          java.base/sun.security.provider:open
  * @summary SecureRandom should be more frugal with file descriptors
  */
@@ -133,11 +132,9 @@ public class FileInputStreamPoolTest {
     /**
      * A proxy for (package)private static methods:
      *   sun.security.provider.FileInputStreamPool.getInputStream
-     *   java.lang.ref.Reference.waitForReferenceProcessing
      */
     static class TestProxy {
         private static final Method getInputStreamMethod;
-        private static final Method waitForReferenceProcessingMethod;
         private static final Field inField;
 
         static {
@@ -148,10 +145,6 @@ public class FileInputStreamPoolTest {
                     fileInputStreamPoolClass.getDeclaredMethod(
                         "getInputStream", File.class);
                 getInputStreamMethod.setAccessible(true);
-
-                waitForReferenceProcessingMethod =
-                    Reference.class.getDeclaredMethod("waitForReferenceProcessing");
-                waitForReferenceProcessingMethod.setAccessible(true);
 
                 inField = FilterInputStream.class.getDeclaredField("in");
                 inField.setAccessible(true);
@@ -168,25 +161,6 @@ public class FileInputStreamPoolTest {
                 Throwable te = e.getTargetException();
                 if (te instanceof IOException) {
                     throw (IOException) te;
-                } else if (te instanceof RuntimeException) {
-                    throw (RuntimeException) te;
-                } else if (te instanceof Error) {
-                    throw (Error) te;
-                } else {
-                    throw new UndeclaredThrowableException(te);
-                }
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        static boolean Reference_waitForReferenceProcessing() {
-            try {
-                return (boolean) waitForReferenceProcessingMethod.invoke(null);
-            } catch (InvocationTargetException e) {
-                Throwable te = e.getTargetException();
-                if (te instanceof InterruptedException) {
-                    return true;
                 } else if (te instanceof RuntimeException) {
                     throw (RuntimeException) te;
                 } else if (te instanceof Error) {


### PR DESCRIPTION
`Reference.waitForReferenceProcessing` is in internal API, which should go away with [JDK-8344332](https://bugs.openjdk.org/browse/JDK-8344332). There is single use of that internal API in the tests, the last use of which was removed by [JDK-8080225](https://bugs.openjdk.org/browse/JDK-8080225). We can remove the `Reference.waitForReferenceProcessing` break-ins in the tests now.

Additional testing:
 - [x] Affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348301](https://bugs.openjdk.org/browse/JDK-8348301): Remove unused Reference.waitForReferenceProcessing break-ins in tests (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23239/head:pull/23239` \
`$ git checkout pull/23239`

Update a local copy of the PR: \
`$ git checkout pull/23239` \
`$ git pull https://git.openjdk.org/jdk.git pull/23239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23239`

View PR using the GUI difftool: \
`$ git pr show -t 23239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23239.diff">https://git.openjdk.org/jdk/pull/23239.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23239#issuecomment-2607799558)
</details>
