### PR TITLE
8348554: Enhance Linux kernel version checks

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -379,9 +379,9 @@ static void next_line(FILE *f) {
 }
 
 void os::Linux::kernel_version(long* major, long* minor, long* patch) {
-  *major = -1;
-  *minor = -1;
-  *patch = -1;
+  *major = 0;
+  *minor = 0;
+  *patch = 0;
 
   struct utsname buffer;
   int ret = uname(&buffer);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -378,10 +378,10 @@ static void next_line(FILE *f) {
   } while (c != '\n' && c != EOF);
 }
 
-void os::Linux::kernel_version(long* major, long* patch, long* sub) {
+void os::Linux::kernel_version(long* major, long* minor, long* patch) {
   *major = -1;
+  *minor = -1;
   *patch = -1;
-  *sub   = -1;
 
   struct utsname buffer;
   int ret = uname(&buffer);
@@ -389,25 +389,25 @@ void os::Linux::kernel_version(long* major, long* patch, long* sub) {
     log_warning(os)("uname(2) failed to get kernel version: %s", os::errno_name(ret));
     return;
   }
-  int nr_matched = sscanf(buffer.release, "%ld.%ld.%ld", major, patch, sub);
+  int nr_matched = sscanf(buffer.release, "%ld.%ld.%ld", major, minor, patch);
   if (nr_matched != 3) {
     log_warning(os)("Parsing kernel version failed, expected 3 version numbers, only matched %d", nr_matched);
   }
 }
 
-int os::Linux::kernel_version_compare(long major1, long patch1, long sub1,
-                                      long major2, long patch2, long sub2) {
+int os::Linux::kernel_version_compare(long major1, long minor1, long patch1,
+                                      long major2, long minor2, long patch2) {
   // Compare major versions
   if (major1 > major2) return 1;
   if (major1 < major2) return -1;
 
-  // Compare patch versions
+  // Compare minor versions
+  if (minor1 > minor2) return 1;
+  if (minor1 < minor2) return -1;
+
+  // Compare patchlevel versions
   if (patch1 > patch2) return 1;
   if (patch1 < patch2) return -1;
-
-  // Compare sublevel versions
-  if (sub1 > sub2) return 1;
-  if (sub1 < sub2) return -1;
 
   return 0;
 }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -378,9 +378,10 @@ static void next_line(FILE *f) {
   } while (c != '\n' && c != EOF);
 }
 
-void os::Linux::kernel_version(long* major, long* minor) {
+void os::Linux::kernel_version(long* major, long* patch, long* sub) {
   *major = -1;
-  *minor = -1;
+  *patch = -1;
+  *sub   = -1;
 
   struct utsname buffer;
   int ret = uname(&buffer);
@@ -388,10 +389,27 @@ void os::Linux::kernel_version(long* major, long* minor) {
     log_warning(os)("uname(2) failed to get kernel version: %s", os::errno_name(ret));
     return;
   }
-  int nr_matched = sscanf(buffer.release, "%ld.%ld", major, minor);
-  if (nr_matched != 2) {
-    log_warning(os)("Parsing kernel version failed, expected 2 version numbers, only matched %d", nr_matched);
+  int nr_matched = sscanf(buffer.release, "%ld.%ld.%ld", major, patch, sub);
+  if (nr_matched != 3) {
+    log_warning(os)("Parsing kernel version failed, expected 3 version numbers, only matched %d", nr_matched);
   }
+}
+
+int os::Linux::kernel_version_compare(long major1, long patch1, long sub1,
+                                      long major2, long patch2, long sub2) {
+  // Compare major versions
+  if (major1 > major2) return 1;
+  if (major1 < major2) return -1;
+
+  // Compare patch versions
+  if (patch1 > patch2) return 1;
+  if (patch1 < patch2) return -1;
+
+  // Compare sublevel versions
+  if (sub1 > sub2) return 1;
+  if (sub1 < sub2) return -1;
+
+  return 0;
 }
 
 bool os::Linux::get_tick_information(CPUPerfTicks* pticks, int which_logical_cpu) {

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -91,13 +91,13 @@ class os::Linux {
   };
 
   static int active_processor_count();
-  static void kernel_version(long* major, long* patch, long* sub);
+  static void kernel_version(long* major, long* minor, long* patch);
 
   // If kernel1 > kernel2 return  1
   // If kernel1 < kernel2 return -1
   // If kernel1 = kernel2 return  0
-  static int kernel_version_compare(long major1, long patch1, long sub1,
-                                    long major2, long patch2, long sub2);
+  static int kernel_version_compare(long major1, long minor1, long patch1,
+                                    long major2, long minor2, long patch2);
 
   // which_logical_cpu=-1 returns accumulated ticks for all cpus.
   static bool get_tick_information(CPUPerfTicks* pticks, int which_logical_cpu);

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -91,7 +91,13 @@ class os::Linux {
   };
 
   static int active_processor_count();
-  static void kernel_version(long* major, long* minor);
+  static void kernel_version(long* major, long* patch, long* sub);
+
+  // If kernel1 > kernel2 return  1
+  // If kernel1 < kernel2 return -1
+  // If kernel1 = kernel2 return  0
+  static int kernel_version_compare(long major1, long patch1, long sub1,
+                                    long major2, long patch2, long sub2);
 
   // which_logical_cpu=-1 returns accumulated ticks for all cpus.
   static bool get_tick_information(CPUPerfTicks* pticks, int which_logical_cpu);

--- a/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
+++ b/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
@@ -66,11 +66,11 @@ bool LinuxSystemMemoryBarrier::initialize() {
 // RISCV port was introduced in kernel 4.4.
 // 4.4 also made membar private expedited mandatory.
 // But RISCV actually don't support it until 6.9.
-  long major, minor;
-  os::Linux::kernel_version(&major, &minor);
-  if (!(major > 6 || (major == 6 && minor >= 9))) {
-    log_info(os)("Linux kernel %ld.%ld does not support MEMBARRIER PRIVATE_EXPEDITED on RISC-V.",
-                 major, minor);
+  long major, patch, sub;
+  os::Linux::kernel_version(&major, &patch, &sub);
+  if (os::Linux::kernel_version_compare(major, patch, sub, 6, 9, 0) == -1) {
+    log_info(os)("Linux kernel %ld.%ld.%ld does not support MEMBARRIER PRIVATE_EXPEDITED on RISC-V.",
+                 major, patch, sub);
     return false;
   }
 #endif

--- a/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
+++ b/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
@@ -66,11 +66,11 @@ bool LinuxSystemMemoryBarrier::initialize() {
 // RISCV port was introduced in kernel 4.4.
 // 4.4 also made membar private expedited mandatory.
 // But RISCV actually don't support it until 6.9.
-  long major, patch, sub;
-  os::Linux::kernel_version(&major, &patch, &sub);
-  if (os::Linux::kernel_version_compare(major, patch, sub, 6, 9, 0) == -1) {
+  long major, minor, patch;
+  os::Linux::kernel_version(&major, &minor, &patch);
+  if (os::Linux::kernel_version_compare(major, minor, patch, 6, 9, 0) == -1) {
     log_info(os)("Linux kernel %ld.%ld.%ld does not support MEMBARRIER PRIVATE_EXPEDITED on RISC-V.",
-                 major, patch, sub);
+                 major, minor, patch);
     return false;
   }
 #endif


### PR DESCRIPTION
Hi, please consider.

As we have kernel bugs to work around in RISC-V, we need a more detailed check.
See:
https://github.com/openjdk/jdk/pull/23256

I updated the naming to align with Linux (major, patch, sub):
https://github.com/torvalds/linux/blob/bc8198dc7ebc492ec3e9fa1617dcdfbe98e73b17/Makefile#L1313

Additionally, I added a comparison function to simplify these checks.

Manually tested. Thanks, Robbin.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348554](https://bugs.openjdk.org/browse/JDK-8348554): Enhance Linux kernel version checks (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23291/head:pull/23291` \
`$ git checkout pull/23291`

Update a local copy of the PR: \
`$ git checkout pull/23291` \
`$ git pull https://git.openjdk.org/jdk.git pull/23291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23291`

View PR using the GUI difftool: \
`$ git pr show -t 23291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23291.diff">https://git.openjdk.org/jdk/pull/23291.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23291#issuecomment-2612023786)
</details>
