### PR TITLE
8336760: [JVMCI] -XX:+PrintCompilation should also print "hosted" JVMCI compilations

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -814,6 +814,12 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
         DirectiveSet* directive = DirectivesStack::getMatchingDirective(method, compiler);
         nm->maybe_print_nmethod(directive);
         DirectivesStack::release(directive);
+
+        {
+          // Since this compilation didn't pass through the broker it wasn't logged yet.
+          ttyLocker ttyl;
+          CompileTask::print(tty, nm, "(hosted JVMCI compilation)");
+        }
       }
 
       BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -815,8 +815,8 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
         nm->maybe_print_nmethod(directive);
         DirectivesStack::release(directive);
 
-        {
-          // Since this compilation didn't pass through the broker it wasn't logged yet.
+        // Since this compilation didn't pass through the broker it wasn't logged yet.
+        if (PrintCompilation) {
           ttyLocker ttyl;
           CompileTask::print(tty, nm, "(hosted JVMCI compilation)");
         }


### PR DESCRIPTION
Currently, `-XX:+PrintCompilation` does not print "hosted" JVMCI compilations (i.e. JVMCI compilations not triggered by the `CompilerBroker` but e.g. by the Truffle framework). On the other hand, if such an nmethod which results from a "hosted" compilation gets deoptimized, it will be printed by `-XX:+PrintCompilation` (with a compilation ID that doesn't appear anywhere before in the compilation log.

This pull request is intended to fix that. The snippet below is an example of output printed (with PrintCompilation and CIPrintCompilerName enabled) for Truffle hosted compilations using this patch.

```
783 JVMCI:4667       4       com.oracle.truffle.runtime.OptimizedCallTarget::callBoundary (19 bytes)   (hosted JVMCI compilation)
785 JVMCI:5342       4       com.oracle.truffle.runtime.hotspot.HotSpotFastThreadLocal::get (4 bytes)   (hosted JVMCI compilation)
786 JVMCI:5411       4       com.oracle.truffle.runtime.hotspot.HotSpotFastThreadLocal::set (5 bytes)   (hosted JVMCI compilation)
1582 JVMCI:10125       4       com.oracle.truffle.runtime.OptimizedCallTarget::profiledPERoot (51 bytes)   (hosted JVMCI compilation)
1591 JVMCI:10899       4       com.oracle.truffle.runtime.OptimizedCallTarget::profiledPERoot (51 bytes)   (hosted JVMCI compilation)
1652 JVMCI:11064       4       com.oracle.truffle.runtime.OptimizedCallTarget::profiledPERoot (51 bytes)   (hosted JVMCI compilation)
1656 JVMCI:11175       4       com.oracle.truffle.runtime.OptimizedCallTarget::profiledPERoot (51 bytes)   (hosted JVMCI compilation)
```

/cc @dougxc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336760](https://bugs.openjdk.org/browse/JDK-8336760): [JVMCI] -XX:+PrintCompilation should also print "hosted" JVMCI compilations (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23278/head:pull/23278` \
`$ git checkout pull/23278`

Update a local copy of the PR: \
`$ git checkout pull/23278` \
`$ git pull https://git.openjdk.org/jdk.git pull/23278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23278`

View PR using the GUI difftool: \
`$ git pr show -t 23278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23278.diff">https://git.openjdk.org/jdk/pull/23278.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23278#issuecomment-2610916195)
</details>
