### PR TITLE
8348013: [doc] fix typo in java.md caused by JDK-8347763

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -4011,12 +4011,12 @@ The values for these options (if specified), should be identical when creating a
 CDS archive. Otherwise, if there is a mismatch of any of these options, the CDS archive may be
 partially or completely disabled, leading to lower performance.
 
-- If the -XX:+AOTClassLoading options *was* used during CDS archive creation, the CDS archive
+- If the -XX:+AOTClassLinking options *was* used during CDS archive creation, the CDS archive
   cannot be used, and the following error message is printed:
 
   `CDS archive has aot-linked classes. It cannot be used when archived full module graph is not used`
 
-- If the -XX:+AOTClassLoading options *was not* used during CDS archive creation, the CDS archive
+- If the -XX:+AOTClassLinking options *was not* used during CDS archive creation, the CDS archive
   can be used, but the "archived module graph" feature will be disabled. This can lead to increased
   start-up time.
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e1cf3517](https://github.com/openjdk/jdk/commit/e1cf3517ae0dcfa98e22d669f9f624dfbbd6ab73) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Calvin Cheung on 18 Jan 2025 and was reviewed by Ioi Lam.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348013](https://bugs.openjdk.org/browse/JDK-8348013): [doc] fix typo in java.md caused by JDK-8347763 (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23241/head:pull/23241` \
`$ git checkout pull/23241`

Update a local copy of the PR: \
`$ git checkout pull/23241` \
`$ git pull https://git.openjdk.org/jdk.git pull/23241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23241`

View PR using the GUI difftool: \
`$ git pr show -t 23241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23241.diff">https://git.openjdk.org/jdk/pull/23241.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23241#issuecomment-2607843449)
</details>
