### PR TITLE
8347994: Add additional diagnostics to macOS failure handler to assist with diagnosing MCast test failures

### DIFF
--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -134,7 +134,7 @@ net.netstat.aL.args=-aL
 net.netstat.m.args=-mm
 net.netstat.s.args=-s
 net.netstat.g.args=-gs
-net.netstat.r.args=-rn 
+net.netstat.r.args=-rn
 net.ifconfig.app=ifconfig
 net.ifconfig.args=-a
 

--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -89,8 +89,9 @@ environment=\
   process.ps process.top \
   memory.vmstat \
   files \
-  net.netstat.anv net.netstat.av net.netstat.aL net.netstat.m net.netstat.s \
+  net.netstat.anv net.netstat.av net.netstat.aL net.netstat.m net.netstat.s net.netstat.g net.netstat.r \
   net.ifconfig net.hostsfile \
+  fw.up \
   scutil.nwi scutil.proxy \
   screenshot
 ################################################################################
@@ -132,6 +133,8 @@ net.netstat.anv.args=-anv
 net.netstat.aL.args=-aL
 net.netstat.m.args=-mm
 net.netstat.s.args=-s
+net.netstat.g.args=-gs
+net.netstat.r.args=-rn 
 net.ifconfig.app=ifconfig
 net.ifconfig.args=-a
 
@@ -144,4 +147,7 @@ scutil.proxy.args=--proxy
 
 screenshot.app=screencapture
 screenshot.args=-x screen1.png screen2.png screen3.png screen4.png screen5.png
+
+fw.app=/usr/libexec/ApplicationFirewall/socketfilterfw
+fw.up.args=--getglobalstate
 ################################################################################


### PR DESCRIPTION
Add additional diagnostics to macOS failure handler to assist with diagnosing MCast test failures

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347994](https://bugs.openjdk.org/browse/JDK-8347994): Add additional diagnostics to macOS failure handler to assist with diagnosing MCast test failures (**Sub-task** - P3)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23260/head:pull/23260` \
`$ git checkout pull/23260`

Update a local copy of the PR: \
`$ git checkout pull/23260` \
`$ git pull https://git.openjdk.org/jdk.git pull/23260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23260`

View PR using the GUI difftool: \
`$ git pr show -t 23260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23260.diff">https://git.openjdk.org/jdk/pull/23260.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23260#issuecomment-2609479881)
</details>
