### PR TITLE
8344581: [TESTBUG] java/awt/Robot/ScreenCaptureRobotTest.java failing on macOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -468,7 +468,6 @@ java/awt/Window/MainKeyWindowTest/TestMainKeyWindow.java 8265985 macosx-all
 java/awt/Robot/Delay/InterruptOfDelay.java 8265986 macosx-all
 java/awt/Robot/InfiniteLoopException.java 8342638 windows-all,linux-all
 java/awt/MenuBar/TestNoScreenMenuBar.java 8265987 macosx-all
-java/awt/Robot/ScreenCaptureRobotTest.java 8344581 macosx-all
 
 java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8266283 generic-all
 java/awt/Graphics2D/DrawString/RotTransText.java 8316878 linux-all

--- a/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
+++ b/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
+++ b/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
@@ -44,6 +44,17 @@ import javax.imageio.ImageIO;
  * @bug 8342098
  * @summary Verify that the image captured from the screen using a Robot
  * and the source image are same.
+ * @requires os.family == "mac"
+ * @run main/othervm ScreenCaptureRobotTest
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 8342098
+ * @summary Verify that the image captured from the screen using a Robot
+ * and the source image are same.
+ * @requires os.family != "mac"
  * @run main/othervm -Dsun.java2d.uiScale=1 ScreenCaptureRobotTest
  */
 public class ScreenCaptureRobotTest {
@@ -104,6 +115,7 @@ public class ScreenCaptureRobotTest {
         Rectangle rect = new Rectangle(point.x + OFFSET, point.y + OFFSET,
                 IMAGE_WIDTH, IMAGE_HEIGHT);
 
+        robot.mouseMove(0,0);
         BufferedImage capturedImage = robot.createScreenCapture(rect);
 
         if (!compareImages(capturedImage, realImage)) {

--- a/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
+++ b/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
@@ -107,7 +107,7 @@ public class ScreenCaptureRobotTest {
 
     private static void doTest() throws Exception {
         Robot robot = new Robot();
-        robot.mouseMove(0,0);
+        robot.mouseMove(0, 0);
         robot.waitForIdle();
         robot.delay(500);
 

--- a/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
+++ b/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
@@ -107,6 +107,7 @@ public class ScreenCaptureRobotTest {
 
     private static void doTest() throws Exception {
         Robot robot = new Robot();
+        robot.mouseMove(0,0);
         robot.waitForIdle();
         robot.delay(500);
 
@@ -115,7 +116,6 @@ public class ScreenCaptureRobotTest {
         Rectangle rect = new Rectangle(point.x + OFFSET, point.y + OFFSET,
                 IMAGE_WIDTH, IMAGE_HEIGHT);
 
-        robot.mouseMove(0,0);
         BufferedImage capturedImage = robot.createScreenCapture(rect);
 
         if (!compareImages(capturedImage, realImage)) {


### PR DESCRIPTION
This contains test fixes for the following issue in ScreenCaptureRobotTest.java

•	Failures in Mac OS because of mouse pointer visible on top of the image that is screen captured by robot.

Testing:
Tested using Mach5(100 times per platform) in MacOS, Linux, Windows & MacOS AArch64. Seen all tests passing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344581](https://bugs.openjdk.org/browse/JDK-8344581): [TESTBUG] java/awt/Robot/ScreenCaptureRobotTest.java failing on macOS (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) Review applies to [2466f426](https://git.openjdk.org/jdk/pull/23264/files/2466f426cf886472e28685ab57783e3d05aba367)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**) Review applies to [b49045c3](https://git.openjdk.org/jdk/pull/23264/files/b49045c325956f7aeb4c945eda3cfc5a63fbe2a3)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23264/head:pull/23264` \
`$ git checkout pull/23264`

Update a local copy of the PR: \
`$ git checkout pull/23264` \
`$ git pull https://git.openjdk.org/jdk.git pull/23264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23264`

View PR using the GUI difftool: \
`$ git pr show -t 23264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23264.diff">https://git.openjdk.org/jdk/pull/23264.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23264#issuecomment-2609597308)
</details>
