### PR TITLE
8348367: Remove hotspot_not_fast_compiler and hotspot_slow_compiler test groups

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -112,6 +112,9 @@ hotspot_vector_2 = \
   compiler/vectorapi/VectorRebracket128Test.java \
   -compiler/intrinsics/string/TestStringLatin1IndexOfChar.java
 
+hotspot_compiler_arraycopy = \
+  compiler/arraycopy/stress
+
 tier1_loom = \
   :tier1_loom_runtime \
   :tier1_loom_serviceability

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -112,9 +112,6 @@ hotspot_vector_2 = \
   compiler/vectorapi/VectorRebracket128Test.java \
   -compiler/intrinsics/string/TestStringLatin1IndexOfChar.java
 
-hotspot_compiler_arraycopy = \
-  compiler/arraycopy/stress
-
 tier1_loom = \
   :tier1_loom_runtime \
   :tier1_loom_serviceability
@@ -152,24 +149,12 @@ tier1_compiler = \
   :tier1_compiler_2 \
   :tier1_compiler_3
 
-hotspot_not_fast_compiler = \
-  :hotspot_compiler \
-  -:tier1_compiler \
-  -:hotspot_slow_compiler
-
-hotspot_slow_compiler = \
-  compiler/codegen/aes \
-  compiler/codecache/stress \
-  compiler/gcbarriers/PreserveFPRegistersTest.java \
-  compiler/memoryinitialization/ZeroTLABTest.java \
-  compiler/classUnloading/methodUnloading/TestOverloadCompileQueues.java \
-  :hotspot_compiler_arraycopy
-
 tier1_compiler_1 = \
   compiler/arraycopy/ \
   compiler/blackhole/ \
   compiler/c1/ \
   compiler/c2/ \
+  -compiler/arraycopy/stress \
   -compiler/c2/Test6850611.java \
   -compiler/c2/cr6890943/Test6890943.java \
   -compiler/c2/Test6905845.java \
@@ -179,8 +164,7 @@ tier1_compiler_1 = \
   -compiler/c2/stemmer \
   -compiler/c2/Test6792161.java \
   -compiler/c2/Test6603011.java \
-  -compiler/c2/Test6912517.java \
-  -:hotspot_slow_compiler
+  -compiler/c2/Test6912517.java
 
 tier1_compiler_2 = \
   compiler/classUnloading/ \
@@ -197,7 +181,10 @@ tier1_compiler_2 = \
   compiler/integerArithmetic/ \
   compiler/interpreter/ \
   compiler/jvmci/ \
-  -:hotspot_slow_compiler
+  -compiler/classUnloading/methodUnloading/TestOverloadCompileQueues.java \
+  -compiler/codecache/stress \
+  -compiler/codegen/aes \
+  -compiler/gcbarriers/PreserveFPRegistersTest.java
 
 tier1_compiler_3 = \
   compiler/intrinsics/ \
@@ -221,6 +208,7 @@ tier1_compiler_3 = \
   -compiler/intrinsics/bigInteger/TestMultiplyToLen.java \
   -compiler/intrinsics/zip/TestAdler32.java \
   -compiler/loopopts/Test7052494.java \
+  -compiler/memoryinitialization/ZeroTLABTest.java \
   -compiler/runtime/Test6826736.java
 
 tier2_compiler = \
@@ -230,7 +218,6 @@ tier2_compiler = \
   compiler/cha/ \
   compiler/controldependency/ \
   compiler/conversions/ \
-  compiler/codegen/ \
   compiler/linkage/ \
   compiler/loopstripmining/ \
   compiler/loopopts/Test7052494.java \
@@ -248,8 +235,7 @@ tier2_compiler = \
   compiler/runtime/Test6826736.java \
   compiler/stable/ \
   compiler/stringopts/ \
-  -:tier1_compiler \
-  -:hotspot_slow_compiler
+  -:tier1_compiler
 
 tier3_compiler = \
   :hotspot_compiler \


### PR DESCRIPTION
Test groups
hotspot_not_fast_compiler and hotspot_slow_compiler test
were used by Oracle. However, now tier2/tier3 are used instead.

So fix remove groups. and add exclusion of "slow" tests from tier1 groups. The content remains the same except 
-compiler/memoryinitialization/ZeroTLABTest.java 
int tier1_compiler_3.


The tier1/2/3 are organized similar to tiers in other groups where
tier1 = set of groups 
  - some long tests/groups
tier2 = set of groups
  - some long tests/groups
 - tier1
 tier3 =
  hotspot_compiler
 - tier1
 - tier2


The  test group
 compiler/codegen/ \
was in the tier1 and tier2, so should be removed it from tier2, not tests are affected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348367](https://bugs.openjdk.org/browse/JDK-8348367): Remove hotspot_not_fast_compiler and hotspot_slow_compiler test groups (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23253/head:pull/23253` \
`$ git checkout pull/23253`

Update a local copy of the PR: \
`$ git checkout pull/23253` \
`$ git pull https://git.openjdk.org/jdk.git pull/23253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23253`

View PR using the GUI difftool: \
`$ git pr show -t 23253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23253.diff">https://git.openjdk.org/jdk/pull/23253.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23253#issuecomment-2608941961)
</details>
