### PR TITLE
8348406: Remove tests GrantAllPermToExtWhenNoPolicy and PrincipalExpansionError from problem list

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -1,6 +1,6 @@
 ###########################################################################
 #
-# Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -636,8 +636,6 @@ sun/security/smartcardio/TestTransmit.java                      8039280 generic-
 com/sun/security/sasl/gsskerb/AuthOnly.java                     8039280 generic-all
 com/sun/security/sasl/gsskerb/ConfSecurityLayer.java            8039280 generic-all
 com/sun/security/sasl/gsskerb/NoSecurityLayer.java              8039280 generic-all
-sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
-sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
 
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183 linux-ppc64le
 


### PR DESCRIPTION
The following test files were deleted and has been removed from the problem list:
- sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java
- sun/security/provider/PolicyParser/PrincipalExpansionError.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348406](https://bugs.openjdk.org/browse/JDK-8348406): Remove tests GrantAllPermToExtWhenNoPolicy and PrincipalExpansionError from problem list (**Bug** - P4)


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23275/head:pull/23275` \
`$ git checkout pull/23275`

Update a local copy of the PR: \
`$ git checkout pull/23275` \
`$ git pull https://git.openjdk.org/jdk.git pull/23275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23275`

View PR using the GUI difftool: \
`$ git pr show -t 23275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23275.diff">https://git.openjdk.org/jdk/pull/23275.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23275#issuecomment-2610640265)
</details>
