### PR TITLE
8348327: Incorrect march flag when building libsleef/vector_math_neon.c

### DIFF
--- a/make/modules/jdk.incubator.vector/Lib.gmk
+++ b/make/modules/jdk.incubator.vector/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ ifeq ($(call isTargetOs, linux)+$(call isTargetCpu, aarch64)+$(INCLUDE_COMPILER2
       EXTRA_SRC := libsleef/generated, \
       DISABLED_WARNINGS_gcc := unused-function sign-compare tautological-compare ignored-qualifiers, \
       DISABLED_WARNINGS_clang := unused-function sign-compare tautological-compare ignored-qualifiers, \
-      CFLAGS := $(SVE_CFLAGS), \
+      vector_math_sve.c_CFLAGS := $(SVE_CFLAGS), \
   ))
 
   TARGETS += $(BUILD_LIBSLEEF)


### PR DESCRIPTION
[JDK-8312425](https://bugs.openjdk.org/browse/JDK-8312425) started building the libsleef library with `$(SVE_CFLAGS)` on aarch64. That variable expands to `-march=armv8-a+sve` if the compiler supports it.

The flag should only be applied to the `vector_math_sve.c` file. Applying it to the whole library means it also gets applied to `vector_math_neon.c`, and the compiler (e.g. GCC) may select SVE instructions when generating code for it. When running the resulting JDK on a CPU which does not support SVE that will lead to an illegal instruction/`SIGILL`.

Testing:

* Manually verified that `vector_math_neon.c` does *not* get built with `-march=armv8-a+sve` and that `vector_math_sve.c` (still) does get built with that flag.
* tier1-5 (in progress)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348327](https://bugs.openjdk.org/browse/JDK-8348327): Incorrect march flag when building libsleef/vector_math_neon.c (**Bug** - P2)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23245/head:pull/23245` \
`$ git checkout pull/23245`

Update a local copy of the PR: \
`$ git checkout pull/23245` \
`$ git pull https://git.openjdk.org/jdk.git pull/23245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23245`

View PR using the GUI difftool: \
`$ git pr show -t 23245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23245.diff">https://git.openjdk.org/jdk/pull/23245.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23245#issuecomment-2608539726)
</details>
