### PR TITLE
8348586: Optionally silence make warnings about non-control variables

### DIFF
--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -99,7 +99,7 @@ if [ "$VERBOSE" = "true" ] ; then
   echo "idea template dir: $IDEA_TEMPLATE"
 fi
 
-cd $TOP ; make idea-gen-config IDEA_OUTPUT=$IDEA_OUTPUT MODULES="$*" $CONF_ARG || exit 1
+cd $TOP ; make idea-gen-config ALLOW=IDEA_OUTPUT,MODULES IDEA_OUTPUT=$IDEA_OUTPUT MODULES="$*" $CONF_ARG || exit 1
 cd $SCRIPT_DIR
 
 . $IDEA_OUTPUT/env.cfg

--- a/make/Global.gmk
+++ b/make/Global.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -108,6 +108,7 @@ help:
 	$(info $(_) MICRO="OPT1=x;OPT2=y"  # Control the MICRO test harness, use 'make test-only MICRO=help' to list)
 	$(info $(_) TEST_OPTS="OPT1=x;..." # Generic control of all test harnesses)
 	$(info $(_) TEST_VM_OPTS="ARG ..." # Same as setting TEST_OPTS to VM_OPTIONS="ARG ...")
+	$(info $(_) ALLOW="FOO,BAR"        # Do not warn that FOO and BAR are non-control variables)
 	$(info )
 	$(if $(all_confs), $(info Available configurations in $(build_dir):) $(foreach var,$(all_confs),$(info * $(var))), \
 	    $(info No configurations were found in $(build_dir).) $(info Run 'bash configure' to create a configuration.))

--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -48,12 +48,15 @@ ifeq ($(HAS_SPEC), )
   # from the command-line.
   ##############################################################################
 
-  # Make control variables, handled by Init.gmk
-  INIT_CONTROL_VARIABLES += LOG CONF CONF_NAME SPEC JOBS TEST_JOBS CONF_CHECK \
-      COMPARE_BUILD JTREG GTEST MICRO TEST_OPTS TEST_VM_OPTS TEST_DEPS
+  # Essential control variables that are handled by Init.gmk
+  INIT_CONTROL_VARIABLES := LOG CONF CONF_NAME SPEC JOBS CONF_CHECK ALLOW \
+      COMPARE_BUILD
 
-  # All known make control variables
-  MAKE_CONTROL_VARIABLES := $(INIT_CONTROL_VARIABLES) TEST JDK_FILTER SPEC_FILTER
+  # All known make control variables; these are handled in other makefiles
+  MAKE_CONTROL_VARIABLES += JDK_FILTER SPEC_FILTER \
+      TEST TEST_JOBS JTREG GTEST MICRO TEST_OPTS TEST_VM_OPTS TEST_DEPS
+
+  ALL_CONTROL_VARIABLES := $(INIT_CONTROL_VARIABLES) $(MAKE_CONTROL_VARIABLES)
 
   # Define a simple reverse function.
   # Should maybe move to MakeBase.gmk, but we can't include that file now.
@@ -87,8 +90,10 @@ ifeq ($(HAS_SPEC), )
     command_line_variables := $$(strip $$(foreach var, \
         $$(subst \ ,_,$$(MAKEOVERRIDES)), \
         $$(firstword $$(subst =, , $$(var)))))
+    allowed_command_line_variables := $$(strip $$(subst $$(COMMA), , $$(ALLOW)))
     unknown_command_line_variables := $$(strip \
-        $$(filter-out $$(MAKE_CONTROL_VARIABLES), $$(command_line_variables)))
+        $$(filter-out $$(ALL_CONTROL_VARIABLES) $$(allowed_command_line_variables), \
+        $$(command_line_variables)))
     ifneq ($$(unknown_command_line_variables), )
       $$(info Note: Command line contains non-control variables:)
       $$(foreach var, $$(unknown_command_line_variables), $$(info * $$(var)=$$($$(var))))


### PR DESCRIPTION
When you set a variable on the make command line that is not a known control variable, make emits a note like this:

```
Note: Command line contains non-control variables:
* MODULES=
* IDEA_OUTPUT=/mnt/h/openjdk/git-jdk2/.idea
Make sure it is not mistyped, and that you intend to override this variable.
'make help' will list known control variables.
```

Since [JDK-8347825](https://bugs.openjdk.org/browse/JDK-8347825), this happens whenever you run idea.sh, and it is confusing to users.

I introduce a general way of silencing such complaints using the new control variable `ALLOW`, and start by applying it on the idea.sh script.