### PR TITLE
8336017: Deprecate java.util.logging.LoggingMXBean, its implementation, and accessor method for removal

### DIFF
--- a/src/java.logging/share/classes/java/util/logging/LogManager.java
+++ b/src/java.logging/share/classes/java/util/logging/LogManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2406,16 +2406,17 @@ public class LogManager {
      * @return a {@link LoggingMXBean} object.
      *
      * @deprecated {@code java.util.logging.LoggingMXBean} is deprecated and
-     *      replaced with {@code java.lang.management.PlatformLoggingMXBean}. Use
-     *      {@link java.management/java.lang.management.ManagementFactory#getPlatformMXBean(Class)
+     *      replaced with {@code java.lang.management.PlatformLoggingMXBean}.
+     *      This method will be removed.
+     *      Use {@link java.management/java.lang.management.ManagementFactory#getPlatformMXBean(Class)
      *      ManagementFactory.getPlatformMXBean}(PlatformLoggingMXBean.class)
      *      instead.
      *
      * @see java.management/java.lang.management.PlatformLoggingMXBean
      * @since 1.5
      */
-    @Deprecated(since="9")
-    @SuppressWarnings("doclint:reference")
+    @Deprecated(since="9", forRemoval=true)
+    @SuppressWarnings({"doclint:reference", "removal"})
     public static synchronized LoggingMXBean getLoggingMXBean() {
         return Logging.getInstance();
     }

--- a/src/java.logging/share/classes/java/util/logging/Logging.java
+++ b/src/java.logging/share/classes/java/util/logging/Logging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,8 @@ import java.util.ArrayList;
  * @see Logger
  * @see LogManager
  */
-@SuppressWarnings("deprecation") // implements LoggingMXBean
+@Deprecated(since="25", forRemoval=true)
+@SuppressWarnings("removal") // implements LoggingMXBean
 final class Logging implements LoggingMXBean {
 
     private static LogManager logManager = LogManager.getLogManager();

--- a/src/java.logging/share/classes/java/util/logging/LoggingMXBean.java
+++ b/src/java.logging/share/classes/java/util/logging/LoggingMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ package java.util.logging;
  * with {@link java.management/java.lang.management.PlatformLoggingMXBean}.
  * It will not register in the platform {@code MBeanServer}.
  * Use {@code ManagementFactory.getPlatformMXBean(PlatformLoggingMXBean.class)}
- * instead.
+ * instead.  This class will be removed.
  *
  * @author  Ron Mann
  * @author  Mandy Chung
@@ -51,7 +51,7 @@ package java.util.logging;
  *
  * @see java.management/java.lang.management.PlatformLoggingMXBean
  */
-@Deprecated(since="9")
+@Deprecated(since="9", forRemoval=true)
 @SuppressWarnings("doclint:reference")
 public interface LoggingMXBean {
 


### PR DESCRIPTION
java.util.logging.LoggingMXBean and java.util.logging.LogManager::getLoggingMXBean are deprecated since JDK-8139982 in JDK 9.

These deprecations should be uprated to state they are for future removal.

java.util.logging.Logging (implements LoggingMXBean) should also be deprecated for removal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Change requires CSR request [JDK-8348407](https://bugs.openjdk.org/browse/JDK-8348407) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8336017](https://bugs.openjdk.org/browse/JDK-8336017): Deprecate java.util.logging.LoggingMXBean, its implementation, and accessor method for removal (**Enhancement** - P4)
 * [JDK-8348407](https://bugs.openjdk.org/browse/JDK-8348407): Deprecate java.util.logging.LoggingMXBean, its implementation, and accessor method for removal (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23271/head:pull/23271` \
`$ git checkout pull/23271`

Update a local copy of the PR: \
`$ git checkout pull/23271` \
`$ git pull https://git.openjdk.org/jdk.git pull/23271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23271`

View PR using the GUI difftool: \
`$ git pr show -t 23271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23271.diff">https://git.openjdk.org/jdk/pull/23271.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23271#issuecomment-2610147698)
</details>
