### PR TITLE
8347997: assert(false) failed: EA: missing memory path

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3772,6 +3772,18 @@ bool LibraryCallKit::inline_native_Continuation_pinning(bool unpin) {
   Node* test_pin_count_over_underflow = _gvn.transform(new BoolNode(pin_count_cmp, BoolTest::eq));
   IfNode* iff_pin_count_over_underflow = create_and_map_if(control(), test_pin_count_over_underflow, PROB_MIN, COUNT_UNKNOWN);
 
+  // True branch, pin count over/underflow.
+  Node* pin_count_over_underflow = _gvn.transform(new IfTrueNode(iff_pin_count_over_underflow));
+  {
+    // Trap (but not deoptimize (Action_none)) and continue in the interpreter
+    // which will throw IllegalStateException for pin count over/underflow.
+    PreserveJVMState pjvms(this);
+    set_control(pin_count_over_underflow);
+    uncommon_trap(Deoptimization::Reason_intrinsic,
+                  Deoptimization::Action_none);
+    assert(stopped(), "invariant");
+  }
+
   // False branch, no pin count over/underflow. Increment or decrement pin count and store back.
   Node* valid_pin_count = _gvn.transform(new IfFalseNode(iff_pin_count_over_underflow));
   set_control(valid_pin_count);
@@ -3783,20 +3795,7 @@ bool LibraryCallKit::inline_native_Continuation_pinning(bool unpin) {
     next_pin_count = _gvn.transform(new AddINode(pin_count, _gvn.intcon(1)));
   }
 
-  Node* updated_pin_count_memory = store_to_memory(control(), pin_count_offset, next_pin_count, T_INT, MemNode::unordered);
-
-  // True branch, pin count over/underflow.
-  Node* pin_count_over_underflow = _gvn.transform(new IfTrueNode(iff_pin_count_over_underflow));
-  {
-    // Trap (but not deoptimize (Action_none)) and continue in the interpreter
-    // which will throw IllegalStateException for pin count over/underflow.
-    PreserveJVMState pjvms(this);
-    set_control(pin_count_over_underflow);
-    set_all_memory(input_memory_state);
-    uncommon_trap_exact(Deoptimization::Reason_intrinsic,
-                        Deoptimization::Action_none);
-    assert(stopped(), "invariant");
-  }
+  store_to_memory(control(), pin_count_offset, next_pin_count, T_INT, MemNode::unordered);
 
   // Result of top level CFG and Memory.
   RegionNode* result_rgn = new RegionNode(PATH_LIMIT);
@@ -3806,7 +3805,7 @@ bool LibraryCallKit::inline_native_Continuation_pinning(bool unpin) {
 
   result_rgn->init_req(_true_path, _gvn.transform(valid_pin_count));
   result_rgn->init_req(_false_path, _gvn.transform(continuation_is_null));
-  result_mem->init_req(_true_path, _gvn.transform(updated_pin_count_memory));
+  result_mem->init_req(_true_path, _gvn.transform(reset_memory()));
   result_mem->init_req(_false_path, _gvn.transform(input_memory_state));
 
   // Set output state.

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3777,6 +3777,8 @@ bool LibraryCallKit::inline_native_Continuation_pinning(bool unpin) {
   {
     // Trap (but not deoptimize (Action_none)) and continue in the interpreter
     // which will throw IllegalStateException for pin count over/underflow.
+    // No memory changed so far - we can use memory create by reset_memory()
+    // at the beginning of this intrinsic. No need to call reset_memory() again.
     PreserveJVMState pjvms(this);
     set_control(pin_count_over_underflow);
     uncommon_trap(Deoptimization::Reason_intrinsic,

--- a/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
@@ -25,36 +25,21 @@
  * @test
  * @bug 8347997
  * @summary Test that Cintinuation.pin() and unpin() intrinsics work with EA.
- * @run main/othervm --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED
- *      TestContinuationPinningAndEA
+ * @modules java.base/jdk.internal.vm
+ * @run main TestContinuationPinningAndEA
  */
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
+import jdk.internal.vm.Continuation;
 
 public class TestContinuationPinningAndEA {
-  public static final MethodHandle pin;
-  public static final MethodHandle unpin;
-
-  static {
-    try {
-      MethodHandles.Lookup lookup = MethodHandles.lookup();
-      Class<?> Continuation = lookup.findClass("jdk.internal.vm.Continuation");
-      pin = lookup.findStatic(Continuation, "pin", MethodType.methodType(void.class));
-      unpin = lookup.findStatic(Continuation, "unpin", MethodType.methodType(void.class));
-    } catch (Throwable e) {
-      throw new RuntimeException(e);
-    }
-  }
 
   static class FailsEA {
     final Object o;
 
     public FailsEA() throws Throwable {
       o = new Object();
-      pin.invokeExact();
-      unpin.invokeExact();
+      Continuation.pin();
+      Continuation.unpin();
     }
   }
 
@@ -62,8 +47,8 @@ public class TestContinuationPinningAndEA {
     final Object o;
 
     public Crashes() throws Throwable {
-      pin.invokeExact();
-      unpin.invokeExact();
+      Continuation.pin();
+      Continuation.unpin();
       o = new Object();
     }
   }

--- a/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
@@ -77,7 +77,7 @@ public class TestContinuationPinningAndEA {
   static void test_Crashes() throws Throwable {
     for (int i = 0; i < 10_000; ++i) {
       new Crashes();
-    }  
+    }
   }
 
   public static void main(String[] args) throws Throwable {

--- a/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 8347997
- * @summary Test that Cintinuation.pin() and unpin() intrinsics work with EA.
+ * @summary Test that Continuation.pin() and unpin() intrinsics work with EA.
  * @modules java.base/jdk.internal.vm
  * @run main TestContinuationPinningAndEA
  */

--- a/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
@@ -33,45 +33,45 @@ import jdk.internal.vm.Continuation;
 
 public class TestContinuationPinningAndEA {
 
-  static class FailsEA {
-    final Object o;
+    static class FailsEA {
+        final Object o;
 
-    public FailsEA() throws Throwable {
-      o = new Object();
-      Continuation.pin();
-      Continuation.unpin();
+        public FailsEA() throws Throwable {
+            o = new Object();
+            Continuation.pin();
+            Continuation.unpin();
+        }
     }
-  }
 
-  static class Crashes {
-    final Object o;
+    static class Crashes {
+        final Object o;
 
-    public Crashes() throws Throwable {
-      Continuation.pin();
-      Continuation.unpin();
-      o = new Object();
+        public Crashes() throws Throwable {
+            Continuation.pin();
+            Continuation.unpin();
+            o = new Object();
+        }
     }
-  }
 
-  static void test_FailsEA() throws Throwable {
-    for (int i = 0; i < 10_000; ++i) {
-      new FailsEA();
+    static void test_FailsEA() throws Throwable {
+        for (int i = 0; i < 10_000; ++i) {
+            new FailsEA();
+        }
     }
-  }
 
-  static void test_Crashes() throws Throwable {
-    for (int i = 0; i < 10_000; ++i) {
-      new Crashes();
+    static void test_Crashes() throws Throwable {
+        for (int i = 0; i < 10_000; ++i) {
+            new Crashes();
+        }
     }
-  }
 
-  public static void main(String[] args) throws Throwable {
-    int iterations = 100;
-    for (int i = 0; i < iterations; ++i) {
-      test_FailsEA();
+    public static void main(String[] args) throws Throwable {
+        int iterations = 100;
+        for (int i = 0; i < iterations; ++i) {
+            test_FailsEA();
+        }
+        for (int i = 0; i < iterations; ++i) {
+            test_Crashes();
+        }
     }
-    for (int i = 0; i < iterations; ++i) {
-      test_Crashes();
-    }
-  }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8347997
+ * @summary Test that Cintinuation.pin() and unpin() intrinsics work with EA.
+ * @run main/othervm --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED
+ *      TestContinuationPinningAndEA
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class TestContinuationPinningAndEA {
+  public static final MethodHandle pin;
+  public static final MethodHandle unpin;
+
+  static {
+    try {
+      MethodHandles.Lookup lookup = MethodHandles.lookup();
+      Class<?> Continuation = lookup.findClass("jdk.internal.vm.Continuation");
+      pin = lookup.findStatic(Continuation, "pin", MethodType.methodType(void.class));
+      unpin = lookup.findStatic(Continuation, "unpin", MethodType.methodType(void.class));
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static class FailsEA {
+    final Object o;
+
+    public FailsEA() throws Throwable {
+      o = new Object();
+      pin.invokeExact();
+      unpin.invokeExact();
+    }
+  }
+
+  static class Crashes {
+    final Object o;
+
+    public Crashes() throws Throwable {
+      pin.invokeExact();
+      unpin.invokeExact();
+      o = new Object();
+    }
+  }
+
+  static void test_FailsEA() throws Throwable {
+    for (int i = 0; i < 10_000; ++i) {
+      new FailsEA();
+    }
+  }
+
+  static void test_Crashes() throws Throwable {
+    for (int i = 0; i < 10_000; ++i) {
+      new Crashes();
+    }  
+  }
+
+  public static void main(String[] args) throws Throwable {
+    int iterations = 100;
+    for (int i = 0; i < iterations; ++i) {
+      test_FailsEA();
+    }
+    for (int i = 0; i < iterations; ++i) {
+      test_Crashes();
+    }
+  }
+}


### PR DESCRIPTION
C2's Escape Analysis does not recognize pattern where one input of memory `Phi` node is `MergeMem` node and an other is RAW store. This pattern is created by Continuation pinning intrinsic. As result EA complains about strange memory graph.

I suggest to add second `MergeMem` between Store and Phi nodes by calling `reset_memory()`. EA recognize such patter and removes allocations.

I checked generated assembler pinning code and it is the same as before. The only difference in the test is eliminated allocations.

I moved Uncommon code up to avoid resetting memory - it is already done at the beginning of this intrinsic code.

We should not use `uncommon_trap_exact()` for `Deoptimization::Action_none` - It is used for other actions to prevent changing them to `Action_none`.

Tested tier1-5, hs-xcomp, hs-comp-stress
Added new regression test based on reproducer from bug report.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347997](https://bugs.openjdk.org/browse/JDK-8347997): assert(false) failed: EA: missing memory path (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23284/head:pull/23284` \
`$ git checkout pull/23284`

Update a local copy of the PR: \
`$ git checkout pull/23284` \
`$ git pull https://git.openjdk.org/jdk.git pull/23284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23284`

View PR using the GUI difftool: \
`$ git pr show -t 23284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23284.diff">https://git.openjdk.org/jdk/pull/23284.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23284#issuecomment-2611274392)
</details>
