### PR TITLE
8348205: Improve cutover time selection when building available currencies set

### DIFF
--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -444,7 +444,6 @@ public final class Currency implements Serializable {
     public static Set<Currency> getAvailableCurrencies() {
         synchronized(Currency.class) {
             if (available == null) {
-                // reuse same time for all special case cut-over date checks
                 var sysTime = System.currentTimeMillis();
                 available = new HashSet<>(256);
                 // Add simple currencies first

--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -444,8 +444,9 @@ public final class Currency implements Serializable {
     public static Set<Currency> getAvailableCurrencies() {
         synchronized(Currency.class) {
             if (available == null) {
+                // reuse same time for all special case cut-over date checks
+                var sysTime = System.currentTimeMillis();
                 available = new HashSet<>(256);
-
                 // Add simple currencies first
                 for (char c1 = 'A'; c1 <= 'Z'; c1 ++) {
                     for (char c2 = 'A'; c2 <= 'Z'; c2 ++) {
@@ -467,7 +468,7 @@ public final class Currency implements Serializable {
                             SpecialCaseEntry scEntry = specialCasesList.get(index);
 
                             if (scEntry.cutOverTime == Long.MAX_VALUE
-                                    || System.currentTimeMillis() < scEntry.cutOverTime) {
+                                    || sysTime < scEntry.cutOverTime) {
                                 available.add(getInstance(scEntry.oldCurrency,
                                         scEntry.oldCurrencyFraction,
                                         scEntry.oldCurrencyNumericCode));


### PR DESCRIPTION
Please review this PR which improves the time measurement for cut-over time comparisons when building the available set of currencies in _java.util.Currency._ Currently, a new time was measured for each special case currency. This PR updates the behavior to use the same time for all such cases

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8348205](https://bugs.openjdk.org/browse/JDK-8348205): Improve cutover time selection when building available currencies set (**Bug** - P4)
 * [JDK-8348216](https://bugs.openjdk.org/browse/JDK-8348216): Improve cutover time selection when building available currencies set (**CSR**) (Withdrawn)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23309/head:pull/23309` \
`$ git checkout pull/23309`

Update a local copy of the PR: \
`$ git checkout pull/23309` \
`$ git pull https://git.openjdk.org/jdk.git pull/23309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23309`

View PR using the GUI difftool: \
`$ git pr show -t 23309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23309.diff">https://git.openjdk.org/jdk/pull/23309.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23309#issuecomment-2613625915)
</details>
