### PR TITLE
8348207: Linux PPC64 PCH build broken after JDK-8347909

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -57,18 +57,18 @@ ifeq ($(call isTargetOs, linux), true)
 
   ifeq ($(TOOLCHAIN_TYPE), clang)
     JVM_PRECOMPILED_HEADER_EXCLUDE := \
-      sharedRuntimeTrig.cpp \
-      sharedRuntimeTrans.cpp \
-      $(OPT_SPEED_SRC) \
-      #
+        sharedRuntimeTrig.cpp \
+        sharedRuntimeTrans.cpp \
+        $(OPT_SPEED_SRC) \
+        #
   endif
 
   ifeq ($(call isTargetCpu, ppc64le)+$(TOOLCHAIN_TYPE), true+gcc)
     JVM_PRECOMPILED_HEADER_EXCLUDE := \
-      sharedRuntimeTrig.cpp \
-      sharedRuntimeTrans.cpp \
-      $(OPT_SPEED_SRC) \
-      #
+        sharedRuntimeTrig.cpp \
+        sharedRuntimeTrans.cpp \
+        $(OPT_SPEED_SRC) \
+        #
   endif
 
   ifeq ($(call isTargetCpu, x86), true)

--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -55,11 +55,21 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_LIBJVM_sharedRuntimeTrig.cpp_CXXFLAGS := $(FDLIBM_CFLAGS) $(LIBJVM_FDLIBM_COPY_OPT_FLAG)
   BUILD_LIBJVM_sharedRuntimeTrans.cpp_CXXFLAGS := $(FDLIBM_CFLAGS) $(LIBJVM_FDLIBM_COPY_OPT_FLAG)
 
-  JVM_PRECOMPILED_HEADER_EXCLUDE := \
+  ifeq ($(TOOLCHAIN_TYPE), clang)
+    JVM_PRECOMPILED_HEADER_EXCLUDE := \
       sharedRuntimeTrig.cpp \
       sharedRuntimeTrans.cpp \
       $(OPT_SPEED_SRC) \
       #
+  endif
+
+  ifeq ($(call isTargetCpu, ppc64le)+$(TOOLCHAIN_TYPE), true+gcc)
+    JVM_PRECOMPILED_HEADER_EXCLUDE := \
+      sharedRuntimeTrig.cpp \
+      sharedRuntimeTrans.cpp \
+      $(OPT_SPEED_SRC) \
+      #
+  endif
 
   ifeq ($(call isTargetCpu, x86), true)
     # Performance measurements show that by compiling GC related code, we could

--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -52,16 +52,14 @@ ifneq ($(FDLIBM_CFLAGS), )
 endif
 
 ifeq ($(call isTargetOs, linux), true)
-  BUILD_LIBJVM_sharedRuntimeTrig.cpp_CXXFLAGS := -DNO_PCH $(FDLIBM_CFLAGS) $(LIBJVM_FDLIBM_COPY_OPT_FLAG)
-  BUILD_LIBJVM_sharedRuntimeTrans.cpp_CXXFLAGS := -DNO_PCH $(FDLIBM_CFLAGS) $(LIBJVM_FDLIBM_COPY_OPT_FLAG)
+  BUILD_LIBJVM_sharedRuntimeTrig.cpp_CXXFLAGS := $(FDLIBM_CFLAGS) $(LIBJVM_FDLIBM_COPY_OPT_FLAG)
+  BUILD_LIBJVM_sharedRuntimeTrans.cpp_CXXFLAGS := $(FDLIBM_CFLAGS) $(LIBJVM_FDLIBM_COPY_OPT_FLAG)
 
-  ifeq ($(TOOLCHAIN_TYPE), clang)
-    JVM_PRECOMPILED_HEADER_EXCLUDE := \
-	sharedRuntimeTrig.cpp \
-	sharedRuntimeTrans.cpp \
-        $(OPT_SPEED_SRC) \
-	#
-  endif
+  JVM_PRECOMPILED_HEADER_EXCLUDE := \
+      sharedRuntimeTrig.cpp \
+      sharedRuntimeTrans.cpp \
+      $(OPT_SPEED_SRC) \
+      #
 
   ifeq ($(call isTargetCpu, x86), true)
     # Performance measurements show that by compiling GC related code, we could


### PR DESCRIPTION
The Linux PPC64 PCH build was broken after JDK-8347909.
Build error
```
* For target hotspot_variant-server_libjvm_objs_sharedRuntimeTrans.o:
cc1plus: error: /jdk25_opt/hotspot/variant-server/libjvm/objs/precompiled/precompiled.hpp.gch: created and used with differing settings of '-mpower8-fusion-sign' [-Werror=invalid-pch]
cc1plus: error: one or more PCH files were found, but they were invalid
<command-line>: fatal error: precompiled.hpp: No such file or directory

* For target hotspot_variant-server_libjvm_objs_sharedRuntimeTrig.o:
cc1plus: error: /jdk25_opt/hotspot/variant-server/libjvm/objs/precompiled/precompiled.hpp.gch: created and used with differing settings of '-mpower8-fusion-sign' [-Werror=invalid-pch]
cc1plus: error: one or more PCH files were found, but they were invalid
<command-line>: fatal error: precompiled.hpp: No such file or directory
```

There was a mismatch of the build settings of  precompiled.hpp.gch and these 2 compilation units leading to this error;  the PCH build exclusion of these 2 files did not work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348207](https://bugs.openjdk.org/browse/JDK-8348207): Linux PPC64 PCH build broken after JDK-8347909 (**Bug** - P2)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) Review applies to [cd1589f6](https://git.openjdk.org/jdk/pull/23268/files/cd1589f6ca7167b13abfe6b6473c046847dfdfad)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) Review applies to [a750c2a2](https://git.openjdk.org/jdk/pull/23268/files/a750c2a2cd25ab6e82da44df0ae064750a70fcf7)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Contributors
 * Stefan Karlsson `<stefank@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23268/head:pull/23268` \
`$ git checkout pull/23268`

Update a local copy of the PR: \
`$ git checkout pull/23268` \
`$ git pull https://git.openjdk.org/jdk.git pull/23268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23268`

View PR using the GUI difftool: \
`$ git pr show -t 23268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23268.diff">https://git.openjdk.org/jdk/pull/23268.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23268#issuecomment-2609760287)
</details>
