### PR TITLE
8347272: [ubsan] JvmLauncher.cpp:262:52: runtime error: applying non-zero offset 40 to null pointer

### DIFF
--- a/src/jdk.jpackage/share/native/applauncher/JvmLauncher.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/JvmLauncher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jpackage/share/native/applauncher/JvmLauncher.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/JvmLauncher.cpp
@@ -259,8 +259,8 @@ private:
 
     int initJvmlLauncherData(JvmlLauncherData* ptr) const {
         // Store path to JLI library just behind JvmlLauncherData header.
-        char dummy = 0;
-        char* curPtr = ptr ? reinterpret_cast<char*>(ptr + 1) : (&dummy + sizeof(JvmlLauncherData));
+        JvmlLauncherData dummy;
+        char* curPtr = reinterpret_cast<char*>((ptr ? ptr : &dummy) + 1);
         {
             const size_t count = sizeof(char)
                     * (jliLibPath.size() + 1 /* trailing zero */);
@@ -305,7 +305,7 @@ private:
         curPtr = copyStrings(envVarValues, ptr,
                             offsetof(JvmlLauncherData, envVarValues), curPtr);
 
-        const size_t bufferSize = curPtr - (ptr ? reinterpret_cast<char*>(ptr) : &dummy);
+        const size_t bufferSize = curPtr - reinterpret_cast<char*>(ptr ? ptr : &dummy);
         if (ptr) {
             LOG_TRACE(tstrings::any() << "Initialized " << bufferSize
                                         << " bytes at " << ptr << " address");

--- a/src/jdk.jpackage/share/native/applauncher/JvmLauncher.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/JvmLauncher.cpp
@@ -259,7 +259,8 @@ private:
 
     int initJvmlLauncherData(JvmlLauncherData* ptr) const {
         // Store path to JLI library just behind JvmlLauncherData header.
-        char* curPtr = reinterpret_cast<char*>(ptr + 1);
+        char dummy = 0;
+        char* curPtr = ptr ? reinterpret_cast<char*>(ptr + 1) : &dummy;
         {
             const size_t count = sizeof(char)
                     * (jliLibPath.size() + 1 /* trailing zero */);
@@ -304,7 +305,7 @@ private:
         curPtr = copyStrings(envVarValues, ptr,
                             offsetof(JvmlLauncherData, envVarValues), curPtr);
 
-        const size_t bufferSize = curPtr - reinterpret_cast<char*>(ptr);
+        const size_t bufferSize = curPtr - (ptr ? reinterpret_cast<char*>(ptr) : &dummy);
         if (ptr) {
             LOG_TRACE(tstrings::any() << "Initialized " << bufferSize
                                         << " bytes at " << ptr << " address");

--- a/src/jdk.jpackage/share/native/applauncher/JvmLauncher.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/JvmLauncher.cpp
@@ -260,7 +260,7 @@ private:
     int initJvmlLauncherData(JvmlLauncherData* ptr) const {
         // Store path to JLI library just behind JvmlLauncherData header.
         char dummy = 0;
-        char* curPtr = ptr ? reinterpret_cast<char*>(ptr + 1) : &dummy;
+        char* curPtr = ptr ? reinterpret_cast<char*>(ptr + 1) : (&dummy + sizeof(JvmlLauncherData));
         {
             const size_t count = sizeof(char)
                     * (jliLibPath.size() + 1 /* trailing zero */);


### PR DESCRIPTION
Rework pointer arithmetic to avoid null pointer

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347272](https://bugs.openjdk.org/browse/JDK-8347272): [ubsan] JvmLauncher.cpp:262:52: runtime error: applying non-zero offset 40 to null pointer (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23320/head:pull/23320` \
`$ git checkout pull/23320`

Update a local copy of the PR: \
`$ git checkout pull/23320` \
`$ git pull https://git.openjdk.org/jdk.git pull/23320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23320`

View PR using the GUI difftool: \
`$ git pr show -t 23320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23320.diff">https://git.openjdk.org/jdk/pull/23320.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23320#issuecomment-2617000184)
</details>
