### PR TITLE
8348308: Make fields of ListSelectionEvent final

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/event/ListSelectionEvent.java
+++ b/src/java.desktop/share/classes/javax/swing/event/ListSelectionEvent.java
@@ -53,9 +53,9 @@ import javax.swing.*;
 @SuppressWarnings("serial") // Same-version serialization only
 public class ListSelectionEvent extends EventObject
 {
-    private int firstIndex;
-    private int lastIndex;
-    private boolean isAdjusting;
+    private final int firstIndex;
+    private final int lastIndex;
+    private final boolean isAdjusting;
 
     /**
      * Represents a change in selection status between {@code firstIndex} and


### PR DESCRIPTION
The fields of `ListSelectionEvent` are set in the constructor and are never modified, mark the fields — `firstIndex`, `lastIndex`, `isAdjusting` — with the `final` modifier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348308](https://bugs.openjdk.org/browse/JDK-8348308): Make fields of ListSelectionEvent final (**Bug** - P5)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23243/head:pull/23243` \
`$ git checkout pull/23243`

Update a local copy of the PR: \
`$ git checkout pull/23243` \
`$ git pull https://git.openjdk.org/jdk.git pull/23243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23243`

View PR using the GUI difftool: \
`$ git pr show -t 23243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23243.diff">https://git.openjdk.org/jdk/pull/23243.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23243#issuecomment-2608203932)
</details>
