### PR TITLE
8348562: ZGC: segmentation fault due to missing node type check in barrier elision analysis

### DIFF
--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -558,7 +558,9 @@ static const Node* get_base_and_offset(const MachNode* mach, intptr_t& offset) {
     // The memory address is computed by 'base' and fed to 'mach' via an
     // indirect memory operand (indicated by offset == 0). The ultimate base and
     // offset can be fetched directly from the inputs and Ideal type of 'base'.
-    offset = base->bottom_type()->isa_oopptr()->offset();
+    const TypeOopPtr* oopptr = base->bottom_type()->isa_oopptr();
+    if (oopptr == nullptr) return nullptr;
+    offset = oopptr->offset();
     // Even if 'base' is not an Ideal AddP node anymore, Matcher::ReduceInst()
     // guarantees that the base address is still available at the same slot.
     base = base->in(AddPNode::Base);


### PR DESCRIPTION
Adding the missing node type check as described in the JBS issue. `oopptr` can be null in which case the current implementation crashes. This was only reported for JFR tests on PPC64 so far. If the expected graph pattern is not found, we bail out and skip the optimization.

`make run-test TEST="jdk/jfr" JTREG="VM_OPTIONS=-XX:+UseZGC"` has passed on linux PPC64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348562](https://bugs.openjdk.org/browse/JDK-8348562): ZGC: segmentation fault due to missing node type check in barrier elision analysis (**Bug** - P3)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23295/head:pull/23295` \
`$ git checkout pull/23295`

Update a local copy of the PR: \
`$ git checkout pull/23295` \
`$ git pull https://git.openjdk.org/jdk.git pull/23295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23295`

View PR using the GUI difftool: \
`$ git pr show -t 23295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23295.diff">https://git.openjdk.org/jdk/pull/23295.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23295#issuecomment-2612218782)
</details>
