### PR TITLE
8348324: The failure handler cannot be build by JDK 24 due to restricted warning

### DIFF
--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/jtreg/GatherProcessInfoTimeoutHandler.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/jtreg/GatherProcessInfoTimeoutHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.nio.file.Path;
  * A timeout handler for jtreg, which gathers information about the timed out
  * process and its children.
  */
+@SuppressWarnings("restricted")
 public class GatherProcessInfoTimeoutHandler extends TimeoutHandler {
     private static final boolean HAS_NATIVE_LIBRARY;
     static {


### PR DESCRIPTION
GatherProcessInfoTimeoutHandler calls System.loadLibrary, which will trigger a `restricted` warning when building with JDK 24 or newer, and failing the build.

This should be fixed by adding a @SuppressWarnings("restricted"). 