### PR TITLE
8346920: Serial: Support allocation in old generation when heap is almost full

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -95,6 +95,7 @@ SerialHeap::SerialHeap() :
     _gc_policy_counters(new GCPolicyCounters("Copy:MSC", 2, 2)),
     _young_manager(nullptr),
     _old_manager(nullptr),
+    _is_heap_almost_full(false),
     _eden_pool(nullptr),
     _survivor_pool(nullptr),
     _old_pool(nullptr) {
@@ -288,7 +289,8 @@ size_t SerialHeap::max_capacity() const {
 bool SerialHeap::should_try_older_generation_allocation(size_t word_size) const {
   size_t young_capacity = _young_gen->capacity_before_gc();
   return    (word_size > heap_word_size(young_capacity))
-         || GCLocker::is_active_and_needs_gc();
+         || GCLocker::is_active_and_needs_gc()
+         || _is_heap_almost_full;
 }
 
 HeapWord* SerialHeap::expand_heap_and_allocate(size_t size, bool is_tlab) {
@@ -950,6 +952,19 @@ void SerialHeap::gc_epilogue(bool full) {
 
   _young_gen->gc_epilogue(full);
   _old_gen->gc_epilogue();
+
+  if (_is_heap_almost_full) {
+    // Reset the emergency state if eden is empty after a young/full gc
+    if (_young_gen->eden()->is_empty()) {
+      _is_heap_almost_full = false;
+    }
+  } else {
+    if (full && !_young_gen->eden()->is_empty()) {
+      // Usually eden should be empty after a full GC, so heap is probably too
+      // full now; entering emergency state.
+      _is_heap_almost_full = true;
+    }
+  }
 
   MetaspaceCounters::update_performance_counters();
 };

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -283,9 +283,7 @@ size_t SerialHeap::max_capacity() const {
 // Return true if any of the following is true:
 // . the allocation won't fit into the current young gen heap
 // . gc locker is occupied (jni critical section)
-// . heap memory is tight -- the most recent previous collection
-//   was a full collection because a partial collection (would
-//   have) failed and is likely to fail again
+// . heap memory is tight
 bool SerialHeap::should_try_older_generation_allocation(size_t word_size) const {
   size_t young_capacity = _young_gen->capacity_before_gc();
   return    (word_size > heap_word_size(young_capacity))

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -95,6 +95,13 @@ private:
   GCMemoryManager* _young_manager;
   GCMemoryManager* _old_manager;
 
+  // Indicate whether heap is almost or approaching full.
+  // Usually, there is some memory headroom for application/gc to run properly.
+  // However, in extreme cases, e.g. young-gen is non-empty after a full gc, we
+  // will attempt some uncommon measures, e.g. alllocating small objs in
+  // old-gen.
+  bool _is_heap_almost_full;
+
   // Helper functions for allocation
   HeapWord* attempt_allocation(size_t size,
                                bool   is_tlab,


### PR DESCRIPTION
This PR restores the support for allocation in old-gen when heap is almost full, detected as non-empty young-gen after full gc, which was removed by mistake in [JDK-8333786](https://bugs.openjdk.org/browse/JDK-8333786). With this change, the benchmark attached to the ticket now completes in ~13 GC.

Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346920](https://bugs.openjdk.org/browse/JDK-8346920): Serial: Support allocation in old generation when heap is almost full (**Bug** - P4)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**) Review applies to [30323d46](https://git.openjdk.org/jdk/pull/23270/files/30323d461989c6ead002033b27c91f10785c8461)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23270/head:pull/23270` \
`$ git checkout pull/23270`

Update a local copy of the PR: \
`$ git checkout pull/23270` \
`$ git pull https://git.openjdk.org/jdk.git pull/23270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23270`

View PR using the GUI difftool: \
`$ git pr show -t 23270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23270.diff">https://git.openjdk.org/jdk/pull/23270.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23270#issuecomment-2610088420)
</details>
