### PR TITLE
8321529: log_on_large_pages_failure reports log_debug(gc, heap, coops) for ReservedCodeSpace failures

### DIFF
--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -63,7 +63,8 @@ static bool large_pages_requested() {
 static void log_on_large_pages_failure(char* req_addr, size_t bytes) {
   if (large_pages_requested()) {
     // Compressed oops logging.
-    log_debug(gc, heap, coops)("Reserve regular memory without large pages");
+    log_debug(os, map)("Reserve regular memory without large pages "
+                       RANGEFMT, RANGEFMTARGS(req_addr, bytes));
     // JVM style warning that we did not succeed in using large pages.
     char msg[128];
     jio_snprintf(msg, sizeof(msg), "Failed to reserve and commit memory using large pages. "

--- a/src/hotspot/share/memory/memoryReserver.cpp
+++ b/src/hotspot/share/memory/memoryReserver.cpp
@@ -62,7 +62,6 @@ static bool large_pages_requested() {
 
 static void log_on_large_pages_failure(char* req_addr, size_t bytes) {
   if (large_pages_requested()) {
-    // Compressed oops logging.
     log_debug(os, map)("Reserve regular memory without large pages "
                        RANGEFMT, RANGEFMTARGS(req_addr, bytes));
     // JVM style warning that we did not succeed in using large pages.

--- a/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
+++ b/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
@@ -64,11 +64,15 @@ public class TestLargePageUseForAuxMemory {
         // Check if there is a large page failure associated with the data  structure
         // being checked. In case of a large page allocation failure the output will
         // include logs like this for the affected data structure:
-        // [0.048s][debug][gc,heap,coops] Reserve regular memory without large pages
-        // [0.048s][info ][pagesize     ] Mark Bitmap: ... page_size=4K ...
+        // [0.044s][debug][os,map  ] Reserve regular memory without large pages [0x0000000000000000 - 0x0000000001000000), (16777216 bytes)
+        // [0.044s][debug][os,map  ] Reserved [0x00007f771de00000 - 0x00007f771ee00000), (16777216 bytes)
+        // [0.044s][info ][pagesize] Mark Bitmap: req_size=16M req_page_size=2M base=0x00007f771de00000 size=16M page_size=4K
         //
         // The pattern passed in should match the second line.
-        String failureMatch = output.firstMatch("Reserve regular memory without large pages\\n.*" + pattern, 1);
+        String failureMatch = output.firstMatch("Reserve regular memory without large pages[^\n]*\n" // First line
+                                                + "[^\n]*\n" // Second line
+                                                + "[^\n]*" + pattern, // Third line
+                                                1);
         if (failureMatch != null) {
             return true;
         }
@@ -112,7 +116,7 @@ public class TestLargePageUseForAuxMemory {
         return List.of("-XX:+UseG1GC",
                        "-XX:G1HeapRegionSize=" + HEAP_REGION_SIZE,
                        "-Xmx" + heapsize,
-                       "-Xlog:pagesize,gc+init,gc+heap+coops=debug",
+                       "-Xlog:pagesize,gc+init,os+map=debug",
                        "-XX:" + (largePageEnabled ? "+" : "-") + "UseLargePages",
                        "-version");
     }

--- a/test/hotspot/jtreg/gc/g1/TestLargePageUseForHeap.java
+++ b/test/hotspot/jtreg/gc/g1/TestLargePageUseForHeap.java
@@ -68,12 +68,15 @@ public class TestLargePageUseForHeap {
             return false;
         }
         // This message is printed when tried to reserve a memory with large page but it failed.
-        String errorStr = "Reserve regular memory without large pages";
-        String heapPattern = ".*Heap: ";
-        // If errorStr is printed just before heap page log, reservation for Java Heap is failed.
-        String result = output.firstMatch(errorStr + "\n" +
-                                          "(?:.*Heap address: .*\n)?" // Heap address: 0x00000000f8000000, size: 128 MB, Compressed Oops mode: 32-bit
-                                          + heapPattern);
+        //
+        // [0.045s][debug][os,map  ] Reserve regular memory without large pages [0x00000000f8000000 - 0x0000000100000000), (134217728 bytes)
+        // [0.045s][debug][os,map  ] Reserved [0x00000000f8000000 - 0x0000000100000000), (134217728 bytes)
+        // [0.045s][info ][pagesize] Heap:  min=8M max=128M base=0x00000000f8000000 size=128M page_size=4K
+        //
+        // If error is printed just before heap page log, reservation for Java Heap is failed.
+        String result = output.firstMatch("Reserve regular memory without large pages[^\n]*\n"
+                                          + "[^\n]*Reserved[^\n]*\n"
+                                          + "[^\n]*Heap: ");
         if (result != null) {
             return false;
         }
@@ -89,7 +92,7 @@ public class TestLargePageUseForHeap {
         OutputAnalyzer output = ProcessTools.executeLimitedTestJava("-XX:+UseG1GC",
                                                                     "-XX:G1HeapRegionSize=" + regionSize,
                                                                     "-Xmx128m",
-                                                                    "-Xlog:gc+init,pagesize,gc+heap+coops=debug",
+                                                                    "-Xlog:gc+init,pagesize,os+map=debug",
                                                                     "-XX:+UseLargePages",
                                                                     "-version");
 


### PR DESCRIPTION
The code path that we use to reserve memory is generic and used by various paths in the JVM, but we log messages about failures to reserve large pages on the 'gc, heap, coops' tag set. This is confusing, so I propose to log this on 'os, map' instead. We already use that tag set to log memory reservation, so I think that's a decent tag set to use.

While doing this change I also added some extra info about the area that we tried to reserve and commit.

A couple of G1 tests had to be tweaked.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321529](https://bugs.openjdk.org/browse/JDK-8321529): log_on_large_pages_failure reports log_debug(gc, heap, coops) for ReservedCodeSpace failures (**Bug** - P4)


### Reviewers
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23297/head:pull/23297` \
`$ git checkout pull/23297`

Update a local copy of the PR: \
`$ git checkout pull/23297` \
`$ git pull https://git.openjdk.org/jdk.git pull/23297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23297`

View PR using the GUI difftool: \
`$ git pr show -t 23297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23297.diff">https://git.openjdk.org/jdk/pull/23297.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23297#issuecomment-2612310611)
</details>
