### PR TITLE
8348420: Shenandoah: Check is_reserved before using ReservedSpace instances

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -166,7 +166,11 @@ static ReservedSpace reserve(size_t size, size_t preferred_page_size) {
     size = align_up(size, alignment);
   }
 
-  return MemoryReserver::reserve(size, alignment, preferred_page_size);
+  const ReservedSpace reserved = MemoryReserver::reserve(size, alignment, preferred_page_size);
+  if (!reserved.is_reserved()) {
+    vm_exit_during_initialization("Could not reserve space");
+  }
+  return reserved;
 }
 
 jint ShenandoahHeap::initialize() {
@@ -386,8 +390,9 @@ jint ShenandoahHeap::initialize() {
 
     if (_collection_set == nullptr) {
       cset_rs = MemoryReserver::reserve(cset_size, cset_align, os::vm_page_size());
-
-      // Maybe Shenandoah wants to check the the memory got reserved here?
+      if (!cset_rs.is_reserved()) {
+        vm_exit_during_initialization("Cannot reserve memory for collection set");
+      }
 
       _collection_set = new ShenandoahCollectionSet(this, cset_rs, sh_rs.base());
     }


### PR DESCRIPTION
Follow up on [JDK-8346572](https://bugs.openjdk.org/browse/JDK-8346572) for Shenandoah.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348420](https://bugs.openjdk.org/browse/JDK-8348420): Shenandoah: Check is_reserved before using ReservedSpace instances (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23308/head:pull/23308` \
`$ git checkout pull/23308`

Update a local copy of the PR: \
`$ git checkout pull/23308` \
`$ git pull https://git.openjdk.org/jdk.git pull/23308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23308`

View PR using the GUI difftool: \
`$ git pr show -t 23308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23308.diff">https://git.openjdk.org/jdk/pull/23308.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23308#issuecomment-2613456265)
</details>
