### PR TITLE
8300708: Some nsk jvmti tests fail with virtual thread wrapper due to jvmti missing some virtual thread support

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -37,8 +37,8 @@ vmTestbase/nsk/jvmti/CompiledMethodUnload/compmethunload001/TestDescription.java
 ####
 ## Tests for functionality which currently is not supported for virtual threads
 
-vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java 8300708 generic-all
-vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/TestDescription.java 8300708 generic-all
+vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java 8348844 generic-all
+vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/TestDescription.java 8348844 generic-all
 
 ####
 ## Test fails because it expects to find vthreads in GetAllThreads

--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -39,15 +39,6 @@ vmTestbase/nsk/jvmti/CompiledMethodUnload/compmethunload001/TestDescription.java
 
 vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/TestDescription.java 8300708 generic-all
 vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/TestDescription.java 8300708 generic-all
-vmTestbase/nsk/jvmti/NotifyFramePop/nframepop002/TestDescription.java    8300708 generic-all
-vmTestbase/nsk/jvmti/NotifyFramePop/nframepop003/TestDescription.java    8300708 generic-all
-vmTestbase/nsk/jvmti/StopThread/stopthrd006/TestDescription.java         8300708 generic-all
-vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t012/TestDescription.java 8300708 generic-all
-vmTestbase/nsk/jvmti/SetLocalVariable/setlocal004/TestDescription.java   8300708 generic-all
-vmTestbase/nsk/jvmti/SetLocalVariable/setlocal003/TestDescription.java   8300708 generic-all
-vmTestbase/nsk/jvmti/SetLocalVariable/setlocal002/TestDescription.java   8300708 generic-all
-vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001/TestDescription.java   8300708 generic-all
-vmTestbase/nsk/jvmti/unit/GetLocalVariable/getlocal003/TestDescription.java 8300708 generic-all
 
 ####
 ## Test fails because it expects to find vthreads in GetAllThreads

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001.java
@@ -102,7 +102,7 @@ public class setlocal001 {
         } else {
             checkPoint();
             if (currThread.isVirtual()) {
-                out.println("meth01: skipping results check for virtual thread");
+                out.println("meth02: skipping results check for virtual thread");
                 return; // SetLocal* should return OPAQUE_FRAME for a virtual thread
             }
             if (i1 != 1 || i2 != 1 || i3 != 1 || i4 != 1 || !i5) {
@@ -118,7 +118,7 @@ public class setlocal001 {
         int[] ob2 = null;
         checkPoint();
         if (currThread.isVirtual()) {
-            out.println("meth01: skipping results check for virtual thread");
+            out.println("meth03: skipping results check for virtual thread");
             return; // SetLocalObject for obj1 and obj2 should return OPAQUE_FRAME for a virtual thread
         }
         if (ob1.val != 3 || ob2[2] != 8) {
@@ -131,7 +131,7 @@ public class setlocal001 {
                               char i3, float f, byte i4, boolean b) {
         checkPoint();
         if (currThread.isVirtual()) {
-            out.println("meth01: skipping results check for virtual thread");
+            out.println("meth04: skipping results check for virtual thread");
             return; // SetLocal* should return OPAQUE_FRAME for a virtual thread
         }
         if (i1 != 1 || i2 != 2 || i3 != 3 || i4 != 4 ||

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,10 @@ public class setlocal001 {
         float f = 0f;
         double d = 0;
         checkPoint();
+        if (currThread.isVirtual()) {
+            out.println("meth01: skipping results check for virtual thread");
+            return d + f + 1; // SetLocal* should return OPAQUE_FRAME for a virtual thread
+        }
         if (l != 22L || f != floatVal || d != doubleVal) {
             out.println("meth01: l =" + l + " f = " + f + " d = " + d);
             result = 2;
@@ -97,6 +101,10 @@ public class setlocal001 {
             meth02(step - 1);
         } else {
             checkPoint();
+            if (currThread.isVirtual()) {
+                out.println("meth01: skipping results check for virtual thread");
+                return; // SetLocal* should return OPAQUE_FRAME for a virtual thread
+            }
             if (i1 != 1 || i2 != 1 || i3 != 1 || i4 != 1 || !i5) {
                 out.println("meth02: i1 =" + i1 + " i2 = " + i2 +
                     " i3 = " + i3 + " i4 = " + i4 + " i5 = " + i5);
@@ -109,6 +117,10 @@ public class setlocal001 {
         setlocal001 ob1 = null;
         int[] ob2 = null;
         checkPoint();
+        if (currThread.isVirtual()) {
+            out.println("meth01: skipping results check for virtual thread");
+            return; // SetLocalObject for obj1 and obj2 should return OPAQUE_FRAME for a virtual thread
+        }
         if (ob1.val != 3 || ob2[2] != 8) {
             out.println("meth03: ob1.val =" + ob1.val + " ob2[2] = " + ob2[2]);
             result = 2;
@@ -118,6 +130,10 @@ public class setlocal001 {
     public static void meth04(int i1, long l, short i2, double d,
                               char i3, float f, byte i4, boolean b) {
         checkPoint();
+        if (currThread.isVirtual()) {
+            out.println("meth01: skipping results check for virtual thread");
+            return; // SetLocal* should return OPAQUE_FRAME for a virtual thread
+        }
         if (i1 != 1 || i2 != 2 || i3 != 3 || i4 != 4 ||
                 l != 22L || f != floatVal || d != doubleVal || !b) {
             out.println("meth04: i1 =" + i1 + " i2 = " + i2 +

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001/setlocal001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001/setlocal001.cpp
@@ -44,6 +44,13 @@ static jdouble doubleVal;
 static jobject objVal;
 static jobject arrVal;
 
+static void check_error(jvmtiError err, bool is_virtual, const char* func_id) {
+    if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
+        printf("(%s) unexpected error: %s (%d)\n", func_id, TranslateError(err), err);
+        result = STATUS_FAILED;
+    }
+}
+
 void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         jthread thr, jmethodID method, jlocation location) {
     jvmtiError err;
@@ -75,27 +82,15 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             if (strcmp(table[i].name, "l") == 0) {
                 err = jvmti_env->SetLocalLong(thr, 1,
                     table[i].slot, longVal);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalLong) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalLong");
             } else if (strcmp(table[i].name, "f") == 0) {
                 err = jvmti_env->SetLocalFloat(thr, 1,
                     table[i].slot, floatVal);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalFloat) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalFloat");
             } else if (strcmp(table[i].name, "d") == 0) {
                 err = jvmti_env->SetLocalDouble(thr, 1,
                     table[i].slot, doubleVal);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalDouble) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalDouble");
             }
         }
     } else if (mid == mid2) {
@@ -103,43 +98,23 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             if (strcmp(table[i].name, "i1") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalInt#i1) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalInt#i1");
             } else if (strcmp(table[i].name, "i2") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalInt#i2) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalInt#i2");
             } else if (strcmp(table[i].name, "i3") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalInt#i3) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalInt#i3");
             } else if (strcmp(table[i].name, "i4") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalInt#i4) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalInt#i4");
             } else if (strcmp(table[i].name, "i5") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalInt#i5) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalInt#i5");
             }
         }
     } else if (mid == mid3) {
@@ -147,19 +122,11 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             if (strcmp(table[i].name, "ob1") == 0) {
                 err = jvmti_env->SetLocalObject(thr, 1,
                     table[i].slot, objVal);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalObject#ob1) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalObject#ob1");
             } else if (strcmp(table[i].name, "ob2") == 0) {
                 err = jvmti_env->SetLocalObject(thr, 1,
                     table[i].slot, arrVal);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalObject#ob2) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalObject#ob2");
             }
         }
     } else if (mid == mid4) {
@@ -167,67 +134,35 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             if (strcmp(table[i].name, "i1") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalInt#i1,param) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalInt#i1,param");
             } else if (strcmp(table[i].name, "i2") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 2);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalInt#i2,param) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalInt#i2,param");
             } else if (strcmp(table[i].name, "i3") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 3);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalInt#i3,param) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalInt#i3,param");
             } else if (strcmp(table[i].name, "i4") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 4);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalInt#i4,param) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalInt#i4,param");
             } else if (strcmp(table[i].name, "b") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, JNI_TRUE);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalInt#b,param) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalInt#b,param");
             } else if (strcmp(table[i].name, "l") == 0) {
                 err = jvmti_env->SetLocalLong(thr, 1,
                     table[i].slot, longVal);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalLong,param) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalLong,param");
             } else if (strcmp(table[i].name, "f") == 0) {
                 err = jvmti_env->SetLocalFloat(thr, 1,
                     table[i].slot, floatVal);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalFloat,param) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalFloat,param");
             } else if (strcmp(table[i].name, "d") == 0) {
                 err = jvmti_env->SetLocalDouble(thr, 1,
                     table[i].slot, doubleVal);
-                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                    printf("(SetLocalDouble,param) unexpected error: %s (%d)\n",
-                           TranslateError(err), err);
-                    result = STATUS_FAILED;
-                }
+                check_error(err, is_virtual, "SetLocalDouble,param");
             }
         }
     } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001/setlocal001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001/setlocal001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
     jlocation loc;
     jint entryCount;
     jvmtiLocalVariableEntry *table = nullptr;
+    bool is_virtual = env->IsVirtualThread(thr);
     int i;
 
     err = jvmti_env->GetFrameLocation(thr, 1, &mid, &loc);
@@ -74,7 +75,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             if (strcmp(table[i].name, "l") == 0) {
                 err = jvmti_env->SetLocalLong(thr, 1,
                     table[i].slot, longVal);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalLong) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -82,7 +83,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "f") == 0) {
                 err = jvmti_env->SetLocalFloat(thr, 1,
                     table[i].slot, floatVal);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalFloat) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -90,7 +91,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "d") == 0) {
                 err = jvmti_env->SetLocalDouble(thr, 1,
                     table[i].slot, doubleVal);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalDouble) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -102,7 +103,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             if (strcmp(table[i].name, "i1") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalInt#i1) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -110,7 +111,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "i2") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalInt#i2) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -118,7 +119,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "i3") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalInt#i3) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -126,7 +127,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "i4") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalInt#i4) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -134,7 +135,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "i5") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalInt#i5) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -146,7 +147,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             if (strcmp(table[i].name, "ob1") == 0) {
                 err = jvmti_env->SetLocalObject(thr, 1,
                     table[i].slot, objVal);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalObject#ob1) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -154,7 +155,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "ob2") == 0) {
                 err = jvmti_env->SetLocalObject(thr, 1,
                     table[i].slot, arrVal);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalObject#ob2) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -166,7 +167,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             if (strcmp(table[i].name, "i1") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 1);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalInt#i1,param) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -174,7 +175,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "i2") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 2);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalInt#i2,param) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -182,7 +183,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "i3") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 3);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalInt#i3,param) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -190,7 +191,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "i4") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, 4);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalInt#i4,param) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -198,7 +199,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "b") == 0) {
                 err = jvmti_env->SetLocalInt(thr, 1,
                     table[i].slot, JNI_TRUE);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalInt#b,param) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -206,7 +207,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "l") == 0) {
                 err = jvmti_env->SetLocalLong(thr, 1,
                     table[i].slot, longVal);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalLong,param) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -214,7 +215,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "f") == 0) {
                 err = jvmti_env->SetLocalFloat(thr, 1,
                     table[i].slot, floatVal);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalFloat,param) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;
@@ -222,7 +223,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
             } else if (strcmp(table[i].name, "d") == 0) {
                 err = jvmti_env->SetLocalDouble(thr, 1,
                     table[i].slot, doubleVal);
-                if (err != JVMTI_ERROR_NONE) {
+                if (err != JVMTI_ERROR_NONE && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                     printf("(SetLocalDouble,param) unexpected error: %s (%d)\n",
                            TranslateError(err), err);
                     result = STATUS_FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal003/setlocal003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal003/setlocal003.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
     jlocation loc;
     jint entryCount;
     jvmtiLocalVariableEntry *table;
+    bool is_virtual = env->IsVirtualThread(thr);
     int i;
 
     err = jvmti_env->GetFrameLocation(thr, 1, &mid, &loc);
@@ -74,45 +75,45 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         if (strcmp(table[i].name, "o") == 0) {
             err = jvmti_env->SetLocalObject(thr, 1,
                 INV_SLOT, (jobject)thr);
-            if (err != JVMTI_ERROR_INVALID_SLOT) {
+            if (err != JVMTI_ERROR_INVALID_SLOT && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                 printf("(%s) ", table[i].name);
-                printf("Error expected: JVMTI_ERROR_INVALID_SLOT,\n");
+                printf("Error expected: JVMTI_ERROR_INVALID_SLOT or JVMTI_ERROR_OPAQUE_FRAME,\n");
                 printf("\t    actual: %s (%d)\n", TranslateError(err), err);
                 result = STATUS_FAILED;
             }
         } else if (strcmp(table[i].name, "i") == 0) {
             err = jvmti_env->SetLocalInt(thr, 1,
                 INV_SLOT, (jint)0);
-            if (err != JVMTI_ERROR_INVALID_SLOT) {
+            if (err != JVMTI_ERROR_INVALID_SLOT && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                 printf("(%s) ", table[i].name);
-                printf("Error expected: JVMTI_ERROR_INVALID_SLOT,\n");
+                printf("Error expected: JVMTI_ERROR_INVALID_SLOT or JVMTI_ERROR_OPAQUE_FRAME,\n");
                 printf("\t    actual: %s (%d)\n", TranslateError(err), err);
                 result = STATUS_FAILED;
             }
         } else if (strcmp(table[i].name, "l") == 0) {
             err = jvmti_env->SetLocalLong(thr, 1,
                 INV_SLOT, (jlong)0);
-            if (err != JVMTI_ERROR_INVALID_SLOT) {
+            if (err != JVMTI_ERROR_INVALID_SLOT && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                 printf("(%s) ", table[i].name);
-                printf("Error expected: JVMTI_ERROR_INVALID_SLOT,\n");
+                printf("Error expected: JVMTI_ERROR_INVALID_SLOT or JVMTI_ERROR_OPAQUE_FRAME,\n");
                 printf("\t    actual: %s (%d)\n", TranslateError(err), err);
                 result = STATUS_FAILED;
             }
         } else if (strcmp(table[i].name, "f") == 0) {
             err = jvmti_env->SetLocalFloat(thr, 1,
                 INV_SLOT, (jfloat)0);
-            if (err != JVMTI_ERROR_INVALID_SLOT) {
+            if (err != JVMTI_ERROR_INVALID_SLOT && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                 printf("(%s) ", table[i].name);
-                printf("Error expected: JVMTI_ERROR_INVALID_SLOT,\n");
+                printf("Error expected: JVMTI_ERROR_INVALID_SLOT or JVMTI_ERROR_OPAQUE_FRAME,\n");
                 printf("\t    actual: %s (%d)\n", TranslateError(err), err);
                 result = STATUS_FAILED;
             }
         } else if (strcmp(table[i].name, "d") == 0) {
             err = jvmti_env->SetLocalDouble(thr, 1,
                 INV_SLOT, (jdouble)0);
-            if (err != JVMTI_ERROR_INVALID_SLOT) {
+            if (err != JVMTI_ERROR_INVALID_SLOT && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                 printf("(%s) ", table[i].name);
-                printf("Error expected: JVMTI_ERROR_INVALID_SLOT,\n");
+                printf("Error expected: JVMTI_ERROR_INVALID_SLOT or JVMTI_ERROR_OPAQUE_FRAME,\n");
                 printf("\t    actual: %s (%d)\n", TranslateError(err), err);
                 result = STATUS_FAILED;
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal003/setlocal003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal003/setlocal003.cpp
@@ -40,6 +40,15 @@ static jvmtiEventCallbacks callbacks;
 static jint result = PASSED;
 static jboolean printdump = JNI_FALSE;
 
+static void check_error(jvmtiError err, bool is_virtual, char* var_name) {
+    if (err != JVMTI_ERROR_INVALID_SLOT && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
+        printf("(%s) ", var_name);
+        printf("Error expected: JVMTI_ERROR_INVALID_SLOT or JVMTI_ERROR_OPAQUE_FRAME,\n");
+        printf("\t    actual: %s (%d)\n", TranslateError(err), err);
+        result = STATUS_FAILED;
+    }
+}
+
 void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         jthread thr, jmethodID method, jlocation location) {
     jvmtiError err;
@@ -72,51 +81,28 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         printf(">>> checking on invalid slot ...\n");
     }
     for (i = 0; i < entryCount; i++) {
+        char* var_name = table[i].name;
+
         if (strcmp(table[i].name, "o") == 0) {
             err = jvmti_env->SetLocalObject(thr, 1,
                 INV_SLOT, (jobject)thr);
-            if (err != JVMTI_ERROR_INVALID_SLOT && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                printf("(%s) ", table[i].name);
-                printf("Error expected: JVMTI_ERROR_INVALID_SLOT or JVMTI_ERROR_OPAQUE_FRAME,\n");
-                printf("\t    actual: %s (%d)\n", TranslateError(err), err);
-                result = STATUS_FAILED;
-            }
+            check_error(err, is_virtual, var_name);
         } else if (strcmp(table[i].name, "i") == 0) {
             err = jvmti_env->SetLocalInt(thr, 1,
                 INV_SLOT, (jint)0);
-            if (err != JVMTI_ERROR_INVALID_SLOT && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                printf("(%s) ", table[i].name);
-                printf("Error expected: JVMTI_ERROR_INVALID_SLOT or JVMTI_ERROR_OPAQUE_FRAME,\n");
-                printf("\t    actual: %s (%d)\n", TranslateError(err), err);
-                result = STATUS_FAILED;
-            }
+            check_error(err, is_virtual, var_name);
         } else if (strcmp(table[i].name, "l") == 0) {
             err = jvmti_env->SetLocalLong(thr, 1,
                 INV_SLOT, (jlong)0);
-            if (err != JVMTI_ERROR_INVALID_SLOT && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                printf("(%s) ", table[i].name);
-                printf("Error expected: JVMTI_ERROR_INVALID_SLOT or JVMTI_ERROR_OPAQUE_FRAME,\n");
-                printf("\t    actual: %s (%d)\n", TranslateError(err), err);
-                result = STATUS_FAILED;
-            }
+            check_error(err, is_virtual, var_name);
         } else if (strcmp(table[i].name, "f") == 0) {
             err = jvmti_env->SetLocalFloat(thr, 1,
                 INV_SLOT, (jfloat)0);
-            if (err != JVMTI_ERROR_INVALID_SLOT && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                printf("(%s) ", table[i].name);
-                printf("Error expected: JVMTI_ERROR_INVALID_SLOT or JVMTI_ERROR_OPAQUE_FRAME,\n");
-                printf("\t    actual: %s (%d)\n", TranslateError(err), err);
-                result = STATUS_FAILED;
-            }
+            check_error(err, is_virtual, var_name);
         } else if (strcmp(table[i].name, "d") == 0) {
             err = jvmti_env->SetLocalDouble(thr, 1,
                 INV_SLOT, (jdouble)0);
-            if (err != JVMTI_ERROR_INVALID_SLOT && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                printf("(%s) ", table[i].name);
-                printf("Error expected: JVMTI_ERROR_INVALID_SLOT or JVMTI_ERROR_OPAQUE_FRAME,\n");
-                printf("\t    actual: %s (%d)\n", TranslateError(err), err);
-                result = STATUS_FAILED;
-            }
+            check_error(err, is_virtual, var_name);
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal004/setlocal004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal004/setlocal004.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
     jlocation loc;
     jint entryCount;
     jvmtiLocalVariableEntry *table;
+    bool is_virtual = env->IsVirtualThread(thr);
     int i;
 
     err = jvmti_env->GetFrameLocation(thr, 1, &mid, &loc);
@@ -76,9 +77,9 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         if (strcmp(table[i].name, "o") != 0) {
             err = jvmti_env->SetLocalObject(thr, 1,
                 table[i].slot, (jobject)thr);
-            if (err != JVMTI_ERROR_TYPE_MISMATCH) {
+            if (err != JVMTI_ERROR_TYPE_MISMATCH && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                 printf("\"%s\" against SetLocalObject:\n", table[i].name);
-                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH,");
+                printf("    expected: JVMTI_ERROR_TYPE_MISMATCHi or JVMTI_ERROR_OPAQUE_FRAME,");
                 printf(" actual: %s (%d)\n", TranslateError(err), err);
                 result = STATUS_FAILED;
             }
@@ -86,9 +87,9 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         if (strcmp(table[i].name, "i") != 0) {
             err = jvmti_env->SetLocalInt(thr, 1,
                 table[i].slot, (jint)0);
-            if (err != JVMTI_ERROR_TYPE_MISMATCH) {
+            if (err != JVMTI_ERROR_TYPE_MISMATCH && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                 printf("\"%s\" against SetLocalInt:\n", table[i].name);
-                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH,");
+                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH or JVMTI_ERROR_OPAQUE_FRAME,");
                 printf(" actual: %s (%d)\n", TranslateError(err), err);
                 result = STATUS_FAILED;
             }
@@ -96,9 +97,9 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         if (strcmp(table[i].name, "l") != 0) {
             err = jvmti_env->SetLocalLong(thr, 1,
                 table[i].slot, (jlong)0);
-            if (err != JVMTI_ERROR_TYPE_MISMATCH) {
+            if (err != JVMTI_ERROR_TYPE_MISMATCH && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                 printf("\"%s\" against SetLocalLong:\n", table[i].name);
-                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH,");
+                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH or JVMTI_ERROR_OPAQUE_FRAME,");
                 printf(" actual: %s (%d)\n", TranslateError(err), err);
                 result = STATUS_FAILED;
             }
@@ -106,9 +107,9 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         if (strcmp(table[i].name, "f") != 0) {
             err = jvmti_env->SetLocalFloat(thr, 1,
                 table[i].slot, (jfloat)0);
-            if (err != JVMTI_ERROR_TYPE_MISMATCH) {
+            if (err != JVMTI_ERROR_TYPE_MISMATCH && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                 printf("\"%s\" against SetLocalFloat:\n", table[i].name);
-                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH,");
+                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH or JVMTI_ERROR_OPAQUE_FRAME,");
                 printf(" actual: %s (%d)\n", TranslateError(err), err);
                 result = STATUS_FAILED;
             }
@@ -116,9 +117,9 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         if (strcmp(table[i].name, "d") != 0) {
             err = jvmti_env->SetLocalDouble(thr, 1,
                 table[i].slot, (jdouble)0);
-            if (err != JVMTI_ERROR_TYPE_MISMATCH) {
+            if (err != JVMTI_ERROR_TYPE_MISMATCH && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
                 printf("\"%s\" against SetLocalDouble:\n", table[i].name);
-                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH,");
+                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH or JVMTI_ERROR_OPAQUE_FRAME,");
                 printf(" actual: %s (%d)\n", TranslateError(err), err);
                 result = STATUS_FAILED;
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal004/setlocal004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal004/setlocal004.cpp
@@ -40,6 +40,15 @@ static jvmtiEventCallbacks callbacks;
 static jint result = PASSED;
 static jboolean printdump = JNI_FALSE;
 
+static void check_error(jvmtiError err, bool is_virtual, char* var_name) {
+    if (err != JVMTI_ERROR_TYPE_MISMATCH && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
+        printf("(%s) ", var_name);
+        printf("Error: expected: JVMTI_ERROR_TYPE_MISMATCH or JVMTI_ERROR_OPAQUE_FRAME,\n");
+        printf("\t    actual: %s (%d)\n", TranslateError(err), err);
+        result = STATUS_FAILED;
+    }
+}
+
 void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         jthread thr, jmethodID method, jlocation location) {
     jvmtiError err;
@@ -73,56 +82,33 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         printf(">>> checking on type mismatch ...\n");
     }
     for (i = 0; i < entryCount; i++) {
+        char* var_name = table[i].name;
+
         if (strlen(table[i].name) != 1) continue;
         if (strcmp(table[i].name, "o") != 0) {
             err = jvmti_env->SetLocalObject(thr, 1,
                 table[i].slot, (jobject)thr);
-            if (err != JVMTI_ERROR_TYPE_MISMATCH && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                printf("\"%s\" against SetLocalObject:\n", table[i].name);
-                printf("    expected: JVMTI_ERROR_TYPE_MISMATCHi or JVMTI_ERROR_OPAQUE_FRAME,");
-                printf(" actual: %s (%d)\n", TranslateError(err), err);
-                result = STATUS_FAILED;
-            }
+            check_error(err, is_virtual, var_name);
         }
         if (strcmp(table[i].name, "i") != 0) {
             err = jvmti_env->SetLocalInt(thr, 1,
                 table[i].slot, (jint)0);
-            if (err != JVMTI_ERROR_TYPE_MISMATCH && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                printf("\"%s\" against SetLocalInt:\n", table[i].name);
-                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH or JVMTI_ERROR_OPAQUE_FRAME,");
-                printf(" actual: %s (%d)\n", TranslateError(err), err);
-                result = STATUS_FAILED;
-            }
+            check_error(err, is_virtual, var_name);
         }
         if (strcmp(table[i].name, "l") != 0) {
             err = jvmti_env->SetLocalLong(thr, 1,
                 table[i].slot, (jlong)0);
-            if (err != JVMTI_ERROR_TYPE_MISMATCH && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                printf("\"%s\" against SetLocalLong:\n", table[i].name);
-                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH or JVMTI_ERROR_OPAQUE_FRAME,");
-                printf(" actual: %s (%d)\n", TranslateError(err), err);
-                result = STATUS_FAILED;
-            }
+            check_error(err, is_virtual, var_name);
         }
         if (strcmp(table[i].name, "f") != 0) {
             err = jvmti_env->SetLocalFloat(thr, 1,
                 table[i].slot, (jfloat)0);
-            if (err != JVMTI_ERROR_TYPE_MISMATCH && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                printf("\"%s\" against SetLocalFloat:\n", table[i].name);
-                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH or JVMTI_ERROR_OPAQUE_FRAME,");
-                printf(" actual: %s (%d)\n", TranslateError(err), err);
-                result = STATUS_FAILED;
-            }
+            check_error(err, is_virtual, var_name);
         }
         if (strcmp(table[i].name, "d") != 0) {
             err = jvmti_env->SetLocalDouble(thr, 1,
                 table[i].slot, (jdouble)0);
-            if (err != JVMTI_ERROR_TYPE_MISMATCH && !(is_virtual && err == JVMTI_ERROR_OPAQUE_FRAME)) {
-                printf("\"%s\" against SetLocalDouble:\n", table[i].name);
-                printf("    expected: JVMTI_ERROR_TYPE_MISMATCH or JVMTI_ERROR_OPAQUE_FRAME,");
-                printf(" actual: %s (%d)\n", TranslateError(err), err);
-                result = STATUS_FAILED;
-            }
+            check_error(err, is_virtual, var_name);
         }
     }
 


### PR DESCRIPTION
Some `nsk.jvmti` tests are failed with the `-testThreadFactory:Virtual`, so they are listed in the `test/hotspot/jtreg/ProblemList-Virtual.txt`.

The fix is to adjust tests expectations regarding tested virtual threads to expect error `JVMTI_ERROR_OPAQUE_FRAME`.

Testing:
- Ran mach5 tiers 1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300708](https://bugs.openjdk.org/browse/JDK-8300708): Some nsk jvmti tests fail with virtual thread wrapper due to jvmti missing some virtual thread support (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23314/head:pull/23314` \
`$ git checkout pull/23314`

Update a local copy of the PR: \
`$ git checkout pull/23314` \
`$ git pull https://git.openjdk.org/jdk.git pull/23314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23314`

View PR using the GUI difftool: \
`$ git pr show -t 23314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23314.diff">https://git.openjdk.org/jdk/pull/23314.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23314#issuecomment-2615507169)
</details>
