### PR TITLE
8338303: Linux ppc64le with toolchain clang - detection failure in early JVM startup

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -735,6 +735,11 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
       if test "x$FLAGS_CPU_ARCH" != xarm &&  test "x$FLAGS_CPU_ARCH" != xppc; then
         # for all archs except arm and ppc, prevent gcc to omit frame pointer
         $1_CFLAGS_CPU_JDK="${$1_CFLAGS_CPU_JDK} -fno-omit-frame-pointer"
+      fi
+      if test "x$FLAGS_CPU" = xppc64le; then
+        # Little endian machine uses ELFv2 ABI.
+        # Use Power8, this is the first CPU to support PPC64 LE with ELFv2 ABI.
+        $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -DABI_ELFv2 -mcpu=power8 -mtune=power8"
       fi
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then


### PR DESCRIPTION
When building on Linux ppc64le with the clang toolchain, the new JVM fails already in the build process with an error/crash :

```
# SIGILL (0x4) at pc=0x000079198fae03ac, pid=2922849, tid=2923410
#
# Problematic frame:
# v ~BufferBlob::detect_cpu_features 0x000079198fae03ac
```

It was noticed the clang build on Linux ppc64le missed some important compile flags, especially  -DABI_ELFv2 (compared to gcc build).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338303](https://bugs.openjdk.org/browse/JDK-8338303): Linux ppc64le with toolchain clang - detection failure in early JVM startup (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23292/head:pull/23292` \
`$ git checkout pull/23292`

Update a local copy of the PR: \
`$ git checkout pull/23292` \
`$ git pull https://git.openjdk.org/jdk.git pull/23292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23292`

View PR using the GUI difftool: \
`$ git pr show -t 23292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23292.diff">https://git.openjdk.org/jdk/pull/23292.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23292#issuecomment-2612033844)
</details>
