### PR TITLE
8348401: [IR Framework] PrintTimes should not require verbose

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
@@ -124,6 +124,12 @@ public class TestFrameworkSocket implements AutoCloseable {
 
     /**
      * Only called by test VM to write to server socket.
+     * <p>
+     * The test VM is spawned by the main jtreg VM. The stdout of the test VM is hidden
+     * unless the Verbose or ReportStdout flag are used. TestFrameworkSocket is used by the parent jtreg
+     * VM and the test VM to communicate. By sending the prints through the TestFrameworkSocket with the
+     * parameter stdout set to true, the parent VM will print the received messages to its stdout, making it
+     * visible to the user.
      */
     public static void write(String msg, String tag, boolean stdout) {
         if (REPRODUCE) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
@@ -43,6 +43,7 @@ public class TestFrameworkSocket implements AutoCloseable {
     public static final String STDOUT_PREFIX = "[STDOUT]";
     public static final String TESTLIST_TAG = "[TESTLIST]";
     public static final String DEFAULT_REGEX_TAG = "[DEFAULT_REGEX]";
+    public static final String PRINT_TIMES_TAG = "[PRINT_TIMES]";
 
     // Static fields used for test VM only.
     private static final String SERVER_PORT_PROPERTY = "ir.framework.server.port";

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
@@ -126,7 +126,7 @@ public class TestFrameworkSocket implements AutoCloseable {
      * Only called by test VM to write to server socket.
      * <p>
      * The test VM is spawned by the main jtreg VM. The stdout of the test VM is hidden
-     * unless the Verbose or ReportStdout flag are used. TestFrameworkSocket is used by the parent jtreg
+     * unless the Verbose or ReportStdout flag is used. TestFrameworkSocket is used by the parent jtreg
      * VM and the test VM to communicate. By sending the prints through the TestFrameworkSocket with the
      * parameter stdout set to true, the parent VM will print the received messages to its stdout, making it
      * visible to the user.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -885,7 +885,8 @@ public class TestVM {
         if (VERBOSE || PRINT_TIMES) {
             System.out.println(System.lineSeparator() + System.lineSeparator() + "Test execution times:");
             for (Map.Entry<Long, String> entry : durations.entrySet()) {
-                System.out.format("%-10s%15d ns%n", entry.getValue() + ":", entry.getKey());
+                TestFrameworkSocket.write(String.format("%-25s%15d ns%n", entry.getValue() + ":", entry.getKey()),
+                        "", true);
             }
         }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -885,7 +885,12 @@ public class TestVM {
 
         // Print execution times
         if (VERBOSE || PRINT_TIMES) {
-            System.out.println(System.lineSeparator() + System.lineSeparator() + "Test execution times:");
+            // Here we are in the test VM, which was spawned by the main jtreg VM. the stdout of the test VM is hidden
+            // unless the Verbose or ReportStdout flag are used. TestFrameworkSocket is used by the parent jtreg
+            // VM and the test VM to communicate. By sending the prints through the TestFrameworkSocket with the
+            // parameter stdout set to true, the parent VM will print the received messages to its stdout, making it
+            // visible to the user.
+            TestFrameworkSocket.write("Test execution times:", PRINT_TIMES_TAG, true);
             for (Map.Entry<Long, String> entry : durations.entrySet()) {
                 TestFrameworkSocket.write(String.format("%-25s%15d ns%n", entry.getValue() + ":", entry.getKey()),
                         PRINT_TIMES_TAG, true);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -38,6 +38,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static compiler.lib.ir_framework.shared.TestFrameworkSocket.PRINT_TIMES_TAG;
+
 /**
  * This class' main method is called from {@link TestFramework} and represents the so-called "test VM". The class is
  * the heart of the framework and is responsible for executing all the specified tests in the test class. It uses the
@@ -886,7 +888,7 @@ public class TestVM {
             System.out.println(System.lineSeparator() + System.lineSeparator() + "Test execution times:");
             for (Map.Entry<Long, String> entry : durations.entrySet()) {
                 TestFrameworkSocket.write(String.format("%-25s%15d ns%n", entry.getValue() + ":", entry.getKey()),
-                        "", true);
+                        PRINT_TIMES_TAG, true);
             }
         }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -885,11 +885,6 @@ public class TestVM {
 
         // Print execution times
         if (VERBOSE || PRINT_TIMES) {
-            // Here we are in the test VM, which was spawned by the main jtreg VM. the stdout of the test VM is hidden
-            // unless the Verbose or ReportStdout flag are used. TestFrameworkSocket is used by the parent jtreg
-            // VM and the test VM to communicate. By sending the prints through the TestFrameworkSocket with the
-            // parameter stdout set to true, the parent VM will print the received messages to its stdout, making it
-            // visible to the user.
             TestFrameworkSocket.write("Test execution times:", PRINT_TIMES_TAG, true);
             for (Map.Entry<Long, String> entry : durations.entrySet()) {
                 TestFrameworkSocket.write(String.format("%-25s%15d ns%n", entry.getValue() + ":", entry.getKey()),


### PR DESCRIPTION
The flag -DPrintTimes=true currently only prints the measured execution time if -DVerbose=true is also used. This patch removes the dependency on -DVerbose=true. 

The measurements are made by the test vm (the VM spawned by the IR framework), which tries to print it to stdout. Since the stdout of the test VM is hidden unless the Verbose or ReportStdout flag are used, the printed times are not visible without these flags. 

This patch addresses this by using the TestFrameworkSocket, which is used by the parent jtreg VM and the test VM to communicate. By sending the prints through the TestFrameworkSocket with the parameter stdout set to true, the parent VM will print the received messages to its stdout, making it visible to the user.

Example command:

```
jtreg -jdk:build/fastdeb/jdk -verbose:all -vmoptions:"-DPrintTimes=true"
```

Example output:

```
Messages from Test VM
---------------------
[PRINT_TIMES] testIntArrayRunner:             66530333 ns
[PRINT_TIMES] testShortArrayRunner:          108031125 ns
[PRINT_TIMES] testLongArrayRunner:           159549917 ns
[PRINT_TIMES] testByteArrayRunner:           201181042 ns
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348401](https://bugs.openjdk.org/browse/JDK-8348401): [IR Framework] PrintTimes should not require verbose (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23267/head:pull/23267` \
`$ git checkout pull/23267`

Update a local copy of the PR: \
`$ git checkout pull/23267` \
`$ git pull https://git.openjdk.org/jdk.git pull/23267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23267`

View PR using the GUI difftool: \
`$ git pr show -t 23267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23267.diff">https://git.openjdk.org/jdk/pull/23267.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23267#issuecomment-2609705213)
</details>
