### PR TITLE
8325068: runtime/os/TestTracePageSizes.java: incorrect page size comparison for kernels < 5.0 with THP 'always' mode

### DIFF
--- a/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
+++ b/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,6 +264,14 @@ public class TestTracePageSizes {
         if (Platform.getOsVersionMajor() < 3 ||
             (Platform.getOsVersionMajor() == 3 && Platform.getOsVersionMinor() < 8)) {
             throw new SkippedException("Kernel older than 3.8 - skipping this test.");
+        }
+
+        // Kernel versions before 5.0 lack the "THPeligible" field in /proc/self/smaps,
+        // causing incorrect page size comparisons when THP mode is set to "always".
+        if (Platform.getOsVersionMajor() < 5 && System.getenv("THP_MODE").equals("always")) {
+            if (System.getenv("THP_MODE").equals("always")) {
+                throw new SkippedException("Kernel older than 5.0 with THP mode \"always\" enabled - skipping this test.");
+            }
         }
 
         // Parse /proc/self/smaps to compare with values logged in the VM.


### PR DESCRIPTION
Hi all, 

This PR addresses [8325068](https://bugs.openjdk.org/browse/JDK-8325068) by disabling the test if running a kernel version < 5.0 with THP 'always' mode enabled. 

On older kernels, when THP mode is "always," the test fails because it doesn’t find the `THPeligible` field to identify that a mapping uses THP. As a result, it incorrectly compares the logged page size to the smaller page size reported in `/proc/self/smaps`.

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325068](https://bugs.openjdk.org/browse/JDK-8325068): runtime/os/TestTracePageSizes.java: incorrect page size comparison for kernels &lt; 5.0 with THP 'always' mode (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23304/head:pull/23304` \
`$ git checkout pull/23304`

Update a local copy of the PR: \
`$ git checkout pull/23304` \
`$ git pull https://git.openjdk.org/jdk.git pull/23304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23304`

View PR using the GUI difftool: \
`$ git pr show -t 23304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23304.diff">https://git.openjdk.org/jdk/pull/23304.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23304#issuecomment-2619128786)
</details>
