### PR TITLE
8348575: SpinLockT is typedef'ed but unused

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -554,20 +554,11 @@ bool Thread::set_as_starting_thread(JavaThread* jt) {
   return os::create_main_thread(jt);
 }
 
-// Ad-hoc mutual exclusion primitives: SpinLock
+// Ad-hoc mutual exclusion primitives: spin lock
 //
-// We employ SpinLocks _only for low-contention, fixed-length
+// We employ spin lock _only for low-contention, fixed-length
 // short-duration critical sections where we're concerned
 // about native mutex_t or HotSpot Mutex:: latency.
-//
-// TODO-FIXME: ListLock should be of type SpinLock.
-// We should make this a 1st-class type, integrated into the lock
-// hierarchy as leaf-locks.  Critically, the SpinLock structure
-// should have sufficient padding to avoid false-sharing and excessive
-// cache-coherency traffic.
-
-
-typedef volatile int SpinLockT;
 
 void Thread::SpinAcquire(volatile int * adr, const char * LockName) {
   if (Atomic::cmpxchg(adr, 0, 1) == 0) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -554,9 +554,9 @@ bool Thread::set_as_starting_thread(JavaThread* jt) {
   return os::create_main_thread(jt);
 }
 
-// Ad-hoc mutual exclusion primitives: spin lock
+// Ad-hoc mutual exclusion primitive: spin lock
 //
-// We employ spin lock _only for low-contention, fixed-length
+// We employ a spin lock _only for low-contention, fixed-length
 // short-duration critical sections where we're concerned
 // about native mutex_t or HotSpot Mutex:: latency.
 


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?

SpinLockT is typedef'ed, but there is no usage of it. I think this is a legacy code from long time before. Also remove/modify some related comment.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348575](https://bugs.openjdk.org/browse/JDK-8348575): SpinLockT is typedef'ed but unused (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23298/head:pull/23298` \
`$ git checkout pull/23298`

Update a local copy of the PR: \
`$ git checkout pull/23298` \
`$ git pull https://git.openjdk.org/jdk.git pull/23298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23298`

View PR using the GUI difftool: \
`$ git pr show -t 23298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23298.diff">https://git.openjdk.org/jdk/pull/23298.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23298#issuecomment-2612379007)
</details>
