### PR TITLE
8342465: Improve API documentation for java.lang.classfile

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/AccessFlags.java
+++ b/src/java.base/share/classes/java/lang/classfile/AccessFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,33 @@ import java.util.Set;
 import jdk.internal.classfile.impl.AccessFlagsImpl;
 
 /**
- * Models the access flags for a class, method, or field.  Delivered as a
- * {@link ClassElement}, {@link FieldElement}, or {@link MethodElement}
- * when traversing the corresponding model type.
+ * Models the access flags for a class, method, or field.  The access flags
+ * appears exactly once in each class, method, or field; a {@link
+ * ClassBuilder} and a {@link FieldBuilder} chooses an unspecified default value
+ * if access flags are not provided, and a {@link MethodBuilder} is always
+ * created with access flags.
+ * <p>
+ * {@code AccessFlags} cannot be created via a factory method directly; it can
+ * be created with {@code withFlags} methods on the respective builders.
+ * <p>
+ * A {@link MethodBuilder} throws an {@link IllegalArgumentException} if it is
+ * supplied an {@code AccessFlags} object that changes the preexisting
+ * {@link ClassFile#ACC_STATIC ACC_STATIC} flag of the builder, because the
+ * access flag change may invalidate previously supplied data to the builder.
  *
+ * @apiNote
+ * The access flags of classes, methods, and fields are modeled as a standalone
+ * object to support streaming as elements for {@link ClassFileTransform}.
+ * Other access flags are not elements of a {@link CompoundElement} and thus not
+ * modeled by {@code AccessFlags}; they provide their own {@code flagsMask},
+ * {@code flags}, and {@code has} methods.
+ *
+ * @see ClassModel#flags()
+ * @see FieldModel#flags()
+ * @see MethodModel#flags()
+ * @see ClassBuilder#withFlags
+ * @see FieldBuilder#withFlags
+ * @see MethodBuilder#withFlags
  * @since 24
  */
 public sealed interface AccessFlags
@@ -41,26 +64,36 @@ public sealed interface AccessFlags
         permits AccessFlagsImpl {
 
     /**
-     * {@return the access flags, as a bit mask}
+     * {@return the access flags, as a bit mask}  It is in the range of unsigned
+     * short, {@code [0, 0xFFFF]}.
      */
     int flagsMask();
 
     /**
-     * {@return the access flags}
+     * {@return the access flags, as a set of flag enums}
+     *
+     * @throws IllegalArgumentException if the flags mask has any undefined bit set
+     * @see #location()
      */
     Set<AccessFlag> flags();
 
     /**
-     * {@return whether the specified flag is present}  The specified flag
-     * should be a valid flag for the classfile location associated with this
-     * element otherwise false is returned.
+     * {@return whether the specified flag is set}  If the specified flag
+     * is not available to this {@linkplain #location() location}, returns
+     * {@code false}.
+     *
      * @param flag the flag to test
+     * @see #location()
      */
     boolean has(AccessFlag flag);
 
     /**
-     * {@return the classfile location for this element, which is either class,
-     * method, or field}
+     * {@return the {@code class} file location for this element, which is
+     * either class, method, or field}
+     *
+     * @see AccessFlag.Location#CLASS
+     * @see AccessFlag.Location#FIELD
+     * @see AccessFlag.Location#METHOD
      */
     AccessFlag.Location location();
 }

--- a/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
+++ b/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
@@ -54,7 +54,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models an annotation value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_ANNOTATION}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_ANNOTATION}.
      *
      * @since 24
      */
@@ -66,7 +66,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models an array value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_ARRAY}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_ARRAY}.
      *
      * @since 24
      */
@@ -122,7 +122,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models a string value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_STRING}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_STRING}.
      *
      * @since 24
      */
@@ -149,7 +149,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models a double value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_DOUBLE}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_DOUBLE}.
      *
      * @since 24
      */
@@ -176,7 +176,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models a float value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_FLOAT}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_FLOAT}.
      *
      * @since 24
      */
@@ -203,7 +203,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models a long value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_LONG}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_LONG}.
      *
      * @since 24
      */
@@ -230,7 +230,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models an int value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_INT}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_INT}.
      *
      * @since 24
      */
@@ -257,7 +257,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models a short value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_SHORT}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_SHORT}.
      *
      * @since 24
      */
@@ -287,7 +287,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models a char value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_CHAR}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_CHAR}.
      *
      * @since 24
      */
@@ -317,7 +317,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models a byte value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_BYTE}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_BYTE}.
      *
      * @since 24
      */
@@ -347,7 +347,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models a boolean value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_BOOLEAN}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_BOOLEAN}.
      *
      * @since 24
      */
@@ -377,7 +377,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models a class value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_CLASS}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_CLASS}.
      *
      * @since 24
      */
@@ -394,7 +394,7 @@ public sealed interface AnnotationValue {
 
     /**
      * Models an enum value of an element-value pair.
-     * The {@linkplain #tag tag} of this value is {@value TAG_ENUM}.
+     * The {@linkplain #tag tag} of this value is {@value %c TAG_ENUM}.
      *
      * @since 24
      */

--- a/src/java.base/share/classes/java/lang/classfile/AttributedElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/AttributedElement.java
@@ -39,7 +39,14 @@ import static java.util.Objects.requireNonNull;
  * A {@link ClassFileElement} describing a {@code class} file structure that has
  * attributes, such as a {@code class} file, a field, a method, a {@link
  * CodeAttribute Code} attribute, or a record component.
+ * <p>
+ * Unless otherwise specified, most attributes that can be discovered in a
+ * {@link CompoundElement} implements the corresponding {@linkplain
+ * ClassFileElement##membership membership subinterface} of {@code
+ * ClassFileElement}, and can be sent to a {@link ClassFileBuilder} to be
+ * integrated into the built structure.
  *
+ * @see java.lang.classfile.attribute
  * @jvms 4.7 Attributes
  * @sealedGraph
  * @since 24

--- a/src/java.base/share/classes/java/lang/classfile/ClassElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,21 @@ package java.lang.classfile;
 import java.lang.classfile.attribute.*;
 
 /**
- * A marker interface for elements that can appear when traversing
- * a {@link ClassModel} or be presented to a {@link ClassBuilder}.
+ * Marker interface for a member element of a {@link ClassModel}.  Such an
+ * element can appear when traversing a {@link ClassModel} unless otherwise
+ * specified, be supplied to a {@link ClassBuilder}, and be processed by a
+ * {@link ClassTransform}.
+ * <p>
+ * {@link AccessFlags}, and {@link ClassFileVersion} are member elements of a
+ * class that appear exactly once during the traversal of a {@link ClassModel}.
+ * {@link Superclass} and {@link Interfaces} may be absent or appear at most
+ * once.  A {@link ClassBuilder} may provide an alternative superclass if it is
+ * not defined but required.
  *
+ * @see ClassFileElement##membership Membership Elements
+ * @see MethodElement
+ * @see FieldElement
+ * @see CodeElement
  * @sealedGraph
  * @since 24
  */

--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -25,18 +25,27 @@
 package java.lang.classfile;
 
 import java.io.IOException;
+import java.lang.classfile.AttributeMapper.AttributeStability;
 import java.lang.classfile.attribute.CharacterRangeInfo;
+import java.lang.classfile.attribute.CodeAttribute;
 import java.lang.classfile.attribute.LocalVariableInfo;
 import java.lang.classfile.attribute.LocalVariableTypeInfo;
 import java.lang.classfile.attribute.ModuleAttribute;
+import java.lang.classfile.attribute.StackMapTableAttribute;
+import java.lang.classfile.attribute.UnknownAttribute;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.Utf8Entry;
 import java.lang.classfile.instruction.BranchInstruction;
+import java.lang.classfile.instruction.CharacterRange;
 import java.lang.classfile.instruction.DiscontinuedInstruction;
 import java.lang.classfile.instruction.ExceptionCatch;
+import java.lang.classfile.instruction.LineNumber;
+import java.lang.classfile.instruction.LocalVariable;
+import java.lang.classfile.instruction.LocalVariableType;
 import java.lang.constant.ClassDesc;
 import java.lang.reflect.AccessFlag;
+import java.lang.reflect.ClassFileFormatVersion;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -50,9 +59,9 @@ import static java.util.Objects.requireNonNull;
 import static jdk.internal.constant.ConstantUtils.CD_module_info;
 
 /**
- * Represents a context for parsing, transforming, and generating classfiles.
- * A {@code ClassFile} has a set of options that condition how parsing and
- * generation is done.
+ * Provides ability to parse, transform, and generate {@code class} files.
+ * A {@code ClassFile} is a context with a set of options that condition how
+ * parsing and generation are done.
  *
  * @since 24
  */
@@ -60,14 +69,20 @@ public sealed interface ClassFile
         permits ClassFileImpl {
 
     /**
-     * {@return a context with default options}
+     * {@return a context with default options}  Each subtype of {@link Option}
+     * specifies its default.
+     * <p>
+     * The default {@link AttributeMapperOption} and {@link
+     * ClassHierarchyResolverOption} may be unsuitable for some {@code class}
+     * files and result in parsing or generation errors.
      */
     static ClassFile of() {
         return ClassFileImpl.DEFAULT_CONTEXT;
     }
 
     /**
-     * {@return a new context with options altered from the default}
+     * {@return a context with options altered from the default}  Equivalent to
+     * {@link #of() ClassFile.of().withOptions(options)}.
      * @param options the desired processing options
      */
     static ClassFile of(Option... options) {
@@ -75,14 +90,15 @@ public sealed interface ClassFile
     }
 
     /**
-     * {@return a copy of the context with altered options}
+     * {@return a context with altered options from this context}
      * @param options the desired processing options
      */
     ClassFile withOptions(Option... options);
 
     /**
-     * An option that affects the parsing and writing of classfiles.
+     * An option that affects the parsing or writing of {@code class} files.
      *
+     * @see java.lang.classfile##options Options
      * @sealedGraph
      * @since 24
      */
@@ -90,16 +106,32 @@ public sealed interface ClassFile
     }
 
     /**
-     * Option describing attribute mappers for custom attributes.
-     * Default is only to process standard attributes.
+     * The option describing user-defined attributes for parsing {@code class}
+     * files.  The default does not recognize any user-defined attribute.
+     * <p>
+     * An {@code AttributeMapperOption} contains a function that maps an
+     * attribute name to a user attribute mapper. The function may return {@code
+     * null} if it does not recognize an attribute name.  The returned mapper
+     * must ensure its {@link AttributeMapper#name() name()} is equivalent to
+     * the {@link Utf8Entry#stringValue() stringValue()} of the input {@link
+     * Utf8Entry}.
+     * <p>
+     * The mapping function in this attribute has lower priority than mappers in
+     * {@link Attributes}, so it is impossible to override built-in attributes
+     * with this option.  If an attribute is not recognized by any mapper in
+     * {@link Attributes} and is not assigned a mapper, or recognized, by this
+     * option, that attribute will be modeled by an {@link UnknownAttribute}.
      *
+     * @see AttributeMapper
+     * @see CustomAttribute
      * @since 24
      */
     sealed interface AttributeMapperOption extends Option
             permits ClassFileImpl.AttributeMapperOptionImpl {
 
         /**
-         * {@return an option describing attribute mappers for custom attributes}
+         * {@return an option describing user-defined attributes for parsing}
+         *
          * @param attributeMapper a function mapping attribute names to attribute mappers
          */
         static AttributeMapperOption of(Function<Utf8Entry, AttributeMapper<?>> attributeMapper) {
@@ -114,17 +146,31 @@ public sealed interface ClassFile
     }
 
     /**
-     * Option describing the class hierarchy resolver to use when generating
-     * stack maps.
+     * The option describing the class hierarchy resolver to use when generating
+     * stack maps or verifying classes.  The default is {@link
+     * ClassHierarchyResolver#defaultResolver()}, which uses core reflection to
+     * find a class with a given name in {@linkplain ClassLoader#getSystemClassLoader()
+     * system class loader} and inspect it, and is insufficient if a class is
+     * not present in the system class loader as in applications, or if loading
+     * of system classes is not desired as in agents.
+     * <p>
+     * A {@code ClassHierarchyResolverOption} contains a {@link ClassHierarchyResolver}.
+     * The resolver must be able to process all classes and interfaces, including
+     * those appearing as the component types of array types, that appear in the
+     * operand stack of the generated bytecode.  If the resolver fails on any
+     * of the classes and interfaces with an {@link IllegalArgumentException},
+     * the {@code class} file generation fails.
      *
+     * @see ClassHierarchyResolver
+     * @jvms 4.10.1.2 Verification Type System
      * @since 24
      */
     sealed interface ClassHierarchyResolverOption extends Option
             permits ClassFileImpl.ClassHierarchyResolverOptionImpl {
 
         /**
-         * {@return an option describing the class hierarchy resolver to use when
-         * generating stack maps}
+         * {@return an option describing the class hierarchy resolver to use}
+         *
          * @param classHierarchyResolver the resolver
          */
         static ClassHierarchyResolverOption of(ClassHierarchyResolver classHierarchyResolver) {
@@ -139,14 +185,22 @@ public sealed interface ClassFile
     }
 
     /**
-     * Option describing whether to preserve the original constant pool when
-     * transforming a {@code class} file.  Reusing the constant pool enables
-     * significant optimizations in processing time and minimizes differences
-     * between the original and transformed {@code class} files, but may result
-     * in a bigger transformed {@code class} file when many elements of the
-     * original {@code class} file are dropped and many original constant
-     * pool entries become unused.  Default is {@link #SHARED_POOL} to preserve
-     * the original constant pool.
+     * Option describing whether to extend from the original constant pool when
+     * transforming a {@code class} file.  The default is {@link #SHARED_POOL}
+     * to extend from the original constant pool.
+     * <p>
+     * This option affects all overloads of {@link #transformClass transformClass}.
+     * Extending from the original constant pool keeps the indices into the
+     * constant pool intact, which enables significant optimizations in processing
+     * time and minimizes differences between the original and transformed {@code
+     * class} files, but may result in a bigger transformed {@code class} file
+     * when many elements of the original {@code class} file are dropped and
+     * many original constant pool entries become unused.
+     * <p>
+     * An alternative to this option is to use {@link #build(ClassEntry,
+     * ConstantPoolBuilder, Consumer)} directly.  It allows extension from
+     * arbitrary constant pools, and may be useful if a built {@code class} file
+     * reuses structures from multiple original {@code class} files.
      *
      * @see ConstantPoolBuilder
      * @see #build(ClassEntry, ConstantPoolBuilder, Consumer)
@@ -156,8 +210,8 @@ public sealed interface ClassFile
     enum ConstantPoolSharingOption implements Option {
 
         /**
-         * Preserves the original constant pool when transforming the {@code
-         * class} file.
+         * Extend the new constant pool from the original constant pool when
+         * transforming the {@code class} file.
          * <p>
          * These two transformations below are equivalent:
          * {@snippet lang=java :
@@ -194,87 +248,143 @@ public sealed interface ClassFile
     }
 
     /**
-     * Option describing whether to patch out unreachable code.
-     * Default is {@code PATCH_DEAD_CODE} to automatically patch out unreachable
-     * code with NOPs.
+     * The option describing whether to patch out unreachable code for stack map
+     * generation.  The default is {@link #PATCH_DEAD_CODE} to automatically
+     * patch unreachable code and generate a valid stack map entry for the
+     * patched code.
+     * <p>
+     * The stack map generation process may fail when it encounters unreachable
+     * code and {@link #KEEP_DEAD_CODE} is set.  In such cases, users should
+     * set {@link StackMapsOption#DROP_STACK_MAPS} and provide their own stack
+     * maps that passes verification (JVMS {@jvms 4.10.1}).
      *
+     * @see StackMapsOption
+     * @jvms 4.10.1 Verification by Type Checking
      * @since 24
      */
     enum DeadCodeOption implements Option {
 
-        /** Patch unreachable code */
+        /**
+         * Patch unreachable code with dummy code, and generate valid dummy
+         * stack map entries.  This ensures the generated code can pass
+         * verification (JVMS {@jvms 4.10.1}).
+         */
         PATCH_DEAD_CODE,
 
-        /** Keep the unreachable code */
+        /**
+         * Keep the unreachable code for the accuracy of the generated {@code
+         * class} file.  Users should set {@link StackMapsOption#DROP_STACK_MAPS}
+         * to prevent stack map generation from running and provide their own
+         * {@link StackMapTableAttribute} to a {@link CodeBuilder}.
+         */
         KEEP_DEAD_CODE
     }
 
     /**
-     * Option describing whether to filter unresolved labels.
-     * Default is {@code FAIL_ON_DEAD_LABELS} to throw IllegalArgumentException
-     * when any {@link ExceptionCatch}, {@link LocalVariableInfo},
-     * {@link LocalVariableTypeInfo}, or {@link CharacterRangeInfo}
-     * reference to unresolved {@link Label} during bytecode serialization.
-     * Setting this option to {@code DROP_DEAD_LABELS} filters the above
-     * elements instead.
+     * The option describing whether to filter {@linkplain
+     * CodeBuilder#labelBinding(Label) unbound labels} and drop their
+     * enclosing structures if possible.  The default is {@link
+     * #FAIL_ON_DEAD_LABELS} to fail fast with an {@link IllegalArgumentException}
+     * when a {@link PseudoInstruction} refers to an unbound label during
+     * bytecode generation.
+     * <p>
+     * The affected {@link PseudoInstruction}s include {@link ExceptionCatch},
+     * {@link LocalVariable}, {@link LocalVariableType}, and {@link
+     * CharacterRange}.  Setting this option to {@link #DROP_DEAD_LABELS}
+     * filters these pseudo-instructions from a {@link CodeBuilder} instead.
+     * Note that instructions, such as {@link BranchInstruction}, with unbound
+     * labels always fail-fast with an {@link IllegalArgumentException}.
      *
+     * @see DebugElementsOption
      * @since 24
      */
     enum DeadLabelsOption implements Option {
 
-        /** Fail on unresolved labels */
+        /**
+         * Fail fast on {@linkplain CodeBuilder#labelBinding(Label) unbound
+         * labels}.  This also ensures the accuracy of the generated {@code
+         * class} files.
+         */
         FAIL_ON_DEAD_LABELS,
 
-        /** Filter unresolved labels */
+        /**
+         * Filter {@link PseudoInstruction}s with {@linkplain
+         * CodeBuilder#labelBinding(Label) unbound labels}.  Note that
+         * instructions with unbound labels still cause an {@link
+         * IllegalArgumentException}.
+         */
         DROP_DEAD_LABELS
     }
 
     /**
-     * Option describing whether to process or discard debug elements.
-     * Debug elements include the local variable table, local variable type
-     * table, and character range table.  Discarding debug elements may
-     * reduce the overhead of parsing or transforming classfiles.
-     * Default is {@code PASS_DEBUG} to process debug elements.
+     * The option describing whether to process or discard debug {@link
+     * PseudoInstruction}s in the traversal of a {@link CodeModel} or a {@link
+     * CodeBuilder}.  The default is {@link #PASS_DEBUG} to process debug
+     * pseudo-instructions as all other {@link CodeElement}.
+     * <p>
+     * Debug pseudo-instructions include {@link LocalVariable}, {@link
+     * LocalVariableType}, and {@link CharacterRange}.  Discarding debug
+     * elements may reduce the overhead of parsing or transforming {@code class}
+     * files and has no impact on the run-time behavior.
      *
+     * @see LineNumbersOption
      * @since 24
      */
     enum DebugElementsOption implements Option {
 
-        /** Process debug elements */
+        /**
+         * Process debug pseudo-instructions like other member elements of a
+         * {@link CodeModel}.
+         */
         PASS_DEBUG,
 
-        /** Drop debug elements */
+        /**
+         * Drop debug pseudo-instructions from traversal and builders.
+         */
         DROP_DEBUG
     }
 
     /**
-     * Option describing whether to process or discard line numbers.
+     * The option describing whether to process or discard {@link LineNumber}s
+     * in the traversal of a {@link CodeModel} or a {@link CodeBuilder}.  The
+     * default is {@link #PASS_LINE_NUMBERS} to process all line number entries
+     * as all other {@link CodeElement}.
+     * <p>
      * Discarding line numbers may reduce the overhead of parsing or transforming
-     * classfiles.
-     * Default is {@code PASS_LINE_NUMBERS} to process line numbers.
+     * {@code class} files and has no impact on the run-time behavior.
      *
+     * @see DebugElementsOption
      * @since 24
      */
     enum LineNumbersOption implements Option {
 
-        /** Process line numbers */
+        /**
+         * Process {@link LineNumber} like other member elements of a {@link
+         * CodeModel}.
+         */
         PASS_LINE_NUMBERS,
 
-        /** Drop line numbers */
+        /**
+         * Drop {@link LineNumber} from traversal and builders.
+         */
         DROP_LINE_NUMBERS;
     }
 
     /**
-     * Option describing whether to automatically rewrite short jumps to
-     * long when necessary.
-     * Default is {@link #FIX_SHORT_JUMPS} to automatically rewrite jump
-     * instructions.
+     * The option describing whether to automatically rewrite short jumps to
+     * equivalent instructions when necessary.  The default is {@link
+     * #FIX_SHORT_JUMPS} to automatically rewrite.
      * <p>
      * Due to physical restrictions, some types of instructions cannot encode
      * certain jump targets with bci offsets less than -32768 or greater than
      * 32767, as they use a {@code s2} to encode such an offset.  (The maximum
      * length of the {@code code} array is 65535.)  These types of instructions
      * are called "short jumps".
+     * <p>
+     * Disabling rewrite can ensure the physical accuracy of a generated {@code
+     * class} file and avoid the overhead from a failed first attempt for
+     * overflowing forward jumps in some cases, if the generated {@code class}
+     * file is stable.
      *
      * @see BranchInstruction
      * @see DiscontinuedInstruction.JsrInstruction
@@ -294,80 +404,153 @@ public sealed interface ClassFile
          * Fail with an {@link IllegalArgumentException} if short jump overflows.
          * <p>
          * This is useful to ensure the physical accuracy of a generated {@code
-         * class} file.
+         * class} file and avoids the overhead from a failed first attempt for
+         * overflowing forward jumps in some cases.
          */
         FAIL_ON_SHORT_JUMPS
     }
 
     /**
-     * Option describing whether to generate stackmaps.
-     * Default is {@code STACK_MAPS_WHEN_REQUIRED} to generate stack
-     * maps for {@link #JAVA_6_VERSION} or above, where specifically for
-     * {@link #JAVA_6_VERSION} the stack maps may not be generated.
-     * @jvms 4.10.1 Verification by Type Checking
+     * The option describing whether to generate stack maps.  The default is
+     * {@link #STACK_MAPS_WHEN_REQUIRED} to generate stack maps or reuse
+     * existing ones if compatible.
+     * <p>
+     * The {@link StackMapTableAttribute} is a derived property from a {@link
+     * CodeAttribute Code} attribute to allow a Java Virtual Machine to perform
+     * verification in one pass.  Thus, it is not modeled as part of a {@link
+     * CodeModel}, but computed on-demand instead via stack maps generation.
+     * <p>
+     * Stack map generation may fail with an {@link IllegalArgumentException} if
+     * there is {@linkplain DeadCodeOption unreachable code} or legacy
+     * {@linkplain DiscontinuedInstruction.JsrInstruction jump routine}
+     * instructions.  When {@link #DROP_STACK_MAPS} option is used, users can
+     * provide their own stack maps by supplying a {@link StackMapTableAttribute}
+     * to a {@link CodeBuilder}.
      *
+     * @see StackMapTableAttribute
+     * @see DeadCodeOption
+     * @jvms 4.10.1 Verification by Type Checking
      * @since 24
      */
     enum StackMapsOption implements Option {
 
-        /** Generate stack maps when required */
+        /**
+         * Generate stack maps or reuse existing ones if compatible.  Stack maps
+         * are present on major versions {@value #JAVA_6_VERSION} or above.  For
+         * these versions, {@link CodeBuilder} tries to reuse compatible stack
+         * maps information if the code array and exception handlers are still
+         * compatible after a transformation; otherwise, it runs stack map
+         * generation.  However, it does not fail fast if the major version is
+         * {@value #JAVA_6_VERSION}, which allows jump subroutine instructions
+         * that are incompatible with stack maps to exist in the {@code code}
+         * array.
+         */
         STACK_MAPS_WHEN_REQUIRED,
 
-        /** Always generate stack maps */
+        /**
+         * Forces running stack map generation.  This runs stack map generation
+         * unconditionally and fails fast if the generation fails due to any
+         * reason.
+         */
         GENERATE_STACK_MAPS,
 
-        /** Drop stack maps from code */
+        /**
+         * Do not run stack map generation.  Users must supply their own
+         * {@link StackMapTableAttribute} to a {@link CodeBuilder} if the code
+         * has branches or exception handlers; otherwise, the generated code
+         * will fail verification (JVMS {@jvms 4.10.1}).
+         * <p>
+         * This option is required for user-supplied {@link StackMapTableAttribute}
+         * to be respected.  Stack maps on an existing {@link CodeAttribute Code}
+         * attribute can be reused as below with this option:
+         * {@snippet lang=java file="PackageSnippets.java" region="manual-reuse-stack-maps"}
+         */
         DROP_STACK_MAPS
     }
 
     /**
-     * Option describing whether to process or discard unrecognized or problematic
-     * original attributes when a class, record component, field, method or code is
-     * transformed in its exploded form.
-     * Default is {@code PASS_ALL_ATTRIBUTES} to process all original attributes.
-     * @see AttributeMapper.AttributeStability
+     * The option describing whether to retain or discard attributes that cannot
+     * verify their correctness after a transformation.  The default is {@link
+     * #PASS_ALL_ATTRIBUTES} to retain all attributes as-is.
+     * <p>
+     * Many attributes only depend on data managed by the Class-File API, such
+     * as constant pool entries or labels into the {@code code} array.  If they
+     * change, the Class-File API knows their updated values and can write a
+     * correct version by expanding the structures and recomputing the updated
+     * indexes, known as "explosion".  However, some attributes, such as type
+     * annotations, depend on arbitrary data that may be modified during
+     * transformations but the Class-File API does not track, such as index to
+     * an entry in the {@linkplain ClassModel#interfaces() interfaces} of a
+     * {@code ClassFile} structure.  As a result, the Class-File API cannot
+     * verify the correctness of such information.
      *
+     * @see AttributeStability
      * @since 24
      */
     enum AttributesProcessingOption implements Option {
 
-        /** Process all original attributes during transformation */
+        /**
+         * Retain all original attributes during transformation.
+         */
         PASS_ALL_ATTRIBUTES,
 
-        /** Drop unknown attributes during transformation */
+        /**
+         * Drop attributes with {@link AttributeStability#UNKNOWN} data
+         * dependency during transformation.
+         */
         DROP_UNKNOWN_ATTRIBUTES,
 
-        /** Drop unknown and unstable original attributes during transformation */
+        /**
+         * Drop attributes with {@link AttributeStability#UNSTABLE} or higher
+         * data dependency during transformation.
+         */
         DROP_UNSTABLE_ATTRIBUTES
     }
 
     /**
-     * Parse a classfile into a {@link ClassModel}.
-     * @param bytes the bytes of the classfile
+     * Parses a {@code class} file into a {@link ClassModel}.
+     * <p>
+     * Due to the on-demand nature of {@code class} file parsing, an {@link
+     * IllegalArgumentException} may be thrown on any accessor method invocation
+     * on the returned model or any structure returned by the accessors in the
+     * structure hierarchy.
+     *
+     * @param bytes the bytes of the {@code class} file
      * @return the class model
-     * @throws IllegalArgumentException or its subclass if the classfile format is
-     * not supported or an incompatibility prevents parsing of the classfile
+     * @throws IllegalArgumentException if the {@code class} file is malformed
+     *         or of a version {@linkplain #latestMajorVersion() not supported}
+     *         by the current runtime
      */
     ClassModel parse(byte[] bytes);
 
     /**
-     * Parse a classfile into a {@link ClassModel}.
-     * @param path the path to the classfile
+     * Parses a {@code class} into a {@link ClassModel}.
+     * <p>
+     * Due to the on-demand nature of {@code class} file parsing, an {@link
+     * IllegalArgumentException} may be thrown on any accessor method invocation
+     * on the returned model or any structure returned by the accessors in the
+     * structure hierarchy.
+     *
+     * @param path the path to the {@code class} file
      * @return the class model
-     * @throws java.io.IOException if an I/O error occurs
-     * @throws IllegalArgumentException or its subclass if the classfile format is
-     * not supported or an incompatibility prevents parsing of the classfile
+     * @throws IOException if an I/O error occurs
+     * @throws IllegalArgumentException if the {@code class} file is malformed
+     *         or of a version {@linkplain #latestMajorVersion() not supported}
+     *         by the current runtime
+     * @see #parse(byte[])
      */
     default ClassModel parse(Path path) throws IOException {
         return parse(Files.readAllBytes(path));
     }
 
     /**
-     * Build a classfile into a byte array.
+     * Builds a {@code class} file into a byte array.
+     *
      * @param thisClass the name of the class to build
      * @param handler a handler that receives a {@link ClassBuilder}
-     * @return the classfile bytes
-     * @throws IllegalArgumentException if {@code thisClass} represents a primitive type
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if {@code thisClass} represents a
+     *         primitive type or building encounters a failure
      */
     default byte[] build(ClassDesc thisClass,
                          Consumer<? super ClassBuilder> handler) {
@@ -376,24 +559,27 @@ public sealed interface ClassFile
     }
 
     /**
-     * Build a classfile into a byte array using the provided constant pool
-     * builder.
+     * Builds a {@code class} file into a byte array using the provided constant
+     * pool builder.
      *
      * @param thisClassEntry the name of the class to build
      * @param constantPool the constant pool builder
      * @param handler a handler that receives a {@link ClassBuilder}
-     * @return the classfile bytes
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if building encounters a failure
      */
     byte[] build(ClassEntry thisClassEntry,
                  ConstantPoolBuilder constantPool,
                  Consumer<? super ClassBuilder> handler);
 
     /**
-     * Build a classfile into a file.
+     * Builds a {@code class} file into a file in a file system.
+     *
      * @param path the path to the file to write
      * @param thisClass the name of the class to build
      * @param handler a handler that receives a {@link ClassBuilder}
-     * @throws java.io.IOException if an I/O error occurs
+     * @throws IOException if an I/O error occurs
+     * @throws IllegalArgumentException if building encounters a failure
      */
     default void buildTo(Path path,
                          ClassDesc thisClass,
@@ -402,14 +588,15 @@ public sealed interface ClassFile
     }
 
     /**
-     * Build a classfile into a file using the provided constant pool
-     * builder.
+     * Builds a {@code class} file into a file in a file system using the
+     * provided constant pool builder.
      *
      * @param path the path to the file to write
      * @param thisClassEntry the name of the class to build
      * @param constantPool the constant pool builder
      * @param handler a handler that receives a {@link ClassBuilder}
-     * @throws java.io.IOException if an I/O error occurs
+     * @throws IOException if an I/O error occurs
+     * @throws IllegalArgumentException if building encounters a failure
      */
     default void buildTo(Path path,
                          ClassEntry thisClassEntry,
@@ -419,22 +606,26 @@ public sealed interface ClassFile
     }
 
     /**
-     * Build a module descriptor into a byte array.
+     * Builds a module descriptor into a byte array.
+     *
      * @param moduleAttribute the {@code Module} attribute
-     * @return the classfile bytes
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if building encounters a failure
      */
     default byte[] buildModule(ModuleAttribute moduleAttribute) {
         return buildModule(moduleAttribute, clb -> {});
     }
 
     /**
-     * Build a module descriptor into a byte array.
+     * Builds a module descriptor into a byte array.
+     *
      * @param moduleAttribute the {@code Module} attribute
      * @param handler a handler that receives a {@link ClassBuilder}
-     * @return the classfile bytes
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if building encounters a failure
      */
     default byte[] buildModule(ModuleAttribute moduleAttribute,
-                                     Consumer<? super ClassBuilder> handler) {
+                               Consumer<? super ClassBuilder> handler) {
         return build(CD_module_info, clb -> {
             clb.withFlags(AccessFlag.MODULE);
             clb.with(moduleAttribute);
@@ -443,10 +634,12 @@ public sealed interface ClassFile
     }
 
     /**
-     * Build a module descriptor into a file.
+     * Builds a module descriptor into a file in a file system.
+     *
      * @param path the file to write
      * @param moduleAttribute the {@code Module} attribute
-     * @throws java.io.IOException if an I/O error occurs
+     * @throws IOException if an I/O error occurs
+     * @throws IllegalArgumentException if building encounters a failure
      */
     default void buildModuleTo(Path path,
                                      ModuleAttribute moduleAttribute) throws IOException {
@@ -454,11 +647,13 @@ public sealed interface ClassFile
     }
 
     /**
-     * Build a module descriptor into a file.
+     * Builds a module descriptor into a file in a file system.
+     *
      * @param path the file to write
      * @param moduleAttribute the {@code Module} attribute
      * @param handler a handler that receives a {@link ClassBuilder}
-     * @throws java.io.IOException if an I/O error occurs
+     * @throws IOException if an I/O error occurs
+     * @throws IllegalArgumentException if building encounters a failure
      */
     default void buildModuleTo(Path path,
                                      ModuleAttribute moduleAttribute,
@@ -467,251 +662,388 @@ public sealed interface ClassFile
     }
 
     /**
-     * Transform one classfile into a new classfile with the aid of a
-     * {@link ClassTransform}.  The transform will receive each element of
+     * Transform one {@code class} file into a new {@code class} file according
+     * to a {@link ClassTransform}.  The transform will receive each element of
      * this class, as well as a {@link ClassBuilder} for building the new class.
      * The transform is free to preserve, remove, or replace elements as it
      * sees fit.
-     *
-     * @implNote
+     * <p>
      * This method behaves as if:
      * {@snippet lang=java :
-     *     this.build(model.thisClass(), ConstantPoolBuilder.of(model),
-     *                     clb -> clb.transform(model, transform));
+     * ConstantPoolBuilder cpb = null; // @replace substring=null; replacement=...
+     * this.build(model.thisClass(), cpb,
+     *            clb -> clb.transform(model, transform));
      * }
+     * where {@code cpb} is determined by {@link ConstantPoolSharingOption}.
+     *
+     * @apiNote
+     * This is named {@code transformClass} instead of {@code transform} for
+     * consistency with {@link ClassBuilder#transformField}, {@link
+     * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
+     * and to distinguish from {@link ClassFileBuilder#transform}, which is
+     * more generic and powerful.
      *
      * @param model the class model to transform
      * @param transform the transform
      * @return the bytes of the new class
+     * @throws IllegalArgumentException if building encounters a failure
+     * @see ConstantPoolSharingOption
      */
     default byte[] transformClass(ClassModel model, ClassTransform transform) {
         return transformClass(model, model.thisClass(), transform);
     }
 
     /**
-     * Transform one classfile into a new classfile with the aid of a
-     * {@link ClassTransform}.  The transform will receive each element of
+     * Transform one {@code class} file into a new {@code class} file according
+     * to a {@link ClassTransform}.  The transform will receive each element of
      * this class, as well as a {@link ClassBuilder} for building the new class.
      * The transform is free to preserve, remove, or replace elements as it
      * sees fit.
+     *
+     * @apiNote
+     * This is named {@code transformClass} instead of {@code transform} for
+     * consistency with {@link ClassBuilder#transformField}, {@link
+     * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
+     * and to distinguish from {@link ClassFileBuilder#transform}, which is
+     * more generic and powerful.
      *
      * @param model the class model to transform
      * @param newClassName new class name
      * @param transform the transform
      * @return the bytes of the new class
+     * @throws IllegalArgumentException if building encounters a failure
+     * @see ConstantPoolSharingOption
      */
     default byte[] transformClass(ClassModel model, ClassDesc newClassName, ClassTransform transform) {
         return transformClass(model, TemporaryConstantPool.INSTANCE.classEntry(newClassName), transform);
     }
 
     /**
-     * Transform one classfile into a new classfile with the aid of a
-     * {@link ClassTransform}.  The transform will receive each element of
+     * Transform one {@code class} file into a new {@code class} file according
+     * to a {@link ClassTransform}.  The transform will receive each element of
      * this class, as well as a {@link ClassBuilder} for building the new class.
      * The transform is free to preserve, remove, or replace elements as it
      * sees fit.
-     *
-     * @implNote
+     * <p>
      * This method behaves as if:
      * {@snippet lang=java :
-     *     this.build(newClassName, ConstantPoolBuilder.of(model),
-     *                     clb -> clb.transform(model, transform));
+     * ConstantPoolBuilder cpb = null; // @replace substring=null; replacement=...
+     * this.build(newClassName, cpb, clb -> clb.transform(model, transform));
      * }
+     * where {@code cpb} is determined by {@link ConstantPoolSharingOption}.
+     *
+     * @apiNote
+     * This is named {@code transformClass} instead of {@code transform} for
+     * consistency with {@link ClassBuilder#transformField}, {@link
+     * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
+     * and to distinguish from {@link ClassFileBuilder#transform}, which is
+     * more generic and powerful.
      *
      * @param model the class model to transform
      * @param newClassName new class name
      * @param transform the transform
      * @return the bytes of the new class
+     * @throws IllegalArgumentException if building encounters a failure
+     * @see ConstantPoolSharingOption
      */
     byte[] transformClass(ClassModel model, ClassEntry newClassName, ClassTransform transform);
 
     /**
-     * Verify a classfile.  Any verification errors found will be returned.
+     * Verify a {@code class} file.  All verification errors found will be returned.
+     *
      * @param model the class model to verify
-     * @return a list of verification errors, or an empty list if no errors are
+     * @return a list of verification errors, or an empty list if no error is
      * found
      */
     List<VerifyError> verify(ClassModel model);
 
     /**
-     * Verify a classfile.  Any verification errors found will be returned.
-     * @param bytes the classfile bytes to verify
-     * @return a list of verification errors, or an empty list if no errors are
+     * Verify a {@code class} file.  All verification errors found will be returned.
+     *
+     * @param bytes the {@code class} file bytes to verify
+     * @return a list of verification errors, or an empty list if no error is
      * found
      */
     List<VerifyError> verify(byte[] bytes);
 
     /**
-     * Verify a classfile.  Any verification errors found will be returned.
-     * @param path the classfile path to verify
-     * @return a list of verification errors, or an empty list if no errors are
+     * Verify a {@code class} file.  All verification errors found will be returned.
+     *
+     * @param path the {@code class} file path to verify
+     * @return a list of verification errors, or an empty list if no error is
      * found
-     * @throws java.io.IOException if an I/O error occurs
+     * @throws IOException if an I/O error occurs
      */
     default List<VerifyError> verify(Path path) throws IOException {
         return verify(Files.readAllBytes(path));
     }
 
-    /** 0xCAFEBABE */
+    /**
+     * The magic number identifying the {@code class} file format,  {@value
+     * "0x%04x" #MAGIC_NUMBER}.  It is a big-endian 4-byte value.
+     */
     int MAGIC_NUMBER = 0xCAFEBABE;
 
-    /** The bit mask of PUBLIC access and property modifier. */
+    /** The bit mask of {@link AccessFlag#PUBLIC} access and property modifier. */
     int ACC_PUBLIC = 0x0001;
 
-    /** The bit mask of PROTECTED access and property modifier. */
+    /** The bit mask of {@link AccessFlag#PROTECTED} access and property modifier. */
     int ACC_PROTECTED = 0x0004;
 
-    /** The bit mask of PRIVATE access and property modifier. */
+    /** The bit mask of {@link AccessFlag#PRIVATE} access and property modifier. */
     int ACC_PRIVATE = 0x0002;
 
-    /** The bit mask of INTERFACE access and property modifier. */
+    /** The bit mask of {@link AccessFlag#INTERFACE} access and property modifier. */
     int ACC_INTERFACE = 0x0200;
 
-    /** The bit mask of ENUM access and property modifier. */
+    /** The bit mask of {@link AccessFlag#ENUM} access and property modifier. */
     int ACC_ENUM = 0x4000;
 
-    /** The bit mask of ANNOTATION access and property modifier. */
+    /** The bit mask of {@link AccessFlag#ANNOTATION} access and property modifier. */
     int ACC_ANNOTATION = 0x2000;
 
-    /** The bit mask of SUPER access and property modifier. */
+    /** The bit mask of {@link AccessFlag#SUPER} access and property modifier. */
     int ACC_SUPER = 0x0020;
 
-    /** The bit mask of ABSTRACT access and property modifier. */
+    /** The bit mask of {@link AccessFlag#ABSTRACT} access and property modifier. */
     int ACC_ABSTRACT = 0x0400;
 
-    /** The bit mask of VOLATILE access and property modifier. */
+    /** The bit mask of {@link AccessFlag#VOLATILE} access and property modifier. */
     int ACC_VOLATILE = 0x0040;
 
-    /** The bit mask of TRANSIENT access and property modifier. */
+    /** The bit mask of {@link AccessFlag#TRANSIENT} access and property modifier. */
     int ACC_TRANSIENT = 0x0080;
 
-    /** The bit mask of SYNTHETIC access and property modifier. */
+    /** The bit mask of {@link AccessFlag#SYNTHETIC} access and property modifier. */
     int ACC_SYNTHETIC = 0x1000;
 
-    /** The bit mask of STATIC access and property modifier. */
+    /** The bit mask of {@link AccessFlag#STATIC} access and property modifier. */
     int ACC_STATIC = 0x0008;
 
-    /** The bit mask of FINAL access and property modifier. */
+    /** The bit mask of {@link AccessFlag#FINAL} access and property modifier. */
     int ACC_FINAL = 0x0010;
 
-    /** The bit mask of SYNCHRONIZED access and property modifier. */
+    /** The bit mask of {@link AccessFlag#SYNCHRONIZED} access and property modifier. */
     int ACC_SYNCHRONIZED = 0x0020;
 
-    /** The bit mask of BRIDGE access and property modifier. */
+    /** The bit mask of {@link AccessFlag#BRIDGE} access and property modifier. */
     int ACC_BRIDGE = 0x0040;
 
-    /** The bit mask of VARARGS access and property modifier. */
+    /** The bit mask of {@link AccessFlag#VARARGS} access and property modifier. */
     int ACC_VARARGS = 0x0080;
 
-    /** The bit mask of NATIVE access and property modifier. */
+    /** The bit mask of {@link AccessFlag#NATIVE} access and property modifier. */
     int ACC_NATIVE = 0x0100;
 
-    /** The bit mask of STRICT access and property modifier. */
+    /** The bit mask of {@link AccessFlag#STRICT} access and property modifier. */
     int ACC_STRICT = 0x0800;
 
-    /** The bit mask of MODULE access and property modifier. */
+    /** The bit mask of {@link AccessFlag#MODULE} access and property modifier. */
     int ACC_MODULE = 0x8000;
 
-    /** The bit mask of OPEN access and property modifier. */
+    /** The bit mask of {@link AccessFlag#OPEN} access and property modifier. */
     int ACC_OPEN = 0x20;
 
-    /** The bit mask of MANDATED access and property modifier. */
+    /** The bit mask of {@link AccessFlag#MANDATED} access and property modifier. */
     int ACC_MANDATED = 0x8000;
 
-    /** The bit mask of TRANSITIVE access and property modifier. */
+    /** The bit mask of {@link AccessFlag#TRANSITIVE} access and property modifier. */
     int ACC_TRANSITIVE = 0x20;
 
-    /** The bit mask of STATIC_PHASE access and property modifier. */
+    /** The bit mask of {@link AccessFlag#STATIC_PHASE} access and property modifier. */
     int ACC_STATIC_PHASE = 0x40;
 
-    /** The class major version of JAVA_1. */
+    /**
+     * The class major version of the initial version of Java, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_0
+     * @see ClassFileFormatVersion#RELEASE_1
+     */
     int JAVA_1_VERSION = 45;
 
-    /** The class major version of JAVA_2. */
+    /**
+     * The class major version introduced by Java 2 SE 1.2, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_2
+     */
     int JAVA_2_VERSION = 46;
 
-    /** The class major version of JAVA_3. */
+    /**
+     * The class major version introduced by Java 2 SE 1.3, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_3
+     */
     int JAVA_3_VERSION = 47;
 
-    /** The class major version of JAVA_4. */
+    /**
+     * The class major version introduced by Java 2 SE 1.4, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_4
+     */
     int JAVA_4_VERSION = 48;
 
-    /** The class major version of JAVA_5. */
+    /**
+     * The class major version introduced by Java 2 SE 5.0, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_5
+     */
     int JAVA_5_VERSION = 49;
 
-    /** The class major version of JAVA_6. */
+    /**
+     * The class major version introduced by Java SE 6, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_6
+     */
     int JAVA_6_VERSION = 50;
 
-    /** The class major version of JAVA_7. */
+    /**
+     * The class major version introduced by Java SE 7, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_7
+     */
     int JAVA_7_VERSION = 51;
 
-    /** The class major version of JAVA_8. */
+    /**
+     * The class major version introduced by Java SE 8, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_8
+     */
     int JAVA_8_VERSION = 52;
 
-    /** The class major version of JAVA_9. */
+    /**
+     * The class major version introduced by Java SE 9, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_9
+     */
     int JAVA_9_VERSION = 53;
 
-    /** The class major version of JAVA_10. */
+    /**
+     * The class major version introduced by Java SE 10, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_10
+     */
     int JAVA_10_VERSION = 54;
 
-    /** The class major version of JAVA_11. */
+    /**
+     * The class major version introduced by Java SE 11, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_11
+     */
     int JAVA_11_VERSION = 55;
 
-    /** The class major version of JAVA_12. */
+    /**
+     * The class major version introduced by Java SE 12, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_12
+     */
     int JAVA_12_VERSION = 56;
 
-    /** The class major version of JAVA_13. */
+    /**
+     * The class major version introduced by Java SE 13, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_13
+     */
     int JAVA_13_VERSION = 57;
 
-    /** The class major version of JAVA_14. */
+    /**
+     * The class major version introduced by Java SE 14, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_14
+     */
     int JAVA_14_VERSION = 58;
 
-    /** The class major version of JAVA_15. */
+    /**
+     * The class major version introduced by Java SE 15, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_15
+     */
     int JAVA_15_VERSION = 59;
 
-    /** The class major version of JAVA_16. */
+    /**
+     * The class major version introduced by Java SE 16, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_16
+     */
     int JAVA_16_VERSION = 60;
 
-    /** The class major version of JAVA_17. */
+    /**
+     * The class major version introduced by Java SE 17, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_17
+     */
     int JAVA_17_VERSION = 61;
 
-    /** The class major version of JAVA_18. */
+    /**
+     * The class major version introduced by Java SE 18, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_18
+     */
     int JAVA_18_VERSION = 62;
 
-    /** The class major version of JAVA_19. */
+    /**
+     * The class major version introduced by Java SE 19, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_19
+     */
     int JAVA_19_VERSION = 63;
 
-    /** The class major version of JAVA_20. */
+    /**
+     * The class major version introduced by Java SE 20, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_20
+     */
     int JAVA_20_VERSION = 64;
 
-    /** The class major version of JAVA_21. */
+    /**
+     * The class major version introduced by Java SE 21, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_21
+     */
     int JAVA_21_VERSION = 65;
 
-    /** The class major version of JAVA_22. */
+    /**
+     * The class major version introduced by Java SE 22, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_22
+     */
     int JAVA_22_VERSION = 66;
 
-    /** The class major version of JAVA_23. */
+    /**
+     * The class major version introduced by Java SE 23, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_23
+     */
     int JAVA_23_VERSION = 67;
 
-    /** The class major version of JAVA_24. */
+    /**
+     * The class major version introduced by Java SE 24, {@value}.
+     *
+     * @see ClassFileFormatVersion#RELEASE_24
+     */
     int JAVA_24_VERSION = 68;
 
     /**
-     * A minor version number indicating a class uses preview features
-     * of a Java SE version since 12, for major versions {@value
+     * A minor version number {@value} indicating a class uses preview features
+     * of a Java SE release since 12, for major versions {@value
      * #JAVA_12_VERSION} and above.
      */
     int PREVIEW_MINOR_VERSION = 65535;
 
     /**
-     * {@return the latest major Java version}
+     * {@return the latest class major version supported by the current runtime}
      */
     static int latestMajorVersion() {
         return JAVA_24_VERSION;
     }
 
     /**
-     * {@return the latest minor Java version}
+     * {@return the latest class minor version supported by the current runtime}
+     *
+     * @apiNote
+     * This does not report the {@link #PREVIEW_MINOR_VERSION} when the current
+     * runtime has preview feature enabled, as {@code class} files with a major
+     * version other than {@link #latestMajorVersion()} and the preview minor
+     * version are not supported.
      */
     static int latestMinorVersion() {
         return 0;

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,34 @@
 package java.lang.classfile;
 
 /**
- * Immutable model for a portion of (or the entirety of) a classfile.  Elements
- * that model parts of the classfile that have attributes will implement {@link
- * AttributedElement}; elements that model complex parts of the classfile that
- * themselves contain their own child elements will implement {@link
- * CompoundElement}.  Elements specific to various locations in the classfile
- * will implement {@link ClassElement}, {@link MethodElement}, etc.
+ * Marker interface for structures with special capabilities in the {@code
+ * class} file format. {@link AttributedElement} indicates a structure has
+ * {@link Attribute}s.  {@link CompoundElement} indicates a structure can be
+ * viewed as a composition of member structures, whose memberships are marked by
+ * {@link ClassElement}, {@link MethodElement}, {@link FieldElement}, or {@link
+ * CodeElement}.
+ *
+ * <h2 id="membership">Membership Elements</h2>
+ * {@link ClassModel}, {@link MethodModel}, {@link FieldModel}, and {@link
+ * CodeModel} each has a dedicated interface marking its member structures:
+ * {@link ClassElement}, {@link MethodElement}, {@link FieldElement}, and
+ * {@link CodeElement}.  They can be supplied to a {@link ClassBuilder}, a
+ * {@link MethodBuilder}, a {@link FieldBuilder}, or a {@link CodeBuilder} to be
+ * included as members of the built model.  Unless otherwise specified, these
+ * structures are delivered during the {@linkplain CompoundElement traversal} of
+ * the corresponding models.  Some of these elements may appear at most once or
+ * exactly once in the traversal of the models; such elements have special
+ * treatment by {@link ClassFileBuilder} and are specified in their modeling
+ * interfaces.  If such elements appear multiple times during traversal, the
+ * last occurrence should be used and all previous instances should be
+ * discarded.
+ * <p>
+ * These membership element marker interfaces are sealed; future versions of the
+ * Java SE Platform may define new elements to the sealed hierarchy when the
+ * {@code class} file format for the Java Platform evolves.  Using an exhaustive
+ * pattern matching switch over these hierarchies indicates the user only wish
+ * the processing code to run on a specific version of Java Platform, and will
+ * fail if unknown new elements are encountered.
  *
  * @sealedGraph
  * @since 24

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileVersion.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,32 +24,62 @@
  */
 package java.lang.classfile;
 
+import java.lang.reflect.ClassFileFormatVersion;
+
 import jdk.internal.classfile.impl.ClassFileVersionImpl;
 
 /**
- * Models the classfile version information for a class.  Delivered as a {@link
- * java.lang.classfile.ClassElement} when traversing the elements of a {@link
- * ClassModel}.
+ * Models the minor and major version numbers of a {@code class} file (JVMS
+ * {@jvms 4.1}).  The {@code class} file version appears exactly once in each
+ * class, and is set to an unspecified default value if not explicitly provided.
+ * <p>
+ * The major versions of {@code class} file format begins at {@value
+ * ClassFile#JAVA_1_VERSION} for Java Platform version 1.0.2, and is continuous
+ * up to {@link ClassFile#latestMajorVersion()}.  In general, each major version
+ * defines a new supported {@code class} file format, modeled by {@link
+ * ClassFileFormatVersion}, and supports all previous formats.
+ * <p>
+ * For major versions up to {@value ClassFile#JAVA_11_VERSION} for Java SE
+ * Platform 11, the minor version of any value is supported.  For major versions
+ * {@value ClassFile#JAVA_12_VERSION} for Java SE Platform version 12 and above,
+ * the minor version must be {@code 0} or {@value ClassFile#PREVIEW_MINOR_VERSION}.
+ * The minor version {@code 0} is always supported, and represents the format
+ * modeled by {@link ClassFileFormatVersion}.  The minor version {@code 65535}
+ * indicates the {@code class} file uses preview features of the Java SE
+ * Platform release represented by the major version.  A Java Virtual Machine
+ * can only load such a {@code class} file if it has the same Java SE Platform
+ * version and the JVM has preview features enabled.
  *
+ * @see ClassModel#majorVersion()
+ * @see ClassModel#minorVersion()
+ * @see ClassFileFormatVersion
+ * @jvms 4.1 The {@code ClassFile} Structure
  * @since 24
  */
 public sealed interface ClassFileVersion
         extends ClassElement
         permits ClassFileVersionImpl {
     /**
-     * {@return the major classfile version}
+     * {@return the major version}  It is in the range of unsigned short, {@code
+     * [0, 65535]}.
+     *
+     * @apiNote
+     * Constants in {@link ClassFile} named {@code Java_#_VERSION}, where # is
+     * a release number, such as {@link ClassFile#JAVA_21_VERSION}, describe the
+     * class major versions of the Java Platform SE.
      */
     int majorVersion();
 
     /**
-     * {@return the minor classfile version}
+     * {@return the minor version}  It is in the range of unsigned short, {@code
+     * [0, 65535]}.
      */
     int minorVersion();
 
     /**
      * {@return a {@link ClassFileVersion} element}
-     * @param majorVersion the major classfile version
-     * @param minorVersion the minor classfile version
+     * @param majorVersion the major version
+     * @param minorVersion the minor version
      */
     static ClassFileVersion of(int majorVersion, int minorVersion) {
         return new ClassFileVersionImpl(majorVersion, minorVersion);

--- a/src/java.base/share/classes/java/lang/classfile/ClassModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,41 @@
 
 package java.lang.classfile;
 
+import java.lang.classfile.attribute.BootstrapMethodsAttribute;
+import java.lang.classfile.attribute.ModuleAttribute;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.ConstantPool;
+import java.lang.classfile.constantpool.ConstantPoolBuilder;
+import java.lang.constant.ClassDesc;
+import java.lang.reflect.AccessFlag;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import jdk.internal.classfile.impl.ClassImpl;
 
 /**
- * Models a classfile.  The contents of the classfile can be traversed via
- * a streaming view, or via random access (e.g.,
- * {@link #flags()}), or by freely mixing the two.
+ * Models a {@code class} file.  A {@code class} file can be viewed as a
+ * {@linkplain CompoundElement composition} of {@link ClassElement}s, or by
+ * random access via accessor methods if only specific parts of the {@code
+ * class} file is needed.
+ * <p>
+ * Use {@link ClassFile#parse(byte[])}, which parses the binary data of a {@code
+ * class} file into a model, to obtain a {@code ClassModel}.
+ * <p>
+ * To construct a {@code class} file, use {@link ClassFile#build(ClassDesc,
+ * Consumer)}.  {@link ClassFile#transformClass(ClassModel, ClassTransform)}
+ * allows creating a new class by selectively processing the original class
+ * elements and directing the results to a class builder.
+ * <p>
+ * A class holds attributes, most of which are accessible as member elements.
+ * {@link BootstrapMethodsAttribute} can only be accessed via {@linkplain
+ * AttributedElement explicit attribute reading}, as it is modeled as part of
+ * the {@linkplain #constantPool() constant pool}.
  *
+ * @see ClassFile#parse(byte[])
+ * @see ClassTransform
+ * @jvms 4.1 The {@code ClassFile} Structure
  * @since 24
  */
 public sealed interface ClassModel
@@ -45,19 +68,35 @@ public sealed interface ClassModel
 
     /**
      * {@return the constant pool for this class}
+     *
+     * @see ConstantPoolBuilder#of(ClassModel)
      */
     ConstantPool constantPool();
 
-    /** {@return the access flags} */
+    /**
+     * {@return the access flags}
+     *
+     * @see AccessFlag.Location#CLASS
+     */
     AccessFlags flags();
 
     /** {@return the constant pool entry describing the name of this class} */
     ClassEntry thisClass();
 
-    /** {@return the major classfile version} */
+    /**
+     * {@return the major version of this class}  It is in the range of unsigned
+     * short, {@code [0, 65535]}.
+     *
+     * @see ClassFileVersion
+     */
     int majorVersion();
 
-    /** {@return the minor classfile version} */
+    /**
+     * {@return the minor version of this class}  It is in the range of unsigned
+     * short, {@code [0, 65535]}.
+     *
+     * @see ClassFileVersion
+     */
     int minorVersion();
 
     /** {@return the fields of this class} */
@@ -66,12 +105,28 @@ public sealed interface ClassModel
     /** {@return the methods of this class} */
     List<MethodModel> methods();
 
-    /** {@return the superclass of this class, if there is one} */
+    /**
+     * {@return the superclass of this class, if there is one}
+     * This {@code class} file may have no superclass if this represents a
+     * {@linkplain #isModuleInfo() module descriptor} or the {@link Object}
+     * class; otherwise, it must have a superclass.  If this is an interface,
+     * the superclass must be {@link Object}.
+     *
+     * @see Superclass
+     */
     Optional<ClassEntry> superclass();
 
-    /** {@return the interfaces implemented by this class} */
+    /**
+     * {@return the interfaces implemented by this class}
+     *
+     * @see Interfaces
+     */
     List<ClassEntry> interfaces();
 
-    /** {@return whether this class is a module descriptor} */
+    /**
+     * {@return whether this {@code class} file is a module descriptor}
+     *
+     * @see ClassFile#buildModule(ModuleAttribute, Consumer)
+     */
     boolean isModuleInfo();
 }

--- a/src/java.base/share/classes/java/lang/classfile/ClassTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,9 +35,12 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A transformation on streams of {@link ClassElement}.
+ * <p>
+ * Refer to {@link ClassFileTransform} for general guidance and caution around
+ * the use of transforms for structures in the {@code class} file format.
  *
- * @see ClassFileTransform
- *
+ * @see ClassModel
+ * @see ClassFile#transformClass(ClassModel, ClassTransform)
  * @since 24
  */
 @FunctionalInterface
@@ -45,7 +48,7 @@ public non-sealed interface ClassTransform
         extends ClassFileTransform<ClassTransform, ClassElement, ClassBuilder> {
 
     /**
-     * A class transform that sends all elements to the builder.
+     * A class transform that passes all elements to the builder.
      */
     static final ClassTransform ACCEPT_ALL = new ClassTransform() {
         @Override
@@ -55,7 +58,7 @@ public non-sealed interface ClassTransform
     };
 
     /**
-     * Create a stateful class transform from a {@link Supplier}.  The supplier
+     * Creates a stateful class transform from a {@link Supplier}.  The supplier
      * will be invoked for each transformation.
      *
      * @param supplier a {@link Supplier} that produces a fresh transform object
@@ -67,7 +70,7 @@ public non-sealed interface ClassTransform
     }
 
     /**
-     * Create a class transform that passes each element through to the builder,
+     * Creates a class transform that passes each element through to the builder,
      * and calls the specified function when transformation is complete.
      *
      * @param finisher the function to call when transformation is complete
@@ -89,8 +92,8 @@ public non-sealed interface ClassTransform
     }
 
     /**
-     * Create a class transform that passes each element through to the builder,
-     * except for those that the supplied {@link Predicate} is true for.
+     * Creates a class transform that passes each element through to the builder,
+     * except for those that the supplied {@link Predicate} returns true for.
      *
      * @param filter the predicate that determines which elements to drop
      * @return the class transform
@@ -104,8 +107,10 @@ public non-sealed interface ClassTransform
     }
 
     /**
-     * Create a class transform that transforms {@link MethodModel} elements
-     * with the supplied method transform.
+     * Creates a class transform that transforms {@link MethodModel} elements
+     * with the supplied method transform for methods that the supplied {@link
+     * Predicate} returns true for, passing other elements through to the
+     * builder.
      *
      * @param filter a predicate that determines which methods to transform
      * @param xform the method transform
@@ -117,8 +122,9 @@ public non-sealed interface ClassTransform
     }
 
     /**
-     * Create a class transform that transforms {@link MethodModel} elements
-     * with the supplied method transform.
+     * Creates a class transform that transforms {@link MethodModel} elements
+     * with the supplied method transform, passing other elements through to the
+     * builder.
      *
      * @param xform the method transform
      * @return the class transform
@@ -128,8 +134,10 @@ public non-sealed interface ClassTransform
     }
 
     /**
-     * Create a class transform that transforms the {@link CodeAttribute} (method body)
-     * of {@link MethodModel} elements with the supplied code transform.
+     * Creates a class transform that transforms the {@link CodeAttribute} (method body)
+     * of {@link MethodModel} elements with the supplied code transform for
+     * methods that the supplied {@link Predicate} returns true for, passing
+     * other elements through to the builder.
      *
      * @param filter a predicate that determines which methods to transform
      * @param xform the code transform
@@ -141,8 +149,9 @@ public non-sealed interface ClassTransform
     }
 
     /**
-     * Create a class transform that transforms the {@link CodeAttribute} (method body)
-     * of {@link MethodModel} elements with the supplied code transform.
+     * Creates a class transform that transforms the {@link CodeAttribute} (method body)
+     * of {@link MethodModel} elements with the supplied code transform, passing
+     * other elements through to the builder.
      *
      * @param xform the code transform
      * @return the class transform
@@ -152,8 +161,9 @@ public non-sealed interface ClassTransform
     }
 
     /**
-     * Create a class transform that transforms {@link FieldModel} elements
-     * with the supplied field transform.
+     * Creates a class transform that transforms {@link FieldModel} elements
+     * with the supplied field transform, passing other elements through to the
+     * builder.
      *
      * @param xform the field transform
      * @return the class transform

--- a/src/java.base/share/classes/java/lang/classfile/CodeElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,13 +29,20 @@ import java.lang.classfile.attribute.RuntimeVisibleTypeAnnotationsAttribute;
 import java.lang.classfile.attribute.StackMapTableAttribute;
 
 /**
- * A marker interface for elements that can appear when traversing
- * a {@link CodeModel} or be presented to a {@link CodeBuilder}. Code elements
- * are either an {@link Instruction}, which models an instruction in the body
- * of a method, or a {@link PseudoInstruction}, which models metadata from
- * the code attribute, such as line number metadata, local variable metadata,
- * exception metadata, label target metadata, etc.
+ * Marker interface for a member element of a {@link CodeModel}.  Such an
+ * element can appear when traversing a {@link CodeModel} unless otherwise
+ * specified, be supplied to a {@link CodeBuilder}, and be processed by a
+ * {@link CodeTransform}.
+ * <p>
+ * Code elements can be categorized into {@link Instruction}, {@link
+ * PseudoInstruction}, and {@link Attribute}.  Unlike in other {@link
+ * CompoundElement}, the order of elements for all {@link Instruction}s and some
+ * {@link PseudoInstruction}s is significant.
  *
+ * @see ClassFileElement##membership Membership Elements
+ * @see ClassElement
+ * @see MethodElement
+ * @see FieldElement
  * @sealedGraph
  * @since 24
  */

--- a/src/java.base/share/classes/java/lang/classfile/CodeModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,44 @@
 
 package java.lang.classfile;
 
+import java.lang.classfile.ClassFile.DeadLabelsOption;
+import java.lang.classfile.ClassFile.DebugElementsOption;
+import java.lang.classfile.ClassFile.LineNumbersOption;
+import java.lang.classfile.attribute.BootstrapMethodsAttribute;
 import java.lang.classfile.attribute.CodeAttribute;
+import java.lang.classfile.attribute.StackMapTableAttribute;
 import java.lang.classfile.instruction.ExceptionCatch;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import jdk.internal.classfile.impl.BufferedCodeBuilder;
 
 /**
- * Models the body of a method (the {@code Code} attribute).  The instructions
- * of the method body are accessed via a streaming view.
+ * Models the body of a method (the {@code Code} attribute).  A {@code Code}
+ * attribute is viewed as a {@linkplain CompoundElement composition} of {@link
+ * CodeElement}s, which is the only way to access {@link Instruction}s; the
+ * order of elements of a code model is significant.
+ * <p>
+ * A {@code CodeModel} is obtained from {@link MethodModel#code()}, or in the
+ * traversal of the member elements of a method.
+ * <p>
+ * {@link MethodBuilder#withCode} is the main way to build code models.  {@link
+ * MethodBuilder#transformCode} and {@link CodeBuilder#transforming} allow
+ * creating new {@code Code} attributes by selectively processing the original
+ * code elements and directing the results to a code builder.
+ * <p>
+ * A {@code Code} attribute holds attributes, but they are usually not member
+ * elements, but are decomposed to {@link PseudoInstruction}, accessible
+ * according to {@link DeadLabelsOption}, {@link DebugElementsOption}, and
+ * {@link LineNumbersOption}.  {@link StackMapTableAttribute} can only be
+ * accessed via {@linkplain AttributedElement explicit attribute reading}, as it
+ * is considered a derived property from the code body.
  *
+ * @see MethodModel#code()
+ * @see CodeTransform
+ * @see CodeAttribute
+ * @jvms 4.7.3 The {@code Code} Attribute
  * @since 24
  */
 public sealed interface CodeModel

--- a/src/java.base/share/classes/java/lang/classfile/CodeTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,10 +32,22 @@ import jdk.internal.classfile.impl.TransformImpl;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A transformation on streams of {@link CodeElement}.
+ * A transformation on streams of {@link CodeElement}.  The stream can come
+ * from a {@link CodeModel}, or a handler to a {@link CodeBuilder} as in
+ * {@link CodeBuilder#transforming}.
+ * <p>
+ * Refer to {@link ClassFileTransform} for general guidance and caution around
+ * the use of transforms for structures in the {@code class} file format.
+ * <p>
+ * A code transform can be lifted to a method or a class transform via {@link
+ * MethodTransform#transformingCode(CodeTransform)} and {@link
+ * ClassTransform#transformingMethodBodies(CodeTransform)}, transforming only
+ * the {@link CodeModel} within those structures and passing all other elements
+ * to the builders.
  *
- * @see ClassFileTransform
- *
+ * @see CodeModel
+ * @see MethodBuilder#transformCode
+ * @see CodeBuilder#transforming
  * @since 24
  */
 @FunctionalInterface
@@ -43,7 +55,7 @@ public non-sealed interface CodeTransform
         extends ClassFileTransform<CodeTransform, CodeElement, CodeBuilder> {
 
     /**
-     * A code transform that sends all elements to the builder.
+     * A code transform that passes all elements to the builder.
      */
     CodeTransform ACCEPT_ALL = new CodeTransform() {
         @Override
@@ -53,7 +65,7 @@ public non-sealed interface CodeTransform
     };
 
     /**
-     * Create a stateful code transform from a {@link Supplier}.  The supplier
+     * Creates a stateful code transform from a {@link Supplier}.  The supplier
      * will be invoked for each transformation.
      *
      * @param supplier a {@link Supplier} that produces a fresh transform object
@@ -65,7 +77,7 @@ public non-sealed interface CodeTransform
     }
 
     /**
-     * Create a code transform that passes each element through to the builder,
+     * Creates a code transform that passes each element through to the builder,
      * and calls the specified function when transformation is complete.
      *
      * @param finisher the function to call when transformation is complete

--- a/src/java.base/share/classes/java/lang/classfile/FieldBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 
 package java.lang.classfile;
 
-import java.lang.classfile.constantpool.Utf8Entry;
+import java.lang.constant.ClassDesc;
 import java.lang.reflect.AccessFlag;
 import java.util.function.Consumer;
 
@@ -34,14 +34,17 @@ import jdk.internal.classfile.impl.ChainedFieldBuilder;
 import jdk.internal.classfile.impl.TerminalFieldBuilder;
 
 /**
- * A builder for fields.  Builders are not created directly; they are passed
- * to handlers by methods such as {@link ClassBuilder#withField(Utf8Entry, Utf8Entry, Consumer)}
- * or to field transforms.  The elements of a field can be specified
- * abstractly (by passing a {@link FieldElement} to {@link #with(ClassFileElement)}
- * or concretely by calling the various {@code withXxx} methods.
+ * A builder for fields.  The main way to obtain a field builder is via {@link
+ * ClassBuilder#withField(String, ClassDesc, Consumer)}.  The {@linkplain
+ * ClassBuilder#withField(String, ClassDesc, int) access flag overload} is
+ * useful if no attribute needs to be configured, skipping the handler.
+ * <p>
+ * Refer to {@link ClassFileBuilder} for general guidance and caution around
+ * the use of builders for structures in the {@code class} file format.
  *
+ * @see ClassBuilder#withField(String, ClassDesc, Consumer)
+ * @see FieldModel
  * @see FieldTransform
- *
  * @since 24
  */
 public sealed interface FieldBuilder
@@ -50,8 +53,12 @@ public sealed interface FieldBuilder
 
     /**
      * Sets the field access flags.
+     *
      * @param flags the access flags, as a bit mask
      * @return this builder
+     * @see AccessFlags
+     * @see AccessFlag.Location#FIELD
+     * @see ClassBuilder#withField(String, ClassDesc, int)
      */
     default FieldBuilder withFlags(int flags) {
         return with(new AccessFlagsImpl(AccessFlag.Location.FIELD, flags));
@@ -59,8 +66,12 @@ public sealed interface FieldBuilder
 
     /**
      * Sets the field access flags.
+     *
      * @param flags the access flags, as a bit mask
      * @return this builder
+     * @see AccessFlags
+     * @see AccessFlag.Location#FIELD
+     * @see ClassBuilder#withField(String, ClassDesc, int)
      */
     default FieldBuilder withFlags(AccessFlag... flags) {
         return with(new AccessFlagsImpl(AccessFlag.Location.FIELD, flags));

--- a/src/java.base/share/classes/java/lang/classfile/FieldElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,18 @@ package java.lang.classfile;
 import java.lang.classfile.attribute.*;
 
 /**
- * A marker interface for elements that can appear when traversing
- * a {@link FieldModel} or be presented to a {@link FieldBuilder}.
+ * Marker interface for a member element of a {@link FieldModel}.  Such an
+ * element can appear when traversing a {@link FieldModel} unless otherwise
+ * specified, be supplied to a {@link FieldBuilder}, and be processed by a
+ * {@link FieldTransform}.
+ * <p>
+ * {@link AccessFlags} is the only member element of a field that appear exactly
+ * once during the traversal of a {@link FieldModel}.
  *
+ * @see ClassFileElement##membership Membership Elements
+ * @see ClassElement
+ * @see MethodElement
+ * @see CodeElement
  * @sealedGraph
  * @since 24
  */

--- a/src/java.base/share/classes/java/lang/classfile/FieldModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,24 +27,43 @@ package java.lang.classfile;
 
 import java.lang.classfile.constantpool.Utf8Entry;
 import java.lang.constant.ClassDesc;
+import java.lang.reflect.AccessFlag;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import jdk.internal.classfile.impl.BufferedFieldBuilder;
 import jdk.internal.classfile.impl.FieldImpl;
 import jdk.internal.classfile.impl.Util;
 
 /**
- * Models a field.  The contents of the field can be traversed via
- * a streaming view, or via random access (e.g.,
- * {@link #flags()}), or by freely mixing the two.
+ * Models a field.  A field can be viewed as a {@linkplain CompoundElement
+ * composition} of {@link FieldElement}s, or by random access via accessor
+ * methods if only specific parts of the field is needed.
+ * <p>
+ * Fields can be obtained from {@link ClassModel#fields()}, or in the traversal
+ * of member elements of a class.
+ * <p>
+ * {@link ClassBuilder#withField(String, ClassDesc, Consumer)} is the main way
+ * to construct fields.  {@link ClassBuilder#transformField} allows creating a
+ * new field by selectively processing the original field elements and directing
+ * the results to a field builder.
+ * <p>
+ * All field attributes are accessible as member elements.
  *
+ * @see ClassModel#fields()
+ * @see FieldTransform
+ * @jvms 4.5 Fields
  * @since 24
  */
 public sealed interface FieldModel
         extends CompoundElement<FieldElement>, AttributedElement, ClassElement
         permits BufferedFieldBuilder.Model, FieldImpl {
 
-    /** {@return the access flags} */
+    /**
+     * {@return the access flags}
+     *
+     * @see AccessFlag.Location#FIELD
+     */
     AccessFlags flags();
 
     /** {@return the class model this field is a member of, if known} */
@@ -53,10 +72,10 @@ public sealed interface FieldModel
     /** {@return the name of this field} */
     Utf8Entry fieldName();
 
-    /** {@return the field descriptor of this field} */
+    /** {@return the field descriptor string of this field} */
     Utf8Entry fieldType();
 
-    /** {@return the field descriptor of this field, as a symbolic descriptor} */
+    /** {@return the field type, as a symbolic descriptor} */
     default ClassDesc fieldTypeSymbol() {
         return Util.fieldTypeSymbol(fieldType());
     }

--- a/src/java.base/share/classes/java/lang/classfile/FieldTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,17 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A transformation on streams of {@link FieldElement}.
+ * <p>
+ * Refer to {@link ClassFileTransform} for general guidance and caution around
+ * the use of transforms for structures in the {@code class} file format.
+ * <p>
+ * A field transform can be lifted to a class transform via {@link
+ * ClassTransform#transformingFields(FieldTransform)}, transforming only
+ * the {@link FieldModel} among the class members and passing all other elements
+ * to the builders.
  *
- * @see ClassFileTransform
- *
+ * @see FieldModel
+ * @see ClassBuilder#transformField
  * @since 24
  */
 @FunctionalInterface
@@ -44,7 +52,7 @@ public non-sealed interface FieldTransform
         extends ClassFileTransform<FieldTransform, FieldElement, FieldBuilder> {
 
     /**
-     * A field transform that sends all elements to the builder.
+     * A field transform that passes all elements to the builder.
      */
     FieldTransform ACCEPT_ALL = new FieldTransform() {
         @Override
@@ -54,7 +62,7 @@ public non-sealed interface FieldTransform
     };
 
     /**
-     * Create a stateful field transform from a {@link Supplier}.  The supplier
+     * Creates a stateful field transform from a {@link Supplier}.  The supplier
      * will be invoked for each transformation.
      *
      * @param supplier a {@link Supplier} that produces a fresh transform object
@@ -66,7 +74,7 @@ public non-sealed interface FieldTransform
     }
 
     /**
-     * Create a field transform that passes each element through to the builder,
+     * Creates a field transform that passes each element through to the builder,
      * and calls the specified function when transformation is complete.
      *
      * @param finisher the function to call when transformation is complete
@@ -88,7 +96,7 @@ public non-sealed interface FieldTransform
     }
 
     /**
-     * Create a field transform that passes each element through to the builder,
+     * Creates a field transform that passes each element through to the builder,
      * except for those that the supplied {@link Predicate} is true for.
      *
      * @param filter the predicate that determines which elements to drop

--- a/src/java.base/share/classes/java/lang/classfile/Instruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/Instruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,15 @@ import jdk.internal.classfile.impl.AbstractInstruction;
 
 /**
  * Models an executable instruction in the {@code code} array of the {@link
- * CodeAttribute Code} attribute of a method.
+ * CodeAttribute Code} attribute of a method.  The order of instructions in
+ * a {@link CodeModel} is significant.
  * <p>
  * The {@link #opcode() opcode} identifies the operation of an instruction.
  * Each {@linkplain Opcode#kind() kind} of opcode has its own modeling interface
  * for instructions.
  *
+ * @see Opcode
+ * @jvms 6.5 Instructions
  * @sealedGraph
  * @since 24
  */

--- a/src/java.base/share/classes/java/lang/classfile/Interfaces.java
+++ b/src/java.base/share/classes/java/lang/classfile/Interfaces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,16 +33,22 @@ import jdk.internal.classfile.impl.InterfacesImpl;
 import jdk.internal.classfile.impl.Util;
 
 /**
- * Models the interfaces of a class.  Delivered as a {@link
- * java.lang.classfile.ClassElement} when traversing a {@link ClassModel}.
+ * Models the interfaces (JVMS {@jvms 4.1}) of a class.  An {@code Interfaces}
+ * appears at most once in a {@link ClassModel}: if it does not appear, the
+ * class has no interfaces, which is equivalent to an {@code Interfaces} whose
+ * {@link #interfaces()} returns an empty list.  A {@link ClassBuilder} sets
+ * the interfaces to an empty list if the interfaces is not supplied.
  *
+ * @see ClassModel#interfaces()
+ * @see ClassBuilder#withInterfaces
+ * @jvms 4.1 The {@code ClassFile} Structure
  * @since 24
  */
 public sealed interface Interfaces
         extends ClassElement
         permits InterfacesImpl {
 
-    /** {@return the interfaces of this class} */
+    /** {@return the interfaces of this class, may be empty} */
     List<ClassEntry> interfaces();
 
     /**
@@ -64,6 +70,7 @@ public sealed interface Interfaces
     /**
      * {@return an {@linkplain Interfaces} element}
      * @param interfaces the interfaces
+     * @throws IllegalArgumentException if any of {@code interfaces} is primitive
      */
     static Interfaces ofSymbols(List<ClassDesc> interfaces) {
         return of(Util.entryList(interfaces));
@@ -72,6 +79,7 @@ public sealed interface Interfaces
     /**
      * {@return an {@linkplain Interfaces} element}
      * @param interfaces the interfaces
+     * @throws IllegalArgumentException if any of {@code interfaces} is primitive
      */
     static Interfaces ofSymbols(ClassDesc... interfaces) {
         return ofSymbols(Arrays.asList(interfaces));

--- a/src/java.base/share/classes/java/lang/classfile/MethodElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,18 @@ package java.lang.classfile;
 import java.lang.classfile.attribute.*;
 
 /**
- * A marker interface for elements that can appear when traversing
- * a {@link MethodModel} or be presented to a {@link MethodBuilder}.
+ * Marker interface for a member element of a {@link MethodModel}.  Such an
+ * element can appear when traversing a {@link MethodModel} unless otherwise
+ * specified, be supplied to a {@link MethodBuilder}, and be processed by a
+ * {@link MethodTransform}.
+ * <p>
+ * {@link AccessFlags} is the only member element of a method that appear
+ * exactly once during the traversal of a {@link MethodModel}.
  *
+ * @see ClassFileElement##membership Membership Elements
+ * @see ClassElement
+ * @see FieldElement
+ * @see CodeElement
  * @sealedGraph
  * @since 24
  */

--- a/src/java.base/share/classes/java/lang/classfile/MethodModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,24 +27,43 @@ package java.lang.classfile;
 
 import java.lang.classfile.constantpool.Utf8Entry;
 import java.lang.constant.MethodTypeDesc;
+import java.lang.reflect.AccessFlag;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import jdk.internal.classfile.impl.BufferedMethodBuilder;
 import jdk.internal.classfile.impl.MethodImpl;
 import jdk.internal.classfile.impl.Util;
 
 /**
- * Models a method.  The contents of the method can be traversed via
- * a streaming view, or via random access (e.g.,
- * {@link #flags()}), or by freely mixing the two.
+ * Models a method.  A method can be viewed as a {@linkplain CompoundElement
+ * composition} of {@link MethodElement}s, or by random access via accessor
+ * methods if only specific parts of the method is needed.
+ * <p>
+ * Methods can be obtained from {@link ClassModel#methods()}, or in the
+ * traversal of member elements of a class.
+ * <p>
+ * {@link ClassBuilder#withMethod(String, MethodTypeDesc, int, Consumer)} is the
+ * main way to construct methods.  {@link ClassBuilder#transformMethod} allows
+ * creating a new method by selectively processing the original method elements
+ * and directing the results to a method builder.
+ * <p>
+ * All method attributes are accessible as member elements.
  *
+ * @see ClassModel#methods()
+ * @see MethodTransform
+ * @jvms 4.6 Methods
  * @since 24
  */
 public sealed interface MethodModel
         extends CompoundElement<MethodElement>, AttributedElement, ClassElement
         permits BufferedMethodBuilder.Model, MethodImpl {
 
-    /** {@return the access flags} */
+    /**
+     * {@return the access flags}
+     *
+     * @see AccessFlag.Location#METHOD
+     */
     AccessFlags flags();
 
     /** {@return the class model this method is a member of, if known} */
@@ -53,10 +72,10 @@ public sealed interface MethodModel
     /** {@return the name of this method} */
     Utf8Entry methodName();
 
-    /** {@return the method descriptor of this method} */
+    /** {@return the method descriptor string of this method} */
     Utf8Entry methodType();
 
-    /** {@return the method descriptor of this method, as a symbolic descriptor} */
+    /** {@return the method type, as a symbolic descriptor} */
     default MethodTypeDesc methodTypeSymbol() {
         return Util.methodTypeSymbol(methodType());
     }

--- a/src/java.base/share/classes/java/lang/classfile/MethodTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,17 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A transformation on streams of {@link MethodElement}.
+ * <p>
+ * Refer to {@link ClassFileTransform} for general guidance and caution around
+ * the use of transforms for structures in the {@code class} file format.
+ * <p>
+ * A method transform can be lifted to a class transform via {@link
+ * ClassTransform#transformingMethods(MethodTransform)}, transforming only
+ * the {@link MethodModel} among the class members and passing all other
+ * elements to the builders.
  *
- * @see ClassFileTransform
- *
+ * @see MethodModel
+ * @see ClassBuilder#transformMethod
  * @since 24
  */
 @FunctionalInterface
@@ -44,7 +52,7 @@ public non-sealed interface MethodTransform
         extends ClassFileTransform<MethodTransform, MethodElement, MethodBuilder> {
 
     /**
-     * A method transform that sends all elements to the builder.
+     * A method transform that passes all elements to the builder.
      */
     MethodTransform ACCEPT_ALL = new MethodTransform() {
         @Override
@@ -54,7 +62,7 @@ public non-sealed interface MethodTransform
     };
 
     /**
-     * Create a stateful method transform from a {@link Supplier}.  The supplier
+     * Creates a stateful method transform from a {@link Supplier}.  The supplier
      * will be invoked for each transformation.
      *
      * @param supplier a {@link Supplier} that produces a fresh transform object
@@ -67,7 +75,7 @@ public non-sealed interface MethodTransform
     }
 
     /**
-     * Create a method transform that passes each element through to the builder,
+     * Creates a method transform that passes each element through to the builder,
      * and calls the specified function when transformation is complete.
      *
      * @param finisher the function to call when transformation is complete
@@ -89,7 +97,7 @@ public non-sealed interface MethodTransform
     }
 
     /**
-     * Create a method transform that passes each element through to the builder,
+     * Creates a method transform that passes each element through to the builder,
      * except for those that the supplied {@link Predicate} is true for.
      *
      * @param filter the predicate that determines which elements to drop
@@ -104,8 +112,9 @@ public non-sealed interface MethodTransform
     }
 
     /**
-     * Create a method transform that transforms {@link CodeModel} elements
-     * with the supplied code transform.
+     * Creates a method transform that transforms {@link CodeModel} elements
+     * with the supplied code transform, passing every other element through to
+     * the builder.
      *
      * @param xform the method transform
      * @return the class transform

--- a/src/java.base/share/classes/java/lang/classfile/Opcode.java
+++ b/src/java.base/share/classes/java/lang/classfile/Opcode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import jdk.internal.classfile.impl.RawBytecodeHelper;
  * instead of wide pseudo-opcodes.
  *
  * @see Instruction
- *
+ * @jvms 6.5 Instructions
  * @since 24
  */
 public enum Opcode {
@@ -1143,7 +1143,7 @@ public enum Opcode {
     LXOR(RawBytecodeHelper.LXOR, 1, Kind.OPERATOR),
 
     /**
-     * Increment local variable by constant.
+     * Increment {@link TypeKind#INT int} local variable by constant.
      *
      * @jvms 6.5.iinc <em>iinc</em>
      * @see Kind#INCREMENT

--- a/src/java.base/share/classes/java/lang/classfile/PseudoInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/PseudoInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,13 +35,16 @@ import java.lang.classfile.instruction.LocalVariableType;
 import jdk.internal.classfile.impl.AbstractPseudoInstruction;
 
 /**
- * Models metadata about a {@link CodeAttribute}, such as entries in the
- * exception table, line number table, local variable table, or the mapping
- * between instructions and labels.  Pseudo-instructions are delivered as part
- * of the element stream of a {@link CodeModel}.  Delivery of some
- * pseudo-instructions can be disabled by modifying the value of classfile
- * options (e.g., {@link ClassFile.DebugElementsOption}).
+ * Models metadata about a {@link CodeModel}, derived from the {@link
+ * CodeAttribute Code} attribute itself or its attributes.
+ * <p>
+ * Order is significant for some pseudo-instructions relative to {@link
+ * Instruction}s, such as {@link LabelTarget} or {@link LineNumber}.  Some
+ * pseudo-instructions can be omitted in reading and writing according to
+ * certain {@link ClassFile.Option}s.  These are specified in the corresponding
+ * modeling interfaces.
  *
+ * @sealedGraph
  * @since 24
  */
 public sealed interface PseudoInstruction

--- a/src/java.base/share/classes/java/lang/classfile/Superclass.java
+++ b/src/java.base/share/classes/java/lang/classfile/Superclass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,24 @@
 package java.lang.classfile;
 
 import java.lang.classfile.constantpool.ClassEntry;
+import java.lang.constant.ClassDesc;
 
 import jdk.internal.classfile.impl.SuperclassImpl;
 
 /**
- * Models the superclass of a class.  Delivered as a {@link
- * java.lang.classfile.ClassElement} when traversing a {@link ClassModel}.
+ * Models the superclass (JVMS {@jvms 4.1}) of a class.  A {@code Superclass}
+ * appears at most once in a {@link ClassModel}: it must be absent for
+ * {@linkplain ClassModel#isModuleInfo() module descriptors} or the {@link
+ * Object} class, and must be present otherwise.  A {@link ClassBuilder} sets
+ * the {@link Object} class as the superclass if the superclass is not supplied
+ * and the class to build is required to have a superclass.
+ * <p>
+ * All {@linkplain ClassFile#ACC_INTERFACE interfaces} have {@link Object} as
+ * their superclass.
  *
+ * @see ClassModel#superclass()
+ * @see ClassBuilder#withSuperclass
+ * @jvms 4.1 The {@code ClassFile} Structure
  * @since 24
  */
 public sealed interface Superclass
@@ -43,6 +54,7 @@ public sealed interface Superclass
 
     /**
      * {@return a {@linkplain Superclass} element}
+     *
      * @param superclassEntry the superclass
      */
     static Superclass of(ClassEntry superclassEntry) {

--- a/src/java.base/share/classes/java/lang/classfile/TypeKind.java
+++ b/src/java.base/share/classes/java/lang/classfile/TypeKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,11 +108,16 @@ public enum TypeKind {
      */
     LONG(2, 11),
     /**
-     * The primitive type {@code float}.
+     * The primitive type {@code float}.  All NaN values of {@code float} may or
+     * may not be collapsed into a single {@linkplain Float#NaN "canonical" NaN
+     * value} in loading and storing.
      */
     FLOAT(1, 6),
     /**
-     * The primitive type {@code double}. It is of {@linkplain #slotSize() category} 2.
+     * The primitive type {@code double}. It is of {@linkplain #slotSize()
+     * category} 2.  All NaN values of {@code double} may or may not be
+     * collapsed into a single {@linkplain Double#NaN "canonical" NaN value}
+     * in loading and storing.
      */
     DOUBLE(2, 7),
     // End primitive types

--- a/src/java.base/share/classes/java/lang/classfile/attribute/CodeAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CodeAttribute.java
@@ -49,6 +49,7 @@ import jdk.internal.classfile.impl.BoundAttribute;
  * being built.
  *
  * @see Attributes#code()
+ * @see CodeModel
  * @jvms 4.7.3 The {@code Code} Attribute
  * @since 24
  */

--- a/src/java.base/share/classes/java/lang/classfile/attribute/InnerClassInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/InnerClassInfo.java
@@ -68,7 +68,8 @@ public sealed interface InnerClassInfo
 
     /**
      * {@return a bit mask of flags denoting access permissions and properties
-     * of the inner class}
+     * of the inner class}  It is in the range of unsigned short, {@code [0,
+     * 0xFFFF]}.
      *
      * @see Class#getModifiers()
      * @see AccessFlag.Location#INNER_CLASS

--- a/src/java.base/share/classes/java/lang/classfile/attribute/MethodParameterInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/MethodParameterInfo.java
@@ -53,7 +53,8 @@ public sealed interface MethodParameterInfo
     Optional<Utf8Entry> name();
 
     /**
-     * {@return the access flags, as a bit mask}
+     * {@return the access flags, as a bit mask}  It is in the range of unsigned
+     * short, {@code [0, 0xFFFF]}.
      *
      * @see Parameter#getModifiers()
      * @see AccessFlag.Location#METHOD_PARAMETER

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleAttribute.java
@@ -81,7 +81,8 @@ public sealed interface ModuleAttribute
     ModuleEntry moduleName();
 
     /**
-     * {@return the module flags of the module, as a bit mask}
+     * {@return the module flags of the module, as a bit mask}  It is in the
+     * range of unsigned short, {@code [0, 0xFFFF]}.
      *
      * @see ModuleDescriptor#modifiers()
      * @see AccessFlag.Location#MODULE

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleExportInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleExportInfo.java
@@ -58,6 +58,7 @@ public sealed interface ModuleExportInfo
 
     /**
      * {@return the flags associated with this export declaration, as a bit mask}
+     * It is in the range of unsigned short, {@code [0, 0xFFFF]}.
      *
      * @see ModuleDescriptor.Exports#modifiers()
      * @see AccessFlag.Location#MODULE_EXPORTS

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleOpenInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleOpenInfo.java
@@ -64,6 +64,7 @@ public sealed interface ModuleOpenInfo
 
     /**
      * {@return the flags associated with this open declaration, as a bit mask}
+     * It is in the range of unsigned short, {@code [0, 0xFFFF]}.
      *
      * @see ModuleDescriptor.Opens#modifiers()
      * @see AccessFlag.Location#MODULE_OPENS

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleRequireInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleRequireInfo.java
@@ -55,6 +55,7 @@ public sealed interface ModuleRequireInfo
 
     /**
      * {@return the flags associated with this require declaration, as a bit mask}
+     * It is in the range of unsigned short, {@code [0, 0xFFFF]}.
      *
      * @see ModuleDescriptor.Requires#modifiers()
      * @see AccessFlag.Location#MODULE_REQUIRES

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleResolutionAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleResolutionAttribute.java
@@ -78,7 +78,8 @@ public sealed interface ModuleResolutionAttribute
         permits BoundAttribute.BoundModuleResolutionAttribute, UnboundAttribute.UnboundModuleResolutionAttribute {
 
     /**
-     * {@return the module resolution flags}
+     * {@return the module resolution flags}  It is in the range of unsigned
+     * short, {@code [0, 0xFFFF]}.
      * <p>
      * The value of the resolution_flags item is a mask of flags used to denote
      * properties of module resolution. The flags are as follows:

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
@@ -467,6 +467,9 @@ public sealed interface ConstantPoolBuilder
 
     /**
      * {@return a {@link FloatEntry} describing the provided value}
+     * <p>
+     * All NaN values of the {@code float} may or may not be collapsed into a
+     * single {@linkplain Float#NaN "canonical" NaN value}.
      *
      * @param value the value
      * @see FloatEntry#floatValue() FloatEntry::floatValue
@@ -483,6 +486,9 @@ public sealed interface ConstantPoolBuilder
 
     /**
      * {@return a {@link DoubleEntry} describing the provided value}
+     * <p>
+     * All NaN values of the {@code double} may or may not be collapsed into a
+     * single {@linkplain Double#NaN "canonical" NaN value}.
      *
      * @param value the value
      * @see DoubleEntry#doubleValue() DoubleEntry::doubleValue

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ExceptionCatch.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ExceptionCatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ import jdk.internal.classfile.impl.AbstractPseudoInstruction;
  * }
  *
  * @see CodeBuilder#exceptionCatch CodeBuilder::exceptionCatch
+ * @see CodeAttribute#exceptionHandlers()
  * @jvms 4.7.3 The {@code Code} Attribute
  * @since 24
  */

--- a/src/java.base/share/classes/java/lang/classfile/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,16 @@
 
 /**
  * <h2>Provides classfile parsing, generation, and transformation library.</h2>
- * The {@code java.lang.classfile} package contains classes for reading, writing, and
- * modifying Java class files, as specified in Chapter {@jvms 4} of the
- * <cite>Java Virtual Machine Specification</cite>.
+ * The {@code java.lang.classfile} package contains API models for reading,
+ * writing, and modifying Java class files, as specified in Chapter {@jvms 4} of
+ * the <cite>Java Virtual Machine Specification</cite>.  This package, {@link
+ * java.lang.classfile.attribute}, {@link java.lang.classfile.constantpool},
+ * and {@link java.lang.classfile.instruction} form the Class-File API.
  *
  * <h2>Reading classfiles</h2>
- * The main class for reading classfiles is {@link java.lang.classfile.ClassModel}; we
- * convert bytes into a {@link java.lang.classfile.ClassModel} with {@link
- * java.lang.classfile.ClassFile#parse(byte[])}:
+ * The main class for reading classfiles is {@link ClassModel}; we
+ * convert bytes into a {@link ClassModel} with {@link
+ * ClassFile#parse(byte[])}:
  *
  * {@snippet lang=java :
  * ClassModel cm = ClassFile.of().parse(bytes);
@@ -41,29 +43,32 @@
  * There are several additional overloads of {@code parse} that let you specify
  * various processing options.
  * <p>
- * A {@link java.lang.classfile.ClassModel} is an immutable description of a class
+ * A {@link ClassModel} is an immutable description of a class
  * file.  It provides accessor methods to get at class metadata (e.g., {@link
- * java.lang.classfile.ClassModel#thisClass()}, {@link java.lang.classfile.ClassModel#flags()}),
- * as well as subordinate classfile entities ({@link java.lang.classfile.ClassModel#fields()},
- * {@link java.lang.classfile.ClassModel#attributes()}). A {@link
- * java.lang.classfile.ClassModel} is inflated lazily; most parts of the classfile are
- * not parsed until they are actually needed.
+ * ClassModel#thisClass()}, {@link ClassModel#flags()}),
+ * as well as subordinate classfile entities ({@link ClassModel#fields()},
+ * {@link ClassModel#attributes()}). A {@link
+ * ClassModel} is inflated lazily; most parts of the classfile are
+ * not parsed until they are actually needed.  Due to the laziness, these models
+ * may not be thread safe.  Additionally, invocations to accessor methods on
+ * models may lead to {@link IllegalArgumentException} due to malformed {@code
+ * class} file format, as parsing happens lazily.
  * <p>
  * We can enumerate the names of the fields and methods in a class by:
  * {@snippet lang="java" class="PackageSnippets" region="enumerateFieldsMethods1"}
  * <p>
- * When we enumerate the methods, we get a {@link java.lang.classfile.MethodModel} for each method; like a
+ * When we enumerate the methods, we get a {@link MethodModel} for each method; like a
  * {@code ClassModel}, it gives us access to method metadata and
  * the ability to descend into subordinate entities such as the bytecodes of the
  * method body. In this way, a {@code ClassModel} is the root of a
  * tree, with children for fields, methods, and attributes, and {@code MethodModel} in
  * turn has its own children (attributes, {@code CodeModel}, etc.)
  * <p>
- * Methods like {@link java.lang.classfile.ClassModel#methods} allows us to traverse the class structure
+ * Methods like {@link ClassModel#methods} allows us to traverse the class structure
  * explicitly, going straight to the parts we are interested in.  This is useful
  * for certain kinds of analysis, but if we wanted to process the whole
  * classfile, we may want something more organized.  A {@link
- * java.lang.classfile.ClassModel} also provides us with a view of the classfile as a
+ * ClassModel} also provides us with a view of the classfile as a
  * series of class <em>elements</em>, which may include methods, fields, attributes,
  * and more, and which can be distinguished with pattern matching.  We could
  * rewrite the above example as:
@@ -87,24 +92,24 @@
  * <em>models</em> and <em>elements</em>.  Models represent complex structures,
  * such as classes, methods, fields, record elements, or the code body of a
  * method.  Models can be explored either via random-access navigation (such as
- * the {@link java.lang.classfile.ClassModel#methods()} accessor) or as a linear
+ * the {@link ClassModel#methods()} accessor) or as a linear
  * sequence of <em>elements</em>. (Elements can in turn also be models; a {@link
- * java.lang.classfile.FieldModel} is also an element of a class.) For each model type
- * (e.g., {@link java.lang.classfile.MethodModel}), there is a corresponding element
- * type ({@link java.lang.classfile.MethodElement}).  Models and elements are immutable
+ * FieldModel} is also an element of a class.) For each model type
+ * (e.g., {@link MethodModel}), there is a corresponding element
+ * type ({@link MethodElement}).  Models and elements are immutable
  * and are inflated lazily so creating a model does not necessarily require
  * processing its entire content.
  *
  * <h3>The constant pool</h3>
  * Much of the interesting content in a classfile lives in the <em>constant
- * pool</em>. {@link java.lang.classfile.ClassModel} provides a lazily-inflated,
- * read-only view of the constant pool via {@link java.lang.classfile.ClassModel#constantPool()}.
+ * pool</em>. {@link ClassModel} provides a lazily-inflated,
+ * read-only view of the constant pool via {@link ClassModel#constantPool()}.
  * Descriptions of classfile content is often exposed in the form of various
- * subtypes of {@link java.lang.classfile.constantpool.PoolEntry}, such as {@link
- * java.lang.classfile.constantpool.ClassEntry} or {@link java.lang.classfile.constantpool.Utf8Entry}.
+ * subtypes of {@link PoolEntry}, such as {@link
+ * ClassEntry} or {@link Utf8Entry}.
  * <p>
  * Constant pool entries are also exposed through models and elements; in the
- * above traversal example, the {@link java.lang.classfile.instruction.InvokeInstruction}
+ * above traversal example, the {@link InvokeInstruction}
  * element exposed a method for {@code owner} that corresponds to a {@code
  * Constant_Class_info} entry in the constant pool.
  *
@@ -112,9 +117,9 @@
  * Much of the contents of a classfile is stored in attributes; attributes are
  * found on classes, methods, fields, record components, and on the {@code Code}
  * attribute.  Most attributes are surfaced as elements; for example, {@link
- * java.lang.classfile.attribute.SignatureAttribute} is a {@link
- * java.lang.classfile.ClassElement}, {@link java.lang.classfile.MethodElement}, and {@link
- * java.lang.classfile.FieldElement} since it can appear in all of those places, and is
+ * SignatureAttribute} is a {@link
+ * ClassElement}, {@link MethodElement}, and {@link
+ * FieldElement} since it can appear in all of those places, and is
  * included when iterating the elements of the corresponding model.
  * <p>
  * Some attributes are not surfaced as elements; these are attributes that are
@@ -125,76 +130,83 @@
  * treated as part of the structure they are coupled to (the entries of the
  * {@code BootstrapMethods} attribute are treated as part of the constant pool;
  * line numbers and local variable metadata are modeled as elements of {@link
- * java.lang.classfile.CodeModel}.)
+ * CodeModel}.)
  * <p>
  * The {@code Code} attribute, in addition to being modeled as a {@link
- * java.lang.classfile.MethodElement}, is also a model in its own right ({@link
- * java.lang.classfile.CodeModel}) due to its complex structure.
+ * MethodElement}, is also a model in its own right ({@link
+ * CodeModel}) due to its complex structure.
  * <p>
  * Each standard attribute has an interface (in {@code java.lang.classfile.attribute})
  * which exposes the contents of the attribute and provides factories to
  * construct the attribute.  For example, the {@code Signature} attribute is
- * defined by the {@link java.lang.classfile.attribute.SignatureAttribute} class, and
- * provides accessors for {@link java.lang.classfile.attribute.SignatureAttribute#signature()}
- * as well as factories taking {@link java.lang.classfile.constantpool.Utf8Entry} or
- * {@link java.lang.String}.
+ * defined by the {@link SignatureAttribute} class, and
+ * provides accessors for {@link SignatureAttribute#signature()}
+ * as well as factories taking {@link Utf8Entry} or
+ * {@link String}.
  *
  * <h3>Custom attributes</h3>
  * Attributes are converted between their classfile form and their corresponding
- * object form via an {@link java.lang.classfile.AttributeMapper}.  An {@code
+ * object form via an {@link AttributeMapper}.  An {@code
  * AttributeMapper} provides the
- * {@link java.lang.classfile.AttributeMapper#readAttribute(AttributedElement,
+ * {@link AttributeMapper#readAttribute(AttributedElement,
  * ClassReader, int)} method for mapping from the classfile format
  * to an attribute instance, and the
- * {@link java.lang.classfile.AttributeMapper#writeAttribute(java.lang.classfile.BufWriter,
- * java.lang.classfile.Attribute)} method for mapping back to the classfile format.  It also
+ * {@link AttributeMapper#writeAttribute(BufWriter,
+ * Attribute)} method for mapping back to the classfile format.  It also
  * contains metadata including the attribute name, the set of classfile entities
  * where the attribute is applicable, and whether multiple attributes of the
  * same kind are allowed on a single entity.
  * <p>
- * There are built-in attribute mappers (in {@link java.lang.classfile.Attributes}) for
+ * There are built-in attribute mappers (in {@link Attributes}) for
  * each of the attribute types defined in section {@jvms 4.7} of <cite>The Java Virtual
  * Machine Specification</cite>, as well as several common nonstandard attributes used by the
  * JDK such as {@code CharacterRangeTable}.
  * <p>
  * Unrecognized attributes are delivered as elements of type {@link
- * java.lang.classfile.attribute.UnknownAttribute}, which provide access only to the
+ * UnknownAttribute}, which provide access only to the
  * {@code byte[]} contents of the attribute.
  * <p>
  * For nonstandard attributes, user-provided attribute mappers can be specified
  * through the use of the {@link
- * java.lang.classfile.ClassFile.AttributeMapperOption#of(java.util.function.Function)}}
+ * ClassFile.AttributeMapperOption#of(Function)}}
  * classfile option.  Implementations of custom attributes should extend {@link
- * java.lang.classfile.CustomAttribute}.
+ * CustomAttribute}.
  *
- * <h3>Options</h3>
+ * <h3 id="options">Options</h3>
  * <p>
- * {@link java.lang.classfile.ClassFile#of(java.lang.classfile.ClassFile.Option[])}
- * accepts a list of options.  {@link java.lang.classfile.ClassFile.Option} is a base interface
+ * {@link ClassFile#of(ClassFile.Option[])}
+ * accepts a list of options.  {@link ClassFile.Option} is a base interface
  * for some statically enumerated options, as well as factories for more complex options,
  * including:
  * <ul>
- *   <li>{@link java.lang.classfile.ClassFile.AttributeMapperOption#of(java.util.function.Function)}
+ *   <li>{@link ClassFile.AttributeMapperOption#of(Function)}
  * -- specify format of custom attributes</li>
- *   <li>{@link java.lang.classfile.ClassFile.AttributesProcessingOption}
+ *   <li>{@link ClassFile.AttributesProcessingOption}
  * -- unrecognized or problematic original attributes (default is {@code PASS_ALL_ATTRIBUTES})</li>
- *   <li>{@link java.lang.classfile.ClassFile.ClassHierarchyResolverOption#of(java.lang.classfile.ClassHierarchyResolver)}
+ *   <li>{@link ClassFile.ClassHierarchyResolverOption#of(ClassHierarchyResolver)}
  * -- specify a custom class hierarchy resolver used by stack map generation</li>
- *   <li>{@link java.lang.classfile.ClassFile.ConstantPoolSharingOption}}
+ *   <li>{@link ClassFile.ConstantPoolSharingOption}}
  * -- share constant pool when transforming (default is {@code SHARED_POOL})</li>
- *   <li>{@link java.lang.classfile.ClassFile.DeadCodeOption}}
+ *   <li>{@link ClassFile.DeadCodeOption}}
  * -- patch out unreachable code (default is {@code PATCH_DEAD_CODE})</li>
- *   <li>{@link java.lang.classfile.ClassFile.DeadLabelsOption}}
+ *   <li>{@link ClassFile.DeadLabelsOption}}
  * -- filter unresolved labels (default is {@code FAIL_ON_DEAD_LABELS})</li>
- *   <li>{@link java.lang.classfile.ClassFile.DebugElementsOption}
+ *   <li>{@link ClassFile.DebugElementsOption}
  * -- processing of debug information, such as local variable metadata (default is {@code PASS_DEBUG}) </li>
- *   <li>{@link java.lang.classfile.ClassFile.LineNumbersOption}
+ *   <li>{@link ClassFile.LineNumbersOption}
  * -- processing of line numbers (default is {@code PASS_LINE_NUMBERS}) </li>
- *   <li>{@link java.lang.classfile.ClassFile.ShortJumpsOption}
+ *   <li>{@link ClassFile.ShortJumpsOption}
  * -- automatically rewrite short jumps to long when necessary (default is {@code FIX_SHORT_JUMPS})</li>
- *   <li>{@link java.lang.classfile.ClassFile.StackMapsOption}
+ *   <li>{@link ClassFile.StackMapsOption}
  * -- generate stackmaps (default is {@code STACK_MAPS_WHEN_REQUIRED})</li>
  * </ul>
+ * <p>
+ * {@link ClassFile.AttributeMapperOption} and {@link ClassFile.ClassHierarchyResolverOption}
+ * are critical to the correctness of {@code class} file parsing and generation.
+ * The attribute mapper is required to parse custom attributes.  A correct
+ * resolver is required to generate {@code class} files that refer to classes
+ * not available to the system class loader in its bytecode, or in corner cases,
+ * when generation wishes to avoid loading system classes, such as in agents.
  * <p>
  * Most options allow you to request that certain parts of the classfile be
  * skipped during traversal, such as debug information or unrecognized
@@ -207,8 +219,8 @@
  * <h2>Writing classfiles</h2>
  * ClassFile generation is accomplished through <em>builders</em>.  For each
  * entity type that has a model, there is also a corresponding builder type;
- * classes are built through {@link java.lang.classfile.ClassBuilder}, methods through
- * {@link java.lang.classfile.MethodBuilder}, etc.
+ * classes are built through {@link ClassBuilder}, methods through
+ * {@link MethodBuilder}, etc.
  * <p>
  * Rather than creating builders directly, builders are provided as an argument
  * to a user-provided lambda.  To generate the familiar "hello world" program,
@@ -226,34 +238,34 @@
  * Builders often support multiple ways of expressing the same entity at
  * different levels of abstraction.  For example, the {@code invokevirtual}
  * instruction invoking {@code println} could have been generated with {@link
- * java.lang.classfile.CodeBuilder#invokevirtual(java.lang.constant.ClassDesc,
- * java.lang.String, java.lang.constant.MethodTypeDesc) CodeBuilder.invokevirtual}, {@link
- * java.lang.classfile.CodeBuilder#invoke(java.lang.classfile.Opcode,
- * java.lang.constant.ClassDesc, java.lang.String, java.lang.constant.MethodTypeDesc,
- * boolean) CodeBuilder.invokeInstruction}, or {@link
- * java.lang.classfile.CodeBuilder#with(java.lang.classfile.ClassFileElement)
+ * CodeBuilder#invokevirtual(ClassDesc,
+ * String, MethodTypeDesc) CodeBuilder.invokevirtual}, {@link
+ * CodeBuilder#invoke(Opcode,
+ * ClassDesc, String, MethodTypeDesc,
+ * boolean) CodeBuilder.invoke}, or {@link
+ * CodeBuilder#with(ClassFileElement)
  * CodeBuilder.with}.
  * <p>
  * The convenience method {@code CodeBuilder.invokevirtual} behaves as if it calls
- * the convenience method {@code CodeBuilder.invokeInstruction}, which in turn behaves
+ * the convenience method {@code CodeBuilder.invoke}, which in turn behaves
  * as if it calls method {@code CodeBuilder.with}. This composing of method calls on the
  * builder enables the composing of transforms (as described later).
  * <p>
  * Unless otherwise noted, passing a {@code null} argument to a constructor
  * or method of any Class-File API class or interface will cause a {@link
- * java.lang.NullPointerException NullPointerException} to be thrown. Additionally,
+ * NullPointerException} to be thrown. Additionally,
  * invoking a method with an array or collection containing a {@code null} element
  * will cause a {@code NullPointerException}, unless otherwise specified. </p>
  *
  * <h3>Symbolic information</h3>
  * To describe symbolic information for classes and types, the API uses the
- * nominal descriptor abstractions from {@code java.lang.constant} such as {@link
- * java.lang.constant.ClassDesc} and {@link java.lang.constant.MethodTypeDesc},
+ * nominal descriptor abstractions from {@link java.lang.constant} such as {@link
+ * ClassDesc} and {@link MethodTypeDesc},
  * which is less error-prone than using raw strings.
  * <p>
  * If a constant pool entry has a nominal representation then it provides a
  * method returning the corresponding nominal descriptor type e.g.
- * method {@link java.lang.classfile.constantpool.ClassEntry#asSymbol} returns
+ * method {@link ClassEntry#asSymbol} returns
  * {@code ClassDesc}.
  * <p>
  * Where appropriate builders provide two methods for building an element with
@@ -266,13 +278,14 @@
  * methods accepts the provided information without implicit validation.
  * However, fatal inconsistencies (like for example invalid code sequence or
  * unresolved labels) affects internal tools and may cause exceptions later in
- * the classfile building process.
+ * the classfile building process.  These fatal exceptions are thrown as
+ * {@link IllegalArgumentException}.
  * <p>
  * Using nominal descriptors assures the right serial form is applied by the
  * ClassFile API library based on the actual context. Also these nominal
  * descriptors are validated during their construction, so it is not possible to
  * create them with invalid content by mistake. Following example pass class
- * name to the {@link java.lang.constant.ClassDesc#of} method for validation
+ * name to the {@link ClassDesc#of} method for validation
  * and the library performs automatic conversion to the right internal form of
  * the class name when serialized in the constant pool as a class entry.
  * {@snippet lang=java :
@@ -290,7 +303,7 @@
  * }
  * <p>
  * More complex verification of a classfile can be achieved by invocation of
- * {@link java.lang.classfile.ClassFile#verify}.
+ * {@link ClassFile#verify}.
  *
  * <h2>Transforming classfiles</h2>
  * ClassFile Processing APIs are most frequently used to combine reading and
@@ -301,9 +314,9 @@
  * to the builder.
  * <p>
  * If we wanted to strip out methods whose names starts with "debug", we could
- * get an existing {@link java.lang.classfile.ClassModel}, build a new classfile that
- * provides a {@link java.lang.classfile.ClassBuilder}, iterate the elements of the
- * original {@link java.lang.classfile.ClassModel}, and pass through all of them to
+ * get an existing {@link ClassModel}, build a new classfile that
+ * provides a {@link ClassBuilder}, iterate the elements of the
+ * original {@link ClassModel}, and pass through all of them to
  * the builder except the methods we want to drop:
  * {@snippet lang="java" class="PackageSnippets" region="stripDebugMethods1"}
  * <p>
@@ -335,7 +348,7 @@
  * operations can be more easily combined.  Suppose we want to redirect
  * invocations of static methods on {@code Foo} to the corresponding method on
  * {@code Bar} instead.  We could express this as a transformation on {@link
- * java.lang.classfile.CodeElement}:
+ * CodeElement}:
  * {@snippet lang="java" class="PackageSnippets" region="fooToBarTransform"}
  * <p>
  * We can then <em>lift</em> this transformation on code elements into a
@@ -376,7 +389,7 @@
  * {@snippet lang="java" class="PackageSnippets" region="instrumentCallsTransform"}
  * <p>
  * Then we can compose {@code fooToBar} and {@code instrumentCalls} with {@link
- * java.lang.classfile.CodeTransform#andThen(java.lang.classfile.CodeTransform)}:
+ * CodeTransform#andThen(CodeTransform)}:
  *
  * {@snippet lang=java :
  * var cc = ClassFile.of();
@@ -399,7 +412,7 @@
  * attributes that are not transformed can be processed by bulk-copying their
  * bytes, rather than parsing them and regenerating their contents.)  If
  * constant pool sharing is not desired it can be suppressed
- * with the {@link java.lang.classfile.ClassFile.ConstantPoolSharingOption} option.
+ * with the {@link ClassFile.ConstantPoolSharingOption} option.
  * Such suppression may be beneficial when transformation removes many elements,
  * resulting in many unreferenced constant pool entries.
  *
@@ -429,14 +442,14 @@
  * corresponding interface to describe that element, and factory methods to
  * create that element.  Some element kinds also have convenience methods on the
  * corresponding builder (e.g., {@link
- * java.lang.classfile.CodeBuilder#invokevirtual(java.lang.constant.ClassDesc,
- * java.lang.String, java.lang.constant.MethodTypeDesc)}).
+ * CodeBuilder#invokevirtual(ClassDesc,
+ * String, MethodTypeDesc)}).
  * <p>
  * Most symbolic information in elements is represented by constant pool entries
  * (for example, the owner of a field is represented by a {@link
- * java.lang.classfile.constantpool.ClassEntry}.) Factories and builders also
- * accept nominal descriptors from {@code java.lang.constant} (e.g., {@link
- * java.lang.constant.ClassDesc}.)
+ * ClassEntry}.) Factories and builders also
+ * accept nominal descriptors from {@link java.lang.constant} (e.g., {@link
+ * ClassDesc}.)
  *
  * <h2><a id="data_model"></a>Data model</h2>
  * We define each kind of element by its name, an optional arity indicator (zero
@@ -485,7 +498,7 @@
  *
  * Fields and methods are models with their own elements.  The elements of fields
  * and methods are fairly simple; most of the complexity of methods lives in the
- * {@link java.lang.classfile.CodeModel} (which models the {@code Code} attribute
+ * {@link CodeModel} (which models the {@code Code} attribute
  * along with the code-related attributes: stack map table, local variable table,
  * line number table, etc.)
  *
@@ -502,7 +515,7 @@
  *     | ExceptionsAttribute?(List<ClassEntry> exceptions)
  * }
  *
- * {@link java.lang.classfile.CodeModel} is unique in that its elements are <em>ordered</em>.
+ * {@link CodeModel} is unique in that its elements are <em>ordered</em>.
  * Elements of {@code Code} include ordinary bytecodes, as well as a number of pseudo-instructions
  * representing branch targets, line number metadata, local variable metadata, and
  * catch blocks.
@@ -549,3 +562,13 @@
  * @since 24
  */
 package java.lang.classfile;
+
+import java.lang.classfile.attribute.SignatureAttribute;
+import java.lang.classfile.attribute.UnknownAttribute;
+import java.lang.classfile.constantpool.ClassEntry;
+import java.lang.classfile.constantpool.PoolEntry;
+import java.lang.classfile.constantpool.Utf8Entry;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.util.function.Function;

--- a/src/java.base/share/classes/java/lang/classfile/snippet-files/PackageSnippets.java
+++ b/src/java.base/share/classes/java/lang/classfile/snippet-files/PackageSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package java.lang.classfile.snippets;
 
 import java.lang.classfile.*;
+import java.lang.classfile.attribute.CodeAttribute;
 import java.lang.classfile.instruction.*;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
@@ -185,10 +186,14 @@ class PackageSnippets {
         // @start region="fooToBarTransform"
         CodeTransform fooToBar = (b, e) -> {
             if (e instanceof InvokeInstruction i
-                    && i.owner().asInternalName().equals("Foo")
-                    && i.opcode() == Opcode.INVOKESTATIC)
-                        b.invoke(i.opcode(), CD_Bar, i.name().stringValue(), i.typeSymbol(), i.isInterface());
-            else b.with(e);
+                    && i.owner().name().equalsString("Foo")
+                    && i.opcode() == Opcode.INVOKESTATIC) {
+                // remove the old element i by doing nothing to the builder
+                // add a new invokestatic instruction to the builder
+                b.invokestatic(CD_Bar, i.name().stringValue(), i.typeSymbol(), i.isInterface());
+            } else {
+                b.with(e);  // leaves the element in place
+            }
         };
         // @end
     }
@@ -322,6 +327,14 @@ class PackageSnippets {
         // @start region="lookup-class-hierarchy-resolver"
         MethodHandles.Lookup lookup = MethodHandles.lookup(); // @replace regex="MethodHandles\.lookup\(\)" replacement="..."
         ClassHierarchyResolver resolver = ClassHierarchyResolver.ofClassLoading(lookup).cached();
+        // @end
+    }
+
+    void manualReuseStackMaps(CodeBuilder cob, MethodModel method) {
+        // @start region="manual-reuse-stack-maps"
+        CodeAttribute code = method.findAttribute(Attributes.code()).orElseThrow();
+        // Note that StackMapTable may be absent, representing code with no branching
+        code.findAttribute(Attributes.stackMapTable()).ifPresent(cob);
         // @end
     }
 }


### PR DESCRIPTION
Please review a non-clean backport of #23277, the final patch in the improvements to the Class-File API. The backport is non-clean because a new JAVA_25_VERSION constant was added in 25; otherwise the patch applied cleanly.

Tests: No related failure in tier 1-3 so far

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8348425](https://bugs.openjdk.org/browse/JDK-8348425) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8342465](https://bugs.openjdk.org/browse/JDK-8342465): Improve API documentation for java.lang.classfile (**Sub-task** - P4)
 * [JDK-8348425](https://bugs.openjdk.org/browse/JDK-8348425): Improve API documentation for java.lang.classfile (**CSR**)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23317/head:pull/23317` \
`$ git checkout pull/23317`

Update a local copy of the PR: \
`$ git checkout pull/23317` \
`$ git pull https://git.openjdk.org/jdk.git pull/23317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23317`

View PR using the GUI difftool: \
`$ git pr show -t 23317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23317.diff">https://git.openjdk.org/jdk/pull/23317.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23317#issuecomment-2616054184)
</details>
