### PR TITLE
simplify constant pool and bootstrap method logic (proof of concept)

### DIFF
--- a/src/hotspot/share/cds/aotConstantPoolResolver.cpp
+++ b/src/hotspot/share/cds/aotConstantPoolResolver.cpp
@@ -411,7 +411,8 @@ bool AOTConstantPoolResolver::check_lambda_metafactory_signature(ConstantPool* c
   return !exclude;
 }
 
-bool AOTConstantPoolResolver::check_lambda_metafactory_methodtype_arg(ConstantPool* cp, BSMAttributeEntry* bsme, int arg_i) {
+bool AOTConstantPoolResolver::check_lambda_metafactory_methodtype_arg(ConstantPool* cp, int bsme_index, int arg_i) {
+  BSMAttributeEntry* bsme = cp->bsm_attribute_entry(bsme_index);
   int mt_index = bsme->argument_index(arg_i);
   if (!cp->tag_at(mt_index).is_method_type()) {
     // malformed class?
@@ -428,7 +429,8 @@ bool AOTConstantPoolResolver::check_lambda_metafactory_methodtype_arg(ConstantPo
   return check_methodtype_signature(cp, sig);
 }
 
-bool AOTConstantPoolResolver::check_lambda_metafactory_methodhandle_arg(ConstantPool* cp, BSMAttributeEntry* bsme, int arg_i) {
+bool AOTConstantPoolResolver::check_lambda_metafactory_methodhandle_arg(ConstantPool* cp, int bsme_index, int arg_i) {
+  BSMAttributeEntry* bsme = cp->bsm_attribute_entry(bsme_index);
   int mh_index = bsme->argument_index(arg_i);
   if (!cp->tag_at(mh_index).is_method_handle()) {
     // malformed class?
@@ -455,9 +457,10 @@ bool AOTConstantPoolResolver::is_indy_resolution_deterministic(ConstantPool* cp,
     return false;
   }
 
-  BSReference indy(cp, cp_index);
+  BootstrapReference indy(cp, cp_index);
   BSMAttributeEntry* bsme    = indy.bsme(cp);
   MethodHandleReference bsmh = bsme->bootstrap_method(cp);
+  int     bsme_index         = indy.bsme_index();
   Symbol* bsm_name           = bsmh.name(cp);
   Symbol* bsm_signature      = bsmh.signature(cp);
   Symbol* bsm_klass          = bsmh.klass_name(cp);
@@ -542,17 +545,17 @@ bool AOTConstantPoolResolver::is_indy_resolution_deterministic(ConstantPool* cp,
     }
 
     // interfaceMethodType
-    if (!check_lambda_metafactory_methodtype_arg(cp, bsme, 0)) {
+    if (!check_lambda_metafactory_methodtype_arg(cp, bsme_index, 0)) {
       return false;
     }
 
     // implementation
-    if (!check_lambda_metafactory_methodhandle_arg(cp, bsme, 1)) {
+    if (!check_lambda_metafactory_methodhandle_arg(cp, bsme_index, 1)) {
       return false;
     }
 
     // dynamicMethodType
-    if (!check_lambda_metafactory_methodtype_arg(cp, bsme, 2)) {
+    if (!check_lambda_metafactory_methodtype_arg(cp, bsme_index, 2)) {
       return false;
     }
 

--- a/src/hotspot/share/cds/aotConstantPoolResolver.cpp
+++ b/src/hotspot/share/cds/aotConstantPoolResolver.cpp
@@ -411,7 +411,7 @@ bool AOTConstantPoolResolver::check_lambda_metafactory_signature(ConstantPool* c
 }
 
 bool AOTConstantPoolResolver::check_lambda_metafactory_methodtype_arg(ConstantPool* cp, int bsms_attribute_index, int arg_i) {
-  int mt_index = cp->operand_argument_index_at(bsms_attribute_index, arg_i);
+  int mt_index = cp->bsm_attribute_entry(bsms_attribute_index)->argument_index(arg_i);
   if (!cp->tag_at(mt_index).is_method_type()) {
     // malformed class?
     return false;
@@ -427,7 +427,7 @@ bool AOTConstantPoolResolver::check_lambda_metafactory_methodtype_arg(ConstantPo
 }
 
 bool AOTConstantPoolResolver::check_lambda_metafactory_methodhandle_arg(ConstantPool* cp, int bsms_attribute_index, int arg_i) {
-  int mh_index = cp->operand_argument_index_at(bsms_attribute_index, arg_i);
+  int mh_index = cp->bsm_attribute_entry(bsms_attribute_index)->argument_index(arg_i);
   if (!cp->tag_at(mh_index).is_method_handle()) {
     // malformed class?
     return false;
@@ -452,7 +452,8 @@ bool AOTConstantPoolResolver::is_indy_resolution_deterministic(ConstantPool* cp,
     return false;
   }
 
-  int bsm = cp->bootstrap_method_ref_index_at(cp_index);
+  int bsms_attribute_index = cp->bootstrap_methods_attribute_index(cp_index);
+  int bsm = cp->bsm_attribute_entry(bsms_attribute_index)->bootstrap_method_index();
   int bsm_ref = cp->method_handle_index_at(bsm);
   Symbol* bsm_name = cp->uncached_name_ref_at(bsm_ref);
   Symbol* bsm_signature = cp->uncached_signature_ref_at(bsm_ref);
@@ -532,8 +533,7 @@ bool AOTConstantPoolResolver::is_indy_resolution_deterministic(ConstantPool* cp,
       return false;
     }
 
-    int bsms_attribute_index = cp->bootstrap_methods_attribute_index(cp_index);
-    int arg_count = cp->operand_argument_count_at(bsms_attribute_index);
+    int arg_count = cp->bsm_attribute_entry(bsms_attribute_index)->argument_count();
     if (arg_count != 3) {
       // Malformed class?
       return false;

--- a/src/hotspot/share/cds/aotConstantPoolResolver.hpp
+++ b/src/hotspot/share/cds/aotConstantPoolResolver.hpp
@@ -34,6 +34,7 @@
 #include "utilities/macros.hpp"
 #include "utilities/resourceHash.hpp"
 
+class BSMAttributeEntry;
 class ConstantPool;
 class constantPoolHandle;
 class InstanceKlass;
@@ -76,8 +77,8 @@ class AOTConstantPoolResolver :  AllStatic {
 
   static bool check_methodtype_signature(ConstantPool* cp, Symbol* sig, Klass** return_type_ret = nullptr);
   static bool check_lambda_metafactory_signature(ConstantPool* cp, Symbol* sig);
-  static bool check_lambda_metafactory_methodtype_arg(ConstantPool* cp, int bsms_attribute_index, int arg_i);
-  static bool check_lambda_metafactory_methodhandle_arg(ConstantPool* cp, int bsms_attribute_index, int arg_i);
+  static bool check_lambda_metafactory_methodtype_arg(ConstantPool* cp, BSMAttributeEntry* bsme, int arg_i);
+  static bool check_lambda_metafactory_methodhandle_arg(ConstantPool* cp, BSMAttributeEntry* bsme, int arg_i);
 
 public:
   static void initialize();

--- a/src/hotspot/share/cds/aotConstantPoolResolver.hpp
+++ b/src/hotspot/share/cds/aotConstantPoolResolver.hpp
@@ -34,7 +34,6 @@
 #include "utilities/macros.hpp"
 #include "utilities/resourceHash.hpp"
 
-class BSMAttributeEntry;
 class ConstantPool;
 class constantPoolHandle;
 class InstanceKlass;
@@ -77,8 +76,8 @@ class AOTConstantPoolResolver :  AllStatic {
 
   static bool check_methodtype_signature(ConstantPool* cp, Symbol* sig, Klass** return_type_ret = nullptr);
   static bool check_lambda_metafactory_signature(ConstantPool* cp, Symbol* sig);
-  static bool check_lambda_metafactory_methodtype_arg(ConstantPool* cp, BSMAttributeEntry* bsme, int arg_i);
-  static bool check_lambda_metafactory_methodhandle_arg(ConstantPool* cp, BSMAttributeEntry* bsme, int arg_i);
+  static bool check_lambda_metafactory_methodtype_arg(ConstantPool* cp, int bsme_index, int arg_i);
+  static bool check_lambda_metafactory_methodhandle_arg(ConstantPool* cp, int bsme_index, int arg_i);
 
 public:
   static void initialize();

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -535,7 +535,7 @@ InstanceKlass* ClassListParser::load_class_from_source(Symbol* class_name, TRAPS
 
 void ClassListParser::populate_cds_indy_info(const constantPoolHandle &pool, int cp_index, CDSIndyInfo* cii, TRAPS) {
   // Caller needs to allocate ResourceMark.
-  BSReference indy(pool, cp_index);
+  BootstrapReference indy(pool, cp_index);
   int name_index = indy.name_index();
   cii->add_item(pool->symbol_at(name_index)->as_C_string());
   int sig_index = indy.signature_index();

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -535,7 +535,7 @@ InstanceKlass* ClassListParser::load_class_from_source(Symbol* class_name, TRAPS
 
 void ClassListParser::populate_cds_indy_info(const constantPoolHandle &pool, int cp_index, CDSIndyInfo* cii, TRAPS) {
   // Caller needs to allocate ResourceMark.
-  auto indy = pool->uncached_bootstrap_specifier_ref_at(cp_index);
+  BSReference indy(pool, cp_index);
   int name_index = indy.name_index();
   cii->add_item(pool->symbol_at(name_index)->as_C_string());
   int sig_index = indy.signature_index();
@@ -547,10 +547,10 @@ void ClassListParser::populate_cds_indy_info(const constantPoolHandle &pool, int
       int arg = bsme->argument_index(arg_i);
       jbyte tag = pool->tag_at(arg).value();
       if (tag == JVM_CONSTANT_MethodType) {
-        auto ref = pool->method_type_ref_at(arg);
+        MethodTypeReference ref(pool, arg);
         cii->add_item(ref.signature(pool)->as_C_string());
       } else if (tag == JVM_CONSTANT_MethodHandle) {
-        auto ref = pool->method_handle_ref_at(arg);
+        MethodHandleReference ref(pool, arg);
         cii->add_ref_kind(ref.ref_kind());
         Klass* callee = ref.klass(pool, CHECK);  // use ref.klass_name here?
         cii->add_item(callee->name()->as_C_string());

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -540,10 +540,11 @@ void ClassListParser::populate_cds_indy_info(const constantPoolHandle &pool, int
   cii->add_item(pool->symbol_at(name_index)->as_C_string());
   int sig_index = pool->signature_ref_index_at(type_index);
   cii->add_item(pool->symbol_at(sig_index)->as_C_string());
-  int argc = pool->bootstrap_argument_count_at(cp_index);
+  auto bsme = pool->bootstrap_methods_attribute_entry(cp_index);
+  int argc = bsme->argument_count();;
   if (argc > 0) {
     for (int arg_i = 0; arg_i < argc; arg_i++) {
-      int arg = pool->bootstrap_argument_index_at(cp_index, arg_i);
+      int arg = bsme->argument_index(arg_i);
       jbyte tag = pool->tag_at(arg).value();
       if (tag == JVM_CONSTANT_MethodType) {
         cii->add_item(pool->method_type_signature_at(arg)->as_C_string());

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -821,7 +821,8 @@ ciMethod* ciEnv::get_method_by_index_impl(const constantPoolHandle& cpool,
     // Patch the call site to the nmethod entry point of the static compiled lambda form.
     // As with other two-component call sites, both values must be independently verified.
     assert(index < cpool->cache()->resolved_indy_entries_length(), "impossible");
-    Method* adapter = cpool->resolved_indy_entry_at(index)->method();
+    auto rie = cpool->resolved_indy_entry_at(index);
+    Method* adapter = rie->method();
     // Resolved if the adapter is non null.
     if (adapter != nullptr) {
       return get_method(adapter);
@@ -830,7 +831,7 @@ ciMethod* ciEnv::get_method_by_index_impl(const constantPoolHandle& cpool,
     // Fake a method that is equivalent to a declared method.
     ciInstanceKlass* holder    = get_instance_klass(vmClasses::MethodHandle_klass());
     ciSymbol*        name      = ciSymbols::invokeBasic_name();
-    ciSymbol*        signature = get_symbol(cpool->signature_ref_at(index, bc));
+    ciSymbol*        signature = get_symbol(rie->signature(cpool()));
     return get_unloaded_method(holder, name, signature, accessor);
   } else {
     const int holder_index = cpool->klass_ref_index_at(index, bc);

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -701,18 +701,20 @@ ciConstant ciEnv::get_constant_by_index_impl(const constantPoolHandle& cpool,
   } else if (tag.is_method_type() || tag.is_method_type_in_error()) {
     // must execute Java code to link this CP entry into cache[i].f1
     assert(obj_index >= 0, "should have an object index");
-    ciSymbol* signature = get_symbol(cpool->method_type_signature_at(index));
+    SymbolicReference ref = cpool->method_type_ref_at(index);
+    ciSymbol* signature = get_symbol(ref.signature(cpool));
     ciObject* ciobj = get_unloaded_method_type_constant(signature);
     return ciConstant(T_OBJECT, ciobj);
   } else if (tag.is_method_handle() || tag.is_method_handle_in_error()) {
     // must execute Java code to link this CP entry into cache[i].f1
     assert(obj_index >= 0, "should have an object index");
+    auto ref            = cpool->method_handle_ref_at(index);
     bool ignore_will_link;
-    int ref_kind        = cpool->method_handle_ref_kind_at(index);
-    int callee_index    = cpool->method_handle_klass_index_at(index);
+    int ref_kind        = ref.ref_kind();
+    int callee_index    = ref.ref_index();
     ciKlass* callee     = get_klass_by_index_impl(cpool, callee_index, ignore_will_link, accessor);
-    ciSymbol* name      = get_symbol(cpool->method_handle_name_ref_at(index));
-    ciSymbol* signature = get_symbol(cpool->method_handle_signature_ref_at(index));
+    ciSymbol* name      = get_symbol(ref.name(cpool));
+    ciSymbol* signature = get_symbol(ref.signature(cpool));
     ciObject* ciobj     = get_unloaded_method_handle_constant(callee, name, signature, ref_kind);
     return ciConstant(T_OBJECT, ciobj);
   } else if (tag.is_dynamic_constant() || tag.is_dynamic_constant_in_error()) {
@@ -834,13 +836,14 @@ ciMethod* ciEnv::get_method_by_index_impl(const constantPoolHandle& cpool,
     ciSymbol*        signature = get_symbol(rie->signature(cpool()));
     return get_unloaded_method(holder, name, signature, accessor);
   } else {
-    const int holder_index = cpool->klass_ref_index_at(index, bc);
+    auto mref = cpool->from_bytecode_ref_at(index, bc);
+    const int holder_index = mref.klass_index();
     bool holder_is_accessible;
     ciKlass* holder = get_klass_by_index_impl(cpool, holder_index, holder_is_accessible, accessor);
 
     // Get the method's name and signature.
-    Symbol* name_sym = cpool->name_ref_at(index, bc);
-    Symbol* sig_sym  = cpool->signature_ref_at(index, bc);
+    Symbol* name_sym = mref.name(cpool);
+    Symbol* sig_sym  = mref.signature(cpool);
 
     if (cpool->has_preresolution()
         || ((holder == ciEnv::MethodHandle_klass() || holder == ciEnv::VarHandle_klass()) &&
@@ -1465,12 +1468,13 @@ void ciEnv::process_invokedynamic(const constantPoolHandle &cp, int indy_index, 
 
 // Process an invokehandle call site and record any dynamic locations.
 void ciEnv::process_invokehandle(const constantPoolHandle &cp, int index, JavaThread* thread) {
-  const int holder_index = cp->klass_ref_index_at(index, Bytecodes::_invokehandle);
+  auto mref = cp->from_bytecode_ref_at(index, Bytecodes::_invokehandle);
+  const int holder_index = mref.klass_index();
   if (!cp->tag_at(holder_index).is_klass()) {
     return;  // not resolved
   }
   Klass* holder = ConstantPool::klass_at_if_loaded(cp, holder_index);
-  Symbol* name = cp->name_ref_at(index, Bytecodes::_invokehandle);
+  Symbol* name = mref.name(cp);
   if (MethodHandles::is_signature_polymorphic_name(holder, name)) {
     ResolvedMethodEntry* method_entry = cp->resolved_method_entry_at(index);
     if (method_entry->is_resolved(Bytecodes::_invokehandle)) {

--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -79,7 +79,7 @@ ciField::ciField(ciInstanceKlass* klass, int index, Bytecodes::Code bc) :
   assert(klass->get_instanceKlass()->is_linked(), "must be linked before using its constant-pool");
 
   constantPoolHandle cpool(THREAD, klass->get_instanceKlass()->constants());
-  SymbolicReference  ref = cpool->from_bytecode_ref_at(index, bc);
+  FMReference ref(cpool, index, bc);
 
   // Get the field's name, signature, and type.
   Symbol* name  = ref.name(cpool);

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -419,8 +419,9 @@ class CompileReplay : public StackObj {
         pool_index = cp->resolved_indy_entry_at(index)->constant_pool_index();
       } else if (bytecode.is_invokehandle()) {
 #ifdef ASSERT
-        Klass* holder = cp->klass_ref_at(index, bytecode.code(), CHECK_NULL);
-        Symbol* name = cp->name_ref_at(index, bytecode.code());
+        auto ref = cp->from_bytecode_ref_at(index, bytecode.code());
+        Klass* holder = ref.klass(cp, CHECK_NULL);
+        Symbol* name  = ref.name(cp);
         assert(MethodHandles::is_signature_polymorphic_name(holder, name), "");
 #endif
         ResolvedMethodEntry* method_entry = cp->cache()->set_method_handle(index, callInfo);

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -419,7 +419,7 @@ class CompileReplay : public StackObj {
         pool_index = cp->resolved_indy_entry_at(index)->constant_pool_index();
       } else if (bytecode.is_invokehandle()) {
 #ifdef ASSERT
-        auto ref = cp->from_bytecode_ref_at(index, bytecode.code());
+        FMReference ref(cp, index, bytecode.code());
         Klass* holder = ref.klass(cp, CHECK_NULL);
         Symbol* name  = ref.name(cp);
         assert(MethodHandles::is_signature_polymorphic_name(holder, name), "");

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -342,7 +342,7 @@ ciInstanceKlass* ciBytecodeStream::get_declared_field_holder() {
 int ciBytecodeStream::get_field_holder_index() {
   GUARDED_VM_ENTRY(
     ConstantPool* cpool = _holder->get_instanceKlass()->constants();
-    return cpool->klass_ref_index_at(get_field_index(), _bc);
+    return cpool->from_bytecode_ref_at(get_field_index(), _bc).klass_index();
   )
 }
 
@@ -526,7 +526,7 @@ ciKlass* ciBytecodeStream::get_declared_method_holder() {
 // deoptimization information.
 int ciBytecodeStream::get_method_holder_index() {
   ConstantPool* cpool = _method->get_Method()->constants();
-  return cpool->klass_ref_index_at(get_method_index(), _bc);
+  return cpool->from_bytecode_ref_at(get_method_index(), _bc).klass_index();
 }
 
 // ------------------------------------------------------------------
@@ -537,8 +537,6 @@ int ciBytecodeStream::get_method_holder_index() {
 // deoptimization information.
 int ciBytecodeStream::get_method_signature_index(const constantPoolHandle& cpool) {
   GUARDED_VM_ENTRY(
-    const int method_index = get_method_index();
-    const int name_and_type_index = cpool->name_and_type_ref_index_at(method_index, _bc);
-    return cpool->signature_ref_index_at(name_and_type_index);
+    return cpool->from_bytecode_ref_at(get_method_index(), _bc).signature_index();
   )
 }

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -252,8 +252,7 @@ ciConstant ciBytecodeStream::get_constant() {
   if (has_cache_index()) {
     cache_index = pool_index;
     pool_index = cpool->object_to_cp_index(cache_index);
-  } else if (cpool->tag_at(pool_index).is_dynamic_constant() ||
-             cpool->tag_at(pool_index).is_dynamic_constant_in_error()) {
+  } else if (cpool->tag_at(pool_index).is_dynamic_constant_or_error()) {
     // Condy with primitive type is not quickened, so the index into resolved reference cache should be reconstructed.
     assert(is_java_primitive(cpool->basic_type_for_constant_at(pool_index)), "not quickened");
     cache_index = cpool->cp_to_object_index(pool_index);
@@ -342,7 +341,7 @@ ciInstanceKlass* ciBytecodeStream::get_declared_field_holder() {
 int ciBytecodeStream::get_field_holder_index() {
   GUARDED_VM_ENTRY(
     ConstantPool* cpool = _holder->get_instanceKlass()->constants();
-    return cpool->from_bytecode_ref_at(get_field_index(), _bc).klass_index();
+    return FMReference(cpool, get_field_index(), _bc).klass_index();
   )
 }
 
@@ -526,7 +525,7 @@ ciKlass* ciBytecodeStream::get_declared_method_holder() {
 // deoptimization information.
 int ciBytecodeStream::get_method_holder_index() {
   ConstantPool* cpool = _method->get_Method()->constants();
-  return cpool->from_bytecode_ref_at(get_method_index(), _bc).klass_index();
+  return FMReference(cpool, get_method_index(), _bc).klass_index();
 }
 
 // ------------------------------------------------------------------
@@ -537,6 +536,7 @@ int ciBytecodeStream::get_method_holder_index() {
 // deoptimization information.
 int ciBytecodeStream::get_method_signature_index(const constantPoolHandle& cpool) {
   GUARDED_VM_ENTRY(
-    return cpool->from_bytecode_ref_at(get_method_index(), _bc).signature_index();
+    // use RawReference because this could be invokedynamic
+    return RawReference(cpool, get_method_index(), _bc).signature_index();
   )
 }

--- a/src/hotspot/share/ci/ciStreams.hpp
+++ b/src/hotspot/share/ci/ciStreams.hpp
@@ -245,8 +245,7 @@ public:
            cur_bc() == Bytecodes::_ldc2_w, "not supported: %s", Bytecodes::name(cur_bc()));
 
     constantTag tag = get_raw_pool_tag();
-    return tag.is_dynamic_constant() ||
-           tag.is_dynamic_constant_in_error();
+    return tag.is_dynamic_constant_or_error();
   }
 
   bool is_string_constant() const {
@@ -265,10 +264,7 @@ public:
 
     int index = get_constant_pool_index();
     constantTag tag = get_constant_pool_tag(index);
-    return tag.is_unresolved_klass_in_error() ||
-           tag.is_method_handle_in_error()    ||
-           tag.is_method_type_in_error()      ||
-           tag.is_dynamic_constant_in_error();
+    return tag.is_in_error();
   }
 
   // If this bytecode is one of get_field, get_static, put_field,

--- a/src/hotspot/share/classfile/bytecodeAssembler.cpp
+++ b/src/hotspot/share/classfile/bytecodeAssembler.cpp
@@ -38,7 +38,7 @@ void BytecodeConstantPool::init() {
     switch(_orig->tag_at(i).value()) {
     case JVM_CONSTANT_Class:
     case JVM_CONSTANT_UnresolvedClass:
-      entry = BytecodeCPEntry::klass(_orig->klass_slot_at(i).name_index());
+      entry = BytecodeCPEntry::klass(KlassReference(_orig, i).name_index());
       break;
     case JVM_CONSTANT_Utf8:
       entry = BytecodeCPEntry::utf8(_orig->symbol_at(i));

--- a/src/hotspot/share/classfile/bytecodeAssembler.cpp
+++ b/src/hotspot/share/classfile/bytecodeAssembler.cpp
@@ -44,10 +44,10 @@ void BytecodeConstantPool::init() {
       entry = BytecodeCPEntry::utf8(_orig->symbol_at(i));
       break;
     case JVM_CONSTANT_NameAndType:
-      entry = BytecodeCPEntry::name_and_type(_orig->name_ref_index_at(i), _orig->signature_ref_index_at(i));
+      entry = BytecodeCPEntry::name_and_type(_orig->name_and_type_pair_at(i));
       break;
     case JVM_CONSTANT_Methodref:
-      entry = BytecodeCPEntry::methodref(_orig->uncached_klass_ref_index_at(i), _orig->uncached_name_and_type_ref_index_at(i));
+      entry = BytecodeCPEntry::methodref(_orig->uncached_field_or_method_ref_at(i));
       break;
     case JVM_CONSTANT_String:
       entry = BytecodeCPEntry::string(_orig->unresolved_string_at(i));

--- a/src/hotspot/share/classfile/bytecodeAssembler.cpp
+++ b/src/hotspot/share/classfile/bytecodeAssembler.cpp
@@ -44,10 +44,10 @@ void BytecodeConstantPool::init() {
       entry = BytecodeCPEntry::utf8(_orig->symbol_at(i));
       break;
     case JVM_CONSTANT_NameAndType:
-      entry = BytecodeCPEntry::name_and_type(_orig->name_and_type_pair_at(i));
+      entry = BytecodeCPEntry::name_and_type(NTReference(_orig, i));
       break;
     case JVM_CONSTANT_Methodref:
-      entry = BytecodeCPEntry::methodref(_orig->uncached_field_or_method_ref_at(i));
+      entry = BytecodeCPEntry::methodref(FMReference(_orig, i));
       break;
     case JVM_CONSTANT_String:
       entry = BytecodeCPEntry::string(_orig->unresolved_string_at(i));

--- a/src/hotspot/share/classfile/bytecodeAssembler.hpp
+++ b/src/hotspot/share/classfile/bytecodeAssembler.hpp
@@ -104,7 +104,7 @@ class BytecodeCPEntry {
     bcpe._u.name_and_type.type_index = type;
     return bcpe;
   }
-  static BytecodeCPEntry name_and_type(const SymbolicReference& ref) {
+  static BytecodeCPEntry name_and_type(const NTReference& ref) {
     assert(ref.tag().is_name_and_type(), "");
     return name_and_type(ref.name_index(), ref.signature_index());
   }
@@ -115,7 +115,7 @@ class BytecodeCPEntry {
     bcpe._u.methodref.name_and_type_index = nat;
     return bcpe;
   }
-  static BytecodeCPEntry methodref(const SymbolicReference& ref) {
+  static BytecodeCPEntry methodref(const FMReference& ref) {
     return methodref(ref.klass_index(), ref.nt_index());
   }
 

--- a/src/hotspot/share/classfile/bytecodeAssembler.hpp
+++ b/src/hotspot/share/classfile/bytecodeAssembler.hpp
@@ -104,12 +104,19 @@ class BytecodeCPEntry {
     bcpe._u.name_and_type.type_index = type;
     return bcpe;
   }
+  static BytecodeCPEntry name_and_type(const SymbolicReference& ref) {
+    assert(ref.tag().is_name_and_type(), "");
+    return name_and_type(ref.name_index(), ref.signature_index());
+  }
 
   static BytecodeCPEntry methodref(u2 class_index, u2 nat) {
     BytecodeCPEntry bcpe(METHODREF);
     bcpe._u.methodref.class_index = class_index;
     bcpe._u.methodref.name_and_type_index = nat;
     return bcpe;
+  }
+  static BytecodeCPEntry methodref(const SymbolicReference& ref) {
+    return methodref(ref.klass_index(), ref.nt_index());
   }
 
   static bool equals(BytecodeCPEntry const& e0, BytecodeCPEntry const& e1) {

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -446,7 +446,7 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
         if (!_need_verify) break;
         // Use RawReference because CP structure is not fully checked yet.
         // A real FMReference causes asserts to fire on some bad classfiles.
-        RawReference ref(/*allow_malformed*/ true, cp, index);
+        RawReference ref = cp->possibly_malformed_RawReference_at(index);
         const int klass_ref_index         = ref.third_index();
         const int name_and_type_ref_index = ref.nt_index();
         guarantee_property(valid_klass_reference_at(klass_ref_index),
@@ -576,8 +576,8 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
       case JVM_CONSTANT_InvokeDynamic:
       case JVM_CONSTANT_Dynamic: {
         // Use RawReference because CP structure is not fully checked yet.
-        // A real BSReference causes asserts to fire on some bad classfiles.
-        RawReference bsref(/*allow_malformed*/ true, cp, index);
+        // A real BootstrapReference causes asserts to fire on some bad classfiles.
+        RawReference bsref = cp->possibly_malformed_RawReference_at(index);
         const int name_and_type_ref_index = bsref.nt_index();
 
         guarantee_property(valid_cp_range(name_and_type_ref_index, length) &&
@@ -646,7 +646,7 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
         if (_need_verify) {
           // CONSTANT_Dynamic's name and signature are verified above, when iterating NameAndType_info.
           // Need only to be sure signature is the right type.
-          BSReference bsref(cp, index);
+          BootstrapReference bsref(cp, index);
           // name, signature are already verified to be utf8
           if (Signature::is_method(bsref.signature(cp))) {
             throwIllegalSignature("CONSTANT_Dynamic", bsref.name(cp), bsref.signature(cp), CHECK);

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2104,7 +2104,6 @@ void ClassFileParser::copy_method_annotations(ConstMethod* cm,
   }
 }
 
-
 // Note: the parse_method below is big and clunky because all parsing of the code and exceptions
 // attribute is inlined. This is cumbersome to avoid since we inline most of the parts in the
 // Method* to save footprint, so we only know the size of the resulting Method* when the
@@ -3280,38 +3279,35 @@ void ClassFileParser::parse_classfile_bootstrap_methods_attribute(const ClassFil
 
   cfs->guarantee_more(attribute_byte_length, CHECK);
 
-  const int attribute_array_length = cfs->get_u2_fast();
+  const int attribute_entry_count = cfs->get_u2_fast();
 
-  guarantee_property(_max_bootstrap_specifier_index < attribute_array_length,
+  guarantee_property(_max_bootstrap_specifier_index < attribute_entry_count,
                      "Short length on BootstrapMethods in class file %s",
                      CHECK);
 
-
   // The attribute contains a counted array of counted tuples of shorts,
   // represending bootstrap specifiers:
-  //    length*{bootstrap_method_index, argument_count*{argument_index}}
-  const unsigned int operand_count = (attribute_byte_length - (unsigned)sizeof(u2)) / (unsigned)sizeof(u2);
-  // operand_count = number of shorts in attr, except for leading length
+  //    length*{bootstrap_method_index, argument_count, argument_count*{argument_index}}
+  const unsigned int attribute_tail_length = attribute_byte_length - (unsigned)sizeof(u2);
 
-  // The attribute is copied into a short[] array.
-  // The array begins with a series of short[2] pairs, one for each tuple.
-  const int index_size = (attribute_array_length * 2);
+  Array<u4>* const offsets =
+    MetadataFactory::new_array<u4>(_loader_data, attribute_entry_count, CHECK);
+  Array<u2>* const entries =  // u2 data holding all the BSM attribute entries
+    MetadataFactory::new_array<u2>(_loader_data, attribute_tail_length / sizeof(u2), CHECK);
 
-  Array<u2>* const operands =
-    MetadataFactory::new_array<u2>(_loader_data, index_size + operand_count, CHECK);
-
-  // Eagerly assign operands so they will be deallocated with the constant
+  // Eagerly assign arrays so they will be deallocated with the constant
   // pool if there is an error.
-  cp->set_operands(operands);
+  cp->set_bsm_attribute_offsets(offsets);
+  cp->set_bsm_attribute_entries(entries);
 
-  int operand_fill_index = index_size;
+  int next_entry = 0;
   const int cp_size = cp->length();
 
-  for (int n = 0; n < attribute_array_length; n++) {
-    // Store a 32-bit offset into the header of the operand array.
-    ConstantPool::operand_offset_at_put(operands, n, operand_fill_index);
+  for (int n = 0; n < attribute_entry_count; n++) {
+    // Store a 32-bit offset into the array of BSM entry offsets.
+    offsets->at_put(n, next_entry);
 
-    // Read a bootstrap specifier.
+    // Read a bootstrap method attribute entry.
     cfs->guarantee_more(sizeof(u2) * 2, CHECK);  // bsm, argc
     const u2 bootstrap_method_index = cfs->get_u2_fast();
     const u2 argument_count = cfs->get_u2_fast();
@@ -3322,12 +3318,12 @@ void ClassFileParser::parse_classfile_bootstrap_methods_attribute(const ClassFil
       bootstrap_method_index,
       CHECK);
 
-    guarantee_property((operand_fill_index + 1 + argument_count) < operands->length(),
+    guarantee_property((next_entry + 2 + argument_count) <= entries->length(),
       "Invalid BootstrapMethods num_bootstrap_methods or num_bootstrap_arguments value in class file %s",
       CHECK);
 
-    operands->at_put(operand_fill_index++, bootstrap_method_index);
-    operands->at_put(operand_fill_index++, argument_count);
+    entries->at_put(next_entry++, bootstrap_method_index);
+    entries->at_put(next_entry++, argument_count);
 
     cfs->guarantee_more(sizeof(u2) * argument_count, CHECK);  // argv[argc]
     for (int j = 0; j < argument_count; j++) {
@@ -3338,12 +3334,35 @@ void ClassFileParser::parse_classfile_bootstrap_methods_attribute(const ClassFil
         "argument_index %u has bad constant type in class file %s",
         argument_index,
         CHECK);
-      operands->at_put(operand_fill_index++, argument_index);
+      entries->at_put(next_entry++, argument_index);
     }
   }
   guarantee_property(current_start + attribute_byte_length == cfs->current(),
                      "Bad length on BootstrapMethods in class file %s",
                      CHECK);
+  assert(next_entry == entries->length(), "");
+
+  // check access methods, for extra luck
+  if (attribute_entry_count > 0) {
+    auto bsme = cp->bsm_attribute_entry(0);
+    assert(bsme->bootstrap_method_index() == entries->at(0), "");
+    assert(bsme->argument_count()         == entries->at(1), "");
+    int nexti = (attribute_entry_count == 1) ? entries->length() : offsets->at(1);
+    assert(nexti == 2 + bsme->argument_count(), "");
+    if (attribute_entry_count > 1) {
+      bsme = cp->bsm_attribute_entry(1);
+      assert(bsme->bootstrap_method_index() == entries->at(nexti+0), "");
+      assert(bsme->argument_count()         == entries->at(nexti+1), "");
+    }
+    int lasti = offsets->at(offsets->length() - 1);
+    bsme = cp->bsm_attribute_entry(attribute_entry_count - 1);
+    assert(bsme->bootstrap_method_index() == entries->at(lasti+0), "");
+    assert(bsme->argument_count()         == entries->at(lasti+1), "");
+    int lastu2 = entries->at(entries->length() - 1);
+    int lastac = bsme->argument_count();
+    int expect_lastu2 = (lastac == 0) ? 0 : bsme->argument_index(lastac-1);
+    assert(lastu2 == expect_lastu2, "");
+  }
 }
 
 void ClassFileParser::parse_classfile_attributes(const ClassFileStream* const cfs,

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -873,7 +873,7 @@ void ClassFileParser::verify_constantvalue(const ConstantPool* const cp,
     constantvalue_index, CHECK);
 
   const constantTag value_type = cp->tag_at(constantvalue_index);
-  switch(cp->basic_type_for_signature_at(signature_index)) {
+  switch (Signature::basic_type(cp->symbol_at(signature_index))) {
     case T_LONG: {
       guarantee_property(value_type.is_long(),
                          "Inconsistent constant value type in class file %s",
@@ -1457,7 +1457,7 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
       }
     }
 
-    const BasicType type = cp->basic_type_for_signature_at(signature_index);
+    const BasicType type = Signature::basic_type(cp->symbol_at(signature_index));
 
     // Update number of static oop fields.
     if (is_static && is_reference_type(type)) {

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5680,11 +5680,11 @@ void ClassFileParser::mangle_hidden_class_name(InstanceKlass* const ik) {
   // Update this_class_index's slot in the constant pool with the new Utf8 entry.
   // We have to update the resolved_klass_index and the name_index together
   // so extract the existing resolved_klass_index first.
-  CPKlassSlot cp_klass_slot = _cp->klass_slot_at(_this_class_index);
+  KlassReference cp_klass_slot(_cp, _this_class_index);
   int resolved_klass_index = cp_klass_slot.resolved_klass_index();
   _cp->unresolved_klass_at_put(_this_class_index, hidden_index, resolved_klass_index);
-  assert(_cp->klass_slot_at(_this_class_index).name_index() == _orig_cp_size,
-         "Bad name_index");
+  KlassReference updated_cp_klass_slot(_cp, _this_class_index);
+  assert(updated_cp_klass_slot.name_index() == hidden_index, "updated name_index");
 }
 
 void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const stream,

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -195,7 +195,7 @@ class ClassFileParser {
   // precomputed flags
   bool _has_finalizer;
   bool _has_empty_finalizer;
-  int _max_bootstrap_specifier_index;  // detects BSS values
+  int _max_bsm_attribute_index;  // detects indexes into the BootstrapMethods attr
 
   void parse_stream(const ClassFileStream* const stream, TRAPS);
 

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -2193,7 +2193,7 @@ void ClassVerifier::verify_ldc(
       VerificationType::reference_type(
         vmSymbols::java_lang_invoke_MethodType()), CHECK_VERIFY(this));
   } else if (tag.is_dynamic_constant()) {
-    BSReference condy(cp, index);
+    BootstrapReference condy(cp, index);
     Symbol* constant_type = condy.signature(cp);
     // Field signature was checked in ClassFileParser.
     assert(SignatureVerifier::is_valid_type_signature(constant_type),

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -2806,9 +2806,9 @@ void ClassVerifier::verify_invoke_instructions(
     default:
       types = 1 << JVM_CONSTANT_Methodref;
   }
-  verify_cp_type(bcs->bci(), index, cp, types, CHECK_VERIFY(this));
 
   // Get method name and signature
+  verify_cp_type(bcs->bci(), index, cp, types, CHECK_VERIFY(this));
   Symbol* method_name = cp->uncached_name_ref_at(index);
   Symbol* method_sig = cp->uncached_signature_ref_at(index);
 

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -296,7 +296,8 @@ class ClassVerifier : public StackObj {
 
   VerificationType cp_ref_index_to_type(
       int index, const constantPoolHandle& cp, TRAPS) {
-    return cp_index_to_type(cp->uncached_klass_ref_index_at(index), cp, THREAD);
+    auto ref = cp->uncached_field_or_method_ref_at(index);  // field or method ref
+    return cp_index_to_type(ref.klass_index(), cp, THREAD);
   }
 
   bool is_protected_access(

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -296,7 +296,7 @@ class ClassVerifier : public StackObj {
 
   VerificationType cp_ref_index_to_type(
       int index, const constantPoolHandle& cp, TRAPS) {
-    auto ref = cp->uncached_field_or_method_ref_at(index);  // field or method ref
+    FMReference ref(cp, index);  // field or method ref
     return cp_index_to_type(ref.klass_index(), cp, THREAD);
   }
 

--- a/src/hotspot/share/interpreter/bootstrapInfo.cpp
+++ b/src/hotspot/share/interpreter/bootstrapInfo.cpp
@@ -48,15 +48,22 @@
 BootstrapInfo::BootstrapInfo(const constantPoolHandle& pool, int bss_index, int indy_index)
   : _pool(pool),
     _bss_index(bss_index),
-    _indy_index(indy_index),
-    // derived and eagerly cached:
-    _argc(      pool->bootstrap_argument_count_at(bss_index) ),
-    _name(      pool->uncached_name_ref_at(bss_index) ),
-    _signature( pool->uncached_signature_ref_at(bss_index) )
+    _indy_index(indy_index)
 {
-  _is_resolved = false;
+  assert(bss_index != 0, "");
+  _bsm_attr_index = _pool->bootstrap_methods_attribute_index(_bss_index);
+  _name = pool->uncached_name_ref_at(bss_index);
+  _signature = pool->uncached_signature_ref_at(bss_index);
   assert(pool->tag_at(bss_index).has_bootstrap(), "");
   assert(indy_index == -1 || pool->resolved_indy_entry_at(indy_index)->constant_pool_index() == bss_index, "invalid bootstrap specifier index");
+  _is_resolved = false;
+}
+
+ResolvedIndyEntry* BootstrapInfo::indy_entry() const {
+  if (_indy_index >= 0) {
+    return _pool->resolved_indy_entry_at(_indy_index);
+  }
+  return nullptr;
 }
 
 // If there is evidence this call site was already linked, set the
@@ -130,7 +137,9 @@ void BootstrapInfo::resolve_args(TRAPS) {
   assert(_bsm.not_null(), "resolve_bsm first");
 
   // if there are no static arguments, return leaving _arg_values as null
-  if (_argc == 0 && UseBootstrapCallInfo < 2) return;
+  BSMAttributeEntry* attr = bsm_attr();
+  int argc = attr->argument_count();
+  if (argc == 0 && UseBootstrapCallInfo < 2) return;
 
   bool use_BSCI;
   switch (UseBootstrapCallInfo) {
@@ -156,8 +165,8 @@ void BootstrapInfo::resolve_args(TRAPS) {
   // potentially cyclic cases from C to Java.
   if (!use_BSCI && _pool->tag_at(_bss_index).is_dynamic_constant()) {
     bool found_unresolved_condy = false;
-    for (int i = 0; i < _argc; i++) {
-      int arg_index = _pool->bootstrap_argument_index_at(_bss_index, i);
+    for (int i = 0; i < argc; i++) {
+      int arg_index = attr->argument_index(i);
       if (_pool->tag_at(arg_index).is_dynamic_constant()) {
         // potential recursion point condy -> condy
         bool found_it = false;
@@ -170,14 +179,14 @@ void BootstrapInfo::resolve_args(TRAPS) {
   }
 
   const int SMALL_ARITY = 5;
-  if (use_BSCI && _argc <= SMALL_ARITY && UseBootstrapCallInfo <= 2) {
+  if (use_BSCI && argc <= SMALL_ARITY && UseBootstrapCallInfo <= 2) {
     // If there are only a few arguments, and none of them need linking,
     // push them, instead of asking the JDK runtime to turn around and
     // pull them, saving a JVM/JDK transition in some simple cases.
     bool all_resolved = true;
-    for (int i = 0; i < _argc; i++) {
+    for (int i = 0; i < argc; i++) {
       bool found_it = false;
-      int arg_index = _pool->bootstrap_argument_index_at(_bss_index, i);
+      int arg_index = attr->argument_index(i);
       _pool->find_cached_constant_at(arg_index, found_it, CHECK);
       if (!found_it) { all_resolved = false; break; }
     }
@@ -187,10 +196,11 @@ void BootstrapInfo::resolve_args(TRAPS) {
 
   if (!use_BSCI) {
     // return {arg...}; resolution of arguments is done immediately, before JDK code is called
-    objArrayOop args_oop = oopFactory::new_objArray(vmClasses::Object_klass(), _argc, CHECK);
+    objArrayOop args_oop = oopFactory::new_objArray(vmClasses::Object_klass(), argc, CHECK);
     objArrayHandle args(THREAD, args_oop);
-    _pool->copy_bootstrap_arguments_at(_bss_index, 0, _argc, args, 0, true, Handle(), CHECK);
-    oop arg_oop = ((_argc == 1) ? args->obj_at(0) : (oop)nullptr);
+    _pool->copy_bootstrap_arguments_at(_bsm_attr_index,
+                                       0, argc, args, 0, true, Handle(), CHECK);
+    oop arg_oop = ((argc == 1) ? args->obj_at(0) : (oop)nullptr);
     // try to discard the singleton array
     if (arg_oop != nullptr && !arg_oop->is_array()) {
       // JVM treats arrays and nulls specially in this position,
@@ -200,10 +210,12 @@ void BootstrapInfo::resolve_args(TRAPS) {
       _arg_values = args;
     }
   } else {
-    // return {arg_count, pool_index}; JDK code must pull the arguments as needed
-    typeArrayOop ints_oop = oopFactory::new_typeArray(T_INT, 2, CHECK);
-    ints_oop->int_at_put(0, _argc);
+    // return {arg_count, pool_index, indy_index}
+    // JDK code must pull the arguments as needed
+    typeArrayOop ints_oop = oopFactory::new_typeArray(T_INT, 3, CHECK);
+    ints_oop->int_at_put(0, argc);
     ints_oop->int_at_put(1, _bss_index);
+    ints_oop->int_at_put(2, _indy_index);
     _arg_values = Handle(THREAD, ints_oop);
   }
 }
@@ -236,6 +248,7 @@ void BootstrapInfo::print_msg_on(outputStream* st, const char* msg) {
     os::snprintf_checked(what, sizeof(what), "condy");
   }
   bool have_msg = (msg != nullptr && strlen(msg) > 0);
+  int argc = arg_count();
   st->print_cr("%s%sBootstrap in %s %s@CP[%d] %s:%s%s BSMS[%d] BSM@CP[%d]%s argc=%d%s",
                 (have_msg ? msg : ""), (have_msg ? " " : ""),
                 caller()->name()->as_C_string(),
@@ -244,13 +257,13 @@ void BootstrapInfo::print_msg_on(outputStream* st, const char* msg) {
                 _name->as_C_string(),
                 _signature->as_C_string(),
                 (_type_arg.is_null() ? "" : "(resolved)"),
-                bsms_attr_index(),
+                bsm_attr_index(),
                 bsm_index(), (_bsm.is_null() ? "" : "(resolved)"),
-                _argc, (_arg_values.is_null() ? "" : "(resolved)"));
-  if (_argc > 0) {
+                argc, (_arg_values.is_null() ? "" : "(resolved)"));
+  if (argc > 0) {
     char argbuf[80];
     argbuf[0] = 0;
-    for (int i = 0; i < _argc; i++) {
+    for (int i = 0; i < argc; i++) {
       int pos = (int) strlen(argbuf);
       if (pos + 20 > (int)sizeof(argbuf)) {
         os::snprintf_checked(argbuf + pos, sizeof(argbuf) - pos, "...");
@@ -272,11 +285,11 @@ void BootstrapInfo::print_msg_on(outputStream* st, const char* msg) {
     // Find the static arguments within the first element of _arg_values.
     objArrayOop static_args = (objArrayOop)_arg_values();
     if (!static_args->is_array()) {
-      assert(_argc == 1, "Invalid BSM _arg_values for non-array");
+      assert(argc == 1, "Invalid BSM _arg_values for non-array");
       st->print("  resolved arg[0]: "); static_args->print_on(st);
     } else if (static_args->is_objArray()) {
       int lines = 0;
-      for (int i = 0; i < _argc; i++) {
+      for (int i = 0; i < argc; i++) {
         oop x = static_args->obj_at(i);
         if (x != nullptr) {
           if (++lines > 6) {

--- a/src/hotspot/share/interpreter/bootstrapInfo.cpp
+++ b/src/hotspot/share/interpreter/bootstrapInfo.cpp
@@ -51,9 +51,10 @@ BootstrapInfo::BootstrapInfo(const constantPoolHandle& pool, int bss_index, int 
     _indy_index(indy_index)
 {
   assert(bss_index != 0, "");
-  _bsm_attr_index = _pool->bootstrap_methods_attribute_index(_bss_index);
-  _name = pool->uncached_name_ref_at(bss_index);
-  _signature = pool->uncached_signature_ref_at(bss_index);
+  auto ref = pool->uncached_bootstrap_specifier_ref_at(bss_index);
+  _bsm_attr_index = ref.bsme_index();
+  _name = ref.name(pool);
+  _signature = ref.signature(pool);
   assert(pool->tag_at(bss_index).has_bootstrap(), "");
   assert(indy_index == -1 || pool->resolved_indy_entry_at(indy_index)->constant_pool_index() == bss_index, "invalid bootstrap specifier index");
   _is_resolved = false;

--- a/src/hotspot/share/interpreter/bootstrapInfo.cpp
+++ b/src/hotspot/share/interpreter/bootstrapInfo.cpp
@@ -48,13 +48,12 @@
 BootstrapInfo::BootstrapInfo(const constantPoolHandle& pool, int bss_index, int indy_index)
   : _pool(pool),
     _bss_index(bss_index),
+    _bss_data(pool, bss_index),
     _indy_index(indy_index)
 {
   assert(bss_index != 0, "");
-  auto ref = pool->uncached_bootstrap_specifier_ref_at(bss_index);
-  _bsm_attr_index = ref.bsme_index();
-  _name = ref.name(pool);
-  _signature = ref.signature(pool);
+  _name = _bss_data.name(pool);
+  _signature = _bss_data.signature(pool);
   assert(pool->tag_at(bss_index).has_bootstrap(), "");
   assert(indy_index == -1 || pool->resolved_indy_entry_at(indy_index)->constant_pool_index() == bss_index, "invalid bootstrap specifier index");
   _is_resolved = false;
@@ -199,7 +198,7 @@ void BootstrapInfo::resolve_args(TRAPS) {
     // return {arg...}; resolution of arguments is done immediately, before JDK code is called
     objArrayOop args_oop = oopFactory::new_objArray(vmClasses::Object_klass(), argc, CHECK);
     objArrayHandle args(THREAD, args_oop);
-    _pool->copy_bootstrap_arguments_at(_bsm_attr_index,
+    _pool->copy_bootstrap_arguments_at(bsm_attr_index(),
                                        0, argc, args, 0, true, Handle(), CHECK);
     oop arg_oop = ((argc == 1) ? args->obj_at(0) : (oop)nullptr);
     // try to discard the singleton array

--- a/src/hotspot/share/interpreter/bootstrapInfo.hpp
+++ b/src/hotspot/share/interpreter/bootstrapInfo.hpp
@@ -33,7 +33,7 @@
 class BootstrapInfo : public StackObj {
   constantPoolHandle _pool;     // constant pool containing the bootstrap specifier
   const int   _bss_index;       // index of bootstrap specifier in CP (condy or indy)
-  BSReference _bss_data;        // indexes unpacked from the _bss_index
+  BootstrapReference _bss_data; // indexes unpacked from the _bss_index
   const int   _indy_index;      // internal index of indy call site, or -1 if a condy call
   Symbol*     _name;            // extracted from JVM_CONSTANT_NameAndType
   Symbol*     _signature;

--- a/src/hotspot/share/interpreter/bootstrapInfo.hpp
+++ b/src/hotspot/share/interpreter/bootstrapInfo.hpp
@@ -34,7 +34,7 @@ class BootstrapInfo : public StackObj {
   constantPoolHandle _pool;     // constant pool containing the bootstrap specifier
   const int   _bss_index;       // index of bootstrap specifier in CP (condy or indy)
   const int   _indy_index;      // internal index of indy call site, or -1 if a condy call
-  const int   _argc;            // number of static arguments
+  int         _bsm_attr_index;  // index in the BootstrapMethods attribute
   Symbol*     _name;            // extracted from JVM_CONSTANT_NameAndType
   Symbol*     _signature;
 
@@ -58,7 +58,7 @@ class BootstrapInfo : public StackObj {
   const constantPoolHandle& pool() const{ return _pool; }
   int bss_index() const                 { return _bss_index; }
   int indy_index() const                { return _indy_index; }
-  int argc() const                      { return _argc; }
+  int bsm_attr_index() const            { return _bsm_attr_index; }
   bool is_method_call() const           { return (_indy_index != -1); }
   Symbol* name() const                  { return _name; }
   Symbol* signature() const             { return _signature; }
@@ -76,10 +76,11 @@ class BootstrapInfo : public StackObj {
   // derived accessors
   InstanceKlass* caller() const         { return _pool->pool_holder(); }
   oop caller_mirror() const             { return caller()->java_mirror(); }
-  int bsms_attr_index() const           { return _pool->bootstrap_methods_attribute_index(_bss_index); }
-  int bsm_index() const                 { return _pool->bootstrap_method_ref_index_at(_bss_index); }
-  //int argc() is eagerly cached in _argc
-  int arg_index(int i) const            { return _pool->bootstrap_argument_index_at(_bss_index, i); }
+  BSMAttributeEntry* bsm_attr() const   { return _pool->bsm_attribute_entry(_bsm_attr_index); }
+  int bsm_index() const                 { return bsm_attr()->bootstrap_method_index(); }
+  int arg_count() const                 { return bsm_attr()->argument_count(); }
+  int arg_index(int j) const            { return bsm_attr()->argument_index(j); }
+  ResolvedIndyEntry* indy_entry() const;
 
   // If there is evidence this call site was already linked, set the
   // existing linkage data into result, or throw previous exception.

--- a/src/hotspot/share/interpreter/bootstrapInfo.hpp
+++ b/src/hotspot/share/interpreter/bootstrapInfo.hpp
@@ -33,8 +33,8 @@
 class BootstrapInfo : public StackObj {
   constantPoolHandle _pool;     // constant pool containing the bootstrap specifier
   const int   _bss_index;       // index of bootstrap specifier in CP (condy or indy)
+  BSReference _bss_data;        // indexes unpacked from the _bss_index
   const int   _indy_index;      // internal index of indy call site, or -1 if a condy call
-  int         _bsm_attr_index;  // index in the BootstrapMethods attribute
   Symbol*     _name;            // extracted from JVM_CONSTANT_NameAndType
   Symbol*     _signature;
 
@@ -58,7 +58,7 @@ class BootstrapInfo : public StackObj {
   const constantPoolHandle& pool() const{ return _pool; }
   int bss_index() const                 { return _bss_index; }
   int indy_index() const                { return _indy_index; }
-  int bsm_attr_index() const            { return _bsm_attr_index; }
+  int bsm_attr_index() const            { return _bss_data.bsme_index(); }
   bool is_method_call() const           { return (_indy_index != -1); }
   Symbol* name() const                  { return _name; }
   Symbol* signature() const             { return _signature; }
@@ -76,7 +76,7 @@ class BootstrapInfo : public StackObj {
   // derived accessors
   InstanceKlass* caller() const         { return _pool->pool_holder(); }
   oop caller_mirror() const             { return caller()->java_mirror(); }
-  BSMAttributeEntry* bsm_attr() const   { return _pool->bsm_attribute_entry(_bsm_attr_index); }
+  BSMAttributeEntry* bsm_attr() const   { return _bss_data.bsme(_pool); }
   int bsm_index() const                 { return bsm_attr()->bootstrap_method_index(); }
   int arg_count() const                 { return bsm_attr()->argument_count(); }
   int arg_index(int j) const            { return bsm_attr()->argument_index(j); }

--- a/src/hotspot/share/interpreter/bytecode.cpp
+++ b/src/hotspot/share/interpreter/bytecode.cpp
@@ -130,23 +130,26 @@ int Bytecode_invoke::size_of_parameters() const {
 
 
 Symbol* Bytecode_member_ref::klass() const {
-  auto cp = constants();
-  auto bc = _code;
-  return cp->from_bytecode_ref_at(index(), bc).klass_name(cp);
+  FMReference ref(constants(), index(), _code);
+  return ref.klass_name(constants());
 }
 
 
 Symbol* Bytecode_member_ref::name() const {
-  auto cp = constants();
-  auto bc = Bytecodes::java_code(_code);  //why is this different?
-  return cp->from_bytecode_ref_at(index(), bc).name(cp);
+  // FIXME: The following line seems useless; compare signature() method.
+  Bytecodes::Code bc = Bytecodes::java_code(_code);
+  ConstantPool *cp = constants();
+  // RawReference covers field, method, and indy.
+  RawReference ref(cp, cp->to_cp_index(index(), bc));
+  return ref.name(cp);
 }
 
 
 Symbol* Bytecode_member_ref::signature() const {
-  auto cp = constants();
-  auto bc = _code;
-  return cp->from_bytecode_ref_at(index(), bc).signature(cp);
+  ConstantPool *cp = constants();
+  // RawReference covers field, method, and indy.
+  RawReference ref(cp, cp->to_cp_index(index(), _code));
+  return ref.signature(cp);
 }
 
 

--- a/src/hotspot/share/interpreter/bytecode.cpp
+++ b/src/hotspot/share/interpreter/bytecode.cpp
@@ -130,17 +130,23 @@ int Bytecode_invoke::size_of_parameters() const {
 
 
 Symbol* Bytecode_member_ref::klass() const {
-  return constants()->klass_ref_at_noresolve(index(), _code);
+  auto cp = constants();
+  auto bc = _code;
+  return cp->from_bytecode_ref_at(index(), bc).klass_name(cp);
 }
 
 
 Symbol* Bytecode_member_ref::name() const {
-  return constants()->name_ref_at(index(), Bytecodes::java_code(_code));
+  auto cp = constants();
+  auto bc = Bytecodes::java_code(_code);  //why is this different?
+  return cp->from_bytecode_ref_at(index(), bc).name(cp);
 }
 
 
 Symbol* Bytecode_member_ref::signature() const {
-  return constants()->signature_ref_at(index(), _code);
+  auto cp = constants();
+  auto bc = _code;
+  return cp->from_bytecode_ref_at(index(), bc).signature(cp);
 }
 
 

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -307,10 +307,11 @@ void BytecodePrinter::print_invokedynamic(int indy_index, int cp_index, outputSt
 
 // cp_index: must be the cp_index of a JVM_CONSTANT_{Dynamic, DynamicInError, InvokeDynamic}
 void BytecodePrinter::print_bsm(int cp_index, outputStream* st) {
-  assert(constants()->tag_at(cp_index).has_bootstrap(), "must be");
-  int bsm = constants()->bootstrap_methods_attribute_index(cp_index);
+  const auto indy = constants()->uncached_bootstrap_specifier_ref_at(cp_index);
+  const auto bsme = indy.bsme(constants());
+  const auto bsmh = bsme->bootstrap_method(constants());
   const char* ref_kind = "";
-  switch (constants()->method_handle_ref_kind_at(bsm)) {
+  switch (bsmh.ref_kind()) {
   case JVM_REF_getField         : ref_kind = "REF_getField"; break;
   case JVM_REF_getStatic        : ref_kind = "REF_getStatic"; break;
   case JVM_REF_putField         : ref_kind = "REF_putField"; break;
@@ -323,8 +324,7 @@ void BytecodePrinter::print_bsm(int cp_index, outputStream* st) {
   default                       : ShouldNotReachHere();
   }
   st->print("  BSM: %s", ref_kind);
-  print_field_or_method(constants()->method_handle_index_at(bsm), st);
-  auto bsme = constants()->bootstrap_methods_attribute_entry(cp_index);
+  print_field_or_method(bsmh.ref_index(), st);
   int argc = bsme->argument_count();;
   st->print("  arguments[%d] = {", argc);
   if (argc > 0) {

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -282,7 +282,7 @@ void BytecodePrinter::print_dynamic(int cp_index, outputStream* st) {
     return;
   }
 
-  int bsm = constants->bootstrap_method_ref_index_at(cp_index);
+  int bsm = constants->bootstrap_methods_attribute_index(cp_index);
   st->print(" bsm=%d", bsm);
 
   Symbol* name = constants->uncached_name_ref_at(cp_index);
@@ -308,7 +308,7 @@ void BytecodePrinter::print_invokedynamic(int indy_index, int cp_index, outputSt
 // cp_index: must be the cp_index of a JVM_CONSTANT_{Dynamic, DynamicInError, InvokeDynamic}
 void BytecodePrinter::print_bsm(int cp_index, outputStream* st) {
   assert(constants()->tag_at(cp_index).has_bootstrap(), "must be");
-  int bsm = constants()->bootstrap_method_ref_index_at(cp_index);
+  int bsm = constants()->bootstrap_methods_attribute_index(cp_index);
   const char* ref_kind = "";
   switch (constants()->method_handle_ref_kind_at(bsm)) {
   case JVM_REF_getField         : ref_kind = "REF_getField"; break;
@@ -324,12 +324,13 @@ void BytecodePrinter::print_bsm(int cp_index, outputStream* st) {
   }
   st->print("  BSM: %s", ref_kind);
   print_field_or_method(constants()->method_handle_index_at(bsm), st);
-  int argc = constants()->bootstrap_argument_count_at(cp_index);
+  auto bsme = constants()->bootstrap_methods_attribute_entry(cp_index);
+  int argc = bsme->argument_count();;
   st->print("  arguments[%d] = {", argc);
   if (argc > 0) {
     st->cr();
     for (int arg_i = 0; arg_i < argc; arg_i++) {
-      int arg = constants()->bootstrap_argument_index_at(cp_index, arg_i);
+      int arg = bsme->argument_index(arg_i);
       st->print("    ");
       print_constant(arg, st);
     }

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -282,7 +282,7 @@ void BytecodePrinter::print_dynamic(int cp_index, outputStream* st) {
     return;
   }
 
-  BSReference ref(constants, cp_index);
+  BootstrapReference ref(constants, cp_index);
   st->print(" bsm=%d", ref.bsme(constants)->bootstrap_method_index());
 
   Symbol* name = ref.name(constants);
@@ -307,7 +307,7 @@ void BytecodePrinter::print_invokedynamic(int indy_index, int cp_index, outputSt
 
 // cp_index: must be the cp_index of a JVM_CONSTANT_{Dynamic, DynamicInError, InvokeDynamic}
 void BytecodePrinter::print_bsm(int cp_index, outputStream* st) {
-  BSReference indy(constants(), cp_index);
+  BootstrapReference indy(constants(), cp_index);
   BSMAttributeEntry* bsme = indy.bsme(constants());
   MethodHandleReference bsmh = bsme->bootstrap_method(constants());
   const char* ref_kind = "";

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -228,11 +228,11 @@ void BytecodePrinter::print_constant(int cp_index, outputStream* st) {
   } else if (tag.is_unresolved_klass()) {
     st->print_cr(" %s", constants->klass_name_at(cp_index)->as_quoted_ascii());
   } else if (tag.is_method_type()) {
-    auto ref = constants->method_type_ref_at(cp_index);
+    MethodTypeReference ref(constants, cp_index);
     st->print(" <MethodType> %d", ref.signature_index());
     st->print_cr(" %s", ref.signature(constants)->as_quoted_ascii());
   } else if (tag.is_method_handle()) {
-    auto ref = constants->method_handle_ref_at(cp_index);
+    MethodHandleReference ref(constants, cp_index);
     st->print(" <MethodHandle of kind %d index at %d>", ref.ref_kind(), ref.ref_index());
     print_field_or_method(ref.ref_index(), st);
   } else if (tag.is_dynamic_constant()) {
@@ -260,7 +260,7 @@ void BytecodePrinter::print_field_or_method(int cp_index, outputStream* st) {
     return;
   }
 
-  auto ref = constants->uncached_field_or_method_ref_at(cp_index);
+  FMReference ref(constants, cp_index);
   Symbol* name      = ref.name(constants);
   Symbol* signature = ref.signature(constants);
   Symbol* klass     = ref.klass_name(constants);
@@ -282,7 +282,7 @@ void BytecodePrinter::print_dynamic(int cp_index, outputStream* st) {
     return;
   }
 
-  auto ref = constants->uncached_bootstrap_specifier_ref_at(cp_index);
+  BSReference ref(constants, cp_index);
   st->print(" bsm=%d", ref.bsme(constants)->bootstrap_method_index());
 
   Symbol* name = ref.name(constants);
@@ -307,9 +307,9 @@ void BytecodePrinter::print_invokedynamic(int indy_index, int cp_index, outputSt
 
 // cp_index: must be the cp_index of a JVM_CONSTANT_{Dynamic, DynamicInError, InvokeDynamic}
 void BytecodePrinter::print_bsm(int cp_index, outputStream* st) {
-  const auto indy = constants()->uncached_bootstrap_specifier_ref_at(cp_index);
-  const auto bsme = indy.bsme(constants());
-  const auto bsmh = bsme->bootstrap_method(constants());
+  BSReference indy(constants(), cp_index);
+  BSMAttributeEntry* bsme = indy.bsme(constants());
+  MethodHandleReference bsmh = bsme->bootstrap_method(constants());
   const char* ref_kind = "";
   switch (bsmh.ref_kind()) {
   case JVM_REF_getField         : ref_kind = "REF_getField"; break;

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -226,7 +226,7 @@ void BytecodePrinter::print_constant(int cp_index, outputStream* st) {
   } else if (tag.is_klass()) {
     st->print_cr(" %s", constants->resolved_klass_at(cp_index)->external_name());
   } else if (tag.is_unresolved_klass()) {
-    st->print_cr(" %s", constants->klass_at_noresolve(cp_index)->as_quoted_ascii());
+    st->print_cr(" %s", constants->klass_name_at(cp_index)->as_quoted_ascii());
   } else if (tag.is_method_type()) {
     auto ref = constants->method_type_ref_at(cp_index);
     st->print(" <MethodType> %d", ref.signature_index());

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1486,7 +1486,7 @@ JRT_ENTRY(void, InterpreterRuntime::member_name_arg_or_null(JavaThread* current,
   }
   ConstantPool* cpool = method->constants();
   int cp_index = Bytes::get_native_u2(bcp + 1);
-  auto mref = cpool->from_bytecode_ref_at(cp_index, code);
+  FMReference mref(cpool, cp_index, code);
   Symbol* cname = mref.klass_name(cpool);
   Symbol* mname = mref.name(cpool);
 

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1486,8 +1486,9 @@ JRT_ENTRY(void, InterpreterRuntime::member_name_arg_or_null(JavaThread* current,
   }
   ConstantPool* cpool = method->constants();
   int cp_index = Bytes::get_native_u2(bcp + 1);
-  Symbol* cname = cpool->klass_name_at(cpool->klass_ref_index_at(cp_index, code));
-  Symbol* mname = cpool->name_ref_at(cp_index, code);
+  auto mref = cpool->from_bytecode_ref_at(cp_index, code);
+  Symbol* cname = mref.klass_name(cpool);
+  Symbol* mname = mref.name(cpool);
 
   if (MethodHandles::has_member_arg(cname, mname)) {
     oop member_name_oop = cast_to_oop(member_name);

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -257,8 +257,7 @@ void CallInfo::print() {
 // Implementation of LinkInfo
 
 LinkInfo::LinkInfo(const constantPoolHandle& pool, int index, const methodHandle& current_method, Bytecodes::Code code, TRAPS) {
-  SymbolicReference ref = pool->from_bytecode_ref_at(index, code);
-  // FIXME: consider copying this struct bitwise into the LinkInfo
+  FMReference ref(pool, index, code);
 
    // resolve klass
   _resolved_klass = ref.klass(pool, CHECK);
@@ -276,7 +275,7 @@ LinkInfo::LinkInfo(const constantPoolHandle& pool, int index, const methodHandle
 }
 
 LinkInfo::LinkInfo(const constantPoolHandle& pool, int index, Bytecodes::Code code, TRAPS) {
-  SymbolicReference ref = pool->from_bytecode_ref_at(index, code);
+  FMReference ref(pool, index, code);
 
    // resolve klass
   _resolved_klass = ref.klass(pool, CHECK);
@@ -652,9 +651,10 @@ Method* LinkResolver::resolve_method_statically(Bytecodes::Code code,
   // FIXME: Remove this method and ciMethod::check_call; refactor to use the other LinkResolver entry points.
   // resolve klass
   if (code == Bytecodes::_invokedynamic) {
+    BSReference indy(pool, index, code);
     Klass* resolved_klass = vmClasses::MethodHandle_klass();
     Symbol* method_name = vmSymbols::invoke_name();
-    Symbol* method_signature = pool->from_bytecode_ref_at(index, code).signature(pool);
+    Symbol* method_signature = indy.signature(pool);
     Klass*  current_klass = pool->pool_holder();
     LinkInfo link_info(resolved_klass, method_name, method_signature, current_klass);
     return resolve_method(link_info, code, THREAD);

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -651,7 +651,7 @@ Method* LinkResolver::resolve_method_statically(Bytecodes::Code code,
   // FIXME: Remove this method and ciMethod::check_call; refactor to use the other LinkResolver entry points.
   // resolve klass
   if (code == Bytecodes::_invokedynamic) {
-    BSReference indy(pool, index, code);
+    BootstrapReference indy(pool, index, code);
     Klass* resolved_klass = vmClasses::MethodHandle_klass();
     Symbol* method_name = vmSymbols::invoke_name();
     Symbol* method_signature = indy.signature(pool);

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -251,7 +251,7 @@ void Rewriter::maybe_rewrite_invokehandle(address opc, int cp_index, int cache_i
       int status = _method_handle_invokers.at(cp_index);
       assert(status >= -1 && status <= 1, "oob tri-state");
       if (status == 0) {
-        auto ref = _pool->uncached_field_or_method_ref_at(cp_index);
+        FMReference ref(_pool, cp_index);
         Symbol* ref_klass = ref.klass_name(_pool);
         if (ref_klass == vmSymbols::java_lang_invoke_MethodHandle() &&
             MethodHandles::is_signature_polymorphic_name(vmClasses::MethodHandle_klass(),
@@ -357,7 +357,7 @@ void Rewriter::maybe_rewrite_ldc(address bcp, int offset, bool is_wide,
         (tag.is_dynamic_constant() &&
          // keep regular ldc interpreter logic for condy primitives
          is_reference_type(Signature::basic_type(
-           _pool->uncached_bootstrap_specifier_ref_at(cp_index).signature(_pool)
+           BSReference(_pool, cp_index).signature(_pool)
          )))
         ) {
       int ref_index = cp_entry_to_resolved_references(cp_index);
@@ -468,7 +468,7 @@ void Rewriter::scan_method(Thread* thread, Method* method, bool reverse, bool* i
           InstanceKlass* klass = method->method_holder();
           u2 bc_index = Bytes::get_Java_u2(bcp + prefix_length + 1);
           constantPoolHandle cp(thread, method->constants());
-          SymbolicReference ref = cp->uncached_field_or_method_ref_at(bc_index);
+          FMReference ref(cp, bc_index);
           Symbol* ref_class_name = ref.klass_name(cp);
 
           if (klass->name() == ref_class_name) {

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -357,7 +357,7 @@ void Rewriter::maybe_rewrite_ldc(address bcp, int offset, bool is_wide,
         (tag.is_dynamic_constant() &&
          // keep regular ldc interpreter logic for condy primitives
          is_reference_type(Signature::basic_type(
-           BSReference(_pool, cp_index).signature(_pool)
+           BootstrapReference(_pool, cp_index).signature(_pool)
          )))
         ) {
       int ref_index = cp_entry_to_resolved_references(cp_index);

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -890,7 +890,7 @@ C2V_END
 
 C2V_VMENTRY_0(jint, bootstrapArgumentIndexAt, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint cpi, jint index))
   constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
-  return cp->bootstrap_argument_index_at(cpi, index);
+  return cp->bootstrap_methods_attribute_entry(cpi)->argument_index(index);
 C2V_END
 
 C2V_VMENTRY_0(jint, lookupNameAndTypeRefIndexInPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint index, jint opcode))

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -748,7 +748,7 @@ C2V_VMENTRY_NULL(jobject, lookupConstantInPool, (JNIEnv* env, jobject, ARGUMENT_
     if (obj == nullptr) {
       return JVMCIENV->get_jobject(JVMCIENV->get_JavaConstant_NULL_POINTER());
     }
-    BSReference condy(cp, cp_index);
+    BootstrapReference condy(cp, cp_index);
     BasicType bt = Signature::basic_type(condy.signature(cp));
     if (!is_reference_type(bt)) {
       if (!is_java_primitive(bt)) {
@@ -891,7 +891,7 @@ C2V_END
 
 C2V_VMENTRY_0(jint, bootstrapArgumentIndexAt, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint cpi, jint index))
   constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
-  BSReference indy(cp, cpi);  // indy or condy
+  BootstrapReference indy(cp, cpi);  // indy or condy
   BSMAttributeEntry* bsme = indy.bsme(cp);
   return bsme->argument_index(index);
 C2V_END

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1833,13 +1833,14 @@ Method* JVMCIRuntime::get_method_by_index_impl(const constantPoolHandle& cpool,
     return nullptr;
   }
 
-  int holder_index = cpool->klass_ref_index_at(index, bc);
+  auto mref = cpool->from_bytecode_ref_at(index, bc);
+  int holder_index = mref.klass_index();
   bool holder_is_accessible;
   Klass* holder = get_klass_by_index_impl(cpool, holder_index, holder_is_accessible, accessor);
 
   // Get the method's name and signature.
-  Symbol* name_sym = cpool->name_ref_at(index, bc);
-  Symbol* sig_sym  = cpool->signature_ref_at(index, bc);
+  Symbol* name_sym = mref.name(cpool);
+  Symbol* sig_sym  = mref.signature(cpool);
 
   if (cpool->has_preresolution()
       || ((holder == vmClasses::MethodHandle_klass() || holder == vmClasses::VarHandle_klass()) &&

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1833,7 +1833,7 @@ Method* JVMCIRuntime::get_method_by_index_impl(const constantPoolHandle& cpool,
     return nullptr;
   }
 
-  auto mref = cpool->from_bytecode_ref_at(index, bc);
+  FMReference mref(cpool, index, bc);
   int holder_index = mref.klass_index();
   bool holder_is_accessible;
   Klass* holder = get_klass_by_index_impl(cpool, holder_index, holder_is_accessible, accessor);

--- a/src/hotspot/share/oops/constMethod.cpp
+++ b/src/hotspot/share/oops/constMethod.cpp
@@ -191,13 +191,14 @@ u2* ConstMethod::last_u2_element() const {
 u2* ConstMethod::generic_signature_index_addr() const {
   // Located at the end of the constMethod.
   assert(has_generic_signature(), "called only if generic signature exists");
-  return last_u2_element();
+  int offset = 0;  // this is always the last u2 (before possible pointers)
+  return last_u2_element() - offset;
 }
 
 u2* ConstMethod::method_parameters_length_addr() const {
   assert(has_method_parameters(), "called only if table is present");
-  return has_generic_signature() ? (last_u2_element() - 1) :
-                                    last_u2_element();
+  int offset = has_generic_signature() ? 1 : 0;
+  return last_u2_element() - offset;
 }
 
 u2* ConstMethod::checked_exceptions_length_addr() const {

--- a/src/hotspot/share/oops/constMethod.hpp
+++ b/src/hotspot/share/oops/constMethod.hpp
@@ -81,7 +81,7 @@
 //     (access flags bit tells whether table is present)
 //     (indexed from end of ConstMethod*)
 //    [EMBEDDED generic signature index (u2)]
-//     (indexed from end of constMethodOop)
+//     (indexed from end of ConstMethod*)
 //    [EMBEDDED annotations arrays - method, parameter, type, default]
 //      pointer to Array<u1> if annotation is present
 //

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -913,7 +913,7 @@ static const char* exception_message(const constantPoolHandle& this_cp, int whic
     break;
   case JVM_CONSTANT_Dynamic:
     // return the name of the condy in the error message
-    message = BSReference(this_cp, which).name(this_cp);
+    message = BootstrapReference(this_cp, which).name(this_cp);
     break;
   default:
     ShouldNotReachHere();
@@ -1017,7 +1017,7 @@ BasicType ConstantPool::basic_type_for_constant_at(int cp_index) {
   constantTag tag = tag_at(cp_index);
   if (tag.is_dynamic_constant_or_error()) {
     // have to look at the signature for this one
-    BSReference condy(this, cp_index);
+    BootstrapReference condy(this, cp_index);
     Symbol* constant_type = condy.signature(this);
     return Signature::basic_type(constant_type);
   }
@@ -1515,8 +1515,8 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   case JVM_CONSTANT_InvokeDynamic:
   case JVM_CONSTANT_Dynamic:
   {
-    BSReference ref1(this, index1);
-    BSReference ref2(cp2,  index2);
+    BootstrapReference ref1(this, index1);
+    BootstrapReference ref2(cp2,  index2);
     if (compare_entry_to(ref1.nt_index(),  cp2, ref2.nt_index()) &&
         compare_bsme_to(ref1.bsme_index(), cp2, ref2.bsme_index())) {
       return true;
@@ -1855,7 +1855,7 @@ void ConstantPool::copy_entry_to(const constantPoolHandle& from_cp, int from_i,
   case JVM_CONSTANT_DynamicInError:
   case JVM_CONSTANT_InvokeDynamic:
   {
-    BSReference ref(from_cp, from_i);
+    BootstrapReference ref(from_cp, from_i);
     int k1 = ref.bsme_index();
     k1 += to_cp->bsm_attribute_count();  // to_cp might already have BSMs
     if (ref.tag().is_invoke_dynamic()) {
@@ -2314,7 +2314,7 @@ int ConstantPool::copy_cpool_bytes(int cpool_size,
       case JVM_CONSTANT_Dynamic:
       case JVM_CONSTANT_DynamicInError: {
         *bytes = JVM_CONSTANT_Dynamic;
-        BSReference ref(this, idx);
+        BootstrapReference ref(this, idx);
         idx1 = ref.bsme_index();
         idx2 = ref.nt_index();
         Bytes::put_Java_u2((address) (bytes+1), idx1);
@@ -2324,7 +2324,7 @@ int ConstantPool::copy_cpool_bytes(int cpool_size,
       }
       case JVM_CONSTANT_InvokeDynamic: {
         *bytes = tag;
-        BSReference ref(this, idx);
+        BootstrapReference ref(this, idx);
         idx1 = ref.bsme_index();
         idx2 = ref.nt_index();
         Bytes::put_Java_u2((address) (bytes+1), idx1);
@@ -2502,7 +2502,7 @@ void ConstantPool::print_entry_on(const int cp_index, outputStream* st) {
     case JVM_CONSTANT_DynamicInError :
     case JVM_CONSTANT_InvokeDynamic :
       {
-        BSReference ref(this, cp_index);
+        BootstrapReference ref(this, cp_index);
         BSMAttributeEntry* bsme = ref.bsme(this);
         st->print("bootstrap_method_index=%d name_and_type_index=%d",
                   ref.bsme_index(), ref.nt_index());

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2395,20 +2395,6 @@ void ConstantPool::set_on_stack(const bool value) {
   }
 }
 
-// Used for sneakily dumping the CP if an assert fails:
-int ConstantPool::cp_index_after_error(int cp_index) {
-#ifdef ASSERT
-  static int entry = 0;
-  if (entry < 10) {
-    entry++;
-    tty->print("at %d: ", cp_index);
-    print_entry_on(cp_index, tty);
-    print_on(tty);
-  }
-#endif //ASSERT
-  return cp_index;
-}
-
 // Printing
 
 void ConstantPool::print_on(outputStream* st) const {

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -133,8 +133,10 @@ void ConstantPool::deallocate_contents(ClassLoaderData* loader_data) {
   MetadataFactory::free_array<Klass*>(loader_data, resolved_klasses());
   set_resolved_klasses(nullptr);
 
-  MetadataFactory::free_array<jushort>(loader_data, operands());
-  set_operands(nullptr);
+  MetadataFactory::free_array<u4>(loader_data, bsm_attribute_offsets());
+  MetadataFactory::free_array<u2>(loader_data, bsm_attribute_entries());
+  set_bsm_attribute_offsets(nullptr);
+  set_bsm_attribute_entries(nullptr);
 
   release_C_heap_structures();
 
@@ -154,7 +156,8 @@ void ConstantPool::metaspace_pointers_do(MetaspaceClosure* it) {
   it->push(&_tags, MetaspaceClosure::_writable);
   it->push(&_cache);
   it->push(&_pool_holder);
-  it->push(&_operands);
+  it->push(&_bsm_attribute_offsets);
+  it->push(&_bsm_attribute_entries);
   it->push(&_resolved_klasses, MetaspaceClosure::_writable);
 
   for (int i = 0; i < length(); i++) {
@@ -293,14 +296,14 @@ void ConstantPool::iterate_archivable_resolved_references(Function function) {
     if (indy_entries != nullptr) {
       for (int i = 0; i < indy_entries->length(); i++) {
         ResolvedIndyEntry *rie = indy_entries->adr_at(i);
+        BSMAttributeEntry *bsme = rie->bsme(this);
         if (rie->is_resolved() && AOTConstantPoolResolver::is_resolution_deterministic(this, rie->constant_pool_index())) {
           int rr_index = rie->resolved_references_index();
           assert(resolved_reference_at(rr_index) != nullptr, "must exist");
           function(rr_index);
 
           // Save the BSM as well (sometimes the JIT looks up the BSM it for replay)
-          int indy_cp_index = rie->constant_pool_index();
-          int bsm_mh_cp_index = bootstrap_method_ref_index_at(indy_cp_index);
+          int bsm_mh_cp_index = bsme->bootstrap_method_index();
           int bsm_rr_index = cp_to_object_index(bsm_mh_cp_index);
           assert(resolved_reference_at(bsm_rr_index) != nullptr, "must exist");
           function(bsm_rr_index);
@@ -814,7 +817,12 @@ int ConstantPool::to_cp_index(int index, Bytecodes::Code code) {
   assert(cache() != nullptr, "'index' is a rewritten index so this class must have been rewritten");
   switch(code) {
     case Bytecodes::_invokedynamic:
-      return invokedynamic_bootstrap_ref_index_at(index);
+      {
+        auto ie = cache()->resolved_indy_entry_at(index);
+        int cp_index = ie->constant_pool_index();
+        assert(tag_at(cp_index).has_bootstrap(), "index contains symbolic ref");
+        return cp_index;
+      }
     case Bytecodes::_getfield:
     case Bytecodes::_getstatic:
     case Bytecodes::_putfield:
@@ -1361,20 +1369,24 @@ oop ConstantPool::uncached_string_at(int cp_index, TRAPS) {
   return str;
 }
 
-void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& this_cp, int cp_index,
+void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& this_cp,
+                                                    int bsme_index,
                                                     int start_arg, int end_arg,
                                                     objArrayHandle info, int pos,
                                                     bool must_resolve, Handle if_not_available,
                                                     TRAPS) {
   int limit = pos + end_arg - start_arg;
-  // checks: cp_index in range [0..this_cp->length),
-  // tag at cp_index, start..end in range [0..this_cp->bootstrap_argument_count],
+  // check explicitly (do not assert) that bsms index is in range
+  BSMAttributeEntry* bsme = nullptr;
+  if (0 <= bsme_index &&
+      bsme_index < this_cp->bsm_attribute_count()) {
+    bsme = this_cp->bsm_attribute_entry(bsme_index);
+  }
+  // also check tag at cp_index, start..end in range,
   // info array non-null, pos..limit in [0..info.length]
-  if ((0 >= cp_index    || cp_index >= this_cp->length())  ||
-      !(this_cp->tag_at(cp_index).is_invoke_dynamic()    ||
-        this_cp->tag_at(cp_index).is_dynamic_constant()) ||
+  if (bsme == nullptr ||
       (0 > start_arg || start_arg > end_arg) ||
-      (end_arg > this_cp->bootstrap_argument_count_at(cp_index)) ||
+      (end_arg > bsme->argument_count()) ||
       (0 > pos       || pos > limit)         ||
       (info.is_null() || limit > info->length())) {
     // An index or something else went wrong; throw an error.
@@ -1385,7 +1397,7 @@ void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& th
   // now we can loop safely
   int info_i = pos;
   for (int i = start_arg; i < end_arg; i++) {
-    int arg_index = this_cp->bootstrap_argument_index_at(cp_index, i);
+    int arg_index = bsme->argument_index(i);
     oop arg_oop;
     if (must_resolve) {
       arg_oop = this_cp->resolve_possibly_cached_constant_at(arg_index, CHECK);
@@ -1580,22 +1592,22 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
   {
     int k1 = bootstrap_name_and_type_ref_index_at(index1);
     int k2 = cp2->bootstrap_name_and_type_ref_index_at(index2);
-    int i1 = bootstrap_methods_attribute_index(index1);
-    int i2 = cp2->bootstrap_methods_attribute_index(index2);
+    int e1 = bootstrap_methods_attribute_index(index1);
+    int e2 = cp2->bootstrap_methods_attribute_index(index2);
     bool match_entry = compare_entry_to(k1, cp2, k2);
-    bool match_operand = compare_operand_to(i1, cp2, i2);
-    return (match_entry && match_operand);
+    bool match_bsme  = compare_bsme_to(e1, cp2, e2);
+    return (match_entry && match_bsme);
   } break;
 
   case JVM_CONSTANT_InvokeDynamic:
   {
     int k1 = bootstrap_name_and_type_ref_index_at(index1);
     int k2 = cp2->bootstrap_name_and_type_ref_index_at(index2);
-    int i1 = bootstrap_methods_attribute_index(index1);
-    int i2 = cp2->bootstrap_methods_attribute_index(index2);
+    int e1 = bootstrap_methods_attribute_index(index1);
+    int e2 = cp2->bootstrap_methods_attribute_index(index2);
     bool match_entry = compare_entry_to(k1, cp2, k2);
-    bool match_operand = compare_operand_to(i1, cp2, i2);
-    return (match_entry && match_operand);
+    bool match_bsme  = compare_bsme_to(e1, cp2, e2);
+    return (match_entry && match_bsme);
   } break;
 
   case JVM_CONSTANT_String:
@@ -1630,139 +1642,146 @@ bool ConstantPool::compare_entry_to(int index1, const constantPoolHandle& cp2,
 } // end compare_entry_to()
 
 
-// Resize the operands array with delta_len and delta_size.
+// Resize the BSM attribute arrays with delta_len and delta_size.
 // Used in RedefineClasses for CP merge.
-void ConstantPool::resize_operands(int delta_len, int delta_size, TRAPS) {
-  int old_len  = operand_array_length(operands());
-  int new_len  = old_len + delta_len;
-  int min_len  = (delta_len > 0) ? old_len : new_len;
+void ConstantPool::resize_bsm_data(int delta_len, int delta_size, TRAPS) {
+  const auto old_offs = bsm_attribute_offsets();
+  const auto old_data = bsm_attribute_entries();
+  const bool have_old = (bsm_attribute_count() != 0);
 
-  int old_size = operands()->length();
-  int new_size = old_size + delta_size;
-  int min_size = (delta_size > 0) ? old_size : new_size;
+  int old_offs_len  = !have_old ? 0 : old_offs->length();
+  int new_offs_len  = old_offs_len + delta_len;
+  int min_offs_len  = (delta_len > 0) ? old_offs_len : new_offs_len;
+
+  int old_data_len = !have_old ? 0 : old_data->length();
+  int new_data_len = old_data_len + delta_size;
+  int min_data_len = (delta_size > 0) ? old_data_len : new_data_len;
 
   ClassLoaderData* loader_data = pool_holder()->class_loader_data();
-  Array<u2>* new_ops = MetadataFactory::new_array<u2>(loader_data, new_size, CHECK);
+  Array<u4>* new_offs = MetadataFactory::new_array<u4>(loader_data, new_offs_len, CHECK);
+  Array<u2>* new_data = MetadataFactory::new_array<u2>(loader_data, new_data_len, CHECK);
 
-  // Set index in the resized array for existing elements only
-  for (int idx = 0; idx < min_len; idx++) {
-    int offset = operand_offset_at(idx);                       // offset in original array
-    operand_offset_at_put(new_ops, idx, offset + 2*delta_len); // offset in resized array
+  // Copy the old array data.  We do not need to change any offsets.
+  if (have_old) {
+    Copy::conjoint_memory_atomic(old_offs->adr_at(0),
+                                 new_offs->adr_at(0),
+                                 min_offs_len * sizeof(u4));
+    Copy::conjoint_memory_atomic(old_data->adr_at(0),
+                                 new_data->adr_at(0),
+                                 min_data_len * sizeof(u2));
   }
-  // Copy the bootstrap specifiers only
-  Copy::conjoint_memory_atomic(operands()->adr_at(2*old_len),
-                               new_ops->adr_at(2*new_len),
-                               (min_size - 2*min_len) * sizeof(u2));
-  // Explicitly deallocate old operands array.
-  // Note, it is not needed for 7u backport.
-  if ( operands() != nullptr) { // the safety check
-    MetadataFactory::free_array<u2>(loader_data, operands());
+  // Explicitly deallocate old bsm_data array.
+  if (bsm_attribute_offsets() != nullptr) { // the safety check
+    MetadataFactory::free_array<u4>(loader_data, bsm_attribute_offsets());
   }
-  set_operands(new_ops);
-} // end resize_operands()
+  if (bsm_attribute_entries() != nullptr) { // the safety check
+    MetadataFactory::free_array<u2>(loader_data, bsm_attribute_entries());
+  }
+  set_bsm_attribute_offsets(new_offs);
+  set_bsm_attribute_entries(new_data);
+} // end resize_bsm_data()
 
 
-// Extend the operands array with the length and size of the ext_cp operands.
+// Extend the BSM attribute arrays with the length and size of the ext_cp data.
 // Used in RedefineClasses for CP merge.
-void ConstantPool::extend_operands(const constantPoolHandle& ext_cp, TRAPS) {
-  int delta_len = operand_array_length(ext_cp->operands());
+void ConstantPool::extend_bsm_data(const constantPoolHandle& ext_cp, TRAPS) {
+  int delta_len = ext_cp->bsm_attribute_count();
   if (delta_len == 0) {
     return; // nothing to do
   }
-  int delta_size = ext_cp->operands()->length();
+  int delta_size = ext_cp->bsm_attribute_entries()->length();
 
-  assert(delta_len  > 0 && delta_size > 0, "extended operands array must be bigger");
+  assert(delta_len > 0 && delta_size > 0, "extended arrays must be bigger");
 
-  if (operand_array_length(operands()) == 0) {
-    ClassLoaderData* loader_data = pool_holder()->class_loader_data();
-    Array<u2>* new_ops = MetadataFactory::new_array<u2>(loader_data, delta_size, CHECK);
-    // The first element index defines the offset of second part
-    operand_offset_at_put(new_ops, 0, 2*delta_len); // offset in new array
-    set_operands(new_ops);
-  } else {
-    resize_operands(delta_len, delta_size, CHECK);
-  }
-
-} // end extend_operands()
+  // Note:  resize_bsm_data can handle bsm_attribute_entries()==nullptr
+  resize_bsm_data(delta_len, delta_size, CHECK);
+} // end extend_bsm_data()
 
 
-// Shrink the operands array to a smaller array with new_len length.
+// Shrink the BSM attribute arrays to a smaller number of entries.
 // Used in RedefineClasses for CP merge.
-void ConstantPool::shrink_operands(int new_len, TRAPS) {
-  int old_len = operand_array_length(operands());
+void ConstantPool::shrink_bsm_data(int new_len, TRAPS) {
+  int old_len = bsm_attribute_count();
   if (new_len == old_len) {
     return; // nothing to do
   }
-  assert(new_len < old_len, "shrunken operands array must be smaller");
+  assert(new_len < old_len, "shrunken bsm_data array must be smaller");
 
-  int free_base  = operand_next_offset_at(new_len - 1);
-  int delta_len  = new_len - old_len;
-  int delta_size = 2*delta_len + free_base - operands()->length();
+  int new_data_len = bsm_attribute_offsets()->at(new_len);  //offset
+  int old_data_len = bsm_attribute_entries()->length();     //length
+  int delta_len    = new_len      - old_len;
+  int delta_size   = new_data_len - old_data_len;
 
-  resize_operands(delta_len, delta_size, CHECK);
+  resize_bsm_data(delta_len, delta_size, CHECK);
+} // end shrink_bsm_data()
 
-} // end shrink_operands()
 
-
-void ConstantPool::copy_operands(const constantPoolHandle& from_cp,
+// Append the BSM attribute entries from one CP to the end of another.
+void ConstantPool::copy_bsm_data(const constantPoolHandle& from_cp,
                                  const constantPoolHandle& to_cp,
                                  TRAPS) {
-
-  int from_oplen = operand_array_length(from_cp->operands());
-  int old_oplen  = operand_array_length(to_cp->operands());
-  if (from_oplen != 0) {
-    ClassLoaderData* loader_data = to_cp->pool_holder()->class_loader_data();
-    // append my operands to the target's operands array
-    if (old_oplen == 0) {
-      // Can't just reuse from_cp's operand list because of deallocation issues
-      int len = from_cp->operands()->length();
-      Array<u2>* new_ops = MetadataFactory::new_array<u2>(loader_data, len, CHECK);
-      Copy::conjoint_memory_atomic(
-          from_cp->operands()->adr_at(0), new_ops->adr_at(0), len * sizeof(u2));
-      to_cp->set_operands(new_ops);
-    } else {
-      int old_len  = to_cp->operands()->length();
-      int from_len = from_cp->operands()->length();
-      int old_off  = old_oplen * sizeof(u2);
-      int from_off = from_oplen * sizeof(u2);
-      // Use the metaspace for the destination constant pool
-      Array<u2>* new_operands = MetadataFactory::new_array<u2>(loader_data, old_len + from_len, CHECK);
-      int fillp = 0, len = 0;
-      // first part of dest
-      Copy::conjoint_memory_atomic(to_cp->operands()->adr_at(0),
-                                   new_operands->adr_at(fillp),
-                                   (len = old_off) * sizeof(u2));
-      fillp += len;
-      // first part of src
-      Copy::conjoint_memory_atomic(from_cp->operands()->adr_at(0),
-                                   new_operands->adr_at(fillp),
-                                   (len = from_off) * sizeof(u2));
-      fillp += len;
-      // second part of dest
-      Copy::conjoint_memory_atomic(to_cp->operands()->adr_at(old_off),
-                                   new_operands->adr_at(fillp),
-                                   (len = old_len - old_off) * sizeof(u2));
-      fillp += len;
-      // second part of src
-      Copy::conjoint_memory_atomic(from_cp->operands()->adr_at(from_off),
-                                   new_operands->adr_at(fillp),
-                                   (len = from_len - from_off) * sizeof(u2));
-      fillp += len;
-      assert(fillp == new_operands->length(), "");
-
-      // Adjust indexes in the first part of the copied operands array.
-      for (int j = 0; j < from_oplen; j++) {
-        int offset = operand_offset_at(new_operands, old_oplen + j);
-        assert(offset == operand_offset_at(from_cp->operands(), j), "correct copy");
-        offset += old_len;  // every new tuple is preceded by old_len extra u2's
-        operand_offset_at_put(new_operands, old_oplen + j, offset);
-      }
-
-      // replace target operands array with combined array
-      to_cp->set_operands(new_operands);
-    }
+  // Append my offsets and data to the target's offset and data arrays.
+  const auto from_offs = from_cp->bsm_attribute_offsets();
+  const auto from_data = from_cp->bsm_attribute_entries();
+  const auto to_offs   = to_cp->bsm_attribute_offsets();
+  const auto to_data   = to_cp->bsm_attribute_entries();
+  if (from_offs == nullptr || from_offs->length() == 0) {
+    return;  // nothing to copy
   }
-} // end copy_operands()
+
+  const bool have_old = (to_offs != nullptr && to_offs->length() != 0);
+  const int old_offs_len = !have_old ? 0 : to_offs->length();
+  const int add_offs_len = from_offs->length();
+  const int new_offs_len = old_offs_len + add_offs_len;
+  const int old_data_len = !have_old ? 0 : to_data->length();
+  const int add_data_len = from_data->length();
+  const int new_data_len = old_data_len + add_data_len;
+
+  // Note: even if old_len is zero, we can't just reuse from_cp's
+  // arrays, because of deallocation issues.  Always make fresh data.
+  ClassLoaderData* loader_data = to_cp->pool_holder()->class_loader_data();
+
+  // Use the metaspace for the destination constant pool
+  const auto new_offs = MetadataFactory::new_array<u4>(loader_data, new_offs_len, CHECK);
+  const auto new_data = MetadataFactory::new_array<u2>(loader_data, new_data_len, CHECK);
+
+  // first, recopy pre-existing parts of both dest arrays:
+  int offs_fillp = 0, data_fillp = 0, offs_copied, data_copied;
+  if (have_old) {
+    Copy::conjoint_memory_atomic(to_offs->adr_at(0),
+                                 new_offs->adr_at(offs_fillp),
+                                 (offs_copied = old_offs_len) * sizeof(u4));
+    Copy::conjoint_memory_atomic(to_data->adr_at(0),
+                                 new_data->adr_at(data_fillp),
+                                 (data_copied = old_data_len) * sizeof(u2));
+    offs_fillp += offs_copied;
+    data_fillp += data_copied;
+  }
+
+  // then, append new parts of both source arrays:
+  Copy::conjoint_memory_atomic(from_offs->adr_at(0),
+                               new_offs->adr_at(offs_fillp),
+                               (offs_copied = add_offs_len) * sizeof(u4));
+  Copy::conjoint_memory_atomic(from_data->adr_at(0),
+                               new_data->adr_at(old_data_len),
+                               (data_copied = add_data_len) * sizeof(u2));
+  offs_fillp += offs_copied;
+  data_fillp += data_copied;
+  assert(offs_fillp == new_offs->length(), "");
+  assert(data_fillp == new_data->length(), "");
+
+  // Adjust indexes in the first part of the copied bsm_data array.
+  for (int j = old_offs_len; j < new_offs_len; j++) {
+    u4 old_offset = new_offs->at(j);
+    u4 new_offset = old_offset + old_data_len;
+    // every new entry is preceded by old_data_len extra u2's
+    new_offs->at_put(j, new_offset);
+  }
+
+  // replace target bsm_data array with combined array
+  to_cp->set_bsm_attribute_offsets(new_offs);
+  to_cp->set_bsm_attribute_entries(new_data);
+} // end copy_bsm_data()
 
 
 // Copy this constant pool's entries at start_i to end_i (inclusive)
@@ -1792,7 +1811,7 @@ void ConstantPool::copy_cp_to_impl(const constantPoolHandle& from_cp, int start_
       break;
     }
   }
-  copy_operands(from_cp, to_cp, CHECK);
+  copy_bsm_data(from_cp, to_cp, CHECK);
 
 } // end copy_cp_to_impl()
 
@@ -1916,7 +1935,7 @@ void ConstantPool::copy_entry_to(const constantPoolHandle& from_cp, int from_i,
   {
     int k1 = from_cp->bootstrap_methods_attribute_index(from_i);
     int k2 = from_cp->bootstrap_name_and_type_ref_index_at(from_i);
-    k1 += operand_array_length(to_cp->operands());  // to_cp might already have operands
+    k1 += to_cp->bsm_attribute_count();  // to_cp might already have BSMs
     to_cp->dynamic_constant_at_put(to_i, k1, k2);
   } break;
 
@@ -1924,7 +1943,7 @@ void ConstantPool::copy_entry_to(const constantPoolHandle& from_cp, int from_i,
   {
     int k1 = from_cp->bootstrap_methods_attribute_index(from_i);
     int k2 = from_cp->bootstrap_name_and_type_ref_index_at(from_i);
-    k1 += operand_array_length(to_cp->operands());  // to_cp might already have operands
+    k1 += to_cp->bsm_attribute_count();  // to_cp might already have BSMs
     to_cp->invoke_dynamic_at_put(to_i, k1, k2);
   } break;
 
@@ -1958,21 +1977,23 @@ int ConstantPool::find_matching_entry(int pattern_i,
 } // end find_matching_entry()
 
 
-// Compare this constant pool's bootstrap specifier at idx1 to the constant pool
-// cp2's bootstrap specifier at idx2.
-bool ConstantPool::compare_operand_to(int idx1, const constantPoolHandle& cp2, int idx2) {
-  int k1 = operand_bootstrap_method_ref_index_at(idx1);
-  int k2 = cp2->operand_bootstrap_method_ref_index_at(idx2);
+// Compare this constant pool's BSM attribute entry at idx1 to the constant pool
+// cp2's BSM attribute entry at idx2.
+bool ConstantPool::compare_bsme_to(int idx1, const constantPoolHandle& cp2, int idx2) {
+  auto e1 = bsm_attribute_entry(idx1);
+  auto e2 = cp2->bsm_attribute_entry(idx2);
+  int k1 = e1->bootstrap_method_index();
+  int k2 = e2->bootstrap_method_index();
   bool match = compare_entry_to(k1, cp2, k2);
 
   if (!match) {
     return false;
   }
-  int argc = operand_argument_count_at(idx1);
-  if (argc == cp2->operand_argument_count_at(idx2)) {
+  int argc = e1->argument_count();
+  if (argc == e2->argument_count()) {
     for (int j = 0; j < argc; j++) {
-      k1 = operand_argument_index_at(idx1, j);
-      k2 = cp2->operand_argument_index_at(idx2, j);
+      k1 = e1->argument_index(j);
+      k2 = e2->argument_index(j);
       match = compare_entry_to(k1, cp2, k2);
       if (!match) {
         return false;
@@ -1981,21 +2002,21 @@ bool ConstantPool::compare_operand_to(int idx1, const constantPoolHandle& cp2, i
     return true;           // got through loop; all elements equal
   }
   return false;
-} // end compare_operand_to()
+} // end compare_bsme_to()
 
-// Search constant pool search_cp for a bootstrap specifier that matches
-// this constant pool's bootstrap specifier data at pattern_i index.
-// Return the index of a matching bootstrap attribute record or (-1) if there is no match.
-int ConstantPool::find_matching_operand(int pattern_i,
+// Search constant pool search_cp for a BSM attribute entry that matches
+// this constant pool's BSM attribute entry at pattern_i index.
+// Return the index of a entry, or (-1) if there was no match.
+int ConstantPool::find_matching_bsme(int pattern_i,
                     const constantPoolHandle& search_cp, int search_len) {
   for (int i = 0; i < search_len; i++) {
-    bool found = compare_operand_to(pattern_i, search_cp, i);
+    bool found = compare_bsme_to(pattern_i, search_cp, i);
     if (found) {
       return i;
     }
   }
   return -1;  // bootstrap specifier data not found; return unused index (-1)
-} // end find_matching_operand()
+} // end find_matching_bsme()
 
 
 #ifndef PRODUCT
@@ -2546,12 +2567,13 @@ void ConstantPool::print_entry_on(const int cp_index, outputStream* st) {
     case JVM_CONSTANT_Dynamic :
     case JVM_CONSTANT_DynamicInError :
       {
-        st->print("bootstrap_method_index=%d", bootstrap_method_ref_index_at(cp_index));
+        auto bsme = bootstrap_methods_attribute_entry(cp_index);
+        st->print("bootstrap_method_index=%d", bsme->bootstrap_method_index());
         st->print(" type_index=%d", bootstrap_name_and_type_ref_index_at(cp_index));
-        int argc = bootstrap_argument_count_at(cp_index);
+        int argc = bsme->argument_count();
         if (argc > 0) {
           for (int arg_i = 0; arg_i < argc; arg_i++) {
-            int arg = bootstrap_argument_index_at(cp_index, arg_i);
+            int arg = bsme->argument_index(arg_i);
             st->print((arg_i == 0 ? " arguments={%d" : ", %d"), arg);
           }
           st->print("}");
@@ -2560,12 +2582,13 @@ void ConstantPool::print_entry_on(const int cp_index, outputStream* st) {
       break;
     case JVM_CONSTANT_InvokeDynamic :
       {
-        st->print("bootstrap_method_index=%d", bootstrap_method_ref_index_at(cp_index));
+        auto bsme = bootstrap_methods_attribute_entry(cp_index);
+        st->print("bootstrap_method_index=%d", bsme->bootstrap_method_index());
         st->print(" name_and_type_index=%d", bootstrap_name_and_type_ref_index_at(cp_index));
-        int argc = bootstrap_argument_count_at(cp_index);
+        int argc = bsme->argument_count();
         if (argc > 0) {
           for (int arg_i = 0; arg_i < argc; arg_i++) {
-            int arg = bootstrap_argument_index_at(cp_index, arg_i);
+            int arg = bsme->argument_index(arg_i);
             st->print((arg_i == 0 ? " arguments={%d" : ", %d"), arg);
           }
           st->print("}");
@@ -2583,7 +2606,7 @@ void ConstantPool::print_value_on(outputStream* st) const {
   assert(is_constantPool(), "must be constantPool");
   st->print("constant pool [%d]", length());
   if (has_preresolution()) st->print("/preresolution");
-  if (operands() != nullptr)  st->print("/operands[%d]", operands()->length());
+  st->print("/bsms[%d]", bsm_attribute_count());
   print_address_on(st);
   if (pool_holder() != nullptr) {
     st->print(" for ");

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -159,19 +159,6 @@ class SymbolicReference {
     return *this;
   }
 
-  #if 0 //@@REMOVE
-  // pseudo-constructor to create a field or method ref
-  SymbolicReference as_field_or_method_ref(constantTag tag, int klass_index) {
-    assert(tag.is_field_or_method(), "");
-    return as_triple_ref(tag, klass_index);
-  }
-  // pseudo-constructor to create an indy or condy specifier
-  SymbolicReference as_bootstrap_specifier_ref(constantTag tag, int bsme_index) {
-    assert(tag.has_bootstrap(), "");
-    return as_triple_ref(tag, bsme_index);
-  }
-  #endif //@@REMOVE
-
   // pseudo-constructor to create a MethodHandle ref
   SymbolicReference as_method_handle(constantTag tag, int ref_kind, int ref_index) {
     assert(!is_method_handle(), "");
@@ -633,8 +620,7 @@ class ConstantPool : public Metadata {
 
   // Unpacks a name&type pair.  Caller may add more data to the struct.
   SymbolicReference name_and_type_pair_at(int cp_index) {
-    assert(tag_at(cp_index).is_name_and_type(), "Corrupted constant pool"
-           " at %d", cp_index_after_error(cp_index));
+    assert(tag_at(cp_index).is_name_and_type(), "Corrupted constant pool");
     jint bits = *int_at_addr(cp_index);
     int name_index      = extract_low_short_from_int(bits);
     int signature_index = extract_high_short_from_int(bits);
@@ -651,8 +637,7 @@ class ConstantPool : public Metadata {
   }
   SymbolicReference method_handle_ref_at(int cp_index) {
     assert(tag_at(cp_index).is_method_handle() ||
-           tag_at(cp_index).is_method_handle_in_error(), "Corrupted constant pool"
-           " at %d", cp_index_after_error(cp_index));
+           tag_at(cp_index).is_method_handle_in_error(), "Corrupted constant pool");
     jint bits  = *int_at_addr(cp_index);
     int kind   = extract_low_short_from_int(bits);  // mask out unwanted ref_index bits
     int member = extract_high_short_from_int(bits);  // shift out unwanted ref_kind bits
@@ -668,8 +653,7 @@ class ConstantPool : public Metadata {
   // even a name&type.  But for better uniformity we will wrap it up.
   SymbolicReference method_type_ref_at(int cp_index) {
     assert(tag_at(cp_index).is_method_type() ||
-           tag_at(cp_index).is_method_type_in_error(), "Corrupted constant pool"
-           " at %d", cp_index_after_error(cp_index));
+           tag_at(cp_index).is_method_type_in_error(), "Corrupted constant pool");
     int signature_index = *int_at_addr(cp_index);
     auto tag = constantTag(JVM_CONSTANT_MethodType);
     return SymbolicReference(tag, signature_index);
@@ -764,10 +748,10 @@ class ConstantPool : public Metadata {
 
   // Lookup for entries consisting of (name_index, signature_index)
   u2 name_ref_index_at(int cp_index) {
-    return name_and_type_pair_at(cp_index).name_index();
+    return name_and_type_pair_at(cp_index).name_index();//@@KILL
   }
   u2 signature_ref_index_at(int cp_index) {
-    return name_and_type_pair_at(cp_index).signature_index();
+    return name_and_type_pair_at(cp_index).signature_index();//@@KILL
   }
 
   BasicType basic_type_for_signature_at(int cp_index) const;
@@ -876,13 +860,11 @@ private:
   // future by other Java code. These take constant pool indices rather than
   // constant pool cache indices as do the peer methods above.
   SymbolicReference uncached_field_or_method_ref_at(int cp_index) {
-    assert(tag_at(cp_index).is_field_or_method(), "Corrupted constant pool"
-           " at %d", cp_index_after_error(cp_index));
+    assert(tag_at(cp_index).is_field_or_method(), "Corrupted constant pool");
     return uncached_triple_ref_at(cp_index);
   }
   SymbolicReference uncached_bootstrap_specifier_ref_at(int cp_index) {
-    assert(tag_at(cp_index).has_bootstrap(), "Corrupted constant pool"
-           " at %d", cp_index_after_error(cp_index));
+    assert(tag_at(cp_index).has_bootstrap(), "Corrupted constant pool");
     return uncached_triple_ref_at(cp_index);
   }
   // A "triple" reference is a 3-tuple of (x, name, type), where x
@@ -891,8 +873,7 @@ private:
   // using common code.
   SymbolicReference uncached_triple_ref_at(int cp_index) {
     auto tag = tag_at(cp_index);
-    assert(tag.is_field_or_method() || tag.has_bootstrap(), "Corrupted constant pool"
-           " at %d", cp_index_after_error(cp_index));
+    assert(tag.is_field_or_method() || tag.has_bootstrap(), "Corrupted constant pool");
     jint ref_bits = *int_at_addr(cp_index);
     int ki =  extract_low_short_from_int(ref_bits);
     int nti = extract_high_short_from_int(ref_bits);
@@ -1022,8 +1003,6 @@ private:
   int  copy_cpool_bytes(int cpool_size,
                         SymbolHash* tbl,
                         unsigned char *bytes);
-
-  int cp_index_after_error(int cp_index);
 
  public:
   // Verify

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -77,6 +77,41 @@ public:
   }
 };
 
+// A single entry from a BootstrapMethods (BSM) attribute.
+// It is an overlaid view of two or more consuctive u2 words within the
+// ConstantPool::bsm_attribute_entries array.
+class BSMAttributeEntry {
+ private:
+  u2 _bootstrap_method_index;
+  u2 _argument_count;
+  // C++ does not have a "Flexible Array Member" feature.
+  //u2 _argument_indexes[_argument_count];
+  const u2* argument_indexes() const { return (const u2*)(this+1); }
+
+  // These are overlays on top of Array<u2> data.  Do not construct.
+  BSMAttributeEntry() { ShouldNotReachHere(); }
+
+  // See also parse_classfile_bootstrap_methods_attribute in the class
+  // file parser, which builds this layout.
+
+ public:
+  int bootstrap_method_index() const { return _bootstrap_method_index; }
+  int argument_count()         const { return _argument_count; }
+  int argument_index(int n)    const { assert((uint)n < _argument_count, "oob");
+                                       return argument_indexes()[n];
+                                     }
+ private:
+  // how to locate one of these inside a packed u2 data array:
+  static BSMAttributeEntry* entry_at_offset(Array<u2>* entries, int offset) {
+    assert(0 <= offset && offset+2 < entries->length(), "oob-1");
+    // do not bother to copy u2 data; just overlay the struct within the array
+    BSMAttributeEntry* bsme = (BSMAttributeEntry*) entries->adr_at(offset);
+    assert(offset+2+bsme->argument_count() <= entries->length(), "oob-2");
+    return bsme;
+  }
+  friend class ConstantPool;  // uses entry_at_offset
+};
+
 class ConstantPool : public Metadata {
   friend class VMStructs;
   friend class JVMCIVMStructs;
@@ -89,11 +124,14 @@ class ConstantPool : public Metadata {
   Array<u1>*           _tags;        // the tag array describing the constant pool's contents
   ConstantPoolCache*   _cache;       // the cache holding interpreter runtime information
   InstanceKlass*       _pool_holder; // the corresponding class
-  Array<u2>*           _operands;    // for variable-sized (InvokeDynamic) nodes, usually empty
 
   // Consider using an array of compressed klass pointers to
   // save space on 64-bit platforms.
   Array<Klass*>*       _resolved_klasses;
+
+  // Support for indy/condy BootstrapMethods attribute, with variable-sized entries
+  Array<u4>*           _bsm_attribute_offsets;  // offsets to the BSMAEs
+  Array<u2>*           _bsm_attribute_entries;  // BSMAttributeEntry structs (variable-sized)
 
   u2              _major_version;        // major version number of class file
   u2              _minor_version;        // minor version number of class file
@@ -130,7 +168,8 @@ class ConstantPool : public Metadata {
 
   u1* tag_addr_at(int cp_index) const            { return tags()->adr_at(cp_index); }
 
-  void set_operands(Array<u2>* operands)       { _operands = operands; }
+  void set_bsm_attribute_offsets(Array<u4>* offs) { _bsm_attribute_offsets = offs; }
+  void set_bsm_attribute_entries(Array<u2>* data) { _bsm_attribute_entries = data; }
 
   u2 flags() const                             { return _flags; }
   void set_flags(u2 f)                         { _flags = f; }
@@ -172,7 +211,8 @@ class ConstantPool : public Metadata {
   virtual bool is_constantPool() const      { return true; }
 
   Array<u1>* tags() const                   { return _tags; }
-  Array<u2>* operands() const               { return _operands; }
+  Array<u2>* bsm_attribute_entries() const  { return _bsm_attribute_entries; }
+  Array<u4>* bsm_attribute_offsets() const  { return _bsm_attribute_offsets; }
 
   bool has_preresolution() const            { return (_flags & _has_preresolution) != 0; }
   void set_has_preresolution() {
@@ -254,11 +294,6 @@ class ConstantPool : public Metadata {
   void allocate_resolved_klasses(ClassLoaderData* loader_data, int num_klasses, TRAPS);
   void initialize_unresolved_klasses(ClassLoaderData* loader_data, TRAPS);
 
-  // Given the per-instruction index of an indy instruction, report the
-  // main constant pool entry for its bootstrap specifier.
-  // From there, uncached_name/signature_ref_at will get the name/type.
-  inline u2 invokedynamic_bootstrap_ref_index_at(int indy_index) const;
-
   // Assembly code support
   static ByteSize tags_offset()         { return byte_offset_of(ConstantPool, _tags); }
   static ByteSize cache_offset()        { return byte_offset_of(ConstantPool, _cache); }
@@ -295,14 +330,14 @@ class ConstantPool : public Metadata {
     *int_at_addr(cp_index) = ref_index;
   }
 
-  void dynamic_constant_at_put(int cp_index, int bsms_attribute_index, int name_and_type_index) {
+  void dynamic_constant_at_put(int cp_index, int bsm_attribute_index, int name_and_type_index) {
     tag_at_put(cp_index, JVM_CONSTANT_Dynamic);
-    *int_at_addr(cp_index) = ((jint) name_and_type_index<<16) | bsms_attribute_index;
+    *int_at_addr(cp_index) = ((jint) name_and_type_index<<16) | bsm_attribute_index;
   }
 
-  void invoke_dynamic_at_put(int cp_index, int bsms_attribute_index, int name_and_type_index) {
+  void invoke_dynamic_at_put(int cp_index, int bsm_attribute_index, int name_and_type_index) {
     tag_at_put(cp_index, JVM_CONSTANT_InvokeDynamic);
-    *int_at_addr(cp_index) = ((jint) name_and_type_index<<16) | bsms_attribute_index;
+    *int_at_addr(cp_index) = ((jint) name_and_type_index<<16) | bsm_attribute_index;
   }
 
   void unresolved_string_at_put(int cp_index, Symbol* s) {
@@ -520,122 +555,31 @@ class ConstantPool : public Metadata {
     assert(tag_at(cp_index).has_bootstrap(), "Corrupted constant pool");
     return extract_low_short_from_int(*int_at_addr(cp_index));
   }
-  int bootstrap_operand_base(int cp_index) {
-    int bsms_attribute_index = bootstrap_methods_attribute_index(cp_index);
-    return operand_offset_at(operands(), bsms_attribute_index);
+  BSMAttributeEntry* bsm_attribute_entry(int bsm_attribute_index) {
+    int offset = bsm_attribute_offsets()->at(bsm_attribute_index);
+    return BSMAttributeEntry::entry_at_offset(bsm_attribute_entries(), offset);
   }
-  // The first part of the operands array consists of an index into the second part.
-  // Extract a 32-bit index value from the first part.
-  static int operand_offset_at(Array<u2>* operands, int bsms_attribute_index) {
-    int n = (bsms_attribute_index * 2);
-    assert(n >= 0 && n+2 <= operands->length(), "oob");
-    // The first 32-bit index points to the beginning of the second part
-    // of the operands array.  Make sure this index is in the first part.
-    DEBUG_ONLY(int second_part = build_int_from_shorts(operands->at(0),
-                                                       operands->at(1)));
-    assert(second_part == 0 || n+2 <= second_part, "oob (2)");
-    int offset = build_int_from_shorts(operands->at(n+0),
-                                       operands->at(n+1));
-    // The offset itself must point into the second part of the array.
-    assert(offset == 0 || (offset >= second_part && offset <= operands->length()), "oob (3)");
-    return offset;
+  int bsm_attribute_count() const {
+    if (bsm_attribute_offsets() == nullptr)  return 0;  // just in case
+    return bsm_attribute_offsets()->length();
   }
-  static void operand_offset_at_put(Array<u2>* operands, int bsms_attribute_index, int offset) {
-    int n = bsms_attribute_index * 2;
-    assert(n >= 0 && n+2 <= operands->length(), "oob");
-    operands->at_put(n+0, extract_low_short_from_int(offset));
-    operands->at_put(n+1, extract_high_short_from_int(offset));
-  }
-  static int operand_array_length(Array<u2>* operands) {
-    if (operands == nullptr || operands->length() == 0)  return 0;
-    int second_part = operand_offset_at(operands, 0);
-    return (second_part / 2);
+  // convenience method, to perform a common extra indirection via CP entry:
+  BSMAttributeEntry* bootstrap_methods_attribute_entry(int cp_index) {
+    return bsm_attribute_entry(bootstrap_methods_attribute_index(cp_index));
   }
 
-#ifdef ASSERT
-  // operand tuples fit together exactly, end to end
-  static int operand_limit_at(Array<u2>* operands, int bsms_attribute_index) {
-    int nextidx = bsms_attribute_index + 1;
-    if (nextidx == operand_array_length(operands))
-      return operands->length();
-    else
-      return operand_offset_at(operands, nextidx);
-  }
-  int bootstrap_operand_limit(int cp_index) {
-    int bsms_attribute_index = bootstrap_methods_attribute_index(cp_index);
-    return operand_limit_at(operands(), bsms_attribute_index);
-  }
-#endif //ASSERT
-
-  // Layout of InvokeDynamic and Dynamic bootstrap method specifier
-  // data in second part of operands array.  This encodes one record in
-  // the BootstrapMethods attribute.  The whole specifier also includes
-  // the name and type information from the main constant pool entry.
-  enum {
-         _indy_bsm_offset  = 0,  // CONSTANT_MethodHandle bsm
-         _indy_argc_offset = 1,  // u2 argc
-         _indy_argv_offset = 2   // u2 argv[argc]
-  };
-
-  // These functions are used in RedefineClasses for CP merge
-
-  int operand_offset_at(int bsms_attribute_index) {
-    assert(0 <= bsms_attribute_index &&
-           bsms_attribute_index < operand_array_length(operands()),
-           "Corrupted CP operands");
-    return operand_offset_at(operands(), bsms_attribute_index);
-  }
-  u2 operand_bootstrap_method_ref_index_at(int bsms_attribute_index) {
-    int offset = operand_offset_at(bsms_attribute_index);
-    return operands()->at(offset + _indy_bsm_offset);
-  }
-  u2 operand_argument_count_at(int bsms_attribute_index) {
-    int offset = operand_offset_at(bsms_attribute_index);
-    u2 argc = operands()->at(offset + _indy_argc_offset);
-    return argc;
-  }
-  u2 operand_argument_index_at(int bsms_attribute_index, int j) {
-    int offset = operand_offset_at(bsms_attribute_index);
-    return operands()->at(offset + _indy_argv_offset + j);
-  }
-  int operand_next_offset_at(int bsms_attribute_index) {
-    int offset = operand_offset_at(bsms_attribute_index) + _indy_argv_offset
-                   + operand_argument_count_at(bsms_attribute_index);
-    return offset;
-  }
-  // Compare a bootstrap specifier data in the operands arrays
-  bool compare_operand_to(int bsms_attribute_index1, const constantPoolHandle& cp2,
-                          int bsms_attribute_index2);
-  // Find a bootstrap specifier data in the operands array
-  int find_matching_operand(int bsms_attribute_index, const constantPoolHandle& search_cp,
-                            int operands_cur_len);
-  // Resize the operands array with delta_len and delta_size
-  void resize_operands(int delta_len, int delta_size, TRAPS);
-  // Extend the operands array with the length and size of the ext_cp operands
-  void extend_operands(const constantPoolHandle& ext_cp, TRAPS);
-  // Shrink the operands array to a smaller array with new_len length
-  void shrink_operands(int new_len, TRAPS);
-
-  u2 bootstrap_method_ref_index_at(int cp_index) {
-    assert(tag_at(cp_index).has_bootstrap(), "Corrupted constant pool");
-    int op_base = bootstrap_operand_base(cp_index);
-    return operands()->at(op_base + _indy_bsm_offset);
-  }
-  u2 bootstrap_argument_count_at(int cp_index) {
-    assert(tag_at(cp_index).has_bootstrap(), "Corrupted constant pool");
-    int op_base = bootstrap_operand_base(cp_index);
-    u2 argc = operands()->at(op_base + _indy_argc_offset);
-    DEBUG_ONLY(int end_offset = op_base + _indy_argv_offset + argc;
-               int next_offset = bootstrap_operand_limit(cp_index));
-    assert(end_offset == next_offset, "matched ending");
-    return argc;
-  }
-  u2 bootstrap_argument_index_at(int cp_index, int j) {
-    int op_base = bootstrap_operand_base(cp_index);
-    DEBUG_ONLY(int argc = operands()->at(op_base + _indy_argc_offset));
-    assert((uint)j < (uint)argc, "oob");
-    return operands()->at(op_base + _indy_argv_offset + j);
-  }
+  // Compare BSM attribute entries between two CPs
+  bool compare_bsme_to(int bsme_index1, const constantPoolHandle& cp2,
+                       int bsme_index2);
+  // Find a matching BSM attribute entries in another CP
+  int find_matching_bsme(int bsme_index, const constantPoolHandle& search_cp,
+                         int search_len);
+  // Resize the BSM data arrays with delta_len and delta_size
+  void resize_bsm_data(int delta_len, int delta_size, TRAPS);
+  // Extend the BSM data arrays with the length and size of the BSM data in ext_cp
+  void extend_bsm_data(const constantPoolHandle& ext_cp, TRAPS);
+  // Shrink the BSM data arrays to a smaller array with new_len length
+  void shrink_bsm_data(int new_len, TRAPS);
 
   // The following methods (name/signature/klass_ref_at, klass_ref_at_noresolve,
   // name_and_type_ref_index_at) all expect to be passed indices obtained
@@ -723,12 +667,13 @@ private:
     return resolve_constant_at_impl(h_this, cp_index, _possible_index_sentinel, &found_it, THREAD);
   }
 
-  void copy_bootstrap_arguments_at(int cp_index,
+  void copy_bootstrap_arguments_at(int bsme_index,
                                    int start_arg, int end_arg,
                                    objArrayHandle info, int pos,
                                    bool must_resolve, Handle if_not_available, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    copy_bootstrap_arguments_at_impl(h_this, cp_index, start_arg, end_arg,
+    copy_bootstrap_arguments_at_impl(h_this, bsme_index,
+                                     start_arg, end_arg,
                                      info, pos, must_resolve, if_not_available, THREAD);
   }
 
@@ -822,7 +767,8 @@ private:
 
   static oop resolve_constant_at_impl(const constantPoolHandle& this_cp, int cp_index, int cache_index,
                                       bool* status_return, TRAPS);
-  static void copy_bootstrap_arguments_at_impl(const constantPoolHandle& this_cp, int cp_index,
+  static void copy_bootstrap_arguments_at_impl(const constantPoolHandle& this_cp,
+                                               int bsme_index,
                                                int start_arg, int end_arg,
                                                objArrayHandle info, int pos,
                                                bool must_resolve, Handle if_not_available, TRAPS);
@@ -842,7 +788,7 @@ private:
   }
   static void copy_cp_to_impl(const constantPoolHandle& from_cp, int start_cpi, int end_cpi, const constantPoolHandle& to_cp, int to_cpi, TRAPS);
   static void copy_entry_to(const constantPoolHandle& from_cp, int from_cpi, const constantPoolHandle& to_cp, int to_cpi);
-  static void copy_operands(const constantPoolHandle& from_cp, const constantPoolHandle& to_cp, TRAPS);
+  static void copy_bsm_data(const constantPoolHandle& from_cp, const constantPoolHandle& to_cp, TRAPS);
   int  find_matching_entry(int pattern_i, const constantPoolHandle& search_cp);
   int  version() const                    { return _saved._version; }
   void set_version(int version)           { _saved._version = version; }

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -68,10 +68,6 @@ inline oop ConstantPool::appendix_if_resolved(int method_index) const {
   return resolved_reference_at(ref_index);
 }
 
-inline u2 ConstantPool::invokedynamic_bootstrap_ref_index_at(int indy_index) const {
-  return cache()->resolved_indy_entry_at(indy_index)->constant_pool_index();
-}
-
 inline ResolvedIndyEntry* ConstantPool::resolved_indy_entry_at(int index) {
   return cache()->resolved_indy_entry_at(index);
 }

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -36,13 +36,9 @@
 inline Klass* ConstantPool::resolved_klass_at(int which) const {  // Used by Compiler
   guarantee(tag_at(which).is_klass(), "Corrupted constant pool"
             DEBUG_ONLY(" [%d]" COMMA which));
-  // Must do an acquire here in case another thread resolved the klass
-  // behind our back, lest we later load stale values thru the oop.
   CPKlassSlot kslot = klass_slot_at(which);
   assert(tag_at(kslot.name_index()).is_symbol(), "sanity");
-
-  Klass** adr = resolved_klasses()->adr_at(kslot.resolved_klass_index());
-  return Atomic::load_acquire(adr);
+  return resolved_klass_at_acquire(kslot.resolved_klass_index());
 }
 
 inline ResolvedFieldEntry* ConstantPool::resolved_field_entry_at(int field_index) {

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -34,7 +34,8 @@
 #include "runtime/atomic.hpp"
 
 inline Klass* ConstantPool::resolved_klass_at(int which) const {  // Used by Compiler
-  guarantee(tag_at(which).is_klass(), "Corrupted constant pool");
+  guarantee(tag_at(which).is_klass(), "Corrupted constant pool"
+            DEBUG_ONLY(" [%d]" COMMA which));
   // Must do an acquire here in case another thread resolved the klass
   // behind our back, lest we later load stale values thru the oop.
   CPKlassSlot kslot = klass_slot_at(which);

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -33,15 +33,7 @@
 #include "oops/resolvedMethodEntry.hpp"
 #include "runtime/atomic.hpp"
 
-inline Klass* ConstantPool::resolved_klass_at(int which) const {  // Used by Compiler
-  guarantee(tag_at(which).is_klass(), "Corrupted constant pool"
-            DEBUG_ONLY(" [%d]" COMMA which));
-  CPKlassSlot kslot = klass_slot_at(which);
-  assert(tag_at(kslot.name_index()).is_symbol(), "sanity");
-  return resolved_klass_at_acquire(kslot.resolved_klass_index());
-}
-
-inline ResolvedFieldEntry* ConstantPool::resolved_field_entry_at(int field_index) {
+inline ResolvedFieldEntry* ConstantPool::resolved_field_entry_at(int field_index) const {
     return cache()->resolved_field_entry_at(field_index);
 }
 
@@ -49,7 +41,7 @@ inline int ConstantPool::resolved_field_entries_length() const {
     return cache()->resolved_field_entries_length();
 }
 
-inline ResolvedMethodEntry* ConstantPool::resolved_method_entry_at(int method_index) {
+inline ResolvedMethodEntry* ConstantPool::resolved_method_entry_at(int method_index) const {
     return cache()->resolved_method_entry_at(method_index);
 }
 
@@ -65,7 +57,7 @@ inline oop ConstantPool::appendix_if_resolved(int method_index) const {
   return resolved_reference_at(ref_index);
 }
 
-inline ResolvedIndyEntry* ConstantPool::resolved_indy_entry_at(int index) {
+inline ResolvedIndyEntry* ConstantPool::resolved_indy_entry_at(int index) const {
   return cache()->resolved_indy_entry_at(index);
 }
 

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -520,7 +520,8 @@ void ConstantPoolCache::remove_resolved_indy_entries_if_non_deterministic() {
       LogStreamHandle(Trace, cds, resolve) log;
       if (log.is_enabled()) {
         ResourceMark rm;
-        int bsm = cp->bootstrap_method_ref_index_at(cp_index);
+        int bsms_attribute_index = cp->bootstrap_methods_attribute_index(cp_index);
+        int bsm = cp->bsm_attribute_entry(bsms_attribute_index)->bootstrap_method_index();
         int bsm_ref = cp->method_handle_index_at(bsm);
         Symbol* bsm_name = cp->uncached_name_ref_at(bsm_ref);
         Symbol* bsm_signature = cp->uncached_signature_ref_at(bsm_ref);
@@ -809,7 +810,7 @@ oop ConstantPoolCache::set_dynamic_call(const CallInfo &call_info, int index) {
 
   // Populate entry with resolved information
   assert(resolved_indy_entries() != nullptr, "Invokedynamic array is empty, cannot fill with resolved information");
-  resolved_indy_entry_at(index)->fill_in(adapter, adapter->size_of_parameters(), as_TosState(adapter->result_type()), has_appendix);
+  resolved_indy_entry_at(index)->fill_in(adapter, has_appendix);
 
   if (log_stream != nullptr) {
     resolved_indy_entry_at(index)->print_on(log_stream);

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -522,7 +522,7 @@ void ConstantPoolCache::remove_resolved_indy_entries_if_non_deterministic() {
       LogStreamHandle(Trace, cds, resolve) log;
       if (log.is_enabled()) {
         ResourceMark rm;
-        BSReference indy(cp, cp_index);
+        BootstrapReference indy(cp, cp_index);
         BSMAttributeEntry* bsme    = indy.bsme(cp);
         MethodHandleReference bsmh = bsme->bootstrap_method(cp);
         Symbol* bsm_name           = bsmh.name(cp);

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -363,7 +363,7 @@ Method* ConstantPoolCache::method_if_resolved(int method_index) const {
       return method_entry->method();
     } else {
       int cp_index = method_entry->constant_pool_index();
-      auto mref = constant_pool()->uncached_field_or_method_ref_at(cp_index);
+      FMReference mref(constant_pool(), cp_index);
       int holder_index = mref.klass_index();
       if (constant_pool()->tag_at(holder_index).is_klass()) {
         Klass* klass = constant_pool()->resolved_klass_at(holder_index);
@@ -442,7 +442,7 @@ void ConstantPoolCache::remove_resolved_field_entries_if_non_deterministic() {
       LogStreamHandle(Trace, cds, resolve) log;
       if (log.is_enabled()) {
         ResourceMark rm;
-        auto fref = cp->uncached_field_or_method_ref_at(cp_index);
+        FMReference fref(cp, cp_index);
         Symbol* klass_name = fref.klass_name(cp);
         Symbol* name      = fref.name(cp);
         Symbol* signature = fref.signature(cp);
@@ -482,7 +482,7 @@ void ConstantPoolCache::remove_resolved_method_entries_if_non_deterministic() {
       LogStreamHandle(Trace, cds, resolve) log;
       if (log.is_enabled()) {
         ResourceMark rm;
-        auto mref = cp->uncached_field_or_method_ref_at(cp_index);
+        FMReference mref(cp, cp_index);
         Symbol* klass_name = mref.klass_name(cp);
         Symbol* name      = mref.name(cp);
         Symbol* signature = mref.signature(cp);
@@ -522,12 +522,12 @@ void ConstantPoolCache::remove_resolved_indy_entries_if_non_deterministic() {
       LogStreamHandle(Trace, cds, resolve) log;
       if (log.is_enabled()) {
         ResourceMark rm;
-        auto indy = cp->uncached_bootstrap_specifier_ref_at(cp_index);
-        auto bsme = indy.bsme(cp);
-        auto bsmh = bsme->bootstrap_method(cp);
-        Symbol* bsm_name      = bsmh.name(cp);
-        Symbol* bsm_signature = bsmh.signature(cp);
-        Symbol* bsm_klass     = bsmh.klass_name(cp);
+        BSReference indy(cp, cp_index);
+        BSMAttributeEntry* bsme    = indy.bsme(cp);
+        MethodHandleReference bsmh = bsme->bootstrap_method(cp);
+        Symbol* bsm_name           = bsmh.name(cp);
+        Symbol* bsm_signature      = bsmh.signature(cp);
+        Symbol* bsm_klass          = bsmh.klass_name(cp);
         log.print("%s indy   CP entry [%3d]: %s (%d)",
                   (archived ? "archived" : "reverted"),
                   cp_index, cp->pool_holder()->name()->as_C_string(), i);

--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -1319,9 +1319,8 @@ void GenerateOopMap::print_current_state(outputStream   *os,
     case Bytecodes::_invokeinterface: {
       int idx = currentBC->has_index_u4() ? currentBC->get_index_u4() : currentBC->get_index_u2();
       ConstantPool* cp      = method()->constants();
-      int nameAndTypeIdx    = cp->name_and_type_ref_index_at(idx, currentBC->code());
-      int signatureIdx      = cp->signature_ref_index_at(nameAndTypeIdx);
-      Symbol* signature     = cp->symbol_at(signatureIdx);
+      SymbolicReference ref = cp->from_bytecode_ref_at(idx, currentBC->code());
+      Symbol* signature     = ref.signature(cp);
       os->print("%s", signature->as_C_string());
     }
     default:
@@ -1932,10 +1931,8 @@ int GenerateOopMap::copy_cts(CellTypeState *dst, CellTypeState *src) {
 
 void GenerateOopMap::do_field(int is_get, int is_static, int idx, int bci, Bytecodes::Code bc) {
   // Dig up signature for field in constant pool
-  ConstantPool* cp     = method()->constants();
-  int nameAndTypeIdx     = cp->name_and_type_ref_index_at(idx, bc);
-  int signatureIdx       = cp->signature_ref_index_at(nameAndTypeIdx);
-  Symbol* signature      = cp->symbol_at(signatureIdx);
+  ConstantPool* cp  = method()->constants();
+  Symbol* signature = cp->from_bytecode_ref_at(idx, bc).signature(cp);
 
   CellTypeState temp[4];
   CellTypeState *eff  = signature_to_effect(signature, bci, temp);
@@ -1958,8 +1955,8 @@ void GenerateOopMap::do_field(int is_get, int is_static, int idx, int bci, Bytec
 
 void GenerateOopMap::do_method(int is_static, int is_interface, int idx, int bci, Bytecodes::Code bc) {
  // Dig up signature for field in constant pool
-  ConstantPool* cp  = _method->constants();
-  Symbol* signature   = cp->signature_ref_at(idx, bc);
+  ConstantPool* cp  = method()->constants();
+  Symbol* signature = cp->from_bytecode_ref_at(idx, bc).signature(cp);
 
   // Parse method signature
   CellTypeState out[4];

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -935,7 +935,8 @@ bool Method::is_klass_loaded_by_klass_index(int klass_index) const {
 
 
 bool Method::is_klass_loaded(int refinfo_index, Bytecodes::Code bc, bool must_be_resolved) const {
-  int klass_index = constants()->from_bytecode_ref_at(refinfo_index, bc).klass_index();
+  FMReference mref(constants(), refinfo_index, bc);
+  int klass_index = mref.klass_index();
   if (must_be_resolved) {
     // Make sure klass is resolved in constantpool.
     if (constants()->tag_at(klass_index).is_unresolved_klass()) return false;

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -935,7 +935,7 @@ bool Method::is_klass_loaded_by_klass_index(int klass_index) const {
 
 
 bool Method::is_klass_loaded(int refinfo_index, Bytecodes::Code bc, bool must_be_resolved) const {
-  int klass_index = constants()->klass_ref_index_at(refinfo_index, bc);
+  int klass_index = constants()->from_bytecode_ref_at(refinfo_index, bc).klass_index();
   if (must_be_resolved) {
     // Make sure klass is resolved in constantpool.
     if (constants()->tag_at(klass_index).is_unresolved_klass()) return false;

--- a/src/hotspot/share/oops/resolvedIndyEntry.cpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.cpp
@@ -27,6 +27,20 @@
 #include "oops/method.hpp"
 #include "oops/resolvedIndyEntry.hpp"
 
+u2 ResolvedIndyEntry::name_index(ConstantPool* cp) const {
+  int nti = cp->uncached_name_and_type_ref_index_at(constant_pool_index());
+  return cp->name_ref_index_at(nti);
+}
+
+u2 ResolvedIndyEntry::signature_index(ConstantPool* cp) const {
+  int nti = cp->uncached_name_and_type_ref_index_at(constant_pool_index());
+  return cp->signature_ref_index_at(nti);
+}
+
+u2 ResolvedIndyEntry::bsme_index(ConstantPool* cp) const {
+  return cp->bootstrap_methods_attribute_index(constant_pool_index());
+}
+
 bool ResolvedIndyEntry::check_no_old_or_obsolete_entry() {
   // return false if m refers to a non-deleted old or obsolete method
   if (_method != nullptr) {
@@ -39,11 +53,8 @@ bool ResolvedIndyEntry::check_no_old_or_obsolete_entry() {
 
 #if INCLUDE_CDS
 void ResolvedIndyEntry::remove_unshareable_info() {
-  u2 saved_resolved_references_index = _resolved_references_index;
-  u2 saved_cpool_index = _cpool_index;
-  memset(this, 0, sizeof(*this));
-  _resolved_references_index = saved_resolved_references_index;
-  _cpool_index = saved_cpool_index;
+  _method = nullptr;  // resolution sets this pointer; the rest is static
+  _flags &= ~(1 << resolution_failed_shift);
 }
 
 void ResolvedIndyEntry::mark_and_relocate() {

--- a/src/hotspot/share/oops/resolvedIndyEntry.cpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.cpp
@@ -28,17 +28,17 @@
 #include "oops/resolvedIndyEntry.hpp"
 
 u2 ResolvedIndyEntry::name_index(ConstantPool* cp) const {
-  auto indy = cp->uncached_bootstrap_specifier_ref_at(constant_pool_index());
+  BSReference indy(cp, constant_pool_index());
   return indy.name_index();
 }
 
 u2 ResolvedIndyEntry::signature_index(ConstantPool* cp) const {
-  auto indy = cp->uncached_bootstrap_specifier_ref_at(constant_pool_index());
+  BSReference indy(cp, constant_pool_index());
   return indy.signature_index();
 }
 
 u2 ResolvedIndyEntry::bsme_index(ConstantPool* cp) const {
-  auto indy = cp->uncached_bootstrap_specifier_ref_at(constant_pool_index());
+  BSReference indy(cp, constant_pool_index());
   return indy.bsme_index();
 }
 

--- a/src/hotspot/share/oops/resolvedIndyEntry.cpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.cpp
@@ -28,17 +28,17 @@
 #include "oops/resolvedIndyEntry.hpp"
 
 u2 ResolvedIndyEntry::name_index(ConstantPool* cp) const {
-  BSReference indy(cp, constant_pool_index());
+  BootstrapReference indy(cp, constant_pool_index());
   return indy.name_index();
 }
 
 u2 ResolvedIndyEntry::signature_index(ConstantPool* cp) const {
-  BSReference indy(cp, constant_pool_index());
+  BootstrapReference indy(cp, constant_pool_index());
   return indy.signature_index();
 }
 
 u2 ResolvedIndyEntry::bsme_index(ConstantPool* cp) const {
-  BSReference indy(cp, constant_pool_index());
+  BootstrapReference indy(cp, constant_pool_index());
   return indy.bsme_index();
 }
 

--- a/src/hotspot/share/oops/resolvedIndyEntry.cpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.cpp
@@ -28,17 +28,18 @@
 #include "oops/resolvedIndyEntry.hpp"
 
 u2 ResolvedIndyEntry::name_index(ConstantPool* cp) const {
-  int nti = cp->uncached_name_and_type_ref_index_at(constant_pool_index());
-  return cp->name_ref_index_at(nti);
+  auto indy = cp->uncached_bootstrap_specifier_ref_at(constant_pool_index());
+  return indy.name_index();
 }
 
 u2 ResolvedIndyEntry::signature_index(ConstantPool* cp) const {
-  int nti = cp->uncached_name_and_type_ref_index_at(constant_pool_index());
-  return cp->signature_ref_index_at(nti);
+  auto indy = cp->uncached_bootstrap_specifier_ref_at(constant_pool_index());
+  return indy.signature_index();
 }
 
 u2 ResolvedIndyEntry::bsme_index(ConstantPool* cp) const {
-  return cp->bootstrap_methods_attribute_index(constant_pool_index());
+  auto indy = cp->uncached_bootstrap_specifier_ref_at(constant_pool_index());
+  return indy.bsme_index();
 }
 
 bool ResolvedIndyEntry::check_no_old_or_obsolete_entry() {

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3674,14 +3674,11 @@ JVM_ENTRY(jobjectArray, JVM_GetEnclosingMethodInfo(JNIEnv *env, jclass ofClass))
   dest->obj_at_put(0, enc_k->java_mirror());
   int encl_method_method_idx = ik->enclosing_method_method_index();
   if (encl_method_method_idx != 0) {
-    Symbol* sym = ik->constants()->symbol_at(
-                        extract_low_short_from_int(
-                          ik->constants()->name_and_type_at(encl_method_method_idx)));
+    auto nt = ik->constants()->name_and_type_pair_at(encl_method_method_idx);
+    Symbol* sym = nt.name(ik->constants());
     Handle str = java_lang_String::create_from_symbol(sym, CHECK_NULL);
     dest->obj_at_put(1, str());
-    sym = ik->constants()->symbol_at(
-              extract_high_short_from_int(
-                ik->constants()->name_and_type_at(encl_method_method_idx)));
+    sym = nt.signature(ik->constants());
     str = java_lang_String::create_from_symbol(sym, CHECK_NULL);
     dest->obj_at_put(2, str());
   }

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -389,14 +389,17 @@ void JvmtiClassFileReconstituter::write_annotations_attribute(const char* attr_n
 //    } bootstrap_methods[num_bootstrap_methods];
 //  }
 void JvmtiClassFileReconstituter::write_bootstrapmethod_attribute() {
-  Array<u2>* operands = cpool()->operands();
   write_attribute_name_index("BootstrapMethods");
-  int num_bootstrap_methods = ConstantPool::operand_array_length(operands);
+
+  const auto bsm_offs = cpool()->bsm_attribute_offsets();
+  const auto bsm_data = cpool()->bsm_attribute_entries();
+  int num_bootstrap_methods = bsm_offs->length();
 
   // calculate length of attribute
   u4 length = sizeof(u2); // num_bootstrap_methods
   for (int n = 0; n < num_bootstrap_methods; n++) {
-    u2 num_bootstrap_arguments = cpool()->operand_argument_count_at(n);
+    auto bsme = cpool()->bsm_attribute_entry(n);
+    u2 num_bootstrap_arguments = bsme->argument_count();
     length += sizeof(u2); // bootstrap_method_ref
     length += sizeof(u2); // num_bootstrap_arguments
     length += (u4)sizeof(u2) * num_bootstrap_arguments; // bootstrap_arguments[num_bootstrap_arguments]
@@ -406,13 +409,12 @@ void JvmtiClassFileReconstituter::write_bootstrapmethod_attribute() {
   // write attribute
   write_u2(checked_cast<u2>(num_bootstrap_methods));
   for (int n = 0; n < num_bootstrap_methods; n++) {
-    u2 bootstrap_method_ref = cpool()->operand_bootstrap_method_ref_index_at(n);
-    u2 num_bootstrap_arguments = cpool()->operand_argument_count_at(n);
-    write_u2(bootstrap_method_ref);
+    auto bsme = cpool()->bsm_attribute_entry(n);
+    u2 num_bootstrap_arguments = bsme->argument_count();
+    write_u2(bsme->bootstrap_method_index());
     write_u2(num_bootstrap_arguments);
     for (int arg = 0; arg < num_bootstrap_arguments; arg++) {
-      u2 bootstrap_argument = cpool()->operand_argument_index_at(n, arg);
-      write_u2(bootstrap_argument);
+      write_u2(bsme->argument_index(arg));
     }
   }
 }
@@ -798,7 +800,7 @@ void JvmtiClassFileReconstituter::write_class_attributes() {
   if (type_anno != nullptr) {
     ++attr_count;     // has RuntimeVisibleTypeAnnotations attribute
   }
-  if (cpool()->operands() != nullptr) {
+  if (cpool()->bsm_attribute_count() != 0) {
     ++attr_count;
   }
   if (ik()->nest_host_index() != 0) {
@@ -843,7 +845,7 @@ void JvmtiClassFileReconstituter::write_class_attributes() {
   if (ik()->record_components() != nullptr) {
     write_record_attribute();
   }
-  if (cpool()->operands() != nullptr) {
+  if (cpool()->bsm_attribute_count() != 0) {
     write_bootstrapmethod_attribute();
   }
   if (inner_classes_length > 0) {

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -399,7 +399,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -414,7 +414,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p) += 2;
     } break;
@@ -433,7 +433,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -468,7 +468,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -521,7 +521,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -540,7 +540,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -560,7 +560,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -569,18 +569,18 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     case JVM_CONSTANT_Dynamic:  // fall through
     case JVM_CONSTANT_InvokeDynamic:
     {
-      // Index of the bootstrap specifier in the operands array
-      int old_bs_i = scratch_cp->bootstrap_methods_attribute_index(scratch_i);
-      int new_bs_i = find_or_append_operand(scratch_cp, old_bs_i, merge_cp_p,
-                                            merge_cp_length_p);
+      // Index of the bootstrap specifier in the BSM data arrays
+      int old_bsme_i = scratch_cp->bootstrap_methods_attribute_index(scratch_i);
+      int new_bsme_i = find_or_append_bsm_data(scratch_cp, old_bsme_i, merge_cp_p,
+                                               merge_cp_length_p);
       // The bootstrap method NameAndType_info index
       int old_ref_i = scratch_cp->bootstrap_name_and_type_ref_index_at(scratch_i);
       int new_ref_i = find_or_append_indirect_entry(scratch_cp, old_ref_i, merge_cp_p,
                                                     merge_cp_length_p);
-      if (new_bs_i != old_bs_i) {
+      if (new_bsme_i != old_bsme_i) {
         log_trace(redefine, class, constantpool)
-          ("Dynamic entry@%d bootstrap_method_attr_index change: %d to %d",
-           *merge_cp_length_p, old_bs_i, new_bs_i);
+          ("Dynamic entry@%d BootstrapMethods entry change: %d to %d",
+           *merge_cp_length_p, old_bsme_i, new_bsme_i);
       }
       if (new_ref_i != old_ref_i) {
         log_trace(redefine, class, constantpool)
@@ -588,13 +588,13 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
       }
 
       if (scratch_cp->tag_at(scratch_i).is_dynamic_constant())
-        (*merge_cp_p)->dynamic_constant_at_put(*merge_cp_length_p, new_bs_i, new_ref_i);
+        (*merge_cp_p)->dynamic_constant_at_put(*merge_cp_length_p, new_bsme_i, new_ref_i);
       else
-        (*merge_cp_p)->invoke_dynamic_at_put(*merge_cp_length_p, new_bs_i, new_ref_i);
+        (*merge_cp_p)->invoke_dynamic_at_put(*merge_cp_length_p, new_bsme_i, new_ref_i);
       if (scratch_i != *merge_cp_length_p) {
         // The new entry in *merge_cp_p is at a different index than
         // the new entry in scratch_cp so we need to map the index values.
-        map_index(scratch_cp, scratch_i, *merge_cp_length_p);
+        map_cp_index(scratch_cp, scratch_i, *merge_cp_length_p);
       }
       (*merge_cp_length_p)++;
     } break;
@@ -639,7 +639,7 @@ u2 VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& s
       guarantee(found_i != ref_i, "compare_entry_to() and find_matching_entry() do not agree");
       // Found a matching entry somewhere else in *merge_cp_p so just need a mapping entry.
       new_ref_i = found_i;
-      map_index(scratch_cp, ref_i, found_i);
+      map_cp_index(scratch_cp, ref_i, found_i);
     } else {
       // no match found so we have to append this entry to *merge_cp_p
       append_entry(scratch_cp, ref_i, merge_cp_p, merge_cp_length_p);
@@ -656,101 +656,106 @@ u2 VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& s
 } // end find_or_append_indirect_entry()
 
 
-// Append a bootstrap specifier into the merge_cp operands that is semantically equal
-// to the scratch_cp operands bootstrap specifier passed by the old_bs_i index.
+// Append a BSM attribute entry into merge_cp that is semantically equal
+// to the scratch_cp BSM entry passed by the old_bsme_i index.
 // Recursively append new merge_cp entries referenced by the new bootstrap specifier.
-void VM_RedefineClasses::append_operand(const constantPoolHandle& scratch_cp, int old_bs_i,
+void VM_RedefineClasses::append_bsm_data(const constantPoolHandle& scratch_cp, int old_bsme_i,
        constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
-  u2 old_ref_i = scratch_cp->operand_bootstrap_method_ref_index_at(old_bs_i);
+  const auto old_bsme = scratch_cp->bsm_attribute_entry(old_bsme_i);
+  u2 old_ref_i = old_bsme->bootstrap_method_index();
   u2 new_ref_i = find_or_append_indirect_entry(scratch_cp, old_ref_i, merge_cp_p,
                                                merge_cp_length_p);
   if (new_ref_i != old_ref_i) {
     log_trace(redefine, class, constantpool)
-      ("operands entry@%d bootstrap method ref_index change: %d to %d", _operands_cur_length, old_ref_i, new_ref_i);
+      ("bsm_data entry@%d bootstrap method ref_index change: %d to %d", _bsm_data_cur_length, old_ref_i, new_ref_i);
   }
 
-  Array<u2>* merge_ops = (*merge_cp_p)->operands();
-  int new_bs_i = _operands_cur_length;
-  // We have _operands_cur_length == 0 when the merge_cp operands is empty yet.
-  // However, the operand_offset_at(0) was set in the extend_operands() call.
-  int new_base = (new_bs_i == 0) ? (*merge_cp_p)->operand_offset_at(0)
-                                 : (*merge_cp_p)->operand_next_offset_at(new_bs_i - 1);
-  u2 argc      = scratch_cp->operand_argument_count_at(old_bs_i);
+  const auto merge_offs = (*merge_cp_p)->bsm_attribute_offsets();
+  const auto merge_data = (*merge_cp_p)->bsm_attribute_entries();
 
-  ConstantPool::operand_offset_at_put(merge_ops, _operands_cur_length, new_base);
-  merge_ops->at_put(new_base++, new_ref_i);
-  merge_ops->at_put(new_base++, argc);
+  int new_bsme_i = _bsm_data_cur_length;
+  int new_base   = _bsm_data_next_offset;
+  u2 argc        = old_bsme->argument_count();
+
+  merge_offs->at_put(new_bsme_i, new_base);
+  merge_data->at_put(new_base++, new_ref_i);
+  merge_data->at_put(new_base++, argc);
 
   for (int i = 0; i < argc; i++) {
-    u2 old_arg_ref_i = scratch_cp->operand_argument_index_at(old_bs_i, i);
+    u2 old_arg_ref_i = old_bsme->argument_index(i);
     u2 new_arg_ref_i = find_or_append_indirect_entry(scratch_cp, old_arg_ref_i, merge_cp_p,
                                                      merge_cp_length_p);
-    merge_ops->at_put(new_base++, new_arg_ref_i);
+    merge_data->at_put(new_base++, new_arg_ref_i);
     if (new_arg_ref_i != old_arg_ref_i) {
       log_trace(redefine, class, constantpool)
-        ("operands entry@%d bootstrap method argument ref_index change: %d to %d",
-         _operands_cur_length, old_arg_ref_i, new_arg_ref_i);
+        ("bsm_data entry@%d bootstrap method argument ref_index change: %d to %d",
+         _bsm_data_cur_length, old_arg_ref_i, new_arg_ref_i);
     }
   }
-  if (old_bs_i != _operands_cur_length) {
+  if (old_bsme_i != _bsm_data_cur_length) {
     // The bootstrap specifier in *merge_cp_p is at a different index than
     // that in scratch_cp so we need to map the index values.
-    map_operand_index(old_bs_i, new_bs_i);
+    map_bsm_index(old_bsme_i, new_bsme_i);
   }
-  _operands_cur_length++;
-} // end append_operand()
+  _bsm_data_cur_length = new_bsme_i + 1;
+  _bsm_data_next_offset = new_base;
+} // end append_bsm_data()
 
 
-int VM_RedefineClasses::find_or_append_operand(const constantPoolHandle& scratch_cp,
-      int old_bs_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
+// Try to Find a BSM attribute entry in merge_cp that is semantically equal
+// to the scratch_cp BSM entry passed by the old_bsme_i index.
+// If none is found, call append_bsm_data to add one into merge_cp.
+int VM_RedefineClasses::find_or_append_bsm_data(const constantPoolHandle& scratch_cp,
+      int old_bsme_i, constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
-  int new_bs_i = old_bs_i; // bootstrap specifier index
-  bool match = (old_bs_i < _operands_cur_length) &&
-               scratch_cp->compare_operand_to(old_bs_i, *merge_cp_p, old_bs_i);
+  int new_bsme_i = old_bsme_i; // bootstrap specifier index
+  bool match = (old_bsme_i < _bsm_data_cur_length) &&
+               scratch_cp->compare_bsme_to(old_bsme_i, *merge_cp_p, old_bsme_i);
 
   if (!match) {
     // forward reference in *merge_cp_p or not a direct match
-    int found_i = scratch_cp->find_matching_operand(old_bs_i, *merge_cp_p,
-                                                    _operands_cur_length);
+    int found_i = scratch_cp->find_matching_bsme(old_bsme_i, *merge_cp_p,
+                                                    _bsm_data_cur_length);
     if (found_i != -1) {
-      guarantee(found_i != old_bs_i, "compare_operand_to() and find_matching_operand() disagree");
-      // found a matching operand somewhere else in *merge_cp_p so just need a mapping
-      new_bs_i = found_i;
-      map_operand_index(old_bs_i, found_i);
+      guarantee(found_i != old_bsme_i, "compare_bsme_to() and find_matching_bsme() disagree");
+      // found a matching bsme somewhere else in *merge_cp_p so just need a mapping
+      new_bsme_i = found_i;
+      map_bsm_index(old_bsme_i, found_i);
     } else {
       // no match found so we have to append this bootstrap specifier to *merge_cp_p
-      append_operand(scratch_cp, old_bs_i, merge_cp_p, merge_cp_length_p);
-      new_bs_i = _operands_cur_length - 1;
+      append_bsm_data(scratch_cp, old_bsme_i, merge_cp_p, merge_cp_length_p);
+      new_bsme_i = _bsm_data_cur_length - 1;
     }
   }
-  return new_bs_i;
-} // end find_or_append_operand()
+  return new_bsme_i;
+} // end find_or_append_bsm_data()
 
 
-void VM_RedefineClasses::finalize_operands_merge(const constantPoolHandle& merge_cp, TRAPS) {
-  if (merge_cp->operands() == nullptr) {
+void VM_RedefineClasses::finalize_bsm_data_merge(const constantPoolHandle& merge_cp, TRAPS) {
+  if (merge_cp->bsm_attribute_count() == 0) {
     return;
   }
-  // Shrink the merge_cp operands
-  merge_cp->shrink_operands(_operands_cur_length, CHECK);
+  // Shrink the merge_cp bsm_data
+  merge_cp->shrink_bsm_data(_bsm_data_cur_length, CHECK);
 
   if (log_is_enabled(Trace, redefine, class, constantpool)) {
     // don't want to loop unless we are tracing
     int count = 0;
-    for (int i = 1; i < _operands_index_map_p->length(); i++) {
-      int value = _operands_index_map_p->at(i);
+    for (int i = 1; i < _bsm_data_index_map_p->length(); i++) {
+      int value = _bsm_data_index_map_p->at(i);
       if (value != -1) {
-        log_trace(redefine, class, constantpool)("operands_index_map[%d]: old=%d new=%d", count, i, value);
+        log_trace(redefine, class, constantpool)("bsm_data_index_map[%d]: old=%d new=%d", count, i, value);
         count++;
       }
     }
   }
   // Clean-up
-  _operands_index_map_p = nullptr;
-  _operands_cur_length = 0;
-  _operands_index_map_count = 0;
-} // end finalize_operands_merge()
+  _bsm_data_index_map_p = nullptr;
+  _bsm_data_cur_length = 0;
+  _bsm_data_next_offset = 0;
+  _bsm_data_index_map_count = 0;
+} // end finalize_bsm_data_merge()
 
 // Symbol* comparator for qsort
 // The caller must have an active ResourceMark.
@@ -1240,7 +1245,7 @@ jvmtiError VM_RedefineClasses::compare_and_normalize_class_versions(
 // Find new constant pool index value for old constant pool index value
 // by searching the index map. Returns zero (0) if there is no mapped
 // value for the old constant pool index.
-u2 VM_RedefineClasses::find_new_index(int old_index) {
+u2 VM_RedefineClasses::find_new_cp_index(int old_index) {
   if (_index_map_count == 0) {
     // map is empty so nothing can be found
     return 0;
@@ -1262,32 +1267,32 @@ u2 VM_RedefineClasses::find_new_index(int old_index) {
   // constant pool indices are u2, unless the merged constant pool overflows which
   // we don't check for.
   return checked_cast<u2>(value);
-} // end find_new_index()
+} // end find_new_cp_index()
 
 
 // Find new bootstrap specifier index value for old bootstrap specifier index
 // value by searching the index map. Returns unused index (-1) if there is
 // no mapped value for the old bootstrap specifier index.
-int VM_RedefineClasses::find_new_operand_index(int old_index) {
-  if (_operands_index_map_count == 0) {
+int VM_RedefineClasses::find_new_bsm_index(int old_index) {
+  if (_bsm_data_index_map_count == 0) {
     // map is empty so nothing can be found
     return -1;
   }
 
-  if (old_index == -1 || old_index >= _operands_index_map_p->length()) {
+  if (old_index == -1 || old_index >= _bsm_data_index_map_p->length()) {
     // The old_index is out of range so it is not mapped.
     // This should not happen in regular constant pool merging use.
     return -1;
   }
 
-  int value = _operands_index_map_p->at(old_index);
+  int value = _bsm_data_index_map_p->at(old_index);
   if (value == -1) {
     // the old_index is not mapped
     return -1;
   }
 
   return value;
-} // end find_new_operand_index()
+} // end find_new_bsm_index()
 
 
 // The bug 6214132 caused the verification to fail.
@@ -1532,9 +1537,9 @@ jvmtiError VM_RedefineClasses::load_new_class_versions() {
 
 // Map old_index to new_index as needed. scratch_cp is only needed
 // for log calls.
-void VM_RedefineClasses::map_index(const constantPoolHandle& scratch_cp,
+void VM_RedefineClasses::map_cp_index(const constantPoolHandle& scratch_cp,
        int old_index, int new_index) {
-  if (find_new_index(old_index) != 0) {
+  if (find_new_cp_index(old_index) != 0) {
     // old_index is already mapped
     return;
   }
@@ -1549,12 +1554,12 @@ void VM_RedefineClasses::map_index(const constantPoolHandle& scratch_cp,
 
   log_trace(redefine, class, constantpool)
     ("mapped tag %d at index %d to %d", scratch_cp->tag_at(old_index).value(), old_index, new_index);
-} // end map_index()
+} // end map_cp_index()
 
 
 // Map old_index to new_index as needed.
-void VM_RedefineClasses::map_operand_index(int old_index, int new_index) {
-  if (find_new_operand_index(old_index) != -1) {
+void VM_RedefineClasses::map_bsm_index(int old_index, int new_index) {
+  if (find_new_bsm_index(old_index) != -1) {
     // old_index is already mapped
     return;
   }
@@ -1564,11 +1569,11 @@ void VM_RedefineClasses::map_operand_index(int old_index, int new_index) {
     return;
   }
 
-  _operands_index_map_p->at_put(old_index, new_index);
-  _operands_index_map_count++;
+  _bsm_data_index_map_p->at_put(old_index, new_index);
+  _bsm_data_index_map_count++;
 
   log_trace(redefine, class, constantpool)("mapped bootstrap specifier at index %d to %d", old_index, new_index);
-} // end map_index()
+} // end map_bsm_index()
 
 
 // Merge old_cp and scratch_cp and return the results of the merge via
@@ -1640,8 +1645,8 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
       }
     } // end for each old_cp entry
 
-    ConstantPool::copy_operands(old_cp, *merge_cp_p, CHECK_false);
-    (*merge_cp_p)->extend_operands(scratch_cp, CHECK_false);
+    ConstantPool::copy_bsm_data(old_cp, *merge_cp_p, CHECK_false);
+    (*merge_cp_p)->extend_bsm_data(scratch_cp, CHECK_false);
 
     // We don't need to sanity check that *merge_cp_length_p is within
     // *merge_cp_p bounds since we have the minimum on-entry check above.
@@ -1687,7 +1692,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
 
         // Found a matching entry somewhere else in *merge_cp_p so
         // just need a mapping entry.
-        map_index(scratch_cp, scratch_i, found_i);
+        map_cp_index(scratch_cp, scratch_i, found_i);
         continue;
       }
 
@@ -1725,7 +1730,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
       if (found_i != 0) {
         // Found a matching entry somewhere else in *merge_cp_p so
         // just need a mapping entry.
-        map_index(scratch_cp, scratch_i, found_i);
+        map_cp_index(scratch_cp, scratch_i, found_i);
         continue;
       }
 
@@ -1738,7 +1743,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
       ("after pass 1b: merge_cp_len=%d, scratch_i=%d, index_map_len=%d",
        *merge_cp_length_p, scratch_i, _index_map_count);
   }
-  finalize_operands_merge(*merge_cp_p, CHECK_false);
+  finalize_bsm_data_merge(*merge_cp_p, CHECK_false);
 
   return true;
 } // end merge_constant_pools()
@@ -1808,12 +1813,14 @@ jvmtiError VM_RedefineClasses::merge_cp_and_rewrite(
   _index_map_count = 0;
   _index_map_p = new intArray(scratch_cp->length(), scratch_cp->length(), -1);
 
-  _operands_cur_length = ConstantPool::operand_array_length(old_cp->operands());
-  _operands_index_map_count = 0;
-  int operands_index_map_len = ConstantPool::operand_array_length(scratch_cp->operands());
-  _operands_index_map_p = new intArray(operands_index_map_len, operands_index_map_len, -1);
+  int bsm_count = old_cp->bsm_attribute_count();
+  _bsm_data_cur_length = bsm_count;
+  _bsm_data_next_offset = (bsm_count == 0) ? 0 : old_cp->bsm_attribute_entries()->length(); 
+  _bsm_data_index_map_count = 0;
+  int bsm_data_index_map_len = scratch_cp->bsm_attribute_count();
+  _bsm_data_index_map_p = new intArray(bsm_data_index_map_len, bsm_data_index_map_len, -1);
 
-  // reference to the cp holder is needed for copy_operands()
+  // reference to the cp holder is needed for copy_bsm_data()
   merge_cp->set_pool_holder(scratch_class);
   bool result = merge_constant_pools(old_cp, scratch_cp, &merge_cp,
                   &merge_cp_length, THREAD);
@@ -1998,7 +2005,7 @@ bool VM_RedefineClasses::rewrite_cp_refs(InstanceKlass* scratch_class) {
   // rewrite source file name index:
   u2 source_file_name_idx = scratch_class->source_file_name_index();
   if (source_file_name_idx != 0) {
-    u2 new_source_file_name_idx = find_new_index(source_file_name_idx);
+    u2 new_source_file_name_idx = find_new_cp_index(source_file_name_idx);
     if (new_source_file_name_idx != 0) {
       scratch_class->set_source_file_name_index(new_source_file_name_idx);
     }
@@ -2007,7 +2014,7 @@ bool VM_RedefineClasses::rewrite_cp_refs(InstanceKlass* scratch_class) {
   // rewrite class generic signature index:
   u2 generic_signature_index = scratch_class->generic_signature_index();
   if (generic_signature_index != 0) {
-    u2 new_generic_signature_index = find_new_index(generic_signature_index);
+    u2 new_generic_signature_index = find_new_cp_index(generic_signature_index);
     if (new_generic_signature_index != 0) {
       scratch_class->set_generic_signature_index(new_generic_signature_index);
     }
@@ -2022,12 +2029,12 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_nest_attributes(
 
   u2 cp_index = scratch_class->nest_host_index();
   if (cp_index != 0) {
-    scratch_class->set_nest_host_index(find_new_index(cp_index));
+    scratch_class->set_nest_host_index(find_new_cp_index(cp_index));
   }
   Array<u2>* nest_members = scratch_class->nest_members();
   for (int i = 0; i < nest_members->length(); i++) {
     u2 cp_index = nest_members->at(i);
-    nest_members->at_put(i, find_new_index(cp_index));
+    nest_members->at_put(i, find_new_cp_index(cp_index));
   }
   return true;
 }
@@ -2039,12 +2046,12 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_record_attribute(InstanceKlass* scra
     for (int i = 0; i < components->length(); i++) {
       RecordComponent* component = components->at(i);
       u2 cp_index = component->name_index();
-      component->set_name_index(find_new_index(cp_index));
+      component->set_name_index(find_new_cp_index(cp_index));
       cp_index = component->descriptor_index();
-      component->set_descriptor_index(find_new_index(cp_index));
+      component->set_descriptor_index(find_new_cp_index(cp_index));
       cp_index = component->generic_signature_index();
       if (cp_index != 0) {
-        component->set_generic_signature_index(find_new_index(cp_index));
+        component->set_generic_signature_index(find_new_cp_index(cp_index));
       }
 
       AnnotationArray* annotations = component->annotations();
@@ -2079,7 +2086,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_permitted_subclasses_attribute(
   assert(permitted_subclasses != nullptr, "unexpected null permitted_subclasses");
   for (int i = 0; i < permitted_subclasses->length(); i++) {
     u2 cp_index = permitted_subclasses->at(i);
-    permitted_subclasses->at_put(i, find_new_index(cp_index));
+    permitted_subclasses->at_put(i, find_new_cp_index(cp_index));
   }
   return true;
 }
@@ -2158,7 +2165,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_method(methodHandle method,
       case Bytecodes::_ldc:
       {
         u1 cp_index = *(bcp + 1);
-        u2 new_index = find_new_index(cp_index);
+        u2 new_index = find_new_cp_index(cp_index);
 
         if (StressLdcRewrite && new_index == 0) {
           // If we are stressing ldc -> ldc_w rewriting, then we
@@ -2232,7 +2239,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_method(methodHandle method,
       {
         address p = bcp + 1;
         int cp_index = Bytes::get_Java_u2(p);
-        u2 new_index = find_new_index(cp_index);
+        u2 new_index = find_new_cp_index(cp_index);
         if (new_index != 0) {
           // the original index is mapped so update w/ new value
           log_trace(redefine, class, constantpool)
@@ -2378,7 +2385,7 @@ u2 VM_RedefineClasses::rewrite_cp_ref_in_annotation_data(
   address cp_index_addr = (address)
     annotations_typeArray->adr_at(byte_i_ref);
   u2 old_cp_index = Bytes::get_Java_u2(cp_index_addr);
-  u2 new_cp_index = find_new_index(old_cp_index);
+  u2 new_cp_index = find_new_cp_index(old_cp_index);
   if (new_cp_index != 0) {
     log_debug(redefine, class, annotation)("mapped old %s=%d", trace_mesg, old_cp_index);
     Bytes::put_Java_u2(cp_index_addr, new_cp_index);
@@ -3447,7 +3454,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_verification_type_info(
   {
     assert(stackmap_p_ref + 2 <= stackmap_end, "no room for cpool_index");
     u2 cpool_index = Bytes::get_Java_u2(stackmap_p_ref);
-    u2 new_cp_index = find_new_index(cpool_index);
+    u2 new_cp_index = find_new_cp_index(cpool_index);
     if (new_cp_index != 0) {
       log_debug(redefine, class, stackmap)("mapped old cpool_index=%d", cpool_index);
       Bytes::put_Java_u2(stackmap_p_ref, new_cp_index);
@@ -3497,7 +3504,7 @@ void VM_RedefineClasses::set_new_constant_pool(
   smaller_cp->set_version(version);
 
   // attach klass to new constant pool
-  // reference to the cp holder is needed for copy_operands()
+  // reference to the cp holder is needed for copy_bsm_data()
   smaller_cp->set_pool_holder(scratch_class);
 
   smaller_cp->copy_fields(scratch_cp());
@@ -3524,28 +3531,28 @@ void VM_RedefineClasses::set_new_constant_pool(
   for (int i = 0; i < java_fields; i++) {
     FieldInfo* fi = fields->adr_at(i);
     jshort cur_index = fi->name_index();
-    jshort new_index = find_new_index(cur_index);
+    jshort new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("field-name_index change: %d to %d", cur_index, new_index);
       fi->set_name_index(new_index);
       update_required = true;
     }
     cur_index = fi->signature_index();
-    new_index = find_new_index(cur_index);
+    new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("field-signature_index change: %d to %d", cur_index, new_index);
       fi->set_signature_index(new_index);
       update_required = true;
     }
     cur_index = fi->initializer_index();
-    new_index = find_new_index(cur_index);
+    new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("field-initval_index change: %d to %d", cur_index, new_index);
       fi->set_initializer_index(new_index);
       update_required = true;
     }
     cur_index = fi->generic_signature_index();
-    new_index = find_new_index(cur_index);
+    new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("field-generic_signature change: %d to %d", cur_index, new_index);
       fi->set_generic_signature_index(new_index);
@@ -3570,19 +3577,19 @@ void VM_RedefineClasses::set_new_constant_pool(
     if (cur_index == 0) {
       continue;  // JVM spec. allows null inner class refs so skip it
     }
-    u2 new_index = find_new_index(cur_index);
+    u2 new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("inner_class_info change: %d to %d", cur_index, new_index);
       iter.set_inner_class_info_index(new_index);
     }
     cur_index = iter.outer_class_info_index();
-    new_index = find_new_index(cur_index);
+    new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("outer_class_info change: %d to %d", cur_index, new_index);
       iter.set_outer_class_info_index(new_index);
     }
     cur_index = iter.inner_name_index();
-    new_index = find_new_index(cur_index);
+    new_index = find_new_cp_index(cur_index);
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)("inner_name change: %d to %d", cur_index, new_index);
       iter.set_inner_name_index(new_index);
@@ -3596,19 +3603,19 @@ void VM_RedefineClasses::set_new_constant_pool(
     methodHandle method(THREAD, methods->at(i));
     method->set_constants(scratch_cp());
 
-    u2 new_index = find_new_index(method->name_index());
+    u2 new_index = find_new_cp_index(method->name_index());
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)
         ("method-name_index change: %d to %d", method->name_index(), new_index);
       method->set_name_index(new_index);
     }
-    new_index = find_new_index(method->signature_index());
+    new_index = find_new_cp_index(method->signature_index());
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)
         ("method-signature_index change: %d to %d", method->signature_index(), new_index);
       method->set_signature_index(new_index);
     }
-    new_index = find_new_index(method->generic_signature_index());
+    new_index = find_new_cp_index(method->generic_signature_index());
     if (new_index != 0) {
       log_trace(redefine, class, constantpool)
         ("method-generic_signature_index change: %d to %d", method->generic_signature_index(), new_index);
@@ -3623,7 +3630,7 @@ void VM_RedefineClasses::set_new_constant_pool(
         method->checked_exceptions_start();
       for (int j = 0; j < cext_length; j++) {
         int cur_index = cext_table[j].class_cp_index;
-        int new_index = find_new_index(cur_index);
+        int new_index = find_new_cp_index(cur_index);
         if (new_index != 0) {
           log_trace(redefine, class, constantpool)("cext-class_cp_index change: %d to %d", cur_index, new_index);
           cext_table[j].class_cp_index = (u2)new_index;
@@ -3641,7 +3648,7 @@ void VM_RedefineClasses::set_new_constant_pool(
 
     for (int j = 0; j < ext_length; j ++) {
       int cur_index = ex_table.catch_type_index(j);
-      u2 new_index = find_new_index(cur_index);
+      u2 new_index = find_new_cp_index(cur_index);
       if (new_index != 0) {
         log_trace(redefine, class, constantpool)("ext-klass_index change: %d to %d", cur_index, new_index);
         ex_table.set_catch_type_index(j, new_index);
@@ -3658,19 +3665,19 @@ void VM_RedefineClasses::set_new_constant_pool(
         method->localvariable_table_start();
       for (int j = 0; j < lvt_length; j++) {
         int cur_index = lv_table[j].name_cp_index;
-        int new_index = find_new_index(cur_index);
+        int new_index = find_new_cp_index(cur_index);
         if (new_index != 0) {
           log_trace(redefine, class, constantpool)("lvt-name_cp_index change: %d to %d", cur_index, new_index);
           lv_table[j].name_cp_index = (u2)new_index;
         }
         cur_index = lv_table[j].descriptor_cp_index;
-        new_index = find_new_index(cur_index);
+        new_index = find_new_cp_index(cur_index);
         if (new_index != 0) {
           log_trace(redefine, class, constantpool)("lvt-descriptor_cp_index change: %d to %d", cur_index, new_index);
           lv_table[j].descriptor_cp_index = (u2)new_index;
         }
         cur_index = lv_table[j].signature_cp_index;
-        new_index = find_new_index(cur_index);
+        new_index = find_new_cp_index(cur_index);
         if (new_index != 0) {
           log_trace(redefine, class, constantpool)("lvt-signature_cp_index change: %d to %d", cur_index, new_index);
           lv_table[j].signature_cp_index = (u2)new_index;
@@ -3684,7 +3691,7 @@ void VM_RedefineClasses::set_new_constant_pool(
       MethodParametersElement* elem = method->method_parameters_start();
       for (int j = 0; j < mp_length; j++) {
         const int cp_index = elem[j].name_cp_index;
-        const int new_cp_index = find_new_index(cp_index);
+        const int new_cp_index = find_new_cp_index(cp_index);
         if (new_cp_index != 0) {
           elem[j].name_cp_index = (u2)new_cp_index;
         }

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -441,7 +441,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     // this is an indirect CP entry so it needs special handling
     case JVM_CONSTANT_NameAndType:
     {
-      auto nt = scratch_cp->name_and_type_pair_at(scratch_i);
+      NTReference nt(scratch_cp, scratch_i);
       int name_ref_i = nt.name_index();
       int new_name_ref_i = find_or_append_indirect_entry(scratch_cp, name_ref_i, merge_cp_p,
                                                          merge_cp_length_p);
@@ -479,7 +479,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     case JVM_CONSTANT_InterfaceMethodref: // fall through
     case JVM_CONSTANT_Methodref:
     {
-      auto ref = scratch_cp->uncached_field_or_method_ref_at(scratch_i);
+      FMReference ref(scratch_cp, scratch_i);
       int klass_ref_i = ref.klass_index();
       int new_klass_ref_i = find_or_append_indirect_entry(scratch_cp, klass_ref_i,
                                                           merge_cp_p, merge_cp_length_p);
@@ -531,7 +531,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     // this is an indirect CP entry so it needs special handling
     case JVM_CONSTANT_MethodType:
     {
-      auto ref = scratch_cp->method_type_ref_at(scratch_i);
+      MethodTypeReference ref(scratch_cp, scratch_i);
       int ref_i = ref.signature_index();
       int new_ref_i = find_or_append_indirect_entry(scratch_cp, ref_i, merge_cp_p,
                                                     merge_cp_length_p);
@@ -551,7 +551,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     // this is an indirect CP entry so it needs special handling
     case JVM_CONSTANT_MethodHandle:
     {
-      auto ref = scratch_cp->method_handle_ref_at(scratch_i);
+      MethodHandleReference ref(scratch_cp, scratch_i);
       int ref_kind = ref.ref_kind();
       int ref_i = ref.ref_index();
       int new_ref_i = find_or_append_indirect_entry(scratch_cp, ref_i, merge_cp_p,
@@ -573,7 +573,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     case JVM_CONSTANT_Dynamic:  // fall through
     case JVM_CONSTANT_InvokeDynamic:
     {
-      auto ref = scratch_cp->uncached_bootstrap_specifier_ref_at(scratch_i);
+      BSReference ref(scratch_cp, scratch_i);
 
       // Index of the bootstrap specifier in the BSM data arrays
       int old_bsme_i = ref.bsme_index();
@@ -668,7 +668,7 @@ u2 VM_RedefineClasses::find_or_append_indirect_entry(const constantPoolHandle& s
 void VM_RedefineClasses::append_bsm_data(const constantPoolHandle& scratch_cp, int old_bsme_i,
        constantPoolHandle *merge_cp_p, int *merge_cp_length_p) {
 
-  const auto old_bsme = scratch_cp->bsm_attribute_entry(old_bsme_i);
+  BSMAttributeEntry* old_bsme = scratch_cp->bsm_attribute_entry(old_bsme_i);
   u2 old_ref_i = old_bsme->bootstrap_method_index();
   u2 new_ref_i = find_or_append_indirect_entry(scratch_cp, old_ref_i, merge_cp_p,
                                                merge_cp_length_p);
@@ -677,8 +677,8 @@ void VM_RedefineClasses::append_bsm_data(const constantPoolHandle& scratch_cp, i
       ("bsm_data entry@%d bootstrap method ref_index change: %d to %d", _bsm_data_cur_length, old_ref_i, new_ref_i);
   }
 
-  const auto merge_offs = (*merge_cp_p)->bsm_attribute_offsets();
-  const auto merge_data = (*merge_cp_p)->bsm_attribute_entries();
+  Array<u4>* merge_offs = (*merge_cp_p)->bsm_attribute_offsets();
+  Array<u2>* merge_data = (*merge_cp_p)->bsm_attribute_entries();
 
   int new_bsme_i = _bsm_data_cur_length;
   int new_base   = _bsm_data_next_offset;

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1821,7 +1821,7 @@ jvmtiError VM_RedefineClasses::merge_cp_and_rewrite(
 
   int bsm_count = old_cp->bsm_attribute_count();
   _bsm_data_cur_length = bsm_count;
-  _bsm_data_next_offset = (bsm_count == 0) ? 0 : old_cp->bsm_attribute_entries()->length(); 
+  _bsm_data_next_offset = (bsm_count == 0) ? 0 : old_cp->bsm_attribute_entries()->length();
   _bsm_data_index_map_count = 0;
   int bsm_data_index_map_len = scratch_cp->bsm_attribute_count();
   _bsm_data_index_map_p = new intArray(bsm_data_index_map_len, bsm_data_index_map_len, -1);

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -441,11 +441,12 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     // this is an indirect CP entry so it needs special handling
     case JVM_CONSTANT_NameAndType:
     {
-      int name_ref_i = scratch_cp->name_ref_index_at(scratch_i);
+      auto nt = scratch_cp->name_and_type_pair_at(scratch_i);
+      int name_ref_i = nt.name_index();
       int new_name_ref_i = find_or_append_indirect_entry(scratch_cp, name_ref_i, merge_cp_p,
                                                          merge_cp_length_p);
 
-      int signature_ref_i = scratch_cp->signature_ref_index_at(scratch_i);
+      int signature_ref_i = nt.signature_index();
       int new_signature_ref_i = find_or_append_indirect_entry(scratch_cp, signature_ref_i,
                                                               merge_cp_p, merge_cp_length_p);
 
@@ -478,11 +479,12 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     case JVM_CONSTANT_InterfaceMethodref: // fall through
     case JVM_CONSTANT_Methodref:
     {
-      int klass_ref_i = scratch_cp->uncached_klass_ref_index_at(scratch_i);
+      auto ref = scratch_cp->uncached_field_or_method_ref_at(scratch_i);
+      int klass_ref_i = ref.klass_index();
       int new_klass_ref_i = find_or_append_indirect_entry(scratch_cp, klass_ref_i,
                                                           merge_cp_p, merge_cp_length_p);
 
-      int name_and_type_ref_i = scratch_cp->uncached_name_and_type_ref_index_at(scratch_i);
+      int name_and_type_ref_i = ref.nt_index();
       int new_name_and_type_ref_i = find_or_append_indirect_entry(scratch_cp, name_and_type_ref_i,
                                                           merge_cp_p, merge_cp_length_p);
 
@@ -529,7 +531,8 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     // this is an indirect CP entry so it needs special handling
     case JVM_CONSTANT_MethodType:
     {
-      int ref_i = scratch_cp->method_type_index_at(scratch_i);
+      auto ref = scratch_cp->method_type_ref_at(scratch_i);
+      int ref_i = ref.signature_index();
       int new_ref_i = find_or_append_indirect_entry(scratch_cp, ref_i, merge_cp_p,
                                                     merge_cp_length_p);
       if (new_ref_i != ref_i) {
@@ -548,8 +551,9 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     // this is an indirect CP entry so it needs special handling
     case JVM_CONSTANT_MethodHandle:
     {
-      int ref_kind = scratch_cp->method_handle_ref_kind_at(scratch_i);
-      int ref_i = scratch_cp->method_handle_index_at(scratch_i);
+      auto ref = scratch_cp->method_handle_ref_at(scratch_i);
+      int ref_kind = ref.ref_kind();
+      int ref_i = ref.ref_index();
       int new_ref_i = find_or_append_indirect_entry(scratch_cp, ref_i, merge_cp_p,
                                                     merge_cp_length_p);
       if (new_ref_i != ref_i) {
@@ -569,12 +573,14 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     case JVM_CONSTANT_Dynamic:  // fall through
     case JVM_CONSTANT_InvokeDynamic:
     {
+      auto ref = scratch_cp->uncached_bootstrap_specifier_ref_at(scratch_i);
+
       // Index of the bootstrap specifier in the BSM data arrays
-      int old_bsme_i = scratch_cp->bootstrap_methods_attribute_index(scratch_i);
+      int old_bsme_i = ref.bsme_index();
       int new_bsme_i = find_or_append_bsm_data(scratch_cp, old_bsme_i, merge_cp_p,
                                                merge_cp_length_p);
       // The bootstrap method NameAndType_info index
-      int old_ref_i = scratch_cp->bootstrap_name_and_type_ref_index_at(scratch_i);
+      int old_ref_i = ref.nt_index();
       int new_ref_i = find_or_append_indirect_entry(scratch_cp, old_ref_i, merge_cp_p,
                                                     merge_cp_length_p);
       if (new_bsme_i != old_bsme_i) {

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -573,7 +573,7 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     case JVM_CONSTANT_Dynamic:  // fall through
     case JVM_CONSTANT_InvokeDynamic:
     {
-      BSReference ref(scratch_cp, scratch_i);
+      BootstrapReference ref(scratch_cp, scratch_i);
 
       // Index of the bootstrap specifier in the BSM data arrays
       int old_bsme_i = ref.bsme_index();

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -385,7 +385,8 @@ void VM_RedefineClasses::append_entry(const constantPoolHandle& scratch_cp,
     case JVM_CONSTANT_Class:
     case JVM_CONSTANT_UnresolvedClass:
     {
-      int name_i = scratch_cp->klass_name_index_at(scratch_i);
+      KlassReference kref_i(scratch_cp, scratch_i);
+      int name_i = kref_i.name_index();
       int new_name_i = find_or_append_indirect_entry(scratch_cp, name_i, merge_cp_p,
                                                      merge_cp_length_p);
 
@@ -1633,7 +1634,7 @@ bool VM_RedefineClasses::merge_constant_pools(const constantPoolHandle& old_cp,
         // May be resolving while calling this so do the same for
         // JVM_CONSTANT_UnresolvedClass (klass_name_at() deals with transition)
         (*merge_cp_p)->temp_unresolved_klass_at_put(old_i,
-          old_cp->klass_name_index_at(old_i));
+          KlassReference(old_cp, old_i).name_index());
         break;
 
       case JVM_CONSTANT_Double:

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -363,11 +363,12 @@ class VM_RedefineClasses: public VM_Operation {
   int                         _index_map_count;
   intArray *                  _index_map_p;
 
-  // _operands_index_map_count is just an optimization for knowing if
-  // _operands_index_map_p contains any entries.
-  int                         _operands_cur_length;
-  int                         _operands_index_map_count;
-  intArray *                  _operands_index_map_p;
+  // _bsm_data_index_map_count is just an optimization for knowing if
+  // _bsm_data_index_map_p contains any entries.
+  int                         _bsm_data_cur_length;   // bsm_attribute_offsets fillp
+  int                         _bsm_data_next_offset;  // bsm_attribute_entries fillp
+  int                         _bsm_data_index_map_count;
+  intArray *                  _bsm_data_index_map_p;
 
   // ptr to _class_count scratch_classes
   InstanceKlass**             _scratch_classes;
@@ -429,17 +430,17 @@ class VM_RedefineClasses: public VM_Operation {
   // Support for constant pool merging (these routines are in alpha order):
   void append_entry(const constantPoolHandle& scratch_cp, int scratch_i,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
-  void append_operand(const constantPoolHandle& scratch_cp, int scratch_bootstrap_spec_index,
+  void append_bsm_data(const constantPoolHandle& scratch_cp, int scratch_bsm_attr_entry_index,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
-  void finalize_operands_merge(const constantPoolHandle& merge_cp, TRAPS);
+  void finalize_bsm_data_merge(const constantPoolHandle& merge_cp, TRAPS);
   u2 find_or_append_indirect_entry(const constantPoolHandle& scratch_cp, int scratch_i,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
-  int find_or_append_operand(const constantPoolHandle& scratch_cp, int scratch_bootstrap_spec_index,
+  int find_or_append_bsm_data(const constantPoolHandle& scratch_cp, int scratch_bsm_attr_entry_index,
     constantPoolHandle *merge_cp_p, int *merge_cp_length_p);
-  u2 find_new_index(int old_index);
-  int find_new_operand_index(int old_bootstrap_spec_index);
-  void map_index(const constantPoolHandle& scratch_cp, int old_index, int new_index);
-  void map_operand_index(int old_bootstrap_spec_index, int new_bootstrap_spec_index);
+  u2 find_new_cp_index(int old_cp_index);
+  int find_new_bsm_index(int old_bsme_index);
+  void map_cp_index(const constantPoolHandle& scratch_cp, int old_index, int new_index);
+  void map_bsm_index(int old_bsme_index, int new_bsme_index);
   bool merge_constant_pools(const constantPoolHandle& old_cp,
     const constantPoolHandle& scratch_cp, constantPoolHandle *merge_cp_p,
     int *merge_cp_length_p, TRAPS);

--- a/src/hotspot/share/prims/methodComparator.cpp
+++ b/src/hotspot/share/prims/methodComparator.cpp
@@ -116,8 +116,8 @@ bool MethodComparator::args_same(Bytecodes::Code const c_old,  Bytecodes::Code c
   }
   case Bytecodes::_invokedynamic: {
     // Encoded indy index, should be negative
-    BSReference old_ref(old_cp, s_old->get_index_u4(), c_old);
-    BSReference new_ref(new_cp, s_new->get_index_u4(), c_new);
+    BootstrapReference old_ref(old_cp, s_old->get_index_u4(), c_old);
+    BootstrapReference new_ref(new_cp, s_new->get_index_u4(), c_new);
 
     // Check if the names of classes, field/method names and signatures at these indexes
     // are the same. Indices which are really into constantpool cache (rather than constant

--- a/src/hotspot/share/prims/methodComparator.cpp
+++ b/src/hotspot/share/prims/methodComparator.cpp
@@ -133,17 +133,19 @@ bool MethodComparator::args_same(Bytecodes::Code const c_old,  Bytecodes::Code c
         (old_cp->uncached_signature_ref_at(cpi_old) != new_cp->uncached_signature_ref_at(cpi_new)))
       return false;
 
-    int bsm_old = old_cp->bootstrap_method_ref_index_at(cpi_old);
-    int bsm_new = new_cp->bootstrap_method_ref_index_at(cpi_new);
+    auto bsme_old = old_cp->bootstrap_methods_attribute_entry(cpi_old);
+    auto bsme_new = new_cp->bootstrap_methods_attribute_entry(cpi_new);
+    int bsm_old = bsme_old->bootstrap_method_index();
+    int bsm_new = bsme_new->bootstrap_method_index();
     if (!pool_constants_same(bsm_old, bsm_new, old_cp, new_cp))
       return false;
-    int cnt_old = old_cp->bootstrap_argument_count_at(cpi_old);
-    int cnt_new = new_cp->bootstrap_argument_count_at(cpi_new);
+    int cnt_old = bsme_old->argument_count();
+    int cnt_new = bsme_new->argument_count();
     if (cnt_old != cnt_new)
       return false;
     for (int arg_i = 0; arg_i < cnt_old; arg_i++) {
-      int idx_old = old_cp->bootstrap_argument_index_at(cpi_old, arg_i);
-      int idx_new = new_cp->bootstrap_argument_index_at(cpi_new, arg_i);
+      int idx_old = bsme_old->argument_index(arg_i);
+      int idx_new = bsme_new->argument_index(arg_i);
       if (!pool_constants_same(idx_old, idx_new, old_cp, new_cp))
         return false;
     }

--- a/src/hotspot/share/prims/methodComparator.cpp
+++ b/src/hotspot/share/prims/methodComparator.cpp
@@ -88,8 +88,8 @@ bool MethodComparator::args_same(Bytecodes::Code const c_old,  Bytecodes::Code c
   case Bytecodes::_putstatic       : // fall through
   case Bytecodes::_getfield        : // fall through
   case Bytecodes::_putfield        : {
-    auto old_ref = old_cp->from_bytecode_ref_at(s_old->get_index_u2(), c_old);
-    auto new_ref = new_cp->from_bytecode_ref_at(s_new->get_index_u2(), c_new);
+    FMReference old_ref(old_cp, s_old->get_index_u2(), c_old);
+    FMReference new_ref(new_cp, s_new->get_index_u2(), c_new);
     // Check if the names of classes, field/method names and signatures at these indexes
     // are the same. Indices which are really into constantpool cache (rather than constant
     // pool itself) are accepted by the constantpool query routines below.
@@ -103,8 +103,8 @@ bool MethodComparator::args_same(Bytecodes::Code const c_old,  Bytecodes::Code c
   case Bytecodes::_invokespecial   : // fall through
   case Bytecodes::_invokestatic    : // fall through
   case Bytecodes::_invokeinterface : {
-    auto old_ref = old_cp->from_bytecode_ref_at(s_old->get_index_u2(), c_old);
-    auto new_ref = new_cp->from_bytecode_ref_at(s_new->get_index_u2(), c_new);
+    FMReference old_ref(old_cp, s_old->get_index_u2(), c_old);
+    FMReference new_ref(new_cp, s_new->get_index_u2(), c_new);
     // Check if the names of classes, field/method names and signatures at these indexes
     // are the same. Indices which are really into constantpool cache (rather than constant
     // pool itself) are accepted by the constantpool query routines below.
@@ -116,8 +116,8 @@ bool MethodComparator::args_same(Bytecodes::Code const c_old,  Bytecodes::Code c
   }
   case Bytecodes::_invokedynamic: {
     // Encoded indy index, should be negative
-    auto old_ref = old_cp->from_bytecode_ref_at(s_old->get_index_u4(), c_old);
-    auto new_ref = new_cp->from_bytecode_ref_at(s_new->get_index_u4(), c_new);
+    BSReference old_ref(old_cp, s_old->get_index_u4(), c_old);
+    BSReference new_ref(new_cp, s_new->get_index_u4(), c_new);
 
     // Check if the names of classes, field/method names and signatures at these indexes
     // are the same. Indices which are really into constantpool cache (rather than constant
@@ -127,8 +127,8 @@ bool MethodComparator::args_same(Bytecodes::Code const c_old,  Bytecodes::Code c
         (old_ref.signature(old_cp)  != new_ref.signature(new_cp)))
       return false;
 
-    auto bsme_old = old_ref.bsme(old_cp);
-    auto bsme_new = new_ref.bsme(new_cp);
+    BSMAttributeEntry* bsme_old = old_ref.bsme(old_cp);
+    BSMAttributeEntry* bsme_new = new_ref.bsme(new_cp);
     int bsm_old = bsme_old->bootstrap_method_index();
     int bsm_new = bsme_new->bootstrap_method_index();
     if (!pool_constants_same(bsm_old, bsm_new, old_cp, new_cp))
@@ -293,17 +293,17 @@ bool MethodComparator::pool_constants_same(const int cpi_old, const int cpi_new,
     if (old_cp->klass_name_at(cpi_old) != new_cp->klass_name_at(cpi_new))
       return false;
   } else if (tag_old.is_method_type() && tag_new.is_method_type()) {
-    auto old_ref = old_cp->method_type_ref_at(cpi_old);
-    auto new_ref = new_cp->method_type_ref_at(cpi_new);
+    MethodTypeReference old_ref(old_cp, cpi_old);
+    MethodTypeReference new_ref(new_cp, cpi_new);
     if (old_ref.signature(old_cp) != new_ref.signature(new_cp))
       return false;
   } else if (tag_old.is_method_handle() && tag_new.is_method_handle()) {
-    auto old_ref = old_cp->method_handle_ref_at(cpi_old);
-    auto new_ref = new_cp->method_handle_ref_at(cpi_new);
+    MethodHandleReference old_ref(old_cp, cpi_old);
+    MethodHandleReference new_ref(new_cp, cpi_new);
     if (old_ref.ref_kind() != new_ref.ref_kind())
       return false;
-    auto old_mh = old_cp->uncached_field_or_method_ref_at(old_ref.ref_index());
-    auto new_mh = new_cp->uncached_field_or_method_ref_at(new_ref.ref_index());
+    FMReference old_mh(old_cp, old_ref.ref_index());
+    FMReference new_mh(new_cp, new_ref.ref_index());
     if ((old_mh.klass_name(old_cp) != new_mh.klass_name(new_cp)) ||
         (old_mh.name(old_cp)       != new_mh.name(new_cp)) ||
         (old_mh.signature(old_cp)  != new_mh.signature(new_cp)))

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -1263,11 +1263,11 @@ JVM_ENTRY(void, MHN_copyOutBootstrapArguments(JNIEnv* env, jobject igcls,
   // While we are here, take a quick look at the index info:
   int bsme_index = -1;
   // FIXME: use a BootstrapInfo record to simplify this logic
-  SymbolicReference indy;
+  BSReference indy;
   if (0 < bss_index_in_pool &&
       bss_index_in_pool < caller->constants()->length() &&
       caller->constants()->tag_at(bss_index_in_pool).has_bootstrap()) {
-    indy = caller->constants()->uncached_bootstrap_specifier_ref_at(bss_index_in_pool);
+    indy = BSReference(caller->constants(), bss_index_in_pool);
     bsme_index = indy.bsme_index();
   }
   if (bsme_index < 0 || (caller->constants()->bsm_attribute_entry(bsme_index)->argument_count()

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -1263,11 +1263,11 @@ JVM_ENTRY(void, MHN_copyOutBootstrapArguments(JNIEnv* env, jobject igcls,
   // While we are here, take a quick look at the index info:
   int bsme_index = -1;
   // FIXME: use a BootstrapInfo record to simplify this logic
-  BSReference indy;
+  BootstrapReference indy;
   if (0 < bss_index_in_pool &&
       bss_index_in_pool < caller->constants()->length() &&
       caller->constants()->tag_at(bss_index_in_pool).has_bootstrap()) {
-    indy = BSReference(caller->constants(), bss_index_in_pool);
+    indy = BootstrapReference(caller->constants(), bss_index_in_pool);
     bsme_index = indy.bsme_index();
   }
   if (bsme_index < 0 || (caller->constants()->bsm_attribute_entry(bsme_index)->argument_count()

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -40,10 +40,12 @@
 #include "memory/oopFactory.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
+#include "oops/constantPool.inline.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "oops/objArrayOop.inline.hpp"
 #include "oops/oop.inline.hpp"
+#include "oops/resolvedIndyEntry.hpp"
 #include "oops/typeArrayOop.inline.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/deoptimization.hpp"
@@ -1257,12 +1259,17 @@ JVM_ENTRY(void, MHN_copyOutBootstrapArguments(JNIEnv* env, jobject igcls,
       THROW_MSG(vmSymbols::java_lang_InternalError(), "bad index info (0)");
   }
   typeArrayHandle index_info(THREAD, index_info_oop);
-  int bss_index_in_pool = index_info->int_at(1);
+  int bss_index_in_pool  = index_info->length() <= 1 ? -1 : index_info->int_at(1);
   // While we are here, take a quick look at the index info:
-  if (bss_index_in_pool <= 0 ||
-      bss_index_in_pool >= caller->constants()->length() ||
-      index_info->int_at(0)
-      != caller->constants()->bootstrap_argument_count_at(bss_index_in_pool)) {
+  int bsme_index = -1;
+  // FIXME: use a BootstrapInfo record to simplify this logic
+  if (0 < bss_index_in_pool &&
+      bss_index_in_pool < caller->constants()->length() &&
+      caller->constants()->tag_at(bss_index_in_pool).has_bootstrap()) {
+    bsme_index = caller->constants()->bootstrap_methods_attribute_index(bss_index_in_pool);
+  }
+  if (bsme_index < 0 || (caller->constants()->bsm_attribute_entry(bsme_index)->argument_count()
+                         != index_info->int_at(0))) {
       THROW_MSG(vmSymbols::java_lang_InternalError(), "bad index info (1)");
   }
   objArrayHandle buf(THREAD, (objArrayOop) JNIHandles::resolve(buf_jh));
@@ -1274,12 +1281,15 @@ JVM_ENTRY(void, MHN_copyOutBootstrapArguments(JNIEnv* env, jobject igcls,
         switch (pseudo_index) {
         case -4:  // bootstrap method
           {
-            int bsm_index = caller->constants()->bootstrap_method_ref_index_at(bss_index_in_pool);
+            // re-derive the bsme at each point
+            auto bsme = caller->constants()->bsm_attribute_entry(bsme_index);
+            int bsm_index = bsme->bootstrap_method_index();
             pseudo_arg = caller->constants()->resolve_possibly_cached_constant_at(bsm_index, CHECK);
             break;
           }
         case -3:  // name
           {
+            assert(bss_index_in_pool > 0, "");
             Symbol* name = caller->constants()->name_ref_at(bss_index_in_pool, Bytecodes::_invokedynamic);
             Handle str = java_lang_String::create_from_symbol(name, CHECK);
             pseudo_arg = str();
@@ -1287,6 +1297,7 @@ JVM_ENTRY(void, MHN_copyOutBootstrapArguments(JNIEnv* env, jobject igcls,
           }
         case -2:  // type
           {
+            assert(bss_index_in_pool > 0, "");
             Symbol* type = caller->constants()->signature_ref_at(bss_index_in_pool, Bytecodes::_invokedynamic);
             Handle th;
             if (type->char_at(0) == JVM_SIGNATURE_FUNC) {
@@ -1299,7 +1310,9 @@ JVM_ENTRY(void, MHN_copyOutBootstrapArguments(JNIEnv* env, jobject igcls,
           }
         case -1:  // argument count
           {
-            int argc = caller->constants()->bootstrap_argument_count_at(bss_index_in_pool);
+            // re-derive the bsme at each point
+            auto bsme = caller->constants()->bsm_attribute_entry(bsme_index);
+            int argc = bsme->argument_count();
             jvalue argc_value; argc_value.i = (jint)argc;
             pseudo_arg = java_lang_boxing_object::create(T_INT, &argc_value, CHECK);
             break;
@@ -1315,7 +1328,7 @@ JVM_ENTRY(void, MHN_copyOutBootstrapArguments(JNIEnv* env, jobject igcls,
   }
   Handle ifna(THREAD, JNIHandles::resolve(ifna_jh));
   caller->constants()->
-    copy_bootstrap_arguments_at(bss_index_in_pool,
+    copy_bootstrap_arguments_at(bsme_index,
                                 start, end, buf, pos,
                                 (resolve == JNI_TRUE), ifna, CHECK);
 }

--- a/src/hotspot/share/prims/nativeLookup.cpp
+++ b/src/hotspot/share/prims/nativeLookup.cpp
@@ -399,6 +399,12 @@ address NativeLookup::lookup_base(const methodHandle& method, TRAPS) {
   entry = lookup_entry_prefixed(method, CHECK_NULL);
   if (entry != nullptr) return entry;
 
+  if (log_is_enabled(Trace, jni, resolve)) {
+    log_trace(jni, resolve)("[Dynamic-linking native method %s.%s ... FAILED]",
+                            method->method_holder()->external_name(),
+                            method->name()->as_C_string());
+  }
+
   if (THREAD->has_pending_exception()) {
     oop exception = THREAD->pending_exception();
     if (exception->is_a(vmClasses::IllegalCallerException_klass())) {

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1280,7 +1280,7 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
     } else {
       // Klass is already loaded.
       constantPoolHandle constants(current, caller->constants());
-      SymbolicReference mref = constants->from_bytecode_ref_at(bytecode_index, bc);
+      FMReference mref(constants, bytecode_index, bc);
       rk = mref.klass(constants, CHECK_NH);
     }
     Klass* static_receiver_klass = rk;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1280,7 +1280,8 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
     } else {
       // Klass is already loaded.
       constantPoolHandle constants(current, caller->constants());
-      rk = constants->klass_ref_at(bytecode_index, bc, CHECK_NH);
+      SymbolicReference mref = constants->from_bytecode_ref_at(bytecode_index, bc);
+      rk = mref.klass(constants, CHECK_NH);
     }
     Klass* static_receiver_klass = rk;
     assert(receiver_klass->is_subtype_of(static_receiver_klass),

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -213,7 +213,8 @@
   nonstatic_field(ConstantPool,                _tags,                                         Array<u1>*)                            \
   nonstatic_field(ConstantPool,                _cache,                                        ConstantPoolCache*)                    \
   nonstatic_field(ConstantPool,                _pool_holder,                                  InstanceKlass*)                        \
-  nonstatic_field(ConstantPool,                _operands,                                     Array<u2>*)                            \
+  nonstatic_field(ConstantPool,                _bsm_attribute_offsets,                        Array<u4>*)                            \
+  nonstatic_field(ConstantPool,                _bsm_attribute_entries,                        Array<u2>*)                            \
   nonstatic_field(ConstantPool,                _resolved_klasses,                             Array<Klass*>*)                        \
   nonstatic_field(ConstantPool,                _length,                                       int)                                   \
   nonstatic_field(ConstantPool,                _minor_version,                                u2)                                    \
@@ -228,7 +229,7 @@
   nonstatic_field(ConstantPoolCache,           _resolved_method_entries,                      Array<ResolvedMethodEntry>*)           \
   nonstatic_field(ResolvedMethodEntry,         _cpool_index,                                  u2)                                    \
   nonstatic_field(ConstantPoolCache,           _resolved_indy_entries,                        Array<ResolvedIndyEntry>*)             \
-  nonstatic_field(ResolvedIndyEntry,           _cpool_index,                                  u2)                                    \
+  nonstatic_field(ResolvedIndyEntry,           _cp_index,                                     u2)                                    \
   volatile_nonstatic_field(InstanceKlass,      _array_klasses,                                ObjArrayKlass*)                        \
   nonstatic_field(InstanceKlass,               _methods,                                      Array<Method*>*)                       \
   nonstatic_field(InstanceKlass,               _default_methods,                              Array<Method*>*)                       \
@@ -2184,14 +2185,6 @@
   /*********************************/                                     \
                                                                           \
   declare_constant(Symbol::max_symbol_length)                             \
-                                                                          \
-  /***********************************************/                       \
-  /* ConstantPool* layout enum for InvokeDynamic */                       \
-  /***********************************************/                       \
-                                                                          \
-  declare_constant(ConstantPool::_indy_bsm_offset)                        \
-  declare_constant(ConstantPool::_indy_argc_offset)                       \
-  declare_constant(ConstantPool::_indy_argv_offset)                       \
                                                                           \
   /***************************************/                               \
   /* JavaThreadStatus enum               */                               \

--- a/src/hotspot/share/utilities/constantTag.hpp
+++ b/src/hotspot/share/utilities/constantTag.hpp
@@ -91,6 +91,9 @@ class constantTag {
   bool is_dynamic_constant_in_error() const {
     return _tag == JVM_CONSTANT_DynamicInError;
   }
+  bool is_dynamic_constant_or_error() const {
+    return is_dynamic_constant() || is_dynamic_constant_in_error();
+  }
 
   bool is_in_error() const {
     return is_unresolved_klass_in_error() ||

--- a/src/hotspot/share/utilities/constantTag.hpp
+++ b/src/hotspot/share/utilities/constantTag.hpp
@@ -81,6 +81,12 @@ class constantTag {
   bool is_method_type_in_error() const {
     return _tag == JVM_CONSTANT_MethodTypeInError;
   }
+  bool is_method_handle_or_error() const {
+    return is_method_handle() || is_method_handle_in_error();
+  }
+  bool is_method_type_or_error() const {
+    return is_method_type() || is_method_type_in_error();
+  }
 
   bool is_dynamic_constant_in_error() const {
     return _tag == JVM_CONSTANT_DynamicInError;
@@ -98,6 +104,7 @@ class constantTag {
 
   bool is_klass_reference() const   { return is_klass_index() || is_unresolved_klass(); }
   bool is_klass_or_reference() const{ return is_klass() || is_klass_reference(); }
+  bool is_string_or_index() const   { return is_string() || is_string_index(); }
   bool is_field_or_method() const   { return is_field() || is_method() || is_interface_method(); }
   bool is_symbol() const            { return is_utf8(); }
 
@@ -111,6 +118,7 @@ class constantTag {
             _tag == JVM_CONSTANT_DynamicInError ||
             _tag == JVM_CONSTANT_InvokeDynamic);
   }
+  bool has_name_and_type() const    { return is_field_or_method() || has_bootstrap(); }
 
   bool is_loadable_constant() const {
     return ((_tag >= JVM_CONSTANT_Integer && _tag <= JVM_CONSTANT_String) ||

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -55,10 +55,6 @@
 // -DINCLUDE_<something>=0 | 1 can be specified on the command line to include
 // or exclude functionality.
 
-#ifndef FILE_AND_LINE
-#define FILE_AND_LINE __FILE__ ":" XSTR(__LINE__)
-#endif
-
 #ifndef INCLUDE_JVMTI
 #define INCLUDE_JVMTI 1
 #endif  // INCLUDE_JVMTI


### PR DESCRIPTION
We propose some cleanups to the VM code which works with bootstrap methods and related metadata.

About 10 obscure access methods are removed from `ConstantPool`, and another dozen renamed or retyped, with the aim of increasing type safety and clarity.

The preferred way to access the contents of the `BootstrapMethods` attribute is now via a new overlay structure `BSMAttributeEntry`.  This gives easy-to-understand access to each BSM entry and the corresponding static argument list.  The old CP accessors which provided less direct access to this information are gone.

The `ConstantPool::operands` array, which has always had two parts, has been split into two arrays, each with an appropriate element type.  (That is, `u2` for BSM attribute data, and `u4` for indexes into that data.)

The index part of the old operands array is now `Array<u4>* ConstantPool::bsm_attribute_offsets`.  Having two arrays for two kinds of data (instead of one that mixes up both) simplifies all of the code that works with this data.  In particular, the affected classfile parser code, CP access methods, and (especially) JVMTI support code are easier to understand now.

The "metadata payload" of the old operands arrays is moved to `Array<u2>* ConstantPool::bsm_attribute_entries`.  This whole array is exactly the second half of the old operands array.

`ConstantPool::copy_bootstrap_arguments_at` is made to take a BSM attribute entry index, rather than the less direct CP index.  Other bits of code are similarly modified, when the logic that should focus on a BSM attribute entry diverts through a CP index.  The connection to Java code in `java.lang.invoke` is adjusted to pass the necessary index value.  This data is now accessed via the type-safe struct `BSMAttributeEntry`.

The `BootstrapInfo` struct is widened a bit, and connected to `BSMAttributeEntry` (which gives access to the relevant BSM and static arguments).  Likewise `ResolvedIndyEntry` is widened slightly to give better access to the underlying symbolic reference (name, signature, BSM entry).  (It is not clear if these improvements are desirable; more thought is needed here.)

A truncation bug is fixed in `Rewriter::rewrite_invokedynamic`, which was preventing the VM from supporting 2^64 or more `invokedynamic` instructions (in one classfile).

`Rewriter::add_invokedynamic_resolved_references_entry` is moved out of line, and a possible cleanup issue written on it.

Remaining issues:  The rewriter processing of `invokehandle` and `invokedynamic` is uncomfortably tangled.  The `BootstrapInfo` and `ResolvedIndyEntry` structs have overlapping state and API.  Although the naming of API points is (mostly) improved, perhaps it is too vigorous, and perhaps we can pick even better names.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23250/head:pull/23250` \
`$ git checkout pull/23250`

Update a local copy of the PR: \
`$ git checkout pull/23250` \
`$ git pull https://git.openjdk.org/jdk.git pull/23250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23250`

View PR using the GUI difftool: \
`$ git pr show -t 23250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23250.diff">https://git.openjdk.org/jdk/pull/23250.diff</a>

</details>
