### PR TITLE
8348303: Remove repeated 'a' from ListSelectionEvent

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/event/ListSelectionEvent.java
+++ b/src/java.desktop/share/classes/javax/swing/event/ListSelectionEvent.java
@@ -64,8 +64,8 @@ public class ListSelectionEvent extends EventObject
      * have changed.
      *
      * @param source the {@code Object} on which the event initially occurred
-     * @param firstIndex the first index in the range, &lt;= lastIndex
-     * @param lastIndex the last index in the range, &gt;= firstIndex
+     * @param firstIndex the first index in the range, &lt;= {@code lastIndex}
+     * @param lastIndex the last index in the range, &gt;= {@code firstIndex}
      * @param isAdjusting whether or not this is one in a series of
      *        multiple events, where changes are still being made
      */

--- a/src/java.desktop/share/classes/javax/swing/event/ListSelectionEvent.java
+++ b/src/java.desktop/share/classes/javax/swing/event/ListSelectionEvent.java
@@ -111,7 +111,7 @@ public class ListSelectionEvent extends EventObject
      * Returns a {@code String} that displays and identifies this
      * object's properties.
      *
-     * @return a String representation of this object
+     * @return a string representation of this object
      */
     public String toString() {
         String properties =

--- a/src/java.desktop/share/classes/javax/swing/event/ListSelectionEvent.java
+++ b/src/java.desktop/share/classes/javax/swing/event/ListSelectionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,11 @@
 package javax.swing.event;
 
 import java.util.EventObject;
-import javax.swing.*;
+import javax.swing.ListSelectionModel;
 
 
 /**
- * An event that characterizes a change in selection. The change is limited to a
+ * An event that characterizes a change in selection. The change is limited to
  * a single inclusive interval. The selection of at least one index within the
  * range will have changed. A decent {@code ListSelectionModel} implementation
  * will keep the range as small as possible. {@code ListSelectionListeners} will


### PR DESCRIPTION
A trivial change which removes repeated ‘a’ from the [javadoc for the `ListSelectionEvent` class](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/javax/swing/event/ListSelectionEvent.html):

> “The change is limited to **a a** single inclusive interval.”

In addition to the above, I 
* expanded the wildcard imports,
* marked up `firstIndex` and `lastIndex` with `{@code}` in the class constructor parameter description (for consistency), and
* used a lower-case _“string”_¹ in the `@return` for `toString()` which aligns with the usage in [`Object.toString()`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Object.html#toString()).

¹ The word _“string”_ refers not to the `String` class but rather to a string in its literal meaning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348303](https://bugs.openjdk.org/browse/JDK-8348303): Remove repeated 'a' from ListSelectionEvent (**Bug** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23240/head:pull/23240` \
`$ git checkout pull/23240`

Update a local copy of the PR: \
`$ git checkout pull/23240` \
`$ git pull https://git.openjdk.org/jdk.git pull/23240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23240`

View PR using the GUI difftool: \
`$ git pr show -t 23240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23240.diff">https://git.openjdk.org/jdk/pull/23240.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23240#issuecomment-2607828914)
</details>
