### PR TITLE
8326485: Assertion due to Type.addMetadata adding annotations to already-annotated type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -472,7 +472,6 @@ public class TypeAnnotations {
                         enclEl.getKind() != ElementKind.PACKAGE &&
                         enclTy != null &&
                         enclTy.getKind() != TypeKind.NONE &&
-                        enclTy.getKind() != TypeKind.ERROR &&
                         (enclTr.getKind() == JCTree.Kind.MEMBER_SELECT ||
                                 enclTr.getKind() == JCTree.Kind.PARAMETERIZED_TYPE ||
                                 enclTr.getKind() == JCTree.Kind.ANNOTATED_TYPE)) {

--- a/test/langtools/tools/javac/T8326485.java
+++ b/test/langtools/tools/javac/T8326485.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8326485
+ * @compile/fail/ref=T8326485.out -XDrawDiagnostics -XDdev T8326485.java
+ * @summary Assertion due to Type.addMetadata adding annotations to already-annotated type
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+public class T8326485 {
+    @Ann
+    not.java.lang.@Ann String f;
+}
+
+@Target({ElementType.TYPE_USE, ElementType.FIELD})
+@interface Ann {}

--- a/test/langtools/tools/javac/T8326485.out
+++ b/test/langtools/tools/javac/T8326485.out
@@ -1,0 +1,2 @@
+T8326485.java:36:18: compiler.err.doesnt.exist: not.java.lang
+1 error


### PR DESCRIPTION
We end up with an errorType having annotation metadata (which subsequently results in this assertion getting invalidated after `Type ret = typeWithAnnotations(type, enclTy, annotations);` is executed).

What if we continue to try to define the `enclTy` (iteratively)? The error can still be reported appropriately. If this PR is merged it reproduces the original test case by running as expected: many errors without a crash:

```
javac src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinChatInputSuggestor.java -cp /tmp/jars/annotations-20.1.0.jar:/tmp/jars/kotlin-compiler-embeddable-1.9.0.jar
```

WDYT?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326485](https://bugs.openjdk.org/browse/JDK-8326485): Assertion due to Type.addMetadata adding annotations to already-annotated type (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23272/head:pull/23272` \
`$ git checkout pull/23272`

Update a local copy of the PR: \
`$ git checkout pull/23272` \
`$ git pull https://git.openjdk.org/jdk.git pull/23272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23272`

View PR using the GUI difftool: \
`$ git pr show -t 23272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23272.diff">https://git.openjdk.org/jdk/pull/23272.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23272#issuecomment-2610295067)
</details>
