### PR TITLE
8348752: Enable -XX:+AOTClassLinking by default when -XX:AOTMode is specified

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -420,6 +420,11 @@ void CDSConfig::check_flag_aliases() {
 bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_flag_cmd_line) {
   check_flag_aliases();
 
+  if (!FLAG_IS_DEFAULT(AOTMode)) {
+    // Using any form of the new AOTMode switch enables enhanced optimizations.
+    FLAG_SET_ERGO_IF_DEFAULT(AOTClassLinking, true);
+  }
+
   if (AOTClassLinking) {
     // If AOTClassLinking is specified, enable all AOT optimizations by default.
     FLAG_SET_ERGO_IF_DEFAULT(AOTInvokeDynamicLinking, true);


### PR DESCRIPTION
According to the CSR [JDK-8339506](https://bugs.openjdk.org/browse/JDK-8339506) (for https://openjdk.org/jeps/483)

> When an AOT cache is created with the new `-XX:AOTMode=create` flag, we assume that the application is aware of AOT class linking and does not depend of the class loading order. In this case, AOTClassLinking has a default value of true. The user can disable it by explicitly passing `-XX:-AOTClassLinking` in the JVM command line.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348752](https://bugs.openjdk.org/browse/JDK-8348752): Enable -XX:+AOTClassLinking by default when -XX:AOTMode is specified (**Bug** - P2) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23323/head:pull/23323` \
`$ git checkout pull/23323`

Update a local copy of the PR: \
`$ git checkout pull/23323` \
`$ git pull https://git.openjdk.org/jdk.git pull/23323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23323`

View PR using the GUI difftool: \
`$ git pr show -t 23323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23323.diff">https://git.openjdk.org/jdk/pull/23323.diff</a>

</details>
