### PR TITLE
8348429: Update cross-compilation devkits to Fedora 41/gcc 13.2

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -235,7 +235,7 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
       CFLAGS_WARNINGS_ARE_ERRORS="-Werror"
 
       # Additional warnings that are not activated by -Wall and -Wextra
-      WARNINGS_ENABLE_ADDITIONAL="-Wpointer-arith -Wreturn-type -Wsign-compare \
+      WARNINGS_ENABLE_ADDITIONAL="-Winvalid-pch -Wpointer-arith -Wreturn-type -Wsign-compare \
           -Wtrampolines -Wundef -Wunused-const-variable=1 -Wunused-function \
           -Wunused-result -Wunused-value -Wtype-limits -Wuninitialized"
       WARNINGS_ENABLE_ADDITIONAL_CXX="-Woverloaded-virtual -Wreorder"

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1092,9 +1092,9 @@ var getJibProfilesDependencies = function (input, common) {
         windows_x64: "VS2022-17.6.5+1.0",
         linux_aarch64: "gcc13.2.0-OL7.6+1.0",
         linux_arm: "gcc8.2.0-Fedora27+1.0",
-        linux_ppc64le: "gcc8.2.0-Fedora27+1.0",
-        linux_s390x: "gcc8.2.0-Fedora27+1.0",
-        linux_riscv64: "gcc11.3.0-Fedora_rawhide_68692+1.1"
+        linux_ppc64le: "gcc13.2.0-Fedora_41+1.0",
+        linux_s390x: "gcc13.2.0-Fedora_41+1.0",
+        linux_riscv64: "gcc13.2.0-Fedora_41+1.0"
     };
 
     var devkit_platform = (input.target_cpu == "x86"

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -63,18 +63,14 @@ ifeq ($(BASE_OS), OL)
     LINUX_VERSION := OL6.4
   endif
 else ifeq ($(BASE_OS), Fedora)
+  DEFAULT_OS_VERSION := 41
+  ifeq ($(BASE_OS_VERSION), )
+    BASE_OS_VERSION := $(DEFAULT_OS_VERSION)
+  endif
   ifeq ($(ARCH), riscv64)
-    DEFAULT_OS_VERSION := rawhide/68692
-    ifeq ($(BASE_OS_VERSION), )
-      BASE_OS_VERSION := $(DEFAULT_OS_VERSION)
-    endif
-    BASE_URL := http://fedora.riscv.rocks/repos-dist/$(BASE_OS_VERSION)/$(ARCH)/Packages/
+    BASE_URL := http://fedora.riscv.rocks/repos-dist/f$(BASE_OS_VERSION)/latest/$(ARCH)/Packages/
   else
-    DEFAULT_OS_VERSION := 27
     LATEST_ARCHIVED_OS_VERSION := 35
-    ifeq ($(BASE_OS_VERSION), )
-      BASE_OS_VERSION := $(DEFAULT_OS_VERSION)
-    endif
     ifeq ($(filter x86_64 armhfp, $(ARCH)), )
       FEDORA_TYPE := fedora-secondary
     else
@@ -203,7 +199,7 @@ RPM_LIST := \
     glibc glibc-headers glibc-devel \
     cups-libs cups-devel \
     libX11 libX11-devel \
-    xorg-x11-proto-devel \
+    libxcb xorg-x11-proto-devel \
     alsa-lib alsa-lib-devel \
     libXext libXext-devel \
     libXtst libXtst-devel \
@@ -441,8 +437,9 @@ $(gcc) \
 # wants.
 $(BUILDDIR)/$(binutils_ver)/Makefile : CONFIG += --enable-64-bit-bfd --libdir=$(PREFIX)/$(word 1,$(LIBDIRS))
 
-ifneq ($(ARCH), riscv64)
-  # gold is not available for riscv64 for some reason,
+ifeq ($(filter $(ARCH), s390x riscv64 ppc64le), )
+  # gold compiles but cannot link properly on s390x @ gcc 13.2 and Fedore 41
+  # gold is not available for riscv64 and ppc64le,
   # and subsequent linking will fail if we try to enable it.
   LINKER_CONFIG := --enable-gold=default
 endif

--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -55,12 +55,19 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_LIBJVM_sharedRuntimeTrig.cpp_CXXFLAGS := -DNO_PCH $(FDLIBM_CFLAGS) $(LIBJVM_FDLIBM_COPY_OPT_FLAG)
   BUILD_LIBJVM_sharedRuntimeTrans.cpp_CXXFLAGS := -DNO_PCH $(FDLIBM_CFLAGS) $(LIBJVM_FDLIBM_COPY_OPT_FLAG)
 
+  ifeq ($(call isTargetCpu, ppc64le)+$(TOOLCHAIN_TYPE), true+gcc)
+    JVM_PRECOMPILED_HEADER_EXCLUDE := \
+        sharedRuntimeTrig.cpp \
+        sharedRuntimeTrans.cpp \
+        #
+  endif
+
   ifeq ($(TOOLCHAIN_TYPE), clang)
     JVM_PRECOMPILED_HEADER_EXCLUDE := \
-	sharedRuntimeTrig.cpp \
-	sharedRuntimeTrans.cpp \
+        sharedRuntimeTrig.cpp \
+        sharedRuntimeTrans.cpp \
         $(OPT_SPEED_SRC) \
-	#
+        #
   endif
 
   ifeq ($(call isTargetCpu, x86), true)


### PR DESCRIPTION
The devkit makefile is a public description on how Oracle builds the JDK in its CI system. This patch will update the devkit makefile to make Fedora 41 default for all platforms, and update the jib configuration to use devkits based on Fedora 41 and gcc 13.2.

Also some additional fixes are needed to make this work:
* `Winvalid-pch` is not as much a warning per se, as an extended diagnostic when gcc encounters PCH failures (which I did on PPC). I think it does not hurt to keep it on for all platforms.
* gold seems mostly abandoned these days. :-( It fails to compile for two of the platforms, and produces a broken linker on the third.
* libxcb is needed by libX11 on riscv64; technically it is not needed for the other architectures but I did not bother make an architecture-specific mechanism.
* And Fedora riscv64 has finally been part of a proper release, so we can skip hardcoding a specific rawhide drop.
* The strange edits in the clang part of the sharedRuntimeTrig etc exceptions is me replacing incorrect leading tabs with spaces.
