### PR TITLE
8343609: Broken links in java.xml

### DIFF
--- a/src/java.xml/share/classes/javax/xml/catalog/Catalog.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/Catalog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,7 @@ import java.util.stream.Stream;
 
 /**
  * The Catalog class represents an entity Catalog as defined by
- * <a
- * href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html">
+ * <a href="https://groups.oasis-open.org/higherlogic/ws/public/download/14810/xml-catalogs.pdf">
  * XML Catalogs, OASIS Standard V1.1, 7 October 2005</a>.
  * <p>
  * A catalog is an XML file that contains a root {@code catalog} entry with a list

--- a/src/java.xml/share/classes/javax/xml/catalog/CatalogFeatures.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/CatalogFeatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,10 +137,9 @@ import jdk.xml.internal.SecuritySupport;
  * <b>[2]</b> The value shall be exactly as listed in this table, case-sensitive.
  * Any unspecified value will result in {@link IllegalArgumentException}.
  * <p>
- * <b>[3]</b> The Catalog specification defined complex rules on
- * <a href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html#attrib.prefer">
- * the prefer attribute</a>. Although the prefer can be public or system, the
- * specification actually made system the preferred option, that is, no matter
+ * <b>[3]</b> The <a href="https://groups.oasis-open.org/higherlogic/ws/public/download/14810/xml-catalogs.pdf">Catalog specification</a>
+ * defined complex rules on the prefer attribute. Although it can be public or system,
+ * the specification made {@code system} the preferred option, that is, no matter
  * the option, a system entry is always used if found. Public entries are only
  * considered if the prefer is public and system entries are not found. It is
  * therefore recommended that the prefer attribute be set as public

--- a/src/java.xml/share/classes/javax/xml/catalog/CatalogManager.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/CatalogManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public final class CatalogManager {
      * those referenced by the {@code nextCatalog} elements in the main catalog.
      * <p>
      * As specified in
-     * <a href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html#s.res.fail">
+     * <a href="https://groups.oasis-open.org/higherlogic/ws/public/download/14810/xml-catalogs.pdf">
      * XML Catalogs, OASIS Standard V1.1</a>, if a catalog entry is invalid, it
      * is ignored. In case all entries are invalid, the resulting Catalog object
      * will contain no Catalog elements. Any matching operation using the Catalog
@@ -126,7 +126,7 @@ public final class CatalogManager {
      * those referenced by the {@code nextCatalog} elements in the main catalog.
      * <p>
      * As specified in
-     * <a href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html#s.res.fail">
+     * <a href="https://groups.oasis-open.org/higherlogic/ws/public/download/14810/xml-catalogs.pdf">
      * XML Catalogs, OASIS Standard V1.1</a>, if a catalog entry is invalid, it
      * is ignored. In case all entries are invalid, the resulting CatalogResolver
      * object will contain no valid catalog. Any resolution operation using the

--- a/src/java.xml/share/classes/javax/xml/catalog/CatalogResolver.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/CatalogResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.xml/share/classes/javax/xml/catalog/CatalogResolver.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/CatalogResolver.java
@@ -40,7 +40,7 @@ import org.xml.sax.InputSource;
  * Transform {@link javax.xml.transform.URIResolver}, and resolves
  * external references using catalogs.
  * <p>
- * The <a href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html">
+ * The <a href="https://groups.oasis-open.org/higherlogic/ws/public/download/14810/xml-catalogs.pdf">
  * Catalog Standard</a> distinguished {@code external identifiers} from {@code uri entries}
  * as being used to solely identify DTDs, while {@code uri entries} for
  * other resources such as stylesheets and schema. The Java APIs, such as

--- a/src/java.xml/share/classes/javax/xml/catalog/Normalizer.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/Normalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 /**
  * The Normalizer is responsible for normalizing Public and System Identifiers
  * as specified in section 6.2, 6.3 and 6.4 of the specification
- *  * <a
- * href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html">
+ * <a href="https://groups.oasis-open.org/higherlogic/ws/public/download/14810/xml-catalogs.pdf">
  * XML Catalogs, OASIS Standard V1.1, 7 October 2005</a>.
  *
  * @since 9

--- a/src/java.xml/share/classes/javax/xml/catalog/package-info.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
 /**
  *
  * Provides the classes for implementing
- * <a href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html">
- *     XML Catalogs OASIS Standard V1.1, 7 October 2005</a>.
+ * <a href="https://groups.oasis-open.org/higherlogic/ws/public/download/14810/xml-catalogs.pdf">
+ * XML Catalogs OASIS Standard V1.1, 7 October 2005</a>.
  *
  * <p>
  * The Catalog API defines a standard solution for resolving external resources

--- a/src/java.xml/share/classes/javax/xml/namespace/QName.java
+++ b/src/java.xml/share/classes/javax/xml/namespace/QName.java
@@ -50,9 +50,9 @@ import jdk.xml.internal.SecuritySupport;
  * <strong><em>only</em></strong> the Namespace URI and local part.</p>
  *
  * <p>If not specified, the Namespace URI is set to {@link
- * javax.xml.XMLConstants#NULL_NS_URI XMLConstants.NULL_NS_URI}.
+ * XMLConstants#NULL_NS_URI XMLConstants.NULL_NS_URI}.
  * If not specified, the prefix is set to {@link
- * javax.xml.XMLConstants#DEFAULT_NS_PREFIX
+ * XMLConstants#DEFAULT_NS_PREFIX
  * XMLConstants.DEFAULT_NS_PREFIX}.</p>
  *
  * <p><code>QName</code> is immutable.</p>
@@ -89,13 +89,13 @@ public class QName implements Serializable {
      * and local part.</p>
      *
      * <p>If the Namespace URI is <code>null</code>, it is set to
-     * {@link javax.xml.XMLConstants#NULL_NS_URI
+     * {@link XMLConstants#NULL_NS_URI
      * XMLConstants.NULL_NS_URI}.  This value represents no
      * explicitly defined Namespace as defined by the <a
      * href="http://www.w3.org/TR/REC-xml-names/#ns-qualnames">Namespaces
      * in XML</a> specification.  This action preserves compatible
      * behavior with QName 1.0.  Explicitly providing the {@link
-     * javax.xml.XMLConstants#NULL_NS_URI
+     * XMLConstants#NULL_NS_URI
      * XMLConstants.NULL_NS_URI} value is the preferred coding
      * style.</p>
      *
@@ -105,7 +105,7 @@ public class QName implements Serializable {
      * compatible behavior with QName 1.0. </p>
      *
      * <p>When using this constructor, the prefix is set to {@link
-     * javax.xml.XMLConstants#DEFAULT_NS_PREFIX
+     * XMLConstants#DEFAULT_NS_PREFIX
      * XMLConstants.DEFAULT_NS_PREFIX}.</p>
      *
      * <p>The Namespace URI is not validated as a
@@ -134,13 +134,13 @@ public class QName implements Serializable {
      * local part and prefix.</p>
      *
      * <p>If the Namespace URI is <code>null</code>, it is set to
-     * {@link javax.xml.XMLConstants#NULL_NS_URI
+     * {@link XMLConstants#NULL_NS_URI
      * XMLConstants.NULL_NS_URI}.  This value represents no
      * explicitly defined Namespace as defined by the <a
      * href="http://www.w3.org/TR/REC-xml-names/#ns-qualnames">Namespaces
      * in XML</a> specification.  This action preserves compatible
      * behavior with QName 1.0.  Explicitly providing the {@link
-     * javax.xml.XMLConstants#NULL_NS_URI
+     * XMLConstants#NULL_NS_URI
      * XMLConstants.NULL_NS_URI} value is the preferred coding
      * style.</p>
      *
@@ -151,7 +151,7 @@ public class QName implements Serializable {
      *
      * <p>If the prefix is <code>null</code>, an
      * <code>IllegalArgumentException</code> is thrown.  Use {@link
-     * javax.xml.XMLConstants#DEFAULT_NS_PREFIX
+     * XMLConstants#DEFAULT_NS_PREFIX
      * XMLConstants.DEFAULT_NS_PREFIX} to explicitly indicate that no
      * prefix is present or the prefix is not relevant.</p>
      *
@@ -204,9 +204,9 @@ public class QName implements Serializable {
      * compatible behavior with QName 1.0. </p>
      *
      * <p>When using this constructor, the Namespace URI is set to
-     * {@link javax.xml.XMLConstants#NULL_NS_URI
+     * {@link XMLConstants#NULL_NS_URI
      * XMLConstants.NULL_NS_URI} and the prefix is set to {@link
-     * javax.xml.XMLConstants#DEFAULT_NS_PREFIX
+     * XMLConstants#DEFAULT_NS_PREFIX
      * XMLConstants.DEFAULT_NS_PREFIX}.</p>
      *
      * <p><em>In an XML context, all Element and Attribute names exist
@@ -353,7 +353,7 @@ public class QName implements Serializable {
      *     {NamespaceURI}LocalPart
      * }</pre>
      * Since the {@code Prefix} is not represented in the string form, it will be
-     * set to {@link javax.xml.XMLConstants#DEFAULT_NS_PREFIX XMLConstants.DEFAULT_NS_PREFIX}.
+     * set to {@link XMLConstants#DEFAULT_NS_PREFIX XMLConstants.DEFAULT_NS_PREFIX}.
      *
      * @apiNote This method does not perform full validation of the resulting
      * {@code QName}. The {@code NamespaceURI} is not validated as a

--- a/src/java.xml/share/classes/javax/xml/namespace/QName.java
+++ b/src/java.xml/share/classes/javax/xml/namespace/QName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -329,28 +329,16 @@ public class QName implements Serializable {
     }
 
     /**
-     * <p><code>String</code> representation of this
-     * <code>QName</code>.</p>
+     * Returns the string representation of this {@code QName}.
+     * The format is:
+     * <pre> {@code
+     *     {NamespaceURI}LocalPart
+     * }</pre>
+     * If {@code NamespaceURI} is {@code null}, only {@code LocalPart} is returned.
      *
-     * <p>The commonly accepted way of representing a <code>QName</code>
-     * as a <code>String</code> was
-     * <a href="http://jclark.com/xml/xmlns.htm">defined</a>
-     * by James Clark.  Although this is not a <em>standard</em>
-     * specification, it is in common use, e.g. {@link
-     * javax.xml.transform.Transformer#setParameter(String name, Object value)}.
-     * This implementation represents a <code>QName</code> as:
-     * "{" + Namespace URI + "}" + local part.  If the Namespace URI
-     * <code>.equals(XMLConstants.NULL_NS_URI)</code>, only the
-     * local part is returned.  An appropriate use of this method is
-     * for debugging or logging for human consumption.</p>
+     * @apiNote The {@code Prefix} is not returned in the string representation.
      *
-     * <p>Note the prefix value is <strong><em>NOT</em></strong>
-     * returned as part of the <code>String</code> representation.</p>
-     *
-     * <p>This method satisfies the general contract of {@link
-     * java.lang.Object#toString() Object.toString()}.</p>
-     *
-     *  @return <code>String</code> representation of this <code>QName</code>
+     *  @return the string representation of this {@code QName}
      */
     public String toString() {
         if (namespaceURI.equals(XMLConstants.NULL_NS_URI)) {
@@ -361,48 +349,27 @@ public class QName implements Serializable {
     }
 
     /**
-     * <p><code>QName</code> derived from parsing the formatted
-     * <code>String</code>.</p>
+     * Returns a {@code QName} from its string representation.
+     * The string representation must be in the format returned by {@link #toString()}:
+     * <pre> {@code
+     *     {NamespaceURI}LocalPart
+     * }</pre>
+     * Since the {@code Prefix} is not represented in the string form, it will be
+     * set to {@link javax.xml.XMLConstants#DEFAULT_NS_PREFIX XMLConstants.DEFAULT_NS_PREFIX}.
      *
-     * <p>If the <code>String</code> is <code>null</code> or does not conform to
-     * {@link #toString() QName.toString()} formatting, an
-     * <code>IllegalArgumentException</code> is thrown.</p>
-     *
-     * <p><em>The <code>String</code> <strong>MUST</strong> be in the
-     * form returned by {@link #toString() QName.toString()}.</em></p>
-     *
-     * <p>The commonly accepted way of representing a <code>QName</code>
-     * as a <code>String</code> was
-     * <a href="http://jclark.com/xml/xmlns.htm">defined</a>
-     * by James Clark.  Although this is not a <em>standard</em>
-     * specification, it is in common use, e.g. {@link
-     * javax.xml.transform.Transformer#setParameter(String name, Object value)}.
-     * This implementation parses a <code>String</code> formatted
-     * as: "{" + Namespace URI + "}" + local part.  If the Namespace
-     * URI <code>.equals(XMLConstants.NULL_NS_URI)</code>, only the
-     * local part should be provided.</p>
-     *
-     * <p>The prefix value <strong><em>CANNOT</em></strong> be
-     * represented in the <code>String</code> and will be set to
-     * {@link javax.xml.XMLConstants#DEFAULT_NS_PREFIX
-     * XMLConstants.DEFAULT_NS_PREFIX}.</p>
-     *
-     * <p>This method does not do full validation of the resulting
-     * <code>QName</code>.
-     * <p>The Namespace URI is not validated as a
+     * @apiNote This method does not perform full validation of the resulting
+     * {@code QName}. The {@code NamespaceURI} is not validated as a
      * <a href="http://www.ietf.org/rfc/rfc2396.txt">URI reference</a>.
-     * The local part is not validated as a
+     * The {@code LocalPart} is not validated as a
      * <a href="http://www.w3.org/TR/REC-xml-names/#NT-NCName">NCName</a>
      * as specified in
-     * <a href="http://www.w3.org/TR/REC-xml-names/">Namespaces in XML</a>.</p>
+     * <a href="http://www.w3.org/TR/REC-xml-names/">Namespaces in XML</a>.
      *
-     * @param qNameAsString <code>String</code> representation
-     * of the <code>QName</code>
+     * @param qNameAsString the string representation of the {@code QName}
      *
-     * @throws IllegalArgumentException When <code>qNameAsString</code> is
-     *   <code>null</code> or malformed
-     *
-     * @return <code>QName</code> corresponding to the given <code>String</code>
+     * @return a {@code QName} from its string representation
+     * @throws IllegalArgumentException if {@code qNameAsString} is {@code null}
+     * or malformed
      * @see #toString() QName.toString()
      */
     public static QName valueOf(String qNameAsString) {

--- a/src/java.xml/share/classes/javax/xml/namespace/QName.java
+++ b/src/java.xml/share/classes/javax/xml/namespace/QName.java
@@ -109,7 +109,7 @@ public class QName implements Serializable {
      * XMLConstants.DEFAULT_NS_PREFIX}.</p>
      *
      * <p>The Namespace URI is not validated as a
-     * <a href="http://www.ietf.org/rfc/rfc2396.txt">URI reference</a>.
+     * <a href="https://www.ietf.org/rfc/rfc2396.txt">URI reference</a>.
      * The local part is not validated as a
      * <a href="http://www.w3.org/TR/REC-xml-names/#NT-NCName">NCName</a>
      * as specified in <a href="http://www.w3.org/TR/REC-xml-names/">Namespaces
@@ -156,7 +156,7 @@ public class QName implements Serializable {
      * prefix is present or the prefix is not relevant.</p>
      *
      * <p>The Namespace URI is not validated as a
-     * <a href="http://www.ietf.org/rfc/rfc2396.txt">URI reference</a>.
+     * <a href="https://www.ietf.org/rfc/rfc2396.txt">URI reference</a>.
      * The local part and prefix are not validated as a
      * <a href="http://www.w3.org/TR/REC-xml-names/#NT-NCName">NCName</a>
      * as specified in <a href="http://www.w3.org/TR/REC-xml-names/">Namespaces
@@ -329,7 +329,7 @@ public class QName implements Serializable {
     }
 
     /**
-     * Returns the string representation of this {@code QName}.
+     * {@return the string representation of this {@code QName}}
      * The format is:
      * <pre> {@code
      *     {NamespaceURI}LocalPart
@@ -337,8 +337,6 @@ public class QName implements Serializable {
      * If {@code NamespaceURI} is {@code null}, only {@code LocalPart} is returned.
      *
      * @apiNote The {@code Prefix} is not returned in the string representation.
-     *
-     *  @return the string representation of this {@code QName}
      */
     public String toString() {
         if (namespaceURI.equals(XMLConstants.NULL_NS_URI)) {
@@ -349,7 +347,7 @@ public class QName implements Serializable {
     }
 
     /**
-     * Returns a {@code QName} from its string representation.
+     * {@return a {@code QName} from its string representation}
      * The string representation must be in the format returned by {@link #toString()}:
      * <pre> {@code
      *     {NamespaceURI}LocalPart
@@ -359,15 +357,13 @@ public class QName implements Serializable {
      *
      * @apiNote This method does not perform full validation of the resulting
      * {@code QName}. The {@code NamespaceURI} is not validated as a
-     * <a href="http://www.ietf.org/rfc/rfc2396.txt">URI reference</a>.
+     * <a href="https://www.ietf.org/rfc/rfc2396.txt">URI reference</a>.
      * The {@code LocalPart} is not validated as a
      * <a href="http://www.w3.org/TR/REC-xml-names/#NT-NCName">NCName</a>
      * as specified in
      * <a href="http://www.w3.org/TR/REC-xml-names/">Namespaces in XML</a>.
      *
      * @param qNameAsString the string representation of the {@code QName}
-     *
-     * @return a {@code QName} from its string representation
      * @throws IllegalArgumentException if {@code qNameAsString} is {@code null}
      * or malformed
      * @see #toString() QName.toString()


### PR DESCRIPTION
Fix broken links in java.xml:

Catalog: contacted Oasis. The standard page (https://www.oasis-open.org/standard/xmlcatalogs/) now links to the PDF version. That is what I'm using now, replacing the html pages. Not ideal, but at least it's displayed within the browser rather than downloaded as the html version did.

QName: rewrote the javadocs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343609](https://bugs.openjdk.org/browse/JDK-8343609): Broken links in java.xml (**Sub-task** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23242/head:pull/23242` \
`$ git checkout pull/23242`

Update a local copy of the PR: \
`$ git checkout pull/23242` \
`$ git pull https://git.openjdk.org/jdk.git pull/23242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23242`

View PR using the GUI difftool: \
`$ git pr show -t 23242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23242.diff">https://git.openjdk.org/jdk/pull/23242.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23242#issuecomment-2608037744)
</details>
