### PR TITLE
8348647: CDS dumping commits 3GB when large pages are used

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -283,7 +283,10 @@ void MetaspaceShared::initialize_for_static_dump() {
   SharedBaseAddress = (size_t)_requested_base_address;
 
   size_t symbol_rs_size = LP64_ONLY(3 * G) NOT_LP64(128 * M);
-  _symbol_rs = MemoryReserver::reserve(symbol_rs_size, mtClassShared);
+  _symbol_rs = MemoryReserver::reserve(symbol_rs_size,
+                                       os::vm_allocation_granularity(),
+                                       os::vm_page_size(),
+                                       mtClassShared);
   if (!_symbol_rs.is_reserved()) {
     log_error(cds)("Unable to reserve memory for symbols: %zu bytes.", symbol_rs_size);
     MetaspaceShared::unrecoverable_writing_error();


### PR DESCRIPTION
CDS inadvertently commits large pages when dumping and -XX:+UseLargePages is used. The fix is simply to use the memory reservation API that doesn't try to allocate large pages.

FWIW, In the future, as a separate RFE, I think that we should change the overloads so that the simplest overloaded function reserves memory without large pages.

I verified manually by looking at /proc/meminfo that we're not using large pages for the symbols after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348647](https://bugs.openjdk.org/browse/JDK-8348647): CDS dumping commits 3GB when large pages are used (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23299/head:pull/23299` \
`$ git checkout pull/23299`

Update a local copy of the PR: \
`$ git checkout pull/23299` \
`$ git pull https://git.openjdk.org/jdk.git pull/23299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23299`

View PR using the GUI difftool: \
`$ git pr show -t 23299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23299.diff">https://git.openjdk.org/jdk/pull/23299.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23299#issuecomment-2615215497)
</details>
