### PR TITLE
8348365: Bad format string in CLDRDisplayNamesTest

### DIFF
--- a/test/jdk/java/util/TimeZone/CLDRDisplayNamesTest.java
+++ b/test/jdk/java/util/TimeZone/CLDRDisplayNamesTest.java
@@ -130,7 +130,7 @@ public class CLDRDisplayNamesTest {
         String displayName = zi.getDisplayName(false, TimeZone.SHORT, Locale.US);
         Locale.setDefault(originalLocale);
         if (!displayName.equals("GMT+05:00")) {
-            System.err.printf("Wrong display name for timezone Etc/GMT-5 : expected GMT+05:00,  Actual " + displayName);
+            System.err.println("Wrong display name for timezone Etc/GMT-5 : expected GMT+05:00,  Actual " + displayName);
             errors++;
         }
 


### PR DESCRIPTION
This change fixes an incorrect call to `printf` for a failure message in `CLDRDisplayNamesTest`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348365](https://bugs.openjdk.org/browse/JDK-8348365): Bad format string in CLDRDisplayNamesTest (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23252/head:pull/23252` \
`$ git checkout pull/23252`

Update a local copy of the PR: \
`$ git checkout pull/23252` \
`$ git pull https://git.openjdk.org/jdk.git pull/23252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23252`

View PR using the GUI difftool: \
`$ git pr show -t 23252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23252.diff">https://git.openjdk.org/jdk/pull/23252.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23252#issuecomment-2608914869)
</details>
