### PR TITLE
8347629: Test FailOverDirectExecutionControlTest.java fails with -Xcomp

### DIFF
--- a/test/langtools/jdk/jshell/FailOverDirectExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/FailOverDirectExecutionControlTest.java
@@ -62,6 +62,7 @@ public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase
 
     ClassLoader ccl;
     ExecutionControlProvider provider;
+    Logger logger;
     LogTestHandler hndlr;
     Map<Level, List<String>> logged;
 
@@ -95,7 +96,7 @@ public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase
     @BeforeMethod
     @Override
     public void setUp() {
-        Logger logger = Logger.getLogger("jdk.jshell.execution");
+        logger = Logger.getLogger("jdk.jshell.execution");
         logger.setLevel(Level.ALL);
         hndlr = new LogTestHandler();
         logger.addHandler(hndlr);
@@ -137,8 +138,8 @@ public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase
     @Override
     public void tearDown() {
         super.tearDown();
-        Logger logger = Logger.getLogger("jdk.jshell.execution");
         logger.removeHandler(hndlr);
+        logger = null;
         Thread.currentThread().setContextClassLoader(ccl);
     }
 


### PR DESCRIPTION
The `FailOverDirectExecutionControlTest` test looks-up/creates a `Logger`, configures it, but it is not holding it while the test is running. As a consequence, the `Logger` may be GCed, loosing the configuration, and consequently failing the test.

The proposal in this PR is to hold the configured `Logger` instance for the duration of the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347629](https://bugs.openjdk.org/browse/JDK-8347629): Test FailOverDirectExecutionControlTest.java fails with -Xcomp (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23265/head:pull/23265` \
`$ git checkout pull/23265`

Update a local copy of the PR: \
`$ git checkout pull/23265` \
`$ git pull https://git.openjdk.org/jdk.git pull/23265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23265`

View PR using the GUI difftool: \
`$ git pr show -t 23265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23265.diff">https://git.openjdk.org/jdk/pull/23265.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23265#issuecomment-2609603112)
</details>
