### PR TITLE
8348278: Trim InitialRAMPercentage to improve startup in default modes

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -289,7 +289,7 @@
           "size on systems with small physical memory size")                \
           range(0.0, 100.0)                                                 \
                                                                             \
-  product(double, InitialRAMPercentage, 1.5625,                             \
+  product(double, InitialRAMPercentage, 0.2,                                \
           "Percentage of real memory used for initial heap size")           \
           range(0.0, 100.0)                                                 \
                                                                             \

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -2448,7 +2448,7 @@ Java HotSpot VM.
 :   Sets the initial amount of memory that the JVM will use for the Java heap
     before applying ergonomics heuristics as a percentage of the maximum amount
     determined as described in the `-XX:MaxRAM` option. The default value is
-    1.5625 percent.
+    0.2 percent.
 
     The following example shows how to set the percentage of the initial
     amount of memory used for the Java heap:


### PR DESCRIPTION
See bug for discussion. This is the code change, which is simple. What is not simple is deciding what the new value should be. The change would probably require CSR, which I can file after we agree on the value.

I think cutting to 0.2% of RAM size gets us into good sweet spot:
 - On huge 1024G machine, this yields 2G initial heap
 - On reasonably sized 128G machine, this gives 256M initial heap
 - On smaller 1G container, this gives 2M initial heap

Additional testing:
 - [x] Linux AArch64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8353837](https://bugs.openjdk.org/browse/JDK-8353837) to be approved

### Issues
 * [JDK-8348278](https://bugs.openjdk.org/browse/JDK-8348278): Trim InitialRAMPercentage to improve startup in default modes (**Enhancement** - P4)
 * [JDK-8353837](https://bugs.openjdk.org/browse/JDK-8353837): Trim InitialRAMPercentage to improve startup in default modes (**CSR**)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23262/head:pull/23262` \
`$ git checkout pull/23262`

Update a local copy of the PR: \
`$ git checkout pull/23262` \
`$ git pull https://git.openjdk.org/jdk.git pull/23262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23262`

View PR using the GUI difftool: \
`$ git pr show -t 23262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23262.diff">https://git.openjdk.org/jdk/pull/23262.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23262#issuecomment-2609577931)
</details>
