### PR TITLE
8347058: When automatically translating the page to pt-br, all CSS styling disappears

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
@@ -347,8 +347,7 @@ public class Head extends Content {
 
     private void addStylesheet(HtmlTree head, DocPath stylesheet) {
         head.add(HtmlTree.LINK("stylesheet", "text/css",
-                pathToRoot.resolve(stylesheet).getPath(), "Style",
-                "no"));
+                pathToRoot.resolve(stylesheet).getPath()));
     }
 
     private void addScripts(HtmlTree head) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,7 +347,8 @@ public class Head extends Content {
 
     private void addStylesheet(HtmlTree head, DocPath stylesheet) {
         head.add(HtmlTree.LINK("stylesheet", "text/css",
-                pathToRoot.resolve(stylesheet).getPath(), "Style"));
+                pathToRoot.resolve(stylesheet).getPath(), "Style",
+                "no"));
     }
 
     private void addScripts(HtmlTree head) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
@@ -779,17 +779,13 @@ public class HtmlTree extends Content {
      * @param rel   the relevance of the link: the {@code rel} attribute
      * @param type  the type of link: the {@code type} attribute
      * @param href  the path for the link: the {@code href} attribute
-     * @param title title for the link: the {@code title} attribute
-     * @param translate translate property for the link: the {@code translate} attribute
      * @return the element
      */
-    public static HtmlTree LINK(String rel, String type, String href, String title, String translate) {
+    public static HtmlTree LINK(String rel, String type, String href) {
         return new HtmlTree(HtmlTag.LINK)
                 .put(HtmlAttr.REL, rel)
                 .put(HtmlAttr.TYPE, type)
-                .put(HtmlAttr.HREF, href)
-                .put(HtmlAttr.TITLE, title)
-                .put(HtmlAttr.TRANSLATE, translate);
+                .put(HtmlAttr.HREF, href);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -780,14 +780,16 @@ public class HtmlTree extends Content {
      * @param type  the type of link: the {@code type} attribute
      * @param href  the path for the link: the {@code href} attribute
      * @param title title for the link: the {@code title} attribute
+     * @param translate translate property for the link: the {@code translate} attribute
      * @return the element
      */
-    public static HtmlTree LINK(String rel, String type, String href, String title) {
+    public static HtmlTree LINK(String rel, String type, String href, String title, String translate) {
         return new HtmlTree(HtmlTag.LINK)
                 .put(HtmlAttr.REL, rel)
                 .put(HtmlAttr.TYPE, type)
                 .put(HtmlAttr.HREF, href)
-                .put(HtmlAttr.TITLE, title);
+                .put(HtmlAttr.TITLE, title)
+                .put(HtmlAttr.TRANSLATE, translate);
     }
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testModuleSpecificStylesheet/TestModuleSpecificStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testModuleSpecificStylesheet/TestModuleSpecificStylesheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8219313
+ * @bug 8219313 8347058
  * @summary Support module specific stylesheets
  * @library /tools/lib ../../lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -82,22 +82,22 @@ public class TestModuleSpecificStylesheet extends JavadocTester {
 
         checkOutput("ma/module-summary.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../ma/doc-files/spanstyle.css" title="Style">""");
+                    <link rel="stylesheet" type="text/css" href="../ma/doc-files/spanstyle.css" title="Style" translate="no">""");
 
         checkOutput("ma/pa/package-summary.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../../ma/doc-files/spanstyle.css" title="Style">""");
+                    <link rel="stylesheet" type="text/css" href="../../ma/doc-files/spanstyle.css" title="Style" translate="no">""");
 
         checkOutput("ma/pa/A.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../../ma/doc-files/spanstyle.css" title="Style">""");
+                    <link rel="stylesheet" type="text/css" href="../../ma/doc-files/spanstyle.css" title="Style" translate="no">""");
 
         checkOutput("ma/pa/pb/B.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../../../ma/doc-files/spanstyle.css" title="Style">""");
+                    <link rel="stylesheet" type="text/css" href="../../../ma/doc-files/spanstyle.css" title="Style" translate="no">""");
 
         checkOutput("ma/pa/pb/package-summary.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../../../ma/doc-files/spanstyle.css" title="Style">""");
+                    <link rel="stylesheet" type="text/css" href="../../../ma/doc-files/spanstyle.css" title="Style" translate="no">""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testModuleSpecificStylesheet/TestModuleSpecificStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testModuleSpecificStylesheet/TestModuleSpecificStylesheet.java
@@ -82,22 +82,22 @@ public class TestModuleSpecificStylesheet extends JavadocTester {
 
         checkOutput("ma/module-summary.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../ma/doc-files/spanstyle.css" title="Style" translate="no">""");
+                    <link rel="stylesheet" type="text/css" href="../ma/doc-files/spanstyle.css">""");
 
         checkOutput("ma/pa/package-summary.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../../ma/doc-files/spanstyle.css" title="Style" translate="no">""");
+                    <link rel="stylesheet" type="text/css" href="../../ma/doc-files/spanstyle.css">""");
 
         checkOutput("ma/pa/A.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../../ma/doc-files/spanstyle.css" title="Style" translate="no">""");
+                    <link rel="stylesheet" type="text/css" href="../../ma/doc-files/spanstyle.css">""");
 
         checkOutput("ma/pa/pb/B.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../../../ma/doc-files/spanstyle.css" title="Style" translate="no">""");
+                    <link rel="stylesheet" type="text/css" href="../../../ma/doc-files/spanstyle.css">""");
 
         checkOutput("ma/pa/pb/package-summary.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../../../ma/doc-files/spanstyle.css" title="Style" translate="no">""");
+                    <link rel="stylesheet" type="text/css" href="../../../ma/doc-files/spanstyle.css">""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testOptions/TestOptions.java
+++ b/test/langtools/jdk/javadoc/doclet/testOptions/TestOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      4749567 8071982 8175200 8186332 8185371 8182765 8217034 8261976 8261976
- *           8275786
+ *           8275786 8347058
  * @summary  Test the output for -header, -footer, -nooverview, -nodeprecatedlist,
  *           -nonavbar, -notree, -stylesheetfile, --main-stylesheet, --add-stylesheet,
  *           --add-script options.
@@ -118,7 +118,7 @@ public class TestOptions extends JavadocTester {
 
         checkOutput("resource-files/custom-stylesheet.css", true, "Custom javadoc style sheet");
         checkOutput("pkg/Foo.html", true, """
-            <link rel="stylesheet" type="text/css" href="../resource-files/custom-stylesheet.css" title="Style">""");
+            <link rel="stylesheet" type="text/css" href="../resource-files/custom-stylesheet.css" title="Style" translate="no">""");
     }
 
     @Test
@@ -131,7 +131,7 @@ public class TestOptions extends JavadocTester {
 
         checkOutput("resource-files/custom-stylesheet.css", true, "Custom javadoc style sheet");
         checkOutput("pkg/Foo.html", true, """
-            <link rel="stylesheet" type="text/css" href="../resource-files/custom-stylesheet.css" title="Style">""");
+            <link rel="stylesheet" type="text/css" href="../resource-files/custom-stylesheet.css" title="Style" translate="no">""");
     }
 
     @Test
@@ -149,9 +149,9 @@ public class TestOptions extends JavadocTester {
         checkOutput("resource-files/additional-stylesheet-3.css", true, "Additional javadoc style sheet 3");
         checkOutput("pkg/Foo.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-1.css" title="Style">
-                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-2.css" title="Style">
-                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-3.css" title="Style">""");
+                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-1.css" title="Style" translate="no">
+                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-2.css" title="Style" translate="no">
+                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-3.css" title="Style" translate="no">""");
     }
 
     @Test

--- a/test/langtools/jdk/javadoc/doclet/testOptions/TestOptions.java
+++ b/test/langtools/jdk/javadoc/doclet/testOptions/TestOptions.java
@@ -118,7 +118,7 @@ public class TestOptions extends JavadocTester {
 
         checkOutput("resource-files/custom-stylesheet.css", true, "Custom javadoc style sheet");
         checkOutput("pkg/Foo.html", true, """
-            <link rel="stylesheet" type="text/css" href="../resource-files/custom-stylesheet.css" title="Style" translate="no">""");
+            <link rel="stylesheet" type="text/css" href="../resource-files/custom-stylesheet.css">""");
     }
 
     @Test
@@ -131,7 +131,7 @@ public class TestOptions extends JavadocTester {
 
         checkOutput("resource-files/custom-stylesheet.css", true, "Custom javadoc style sheet");
         checkOutput("pkg/Foo.html", true, """
-            <link rel="stylesheet" type="text/css" href="../resource-files/custom-stylesheet.css" title="Style" translate="no">""");
+            <link rel="stylesheet" type="text/css" href="../resource-files/custom-stylesheet.css">""");
     }
 
     @Test
@@ -149,9 +149,9 @@ public class TestOptions extends JavadocTester {
         checkOutput("resource-files/additional-stylesheet-3.css", true, "Additional javadoc style sheet 3");
         checkOutput("pkg/Foo.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-1.css" title="Style" translate="no">
-                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-2.css" title="Style" translate="no">
-                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-3.css" title="Style" translate="no">""");
+                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-1.css">
+                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-2.css">
+                    <link rel="stylesheet" type="text/css" href="../resource-files/additional-stylesheet-3.css">""");
     }
 
     @Test

--- a/test/langtools/jdk/javadoc/doclet/testPackageSpecificStylesheet/TestPackageSpecificStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageSpecificStylesheet/TestPackageSpecificStylesheet.java
@@ -82,15 +82,15 @@ public class TestPackageSpecificStylesheet extends JavadocTester {
 
         checkOutput("pkg/A.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../pkg/doc-files/spanstyle.css" title="Style" translate="no">""");
+                    <link rel="stylesheet" type="text/css" href="../pkg/doc-files/spanstyle.css">""");
 
         checkOutput("pkg/package-summary.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../pkg/doc-files/spanstyle.css" title="Style" translate="no">""");
+                    <link rel="stylesheet" type="text/css" href="../pkg/doc-files/spanstyle.css">""");
 
         checkOutput("pkg2/B.html", false,
                 """
-                    <link rel="stylesheet" type="text/css" href="../pkg2/doc-files/spanstyle.css" title="Style" translate="no">""");
+                    <link rel="stylesheet" type="text/css" href="../pkg2/doc-files/spanstyle.css">""");
 
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testPackageSpecificStylesheet/TestPackageSpecificStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageSpecificStylesheet/TestPackageSpecificStylesheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8213354
+ * @bug 8213354 8347058
  * @summary Support package-specific stylesheets
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -82,15 +82,15 @@ public class TestPackageSpecificStylesheet extends JavadocTester {
 
         checkOutput("pkg/A.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../pkg/doc-files/spanstyle.css" title="Style">""");
+                    <link rel="stylesheet" type="text/css" href="../pkg/doc-files/spanstyle.css" title="Style" translate="no">""");
 
         checkOutput("pkg/package-summary.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="../pkg/doc-files/spanstyle.css" title="Style">""");
+                    <link rel="stylesheet" type="text/css" href="../pkg/doc-files/spanstyle.css" title="Style" translate="no">""");
 
         checkOutput("pkg2/B.html", false,
                 """
-                    <link rel="stylesheet" type="text/css" href="../pkg2/doc-files/spanstyle.css" title="Style">""");
+                    <link rel="stylesheet" type="text/css" href="../pkg2/doc-files/spanstyle.css" title="Style" translate="no">""");
 
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -418,7 +418,7 @@ public class TestSearch extends JavadocTester {
         // Test for search related markup
         checkOutput(fileName, expectedOutput,
                 """
-                    <link rel="stylesheet" type="text/css" href="resource-files/jquery-ui.min.css" title="Style" translate="no">
+                    <link rel="stylesheet" type="text/css" href="resource-files/jquery-ui.min.css">
                     """,
                 """
                     <script type="text/javascript" src="script-files/jquery-3.7.1.min.js"></script>

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8141492 8071982 8141636 8147890 8166175 8168965 8176794 8175218 8147881
  *      8181622 8182263 8074407 8187521 8198522 8182765 8199278 8196201 8196202
  *      8184205 8214468 8222548 8223378 8234746 8241219 8254627 8247994 8263528
- *      8266808 8248863 8305710 8318082
+ *      8266808 8248863 8305710 8318082 8347058
  * @summary Test the search feature of javadoc.
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -418,7 +418,7 @@ public class TestSearch extends JavadocTester {
         // Test for search related markup
         checkOutput(fileName, expectedOutput,
                 """
-                    <link rel="stylesheet" type="text/css" href="resource-files/jquery-ui.min.css" title="Style">
+                    <link rel="stylesheet" type="text/css" href="resource-files/jquery-ui.min.css" title="Style" translate="no">
                     """,
                 """
                     <script type="text/javascript" src="script-files/jquery-3.7.1.min.js"></script>

--- a/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug      4494033 7028815 7052425 8007338 8023608 8008164 8016549 8072461 8154261 8162363 8160196 8151743 8177417
  *           8175218 8176452 8181215 8182263 8183511 8169819 8183037 8185369 8182765 8196201 8184205 8223378 8241544
- *           8253117 8263528 8289334 8292594
+ *           8253117 8263528 8289334 8292594 8347058
  * @summary  Run tests on doclet stylesheet.
  * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -186,7 +186,7 @@ public class TestStylesheet extends JavadocTester {
                 // Test whether a link to the stylesheet file is inserted properly
                 // in the class documentation.
                 """
-                    <link rel="stylesheet" type="text/css" href="../resource-files/stylesheet.css" title="Style">""",
+                    <link rel="stylesheet" type="text/css" href="../resource-files/stylesheet.css" title="Style" translate="no">""",
                 """
                     <div class="block">Test comment for a class which has an <a name="named_anchor">anchor_with_name</a> and
                      an <a id="named_anchor1">anchor_with_id</a>.</div>""");
@@ -200,7 +200,7 @@ public class TestStylesheet extends JavadocTester {
 
         checkOutput("index.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="resource-files/stylesheet.css" title="Style">""");
+                    <link rel="stylesheet" type="text/css" href="resource-files/stylesheet.css" title="Style" translate="no">""");
 
         checkOutput("resource-files/stylesheet.css", false,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
@@ -186,7 +186,7 @@ public class TestStylesheet extends JavadocTester {
                 // Test whether a link to the stylesheet file is inserted properly
                 // in the class documentation.
                 """
-                    <link rel="stylesheet" type="text/css" href="../resource-files/stylesheet.css" title="Style" translate="no">""",
+                    <link rel="stylesheet" type="text/css" href="../resource-files/stylesheet.css">""",
                 """
                     <div class="block">Test comment for a class which has an <a name="named_anchor">anchor_with_name</a> and
                      an <a id="named_anchor1">anchor_with_id</a>.</div>""");
@@ -200,7 +200,7 @@ public class TestStylesheet extends JavadocTester {
 
         checkOutput("index.html", true,
                 """
-                    <link rel="stylesheet" type="text/css" href="resource-files/stylesheet.css" title="Style" translate="no">""");
+                    <link rel="stylesheet" type="text/css" href="resource-files/stylesheet.css">""");
 
         checkOutput("resource-files/stylesheet.css", false,
                 """


### PR DESCRIPTION
When translating to some languages like Portuguese or Arabic google translate will modify the HTML and changes the value of the HTML title Attribute.
Example when auto-translating the page to Arabic `<link rel="stylesheet" type="text/css" href="resource-files/jquery-ui.min.css" title="أسلوب">`

This patch to add a `translate="no"` attribute to the HTML `link` tag used to link CSS stylesheets, this seems to prevent the translation of the `title` property by google chrome on my local machine.

TIA

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347058](https://bugs.openjdk.org/browse/JDK-8347058): When automatically translating the page to pt-br, all CSS styling disappears (**Bug** - P3)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23263/head:pull/23263` \
`$ git checkout pull/23263`

Update a local copy of the PR: \
`$ git checkout pull/23263` \
`$ git pull https://git.openjdk.org/jdk.git pull/23263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23263`

View PR using the GUI difftool: \
`$ git pr show -t 23263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23263.diff">https://git.openjdk.org/jdk/pull/23263.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23263#issuecomment-2609745447)
</details>
