### PR TITLE
8348567: [ASAN] Memory access partially overflows by NativeCallStack

### DIFF
--- a/test/hotspot/gtest/nmt/test_nmt_nativecallstackstorage.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_nativecallstackstorage.cpp
@@ -42,7 +42,7 @@ TEST_VM_F(NMTNativeCallStackStorageTest, DoNotStoreStackIfNotDetailed) {
 TEST_VM_F(NMTNativeCallStackStorageTest, CollisionsReceiveDifferentIndexes) {
   constexpr const int nr_of_stacks = 10;
   NativeCallStack ncs_arr[nr_of_stacks];
-  for (int i = 0; i < nr_of_stacks; i++) {
+  for (size_t i = 0; i < nr_of_stacks; i++) {
     ncs_arr[i] = NativeCallStack((address*)(&i), 1);
   }
 
@@ -52,7 +52,7 @@ TEST_VM_F(NMTNativeCallStackStorageTest, CollisionsReceiveDifferentIndexes) {
     si_arr[i] = ncss.push(ncs_arr[i]);
   }
 
-  // Every SI should be different as every sack is different
+  // Every SI should be different as every stack is different
   for (int i = 0; i < nr_of_stacks; i++) {
     for (int j = 0; j < nr_of_stacks; j++) {
       if (i == j) continue;


### PR DESCRIPTION
Hi all,
This PR fix a undefined behaviour in 'CollisionsReceiveDifferentIndexes' testcase 
locate in 'test/hotspot/gtest/nmt/test_nmt_nativecallstackstorage.cpp' file when call `NativeCallStack::NativeCallStack` function. Before this PR, 'CollisionsReceiveDifferentIndexes' test allocate 4 type variable `i` and then pass the address `&i`, but in 'NativeCallStack' function read the pointer as 8 types, so the AddressSanitizer report "Memory access partially overflows variable i". This PR change the variable `i` to `size_t` to avoid this undefined behaviour.
Change has been verified locally, test-fix only, no risk.

Below code snippet can reproduce the same issue:

```c
#include <stdio.h>
typedef unsigned char u_char;
typedef u_char*       address;
int main()
{
  int i = 0;
  address* pc = (address*)(&i);
  address _stack = pc[0];
  printf("_stack = %p\n", _stack);
  return 0;
}
```

Reproduce command:

clang -g3 -Wall -Wextra -fsanitize=address -fsanitize=leak -fsanitize=undefined partially-overflows.c && ./a.out

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348567](https://bugs.openjdk.org/browse/JDK-8348567): [ASAN] Memory access partially overflows by NativeCallStack (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23294/head:pull/23294` \
`$ git checkout pull/23294`

Update a local copy of the PR: \
`$ git checkout pull/23294` \
`$ git pull https://git.openjdk.org/jdk.git pull/23294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23294`

View PR using the GUI difftool: \
`$ git pr show -t 23294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23294.diff">https://git.openjdk.org/jdk/pull/23294.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23294#issuecomment-2612336074)
</details>
