### PR TITLE
8348387: Add fixpath if needed for user-supplied tools

### DIFF
--- a/make/autoconf/util_paths.m4
+++ b/make/autoconf/util_paths.m4
@@ -357,6 +357,8 @@ AC_DEFUN([UTIL_SETUP_TOOL],
           fi
           $1="$tool_command"
         fi
+        # Make sure we add fixpath if needed
+        UTIL_FIXUP_EXECUTABLE($1)
         if test "x$tool_args" != x; then
           # If we got arguments, re-append them to the command after the fixup.
           $1="[$]$1 $tool_args"


### PR DESCRIPTION
When discovering tools, configure checks if it is a program that can handle unix-style paths or not. If it isn't, a fixpath prefix is automatically added.

But when the user supplies a tool like `configure FOO=foo.exe`, this does not happen. If that tool does not understand unix-style paths, then it will fail, and there is no easy way for the user to fix this.

Instead, we should apply the fixpath check also to user-supplied tools.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348387](https://bugs.openjdk.org/browse/JDK-8348387): Add fixpath if needed for user-supplied tools (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23257/head:pull/23257` \
`$ git checkout pull/23257`

Update a local copy of the PR: \
`$ git checkout pull/23257` \
`$ git pull https://git.openjdk.org/jdk.git pull/23257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23257`

View PR using the GUI difftool: \
`$ git pr show -t 23257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23257.diff">https://git.openjdk.org/jdk/pull/23257.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23257#issuecomment-2609391274)
</details>
