### PR TITLE
8348678: [PPC64] C2: unaligned vector load/store is ok

### DIFF
--- a/src/hotspot/cpu/ppc/matcher_ppc.hpp
+++ b/src/hotspot/cpu/ppc/matcher_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/matcher_ppc.hpp
+++ b/src/hotspot/cpu/ppc/matcher_ppc.hpp
@@ -37,10 +37,12 @@
     return false;
   }
 
-  // PPC implementation uses VSX load/store instructions (if
-  // SuperwordUseVSX) which support 4 byte but not arbitrary alignment
+  // The PPC implementation uses VSX lxvd2x/stxvd2x instructions (if
+  // SuperwordUseVSX). They do not have alignment requirements.
+  // Some VSX storage access instructions cannot encode arbitrary displacements
+  // (e.g. lxv). None of them is currently used.
   static constexpr bool misaligned_vectors_ok() {
-    return false;
+    return true;
   }
 
   // Whether code generation need accurate ConvI2L types.

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -124,6 +124,9 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(SuperwordUseVSX)) {
       FLAG_SET_ERGO(SuperwordUseVSX, true);
     }
+    if (FLAG_IS_DEFAULT(AlignVector)) {
+      FLAG_SET_ERGO(AlignVector, false);
+    }
   } else {
     if (SuperwordUseVSX) {
       warning("SuperwordUseVSX specified, but needs at least Power8.");

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -124,9 +124,6 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(SuperwordUseVSX)) {
       FLAG_SET_ERGO(SuperwordUseVSX, true);
     }
-    if (FLAG_IS_DEFAULT(AlignVector)) {
-      FLAG_SET_ERGO(AlignVector, false);
-    }
   } else {
     if (SuperwordUseVSX) {
       warning("SuperwordUseVSX specified, but needs at least Power8.");
@@ -134,6 +131,9 @@ void VM_Version::initialize() {
     }
   }
   MaxVectorSize = SuperwordUseVSX ? 16 : 8;
+  if (FLAG_IS_DEFAULT(AlignVector)) {
+    FLAG_SET_ERGO(AlignVector, false);
+  }
 
   if (PowerArchitecturePPC64 >= 9) {
     if (FLAG_IS_DEFAULT(UseCountTrailingZerosInstructionsPPC64)) {

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2024 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
@@ -77,7 +77,7 @@ public class TestCastX2NotProcessedIGVN {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_I, "> 1"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfPlatformOr = {"x64", "true", "aarch64", "true"})
+        applyIfPlatformOr = {"x64", "true", "aarch64", "true", "ppc", "true"})
     public static int test2(int stop, int[] array) {
         int v = 0;
         stop = Math.min(stop, Integer.MAX_VALUE / 4);


### PR DESCRIPTION
This pr changes `Matcher::misaligned_vectors_ok`  to return `true` on PPC64 for better vectorization during `SuperWord`.
IR checking of the corresponding test `TestCastX2NotProcessedIGVN.java` is also enabled.

Tested with `TestCastX2NotProcessedIGVN.java`

The change passed our CI testing:
Tier 1-4 of hotspot and jdk. All of langtools and jaxp. Renaissance Suite and SAP specific tests.
Testing was done on the main platforms and also on Linux/PPC64le and AIX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8348678](https://bugs.openjdk.org/browse/JDK-8348678): [PPC64] C2: unaligned vector load/store is ok (**Enhancement** - P4)
 * [JDK-8343906](https://bugs.openjdk.org/browse/JDK-8343906): test2 of compiler/c2/TestCastX2NotProcessedIGVN.java fails on some platforms (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer) Review applies to [c75622fa](https://git.openjdk.org/jdk/pull/23318/files/c75622fa56eb762ebcbd72f4714ca4cca6e85763)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23318/head:pull/23318` \
`$ git checkout pull/23318`

Update a local copy of the PR: \
`$ git checkout pull/23318` \
`$ git pull https://git.openjdk.org/jdk.git pull/23318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23318`

View PR using the GUI difftool: \
`$ git pr show -t 23318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23318.diff">https://git.openjdk.org/jdk/pull/23318.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23318#issuecomment-2616266545)
</details>
