### PR TITLE
8347291: Exhaustive switch over a generic sealed abstract class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4233,7 +4233,7 @@ public class Attr extends JCTree.Visitor {
             Type type = attribType(tree.deconstructor, env);
             if (type.isRaw() && type.tsym.getTypeParameters().nonEmpty()) {
                 Type inferred = infer.instantiatePatternType(resultInfo.pt, type.tsym);
-                if (inferred == null) {
+                if (inferred == null || inferred.isErroneous()) {
                     log.error(tree.pos(), Errors.PatternTypeCannotInfer);
                 } else {
                     type = inferred;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -928,8 +928,8 @@ public class Flow {
                                 } else {
                                     instantiated = infer.instantiatePatternType(selectorType, csym);
                                 }
-
-                                return instantiated != null && types.isCastable(selectorType, instantiated);
+                                return instantiated != null &&
+                                        (instantiated.isErroneous() || types.isCastable(selectorType, instantiated));
                             });
 
                             for (PatternDescription pdOther : patterns) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -737,7 +737,7 @@ public class Infer {
             //step 4:
             return types.upward(substituted, freshVars);
         } catch (Infer.InferenceException ex) {
-            return null;
+            return types.createErrorType(expressionType);
         }
     }
 

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -2182,6 +2182,36 @@ public class Exhaustiveness extends TestRunner {
                """);
     }
 
+    @Test
+    public void testNonExhaustiveCapture(Path base) throws Exception {
+        doTest(base,
+               new String[]{"""
+                            package lib;
+                            public sealed interface S<T extends S<T>> permits A, B {}
+                            """,
+                            """
+                            package lib;
+                            public final class A implements S<A> {}
+                            """,
+                            """
+                            package lib;
+                            public final class B<T extends B<T>> implements S<T> {}
+                            """},
+               """
+               package test;
+               import lib.*;
+               public class Test {
+                 public static void test(S<?> sealed) {
+                   switch (sealed) {
+                     case A one -> {}
+                   }
+                 }
+               }
+               """,
+               "Test.java:5:5: compiler.err.not.exhaustive.statement",
+               "1 error");
+    }
+
     private void doTest(Path base, String[] libraryCode, String testCode, String... expectedErrors) throws IOException {
         doTest(base, libraryCode, testCode, false, expectedErrors);
     }


### PR DESCRIPTION
This change avoids javac incorrectly reporting switches like the example in [JDK-8347291](https://bugs.openjdk.org/browse/JDK-8347291) as exhaustive.

As Jan noted in the bug it seems like the inference behaviour here may not be correct. If it was able to infer a type without crashing that would also avoid the bug.

However with the current inference behaviour, it's safer to assume that if inference crashes the subtype may need to be handled by the switch, instead of assuming that it doesn't.