### PR TITLE
8348283: java.lang.classfile.components.snippets.PackageSnippets shipped in java.base.jmod

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/components/snippet-files/PackageSnippets.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/components/snippet-files/PackageSnippets.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package java.lang.classfile.components.snippets;
+package jdk.internal.classfile.components.snippet;
 
 import java.lang.classfile.*;
 import jdk.internal.classfile.components.ClassPrinter;


### PR DESCRIPTION
JDK-8345486 moved java.lang.classfile.components.snippet-files.PackageSnippets to jdk.internal.classfile.components.snippet-files folder. However change of the package name declared  in the snippet file was omitted.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348283](https://bugs.openjdk.org/browse/JDK-8348283): java.lang.classfile.components.snippets.PackageSnippets shipped in java.base.jmod (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23254/head:pull/23254` \
`$ git checkout pull/23254`

Update a local copy of the PR: \
`$ git checkout pull/23254` \
`$ git pull https://git.openjdk.org/jdk.git pull/23254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23254`

View PR using the GUI difftool: \
`$ git pr show -t 23254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23254.diff">https://git.openjdk.org/jdk/pull/23254.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23254#issuecomment-2609034631)
</details>
