### PR TITLE
8332980: [IR Framework] Add option to measure IR rule processing time

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -178,6 +178,7 @@ The framework provides various stress and debug flags. They should mainly be use
 - `-DVerbose=true`: Enable more fain-grained logging (slows the execution down).
 - `-DReproduce=true`: Flag to use when directly running a test VM to bypass dependencies to the driver VM state (for example, when reproducing an issue).
 - `-DPrintTimes=true`: Print the execution time measurements of each executed test.
+- `-DPrintRuleMatchingTime=true`: Print the time of matching IR rules per method. Slows down the execution as the rules are warmed up before meassurement.
 - `-DVerifyVM=true`: The framework runs the test VM with additional verification flags (slows the execution down).
 - `-DExcluceRandom=true`: The framework randomly excludes some methods from compilation. IR verification is disabled completely with this flag.
 - `-DFlipC1C2=true`: The framework compiles all `@Test` annotated method with C1 if a C2 compilation would have been applied and vice versa. IR verification is disabled completely with this flag.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,6 +148,7 @@ public class TestFramework {
     );
 
     public static final boolean VERBOSE = Boolean.getBoolean("Verbose");
+    public static final boolean PRINT_RULE_MATCHING_TIME = Boolean.getBoolean("PrintRuleMatchingTime");
     public static final boolean TESTLIST = !System.getProperty("Test", "").isEmpty();
     public static final boolean EXCLUDELIST = !System.getProperty("Exclude", "").isEmpty();
     private static final boolean REPORT_STDOUT = Boolean.getBoolean("ReportStdout");

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethod.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,9 @@ import compiler.lib.ir_framework.shared.TestFormatException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+
+import static compiler.lib.ir_framework.TestFramework.PRINT_RULE_MATCHING_TIME;
+import static compiler.lib.ir_framework.TestFramework.VERBOSE;
 
 /**
  * This class represents a {@link Test @Test} annotated method that has an associated non-empty list of applicable
@@ -83,6 +86,20 @@ public class IRMethod implements IRMethodMatchable {
      */
     @Override
     public MatchResult match() {
-        return new IRMethodMatchResult(method, matcher.match());
+        if (!PRINT_RULE_MATCHING_TIME) {
+            return new IRMethodMatchResult(method, matcher.match());
+        }
+
+        List<MatchResult> match;
+        for (int i = 0; i < 10; i++) {  // warm up
+            match = matcher.match();
+        }
+
+        long startTime = System.nanoTime();
+        match = matcher.match();
+        long endTime = System.nanoTime();
+        long duration = (endTime - startTime);
+        System.out.println("Verifying IR rules for " + name() + ": " + duration + " ns = " + (duration / 1000000) + " ms");
+        return new IRMethodMatchResult(method, match);
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethod.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethod.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static compiler.lib.ir_framework.TestFramework.PRINT_RULE_MATCHING_TIME;
-import static compiler.lib.ir_framework.TestFramework.VERBOSE;
 
 /**
  * This class represents a {@link Test @Test} annotated method that has an associated non-empty list of applicable


### PR DESCRIPTION
Adds a flag to the IR Framework that prints the time it took to verify the IR rules for each method.

Example use:

```
jtreg -jdk:build/fastdeb/jdk -verbose:all vmoptions:"-DPrintRuleMatchingTime=true" path/to/Test.java  
```

Example output:

```
Verifying IR rules for testByteArray: 548584 ns = 0 ms
Verifying IR rules for testIntArray: 702042 ns = 0 ms
Verifying IR rules for testLongArray: 466209 ns = 0 ms
Verifying IR rules for testShortArray: 731708 ns = 0 ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332980](https://bugs.openjdk.org/browse/JDK-8332980): [IR Framework] Add option to measure IR rule processing time (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23266/head:pull/23266` \
`$ git checkout pull/23266`

Update a local copy of the PR: \
`$ git checkout pull/23266` \
`$ git pull https://git.openjdk.org/jdk.git pull/23266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23266`

View PR using the GUI difftool: \
`$ git pr show -t 23266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23266.diff">https://git.openjdk.org/jdk/pull/23266.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23266#issuecomment-2609649637)
</details>
