### PR TITLE
345826: Do not automatically resolve jdk.internal.vm.ci when libgraal is used

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -603,15 +603,13 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
   __ ldr(rscratch1, Address(rmethod, in_bytes(Method::from_compiled_offset())));
 
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    // check if this call should be routed towards a specific entry point
-    __ ldr(rscratch2, Address(rthread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
-    Label no_alternative_target;
-    __ cbz(rscratch2, no_alternative_target);
-    __ mov(rscratch1, rscratch2);
-    __ str(zr, Address(rthread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
-    __ bind(no_alternative_target);
-  }
+  // check if this call should be routed towards a specific entry point
+  __ ldr(rscratch2, Address(rthread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
+  Label no_alternative_target;
+  __ cbz(rscratch2, no_alternative_target);
+  __ mov(rscratch1, rscratch2);
+  __ str(zr, Address(rthread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
+  __ bind(no_alternative_target);
 #endif // INCLUDE_JVMCI
 
   // Now generate the shuffle code.
@@ -2212,9 +2210,7 @@ void SharedRuntime::generate_deopt_blob() {
   // Setup code generation tools
   int pad = 0;
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    pad += 512; // Increase the buffer size when compiling for JVMCI
-  }
+  pad += 512; // Increase the buffer size for JVMCI
 #endif
   const char* name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2048+pad, 1024);
@@ -2285,12 +2281,9 @@ void SharedRuntime::generate_deopt_blob() {
 
 #if INCLUDE_JVMCI
   Label after_fetch_unroll_info_call;
-  int implicit_exception_uncommon_trap_offset = 0;
-  int uncommon_trap_offset = 0;
-
-  if (EnableJVMCI) {
-    implicit_exception_uncommon_trap_offset = __ pc() - start;
-
+  int implicit_exception_uncommon_trap_offset = __ pc() - start;
+  int uncommon_trap_offset;
+  {
     __ ldr(lr, Address(rthread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())));
     __ str(zr, Address(rthread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())));
 
@@ -2310,8 +2303,8 @@ void SharedRuntime::generate_deopt_blob() {
     __ mov(c_rarg0, rthread);
     __ movw(c_rarg2, rcpool); // exec mode
     __ lea(rscratch1,
-           RuntimeAddress(CAST_FROM_FN_PTR(address,
-                                           Deoptimization::uncommon_trap)));
+            RuntimeAddress(CAST_FROM_FN_PTR(address,
+                                            Deoptimization::uncommon_trap)));
     __ blr(rscratch1);
     __ bind(retaddr);
     oop_maps->add_gc_map( __ pc()-start, map->deep_copy());
@@ -2319,7 +2312,7 @@ void SharedRuntime::generate_deopt_blob() {
     __ reset_last_Java_frame(false);
 
     __ b(after_fetch_unroll_info_call);
-  } // EnableJVMCI
+  }
 #endif // INCLUDE_JVMCI
 
   int exception_offset = __ pc() - start;
@@ -2413,9 +2406,7 @@ void SharedRuntime::generate_deopt_blob() {
   __ reset_last_Java_frame(false);
 
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    __ bind(after_fetch_unroll_info_call);
-  }
+  __ bind(after_fetch_unroll_info_call);
 #endif
 
   // Load UnrollBlock* into r5
@@ -2575,10 +2566,8 @@ void SharedRuntime::generate_deopt_blob() {
   _deopt_blob = DeoptimizationBlob::create(&buffer, oop_maps, 0, exception_offset, reexecute_offset, frame_size_in_words);
   _deopt_blob->set_unpack_with_exception_in_tls_offset(exception_in_tls_offset);
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    _deopt_blob->set_uncommon_trap_offset(uncommon_trap_offset);
-    _deopt_blob->set_implicit_exception_uncommon_trap_offset(implicit_exception_uncommon_trap_offset);
-  }
+  _deopt_blob->set_uncommon_trap_offset(uncommon_trap_offset);
+  _deopt_blob->set_implicit_exception_uncommon_trap_offset(implicit_exception_uncommon_trap_offset);
 #endif
 }
 

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -527,7 +527,7 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state,
 #if INCLUDE_JVMCI
   // Check if we need to take lock at entry of synchronized method.  This can
   // only occur on method entry so emit it only for vtos with step 0.
-  if (EnableJVMCI && state == vtos && step == 0) {
+  if (state == vtos && step == 0) {
     Label L;
     __ ldrb(rscratch1, Address(rthread, JavaThread::pending_monitorenter_offset()));
     __ cbz(rscratch1, L);
@@ -538,13 +538,11 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state,
     __ bind(L);
   } else {
 #ifdef ASSERT
-    if (EnableJVMCI) {
-      Label L;
-      __ ldrb(rscratch1, Address(rthread, JavaThread::pending_monitorenter_offset()));
-      __ cbz(rscratch1, L);
-      __ stop("unexpected pending monitor in deopt entry");
-      __ bind(L);
-    }
+    Label L;
+    __ ldrb(rscratch1, Address(rthread, JavaThread::pending_monitorenter_offset()));
+    __ cbz(rscratch1, L);
+    __ stop("unexpected pending monitor in deopt entry");
+    __ bind(L);
 #endif
   }
 #endif

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -936,15 +936,13 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
   __ movptr(r11, Address(rbx, in_bytes(Method::from_compiled_offset())));
 
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    // check if this call should be routed towards a specific entry point
-    __ cmpptr(Address(r15_thread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())), 0);
-    Label no_alternative_target;
-    __ jcc(Assembler::equal, no_alternative_target);
-    __ movptr(r11, Address(r15_thread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
-    __ movptr(Address(r15_thread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())), 0);
-    __ bind(no_alternative_target);
-  }
+  // check if this call should be routed towards a specific entry point
+  __ cmpptr(Address(r15_thread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())), 0);
+  Label no_alternative_target;
+  __ jcc(Assembler::equal, no_alternative_target);
+  __ movptr(r11, Address(r15_thread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
+  __ movptr(Address(r15_thread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())), 0);
+  __ bind(no_alternative_target);
 #endif // INCLUDE_JVMCI
 
   // Now generate the shuffle code.  Pick up all register args and move the
@@ -2643,9 +2641,7 @@ void SharedRuntime::generate_deopt_blob() {
     pad += 1024;
   }
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    pad += 512; // Increase the buffer size when compiling for JVMCI
-  }
+  pad += 512; // Increase the buffer size for JVMCI
 #endif
   const char* name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2560+pad, 1024);
@@ -2715,35 +2711,30 @@ void SharedRuntime::generate_deopt_blob() {
 
 #if INCLUDE_JVMCI
   Label after_fetch_unroll_info_call;
-  int implicit_exception_uncommon_trap_offset = 0;
-  int uncommon_trap_offset = 0;
+  int implicit_exception_uncommon_trap_offset = __ pc() - start;
 
-  if (EnableJVMCI) {
-    implicit_exception_uncommon_trap_offset = __ pc() - start;
+  __ pushptr(Address(r15_thread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())));
+  __ movptr(Address(r15_thread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())), NULL_WORD);
 
-    __ pushptr(Address(r15_thread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())));
-    __ movptr(Address(r15_thread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())), NULL_WORD);
+  int uncommon_trap_offset = __ pc() - start;
 
-    uncommon_trap_offset = __ pc() - start;
+  // Save everything in sight.
+  RegisterSaver::save_live_registers(masm, 0, &frame_size_in_words, /*save_wide_vectors*/ true);
+  // fetch_unroll_info needs to call last_java_frame()
+  __ set_last_Java_frame(noreg, noreg, nullptr, rscratch1);
 
-    // Save everything in sight.
-    RegisterSaver::save_live_registers(masm, 0, &frame_size_in_words, /*save_wide_vectors*/ true);
-    // fetch_unroll_info needs to call last_java_frame()
-    __ set_last_Java_frame(noreg, noreg, nullptr, rscratch1);
+  __ movl(c_rarg1, Address(r15_thread, in_bytes(JavaThread::pending_deoptimization_offset())));
+  __ movl(Address(r15_thread, in_bytes(JavaThread::pending_deoptimization_offset())), -1);
 
-    __ movl(c_rarg1, Address(r15_thread, in_bytes(JavaThread::pending_deoptimization_offset())));
-    __ movl(Address(r15_thread, in_bytes(JavaThread::pending_deoptimization_offset())), -1);
+  __ movl(r14, Deoptimization::Unpack_reexecute);
+  __ mov(c_rarg0, r15_thread);
+  __ movl(c_rarg2, r14); // exec mode
+  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::uncommon_trap)));
+  oop_maps->add_gc_map( __ pc()-start, map->deep_copy());
 
-    __ movl(r14, Deoptimization::Unpack_reexecute);
-    __ mov(c_rarg0, r15_thread);
-    __ movl(c_rarg2, r14); // exec mode
-    __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::uncommon_trap)));
-    oop_maps->add_gc_map( __ pc()-start, map->deep_copy());
+  __ reset_last_Java_frame(false);
 
-    __ reset_last_Java_frame(false);
-
-    __ jmp(after_fetch_unroll_info_call);
-  } // EnableJVMCI
+  __ jmp(after_fetch_unroll_info_call);
 #endif // INCLUDE_JVMCI
 
   int exception_offset = __ pc() - start;
@@ -2831,9 +2822,7 @@ void SharedRuntime::generate_deopt_blob() {
   __ reset_last_Java_frame(false);
 
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    __ bind(after_fetch_unroll_info_call);
-  }
+  __ bind(after_fetch_unroll_info_call);
 #endif
 
   // Load UnrollBlock* into rdi
@@ -2994,10 +2983,8 @@ void SharedRuntime::generate_deopt_blob() {
   _deopt_blob = DeoptimizationBlob::create(&buffer, oop_maps, 0, exception_offset, reexecute_offset, frame_size_in_words);
   _deopt_blob->set_unpack_with_exception_in_tls_offset(exception_in_tls_offset);
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    _deopt_blob->set_uncommon_trap_offset(uncommon_trap_offset);
-    _deopt_blob->set_implicit_exception_uncommon_trap_offset(implicit_exception_uncommon_trap_offset);
-  }
+  _deopt_blob->set_uncommon_trap_offset(uncommon_trap_offset);
+  _deopt_blob->set_implicit_exception_uncommon_trap_offset(implicit_exception_uncommon_trap_offset);
 #endif
 }
 

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -227,7 +227,7 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state, i
 #if INCLUDE_JVMCI
   // Check if we need to take lock at entry of synchronized method.  This can
   // only occur on method entry so emit it only for vtos with step 0.
-  if (EnableJVMCI && state == vtos && step == 0) {
+  if (state == vtos && step == 0) {
     Label L;
     __ cmpb(Address(thread, JavaThread::pending_monitorenter_offset()), 0);
     __ jcc(Assembler::zero, L);
@@ -240,13 +240,11 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state, i
     __ bind(L);
   } else {
 #ifdef ASSERT
-    if (EnableJVMCI) {
-      Label L;
-      __ cmpb(Address(r15_thread, JavaThread::pending_monitorenter_offset()), 0);
-      __ jcc(Assembler::zero, L);
-      __ stop("unexpected pending monitor in deopt entry");
-      __ bind(L);
-    }
+    Label L;
+    __ cmpb(Address(r15_thread, JavaThread::pending_monitorenter_offset()), 0);
+    __ jcc(Assembler::zero, L);
+    __ stop("unexpected pending monitor in deopt entry");
+    __ bind(L);
 #endif
   }
 #endif

--- a/src/hotspot/share/classfile/modules.cpp
+++ b/src/hotspot/share/classfile/modules.cpp
@@ -297,6 +297,13 @@ void Modules::define_module(Handle module, jboolean is_open, jstring version,
               "Module name cannot be null");
   }
 
+#if INCLUDE_JVMCI
+  if (!EnableJVMCI && !strcmp(module_name, "jdk.internal.vm.ci")) {
+    THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
+              err_msg("Module %s requires EnableJVMCI", module_name));
+  }
+#endif
+
   // Resolve packages
   objArrayHandle packages_h(THREAD, objArrayOop(JNIHandles::resolve(packages)));
   int num_packages = (packages_h.is_null() ? 0 : packages_h->length());

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1225,6 +1225,9 @@ nmethod* nmethod::new_nmethod(const methodHandle& method,
     DEBUG_ONLY(nm->verify();)
     nm->log_new_nmethod();
   }
+#if INCLUDE_JVMCI
+  JVMCI::installed_code();
+#endif
   return nm;
 }
 

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -626,26 +626,24 @@ void CompileBroker::compilation_init(JavaThread* THREAD) {
   _c2_count = CompilationPolicy::c2_count();
 
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    // This is creating a JVMCICompiler singleton.
-    JVMCICompiler* jvmci = new JVMCICompiler();
+  // This is creating a JVMCICompiler singleton.
+  JVMCICompiler* jvmci = new JVMCICompiler();
 
-    if (UseJVMCICompiler) {
-      _compilers[1] = jvmci;
-      if (FLAG_IS_DEFAULT(JVMCIThreads)) {
-        if (BootstrapJVMCI) {
-          // JVMCI will bootstrap so give it more threads
-          _c2_count = MIN2(32, os::active_processor_count());
-        }
-      } else {
-        _c2_count = JVMCIThreads;
+  if (UseJVMCICompiler) {
+    _compilers[1] = jvmci;
+    if (FLAG_IS_DEFAULT(JVMCIThreads)) {
+      if (BootstrapJVMCI) {
+        // JVMCI will bootstrap so give it more threads
+        _c2_count = MIN2(32, os::active_processor_count());
       }
-      if (FLAG_IS_DEFAULT(JVMCIHostThreads)) {
-      } else {
+    } else {
+      _c2_count = JVMCIThreads;
+    }
+    if (FLAG_IS_DEFAULT(JVMCIHostThreads)) {
+    } else {
 #ifdef COMPILER1
-        _c1_count = JVMCIHostThreads;
+      _c1_count = JVMCIHostThreads;
 #endif // COMPILER1
-      }
     }
   }
 #endif // INCLUDE_JVMCI
@@ -668,11 +666,9 @@ void CompileBroker::compilation_init(JavaThread* THREAD) {
 #endif // COMPILER2
 
 #if INCLUDE_JVMCI
-   // Register after c2 registration.
-   // JVMCI CompilerPhaseType idToPhase mapping is dynamic.
-   if (EnableJVMCI) {
-     JFR_ONLY(register_jfr_phasetype_serializer(compiler_jvmci);)
-   }
+  // Register after c2 registration.
+  // JVMCI CompilerPhaseType idToPhase mapping is dynamic.
+  JFR_ONLY(register_jfr_phasetype_serializer(compiler_jvmci);)
 #endif // INCLUDE_JVMCI
 
   if (CompilerOracle::should_collect_memstat()) {
@@ -2728,12 +2724,10 @@ void CompileBroker::print_times(bool per_compiler, bool aggregate) {
     comp->print_timers();
   }
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    JVMCICompiler *jvmci_comp = JVMCICompiler::instance(false, JavaThread::current_or_null());
-    if (jvmci_comp != nullptr && jvmci_comp != comp) {
-      tty->cr();
-      jvmci_comp->print_timers();
-    }
+  JVMCICompiler *jvmci_comp = JVMCICompiler::instance(false, JavaThread::current_or_null());
+  if (jvmci_comp != nullptr && jvmci_comp != comp) {
+    tty->cr();
+    jvmci_comp->print_timers();
   }
 #endif
 

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -191,7 +191,6 @@ void CompilerConfig::set_client_emulation_mode_flags() {
 
   FLAG_SET_ERGO(ProfileInterpreter, false);
 #if INCLUDE_JVMCI
-  FLAG_SET_ERGO(EnableJVMCI, false);
   FLAG_SET_ERGO(UseJVMCICompiler, false);
 #endif
   if (FLAG_IS_DEFAULT(NeverActAsServerClassMachine)) {
@@ -229,8 +228,7 @@ bool CompilerConfig::is_compilation_mode_selected() {
   return !FLAG_IS_DEFAULT(TieredCompilation) ||
          !FLAG_IS_DEFAULT(TieredStopAtLevel) ||
          !FLAG_IS_DEFAULT(CompilationMode)
-         JVMCI_ONLY(|| !FLAG_IS_DEFAULT(EnableJVMCI)
-                    || !FLAG_IS_DEFAULT(UseJVMCICompiler));
+         JVMCI_ONLY(|| !FLAG_IS_DEFAULT(UseJVMCICompiler));
 }
 
 static bool check_legacy_flags() {
@@ -536,11 +534,10 @@ bool CompilerConfig::check_args_consistency(bool status) {
       FLAG_SET_DEFAULT(SegmentedCodeCache, false);
     }
 #if INCLUDE_JVMCI
-    if (EnableJVMCI || UseJVMCICompiler) {
-      if (!FLAG_IS_DEFAULT(EnableJVMCI) || !FLAG_IS_DEFAULT(UseJVMCICompiler)) {
+    if (UseJVMCICompiler) {
+      if (!FLAG_IS_DEFAULT(UseJVMCICompiler)) {
         warning("JVMCI Compiler disabled due to -Xint.");
       }
-      FLAG_SET_CMDLINE(EnableJVMCI, false);
       FLAG_SET_CMDLINE(UseJVMCICompiler, false);
     }
 #endif
@@ -572,10 +569,6 @@ void CompilerConfig::ergo_initialize() {
   set_compilation_policy_flags();
 
 #if INCLUDE_JVMCI
-  // Check that JVMCI supports selected GC.
-  // Should be done after GCConfig::initialize() was called.
-  JVMCIGlobals::check_jvmci_supported_gc();
-
   // Do JVMCI specific settings
   set_jvmci_specific_flags();
 #endif

--- a/src/hotspot/share/compiler/compilerDefinitions.inline.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.inline.hpp
@@ -35,7 +35,7 @@ inline bool CompilerConfig::is_interpreter_only() {
 }
 
 inline bool CompilerConfig::is_jvmci_compiler()    { return JVMCI_ONLY(has_jvmci() && UseJVMCICompiler) NOT_JVMCI(false); }
-inline bool CompilerConfig::is_jvmci()             { return JVMCI_ONLY(has_jvmci() && EnableJVMCI     ) NOT_JVMCI(false); }
+inline bool CompilerConfig::is_jvmci()             { return JVMCI_ONLY(has_jvmci()    ) NOT_JVMCI(false); }
 
 // is_*_only() functions describe situations in which the JVM is in one way or another
 // forced to use a particular compiler or their combination. The constraint functions

--- a/src/hotspot/share/compiler/oopMap.inline.hpp
+++ b/src/hotspot/share/compiler/oopMap.inline.hpp
@@ -66,12 +66,9 @@ void OopMapDo<OopFnT, DerivedOopFnT, ValueFilterT>::iterate_oops_do(const frame 
       if (omv.type() != OopMapValue::derived_oop_value)
         continue;
 
-  #ifndef COMPILER2
-  #if INCLUDE_JVMCI
-      if (!EnableJVMCI)
-  #endif
-        ShouldNotReachHere();
-  #endif // !COMPILER2
+  #ifndef COMPILER2_OR_JVMCI
+      ShouldNotReachHere();
+  #endif // !COMPILER2_OR_JVMCI
 
       address loc = fr->oopmapreg_to_location(omv.reg(), reg_map);
 

--- a/src/hotspot/share/gc/g1/g1ParallelCleaning.cpp
+++ b/src/hotspot/share/gc/g1/g1ParallelCleaning.cpp
@@ -44,7 +44,7 @@ bool JVMCICleaningTask::claim_cleaning_task() {
 
 void JVMCICleaningTask::work(bool unloading_occurred) {
   // One worker will clean JVMCI metadata handles.
-  if (unloading_occurred && EnableJVMCI && claim_cleaning_task()) {
+  if (unloading_occurred && claim_cleaning_task()) {
     JVMCI::do_unloading(unloading_occurred);
   }
 }

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -527,7 +527,7 @@ JRT_ENTRY(address, InterpreterRuntime::exception_handler_for_exception(JavaThrea
   } while (should_repeat == true);
 
 #if INCLUDE_JVMCI
-  if (EnableJVMCI && h_method->method_data() != nullptr) {
+  if (h_method->method_data() != nullptr) {
     ResourceMark rm(current);
     MethodData* mdo = h_method->method_data();
 

--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -43,6 +43,7 @@ JVMCIRuntime* JVMCI::_compiler_runtimes = nullptr;
 JVMCIRuntime* JVMCI::_java_runtime = nullptr;
 JVMCIRuntime* JVMCI::_shutdown_compiler_runtime = nullptr;
 volatile bool JVMCI::_is_initialized = false;
+volatile bool JVMCI::_has_installed_code = false;
 bool JVMCI::_box_caches_initialized = false;
 void* JVMCI::_shared_library_handle = nullptr;
 char* JVMCI::_shared_library_path = nullptr;

--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -93,6 +93,9 @@ class JVMCI : public AllStatic {
   // execution has completed successfully.
   static volatile bool _is_initialized;
 
+  // True when at least one nmethod has been installed in the code cache.
+  static volatile bool _has_installed_code;
+
   // True once boxing cache classes are guaranteed to be initialized.
   static bool _box_caches_initialized;
 
@@ -183,6 +186,14 @@ class JVMCI : public AllStatic {
   static bool in_shutdown();
 
   static bool is_compiler_initialized();
+
+  // Notifies that an nmethod was installed in the code cache.
+  static void installed_code() { _has_installed_code = true; }
+
+  // Queries whether an JVMCI compiled nmethod was ever installed in the code cache.
+  static bool has_installed_code() {
+    return _has_installed_code;
+  }
 
   /**
    * Determines if the VM is sufficiently booted to initialize JVMCI.

--- a/src/hotspot/share/jvmci/jvmciCompiler.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompiler.cpp
@@ -47,9 +47,6 @@ JVMCICompiler::JVMCICompiler() : AbstractCompiler(compiler_jvmci) {
 }
 
 JVMCICompiler* JVMCICompiler::instance(bool require_non_null, TRAPS) {
-  if (!EnableJVMCI) {
-    THROW_MSG_NULL(vmSymbols::java_lang_InternalError(), "JVMCI is not enabled")
-  }
   if (_instance == nullptr && require_non_null) {
     THROW_MSG_NULL(vmSymbols::java_lang_InternalError(), "The JVMCI compiler instance has not been created");
   }
@@ -61,7 +58,7 @@ void compiler_stubs_init(bool in_compiler_thread);
 // Initialization
 void JVMCICompiler::initialize() {
   assert(!CompilerConfig::is_c1_or_interpreter_only_no_jvmci(), "JVMCI is launched, it's not c1/interpreter only mode");
-  if (!UseCompiler || !EnableJVMCI || !UseJVMCICompiler || !should_perform_init()) {
+  if (!UseCompiler || !UseJVMCICompiler || !should_perform_init()) {
     return;
   }
   compiler_stubs_init(true /* in_compiler_thread */); // generate compiler's intrinsics stubs

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -24,6 +24,8 @@
 #include "classfile/javaClasses.inline.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "classfile/moduleEntry.hpp"
+#include "classfile/modules.hpp"
 #include "classfile/vmClasses.hpp"
 #include "compiler/compileBroker.hpp"
 #include "gc/shared/collectedHeap.hpp"
@@ -719,9 +721,6 @@ JRT_END
 // When called from libjvmci, `libjvmciOrHotspotEnv` is a libjvmci env so use JVM_ENTRY_NO_ENV.
 JVM_ENTRY_NO_ENV(jobject, JVM_GetJVMCIRuntime(JNIEnv *libjvmciOrHotspotEnv, jclass c))
   JVMCIENV_FROM_JNI(thread, libjvmciOrHotspotEnv);
-  if (!EnableJVMCI) {
-    JVMCI_THROW_MSG_NULL(InternalError, "JVMCI is not enabled");
-  }
   JVMCIENV->runtime()->initialize_HotSpotJVMCIRuntime(JVMCI_CHECK_NULL);
   JVMCIObject runtime = JVMCIENV->runtime()->get_HotSpotJVMCIRuntime(JVMCI_CHECK_NULL);
   return JVMCIENV->get_jobject(runtime);
@@ -731,9 +730,6 @@ JVM_END
 // When called from libjvmci, `env` is a libjvmci env so use JVM_ENTRY_NO_ENV.
 JVM_ENTRY_NO_ENV(jlong, JVM_ReadSystemPropertiesInfo(JNIEnv *env, jclass c, jintArray offsets_handle))
   JVMCIENV_FROM_JNI(thread, env);
-  if (!EnableJVMCI) {
-    JVMCI_THROW_MSG_0(InternalError, "JVMCI is not enabled");
-  }
   JVMCIPrimitiveArray offsets = JVMCIENV->wrap(offsets_handle);
   JVMCIENV->put_int_at(offsets, 0, SystemProperty::next_offset_in_bytes());
   JVMCIENV->put_int_at(offsets, 1, SystemProperty::key_offset_in_bytes());
@@ -1513,10 +1509,6 @@ JVMCIObject JVMCIRuntime::get_HotSpotJVMCIRuntime(JVMCI_TRAPS) {
 // When called from libjvmci, `libjvmciOrHotspotEnv` is a libjvmci env so use JVM_ENTRY_NO_ENV.
 JVM_ENTRY_NO_ENV(void, JVM_RegisterJVMCINatives(JNIEnv *libjvmciOrHotspotEnv, jclass c2vmClass))
   JVMCIENV_FROM_JNI(thread, libjvmciOrHotspotEnv);
-
-  if (!EnableJVMCI) {
-    JVMCI_THROW_MSG(InternalError, "JVMCI is not enabled");
-  }
 
   JVMCIENV->runtime()->initialize(JVMCIENV);
 

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -60,10 +60,7 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
   }
 
   if (EnableJVMCIProduct) {
-    if (FLAG_IS_DEFAULT(EnableJVMCI)) {
-      FLAG_SET_DEFAULT(EnableJVMCI, true);
-    }
-    if (EnableJVMCI && FLAG_IS_DEFAULT(UseJVMCICompiler)) {
+    if (FLAG_IS_DEFAULT(UseJVMCICompiler)) {
       FLAG_SET_DEFAULT(UseJVMCICompiler, true);
     }
   }
@@ -72,6 +69,19 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
   JVMCI_FLAG_CHECKED(EnableJVMCI)
   JVMCI_FLAG_CHECKED(EnableJVMCIProduct)
   JVMCI_FLAG_CHECKED(UseGraalJIT)
+  JVMCI_FLAG_CHECKED(JVMCIEventLogLevel)
+  JVMCI_FLAG_CHECKED(JVMCITraceLevel)
+  JVMCI_FLAG_CHECKED(JVMCICounterSize)
+  JVMCI_FLAG_CHECKED(JVMCICountersExcludeCompiler)
+  JVMCI_FLAG_CHECKED(JVMCINMethodSizeLimit)
+  JVMCI_FLAG_CHECKED(JVMCIPrintProperties)
+  JVMCI_FLAG_CHECKED(JVMCIThreadsPerNativeLibraryRuntime)
+  JVMCI_FLAG_CHECKED(JVMCICompilerIdleDelay)
+  JVMCI_FLAG_CHECKED(UseJVMCINativeLibrary)
+  JVMCI_FLAG_CHECKED(JVMCINativeLibraryThreadFraction)
+  JVMCI_FLAG_CHECKED(JVMCILibPath)
+  JVMCI_FLAG_CHECKED(JVMCINativeLibraryErrorFile)
+  JVMCI_FLAG_CHECKED(JVMCILibDumpJNIConfig)
 
   CHECK_NOT_SET(BootstrapJVMCI,               UseJVMCICompiler)
   CHECK_NOT_SET(PrintBootstrap,               UseJVMCICompiler)
@@ -79,26 +89,21 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
   CHECK_NOT_SET(JVMCIHostThreads,             UseJVMCICompiler)
   CHECK_NOT_SET(LibJVMCICompilerThreadHidden, UseJVMCICompiler)
 
-  if (UseJVMCICompiler) {
-    if (!FLAG_IS_DEFAULT(EnableJVMCI) && !EnableJVMCI) {
-      jio_fprintf(defaultStream::error_stream(),
-          "Improperly specified VM option UseJVMCICompiler: EnableJVMCI cannot be disabled\n");
-      return false;
-    }
-    FLAG_SET_DEFAULT(EnableJVMCI, true);
-  }
-
-  if (EnableJVMCI) {
-    if (FLAG_IS_DEFAULT(UseJVMCINativeLibrary) && !UseJVMCINativeLibrary) {
-      if (JVMCI::shared_library_exists()) {
-        // If a JVMCI native library is present,
-        // we enable UseJVMCINativeLibrary by default.
-        FLAG_SET_DEFAULT(UseJVMCINativeLibrary, true);
-      }
+  if (FLAG_IS_DEFAULT(UseJVMCINativeLibrary) && !UseJVMCINativeLibrary) {
+    if (JVMCI::shared_library_exists()) {
+      // If a JVMCI native library is present,
+      // we enable UseJVMCINativeLibrary by default.
+      FLAG_SET_DEFAULT(UseJVMCINativeLibrary, true);
     }
   }
 
   if (UseJVMCICompiler) {
+    if (!UseJVMCINativeLibrary && !EnableJVMCI) {
+      jio_fprintf(defaultStream::error_stream(), "Using JVMCI compiler requires -XX:+EnableJVMCI when no JVMCI shared library is available\n");
+      FLAG_SET_DEFAULT(EnableJVMCI, true);
+
+      //return false;
+    }
     if (BootstrapJVMCI && UseJVMCINativeLibrary) {
       jio_fprintf(defaultStream::error_stream(), "-XX:+BootstrapJVMCI is not compatible with -XX:+UseJVMCINativeLibrary\n");
       return false;
@@ -110,28 +115,7 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
     }
   }
 
-  if (!EnableJVMCI) {
-    // Switch off eager JVMCI initialization if JVMCI is disabled.
-    // Don't throw error if EagerJVMCI is set to allow testing.
-    if (EagerJVMCI) {
-      FLAG_SET_DEFAULT(EagerJVMCI, false);
-    }
-  }
   JVMCI_FLAG_CHECKED(EagerJVMCI)
-
-  CHECK_NOT_SET(JVMCIEventLogLevel,                  EnableJVMCI)
-  CHECK_NOT_SET(JVMCITraceLevel,                     EnableJVMCI)
-  CHECK_NOT_SET(JVMCICounterSize,                    EnableJVMCI)
-  CHECK_NOT_SET(JVMCICountersExcludeCompiler,        EnableJVMCI)
-  CHECK_NOT_SET(JVMCINMethodSizeLimit,               EnableJVMCI)
-  CHECK_NOT_SET(JVMCIPrintProperties,                EnableJVMCI)
-  CHECK_NOT_SET(JVMCIThreadsPerNativeLibraryRuntime, EnableJVMCI)
-  CHECK_NOT_SET(JVMCICompilerIdleDelay,              EnableJVMCI)
-  CHECK_NOT_SET(UseJVMCINativeLibrary,               EnableJVMCI)
-  CHECK_NOT_SET(JVMCINativeLibraryThreadFraction,    EnableJVMCI)
-  CHECK_NOT_SET(JVMCILibPath,                        EnableJVMCI)
-  CHECK_NOT_SET(JVMCINativeLibraryErrorFile,         EnableJVMCI)
-  CHECK_NOT_SET(JVMCILibDumpJNIConfig,               EnableJVMCI)
 
 #ifndef COMPILER2
   JVMCI_FLAG_CHECKED(EnableVectorAggressiveReboxing)
@@ -220,23 +204,10 @@ bool JVMCIGlobals::enable_jvmci_product_mode(JVMFlagOrigin origin, bool use_graa
     }
   }
 
-  // Effect of EnableJVMCIProduct on changing defaults of EnableJVMCI
-  // and UseJVMCICompiler is deferred to check_jvmci_flags_are_consistent
+  // Effect of EnableJVMCIProduct on changing defaults of
+  // UseJVMCICompiler is deferred to check_jvmci_flags_are_consistent
   // so that setting these flags explicitly (e.g. on the command line)
   // takes precedence.
 
   return true;
-}
-
-bool JVMCIGlobals::gc_supports_jvmci() {
-  return UseSerialGC || UseParallelGC || UseG1GC || UseZGC || UseEpsilonGC;
-}
-
-void JVMCIGlobals::check_jvmci_supported_gc() {
-  if (EnableJVMCI) {
-    // Check if selected GC is supported by JVMCI and Java compiler
-    if (!gc_supports_jvmci()) {
-      fatal("JVMCI does not support the selected GC");
-    }
-  }
 }

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -45,7 +45,9 @@ class fileStream;
                     constraint)                                             \
                                                                             \
   product(bool, EnableJVMCI, false, EXPERIMENTAL,                           \
-          "Enable JVMCI. Defaults to true if UseJVMCICompiler is true.")    \
+          "Enables the jdk.internal.vm.ci module and resolves it as a "     \
+          "root module as if --add-modules=jdk.internal.vm.ci was "         \
+          "specified to the launcher.")                                     \
                                                                             \
   product(bool, UseGraalJIT, false, EXPERIMENTAL,                           \
           "Select the Graal JVMCI compiler. This is an alias for: "         \
@@ -55,8 +57,9 @@ class fileStream;
   product(bool, EnableJVMCIProduct, false, EXPERIMENTAL,                    \
           "Allow JVMCI to be used in product mode. This alters a subset of "\
           "JVMCI flags to be non-experimental, defaults UseJVMCICompiler "  \
-          "and EnableJVMCI to true and defaults UseJVMCINativeLibrary "     \
-          "to true if a JVMCI native library is available.")                \
+          "to true and defaults UseJVMCINativeLibrary to true if a JVMCI "  \
+          "native library is available. Note that it does not change "      \
+          "EnableJVMCI.")                                                   \
                                                                             \
   product(bool, UseJVMCICompiler, false, EXPERIMENTAL,                      \
           "Use JVMCI as the default compiler. Defaults to true if "         \
@@ -140,8 +143,8 @@ class fileStream;
   product(bool, UseJVMCINativeLibrary, false, EXPERIMENTAL,                 \
           "Execute JVMCI Java code from a shared library (\"libjvmci\") "   \
           "instead of loading it from class files and executing it "        \
-          "on the HotSpot heap. Defaults to true if UseJVMCICompiler or "   \
-          "EnableJVMCI is true and a JVMCI native library is available.")   \
+          "on the HotSpot heap. Defaults to true if UseJVMCICompiler "   \
+          "is true and a JVMCI native library is available.")   \
                                                                             \
   product(double, JVMCINativeLibraryThreadFraction, 0.66, EXPERIMENTAL,     \
           "The fraction of compiler threads used by libjvmci. "             \
@@ -206,12 +209,6 @@ class JVMCIGlobals {
 
   // Convert JVMCI experimental flags to product
   static bool enable_jvmci_product_mode(JVMFlagOrigin origin, bool use_graal_jit);
-
-  // Returns true iff the GC fully supports JVMCI.
-  static bool gc_supports_jvmci();
-
-  // Check and turn off EnableJVMCI if selected GC does not support JVMCI.
-  static void check_jvmci_supported_gc();
 
   static fileStream* get_jni_config_file() { return _jni_config_file; }
 };

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3595,17 +3595,15 @@ static jint JNI_CreateJavaVM_inner(JavaVM **vm, void **penv, void *args) {
     Atomic::release_store(&vm_created, COMPLETE);
 
 #if INCLUDE_JVMCI
-    if (EnableJVMCI) {
-      if (UseJVMCICompiler) {
-        // JVMCI is initialized on a CompilerThread
-        if (BootstrapJVMCI) {
-          JavaThread* THREAD = thread; // For exception macros.
-          JVMCICompiler* compiler = JVMCICompiler::instance(true, CATCH);
-          compiler->bootstrap(THREAD);
-          if (HAS_PENDING_EXCEPTION) {
-            HandleMark hm(THREAD);
-            vm_exit_during_initialization(Handle(THREAD, PENDING_EXCEPTION));
-          }
+    if (UseJVMCICompiler) {
+      // JVMCI is initialized on a CompilerThread
+      if (BootstrapJVMCI) {
+        JavaThread* THREAD = thread; // For exception macros.
+        JVMCICompiler* compiler = JVMCICompiler::instance(true, CATCH);
+        compiler->bootstrap(THREAD);
+        if (HAS_PENDING_EXCEPTION) {
+          HandleMark hm(THREAD);
+          vm_exit_during_initialization(Handle(THREAD, PENDING_EXCEPTION));
         }
       }
     }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -416,11 +416,9 @@ WB_END
 
 WB_ENTRY(jboolean, WB_IsGCSupportedByJVMCICompiler(JNIEnv* env, jobject o, jint name))
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    // Enter the JVMCI env that will be used by the CompileBroker.
-    JVMCIEnv jvmciEnv(thread, __FILE__, __LINE__);
-    return jvmciEnv.init_error() == JNI_OK && jvmciEnv.runtime()->is_gc_supported(&jvmciEnv, (CollectedHeap::Name)name);
-  }
+  // Enter the JVMCI env that will be used by the CompileBroker.
+  JVMCIEnv jvmciEnv(thread, __FILE__, __LINE__);
+  return jvmciEnv.init_error() == JNI_OK && jvmciEnv.runtime()->is_gc_supported(&jvmciEnv, (CollectedHeap::Name)name);
 #endif
   return false;
 WB_END
@@ -2195,14 +2193,6 @@ WB_ENTRY(jboolean, WB_isC2OrJVMCIIncluded(JNIEnv* env))
 #endif
 WB_END
 
-WB_ENTRY(jboolean, WB_IsJVMCISupportedByGC(JNIEnv* env))
-#if INCLUDE_JVMCI
-  return JVMCIGlobals::gc_supports_jvmci();
-#else
-  return false;
-#endif
-WB_END
-
 WB_ENTRY(jboolean, WB_CanWriteJavaHeapArchive(JNIEnv* env))
   return !CDSConfig::are_vm_options_incompatible_with_dumping_heap();
 WB_END
@@ -2948,7 +2938,6 @@ static JNINativeMethod methods[] = {
   {CC"isDTraceIncluded",                  CC"()Z",    (void*)&WB_IsDTraceIncluded },
   {CC"hasLibgraal",                       CC"()Z",    (void*)&WB_HasLibgraal },
   {CC"isC2OrJVMCIIncluded",               CC"()Z",    (void*)&WB_isC2OrJVMCIIncluded },
-  {CC"isJVMCISupportedByGC",              CC"()Z",    (void*)&WB_IsJVMCISupportedByGC},
   {CC"canWriteJavaHeapArchive",           CC"()Z",    (void*)&WB_CanWriteJavaHeapArchive },
   {CC"cdsMemoryMappingFailed",            CC"()Z",    (void*)&WB_CDSMemoryMappingFailed },
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1798,9 +1798,9 @@ bool Arguments::check_vm_args_consistency() {
   status = CompilerConfig::check_args_consistency(status);
 #if INCLUDE_JVMCI
   if (status && EnableJVMCI) {
-    PropertyList_unique_add(&_system_properties, "jdk.internal.vm.ci.enabled", "true",
-        AddProperty, UnwriteableProperty, InternalProperty);
     if (ClassLoader::is_module_observable("jdk.internal.vm.ci")) {
+      PropertyList_unique_add(&_system_properties, "jdk.internal.vm.ci.enabled", "true",
+          AddProperty, UnwriteableProperty, InternalProperty);
       if (!create_numbered_module_property("jdk.module.addmods", "jdk.internal.vm.ci", _addmods_count++)) {
         return false;
       }

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -452,10 +452,10 @@ bool Deoptimization::deoptimize_objects_internal(JavaThread* thread, GrowableArr
   RegisterMap map(chunk->at(0)->register_map());
   bool deoptimized_objects = false;
 
-  bool const jvmci_enabled = JVMCI_ONLY(EnableJVMCI) NOT_JVMCI(false);
+  bool const jvmci_has_installed_code = JVMCI::has_installed_code();
 
   // Reallocate the non-escaping objects and restore their fields.
-  if (jvmci_enabled COMPILER2_PRESENT(|| (DoEscapeAnalysis && EliminateAllocations)
+  if (jvmci_has_installed_code COMPILER2_PRESENT(|| (DoEscapeAnalysis && EliminateAllocations)
                                       || EliminateAutoBox || EnableVectorAggressiveReboxing)) {
     realloc_failures = rematerialize_objects(thread, Unpack_none, nm, deoptee, map, chunk, deoptimized_objects);
   }
@@ -464,7 +464,7 @@ bool Deoptimization::deoptimize_objects_internal(JavaThread* thread, GrowableArr
   NoSafepointVerifier no_safepoint;
 
   // Now relock objects if synchronization on them was eliminated.
-  if (jvmci_enabled COMPILER2_PRESENT(|| ((DoEscapeAnalysis || EliminateNestedLocks) && EliminateLocks))) {
+  if (jvmci_has_installed_code COMPILER2_PRESENT(|| ((DoEscapeAnalysis || EliminateNestedLocks) && EliminateLocks))) {
     restore_eliminated_locks(thread, chunk, realloc_failures, deoptee, Unpack_none, deoptimized_objects);
   }
   return deoptimized_objects;
@@ -524,11 +524,11 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   bool realloc_failures = false;
 
 #if COMPILER2_OR_JVMCI
-  bool const jvmci_enabled = JVMCI_ONLY(EnableJVMCI) NOT_JVMCI(false);
+  bool const jvmci_has_installed_code = JVMCI::has_installed_code();
 
   // Reallocate the non-escaping objects and restore their fields. Then
   // relock objects if synchronization on them was eliminated.
-  if (jvmci_enabled COMPILER2_PRESENT( || (DoEscapeAnalysis && EliminateAllocations)
+  if (jvmci_has_installed_code COMPILER2_PRESENT( || (DoEscapeAnalysis && EliminateAllocations)
                                        || EliminateAutoBox || EnableVectorAggressiveReboxing )) {
     bool unused;
     realloc_failures = rematerialize_objects(current, exec_mode, nm, deoptee, map, chunk, unused);
@@ -542,7 +542,7 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   NoSafepointVerifier no_safepoint;
 
 #if COMPILER2_OR_JVMCI
-  if ((jvmci_enabled COMPILER2_PRESENT( || ((DoEscapeAnalysis || EliminateNestedLocks) && EliminateLocks) ))
+  if ((jvmci_has_installed_code COMPILER2_PRESENT( || ((DoEscapeAnalysis || EliminateNestedLocks) && EliminateLocks) ))
       && !EscapeBarrier::objs_are_deoptimized(current, deoptee.id())) {
     bool unused = false;
     restore_eliminated_locks(current, chunk, realloc_failures, deoptee, exec_mode, unused);

--- a/src/hotspot/share/runtime/escapeBarrier.hpp
+++ b/src/hotspot/share/runtime/escapeBarrier.hpp
@@ -29,6 +29,9 @@
 #include "compiler/compiler_globals.hpp"
 #include "memory/allocation.hpp"
 #include "utilities/macros.hpp"
+#if INCLUDE_JVMCI
+#include "jvmci/jvmci.hpp"
+#endif
 
 class JavaThread;
 
@@ -71,7 +74,7 @@ public:
   // Revert ea based optimizations for given deoptee thread
   EscapeBarrier(bool barrier_active, JavaThread* calling_thread, JavaThread* deoptee_thread)
     : _calling_thread(calling_thread), _deoptee_thread(deoptee_thread),
-      _barrier_active(barrier_active && (JVMCI_ONLY(EnableJVMCI) NOT_JVMCI(false)
+      _barrier_active(barrier_active && (JVMCI_ONLY(JVMCI::has_installed_code()) NOT_JVMCI(false)
                       COMPILER2_PRESENT(|| DoEscapeAnalysis)))
   {
     if (_barrier_active) sync_and_suspend_one();
@@ -80,7 +83,7 @@ public:
   // Revert ea based optimizations for all java threads
   EscapeBarrier(bool barrier_active, JavaThread* calling_thread)
     : _calling_thread(calling_thread), _deoptee_thread(nullptr),
-      _barrier_active(barrier_active && (JVMCI_ONLY(EnableJVMCI) NOT_JVMCI(false)
+      _barrier_active(barrier_active && (JVMCI_ONLY(JVMCI::has_installed_code()) NOT_JVMCI(false)
                       COMPILER2_PRESENT(|| DoEscapeAnalysis)))
   {
     if (_barrier_active) sync_and_suspend_all();

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -180,9 +180,7 @@ jint init_globals2() {
     return JNI_EINVAL;
   }
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    JVMCI::initialize_globals();
-  }
+  JVMCI::initialize_globals();
 #endif
 
   if (!universe_post_init()) {

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -433,9 +433,7 @@ void before_exit(JavaThread* thread, bool halt) {
   // Actual shutdown logic begins here.
 
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
-    JVMCI::shutdown(thread);
-  }
+  JVMCI::shutdown(thread);
 #endif
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -86,6 +86,9 @@
 #if INCLUDE_JFR
 #include "jfr/jfr.hpp"
 #endif
+#if INCLUDE_JVMCI
+#include "jvmci/jvmci.hpp"
+#endif
 
 // Shared runtime stub routines reside in their own unique blob with a
 // single entry point
@@ -649,7 +652,7 @@ void SharedRuntime::throw_and_post_jvmti_exception(JavaThread* current, Handle h
   }
 
 #if INCLUDE_JVMCI
-  if (EnableJVMCI) {
+  if (JVMCI::has_installed_code()) {
     vframeStream vfst(current, true);
     methodHandle method = methodHandle(current, vfst.method());
     int bci = vfst.bci();

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -745,21 +745,19 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   bool init_compilation = true;
 #if INCLUDE_JVMCI
   bool force_JVMCI_initialization = false;
-  if (EnableJVMCI) {
-    // Initialize JVMCI eagerly when it is explicitly requested.
-    // Or when JVMCILibDumpJNIConfig or JVMCIPrintProperties is enabled.
-    force_JVMCI_initialization = EagerJVMCI || JVMCIPrintProperties || JVMCILibDumpJNIConfig;
-    if (!force_JVMCI_initialization && UseJVMCICompiler && !UseJVMCINativeLibrary && (!UseInterpreter || !BackgroundCompilation)) {
-      // Force initialization of jarjvmci otherwise requests for blocking
-      // compilations will not actually block until jarjvmci is initialized.
-      force_JVMCI_initialization = true;
-    }
-    if (JVMCIPrintProperties || JVMCILibDumpJNIConfig) {
-      // Both JVMCILibDumpJNIConfig and JVMCIPrintProperties exit the VM
-      // so compilation should be disabled. This prevents dumping or
-      // printing from happening more than once.
-      init_compilation = false;
-    }
+  // Initialize JVMCI eagerly when it is explicitly requested.
+  // Or when JVMCILibDumpJNIConfig or JVMCIPrintProperties is enabled.
+  force_JVMCI_initialization = EagerJVMCI || JVMCIPrintProperties || JVMCILibDumpJNIConfig;
+  if (!force_JVMCI_initialization && UseJVMCICompiler && !UseJVMCINativeLibrary && (!UseInterpreter || !BackgroundCompilation)) {
+    // Force initialization of jarjvmci otherwise requests for blocking
+    // compilations will not actually block until jarjvmci is initialized.
+    force_JVMCI_initialization = true;
+  }
+  if (JVMCIPrintProperties || JVMCILibDumpJNIConfig) {
+    // Both JVMCILibDumpJNIConfig and JVMCIPrintProperties exit the VM
+    // so compilation should be disabled. This prevents dumping or
+    // printing from happening more than once.
+    init_compilation = false;
   }
 #endif
   if (init_compilation) {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -524,7 +524,7 @@ static void report_vm_version(outputStream* st, char* buf, int buflen) {
                  VM_Version::vm_info_string(),
                  TieredCompilation ? ", tiered" : "",
 #if INCLUDE_JVMCI
-                 EnableJVMCI ? ", jvmci" : "",
+                 EnableJVMCI ? ", jvmci module" : "",
                  UseJVMCICompiler ? ", jvmci compiler" : "",
 #else
                  "", "",

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/runtime/JVMCI.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/runtime/JVMCI.java
@@ -35,6 +35,10 @@ public class JVMCI {
 
     private static boolean initializing;
 
+    static {
+        Services.checkJVMCIEnabled();
+    }
+
     public static void initialize() {
         // force static initializer
     }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/services/Services.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/services/Services.java
@@ -64,15 +64,17 @@ public final class Services {
      */
     private static volatile Map<String, String> savedProperties;
 
-    static final boolean JVMCI_ENABLED = Boolean.parseBoolean(VM.getSavedProperties().get("jdk.internal.vm.ci.enabled"));
+    static {
+        if (!Boolean.parseBoolean(VM.getSavedProperties().get("jdk.internal.vm.ci.enabled"))) {
+            throw new Error("The EnableJVMCI VM option must be true (i.e., -XX:+EnableJVMCI) to use jdk.internal.vm.ci");
+        }
+    }
 
     /**
      * Checks that JVMCI is enabled in the VM and throws an error if it isn't.
      */
-    static void checkJVMCIEnabled() {
-        if (!JVMCI_ENABLED) {
-            throw new Error("The EnableJVMCI VM option must be true (i.e., -XX:+EnableJVMCI) to use JVMCI");
-        }
+    public static void checkJVMCIEnabled() {
+        // First call to this will trigger <clinit> which does the check.
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -3133,12 +3133,6 @@ public class IRNode {
      */
     public static void checkIRNodeSupported(String node) throws CheckedTestFrameworkException {
         switch (node) {
-            case INTRINSIC_OR_TYPE_CHECKED_INLINING_TRAP -> {
-                if (!WhiteBox.getWhiteBox().isJVMCISupportedByGC()) {
-                    throw new CheckedTestFrameworkException("INTRINSIC_OR_TYPE_CHECKED_INLINING_TRAP is unsupported " +
-                                                            "in builds without JVMCI.");
-                }
-            }
             case CHECKCAST_ARRAYCOPY -> {
                 if (Platform.isS390x()) {
                     throw new CheckedTestFrameworkException("CHECKCAST_ARRAYCOPY is unsupported on s390.");

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
@@ -223,9 +223,7 @@ public class TestIRMatching {
                  BadFailOnConstraint.create(Traps.class, "rangeCheck()", 3, "CallStaticJava", "uncommon_trap", "null_check"),
                  GoodRuleConstraint.create(Traps.class, "rangeCheck()", 4),
                  BadFailOnConstraint.create(Traps.class, "instrinsicOrTypeCheckedInlining()", 1, "CallStaticJava", "uncommon_trap"),
-                 WhiteBox.getWhiteBox().isJVMCISupportedByGC() ?
-                    BadFailOnConstraint.create(Traps.class, "instrinsicOrTypeCheckedInlining()", 2, "CallStaticJava", "uncommon_trap", "intrinsic_or_type_checked_inlining")
-                    : GoodRuleConstraint.create(Traps.class, "instrinsicOrTypeCheckedInlining()", 2),
+                 BadFailOnConstraint.create(Traps.class, "instrinsicOrTypeCheckedInlining()", 2, "CallStaticJava", "uncommon_trap", "intrinsic_or_type_checked_inlining")
                  BadFailOnConstraint.create(Traps.class, "instrinsicOrTypeCheckedInlining()", 3, "CallStaticJava", "uncommon_trap", "intrinsic"),
                  BadFailOnConstraint.create(Traps.class, "instrinsicOrTypeCheckedInlining()", 4, "CallStaticJava", "uncommon_trap", "null_check"),
                  GoodRuleConstraint.create(Traps.class, "instrinsicOrTypeCheckedInlining()", 5)

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -266,11 +266,6 @@ public class VMProps implements Callable<Map<String, String>> {
             return "false";
         }
 
-        // Not all GCs have full JVMCI support
-        if (!WB.isJVMCISupportedByGC()) {
-          return "false";
-        }
-
         // Interpreted mode cannot enable JVMCI
         if (vmCompMode().equals("Xint")) {
           return "false";

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -331,7 +331,6 @@ public class WhiteBox {
   // Determines if the libgraal shared library file is present.
   public native boolean hasLibgraal();
   public native boolean isC2OrJVMCIIncluded();
-  public native boolean isJVMCISupportedByGC();
 
   public native int     matchesMethod(Executable method, String pattern);
   public native int     matchesInline(Executable method, String pattern);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ The pull request body must not be empty.

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `345826`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `345826`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23289/head:pull/23289` \
`$ git checkout pull/23289`

Update a local copy of the PR: \
`$ git checkout pull/23289` \
`$ git pull https://git.openjdk.org/jdk.git pull/23289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23289`

View PR using the GUI difftool: \
`$ git pr show -t 23289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23289.diff">https://git.openjdk.org/jdk/pull/23289.diff</a>

</details>
