### PR TITLE
8184352: Remove Sun provider information from KeyPairGenerator javadoc

### DIFF
--- a/src/java.base/share/classes/java/security/KeyPairGenerator.java
+++ b/src/java.base/share/classes/java/security/KeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/KeyPairGenerator.java
+++ b/src/java.base/share/classes/java/security/KeyPairGenerator.java
@@ -69,7 +69,7 @@ import sun.security.util.Debug;
  * algorithm-independent {@code initialize} methods, it is up to the
  * provider what to do about the algorithm-specific parameters (if any) to be
  * associated with each of the keys. See the
- * {@extlink security_guide_jdk_providers JDK Providers} document for information
+ * {@extLink security_guide_jdk_providers JDK Providers} document for information
  * on the default algorithm-specific parameters used by JDK providers.
  *
  * <li><b>Algorithm-Specific Initialization</b>

--- a/src/java.base/share/classes/java/security/KeyPairGenerator.java
+++ b/src/java.base/share/classes/java/security/KeyPairGenerator.java
@@ -68,10 +68,9 @@ import sun.security.util.Debug;
  * <p>Since no other parameters are specified when you call the above
  * algorithm-independent {@code initialize} methods, it is up to the
  * provider what to do about the algorithm-specific parameters (if any) to be
- * associated with each of the keys. Information about how the <i>Sun</i> prover
- * handles such algorithm-specific parameters can be found in the
- * <a href="https://docs.oracle.com/en/java/javase/11/security/oracle-providers.html">
- *     JDK Providers Documentation</a>.
+ * associated with each of the keys. See the
+ * {@extlink security_guide_jdk_providers JDK Providers} document for information
+ * on the default algorithm-specific parameters used by JDK providers.
  *
  * <li><b>Algorithm-Specific Initialization</b>
  * <p>For situations where a set of algorithm-specific parameters already

--- a/src/java.base/share/classes/java/security/KeyPairGenerator.java
+++ b/src/java.base/share/classes/java/security/KeyPairGenerator.java
@@ -68,16 +68,10 @@ import sun.security.util.Debug;
  * <p>Since no other parameters are specified when you call the above
  * algorithm-independent {@code initialize} methods, it is up to the
  * provider what to do about the algorithm-specific parameters (if any) to be
- * associated with each of the keys.
- *
- * <p>If the algorithm is the <i>DSA</i> algorithm, and the keysize (modulus
- * size) is 512, 768, 1024, or 2048, then the <i>Sun</i> provider uses a set of
- * precomputed values for the {@code p}, {@code q}, and
- * {@code g} parameters. If the modulus size is not one of the above
- * values, the <i>Sun</i> provider creates a new set of parameters. Other
- * providers might have precomputed parameter sets for more than just the
- * modulus sizes mentioned above. Still others might not have a list of
- * precomputed parameters at all and instead always create new parameter sets.
+ * associated with each of the keys. Information about how the <i>Sun</i> prover
+ * handles such algorithm-specific parameters can be found in the
+ * <a href="https://docs.oracle.com/en/java/javase/11/security/oracle-providers.html">
+ *     JDK Providers Documentation</a>.
  *
  * <li><b>Algorithm-Specific Initialization</b>
  * <p>For situations where a set of algorithm-specific parameters already


### PR DESCRIPTION
Removed algorithm-specific information from `KeyPairGenerator` class description and instead linked out to the Sun Provider documentation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8184352](https://bugs.openjdk.org/browse/JDK-8184352): Remove Sun provider information from KeyPairGenerator javadoc (**Bug** - P3)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23280/head:pull/23280` \
`$ git checkout pull/23280`

Update a local copy of the PR: \
`$ git checkout pull/23280` \
`$ git pull https://git.openjdk.org/jdk.git pull/23280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23280`

View PR using the GUI difftool: \
`$ git pr show -t 23280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23280.diff">https://git.openjdk.org/jdk/pull/23280.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23280#issuecomment-2611009924)
</details>
