### PR TITLE
8337548: Parallel class loading can pass is_superclass true for interfaces

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -447,7 +447,7 @@ InstanceKlass* SystemDictionary::resolve_with_circularity_detection(Symbol* clas
 
     // Must check ClassCircularity before resolving next_name (superclass or interface).
     PlaceholderEntry* probe = PlaceholderTable::get_entry(class_name, loader_data);
-    if (probe && probe->check_seen_thread(THREAD, PlaceholderTable::DETECT_CIRCULARITY)) {
+    if (probe != nullptr && probe->check_seen_thread(THREAD, PlaceholderTable::DETECT_CIRCULARITY)) {
         log_circularity_error(class_name, probe);
         throw_circularity_error = true;
     }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -502,12 +502,11 @@ static void handle_parallel_super_load(Symbol* name,
                                        TRAPS) {
 
   // The result superk is not used; resolve_with_circularity_detection is called for circularity check only.
-  // This passes true to check_is_superclass even though it might not be the super class in order to perform the
-  // check anyway.
+  // This passes false to check_is_superclass to skip doing the unlikely optimization.
   Klass* superk = SystemDictionary::resolve_with_circularity_detection(name,
                                                                        superclassname,
                                                                        class_loader,
-                                                                       true,
+                                                                       false,
                                                                        CHECK);
 }
 

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -106,7 +106,7 @@ class SystemDictionary : AllStatic {
   static InstanceKlass* resolve_with_circularity_detection(Symbol* class_name,
                                                            Symbol* next_name,
                                                            Handle class_loader,
-                                                           bool check_is_superclass,
+                                                           bool is_superclass,
                                                            TRAPS);
 
   // Resolve a superclass or superinterface. Called from ClassFileParser,
@@ -114,8 +114,8 @@ class SystemDictionary : AllStatic {
   // "class_name" is the class whose super class or interface is being resolved.
   static InstanceKlass* resolve_super_or_fail(Symbol* class_name, Symbol* super_name,
                                               Handle class_loader,
-                                              bool check_is_superclass, TRAPS) {
-    return resolve_with_circularity_detection(class_name, super_name, class_loader, check_is_superclass, THREAD);
+                                              bool is_superclass, TRAPS) {
+    return resolve_with_circularity_detection(class_name, super_name, class_loader, is_superclass, THREAD);
   }
 
  private:
@@ -319,7 +319,7 @@ private:
                                            Handle class_loader);
   static bool check_shared_class_super_type(InstanceKlass* klass, InstanceKlass* super,
                                             Handle class_loader,
-                                            bool check_is_superclass, TRAPS);
+                                            bool is_superclass, TRAPS);
   static bool check_shared_class_super_types(InstanceKlass* ik, Handle class_loader, TRAPS);
   // Second part of load_shared_class
   static void load_shared_class_misc(InstanceKlass* ik, ClassLoaderData* loader_data) NOT_CDS_RETURN;

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ class SystemDictionary : AllStatic {
   static InstanceKlass* resolve_with_circularity_detection(Symbol* class_name,
                                                            Symbol* next_name,
                                                            Handle class_loader,
-                                                           bool is_superclass,
+                                                           bool check_is_superclass,
                                                            TRAPS);
 
   // Resolve a superclass or superinterface. Called from ClassFileParser,
@@ -114,8 +114,8 @@ class SystemDictionary : AllStatic {
   // "class_name" is the class whose super class or interface is being resolved.
   static InstanceKlass* resolve_super_or_fail(Symbol* class_name, Symbol* super_name,
                                               Handle class_loader,
-                                              bool is_superclass, TRAPS) {
-    return resolve_with_circularity_detection(class_name, super_name, class_loader, is_superclass, THREAD);
+                                              bool check_is_superclass, TRAPS) {
+    return resolve_with_circularity_detection(class_name, super_name, class_loader, check_is_superclass, THREAD);
   }
 
  private:
@@ -319,7 +319,7 @@ private:
                                            Handle class_loader);
   static bool check_shared_class_super_type(InstanceKlass* klass, InstanceKlass* super,
                                             Handle class_loader,
-                                            bool is_superclass, TRAPS);
+                                            bool check_is_superclass, TRAPS);
   static bool check_shared_class_super_types(InstanceKlass* ik, Handle class_loader, TRAPS);
   // Second part of load_shared_class
   static void load_shared_class_misc(InstanceKlass* ik, ClassLoaderData* loader_data) NOT_CDS_RETURN;


### PR DESCRIPTION
There's an optimization in class loading that looks up class being loaded while loading its superclass, and if the class is found, it will check the superclass name against klass->_super and match class loaders. It's supposed to be a optimization to short circuit taking out the LOAD_SUPER (now called DETECT_CIRCULARITY) placeholder for the class being loaded.  So for example, loading class C, super S, we take out a DETECT_CIRCULARITY placeholder for C to detect if S then tries to load C as a super class by the same thread.

This optimization is almost never done because it requires just the right timing for a parallel thread to load the class right before this thread reaches the if statement (perhaps some long stall). The only case where this code is reached normally is for redefinition.  Loading a new class file version will find the class in the System Dictionary because we can only redefine already loaded classes.

It should be harmess to remove this if-statement in the case of redefinition also, but I think having a placeholder created for a known already-loaded class seems to break an understanding of how this works.  So I opted to just add to the comment and restructure the method a little bit.  The dictionary->find_class() call doesn't need to be inside the SystemDictionary_lock.

Tested with tier1-4 and internal parallel class loading tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337548](https://bugs.openjdk.org/browse/JDK-8337548): Parallel class loading can pass is_superclass true for interfaces (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23322/head:pull/23322` \
`$ git checkout pull/23322`

Update a local copy of the PR: \
`$ git checkout pull/23322` \
`$ git pull https://git.openjdk.org/jdk.git pull/23322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23322`

View PR using the GUI difftool: \
`$ git pr show -t 23322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23322.diff">https://git.openjdk.org/jdk/pull/23322.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23322#issuecomment-2617091717)
</details>
