### PR TITLE
8348239: SA does not know about DeoptimizeObjectsALotThread

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -773,20 +773,6 @@ void CompileBroker::compilation_init(JavaThread* THREAD) {
 }
 
 #if defined(ASSERT) && COMPILER2_OR_JVMCI
-// Stress testing. Dedicated threads revert optimizations based on escape analysis concurrently to
-// the running java application.  Configured with vm options DeoptimizeObjectsALot*.
-class DeoptimizeObjectsALotThread : public JavaThread {
-
-  static void deopt_objs_alot_thread_entry(JavaThread* thread, TRAPS);
-  void deoptimize_objects_alot_loop_single();
-  void deoptimize_objects_alot_loop_all();
-
-public:
-  DeoptimizeObjectsALotThread() : JavaThread(&deopt_objs_alot_thread_entry) { }
-
-  bool is_hidden_from_external_view() const      { return true; }
-};
-
 // Entry for DeoptimizeObjectsALotThread. The threads are started in
 // CompileBroker::init_compiler_threads() iff DeoptimizeObjectsALot is enabled
 void DeoptimizeObjectsALotThread::deopt_objs_alot_thread_entry(JavaThread* thread, TRAPS) {

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,22 @@
 #endif
 
 class nmethod;
+
+#if defined(ASSERT) && COMPILER2_OR_JVMCI
+// Stress testing. Dedicated threads revert optimizations based on escape analysis concurrently to
+// the running java application.  Configured with vm options DeoptimizeObjectsALot*.
+class DeoptimizeObjectsALotThread : public JavaThread {
+
+  static void deopt_objs_alot_thread_entry(JavaThread* thread, TRAPS);
+  void deoptimize_objects_alot_loop_single();
+  void deoptimize_objects_alot_loop_all();
+
+public:
+  DeoptimizeObjectsALotThread() : JavaThread(&deopt_objs_alot_thread_entry) { }
+
+  bool is_hidden_from_external_view() const      { return true; }
+};
+#endif
 
 // CompilerCounters
 //

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1261,6 +1261,8 @@
         declare_type(CompilerThread, JavaThread)                          \
         declare_type(StringDedupThread, JavaThread)                       \
         declare_type(AttachListenerThread, JavaThread)                    \
+        DEBUG_ONLY(COMPILER2_OR_JVMCI_PRESENT(                            \
+          declare_type(DeoptimizeObjectsALotThread, JavaThread)))         \
   declare_toplevel_type(OSThread)                                         \
   declare_toplevel_type(JavaFrameAnchor)                                  \
                                                                           \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/DeoptimizeObjectsALotThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/DeoptimizeObjectsALotThread.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.runtime;
+
+import java.io.*;
+
+import sun.jvm.hotspot.debugger.Address;
+
+public class DeoptimizeObjectsALotThread extends JavaThread {
+
+  public DeoptimizeObjectsALotThread (Address addr) {
+    super(addr);
+  }
+
+  public boolean isJavaThread() { return false; }
+  public boolean isHiddenFromExternalView() { return true; }
+
+  public boolean isDeoptimizeObjectsALotThread() { return true; }
+
+}

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,6 +89,7 @@ public class Thread extends VMObject {
   public boolean   isServiceThread()             { return false; }
   public boolean   isMonitorDeflationThread()    { return false; }
   public boolean   isAttachListenerThread()      { return false; }
+  public boolean   isDeoptimizeObjectsALotThread() { return false; }
 
   /** Memory operations */
   public void oopsDo(AddressVisitor oopVisitor) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,6 +155,7 @@ public class Threads {
         virtualConstructor.addMapping("NotificationThread", NotificationThread.class);
         virtualConstructor.addMapping("StringDedupThread", StringDedupThread.class);
         virtualConstructor.addMapping("AttachListenerThread", AttachListenerThread.class);
+        virtualConstructor.addMapping("DeoptimizeObjectsALotThread", DeoptimizeObjectsALotThread.class);
     }
 
     public Threads() {
@@ -163,8 +164,8 @@ public class Threads {
 
     /** NOTE: this returns objects of type JavaThread, CompilerThread,
       JvmtiAgentThread, NotificationThread, MonitorDeflationThread,
-      StringDedupThread, AttachListenerThread and ServiceThread.
-      The latter seven subclasses of the former. Most operations
+      StringDedupThread, AttachListenerThread, DeoptimizeObjectsALotThread and
+      ServiceThread. The latter seven subclasses of the former. Most operations
       (fetching the top frame, etc.) are only allowed to be performed on
       a "pure" JavaThread. For this reason, {@link
       sun.jvm.hotspot.runtime.JavaThread#isJavaThread} has been
@@ -195,7 +196,7 @@ public class Threads {
         } catch (Exception e) {
             throw new RuntimeException("Unable to deduce type of thread from address " + threadAddr +
             " (expected type JavaThread, CompilerThread, MonitorDeflationThread, AttachListenerThread," +
-            " StringDedupThread, NotificationThread, ServiceThread or JvmtiAgentThread)", e);
+            " DeoptimizeObjectsALotThread, StringDedupThread, NotificationThread, ServiceThread or JvmtiAgentThread)", e);
         }
     }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -162,13 +162,12 @@ public class Threads {
         _list = VMObjectFactory.newObject(ThreadsList.class, threadListField.getValue());
     }
 
-    /** NOTE: this returns objects of type JavaThread, CompilerThread,
-      JvmtiAgentThread, NotificationThread, MonitorDeflationThread,
+    /** NOTE: this returns objects of type JavaThread or one if its subclasses:
+      CompilerThread, JvmtiAgentThread, NotificationThread, MonitorDeflationThread,
       StringDedupThread, AttachListenerThread, DeoptimizeObjectsALotThread and
-      ServiceThread. The latter seven subclasses of the former. Most operations
-      (fetching the top frame, etc.) are only allowed to be performed on
-      a "pure" JavaThread. For this reason, {@link
-      sun.jvm.hotspot.runtime.JavaThread#isJavaThread} has been
+      ServiceThread. Most operations (fetching the top frame, etc.) are only
+      allowed to be performed on a "pure" JavaThread. For this reason,
+      {@link sun.jvm.hotspot.runtime.JavaThread#isJavaThread} has been
       changed from the definition in the VM (which returns true for
       all of these thread types) to return true for JavaThreads and
       false for the seven subclasses. FIXME: should reconsider the


### PR DESCRIPTION
If you run hotspot with -XX:+DeoptimizeObjectsALot, it will create one or more DeoptimizeObjectsALotThread threads. This is one of many JavaThread subclasses that SA needs to know about, but in this case it does not. When SA tries to create a mirror of one of these threads, it fails with:

```
 stderr: [java.lang.RuntimeException: Unable to deduce type of thread from address 0x0000ffff34144e30 (expected type JavaThread, CompilerThread, MonitorDeflationThread, AttachListenerThread, StringDedupThread, NotificationThread, ServiceThread or JvmtiAgentThread)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.Threads.createJavaThreadWrapper(Threads.java:196)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.Threads.getJavaThreadAt(Threads.java:178)
```

The following can be used to reproduce this failure. Most SA tests will fail:

 make test TEST=serviceability/sa TEST_VM_OPTS=-XX:+DeoptimizeObjectsALot 

I had to move the native DeoptimizeObjectsALotThread declaration to compileBroker.hpp to make it visible to vmStructs.cpp.

I tested with the above "make test" command and ran all svc tier1, tier2, tier3, and tier5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348239](https://bugs.openjdk.org/browse/JDK-8348239): SA does not know about DeoptimizeObjectsALotThread (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) Review applies to [8ba5e23a](https://git.openjdk.org/jdk/pull/23279/files/8ba5e23a253a4b8250e9e2c6c9bb2e5626350268)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [8ba5e23a](https://git.openjdk.org/jdk/pull/23279/files/8ba5e23a253a4b8250e9e2c6c9bb2e5626350268)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) Review applies to [8ba5e23a](https://git.openjdk.org/jdk/pull/23279/files/8ba5e23a253a4b8250e9e2c6c9bb2e5626350268)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23279/head:pull/23279` \
`$ git checkout pull/23279`

Update a local copy of the PR: \
`$ git checkout pull/23279` \
`$ git pull https://git.openjdk.org/jdk.git pull/23279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23279`

View PR using the GUI difftool: \
`$ git pr show -t 23279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23279.diff">https://git.openjdk.org/jdk/pull/23279.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23279#issuecomment-2610939969)
</details>
