### PR TITLE
8347718: Unexpected NullPointerException in C2 compiled code due to ReduceAllocationMerges

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -985,7 +985,7 @@ void ConnectionGraph::reduce_phi_on_cmp(Node* cmp) {
   BoolTest::mask mask = cmp->unique_out()->as_Bool()->_test._test;
 
   // This Phi will merge the result of the Cmps split through the Phi
-  Node* res_phi  = _igvn->transform(PhiNode::make(ophi->in(0), zero, TypeInt::INT));
+  Node* res_phi = PhiNode::make(ophi->in(0), zero, TypeInt::INT);
 
   for (uint i=1; i<ophi->req(); i++) {
     Node* ophi_input = ophi->in(i);
@@ -1011,7 +1011,7 @@ void ConnectionGraph::reduce_phi_on_cmp(Node* cmp) {
   }
 
   // This CMP always compares whether the output of "res_phi" is TRUE as far as the "mask".
-  Node* new_cmp = _igvn->transform(new CmpINode(res_phi, (mask == BoolTest::mask::eq) ? one : zero));
+  Node* new_cmp = _igvn->transform(new CmpINode(_igvn->transform(res_phi), (mask == BoolTest::mask::eq) ? one : zero));
   _igvn->replace_node(cmp, new_cmp);
 }
 

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -981,6 +981,7 @@ void ConnectionGraph::reduce_phi_on_cmp(Node* cmp) {
 
   Node* other = cmp->in(1)->is_Con() ? cmp->in(1) : cmp->in(2);
   Node* zero = _igvn->intcon(0);
+  Node* one = _igvn->intcon(1);
   BoolTest::mask mask = cmp->unique_out()->as_Bool()->_test._test;
 
   // This Phi will merge the result of the Cmps split through the Phi
@@ -992,7 +993,12 @@ void ConnectionGraph::reduce_phi_on_cmp(Node* cmp) {
 
     const TypeInt* tcmp = optimize_ptr_compare(ophi_input, other);
     if (tcmp->singleton()) {
-      res_phi_input = _igvn->makecon(tcmp);
+      if ((mask == BoolTest::mask::eq && tcmp == TypeInt::CC_EQ) ||
+          (mask == BoolTest::mask::ne && tcmp == TypeInt::CC_GT)) {
+        res_phi_input = one;
+      } else {
+        res_phi_input = zero;
+      }
     } else {
       Node* ncmp = _igvn->transform(cmp->clone());
       ncmp->set_req(1, ophi_input);
@@ -1004,7 +1010,8 @@ void ConnectionGraph::reduce_phi_on_cmp(Node* cmp) {
     res_phi->set_req(i, res_phi_input);
   }
 
-  Node* new_cmp = _igvn->transform(new CmpINode(res_phi, zero));
+  // This CMP always compares whether the output of "res_phi" is TRUE as far as the "mask".
+  Node* new_cmp = _igvn->transform(new CmpINode(res_phi, (mask == BoolTest::mask::eq) ? one : zero));
   _igvn->replace_node(cmp, new_cmp);
 }
 

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndPointerComparisons.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndPointerComparisons.java
@@ -30,7 +30,7 @@
  *                   -XX:CompileCommand=dontinline,*TestReduceAllocationAndPointerComparisons*::*
  *                   -XX:-TieredCompilation -Xcomp -server
  *                   compiler.c2.TestReduceAllocationAndPointerComparisons
- * @run main/othervm compiler.c2.TestReduceAllocationAndPointerComparisons
+ * @run main compiler.c2.TestReduceAllocationAndPointerComparisons
  */
 
 package compiler.c2;

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndPointerComparisons.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndPointerComparisons.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8347718
+ * @summary Check that Reduce Allocation Merges correctly handle "NE" pointer comparisons.
+ * @requires vm.flagless & vm.compiler2.enabled & vm.opt.final.EliminateAllocations
+ * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndPointerComparisons*::*
+ *                   -XX:CompileCommand=dontinline,*TestReduceAllocationAndPointerComparisons*::*
+ *                   -XX:-TieredCompilation -Xcomp -server
+ *                   compiler.c2.TestReduceAllocationAndPointerComparisons
+ * @run main/othervm compiler.c2.TestReduceAllocationAndPointerComparisons
+ */
+
+package compiler.c2;
+
+public class TestReduceAllocationAndPointerComparisons {
+    public static void main(String[] args) {
+        for (int i=0; i<50000; i++) {
+            if (test(true) == false) {
+                throw new RuntimeException("Unexpected result.");
+            }
+        }
+    }
+
+    public static boolean test(boolean b) {
+        MyClass obj = new MyClass();
+
+        for (int i = 0; i < 100_000; ++i) { }
+
+        obj = b ? obj : new MyClass();
+        obj = b ? obj : new MyClass();
+
+        if (obj == null) {
+            return false;
+        }
+
+        return b;
+    }
+
+    static class MyClass {
+    }
+}


### PR DESCRIPTION
Please, review this patch to fix an issue in reducing allocation merges used by Cmp nodes. The attached test case, adapted from the one attached to the JBS issue, can be used to reproduce the issue. The root of the problem was not properly checking the return value of `optimize_ptr_compare` against different Cmp mask predicates.

I tested this on OSX(ARM64) & Linux(Intel) tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347718](https://bugs.openjdk.org/browse/JDK-8347718): Unexpected NullPointerException in C2 compiled code due to ReduceAllocationMerges (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23312/head:pull/23312` \
`$ git checkout pull/23312`

Update a local copy of the PR: \
`$ git checkout pull/23312` \
`$ git pull https://git.openjdk.org/jdk.git pull/23312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23312`

View PR using the GUI difftool: \
`$ git pr show -t 23312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23312.diff">https://git.openjdk.org/jdk/pull/23312.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23312#issuecomment-2614794794)
</details>
