### PR TITLE
8348391: Keep case if possible for TOPDIR

### DIFF
--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -84,9 +84,15 @@ AC_DEFUN_ONCE([BASIC_SETUP_PATHS],
 
   # We get the top-level directory from the supporting wrappers.
   BASIC_WINDOWS_VERIFY_DIR($TOPDIR, source)
+  orig_topdir="$TOPDIR"
   UTIL_FIXUP_PATH(TOPDIR)
   AC_MSG_CHECKING([for top-level directory])
   AC_MSG_RESULT([$TOPDIR])
+  if test "x$TOPDIR" != "x$orig_topdir"; then
+    AC_MSG_WARN([Your top dir was originally represented as $orig_topdir,])
+    AC_MSG_WARN([but after rewriting it became $TOPDIR.])
+    AC_MSG_WARN([This typically means you have characters like space in the path, which can cause all kind of trouble.])
+  fi
   AC_SUBST(TOPDIR)
 
   if test "x$CUSTOM_ROOT" != x; then

--- a/make/autoconf/util_paths.m4
+++ b/make/autoconf/util_paths.m4
@@ -77,7 +77,10 @@ AC_DEFUN([UTIL_FIXUP_PATH],
           imported_path=""
         fi
       fi
-      if test "x$imported_path" != "x$path"; then
+      [ imported_path_lower=`$ECHO $imported_path | $TR '[:upper:]' '[:lower:]'` ]
+      [ orig_path_lower=`$ECHO $path | $TR '[:upper:]' '[:lower:]'` ]
+      # If only case differs, keep original path
+      if test "x$imported_path_lower" != "x$orig_path_lower"; then
         $1="$imported_path"
       fi
     else


### PR DESCRIPTION
To figure out the root of the JDK build, we set the TOPDIR variable in configure. Furthermore, we clean it up using UTIL_FIXUP_PATH as we do with all paths. On Windows, this can result in the path becoming all lowercase. Since Windows paths are case insensitive, this is normally not a problem. However, we try to strip the TOPDIR from paths in several locations like this:

```
$$(subst $$(TOPDIR)/, , $$($1_TEST_RESULTS_DIR))
```

and that will only work if the case actually matches. 