### PR TITLE
8342524: Use latch in AbstractButton/bug6298940.java instead of delay

### DIFF
--- a/test/jdk/javax/swing/AbstractButton/bug6298940.java
+++ b/test/jdk/javax/swing/AbstractButton/bug6298940.java
@@ -83,7 +83,11 @@ public final class bug6298940 {
                 throw new RuntimeException("Mnemonic didn't fire an action");
             }
         } finally {
-            SwingUtilities.invokeAndWait(() -> frame.dispose());
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 }

--- a/test/jdk/javax/swing/AbstractButton/bug6298940.java
+++ b/test/jdk/javax/swing/AbstractButton/bug6298940.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6298940
+ * @key headful
+ * @summary Tests that mnemonic keystroke fires an action
+ * @library /javax/swing/regtesthelpers
+ * @build Util
+ * @run main bug6298940
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+
+import javax.swing.ButtonModel;
+import javax.swing.DefaultButtonModel;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public final class bug6298940 {
+    private static JFrame frame;
+
+    private static final CountDownLatch actionEvent = new CountDownLatch(1);
+
+    private static void createAndShowGUI() {
+        ButtonModel model = new DefaultButtonModel();
+        model.addActionListener(event -> {
+            System.out.println("ActionEvent");
+            actionEvent.countDown();
+        });
+        model.setMnemonic('T');
+
+        JButton button = new JButton("Test");
+        button.setModel(model);
+
+        frame = new JFrame("bug6298940");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.add(button);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.toFront();
+    }
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+
+        SwingUtilities.invokeAndWait(bug6298940::createAndShowGUI);
+
+        robot.waitForIdle();
+        robot.delay(500);
+
+        Util.hitMnemonics(robot, KeyEvent.VK_T);
+
+        try {
+            if (!actionEvent.await(1, SECONDS)) {
+                throw new RuntimeException("Mnemonic didn't fire an action");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> frame.dispose());
+        }
+    }
+}


### PR DESCRIPTION
Use a `CountDownLatch` in `javax/swing/AbstractButton/bug6298940.java` instead of delay.  
Use `Util.hitMnemonics` instead of custom code to handle macOS.

I ran the updated test a few times with `JTREG=REPEAT_COUNT=20`, the test always passed in the CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342524](https://bugs.openjdk.org/browse/JDK-8342524): Use latch in AbstractButton/bug6298940.java instead of delay (**Bug** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) Review applies to [c5c6b6a4](https://git.openjdk.org/jdk/pull/23301/files/c5c6b6a473aa90262be63b216bc672820b936df7)
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer) Review applies to [c5c6b6a4](https://git.openjdk.org/jdk/pull/23301/files/c5c6b6a473aa90262be63b216bc672820b936df7)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23301/head:pull/23301` \
`$ git checkout pull/23301`

Update a local copy of the PR: \
`$ git checkout pull/23301` \
`$ git pull https://git.openjdk.org/jdk.git pull/23301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23301`

View PR using the GUI difftool: \
`$ git pr show -t 23301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23301.diff">https://git.openjdk.org/jdk/pull/23301.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23301#issuecomment-2612976346)
</details>
