### PR TITLE
Refactor FloatingDecimal

### DIFF
--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -300,11 +300,10 @@ final class DigitList implements Cloneable {
      * fractional digits to be converted.  If false, total digits.
      */
     final void set(boolean isNegative, double source, int maximumDigits, boolean fixedPoint) {
-
-        FloatingDecimal.BinaryToASCIIConverter fdConverter  = FloatingDecimal.getBinaryToASCIIConverter(source);
+        assert !FloatingDecimal.isExceptional(source);
+        FloatingDecimal.BinaryToASCIIConverter fdConverter = FloatingDecimal.getBinaryToASCIIConverter(source);
         boolean hasBeenRoundedUp = fdConverter.digitsRoundedUp();
         boolean valueExactAsDecimal = fdConverter.decimalDigitsExact();
-        assert !fdConverter.isExceptional();
         String digitsString = fdConverter.toJavaFormatString();
 
         set(isNegative, digitsString,

--- a/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
@@ -25,9 +25,11 @@
 
 package jdk.internal.math;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.regex.*;
 
+import jdk.internal.util.DecimalDigits;
 /**
  * A class for converting between ASCII and decimal representations of a single
  * or double precision floating point number. Most conversions are provided via
@@ -61,44 +63,6 @@ public class FloatingDecimal{
     static final int    INT_DECIMAL_DIGITS = 9;
 
     /**
-     * Converts a double precision floating point value to a <code>String</code>.
-     *
-     * @param d The double precision value.
-     * @return The value converted to a <code>String</code>.
-     */
-    public static String toJavaFormatString(double d) {
-        return getBinaryToASCIIConverter(d).toJavaFormatString();
-    }
-
-    /**
-     * Converts a single precision floating point value to a <code>String</code>.
-     *
-     * @param f The single precision value.
-     * @return The value converted to a <code>String</code>.
-     */
-    public static String toJavaFormatString(float f) {
-        return getBinaryToASCIIConverter(f).toJavaFormatString();
-    }
-
-    /**
-     * Appends a double precision floating point value to an <code>Appendable</code>.
-     * @param d The double precision value.
-     * @param buf The <code>Appendable</code> with the value appended.
-     */
-    public static void appendTo(double d, Appendable buf) {
-        getBinaryToASCIIConverter(d).appendTo(buf);
-    }
-
-    /**
-     * Appends a single precision floating point value to an <code>Appendable</code>.
-     * @param f The single precision value.
-     * @param buf The <code>Appendable</code> with the value appended.
-     */
-    public static void appendTo(float f, Appendable buf) {
-        getBinaryToASCIIConverter(f).appendTo(buf);
-    }
-
-    /**
      * Converts a <code>String</code> to a double precision floating point value.
      *
      * @param s The <code>String</code> to convert.
@@ -122,147 +86,24 @@ public class FloatingDecimal{
         return readJavaFormatString(s).floatValue();
     }
 
-    /**
-     * A converter which can process single or double precision floating point
-     * values into an ASCII <code>String</code> representation.
-     */
-    public interface BinaryToASCIIConverter {
-        /**
-         * Converts a floating point value into an ASCII <code>String</code>.
-         * @return The value converted to a <code>String</code>.
-         */
-        String toJavaFormatString();
-
-        /**
-         * Appends a floating point value to an <code>Appendable</code>.
-         * @param buf The <code>Appendable</code> to receive the value.
-         */
-        void appendTo(Appendable buf);
-
-        /**
-         * Retrieves the decimal exponent most closely corresponding to this value.
-         * @return The decimal exponent.
-         */
-        int getDecimalExponent();
-
-        /**
-         * Retrieves the value as an array of digits.
-         * @param digits The digit array.
-         * @return The number of valid digits copied into the array.
-         */
-        int getDigits(char[] digits);
-
-        /**
-         * Indicates the sign of the value.
-         * @return {@code value < 0.0}.
-         */
-        boolean isNegative();
-
-        /**
-         * Indicates whether the value is either infinite or not a number.
-         *
-         * @return <code>true</code> if and only if the value is <code>NaN</code>
-         * or infinite.
-         */
-        boolean isExceptional();
-
-        /**
-         * Indicates whether the value was rounded up during the binary to ASCII
-         * conversion.
-         *
-         * @return <code>true</code> if and only if the value was rounded up.
-         */
-        boolean digitsRoundedUp();
-
-        /**
-         * Indicates whether the binary to ASCII conversion was exact.
-         *
-         * @return <code>true</code> if any only if the conversion was exact.
-         */
-        boolean decimalDigitsExact();
-    }
-
-    /**
-     * A <code>BinaryToASCIIConverter</code> which represents <code>NaN</code>
-     * and infinite values.
-     */
-    private static class ExceptionalBinaryToASCIIBuffer implements BinaryToASCIIConverter {
-        private final String image;
-        private boolean isNegative;
-
-        public ExceptionalBinaryToASCIIBuffer(String image, boolean isNegative) {
-            this.image = image;
-            this.isNegative = isNegative;
-        }
-
-        @Override
-        public String toJavaFormatString() {
-            return image;
-        }
-
-        @Override
-        public void appendTo(Appendable buf) {
-            if (buf instanceof StringBuilder) {
-                ((StringBuilder) buf).append(image);
-            } else if (buf instanceof StringBuffer) {
-                ((StringBuffer) buf).append(image);
-            } else {
-                assert false;
-            }
-        }
-
-        @Override
-        public int getDecimalExponent() {
-            throw new IllegalArgumentException("Exceptional value does not have an exponent");
-        }
-
-        @Override
-        public int getDigits(char[] digits) {
-            throw new IllegalArgumentException("Exceptional value does not have digits");
-        }
-
-        @Override
-        public boolean isNegative() {
-            return isNegative;
-        }
-
-        @Override
-        public boolean isExceptional() {
-            return true;
-        }
-
-        @Override
-        public boolean digitsRoundedUp() {
-            throw new IllegalArgumentException("Exceptional value is not rounded");
-        }
-
-        @Override
-        public boolean decimalDigitsExact() {
-            throw new IllegalArgumentException("Exceptional value is not exact");
-        }
-    }
-
     private static final String INFINITY_REP = "Infinity";
     private static final int INFINITY_LENGTH = INFINITY_REP.length();
     private static final String NAN_REP = "NaN";
     private static final int NAN_LENGTH = NAN_REP.length();
 
-    private static final BinaryToASCIIConverter B2AC_POSITIVE_INFINITY = new ExceptionalBinaryToASCIIBuffer(INFINITY_REP, false);
-    private static final BinaryToASCIIConverter B2AC_NEGATIVE_INFINITY = new ExceptionalBinaryToASCIIBuffer("-" + INFINITY_REP, true);
-    private static final BinaryToASCIIConverter B2AC_NOT_A_NUMBER = new ExceptionalBinaryToASCIIBuffer(NAN_REP, false);
-    private static final BinaryToASCIIConverter B2AC_POSITIVE_ZERO = new BinaryToASCIIBuffer(false, new char[]{'0'});
-    private static final BinaryToASCIIConverter B2AC_NEGATIVE_ZERO = new BinaryToASCIIBuffer(true,  new char[]{'0'});
+    private static final BinaryToASCIIConverter B2AC_POSITIVE_ZERO = new BinaryToASCIIConverter(false, new byte[]{'0'});
+    private static final BinaryToASCIIConverter B2AC_NEGATIVE_ZERO = new BinaryToASCIIConverter(true,  new byte[]{'0'});
 
     /**
-     * A buffered implementation of <code>BinaryToASCIIConverter</code>.
+     * A converter which can process single or double precision floating point
+     * values into an ASCII <code>String</code> representation.
      */
-    static class BinaryToASCIIBuffer implements BinaryToASCIIConverter {
-        private boolean isNegative;
+    public final static class BinaryToASCIIConverter {
+        private final boolean isNegative;
         private int decExponent;
         private int firstDigitIndex;
         private int nDigits;
-        private final char[] digits;
-        private final char[] buffer = new char[26];
+        private final byte[] digits;
 
         //
         // The fields below provide additional information about the result of
@@ -278,17 +119,9 @@ public class FloatingDecimal{
         private boolean decimalDigitsRoundedUp = false;
 
         /**
-         * Default constructor; used for non-zero values,
-         * <code>BinaryToASCIIBuffer</code> may be thread-local and reused
-         */
-        BinaryToASCIIBuffer(){
-            this.digits = new char[20];
-        }
-
-        /**
          * Creates a specialized value (positive and negative zeros).
          */
-        BinaryToASCIIBuffer(boolean isNegative, char[] digits){
+        BinaryToASCIIConverter(boolean isNegative, byte[] digits){
             this.isNegative = isNegative;
             this.decExponent  = 0;
             this.digits = digits;
@@ -296,57 +129,33 @@ public class FloatingDecimal{
             this.nDigits = digits.length;
         }
 
-        @Override
+        /**
+         * Converts a floating point value into an ASCII <code>String</code>.
+         * @return The value converted to a <code>String</code>.
+         */
         public String toJavaFormatString() {
+            byte[] buffer = new byte[26];
             int len = getChars(buffer);
-            return new String(buffer, 0, len);
+            return new String(buffer, 0, len, StandardCharsets.ISO_8859_1);
         }
 
-        @Override
-        public void appendTo(Appendable buf) {
-            int len = getChars(buffer);
-            if (buf instanceof StringBuilder) {
-                ((StringBuilder) buf).append(buffer, 0, len);
-            } else if (buf instanceof StringBuffer) {
-                ((StringBuffer) buf).append(buffer, 0, len);
-            } else {
-                assert false;
-            }
-        }
-
-        @Override
-        public int getDecimalExponent() {
-            return decExponent;
-        }
-
-        @Override
-        public int getDigits(char[] digits) {
-            System.arraycopy(this.digits, firstDigitIndex, digits, 0, this.nDigits);
-            return this.nDigits;
-        }
-
-        @Override
-        public boolean isNegative() {
-            return isNegative;
-        }
-
-        @Override
-        public boolean isExceptional() {
-            return false;
-        }
-
-        @Override
+        /**
+         * Indicates whether the value was rounded up during the binary to ASCII
+         * conversion.
+         *
+         * @return <code>true</code> if and only if the value was rounded up.
+         */
         public boolean digitsRoundedUp() {
             return decimalDigitsRoundedUp;
         }
 
-        @Override
+        /**
+         * Indicates whether the binary to ASCII conversion was exact.
+         *
+         * @return <code>true</code> if any only if the conversion was exact.
+         */
         public boolean decimalDigitsExact() {
             return exactDecimalConversion;
-        }
-
-        private void setSign(boolean isNegative) {
-            this.isNegative = isNegative;
         }
 
         /**
@@ -392,12 +201,12 @@ public class FloatingDecimal{
                     ivalue /= 10;
                 }
                 while ( ivalue != 0){
-                    digits[digitno--] = (char)(c+'0');
+                    digits[digitno--] = (byte)(c+'0');
                     decExponent++;
                     c = ivalue%10;
                     ivalue /= 10;
                 }
-                digits[digitno] = (char)(c+'0');
+                digits[digitno] = (byte)(c+'0');
             } else {
                 // same algorithm as above (same bugs, too )
                 // but using long arithmetic.
@@ -409,19 +218,19 @@ public class FloatingDecimal{
                     lvalue /= 10L;
                 }
                 while ( lvalue != 0L ){
-                    digits[digitno--] = (char)(c+'0');
+                    digits[digitno--] = (byte)(c+'0');
                     decExponent++;
                     c = (int)(lvalue%10L);
                     lvalue /= 10;
                 }
-                digits[digitno] = (char)(c+'0');
+                digits[digitno] = (byte)(c+'0');
             }
             this.decExponent = decExponent+1;
             this.firstDigitIndex = digitno;
             this.nDigits = this.digits.length - digitno;
         }
 
-        private void dtoa( int binExp, long fractBits, int nSignificantBits, boolean isCompatibleFormat)
+        private void dtoa( int binExp, long fractBits, int nSignificantBits)
         {
             assert fractBits > 0 ; // fractBits here can't be zero or negative
             assert (fractBits & FRACT_HOB)!=0  ; // Hi-order bit should be set
@@ -615,7 +424,7 @@ public class FloatingDecimal{
                         // oops. Usually ignore leading zero.
                         decExp--;
                     } else {
-                        digits[ndigit++] = (char)('0' + q);
+                        digits[ndigit++] = (byte)('0' + q);
                     }
                     //
                     // HACK! Java spec sez that we always have at least
@@ -623,7 +432,7 @@ public class FloatingDecimal{
                     // Thus we will need more than one digit if we're using
                     // E-form
                     //
-                    if ( !isCompatibleFormat ||decExp < -3 || decExp >= 8 ){
+                    if (decExp < -3 || decExp >= 8 ){
                         high = low = false;
                     }
                     while( ! low && ! high ){
@@ -643,7 +452,7 @@ public class FloatingDecimal{
                             low = true;
                             high = true;
                         }
-                        digits[ndigit++] = (char)('0' + q);
+                        digits[ndigit++] = (byte)('0' + q);
                     }
                     lowDigitDifference = (b<<1) - tens;
                     exactDecimalConversion  = (b == 0);
@@ -669,7 +478,7 @@ public class FloatingDecimal{
                         // oops. Usually ignore leading zero.
                         decExp--;
                     } else {
-                        digits[ndigit++] = (char)('0' + q);
+                        digits[ndigit++] = (byte)('0' + q);
                     }
                     //
                     // HACK! Java spec sez that we always have at least
@@ -677,7 +486,7 @@ public class FloatingDecimal{
                     // Thus we will need more than one digit if we're using
                     // E-form
                     //
-                    if ( !isCompatibleFormat || decExp < -3 || decExp >= 8 ){
+                    if ( decExp < -3 || decExp >= 8 ){
                         high = low = false;
                     }
                     while( ! low && ! high ){
@@ -697,7 +506,7 @@ public class FloatingDecimal{
                             low = true;
                             high = true;
                         }
-                        digits[ndigit++] = (char)('0' + q);
+                        digits[ndigit++] = (byte)('0' + q);
                     }
                     lowDigitDifference = (b<<1) - tens;
                     exactDecimalConversion  = (b == 0);
@@ -730,7 +539,7 @@ public class FloatingDecimal{
                     // oops. Usually ignore leading zero.
                     decExp--;
                 } else {
-                    digits[ndigit++] = (char)('0' + q);
+                    digits[ndigit++] = (byte)('0' + q);
                 }
                 //
                 // HACK! Java spec sez that we always have at least
@@ -738,7 +547,7 @@ public class FloatingDecimal{
                 // Thus we will need more than one digit if we're using
                 // E-form
                 //
-                if (!isCompatibleFormat || decExp < -3 || decExp >= 8 ){
+                if (decExp < -3 || decExp >= 8 ){
                     high = low = false;
                 }
                 while( ! low && ! high ){
@@ -747,7 +556,7 @@ public class FloatingDecimal{
                     Mval = Mval.multBy10(); //Mval = Mval.mult( 10 );
                     low  = (Bval.cmp( Mval ) < 0);
                     high = tenSval.addAndCmp(Bval,Mval)<=0;
-                    digits[ndigit++] = (char)('0' + q);
+                    digits[ndigit++] = (byte)('0' + q);
                 }
                 if ( high && low ){
                     Bval = Bval.leftShift(1);
@@ -801,7 +610,7 @@ public class FloatingDecimal{
                 }
                 // else fall through.
             }
-            digits[i] = (char) (q + 1);
+            digits[i] = (byte) (q + 1);
             decimalDigitsRoundedUp = true;
         }
 
@@ -902,7 +711,7 @@ public class FloatingDecimal{
                 61,
         };
 
-        private int getChars(char[] result) {
+        private int getChars(byte[] result) {
             assert nDigits <= 19 : nDigits; // generous bound on size of nDigits
             int i = 0;
             if (isNegative) {
@@ -916,10 +725,11 @@ public class FloatingDecimal{
                 i += charLength;
                 if (charLength < decExponent) {
                     charLength = decExponent - charLength;
-                    Arrays.fill(result,i,i+charLength,'0');
+                    Arrays.fill(result,i,i+charLength, (byte) '0');
                     i += charLength;
-                    result[i++] = '.';
-                    result[i++] = '0';
+                    result[i    ] = '.';
+                    result[i + 1] = '0';
+                    i += 2;
                 } else {
                     result[i++] = '.';
                     if (charLength < nDigits) {
@@ -931,10 +741,11 @@ public class FloatingDecimal{
                     }
                 }
             } else if (decExponent <= 0 && decExponent > -3) {
-                result[i++] = '0';
-                result[i++] = '.';
+                result[i    ] = '0';
+                result[i + 1] = '.';
+                i += 2;
                 if (decExponent != 0) {
-                    Arrays.fill(result, i, i-decExponent, '0');
+                    Arrays.fill(result, i, i-decExponent, (byte) '0');
                     i -= decExponent;
                 }
                 System.arraycopy(digits, firstDigitIndex, result, i, nDigits);
@@ -958,32 +769,20 @@ public class FloatingDecimal{
                 }
                 // decExponent has 1, 2, or 3, digits
                 if (e <= 9) {
-                    result[i++] = (char) (e + '0');
+                    result[i++] = (byte) (e + '0');
                 } else if (e <= 99) {
-                    result[i++] = (char) (e / 10 + '0');
-                    result[i++] = (char) (e % 10 + '0');
+                    DecimalDigits.putPairLatin1(result, i, e);
+                    i += 2;
                 } else {
-                    result[i++] = (char) (e / 100 + '0');
+                    result[i++] = (byte) (e / 100 + '0');
                     e %= 100;
-                    result[i++] = (char) (e / 10 + '0');
-                    result[i++] = (char) (e % 10 + '0');
+                    DecimalDigits.putPairLatin1(result, i, e);
+                    i += 2;
                 }
             }
             return i;
         }
 
-    }
-
-    private static final ThreadLocal<BinaryToASCIIBuffer> threadLocalBinaryToASCIIBuffer =
-            new ThreadLocal<BinaryToASCIIBuffer>() {
-                @Override
-                protected BinaryToASCIIBuffer initialValue() {
-                    return new BinaryToASCIIBuffer();
-                }
-            };
-
-    private static BinaryToASCIIBuffer getBinaryToASCIIBuffer() {
-        return threadLocalBinaryToASCIIBuffer.get();
     }
 
     /**
@@ -1727,6 +1526,10 @@ public class FloatingDecimal{
 
     }
 
+    public static boolean isExceptional(double d) {
+        return Double.isNaN(d) || Double.isInfinite(d);
+    }
+
     /**
      * Returns a <code>BinaryToASCIIConverter</code> for a <code>double</code>.
      * The returned object is a <code>ThreadLocal</code> variable of this class.
@@ -1735,29 +1538,13 @@ public class FloatingDecimal{
      * @return The converter.
      */
     public static BinaryToASCIIConverter getBinaryToASCIIConverter(double d) {
-        return getBinaryToASCIIConverter(d, true);
-    }
-
-    /**
-     * Returns a <code>BinaryToASCIIConverter</code> for a <code>double</code>.
-     * The returned object is a <code>ThreadLocal</code> variable of this class.
-     *
-     * @param d The double precision value to convert.
-     * @param isCompatibleFormat
-     * @return The converter.
-     */
-    static BinaryToASCIIConverter getBinaryToASCIIConverter(double d, boolean isCompatibleFormat) {
         long dBits = Double.doubleToRawLongBits(d);
         boolean isNegative = (dBits&DoubleConsts.SIGN_BIT_MASK) != 0; // discover sign
         long fractBits = dBits & DoubleConsts.SIGNIF_BIT_MASK;
         int  binExp = (int)( (dBits&DoubleConsts.EXP_BIT_MASK) >> EXP_SHIFT );
         // Discover obvious special cases of NaN and Infinity.
         if ( binExp == (int)(DoubleConsts.EXP_BIT_MASK>>EXP_SHIFT) ) {
-            if ( fractBits == 0L ){
-                return isNegative ? B2AC_NEGATIVE_INFINITY : B2AC_POSITIVE_INFINITY;
-            } else {
-                return B2AC_NOT_A_NUMBER;
-            }
+            assert false;
         }
         // Finish unpacking
         // Normalize denormalized numbers.
@@ -1779,50 +1566,9 @@ public class FloatingDecimal{
             nSignificantBits = EXP_SHIFT+1;
         }
         binExp -= DoubleConsts.EXP_BIAS;
-        BinaryToASCIIBuffer buf = getBinaryToASCIIBuffer();
-        buf.setSign(isNegative);
+        BinaryToASCIIConverter buf = new BinaryToASCIIConverter(isNegative, new byte[20]);
         // call the routine that actually does all the hard work.
-        buf.dtoa(binExp, fractBits, nSignificantBits, isCompatibleFormat);
-        return buf;
-    }
-
-    private static BinaryToASCIIConverter getBinaryToASCIIConverter(float f) {
-        int fBits = Float.floatToRawIntBits( f );
-        boolean isNegative = (fBits&FloatConsts.SIGN_BIT_MASK) != 0;
-        int fractBits = fBits&FloatConsts.SIGNIF_BIT_MASK;
-        int binExp = (fBits&FloatConsts.EXP_BIT_MASK) >> SINGLE_EXP_SHIFT;
-        // Discover obvious special cases of NaN and Infinity.
-        if ( binExp == (FloatConsts.EXP_BIT_MASK>>SINGLE_EXP_SHIFT) ) {
-            if ( fractBits == 0L ){
-                return isNegative ? B2AC_NEGATIVE_INFINITY : B2AC_POSITIVE_INFINITY;
-            } else {
-                return B2AC_NOT_A_NUMBER;
-            }
-        }
-        // Finish unpacking
-        // Normalize denormalized numbers.
-        // Insert assumed high-order bit for normalized numbers.
-        // Subtract exponent bias.
-        int  nSignificantBits;
-        if ( binExp == 0 ){
-            if ( fractBits == 0 ){
-                // not a denorm, just a 0!
-                return isNegative ? B2AC_NEGATIVE_ZERO : B2AC_POSITIVE_ZERO;
-            }
-            int leadingZeros = Integer.numberOfLeadingZeros(fractBits);
-            int shift = leadingZeros-(31-SINGLE_EXP_SHIFT);
-            fractBits <<= shift;
-            binExp = 1 - shift;
-            nSignificantBits =  32 - leadingZeros; // recall binExp is  - shift count.
-        } else {
-            fractBits |= SINGLE_FRACT_HOB;
-            nSignificantBits = SINGLE_EXP_SHIFT+1;
-        }
-        binExp -= FloatConsts.EXP_BIAS;
-        BinaryToASCIIBuffer buf = getBinaryToASCIIBuffer();
-        buf.setSign(isNegative);
-        // call the routine that actually does all the hard work.
-        buf.dtoa(binExp, ((long)fractBits)<<(EXP_SHIFT-SINGLE_EXP_SHIFT), nSignificantBits, true);
+        buf.dtoa(binExp, fractBits, nSignificantBits);
         return buf;
     }
 


### PR DESCRIPTION
Since FloatToDecimal and DoubleToDecimal are used in Float.toString and Double.toString, some code in FloatingDecimal is not used. This refactoring is to remove the unused code and reuse DecimalDigits to reduce duplication of code.