### PR TITLE
8348388: Incorrect copyright header in TestFluidAndNonFluid.java

### DIFF
--- a/test/hotspot/jtreg/compiler/stringopts/TestFluidAndNonFluid.java
+++ b/test/hotspot/jtreg/compiler/stringopts/TestFluidAndNonFluid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Fixes a missing comma in the copyright header.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348388](https://bugs.openjdk.org/browse/JDK-8348388): Incorrect copyright header in TestFluidAndNonFluid.java (**Bug** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23258/head:pull/23258` \
`$ git checkout pull/23258`

Update a local copy of the PR: \
`$ git checkout pull/23258` \
`$ git pull https://git.openjdk.org/jdk.git pull/23258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23258`

View PR using the GUI difftool: \
`$ git pr show -t 23258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23258.diff">https://git.openjdk.org/jdk/pull/23258.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23258#issuecomment-2609409169)
</details>
