### PR TITLE
8348392: Make claims "other matches are possible" even when that is not true

### DIFF
--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -211,13 +211,15 @@ ifeq ($(HAS_SPEC), )
                 $$(if $$(findstring $$(CONF), $$(var)), $$(var))))
           endif
           ifneq ($$(filter $$(CONF), $$(matching_confs)), )
+            ifneq ($$(word 2, $$(matching_confs)), )
+              # Don't repeat this output on make restarts caused by including
+              # generated files.
+              ifeq ($$(MAKE_RESTARTS), )
+                $$(info Using exact match for CONF=$$(CONF) (other matches are possible))
+              endif
+            endif
             # If we found an exact match, use that
             matching_confs := $$(CONF)
-            # Don't repeat this output on make restarts caused by including
-            # generated files.
-            ifeq ($$(MAKE_RESTARTS), )
-              $$(info Using exact match for CONF=$$(CONF) (other matches are possible))
-            endif
           endif
         endif
         ifeq ($$(matching_confs), )


### PR DESCRIPTION
When matching configurations using CONF, normally this is treated as a pattern. However, if an exact match is found, this is exclusively used. This is to allow matching for e.g. linux-x64 and not matching linux-x64-debug, which is otherwise impossible.

To inform the user that this has happened, make prints

```
Using exact match for CONF=linux-x64 (other matches are possible)
```

even if no other matches are possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348392](https://bugs.openjdk.org/browse/JDK-8348392): Make claims "other matches are possible" even when that is not true (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23261/head:pull/23261` \
`$ git checkout pull/23261`

Update a local copy of the PR: \
`$ git checkout pull/23261` \
`$ git pull https://git.openjdk.org/jdk.git pull/23261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23261`

View PR using the GUI difftool: \
`$ git pr show -t 23261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23261.diff">https://git.openjdk.org/jdk/pull/23261.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23261#issuecomment-2609513425)
</details>
