### PR TITLE
8344983: [PPC64] Rename ConditionRegisters

### DIFF
--- a/src/hotspot/cpu/ppc/assembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.cpp
@@ -562,20 +562,20 @@ void Assembler::test_asm() {
   li(     R3, -4711);
 
   // PPC 1, section 3.3.9, Fixed-Point Compare Instructions
-  cmpi(   CCR7,  0, R27, 4711);
-  cmp(    CCR0, 1, R14, R11);
-  cmpli(  CCR5,  1, R17, 45);
-  cmpl(   CCR3, 0, R9,  R10);
+  cmpi(   CR7,  0, R27, 4711);
+  cmp(    CR0, 1, R14, R11);
+  cmpli(  CR5,  1, R17, 45);
+  cmpl(   CR3, 0, R9,  R10);
 
-  cmpwi(  CCR7,  R27, 4711);
-  cmpw(   CCR0, R14, R11);
-  cmplwi( CCR5,  R17, 45);
-  cmplw(  CCR3, R9,  R10);
+  cmpwi(  CR7,  R27, 4711);
+  cmpw(   CR0, R14, R11);
+  cmplwi( CR5,  R17, 45);
+  cmplw(  CR3, R9,  R10);
 
-  cmpdi(  CCR7,  R27, 4711);
-  cmpd(   CCR0, R14, R11);
-  cmpldi( CCR5,  R17, 45);
-  cmpld(  CCR3, R9,  R10);
+  cmpdi(  CR7,  R27, 4711);
+  cmpd(   CR0, R14, R11);
+  cmpldi( CR5,  R17, 45);
+  cmpld(  CR3, R9,  R10);
 
   // PPC 1, section 3.3.11, Fixed-Point Logical Instructions
   andi_(  R4,  R5,  0xff);
@@ -715,23 +715,23 @@ void Assembler::test_asm() {
   bcctr( 4, 6, 0);
   bcctrl(4, 6, 0);
 
-  blt(CCR0, lbl2);
-  bgt(CCR1, lbl2);
-  beq(CCR2, lbl2);
-  bso(CCR3, lbl2);
-  bge(CCR4, lbl2);
-  ble(CCR5, lbl2);
-  bne(CCR6, lbl2);
-  bns(CCR7, lbl2);
+  blt(CR0, lbl2);
+  bgt(CR1, lbl2);
+  beq(CR2, lbl2);
+  bso(CR3, lbl2);
+  bge(CR4, lbl2);
+  ble(CR5, lbl2);
+  bne(CR6, lbl2);
+  bns(CR7, lbl2);
 
-  bltl(CCR0, lbl2);
-  bgtl(CCR1, lbl2);
-  beql(CCR2, lbl2);
-  bsol(CCR3, lbl2);
-  bgel(CCR4, lbl2);
-  blel(CCR5, lbl2);
-  bnel(CCR6, lbl2);
-  bnsl(CCR7, lbl2);
+  bltl(CR0, lbl2);
+  bgtl(CR1, lbl2);
+  beql(CR2, lbl2);
+  bsol(CR3, lbl2);
+  bgel(CR4, lbl2);
+  blel(CR5, lbl2);
+  bnel(CR6, lbl2);
+  bnsl(CR7, lbl2);
   blr();
 
   sync();
@@ -794,7 +794,7 @@ void Assembler::test_asm() {
   fcfid( F22, F23);
 
   // PPC 1, section 4.6.7 Floating-Point Compare Instructions
-  fcmpu( CCR7, F24, F25);
+  fcmpu( CR7, F24, F25);
 
   tty->print_cr("\ntest_asm disassembly (0x%lx 0x%lx):", p2i(code()->insts_begin()), p2i(code()->insts_end()));
   code()->decode();

--- a/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
@@ -246,9 +246,9 @@ inline void Assembler::nop()                              { Assembler::ori(R0, R
 // NOP for FP and BR units (different versions to allow them to be in one group)
 inline void Assembler::fpnop0()                           { Assembler::fmr(F30, F30); }
 inline void Assembler::fpnop1()                           { Assembler::fmr(F31, F31); }
-inline void Assembler::brnop0()                           { Assembler::mcrf(CCR2, CCR2); }
-inline void Assembler::brnop1()                           { Assembler::mcrf(CCR3, CCR3); }
-inline void Assembler::brnop2()                           { Assembler::mcrf(CCR4,  CCR4); }
+inline void Assembler::brnop0()                           { Assembler::mcrf(CR2, CR2); }
+inline void Assembler::brnop1()                           { Assembler::mcrf(CR3, CR3); }
+inline void Assembler::brnop2()                           { Assembler::mcrf(CR4,  CR4); }
 
 inline void Assembler::mr(      Register d, Register s)   { Assembler::orr(d, s, s); }
 inline void Assembler::ori_opt( Register d, int ui16)     { if (ui16!=0) Assembler::ori( d, d, ui16); }
@@ -303,7 +303,7 @@ inline void Assembler::clrlsldi_(Register a, Register s, int clrl6, int shl6) { 
 inline void Assembler::extrdi(  Register a, Register s, int n, int b){ Assembler::rldicl(a, s, b+n, 64-n); }
 // testbit with condition register.
 inline void Assembler::testbitdi(ConditionRegister cr, Register a, Register s, int ui6) {
-  if (cr == CCR0) {
+  if (cr == CR0) {
     Assembler::rldicr_(a, s, 63-ui6, 0);
   } else {
     Assembler::rldicr(a, s, 63-ui6, 0);

--- a/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
@@ -367,9 +367,9 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
     __ mr(R0, _obj); // spill
     __ ld(_obj, java_lang_Class::klass_offset(), _obj);
     __ ld(_obj, in_bytes(InstanceKlass::init_thread_offset()), _obj);
-    __ cmpd(CCR0, _obj, R16_thread);
+    __ cmpd(CR0, _obj, R16_thread);
     __ mr(_obj, R0); // restore
-    __ bne(CCR0, call_patch);
+    __ bne(CR0, call_patch);
 
     // Load_klass patches may execute the patched code before it's
     // copied back into place so we need to jump back into the main

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -48,7 +48,7 @@
 #define __ _masm->
 
 
-const ConditionRegister LIR_Assembler::BOOL_RESULT = CCR5;
+const ConditionRegister LIR_Assembler::BOOL_RESULT = CR5;
 
 
 bool LIR_Assembler::is_small_constant(LIR_Opr opr) {
@@ -156,8 +156,8 @@ void LIR_Assembler::osr_entry() {
       {
         Label L;
         __ ld(R0, slot_offset + 1*BytesPerWord, OSR_buf);
-        __ cmpdi(CCR0, R0, 0);
-        __ bne(CCR0, L);
+        __ cmpdi(CR0, R0, 0);
+        __ bne(CR0, L);
         __ stop("locked object is null");
         __ bind(L);
       }
@@ -410,11 +410,11 @@ void LIR_Assembler::arithmetic_idiv(LIR_Code code, LIR_Opr left, LIR_Opr right, 
 
   Label regular, done;
   if (is_int) {
-    __ cmpwi(CCR0, Rdivisor, -1);
+    __ cmpwi(CR0, Rdivisor, -1);
   } else {
-    __ cmpdi(CCR0, Rdivisor, -1);
+    __ cmpdi(CR0, Rdivisor, -1);
   }
-  __ bne(CCR0, regular);
+  __ bne(CR0, regular);
   if (code == lir_idiv) {
     __ neg(Rresult, Rdividend);
     __ b(done);
@@ -597,14 +597,14 @@ void LIR_Assembler::emit_opConvert(LIR_OpConvert* op) {
       Address       addr = dst_in_memory ? frame_map()->address_for_slot(dst->double_stack_ix()) : Address();
       Label L;
       // Result must be 0 if value is NaN; test by comparing value to itself.
-      __ fcmpu(CCR0, rsrc, rsrc);
+      __ fcmpu(CR0, rsrc, rsrc);
       if (dst_in_memory) {
         __ li(R0, 0); // 0 in case of NAN
         __ std(R0, addr);
       } else {
         __ li(dst->as_register(), 0);
       }
-      __ bso(CCR0, L);
+      __ bso(CR0, L);
       __ fctiwz(rsrc, rsrc); // USE_KILL
       if (dst_in_memory) {
         __ stfd(rsrc, addr.disp(), addr.base());
@@ -621,14 +621,14 @@ void LIR_Assembler::emit_opConvert(LIR_OpConvert* op) {
       Address       addr = dst_in_memory ? frame_map()->address_for_slot(dst->double_stack_ix()) : Address();
       Label L;
       // Result must be 0 if value is NaN; test by comparing value to itself.
-      __ fcmpu(CCR0, rsrc, rsrc);
+      __ fcmpu(CR0, rsrc, rsrc);
       if (dst_in_memory) {
         __ li(R0, 0); // 0 in case of NAN
         __ std(R0, addr);
       } else {
         __ li(dst->as_register_lo(), 0);
       }
-      __ bso(CCR0, L);
+      __ bso(CR0, L);
       __ fctidz(rsrc, rsrc); // USE_KILL
       if (dst_in_memory) {
         __ stfd(rsrc, addr.disp(), addr.base());
@@ -1530,15 +1530,15 @@ void LIR_Assembler::comp_fl2i(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Op
   if (code == lir_cmp_fd2i || code == lir_ucmp_fd2i) {
     bool is_unordered_less = (code == lir_ucmp_fd2i);
     if (left->is_single_fpu()) {
-      __ fcmpu(CCR0, left->as_float_reg(), right->as_float_reg());
+      __ fcmpu(CR0, left->as_float_reg(), right->as_float_reg());
     } else if (left->is_double_fpu()) {
-      __ fcmpu(CCR0, left->as_double_reg(), right->as_double_reg());
+      __ fcmpu(CR0, left->as_double_reg(), right->as_double_reg());
     } else {
       ShouldNotReachHere();
     }
     __ set_cmpu3(Rdst, is_unordered_less); // is_unordered_less ? -1 : 1
   } else if (code == lir_cmp_l2i) {
-    __ cmpd(CCR0, left->as_register_lo(), right->as_register_lo());
+    __ cmpd(CR0, left->as_register_lo(), right->as_register_lo());
     __ set_cmp3(Rdst);  // set result as follows: <: -1, =: 0, >: 1
   } else {
     ShouldNotReachHere();
@@ -1893,8 +1893,8 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
     __ add(src_pos, tmp, src_pos);
     __ add(dst_pos, tmp, dst_pos);
 
-    __ cmpwi(CCR0, R3_RET, 0);
-    __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CCR0, Assembler::less), *stub->entry());
+    __ cmpwi(CR0, R3_RET, 0);
+    __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CR0, Assembler::less), *stub->entry());
     __ bind(*stub->continuation());
     return;
   }
@@ -1910,12 +1910,12 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 
   // Use only one conditional branch for simple checks.
   if (simple_check_flag_set) {
-    ConditionRegister combined_check = CCR1, tmp_check = CCR1;
+    ConditionRegister combined_check = CR1, tmp_check = CR1;
 
     // Make sure src and dst are non-null.
     if (flags & LIR_OpArrayCopy::src_null_check) {
       __ cmpdi(combined_check, src, 0);
-      tmp_check = CCR0;
+      tmp_check = CR0;
     }
 
     if (flags & LIR_OpArrayCopy::dst_null_check) {
@@ -1923,13 +1923,13 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
       if (tmp_check != combined_check) {
         __ cror(combined_check, Assembler::equal, tmp_check, Assembler::equal);
       }
-      tmp_check = CCR0;
+      tmp_check = CR0;
     }
 
     // Clear combined_check.eq if not already used.
     if (tmp_check == combined_check) {
       __ crandc(combined_check, Assembler::equal, combined_check, Assembler::equal);
-      tmp_check = CCR0;
+      tmp_check = CR0;
     }
 
     if (flags & LIR_OpArrayCopy::src_pos_positive_check) {
@@ -1960,15 +1960,15 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
     if (!(flags & LIR_OpArrayCopy::dst_objarray)) {
       __ load_klass(tmp, dst);
       __ lwz(tmp2, in_bytes(Klass::layout_helper_offset()), tmp);
-      __ cmpwi(CCR0, tmp2, Klass::_lh_neutral_value);
-      __ bge(CCR0, slow);
+      __ cmpwi(CR0, tmp2, Klass::_lh_neutral_value);
+      __ bge(CR0, slow);
     }
 
     if (!(flags & LIR_OpArrayCopy::src_objarray)) {
       __ load_klass(tmp, src);
       __ lwz(tmp2, in_bytes(Klass::layout_helper_offset()), tmp);
-      __ cmpwi(CCR0, tmp2, Klass::_lh_neutral_value);
-      __ bge(CCR0, slow);
+      __ cmpwi(CR0, tmp2, Klass::_lh_neutral_value);
+      __ bge(CR0, slow);
     }
   }
 
@@ -1979,16 +1979,16 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
   if (flags & LIR_OpArrayCopy::src_range_check) {
     __ lwz(tmp2, arrayOopDesc::length_offset_in_bytes(), src);
     __ add(tmp, length, src_pos);
-    __ cmpld(CCR0, tmp2, tmp);
-    __ ble(CCR0, slow);
+    __ cmpld(CR0, tmp2, tmp);
+    __ ble(CR0, slow);
   }
 
   __ extsw(dst_pos, dst_pos);
   if (flags & LIR_OpArrayCopy::dst_range_check) {
     __ lwz(tmp2, arrayOopDesc::length_offset_in_bytes(), dst);
     __ add(tmp, length, dst_pos);
-    __ cmpld(CCR0, tmp2, tmp);
-    __ ble(CCR0, slow);
+    __ cmpld(CR0, tmp2, tmp);
+    __ ble(CR0, slow);
   }
 
   int shift = shift_amount(basic_type);
@@ -2003,8 +2003,8 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
     // We don't know the array types are compatible.
     if (basic_type != T_OBJECT) {
       // Simple test for basic type arrays.
-      __ cmp_klasses_from_objects(CCR0, src, dst, tmp, tmp2);
-      __ beq(CCR0, cont);
+      __ cmp_klasses_from_objects(CR0, src, dst, tmp, tmp2);
+      __ beq(CR0, cont);
     } else {
       // For object arrays, if src is a sub class of dst then we can
       // safely do the copy.
@@ -2024,7 +2024,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
       __ calculate_address_from_global_toc(tmp, slow_stc, true, true, false);
       __ mtctr(tmp);
       __ bctrl(); // sets CR0
-      __ beq(CCR0, cont);
+      __ beq(CR0, cont);
 
       if (copyfunc_addr != nullptr) { // Use stub if available.
         __ bind(copyfunc);
@@ -2044,8 +2044,8 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 
           jint objArray_lh = Klass::array_layout_helper(T_OBJECT);
           __ load_const_optimized(tmp, objArray_lh);
-          __ cmpw(CCR0, tmp, tmp2);
-          __ bne(CCR0, slow);
+          __ cmpw(CR0, tmp, tmp2);
+          __ bne(CR0, slow);
         }
 
         Register src_ptr = R3_ARG1;
@@ -2080,8 +2080,8 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 #ifndef PRODUCT
         if (PrintC1Statistics) {
           Label failed;
-          __ cmpwi(CCR0, R3_RET, 0);
-          __ bne(CCR0, failed);
+          __ cmpwi(CR0, R3_RET, 0);
+          __ bne(CR0, failed);
           address counter = (address)&Runtime1::_arraycopy_checkcast_cnt;
           int simm16_offs = __ load_const_optimized(tmp, counter, tmp2, true);
           __ lwz(R11_scratch1, simm16_offs, tmp);
@@ -2092,8 +2092,8 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 #endif
 
         __ nand(tmp, R3_RET, R3_RET);
-        __ cmpwi(CCR0, R3_RET, 0);
-        __ beq(CCR0, *stub->continuation());
+        __ cmpwi(CR0, R3_RET, 0);
+        __ beq(CR0, *stub->continuation());
 
 #ifndef PRODUCT
         if (PrintC1Statistics) {
@@ -2126,15 +2126,15 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
     // but not necessarily exactly of type default_type.
     Label known_ok, halt;
     metadata2reg(default_type->constant_encoding(), tmp);
-    __ cmp_klass(CCR0, dst, tmp, R11_scratch1, R12_scratch2);
+    __ cmp_klass(CR0, dst, tmp, R11_scratch1, R12_scratch2);
     if (basic_type != T_OBJECT) {
-      __ bne(CCR0, halt);
-      __ cmp_klass(CCR0, src, tmp, R11_scratch1, R12_scratch2);
-      __ beq(CCR0, known_ok);
+      __ bne(CR0, halt);
+      __ cmp_klass(CR0, src, tmp, R11_scratch1, R12_scratch2);
+      __ beq(CR0, known_ok);
     } else {
-      __ beq(CCR0, known_ok);
-      __ cmpw(CCR0, src, dst);
-      __ beq(CCR0, known_ok);
+      __ beq(CR0, known_ok);
+      __ cmpw(CR0, src, dst);
+      __ beq(CR0, known_ok);
     }
     __ bind(halt);
     __ stop("incorrect type information in arraycopy");
@@ -2269,8 +2269,8 @@ void LIR_Assembler::emit_alloc_obj(LIR_OpAllocObj* op) {
     __ lbz(op->tmp1()->as_register(),
            in_bytes(InstanceKlass::init_state_offset()), op->klass()->as_register());
     // acquire barrier included in membar_storestore() which follows the allocation immediately.
-    __ cmpwi(CCR0, op->tmp1()->as_register(), InstanceKlass::fully_initialized);
-    __ bc_far_optimized(Assembler::bcondCRbiIs0, __ bi0(CCR0, Assembler::equal), *op->stub()->entry());
+    __ cmpwi(CR0, op->tmp1()->as_register(), InstanceKlass::fully_initialized);
+    __ bc_far_optimized(Assembler::bcondCRbiIs0, __ bi0(CR0, Assembler::equal), *op->stub()->entry());
   }
   __ allocate_object(op->obj()->as_register(),
                      op->tmp1()->as_register(),
@@ -2317,8 +2317,8 @@ void LIR_Assembler::type_profile_helper(Register mdo, int mdo_offset_bias,
     // See if the receiver is receiver[n].
     __ ld(tmp1, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_offset(i)) - mdo_offset_bias, mdo);
     __ verify_klass_ptr(tmp1);
-    __ cmpd(CCR0, recv, tmp1);
-    __ bne(CCR0, next_test);
+    __ cmpd(CR0, recv, tmp1);
+    __ bne(CR0, next_test);
 
     __ ld(tmp1, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_count_offset(i)) - mdo_offset_bias, mdo);
     __ addi(tmp1, tmp1, DataLayout::counter_increment);
@@ -2332,8 +2332,8 @@ void LIR_Assembler::type_profile_helper(Register mdo, int mdo_offset_bias,
   for (i = 0; i < VirtualCallData::row_limit(); i++) {
     Label next_test;
     __ ld(tmp1, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_offset(i)) - mdo_offset_bias, mdo);
-    __ cmpdi(CCR0, tmp1, 0);
-    __ bne(CCR0, next_test);
+    __ cmpdi(CR0, tmp1, 0);
+    __ bne(CR0, next_test);
     __ li(tmp1, DataLayout::counter_increment);
     __ std(recv, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_offset(i)) - mdo_offset_bias, mdo);
     __ std(tmp1, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_count_offset(i)) - mdo_offset_bias, mdo);
@@ -2394,8 +2394,8 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
     Label not_null;
     metadata2reg(md->constant_encoding(), mdo);
     __ add_const_optimized(mdo, mdo, mdo_offset_bias, R0);
-    __ cmpdi(CCR0, obj, 0);
-    __ bne(CCR0, not_null);
+    __ cmpdi(CR0, obj, 0);
+    __ bne(CR0, not_null);
     __ lbz(data_val, md->byte_offset_of_slot(data, DataLayout::flags_offset()) - mdo_offset_bias, mdo);
     __ ori(data_val, data_val, BitData::null_seen_byte_constant());
     __ stb(data_val, md->byte_offset_of_slot(data, DataLayout::flags_offset()) - mdo_offset_bias, mdo);
@@ -2412,8 +2412,8 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
     __ std(Rtmp1, slot_offset, mdo);
     __ bind(update_done);
   } else {
-    __ cmpdi(CCR0, obj, 0);
-    __ beq(CCR0, *obj_is_null);
+    __ cmpdi(CR0, obj, 0);
+    __ beq(CR0, *obj_is_null);
   }
 
   // get object class
@@ -2427,8 +2427,8 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
 
   if (op->fast_check()) {
     assert_different_registers(klass_RInfo, k_RInfo);
-    __ cmpd(CCR0, k_RInfo, klass_RInfo);
-    __ beq(CCR0, *success);
+    __ cmpd(CR0, k_RInfo, klass_RInfo);
+    __ beq(CR0, *success);
     // Fall through to failure case.
   } else {
     bool need_slow_path = true;
@@ -2462,7 +2462,7 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
       __ mtctr(original_Rtmp1);
       __ bctrl(); // sets CR0
       if (keep_obj_alive) { __ mr(obj, dst); }
-      __ beq(CCR0, *success);
+      __ beq(CR0, *success);
       // Fall through to failure case.
     }
   }
@@ -2501,8 +2501,8 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
       Register data_val = Rtmp1;
       metadata2reg(md->constant_encoding(), mdo);
       __ add_const_optimized(mdo, mdo, mdo_offset_bias, R0);
-      __ cmpdi(CCR0, value, 0);
-      __ bne(CCR0, not_null);
+      __ cmpdi(CR0, value, 0);
+      __ bne(CR0, not_null);
       __ lbz(data_val, md->byte_offset_of_slot(data, DataLayout::flags_offset()) - mdo_offset_bias, mdo);
       __ ori(data_val, data_val, BitData::null_seen_byte_constant());
       __ stb(data_val, md->byte_offset_of_slot(data, DataLayout::flags_offset()) - mdo_offset_bias, mdo);
@@ -2519,8 +2519,8 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
       __ std(Rtmp1, slot_offset, mdo);
       __ bind(update_done);
     } else {
-      __ cmpdi(CCR0, value, 0);
-      __ beq(CCR0, done);
+      __ cmpdi(CR0, value, 0);
+      __ beq(CR0, done);
     }
     if (!os::zero_page_read_protected() || !ImplicitNullChecks) {
       explicit_null_check(array, op->info_for_exception());
@@ -2543,7 +2543,7 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
     __ add_const_optimized(R0, R29_TOC, MacroAssembler::offset_to_global_toc(slow_path));
     __ mtctr(R0);
     __ bctrl(); // sets CR0
-    __ beq(CCR0, done);
+    __ beq(CR0, done);
 
     __ bind(failure);
     __ b(*stub->entry());
@@ -3024,9 +3024,9 @@ void LIR_Assembler::atomic_op(LIR_Code code, LIR_Opr src, LIR_Opr data, LIR_Opr 
   }
 
   if (UseStaticBranchPredictionInCompareAndSwapPPC64) {
-    __ bne_predict_not_taken(CCR0, Lretry);
+    __ bne_predict_not_taken(CR0, Lretry);
   } else {
-    __ bne(                  CCR0, Lretry);
+    __ bne(                  CR0, Lretry);
   }
 
   if (UseCompressedOops && data->is_oop()) {
@@ -3063,8 +3063,8 @@ void LIR_Assembler::emit_profile_type(LIR_OpProfileType* op) {
 
   if (do_null) {
     if (!TypeEntries::was_null_seen(current_klass)) {
-      __ cmpdi(CCR0, obj, 0);
-      __ bne(CCR0, Lupdate);
+      __ cmpdi(CR0, obj, 0);
+      __ bne(CR0, Lupdate);
       __ ld(R0, index_or_disp(mdo_addr), mdo_addr->base()->as_pointer_register());
       __ ori(R0, R0, TypeEntries::null_seen);
       if (do_update) {
@@ -3074,14 +3074,14 @@ void LIR_Assembler::emit_profile_type(LIR_OpProfileType* op) {
       }
     } else {
       if (do_update) {
-        __ cmpdi(CCR0, obj, 0);
-        __ beq(CCR0, Ldone);
+        __ cmpdi(CR0, obj, 0);
+        __ beq(CR0, Ldone);
       }
     }
 #ifdef ASSERT
   } else {
-    __ cmpdi(CCR0, obj, 0);
-    __ bne(CCR0, Lupdate);
+    __ cmpdi(CR0, obj, 0);
+    __ bne(CR0, Lupdate);
     __ stop("unexpected null obj");
 #endif
   }
@@ -3097,8 +3097,8 @@ void LIR_Assembler::emit_profile_type(LIR_OpProfileType* op) {
       klass_reg_used = true;
       __ load_klass(klass, obj);
       metadata2reg(exact_klass->constant_encoding(), R0);
-      __ cmpd(CCR0, klass, R0);
-      __ beq(CCR0, ok);
+      __ cmpd(CR0, klass, R0);
+      __ beq(CR0, ok);
       __ stop("exact klass and actual klass differ");
       __ bind(ok);
     }
@@ -3118,20 +3118,20 @@ void LIR_Assembler::emit_profile_type(LIR_OpProfileType* op) {
         // Like InterpreterMacroAssembler::profile_obj_type
         __ clrrdi(R0, tmp, exact_log2(-TypeEntries::type_klass_mask));
         // Basically same as andi(R0, tmp, TypeEntries::type_klass_mask);
-        __ cmpd(CCR1, R0, klass);
+        __ cmpd(CR1, R0, klass);
         // Klass seen before, nothing to do (regardless of unknown bit).
-        //beq(CCR1, do_nothing);
+        //beq(CR1, do_nothing);
 
         __ andi_(R0, tmp, TypeEntries::type_unknown);
         // Already unknown. Nothing to do anymore.
-        //bne(CCR0, do_nothing);
-        __ crorc(CCR0, Assembler::equal, CCR1, Assembler::equal); // cr0 eq = cr1 eq or cr0 ne
-        __ beq(CCR0, Lnext);
+        //bne(CR0, do_nothing);
+        __ crorc(CR0, Assembler::equal, CR1, Assembler::equal); // cr0 eq = cr1 eq or cr0 ne
+        __ beq(CR0, Lnext);
 
         if (TypeEntries::is_type_none(current_klass)) {
           __ clrrdi_(R0, tmp, exact_log2(-TypeEntries::type_mask));
           __ orr(R0, klass, tmp); // Combine klass and null_seen bit (only used if (tmp & type_mask)==0).
-          __ beq(CCR0, Ldo_update); // First time here. Set profile type.
+          __ beq(CR0, Ldo_update); // First time here. Set profile type.
         }
 
       } else {
@@ -3141,7 +3141,7 @@ void LIR_Assembler::emit_profile_type(LIR_OpProfileType* op) {
         __ ld(tmp, index_or_disp(mdo_addr), mdo_addr->base()->as_pointer_register());
         __ andi_(R0, tmp, TypeEntries::type_unknown);
         // Already unknown. Nothing to do anymore.
-        __ bne(CCR0, Lnext);
+        __ bne(CR0, Lnext);
       }
 
       // Different than before. Cannot keep accurate profile.
@@ -3157,14 +3157,14 @@ void LIR_Assembler::emit_profile_type(LIR_OpProfileType* op) {
 
         __ clrrdi(R0, tmp, exact_log2(-TypeEntries::type_klass_mask));
         // Basically same as andi(R0, tmp, TypeEntries::type_klass_mask);
-        __ cmpd(CCR1, R0, klass);
+        __ cmpd(CR1, R0, klass);
         // Klass seen before, nothing to do (regardless of unknown bit).
-        __ beq(CCR1, Lnext);
+        __ beq(CR1, Lnext);
 #ifdef ASSERT
         {
           Label ok;
           __ clrrdi_(R0, tmp, exact_log2(-TypeEntries::type_mask));
-          __ beq(CCR0, ok); // First time here.
+          __ beq(CR0, ok); // First time here.
 
           __ stop("unexpected profiling mismatch");
           __ bind(ok);
@@ -3178,7 +3178,7 @@ void LIR_Assembler::emit_profile_type(LIR_OpProfileType* op) {
 
         // Already unknown. Nothing to do anymore.
         __ andi_(R0, tmp, TypeEntries::type_unknown);
-        __ bne(CCR0, Lnext);
+        __ bne(CR0, Lnext);
 
         // Different than before. Cannot keep accurate profile.
         __ ori(R0, tmp, TypeEntries::type_unknown);

--- a/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
@@ -86,8 +86,8 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
   if (DiagnoseSyncOnValueBasedClasses != 0) {
     load_klass(Rscratch, Roop);
     lbz(Rscratch, in_bytes(Klass::misc_flags_offset()), Rscratch);
-    testbitdi(CCR0, R0, Rscratch, exact_log2(KlassFlags::_misc_is_value_based_class));
-    bne(CCR0, slow_int);
+    testbitdi(CR0, R0, Rscratch, exact_log2(KlassFlags::_misc_is_value_based_class));
+    bne(CR0, slow_int);
   }
 
   if (LockingMode == LM_LIGHTWEIGHT) {
@@ -101,7 +101,7 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
 
     // Compare object markWord with Rmark and if equal exchange Rscratch with object markWord.
     assert(oopDesc::mark_offset_in_bytes() == 0, "cas must take a zero displacement");
-    cmpxchgd(/*flag=*/CCR0,
+    cmpxchgd(/*flag=*/CR0,
              /*current_value=*/Rscratch,
              /*compare_value=*/Rmark,
              /*exchange_value=*/Rbox,
@@ -128,7 +128,7 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
     load_const_optimized(R0, (~(os::vm_page_size()-1) | markWord::lock_mask_in_place));
     and_(R0/*==0?*/, Rscratch, R0);
     std(R0/*==0, perhaps*/, BasicLock::displaced_header_offset_in_bytes(), Rbox);
-    bne(CCR0, slow_int);
+    bne(CR0, slow_int);
   }
 
   bind(done);
@@ -149,8 +149,8 @@ void C1_MacroAssembler::unlock_object(Register Rmark, Register Roop, Register Rb
   if (LockingMode != LM_LIGHTWEIGHT) {
     // Test first if it is a fast recursive unlock.
     ld(Rmark, BasicLock::displaced_header_offset_in_bytes(), Rbox);
-    cmpdi(CCR0, Rmark, 0);
-    beq(CCR0, done);
+    cmpdi(CR0, Rmark, 0);
+    beq(CR0, done);
   }
 
   // Load object.
@@ -162,7 +162,7 @@ void C1_MacroAssembler::unlock_object(Register Rmark, Register Roop, Register Rb
   } else if (LockingMode == LM_LEGACY) {
     // Check if it is still a light weight lock, this is is true if we see
     // the stack address of the basicLock in the markWord of the object.
-    cmpxchgd(/*flag=*/CCR0,
+    cmpxchgd(/*flag=*/CR0,
              /*current_value=*/R0,
              /*compare_value=*/Rbox,
              /*exchange_value=*/Rmark,
@@ -285,9 +285,9 @@ void C1_MacroAssembler::initialize_object(
   {
     lwz(t1, in_bytes(Klass::layout_helper_offset()), klass);
     if (var_size_in_bytes != noreg) {
-      cmpw(CCR0, t1, var_size_in_bytes);
+      cmpw(CR0, t1, var_size_in_bytes);
     } else {
-      cmpwi(CCR0, t1, con_size_in_bytes);
+      cmpwi(CR0, t1, con_size_in_bytes);
     }
     asm_assert_eq("bad size in initialize_object");
   }
@@ -340,8 +340,8 @@ void C1_MacroAssembler::allocate_array(
     if (max_tlab < max_length) { max_length = max_tlab; }
   }
   load_const_optimized(t1, max_length);
-  cmpld(CCR0, len, t1);
-  bc_far_optimized(Assembler::bcondCRbiIs1, bi0(CCR0, Assembler::greater), slow_case);
+  cmpld(CR0, len, t1);
+  bc_far_optimized(Assembler::bcondCRbiIs1, bi0(CR0, Assembler::greater), slow_case);
 
   // compute array size
   // note: If 0 <= len <= max_length, len*elt_size + header + alignment is
@@ -399,8 +399,8 @@ void C1_MacroAssembler::verify_stack_oop(int stack_offset) {
 
 void C1_MacroAssembler::verify_not_null_oop(Register r) {
   Label not_null;
-  cmpdi(CCR0, r, 0);
-  bne(CCR0, not_null);
+  cmpdi(CR0, r, 0);
+  bne(CR0, not_null);
   stop("non-null oop required");
   bind(not_null);
   verify_oop(r, FILE_AND_LINE);
@@ -414,7 +414,7 @@ void C1_MacroAssembler::null_check(Register r, Label* Lnull) {
   } else { // explicit
     //const address exception_entry = Runtime1::entry_for(C1StubId::throw_null_pointer_exception_id);
     assert(Lnull != nullptr, "must have Label for explicit check");
-    cmpdi(CCR0, r, 0);
-    bc_far_optimized(Assembler::bcondCRbiIs1, bi0(CCR0, Assembler::equal), *Lnull);
+    cmpdi(CR0, r, 0);
+    bc_far_optimized(Assembler::bcondCRbiIs1, bi0(CR0, Assembler::equal), *Lnull);
   }
 }

--- a/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
@@ -69,14 +69,14 @@ int StubAssembler::call_RT(Register oop_result1, Register metadata_result,
   // Check for pending exceptions.
   {
     ld(R0, in_bytes(Thread::pending_exception_offset()), R16_thread);
-    cmpdi(CCR0, R0, 0);
+    cmpdi(CR0, R0, 0);
 
     // This used to conditionally jump to forward_exception however it is
     // possible if we relocate that the branch will not reach. So we must jump
     // around so we can always reach.
 
     Label ok;
-    beq(CCR0, ok);
+    beq(CR0, ok);
 
     // Make sure that the vm_results are cleared.
     if (oop_result1->is_valid() || metadata_result->is_valid()) {
@@ -368,7 +368,7 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
   int call_offset = __ call_RT(noreg, noreg, target);
   OopMapSet* oop_maps = new OopMapSet();
   oop_maps->add_gc_map(call_offset, oop_map);
-  __ cmpdi(CCR0, R3_RET, 0);
+  __ cmpdi(CR0, R3_RET, 0);
 
   // Re-execute the patched instruction or, if the nmethod was deoptmized,
   // return to the deoptimization handler entry that will cause re-execution
@@ -382,7 +382,7 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
 
   restore_live_registers(sasm, noreg, noreg);
   // Return if patching routine returned 0.
-  __ bclr(Assembler::bcondCRbiIs1, Assembler::bi0(CCR0, Assembler::equal), Assembler::bhintbhBCLRisReturn);
+  __ bclr(Assembler::bcondCRbiIs1, Assembler::bi0(CR0, Assembler::equal), Assembler::bhintbhBCLRisReturn);
 
   address stub = deopt_blob->unpack_with_reexecution();
   //__ load_const_optimized(R0, stub);
@@ -448,8 +448,8 @@ OopMapSet* Runtime1::generate_code_for(C1StubId id, StubAssembler* sasm) {
           Label ok;
           __ lwz(R0, in_bytes(Klass::layout_helper_offset()), R4_ARG2);
           __ srawi(R0, R0, Klass::_lh_array_tag_shift);
-          __ cmpwi(CCR0, R0, tag);
-          __ beq(CCR0, ok);
+          __ cmpwi(CR0, R0, tag);
+          __ beq(CR0, ok);
           __ stop("assert(is an array klass)");
           __ should_not_reach_here();
           __ bind(ok);
@@ -485,9 +485,9 @@ OopMapSet* Runtime1::generate_code_for(C1StubId id, StubAssembler* sasm) {
         // Load the klass and check the has finalizer flag.
         __ load_klass(t, R3_ARG1);
         __ lbz(t, in_bytes(Klass::misc_flags_offset()), t);
-        __ testbitdi(CCR0, R0, t, exact_log2(KlassFlags::_misc_has_finalizer));
+        __ testbitdi(CR0, R0, t, exact_log2(KlassFlags::_misc_has_finalizer));
         // Return if has_finalizer bit == 0 (CR0.eq).
-        __ bclr(Assembler::bcondCRbiIs1, Assembler::bi0(CCR0, Assembler::equal), Assembler::bhintbhBCLRisReturn);
+        __ bclr(Assembler::bcondCRbiIs1, Assembler::bi0(CR0, Assembler::equal), Assembler::bhintbhBCLRisReturn);
 
         __ mflr(R0);
         __ std(R0, _abi0(lr), R1_SP);
@@ -805,10 +805,10 @@ OopMapSet* Runtime1::generate_handle_exception(C1StubId id, StubAssembler* sasm)
   // Check that fields in JavaThread for exception oop and issuing pc are
   // empty before writing to them.
   __ ld(R0, in_bytes(JavaThread::exception_oop_offset()), R16_thread);
-  __ cmpdi(CCR0, R0, 0);
+  __ cmpdi(CR0, R0, 0);
   __ asm_assert_eq("exception oop already set");
   __ ld(R0, in_bytes(JavaThread::exception_pc_offset() ), R16_thread);
-  __ cmpdi(CCR0, R0, 0);
+  __ cmpdi(CR0, R0, 0);
   __ asm_assert_eq("exception pc already set");
 #endif
 

--- a/src/hotspot/cpu/ppc/downcallLinker_ppc.cpp
+++ b/src/hotspot/cpu/ppc/downcallLinker_ppc.cpp
@@ -282,8 +282,8 @@ void DowncallLinker::StubGenerator::generate() {
     __ safepoint_poll(L_safepoint_poll_slow_path, tmp, true /* at_return */, false /* in_nmethod */);
 
     __ lwz(tmp, in_bytes(JavaThread::suspend_flags_offset()), R16_thread);
-    __ cmpwi(CCR0, tmp, 0);
-    __ bne(CCR0, L_safepoint_poll_slow_path);
+    __ cmpwi(CR0, tmp, 0);
+    __ bne(CR0, L_safepoint_poll_slow_path);
     __ bind(L_after_safepoint_poll);
 
     // change thread state
@@ -293,8 +293,8 @@ void DowncallLinker::StubGenerator::generate() {
 
     __ block_comment("reguard stack check");
     __ lwz(tmp, in_bytes(JavaThread::stack_guard_state_offset()), R16_thread);
-    __ cmpwi(CCR0, tmp, StackOverflow::stack_guard_yellow_reserved_disabled);
-    __ beq(CCR0, L_reguard);
+    __ cmpwi(CR0, tmp, StackOverflow::stack_guard_yellow_reserved_disabled);
+    __ beq(CR0, L_reguard);
     __ bind(L_after_reguard);
 
     __ reset_last_Java_frame();

--- a/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/g1/g1BarrierSetAssembler_ppc.cpp
@@ -51,7 +51,7 @@ static void generate_marking_inactive_test(MacroAssembler* masm) {
   int active_offset = in_bytes(G1ThreadLocalData::satb_mark_queue_active_offset());
   assert(in_bytes(SATBMarkQueue::byte_width_of_active()) == 1, "Assumption");
   __ lbz(R0, active_offset, R16_thread);  // tmp1 := *(mark queue active address)
-  __ cmpwi(CCR0, R0, 0);
+  __ cmpwi(CR0, R0, 0);
 }
 
 void G1BarrierSetAssembler::gen_write_ref_array_pre_barrier(MacroAssembler* masm, DecoratorSet decorators,
@@ -68,7 +68,7 @@ void G1BarrierSetAssembler::gen_write_ref_array_pre_barrier(MacroAssembler* masm
 
     // Is marking active?
     generate_marking_inactive_test(masm);
-    __ beq(CCR0, filtered);
+    __ beq(CR0, filtered);
 
     __ save_LR(R0);
     __ push_frame(frame_size, R0);
@@ -118,8 +118,8 @@ static void generate_queue_insertion(MacroAssembler* masm, ByteSize index_offset
   // Can we store a value in the given thread's buffer?
   // (The index field is typed as size_t.)
   __ ld(temp, in_bytes(index_offset), R16_thread);  // temp := *(index address)
-  __ cmpdi(CCR0, temp, 0);                          // jump to runtime if index == 0 (full buffer)
-  __ beq(CCR0, runtime);
+  __ cmpdi(CR0, temp, 0);                          // jump to runtime if index == 0 (full buffer)
+  __ beq(CR0, runtime);
   // The buffer is not full, store value into it.
   __ ld(R0, in_bytes(buffer_offset), R16_thread);   // R0 := buffer address
   __ addi(temp, temp, -wordSize);                   // temp := next index
@@ -154,7 +154,7 @@ void G1BarrierSetAssembler::g1_write_barrier_pre(MacroAssembler* masm, Decorator
   Label runtime, filtered;
 
   generate_marking_inactive_test(masm);
-  __ beq(CCR0, filtered);
+  __ beq(CR0, filtered);
 
   // Do we need to load the previous value?
   if (!preloaded) {
@@ -171,12 +171,12 @@ void G1BarrierSetAssembler::g1_write_barrier_pre(MacroAssembler* masm, Decorator
   // Is the previous value null?
   if (preloaded && not_null) {
 #ifdef ASSERT
-    __ cmpdi(CCR0, pre_val, 0);
+    __ cmpdi(CR0, pre_val, 0);
     __ asm_assert_ne("null oop not allowed (G1 pre)"); // Checked by caller.
 #endif
   } else {
-    __ cmpdi(CCR0, pre_val, 0);
-    __ beq(CCR0, filtered);
+    __ cmpdi(CR0, pre_val, 0);
+    __ beq(CR0, filtered);
   }
 
   if (!preloaded && UseCompressedOops) {
@@ -240,14 +240,14 @@ static Address generate_card_young_test(MacroAssembler* masm, const Register sto
   __ load_const_optimized(tmp1, (address)(ct->card_table()->byte_map_base()), tmp2);
   __ srdi(tmp2, store_addr, CardTable::card_shift());        // tmp1 := card address relative to card table base
   __ lbzx(R0, tmp1, tmp2);                                   // tmp1 := card address
-  __ cmpwi(CCR0, R0, (int)G1CardTable::g1_young_card_val());
+  __ cmpwi(CR0, R0, (int)G1CardTable::g1_young_card_val());
   return Address(tmp1, tmp2); // return card address
 }
 
 static void generate_card_dirty_test(MacroAssembler* masm, Address card_addr) {
   __ membar(Assembler::StoreLoad);                        // Must reload after StoreLoad membar due to concurrent refinement
   __ lbzx(R0, card_addr.base(), card_addr.index());       // tmp2 := card
-  __ cmpwi(CCR0, R0, (int)G1CardTable::dirty_card_val()); // tmp2 := card == dirty_card_val?
+  __ cmpwi(CR0, R0, (int)G1CardTable::dirty_card_val()); // tmp2 := card == dirty_card_val?
 }
 
 void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm, DecoratorSet decorators,
@@ -262,24 +262,24 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm, Decorato
   CardTableBarrierSet* ct = barrier_set_cast<CardTableBarrierSet>(BarrierSet::barrier_set());
 
   generate_region_crossing_test(masm, store_addr, new_val);
-  __ beq(CCR0, filtered);
+  __ beq(CR0, filtered);
 
   // Crosses regions, storing null?
   if (not_null) {
 #ifdef ASSERT
-    __ cmpdi(CCR0, new_val, 0);
+    __ cmpdi(CR0, new_val, 0);
     __ asm_assert_ne("null oop not allowed (G1 post)"); // Checked by caller.
 #endif
   } else {
-    __ cmpdi(CCR0, new_val, 0);
-    __ beq(CCR0, filtered);
+    __ cmpdi(CR0, new_val, 0);
+    __ beq(CR0, filtered);
   }
 
   Address card_addr = generate_card_young_test(masm, store_addr, tmp1, tmp2);
-  __ beq(CCR0, filtered);
+  __ beq(CR0, filtered);
 
   generate_card_dirty_test(masm, card_addr);
-  __ beq(CCR0, filtered);
+  __ beq(CR0, filtered);
 
   __ li(R0, (int)G1CardTable::dirty_card_val());
   __ stbx(R0, card_addr.base(), card_addr.index()); // *(card address) := dirty_card_val
@@ -371,14 +371,14 @@ void G1BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value
                                             Register tmp1, Register tmp2,
                                             MacroAssembler::PreservationLevel preservation_level) {
   Label done, not_weak;
-  __ cmpdi(CCR0, value, 0);
-  __ beq(CCR0, done);         // Use null as-is.
+  __ cmpdi(CR0, value, 0);
+  __ beq(CR0, done);         // Use null as-is.
 
   __ clrrdi(tmp1, value, JNIHandles::tag_size);
   __ andi_(tmp2, value, JNIHandles::TypeTag::weak_global);
   __ ld(value, 0, tmp1);      // Resolve (untagged) jobject.
 
-  __ beq(CCR0, not_weak);     // Test for jweak tag.
+  __ beq(CR0, not_weak);     // Test for jweak tag.
   __ verify_oop(value, FILE_AND_LINE);
   g1_write_barrier_pre(masm, IN_NATIVE | ON_PHANTOM_OOP_REF,
                        noreg, noreg, value,
@@ -409,7 +409,7 @@ void G1BarrierSetAssembler::g1_write_barrier_pre_c2(MacroAssembler* masm,
   stub->initialize_registers(obj, pre_val, R16_thread, tmp1, tmp2);
 
   generate_marking_inactive_test(masm);
-  __ bc_far_optimized(Assembler::bcondCRbiIs0, __ bi0(CCR0, Assembler::equal), *stub->entry());
+  __ bc_far_optimized(Assembler::bcondCRbiIs0, __ bi0(CR0, Assembler::equal), *stub->entry());
 
   __ bind(*stub->continuation());
 }
@@ -433,8 +433,8 @@ void G1BarrierSetAssembler::generate_c2_pre_barrier_stub(MacroAssembler* masm,
       __ ld(pre_val, 0, obj);
     }
   }
-  __ cmpdi(CCR0, pre_val, 0);
-  __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CCR0, Assembler::equal), *stub->continuation());
+  __ cmpdi(CR0, pre_val, 0);
+  __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CR0, Assembler::equal), *stub->continuation());
 
   Register pre_val_decoded = pre_val;
   if (UseCompressedOops) {
@@ -472,25 +472,25 @@ void G1BarrierSetAssembler::g1_write_barrier_post_c2(MacroAssembler* masm,
     if (null_check_required && CompressedOops::base() != nullptr) {
       // We prefer doing the null check after the region crossing check.
       // Only compressed oop modes with base != null require a null check here.
-      __ cmpwi(CCR0, new_val, 0);
-      __ beq(CCR0, *stub->continuation());
+      __ cmpwi(CR0, new_val, 0);
+      __ beq(CR0, *stub->continuation());
       null_check_required = false;
     }
     new_val_decoded = __ decode_heap_oop_not_null(tmp2, new_val);
   }
 
   generate_region_crossing_test(masm, store_addr, new_val_decoded);
-  __ beq(CCR0, *stub->continuation());
+  __ beq(CR0, *stub->continuation());
 
   // crosses regions, storing null?
   if (null_check_required) {
-    __ cmpdi(CCR0, new_val_decoded, 0);
-    __ beq(CCR0, *stub->continuation());
+    __ cmpdi(CR0, new_val_decoded, 0);
+    __ beq(CR0, *stub->continuation());
   }
 
   Address card_addr = generate_card_young_test(masm, store_addr, tmp1, tmp2);
   assert(card_addr.base() == tmp1 && card_addr.index() == tmp2, "needed by post barrier stub");
-  __ bc_far_optimized(Assembler::bcondCRbiIs0, __ bi0(CCR0, Assembler::equal), *stub->entry());
+  __ bc_far_optimized(Assembler::bcondCRbiIs0, __ bi0(CR0, Assembler::equal), *stub->entry());
 
   __ bind(*stub->continuation());
 }
@@ -504,7 +504,7 @@ void G1BarrierSetAssembler::generate_c2_post_barrier_stub(MacroAssembler* masm,
   __ bind(*stub->entry());
 
   generate_card_dirty_test(masm, card_addr);
-  __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CCR0, Assembler::equal), *stub->continuation());
+  __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CR0, Assembler::equal), *stub->continuation());
 
   __ li(R0, (int)G1CardTable::dirty_card_val());
   __ stbx(R0, card_addr.base(), card_addr.index()); // *(card address) := dirty_card_val
@@ -546,8 +546,8 @@ void G1BarrierSetAssembler::gen_pre_barrier_stub(LIR_Assembler* ce, G1PreBarrier
     ce->mem2reg(stub->addr(), stub->pre_val(), T_OBJECT, stub->patch_code(), stub->info(), false /*wide*/);
   }
 
-  __ cmpdi(CCR0, pre_val_reg, 0);
-  __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CCR0, Assembler::equal), *stub->continuation());
+  __ cmpdi(CR0, pre_val_reg, 0);
+  __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CR0, Assembler::equal), *stub->continuation());
 
   address c_code = bs->pre_barrier_c1_runtime_code_blob()->code_begin();
   //__ load_const_optimized(R0, c_code);
@@ -567,8 +567,8 @@ void G1BarrierSetAssembler::gen_post_barrier_stub(LIR_Assembler* ce, G1PostBarri
   Register addr_reg = stub->addr()->as_pointer_register();
   Register new_val_reg = stub->new_val()->as_register();
 
-  __ cmpdi(CCR0, new_val_reg, 0);
-  __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CCR0, Assembler::equal), *stub->continuation());
+  __ cmpdi(CR0, new_val_reg, 0);
+  __ bc_far_optimized(Assembler::bcondCRbiIs1, __ bi0(CR0, Assembler::equal), *stub->continuation());
 
   address c_code = bs->post_barrier_c1_runtime_code_blob()->code_begin();
   //__ load_const_optimized(R0, c_code);
@@ -604,7 +604,7 @@ void G1BarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAssembler* 
 
   // Is marking still active?
   generate_marking_inactive_test(sasm);
-  __ beq(CCR0, marking_not_active);
+  __ beq(CR0, marking_not_active);
 
   __ bind(restart);
   // Load the index into the SATB buffer. SATBMarkQueue::_index is a
@@ -612,8 +612,8 @@ void G1BarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAssembler* 
   __ ld(tmp, satb_q_index_byte_offset, R16_thread);
 
   // index == 0?
-  __ cmpdi(CCR0, tmp, 0);
-  __ beq(CCR0, refill);
+  __ cmpdi(CR0, tmp, 0);
+  __ beq(CR0, refill);
 
   __ ld(tmp2, satb_q_buf_byte_offset, R16_thread);
   __ ld(pre_val, -8, R1_SP); // Load from stack.
@@ -666,15 +666,15 @@ void G1BarrierSetAssembler::generate_c1_post_barrier_runtime_stub(StubAssembler*
   __ lbz(tmp, 0, addr); // tmp := [addr + cardtable]
 
   // Return if young card.
-  __ cmpwi(CCR0, tmp, G1CardTable::g1_young_card_val());
-  __ beq(CCR0, ret);
+  __ cmpwi(CR0, tmp, G1CardTable::g1_young_card_val());
+  __ beq(CR0, ret);
 
   // Return if sequential consistent value is already dirty.
   __ membar(Assembler::StoreLoad);
   __ lbz(tmp, 0, addr); // tmp := [addr + cardtable]
 
-  __ cmpwi(CCR0, tmp, G1CardTable::dirty_card_val());
-  __ beq(CCR0, ret);
+  __ cmpwi(CR0, tmp, G1CardTable::dirty_card_val());
+  __ beq(CR0, ret);
 
   // Not dirty.
 
@@ -692,8 +692,8 @@ void G1BarrierSetAssembler::generate_c1_post_barrier_runtime_stub(StubAssembler*
   __ ld(tmp2, dirty_card_q_index_byte_offset, R16_thread);
 
   // index == 0?
-  __ cmpdi(CCR0, tmp2, 0);
-  __ beq(CCR0, refill);
+  __ cmpdi(CR0, tmp2, 0);
+  __ beq(CR0, refill);
 
   __ ld(tmp, dirty_card_q_buf_byte_offset, R16_thread);
   __ addi(tmp2, tmp2, -oopSize);

--- a/src/hotspot/cpu/ppc/gc/g1/g1_ppc.ad
+++ b/src/hotspot/cpu/ppc/gc/g1/g1_ppc.ad
@@ -164,7 +164,7 @@ instruct g1CompareAndExchangeP(iRegPdst res, indirect mem, iRegPsrc oldval, iReg
   format %{ "cmpxchgd $newval, $mem" %}
   ins_encode %{
     Label no_update;
-    __ cmpxchgd(CCR0, $res$$Register, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgd(CR0, $res$$Register, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true);
     // Pass oldval to SATB which is the only value which can get overwritten.
@@ -194,7 +194,7 @@ instruct g1CompareAndExchangeP_acq(iRegPdst res, indirect mem, iRegPsrc oldval, 
   format %{ "cmpxchgd acq $newval, $mem" %}
   ins_encode %{
     Label no_update;
-    __ cmpxchgd(CCR0, $res$$Register, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgd(CR0, $res$$Register, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true);
     // Pass oldval to SATB which is the only value which can get overwritten.
@@ -230,7 +230,7 @@ instruct g1CompareAndExchangeN(iRegNdst res, indirect mem, iRegNsrc oldval, iReg
   format %{ "cmpxchgw $newval, $mem" %}
   ins_encode %{
     Label no_update;
-    __ cmpxchgw(CCR0, $res$$Register, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgw(CR0, $res$$Register, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true);
     // Pass oldval to SATB which is the only value which can get overwritten.
@@ -261,7 +261,7 @@ instruct g1CompareAndExchangeN_acq(iRegNdst res, indirect mem, iRegNsrc oldval, 
   format %{ "cmpxchgw acq $newval, $mem" %}
   ins_encode %{
     Label no_update;
-    __ cmpxchgw(CCR0, $res$$Register, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgw(CR0, $res$$Register, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true);
     // Pass oldval to SATB which is the only value which can get overwritten.
@@ -299,7 +299,7 @@ instruct g1CompareAndSwapP(iRegIdst res, indirect mem, iRegPsrc oldval, iRegPsrc
   ins_encode %{
     Label no_update;
     __ li($res$$Register, 0);
-    __ cmpxchgd(CCR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgd(CR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true);
     // Pass oldval to SATB which is the only value which can get overwritten.
@@ -332,7 +332,7 @@ instruct g1CompareAndSwapP_acq(iRegIdst res, indirect mem, iRegPsrc oldval, iReg
   ins_encode %{
     Label no_update;
     __ li($res$$Register, 0);
-    __ cmpxchgd(CCR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgd(CR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true);
     // Pass oldval to SATB which is the only value which can get overwritten.
@@ -371,7 +371,7 @@ instruct g1CompareAndSwapN(iRegIdst res, indirect mem, iRegNsrc oldval, iRegNsrc
   ins_encode %{
     Label no_update;
     __ li($res$$Register, 0);
-    __ cmpxchgw(CCR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgw(CR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true);
     // Pass oldval to SATB which is the only value which can get overwritten.
@@ -405,7 +405,7 @@ instruct g1CompareAndSwapN_acq(iRegIdst res, indirect mem, iRegNsrc oldval, iReg
   ins_encode %{
     Label no_update;
     __ li($res$$Register, 0);
-    __ cmpxchgw(CCR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgw(CR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true);
     // Pass oldval to SATB which is the only value which can get overwritten.
@@ -445,7 +445,7 @@ instruct weakG1CompareAndSwapP(iRegIdst res, indirect mem, iRegPsrc oldval, iReg
   ins_encode %{
     Label no_update;
     __ li($res$$Register, 0);
-    __ cmpxchgd(CCR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgd(CR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true, true);
     // Pass oldval to SATB which is the only value which can get overwritten.
@@ -478,7 +478,7 @@ instruct weakG1CompareAndSwapP_acq(iRegIdst res, indirect mem, iRegPsrc oldval, 
   ins_encode %{
     Label no_update;
     __ li($res$$Register, 0);
-    __ cmpxchgd(CCR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgd(CR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true, true);
     // Pass oldval to SATB which is the only value which can get overwritten.
@@ -517,7 +517,7 @@ instruct weakG1CompareAndSwapN(iRegIdst res, indirect mem, iRegNsrc oldval, iReg
   ins_encode %{
     Label no_update;
     __ li($res$$Register, 0);
-    __ cmpxchgw(CCR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgw(CR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true, true);
     // Pass oldval to SATB which is the only value which can get overwritten.
@@ -551,7 +551,7 @@ instruct weakG1CompareAndSwapN_acq(iRegIdst res, indirect mem, iRegNsrc oldval, 
   ins_encode %{
     Label no_update;
     __ li($res$$Register, 0);
-    __ cmpxchgw(CCR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
+    __ cmpxchgw(CR0, R0, $oldval$$Register, $newval$$Register, $mem$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, &no_update, true, true);
     // Pass oldval to SATB which is the only value which can get overwritten.

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -89,8 +89,8 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
     if (UseCompressedOops && in_heap) {
       if (L_handle_null != nullptr) { // Label provided.
         __ lwz(dst, ind_or_offs, base);
-        __ cmpwi(CCR0, dst, 0);
-        __ beq(CCR0, *L_handle_null);
+        __ cmpwi(CR0, dst, 0);
+        __ beq(CR0, *L_handle_null);
         __ decode_heap_oop_not_null(dst);
       } else if (not_null) { // Guaranteed to be not null.
         Register narrowOop = (tmp1 != noreg && CompressedOops::base_disjoint()) ? tmp1 : dst;
@@ -103,8 +103,8 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
     } else {
       __ ld(dst, ind_or_offs, base);
       if (L_handle_null != nullptr) {
-        __ cmpdi(CCR0, dst, 0);
-        __ beq(CCR0, *L_handle_null);
+        __ cmpdi(CR0, dst, 0);
+        __ beq(CR0, *L_handle_null);
       }
     }
     break;
@@ -118,11 +118,11 @@ void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value,
                                           Register tmp1, Register tmp2,
                                           MacroAssembler::PreservationLevel preservation_level) {
   Label done, tagged, weak_tagged, verify;
-  __ cmpdi(CCR0, value, 0);
-  __ beq(CCR0, done);         // Use null as-is.
+  __ cmpdi(CR0, value, 0);
+  __ beq(CR0, done);         // Use null as-is.
 
   __ andi_(tmp1, value, JNIHandles::tag_mask);
-  __ bne(CCR0, tagged);       // Test for tag.
+  __ bne(CR0, tagged);       // Test for tag.
 
   __ access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, // no uncoloring
                     value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
@@ -131,7 +131,7 @@ void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value,
   __ bind(tagged);
   __ andi_(tmp1, value, JNIHandles::TypeTag::weak_global);
   __ clrrdi(value, value, JNIHandles::tag_size); // Untag.
-  __ bne(CCR0, weak_tagged);   // Test for jweak tag.
+  __ bne(CR0, weak_tagged);   // Test for jweak tag.
 
   __ access_load_at(T_OBJECT, IN_NATIVE,
                     value, (intptr_t)0, value, tmp1, tmp2, preservation_level);
@@ -152,14 +152,14 @@ void BarrierSetAssembler::resolve_global_jobject(MacroAssembler* masm, Register 
                                           MacroAssembler::PreservationLevel preservation_level) {
   Label done;
 
-  __ cmpdi(CCR0, value, 0);
-  __ beq(CCR0, done);         // Use null as-is.
+  __ cmpdi(CR0, value, 0);
+  __ beq(CR0, done);         // Use null as-is.
 
 #ifdef ASSERT
   {
     Label valid_global_tag;
     __ andi_(tmp1, value, JNIHandles::TypeTag::global);
-    __ bne(CCR0, valid_global_tag);       // Test for global tag.
+    __ bne(CR0, valid_global_tag);       // Test for global tag.
     __ stop("non global jobject using resolve_global_jobject");
     __ bind(valid_global_tag);
   }
@@ -200,9 +200,9 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register t
 
   // Low order half of 64 bit value is currently used.
   __ ld(R0, in_bytes(bs_nm->thread_disarmed_guard_value_offset()), R16_thread);
-  __ cmpw(CCR0, R0, tmp);
+  __ cmpw(CR0, R0, tmp);
 
-  __ bnectrl(CCR0);
+  __ bnectrl(CR0);
 
   // Oops may have been changed. Make those updates observable.
   // "isync" can serve both, data and instruction patching.
@@ -229,8 +229,8 @@ void BarrierSetAssembler::c2i_entry_barrier(MacroAssembler *masm, Register tmp1,
   Label bad_call, skip_barrier;
 
   // Fast path: If no method is given, the call is definitely bad.
-  __ cmpdi(CCR0, R19_method, 0);
-  __ beq(CCR0, bad_call);
+  __ cmpdi(CR0, R19_method, 0);
+  __ beq(CR0, bad_call);
 
   // Load class loader data to determine whether the method's holder is concurrently unloading.
   __ load_method_holder(tmp1, R19_method);
@@ -238,14 +238,14 @@ void BarrierSetAssembler::c2i_entry_barrier(MacroAssembler *masm, Register tmp1,
 
   // Fast path: If class loader is strong, the holder cannot be unloaded.
   __ lwz(tmp2, in_bytes(ClassLoaderData::keep_alive_ref_count_offset()), tmp1_class_loader_data);
-  __ cmpdi(CCR0, tmp2, 0);
-  __ bne(CCR0, skip_barrier);
+  __ cmpdi(CR0, tmp2, 0);
+  __ bne(CR0, skip_barrier);
 
   // Class loader is weak. Determine whether the holder is still alive.
   __ ld(tmp2, in_bytes(ClassLoaderData::holder_offset()), tmp1_class_loader_data);
   __ resolve_weak_handle(tmp2, tmp1, tmp3, MacroAssembler::PreservationLevel::PRESERVATION_FRAME_LR_GP_FP_REGS);
-  __ cmpdi(CCR0, tmp2, 0);
-  __ bne(CCR0, skip_barrier);
+  __ cmpdi(CR0, tmp2, 0);
+  __ bne(CR0, skip_barrier);
 
   __ bind(bad_call);
 

--- a/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/cardTableBarrierSetAssembler_ppc.cpp
@@ -49,7 +49,7 @@ void CardTableBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembl
   Label Lskip_loop, Lstore_loop;
 
   __ sldi_(count, count, LogBytesPerHeapOop);
-  __ beq(CCR0, Lskip_loop); // zero length
+  __ beq(CR0, Lskip_loop); // zero length
   __ addi(count, count, -BytesPerHeapOop);
   __ add(count, addr, count);
   // Use two shifts to clear out those low order two bits! (Cannot opt. into 1.)

--- a/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/modRefBarrierSetAssembler_ppc.cpp
@@ -80,8 +80,8 @@ void ModRefBarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register v
                                                 Register tmp1, Register tmp2,
                                                 MacroAssembler::PreservationLevel preservation_level) {
   Label done;
-  __ cmpdi(CCR0, value, 0);
-  __ beq(CCR0, done);         // Use null as-is.
+  __ cmpdi(CR0, value, 0);
+  __ beq(CR0, done);         // Use null as-is.
 
   __ clrrdi(tmp1, value, JNIHandles::tag_size);
   __ ld(value, 0, tmp1);      // Resolve (untagged) jobject.

--- a/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
@@ -102,8 +102,8 @@ void ShenandoahBarrierSetAssembler::arraycopy_prologue(MacroAssembler *masm, Dec
   Label skip_prologue;
 
   // Fast path: Array is of length zero.
-  __ cmpdi(CCR0, count, 0);
-  __ beq(CCR0, skip_prologue);
+  __ cmpdi(CR0, count, 0);
+  __ beq(CR0, skip_prologue);
 
   /* ==== Check whether barrier is required (gc state) ==== */
   __ lbz(R11_tmp, in_bytes(ShenandoahThreadLocalData::gc_state_offset()),
@@ -118,7 +118,7 @@ void ShenandoahBarrierSetAssembler::arraycopy_prologue(MacroAssembler *masm, Dec
                               : ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::MARKING;
 
   __ andi_(R11_tmp, R11_tmp, required_states);
-  __ beq(CCR0, skip_prologue);
+  __ beq(CR0, skip_prologue);
 
   /* ==== Invoke runtime ==== */
   // Save to-be-preserved registers.
@@ -216,7 +216,7 @@ void ShenandoahBarrierSetAssembler::satb_write_barrier_impl(MacroAssembler *masm
   __ lbz(tmp1, in_bytes(ShenandoahThreadLocalData::gc_state_offset()), R16_thread);
 
   __ andi_(tmp1, tmp1, ShenandoahHeap::MARKING);
-  __ beq(CCR0, skip_barrier);
+  __ beq(CR0, skip_barrier);
 
   /* ==== Determine the reference's previous value ==== */
   bool preloaded_mode = base == noreg;
@@ -235,12 +235,12 @@ void ShenandoahBarrierSetAssembler::satb_write_barrier_impl(MacroAssembler *masm
 
     if ((decorators & IS_NOT_NULL) != 0) {
 #ifdef ASSERT
-      __ cmpdi(CCR0, pre_val, 0);
+      __ cmpdi(CR0, pre_val, 0);
       __ asm_assert_ne("null oop is not allowed");
 #endif // ASSERT
     } else {
-      __ cmpdi(CCR0, pre_val, 0);
-      __ beq(CCR0, skip_barrier);
+      __ cmpdi(CR0, pre_val, 0);
+      __ beq(CR0, skip_barrier);
     }
   } else {
     // Load from the reference address to determine the reference's current value (before the store is being performed).
@@ -254,8 +254,8 @@ void ShenandoahBarrierSetAssembler::satb_write_barrier_impl(MacroAssembler *masm
       __ ld(pre_val, ind_or_offs, base);
     }
 
-    __ cmpdi(CCR0, pre_val, 0);
-    __ beq(CCR0, skip_barrier);
+    __ cmpdi(CR0, pre_val, 0);
+    __ beq(CR0, skip_barrier);
 
     if (UseCompressedOops) {
       __ decode_heap_oop_not_null(pre_val);
@@ -271,8 +271,8 @@ void ShenandoahBarrierSetAssembler::satb_write_barrier_impl(MacroAssembler *masm
     // If not, jump to the runtime to commit the buffer and to allocate a new one.
     // (The buffer's index corresponds to the amount of remaining free space.)
     __ ld(Rindex, in_bytes(ShenandoahThreadLocalData::satb_mark_queue_index_offset()), R16_thread);
-    __ cmpdi(CCR0, Rindex, 0);
-    __ beq(CCR0, runtime); // If index == 0 (buffer is full), goto runtime.
+    __ cmpdi(CR0, Rindex, 0);
+    __ beq(CR0, runtime); // If index == 0 (buffer is full), goto runtime.
 
     // Capacity suffices.  Decrement the queue's size by the size of one oop.
     // (The buffer is filled contrary to the heap's growing direction, i.e., it is filled downwards.)
@@ -362,9 +362,9 @@ void ShenandoahBarrierSetAssembler::resolve_forward_pointer_not_null(MacroAssemb
          "marked value must equal the value obtained when all lock bits are being set");
   if (VM_Version::has_isel()) {
     __ xori(tmp1, tmp1, markWord::lock_mask_in_place);
-    __ isel(dst, CCR0, Assembler::equal, false, tmp1);
+    __ isel(dst, CR0, Assembler::equal, false, tmp1);
   } else {
-    __ bne(CCR0, done);
+    __ bne(CR0, done);
     __ xori(dst, tmp1, markWord::lock_mask_in_place);
   }
 
@@ -402,7 +402,7 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier_impl(
   if (is_strong) {
     // For strong references, the heap is considered stable if "has forwarded" is not active.
     __ andi_(tmp1, tmp2, ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::EVACUATION);
-    __ beq(CCR0, skip_barrier);
+    __ beq(CR0, skip_barrier);
 #ifdef ASSERT
     // "evacuation" -> (implies) "has forwarded".  If we reach this code, "has forwarded" must thus be set.
     __ andi_(tmp1, tmp1, ShenandoahHeap::HAS_FORWARDED);
@@ -414,10 +414,10 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier_impl(
     // The additional phase conditions are in place to avoid the resurrection of weak references (see JDK-8266440).
     Label skip_fastpath;
     __ andi_(tmp1, tmp2, ShenandoahHeap::WEAK_ROOTS);
-    __ bne(CCR0, skip_fastpath);
+    __ bne(CR0, skip_fastpath);
 
     __ andi_(tmp1, tmp2, ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::EVACUATION);
-    __ beq(CCR0, skip_barrier);
+    __ beq(CR0, skip_barrier);
 #ifdef ASSERT
     // "evacuation" -> (implies) "has forwarded".  If we reach this code, "has forwarded" must thus be set.
     __ andi_(tmp1, tmp1, ShenandoahHeap::HAS_FORWARDED);
@@ -453,7 +453,7 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier_impl(
     __ srdi(tmp1, dst, ShenandoahHeapRegion::region_size_bytes_shift_jint());
     __ lbzx(tmp2, tmp1, tmp2);
     __ andi_(tmp2, tmp2, 1);
-    __ beq(CCR0, skip_barrier);
+    __ beq(CR0, skip_barrier);
   }
 
   /* ==== Invoke runtime ==== */
@@ -639,8 +639,8 @@ void ShenandoahBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler
   Label done;
 
   // Fast path: Reference is null (JNI tags are zero for null pointers).
-  __ cmpdi(CCR0, obj, 0);
-  __ beq(CCR0, done);
+  __ cmpdi(CR0, obj, 0);
+  __ beq(CR0, done);
 
   // Resolve jobject using standard implementation.
   BarrierSetAssembler::try_resolve_jobject_in_native(masm, dst, jni_env, obj, tmp, slowpath);
@@ -651,7 +651,7 @@ void ShenandoahBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler
          jni_env);
 
   __ andi_(tmp, tmp, ShenandoahHeap::EVACUATION | ShenandoahHeap::HAS_FORWARDED);
-  __ bne(CCR0, slowpath);
+  __ bne(CR0, slowpath);
 
   __ bind(done);
   __ block_comment("} try_resolve_jobject_in_native (shenandoahgc)");
@@ -701,23 +701,23 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler *masm, Register b
   // Given that 'expected' must refer to the to-space object of an evacuated object (strong to-space invariant),
   // no special processing is required.
   if (UseCompressedOops) {
-    __ cmpxchgw(CCR0, current_value, expected, new_val, base_addr, MacroAssembler::MemBarNone,
+    __ cmpxchgw(CR0, current_value, expected, new_val, base_addr, MacroAssembler::MemBarNone,
                 false, success_flag, nullptr, true);
   } else {
-    __ cmpxchgd(CCR0, current_value, expected, new_val, base_addr, MacroAssembler::MemBarNone,
+    __ cmpxchgd(CR0, current_value, expected, new_val, base_addr, MacroAssembler::MemBarNone,
                 false, success_flag, nullptr, true);
   }
 
   // Skip the rest of the barrier if the CAS operation succeeds immediately.
   // If it does not, the value stored at the address is either the from-space pointer of the
   // referenced object (success criteria s2)) or simply another object.
-  __ beq(CCR0, done);
+  __ beq(CR0, done);
 
   /* ==== Step 2 (Null check) ==== */
   // The success criteria s2) cannot be matched with a null pointer
   // (null pointers cannot be subject to concurrent evacuation).  The failure of the CAS operation is thus legitimate.
-  __ cmpdi(CCR0, current_value, 0);
-  __ beq(CCR0, done);
+  __ cmpdi(CR0, current_value, 0);
+  __ beq(CR0, done);
 
   /* ==== Step 3 (reference pointer refers to from-space version; success criteria s2)) ==== */
   // To check whether the reference pointer refers to the from-space version, the forward
@@ -737,15 +737,15 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler *masm, Register b
     // Load zero into register for the potential failure case.
     __ li(success_flag, 0);
   }
-  __ cmpd(CCR0, current_value, expected);
-  __ bne(CCR0, done);
+  __ cmpd(CR0, current_value, expected);
+  __ bne(CR0, done);
 
   // Discard fetched value as it might be a reference to the from-space version of an object.
   if (UseCompressedOops) {
-    __ cmpxchgw(CCR0, R0, initial_value, new_val, base_addr, MacroAssembler::MemBarNone,
+    __ cmpxchgw(CR0, R0, initial_value, new_val, base_addr, MacroAssembler::MemBarNone,
                 false, success_flag);
   } else {
-    __ cmpxchgd(CCR0, R0, initial_value, new_val, base_addr, MacroAssembler::MemBarNone,
+    __ cmpxchgd(CR0, R0, initial_value, new_val, base_addr, MacroAssembler::MemBarNone,
                 false, success_flag);
   }
 
@@ -770,7 +770,7 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler *masm, Register b
   //           guaranteed to be the case.
   //           In case of a concurrent update, the CAS would be retried again. This is legitimate
   //           in terms of program correctness (even though it is not desired).
-  __ bne(CCR0, step_four);
+  __ bne(CR0, step_four);
 
   __ bind(done);
   __ block_comment("} cmpxchg_oop (shenandoahgc)");
@@ -789,7 +789,7 @@ void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssemb
   __ sldi_(count, count, LogBytesPerHeapOop);
 
   // Zero length? Skip.
-  __ beq(CCR0, L_skip_loop);
+  __ beq(CR0, L_skip_loop);
 
   __ addi(count, count, -BytesPerHeapOop);
   __ add(count, addr, count);
@@ -835,8 +835,8 @@ void ShenandoahBarrierSetAssembler::gen_pre_barrier_stub(LIR_Assembler *ce, Shen
   }
 
   // Fast path: Reference is null.
-  __ cmpdi(CCR0, pre_val, 0);
-  __ bc_far_optimized(Assembler::bcondCRbiIs1_bhintNoHint, __ bi0(CCR0, Assembler::equal), *stub->continuation());
+  __ cmpdi(CR0, pre_val, 0);
+  __ bc_far_optimized(Assembler::bcondCRbiIs1_bhintNoHint, __ bi0(CR0, Assembler::equal), *stub->continuation());
 
   // Argument passing via the stack.
   __ std(pre_val, -8, R1_SP);
@@ -866,7 +866,7 @@ void ShenandoahBarrierSetAssembler::gen_load_reference_barrier_stub(LIR_Assemble
   // Ensure that 'res' is 'R3_ARG1' and contains the same value as 'obj' to reduce the number of required
   // copy instructions.
   assert(R3_RET == res, "res must be r3");
-  __ cmpd(CCR0, res, obj);
+  __ cmpd(CR0, res, obj);
   __ asm_assert_eq("result register must contain the reference stored in obj");
 #endif
 
@@ -888,7 +888,7 @@ void ShenandoahBarrierSetAssembler::gen_load_reference_barrier_stub(LIR_Assemble
     __ lbzx(tmp2, tmp1, tmp2);
 
     __ andi_(tmp2, tmp2, 1);
-    __ bc_far_optimized(Assembler::bcondCRbiIs1_bhintNoHint, __ bi0(CCR0, Assembler::equal), *stub->continuation());
+    __ bc_far_optimized(Assembler::bcondCRbiIs1_bhintNoHint, __ bi0(CR0, Assembler::equal), *stub->continuation());
   }
 
   address blob_addr = nullptr;
@@ -946,13 +946,13 @@ void ShenandoahBarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAss
   __ lbz(R12_tmp2, in_bytes(ShenandoahThreadLocalData::gc_state_offset()), R16_thread);
 
   __ andi_(R12_tmp2, R12_tmp2, ShenandoahHeap::MARKING);
-  __ beq(CCR0, skip_barrier);
+  __ beq(CR0, skip_barrier);
 
   /* ==== Add previous value directly to thread-local SATB mark queue ==== */
   // Check queue's capacity.  Jump to runtime if no free slot is available.
   __ ld(R12_tmp2, in_bytes(ShenandoahThreadLocalData::satb_mark_queue_index_offset()), R16_thread);
-  __ cmpdi(CCR0, R12_tmp2, 0);
-  __ beq(CCR0, runtime);
+  __ cmpdi(CR0, R12_tmp2, 0);
+  __ beq(CR0, runtime);
 
   // Capacity suffices.  Decrement the queue's size by one slot (size of one oop).
   __ addi(R12_tmp2, R12_tmp2, -wordSize);

--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
@@ -169,7 +169,7 @@ void ZBarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators
   // if the pointer is not dirty.
   // Only dirty pointers must be processed by this barrier, so we can skip it in case the latter condition holds true.
   __ and_(tmp1, tmp1, dst);
-  __ beq(CCR0, uncolor);
+  __ beq(CR0, uncolor);
 
   /* ==== Invoke barrier ==== */
   {
@@ -193,8 +193,8 @@ void ZBarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators
 
   // Slow-path has already uncolored
   if (L_handle_null != nullptr) {
-    __ cmpdi(CCR0, dst, 0);
-    __ beq(CCR0, *L_handle_null);
+    __ cmpdi(CR0, dst, 0);
+    __ beq(CR0, *L_handle_null);
   }
   __ b(done);
 
@@ -203,7 +203,7 @@ void ZBarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators
     __ srdi(dst, dst, ZPointerLoadShift);
   } else {
     __ srdi_(dst, dst, ZPointerLoadShift);
-    __ beq(CCR0, *L_handle_null);
+    __ beq(CR0, *L_handle_null);
   }
 
   __ bind(done);
@@ -234,7 +234,7 @@ static void emit_store_fast_path_check(MacroAssembler* masm, Register base, Regi
     // A not relocatable object could have spurious raw null pointers in its fields after
     // getting promoted to the old generation.
     __ relocate(barrier_Relocation::spec(), ZBarrierRelocationFormatStoreGoodBits);
-    __ cmplwi(CCR0, R0, barrier_Relocation::unpatched);
+    __ cmplwi(CR0, R0, barrier_Relocation::unpatched);
   } else {
     __ ld(R0, ind_or_offs, base);
     // Stores on relocatable objects never need to deal with raw null pointers in fields.
@@ -244,7 +244,7 @@ static void emit_store_fast_path_check(MacroAssembler* masm, Register base, Regi
     __ relocate(barrier_Relocation::spec(), ZBarrierRelocationFormatStoreBadMask);
     __ andi_(R0, R0, barrier_Relocation::unpatched);
   }
-  __ bc_far_optimized(Assembler::bcondCRbiIs0, __ bi0(CCR0, Assembler::equal), medium_path);
+  __ bc_far_optimized(Assembler::bcondCRbiIs0, __ bi0(CR0, Assembler::equal), medium_path);
 }
 
 void ZBarrierSetAssembler::store_barrier_fast(MacroAssembler* masm,
@@ -274,7 +274,7 @@ void ZBarrierSetAssembler::store_barrier_fast(MacroAssembler* masm,
     __ ld(R0, ind_or_offset, ref_base);
     __ ld(rnew_zpointer, in_bytes(ZThreadLocalData::store_bad_mask_offset()), R16_thread);
     __ and_(R0, R0, rnew_zpointer);
-    __ bne(CCR0, medium_path);
+    __ bne(CR0, medium_path);
     __ bind(medium_path_continuation);
     __ ld(rnew_zpointer, in_bytes(ZThreadLocalData::store_good_mask_offset()), R16_thread);
   }
@@ -293,7 +293,7 @@ static void store_barrier_buffer_add(MacroAssembler* masm,
   // Combined pointer bump and check if the buffer is disabled or full
   __ ld(R0, in_bytes(ZStoreBarrierBuffer::current_offset()), tmp1);
   __ addic_(R0, R0, -(int)sizeof(ZStoreBarrierEntry));
-  __ blt(CCR0, slow_path);
+  __ blt(CR0, slow_path);
   __ std(R0, in_bytes(ZStoreBarrierBuffer::current_offset()), tmp1);
 
   // Entry is at ZStoreBarrierBuffer (tmp1) + buffer_offset + scaled index (R0)
@@ -327,8 +327,8 @@ void ZBarrierSetAssembler::store_barrier_medium(MacroAssembler* masm,
     // Atomic accesses can get to the medium fast path because the value was a
     // raw null value. If it was not null, then there is no doubt we need to take a slow path.
     __ ld(tmp, ind_or_offs, ref_base);
-    __ cmpdi(CCR0, tmp, 0);
-    __ bne(CCR0, slow_path);
+    __ cmpdi(CR0, tmp, 0);
+    __ bne(CR0, slow_path);
 
     // If we get this far, we know there is a young raw null value in the field.
     // Try to self-heal null values for atomic accesses
@@ -338,12 +338,12 @@ void ZBarrierSetAssembler::store_barrier_medium(MacroAssembler* masm,
       need_restore = true;
     }
     __ ld(R0, in_bytes(ZThreadLocalData::store_good_mask_offset()), R16_thread);
-    __ cmpxchgd(CCR0, tmp, (intptr_t)0, R0, ref_base,
+    __ cmpxchgd(CR0, tmp, (intptr_t)0, R0, ref_base,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, need_restore ? nullptr : &slow_path);
     if (need_restore) {
       __ sub(ref_base, ref_base, ind_or_offs);
-      __ bne(CCR0, slow_path);
+      __ bne(CR0, slow_path);
     }
   } else {
     // A non-atomic relocatable object won't get to the medium fast path due to a
@@ -447,7 +447,7 @@ void ZBarrierSetAssembler::copy_load_at_fast(MacroAssembler* masm,
                                              Label& continuation) const {
   __ ldx(zpointer, addr);
   __ and_(R0, zpointer, load_bad_mask);
-  __ bne(CCR0, slow_path);
+  __ bne(CR0, slow_path);
   __ bind(continuation);
 }
 void ZBarrierSetAssembler::copy_load_at_slow(MacroAssembler* masm,
@@ -480,7 +480,7 @@ void ZBarrierSetAssembler::copy_store_at_fast(MacroAssembler* masm,
   if (!dest_uninitialized) {
     __ ldx(R0, addr);
     __ and_(R0, R0, store_bad_mask);
-    __ bne(CCR0, medium_path);
+    __ bne(CR0, medium_path);
     __ bind(continuation);
   }
   __ rldimi(zpointer, store_good_mask, 0, 64 - ZPointerLoadShift); // Replace color bits.
@@ -515,8 +515,8 @@ void ZBarrierSetAssembler::copy_store_at_slow(MacroAssembler* masm,
 void ZBarrierSetAssembler::generate_disjoint_oop_copy(MacroAssembler* masm, bool dest_uninitialized) {
   const Register zpointer = R2, tmp = R9;
   Label done, loop, load_bad, load_good, store_bad, store_good;
-  __ cmpdi(CCR0, R5_ARG3, 0);
-  __ beq(CCR0, done);
+  __ cmpdi(CR0, R5_ARG3, 0);
+  __ beq(CR0, done);
   __ mtctr(R5_ARG3);
 
   __ align(32);
@@ -539,7 +539,7 @@ void ZBarrierSetAssembler::generate_conjoint_oop_copy(MacroAssembler* masm, bool
   const Register zpointer = R2, tmp = R9;
   Label done, loop, load_bad, load_good, store_bad, store_good;
   __ sldi_(R0, R5_ARG3, 3);
-  __ beq(CCR0, done);
+  __ beq(CR0, done);
   __ mtctr(R5_ARG3);
   // Point behind last elements and copy backwards.
   __ add(R3_ARG1, R3_ARG1, R0);
@@ -570,12 +570,12 @@ void ZBarrierSetAssembler::check_oop(MacroAssembler *masm, Register obj, const c
   Label done, skip_uncolor;
   // Skip (colored) null.
   __ srdi_(R0, obj, ZPointerLoadShift);
-  __ beq(CCR0, done);
+  __ beq(CR0, done);
 
   // Check if ZAddressHeapBase << ZPointerLoadShift is set. If so, we need to uncolor.
   __ rldicl_(R0, obj, 64 - ZAddressHeapBaseShift - ZPointerLoadShift, 63);
   __ mr(R0, obj);
-  __ beq(CCR0, skip_uncolor);
+  __ beq(CR0, skip_uncolor);
   __ srdi(R0, obj, ZPointerLoadShift);
   __ bind(skip_uncolor);
 
@@ -594,7 +594,7 @@ void ZBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, R
 
   // Test for tag
   __ andi_(tmp, obj, JNIHandles::tag_mask);
-  __ bne(CCR0, tagged);
+  __ bne(CR0, tagged);
 
   // Resolve local handle
   __ ld(dst, 0, obj);
@@ -605,7 +605,7 @@ void ZBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, R
   // Test for weak tag
   __ andi_(tmp, obj, JNIHandles::TypeTag::weak_global);
   __ clrrdi(dst, obj, JNIHandles::tag_size); // Untag.
-  __ bne(CCR0, weak_tagged);
+  __ bne(CR0, weak_tagged);
 
   // Resolve global handle
   __ ld(dst, 0, dst);
@@ -620,7 +620,7 @@ void ZBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, R
 
   __ bind(check_color);
   __ and_(tmp, tmp, dst);
-  __ bne(CCR0, slowpath);
+  __ bne(CR0, slowpath);
 
   // Uncolor
   __ srdi(dst, dst, ZPointerLoadShift);
@@ -666,7 +666,7 @@ void ZBarrierSetAssembler::generate_c1_load_barrier(LIR_Assembler* ce,
                                                     ZLoadBarrierStubC1* stub,
                                                     bool on_non_strong) const {
   check_color(ce, ref, on_non_strong);
-  __ bc_far_optimized(Assembler::bcondCRbiIs0, __ bi0(CCR0, Assembler::equal), *stub->entry());
+  __ bc_far_optimized(Assembler::bcondCRbiIs0, __ bi0(CR0, Assembler::equal), *stub->entry());
   z_uncolor(ce, ref);
   __ bind(*stub->continuation());
 }

--- a/src/hotspot/cpu/ppc/gc/z/z_ppc.ad
+++ b/src/hotspot/cpu/ppc/gc/z/z_ppc.ad
@@ -70,7 +70,7 @@ static void z_load_barrier(MacroAssembler* masm, const MachNode* node, Address r
     check_color(masm, ref, on_non_strong);
 
     ZLoadBarrierStubC2* const stub = ZLoadBarrierStubC2::create(node, ref_addr, ref);
-    __ bne_far(CCR0, *stub->entry(), MacroAssembler::bc_far_optimize_on_relocate);
+    __ bne_far(CR0, *stub->entry(), MacroAssembler::bc_far_optimize_on_relocate);
 
     z_uncolor(masm, ref);
     __ bind(*stub->continuation());
@@ -97,7 +97,7 @@ static void z_compare_and_swap(MacroAssembler* masm, const MachNode* node,
   Register rold_zpointer = tmp1, rnew_zpointer = tmp2;
   z_store_barrier(masm, node, mem, 0, newval, rnew_zpointer, true /* is_atomic */);
   z_color(masm, rold_zpointer, oldval);
-  __ cmpxchgd(CCR0, R0, rold_zpointer, rnew_zpointer, mem,
+  __ cmpxchgd(CR0, R0, rold_zpointer, rnew_zpointer, mem,
               MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(), res, nullptr, true,
               false /* we could support weak, but benefit is questionable */);
 
@@ -119,7 +119,7 @@ static void z_compare_and_exchange(MacroAssembler* masm, const MachNode* node,
   Register rold_zpointer = R0, rnew_zpointer = tmp;
   z_store_barrier(masm, node, mem, 0, newval, rnew_zpointer, true /* is_atomic */);
   z_color(masm, rold_zpointer, oldval);
-  __ cmpxchgd(CCR0, res, rold_zpointer, rnew_zpointer, mem,
+  __ cmpxchgd(CR0, res, rold_zpointer, rnew_zpointer, mem,
               MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(), noreg, nullptr, true,
               false /* we could support weak, but benefit is questionable */);
   z_uncolor(masm, res);

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -126,10 +126,10 @@ void InterpreterMacroAssembler::check_and_handle_popframe(Register scratch_reg) 
     // means that this code is called *during* popframe handling - we
     // don't want to reenter.
     andi_(R0, scratch_reg, JavaThread::popframe_pending_bit);
-    beq(CCR0, L);
+    beq(CR0, L);
 
     andi_(R0, scratch_reg, JavaThread::popframe_processing_bit);
-    bne(CCR0, L);
+    bne(CR0, L);
 
     // Call the Interpreter::remove_activation_preserving_args_entry()
     // func to get the address of the same-named entrypoint in the
@@ -150,12 +150,12 @@ void InterpreterMacroAssembler::check_and_handle_earlyret(Register scratch_reg) 
   if (JvmtiExport::can_force_early_return()) {
     Label Lno_early_ret;
     ld(Rthr_state_addr, in_bytes(JavaThread::jvmti_thread_state_offset()), R16_thread);
-    cmpdi(CCR0, Rthr_state_addr, 0);
-    beq(CCR0, Lno_early_ret);
+    cmpdi(CR0, Rthr_state_addr, 0);
+    beq(CR0, Lno_early_ret);
 
     lwz(R0, in_bytes(JvmtiThreadState::earlyret_state_offset()), Rthr_state_addr);
-    cmpwi(CCR0, R0, JvmtiThreadState::earlyret_pending);
-    bne(CCR0, Lno_early_ret);
+    cmpwi(CR0, R0, JvmtiThreadState::earlyret_pending);
+    bne(CR0, Lno_early_ret);
 
     // Jump to Interpreter::_earlyret_entry.
     lwz(R3_ARG1, in_bytes(JvmtiThreadState::earlyret_tos_offset()), Rthr_state_addr);
@@ -229,7 +229,7 @@ void InterpreterMacroAssembler::dispatch_Lbyte_code(TosState state, Register byt
       ld(R0, in_bytes(JavaThread::polling_word_offset()), R16_thread);
       // Armed page has poll_bit set, if poll bit is cleared just continue.
       andi_(R0, R0, SafepointMechanism::poll_bit());
-      beq(CCR0, dispatch);
+      beq(CR0, dispatch);
       load_dispatch_table(R11_scratch1, sfpt_tbl);
       align(32, 16);
       bind(dispatch);
@@ -528,8 +528,8 @@ void InterpreterMacroAssembler::load_resolved_reference_at_index(Register result
   Label index_ok;
   lwa(R0, arrayOopDesc::length_offset_in_bytes(), result);
   sldi(R0, R0, LogBytesPerHeapOop);
-  cmpd(CCR0, index, R0);
-  blt(CCR0, index_ok);
+  cmpd(CR0, index, R0);
+  blt(CR0, index_ok);
   stop("resolved reference index out of bounds");
   bind(index_ok);
 #endif
@@ -592,8 +592,8 @@ void InterpreterMacroAssembler::index_check_without_pop(Register Rarray, Registe
 
   // Array nullcheck
   if (!ImplicitNullChecks) {
-    cmpdi(CCR0, Rarray, 0);
-    beq(CCR0, LisNull);
+    cmpdi(CR0, Rarray, 0);
+    beq(CR0, LisNull);
   } else {
     null_check_throw(Rarray, arrayOopDesc::length_offset_in_bytes(), /*temp*/RsxtIndex);
   }
@@ -605,9 +605,9 @@ void InterpreterMacroAssembler::index_check_without_pop(Register Rarray, Registe
 
   // Index check
   lwz(Rlength, arrayOopDesc::length_offset_in_bytes(), Rarray);
-  cmplw(CCR0, Rindex, Rlength);
+  cmplw(CR0, Rindex, Rlength);
   sldi(RsxtIndex, RsxtIndex, index_shift);
-  blt(CCR0, LnotOOR);
+  blt(CR0, LnotOOR);
   // Index should be in R17_tos, array should be in R4_ARG2.
   mr_if_needed(R17_tos, Rindex);
   mr_if_needed(R4_ARG2, Rarray);
@@ -687,11 +687,11 @@ void InterpreterMacroAssembler::unlock_if_synchronized_method(TosState state,
     push(state);
 
     // Skip if we don't have to unlock.
-    testbitdi(CCR0, R0, Raccess_flags, JVM_ACC_SYNCHRONIZED_BIT);
-    beq(CCR0, Lunlocked);
+    testbitdi(CR0, R0, Raccess_flags, JVM_ACC_SYNCHRONIZED_BIT);
+    beq(CR0, Lunlocked);
 
-    cmpwi(CCR0, Rdo_not_unlock_flag, 0);
-    bne(CCR0, Lno_unlock);
+    cmpwi(CR0, Rdo_not_unlock_flag, 0);
+    bne(CR0, Lno_unlock);
   }
 
   // Unlock
@@ -705,8 +705,8 @@ void InterpreterMacroAssembler::unlock_if_synchronized_method(TosState state,
          -(frame::ijava_state_size + frame::interpreter_frame_monitor_size_in_bytes())); // Monitor base
 
     ld(R0, BasicObjectLock::obj_offset(), Rmonitor_base);
-    cmpdi(CCR0, R0, 0);
-    bne(CCR0, Lunlock);
+    cmpdi(CR0, R0, 0);
+    bne(CR0, Lunlock);
 
     // If it's already unlocked, throw exception.
     if (throw_monitor_exception) {
@@ -740,7 +740,7 @@ void InterpreterMacroAssembler::unlock_if_synchronized_method(TosState state,
       addi(Rmonitor_base, Rmonitor_base, - frame::ijava_state_size);  // Monitor base
 
       subf_(Riterations, R26_monitor, Rmonitor_base);
-      ble(CCR0, Lno_unlock);
+      ble(CR0, Lno_unlock);
 
       addi(Rcurrent_obj_addr, Rmonitor_base,
            in_bytes(BasicObjectLock::obj_offset()) - frame::interpreter_frame_monitor_size_in_bytes());
@@ -759,8 +759,8 @@ void InterpreterMacroAssembler::unlock_if_synchronized_method(TosState state,
       bind(Lloop);
 
       // Check if current entry is used.
-      cmpdi(CCR0, Rcurrent_obj, 0);
-      bne(CCR0, Lexception);
+      cmpdi(CR0, Rcurrent_obj, 0);
+      bne(CR0, Lexception);
       // Preload next iteration's compare value.
       ld(Rcurrent_obj, 0, Rcurrent_obj_addr);
       addi(Rcurrent_obj_addr, Rcurrent_obj_addr, -delta);
@@ -816,29 +816,29 @@ void InterpreterMacroAssembler::narrow(Register result) {
   Label notBool, notByte, notChar, done;
 
   // common case first
-  cmpwi(CCR0, ret_type, T_INT);
-  beq(CCR0, done);
+  cmpwi(CR0, ret_type, T_INT);
+  beq(CR0, done);
 
-  cmpwi(CCR0, ret_type, T_BOOLEAN);
-  bne(CCR0, notBool);
+  cmpwi(CR0, ret_type, T_BOOLEAN);
+  bne(CR0, notBool);
   andi(result, result, 0x1);
   b(done);
 
   bind(notBool);
-  cmpwi(CCR0, ret_type, T_BYTE);
-  bne(CCR0, notByte);
+  cmpwi(CR0, ret_type, T_BYTE);
+  bne(CR0, notByte);
   extsb(result, result);
   b(done);
 
   bind(notByte);
-  cmpwi(CCR0, ret_type, T_CHAR);
-  bne(CCR0, notChar);
+  cmpwi(CR0, ret_type, T_CHAR);
+  bne(CR0, notChar);
   andi(result, result, 0xffff);
   b(done);
 
   bind(notChar);
-  // cmpwi(CCR0, ret_type, T_SHORT);  // all that's left
-  // bne(CCR0, done);
+  // cmpwi(CR0, ret_type, T_SHORT);  // all that's left
+  // bne(CR0, done);
   extsh(result, result);
 
   // Nothing to do for T_INT
@@ -893,8 +893,8 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
     // check if already enabled - if so no re-enabling needed
     assert(sizeof(StackOverflow::StackGuardState) == 4, "unexpected size");
     lwz(R0, in_bytes(JavaThread::stack_guard_state_offset()), R16_thread);
-    cmpwi(CCR0, R0, StackOverflow::stack_guard_enabled);
-    beq_predict_taken(CCR0, no_reserved_zone_enabling);
+    cmpwi(CR0, R0, StackOverflow::stack_guard_enabled);
+    beq_predict_taken(CR0, no_reserved_zone_enabling);
 
     // Compare frame pointers. There is no good stack pointer, as with stack
     // frame compression we can get different SPs when we do calls. A subsequent
@@ -902,8 +902,8 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
     // inner call of the method annotated with ReservedStack.
     ld_ptr(R0, JavaThread::reserved_stack_activation_offset(), R16_thread);
     ld_ptr(R11_scratch1, _abi0(callers_sp), R1_SP); // Load frame pointer.
-    cmpld(CCR0, R11_scratch1, R0);
-    blt_predict_taken(CCR0, no_reserved_zone_enabling);
+    cmpld(CR0, R11_scratch1, R0);
+    blt_predict_taken(CR0, no_reserved_zone_enabling);
 
     // Enable reserved zone again, throw stack overflow exception.
     call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::enable_stack_reserved_zone), R16_thread);
@@ -961,8 +961,8 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
     if (DiagnoseSyncOnValueBasedClasses != 0) {
       load_klass(tmp, object);
       lbz(tmp, in_bytes(Klass::misc_flags_offset()), tmp);
-      testbitdi(CCR0, R0, tmp, exact_log2(KlassFlags::_misc_is_value_based_class));
-      bne(CCR0, slow_case);
+      testbitdi(CR0, R0, tmp, exact_log2(KlassFlags::_misc_is_value_based_class));
+      bne(CR0, slow_case);
     }
 
     if (LockingMode == LM_LIGHTWEIGHT) {
@@ -989,8 +989,8 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
       addi(object_mark_addr, object, oopDesc::mark_offset_in_bytes());
 
       // Must fence, otherwise, preceding store(s) may float below cmpxchg.
-      // CmpxchgX sets CCR0 to cmpX(current, displaced).
-      cmpxchgd(/*flag=*/CCR0,
+      // CmpxchgX sets CR0 to cmpX(current, displaced).
+      cmpxchgd(/*flag=*/CR0,
                /*current_value=*/current_header,
                /*compare_value=*/header, /*exchange_value=*/monitor,
                /*where=*/object_mark_addr,
@@ -1021,7 +1021,7 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
       and_(R0/*==0?*/, current_header, tmp);
       // If condition is true we are done and hence we can store 0 in the displaced
       // header indicating it is a recursive lock.
-      bne(CCR0, slow_case);
+      bne(CR0, slow_case);
       std(R0/*==0!*/, mark_offset, monitor);
       b(count_locking);
     }
@@ -1087,8 +1087,8 @@ void InterpreterMacroAssembler::unlock_object(Register monitor) {
                  BasicLock::displaced_header_offset_in_bytes(), monitor);
 
       // If the displaced header is zero, we have a recursive unlock.
-      cmpdi(CCR0, header, 0);
-      beq(CCR0, free_slot); // recursive unlock
+      cmpdi(CR0, header, 0);
+      beq(CR0, free_slot); // recursive unlock
     }
 
     // } else if (Atomic::cmpxchg(obj->mark_addr(), monitor, displaced_header) == monitor) {
@@ -1108,8 +1108,8 @@ void InterpreterMacroAssembler::unlock_object(Register monitor) {
       // We have the displaced header in displaced_header. If the lock is still
       // lightweight, it will contain the monitor address and we'll store the
       // displaced header back into the object's mark word.
-      // CmpxchgX sets CCR0 to cmpX(current, monitor).
-      cmpxchgd(/*flag=*/CCR0,
+      // CmpxchgX sets CR0 to cmpX(current, monitor).
+      cmpxchgd(/*flag=*/CR0,
                /*current_value=*/current_header,
                /*compare_value=*/monitor, /*exchange_value=*/header,
                /*where=*/object_mark_addr,
@@ -1170,8 +1170,8 @@ void InterpreterMacroAssembler::call_from_interpreter(Register Rtarget_method, R
     // compiled code in threads for which the event is enabled. Check here for
     // interp_only_mode if these events CAN be enabled.
     Label done;
-    cmpwi(CCR0, Rinterp_only, 0);
-    beq(CCR0, done);
+    cmpwi(CR0, Rinterp_only, 0);
+    beq(CR0, done);
     ld(Rtarget_addr, in_bytes(Method::interpreter_entry_offset()), Rtarget_method);
     align(32, 12);
     bind(done);
@@ -1180,8 +1180,8 @@ void InterpreterMacroAssembler::call_from_interpreter(Register Rtarget_method, R
 #ifdef ASSERT
   {
     Label Lok;
-    cmpdi(CCR0, Rtarget_addr, 0);
-    bne(CCR0, Lok);
+    cmpdi(CR0, Rtarget_addr, 0);
+    bne(CR0, Lok);
     stop("null entry point");
     bind(Lok);
   }
@@ -1211,7 +1211,7 @@ void InterpreterMacroAssembler::call_from_interpreter(Register Rtarget_method, R
   sldi(Rscratch1, Rscratch1, Interpreter::logStackElementSize);
   add(Rscratch1, Rscratch1, Rscratch2); // Rscratch2 contains fp
   // Compare sender_sp with the derelativized top_frame_sp
-  cmpd(CCR0, R21_sender_SP, Rscratch1);
+  cmpd(CR0, R21_sender_SP, Rscratch1);
   asm_assert_eq("top_frame_sp incorrect");
 #endif
 
@@ -1234,8 +1234,8 @@ void InterpreterMacroAssembler::set_method_data_pointer_for_bcp() {
 // Test ImethodDataPtr. If it is null, continue at the specified label.
 void InterpreterMacroAssembler::test_method_data_pointer(Label& zero_continue) {
   assert(ProfileInterpreter, "must be profiling interpreter");
-  cmpdi(CCR0, R28_mdx, 0);
-  beq(CCR0, zero_continue);
+  cmpdi(CR0, R28_mdx, 0);
+  beq(CR0, zero_continue);
 }
 
 void InterpreterMacroAssembler::verify_method_data_pointer() {
@@ -1250,8 +1250,8 @@ void InterpreterMacroAssembler::verify_method_data_pointer() {
   ld(R12_scratch2, in_bytes(Method::const_offset()), R19_method);
   addi(R11_scratch1, R11_scratch1, in_bytes(ConstMethod::codes_offset()));
   add(R11_scratch1, R12_scratch2, R12_scratch2);
-  cmpd(CCR0, R11_scratch1, R14_bcp);
-  beq(CCR0, verify_continue);
+  cmpd(CR0, R11_scratch1, R14_bcp);
+  beq(CR0, verify_continue);
 
   call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::verify_mdp ), R19_method, R14_bcp, R28_mdx);
 
@@ -1334,8 +1334,8 @@ void InterpreterMacroAssembler::test_mdp_data_at(int offset,
   assert(ProfileInterpreter, "must be profiling interpreter");
 
   ld(test_out, offset, R28_mdx);
-  cmpd(CCR0,  value, test_out);
-  bne(CCR0, not_equal_continue);
+  cmpd(CR0,  value, test_out);
+  bne(CR0, not_equal_continue);
 }
 
 // Update the method data pointer by the displacement located at some fixed
@@ -1491,8 +1491,8 @@ void InterpreterMacroAssembler::profile_virtual_call(Register Rreceiver,
   Label skip_receiver_profile;
   if (receiver_can_be_null) {
     Label not_null;
-    cmpdi(CCR0, Rreceiver, 0);
-    bne(CCR0, not_null);
+    cmpdi(CR0, Rreceiver, 0);
+    bne(CR0, not_null);
     // We are making a call. Increment the count for null receiver.
     increment_mdp_data_at(in_bytes(CounterData::count_offset()), Rscratch1, Rscratch2);
     b(skip_receiver_profile);
@@ -1681,8 +1681,8 @@ void InterpreterMacroAssembler::record_klass_in_profile_helper(
       if (start_row == last_row) {
         // The only thing left to do is handle the null case.
         // Scratch1 contains test_out from test_mdp_data_at.
-        cmpdi(CCR0, scratch1, 0);
-        beq(CCR0, found_null);
+        cmpdi(CR0, scratch1, 0);
+        beq(CR0, found_null);
         // Receiver did not match any saved receiver and there is no empty row for it.
         // Increment total counter to indicate polymorphic case.
         increment_mdp_data_at(in_bytes(CounterData::count_offset()), scratch1, scratch2);
@@ -1691,8 +1691,8 @@ void InterpreterMacroAssembler::record_klass_in_profile_helper(
         break;
       }
       // Since null is rare, make it be the branch-taken case.
-      cmpdi(CCR0, scratch1, 0);
-      beq(CCR0, found_null);
+      cmpdi(CR0, scratch1, 0);
+      beq(CR0, found_null);
 
       // Put all the "Case 3" tests here.
       record_klass_in_profile_helper(receiver, scratch1, scratch2, start_row + 1, done);
@@ -1734,27 +1734,27 @@ void InterpreterMacroAssembler::profile_obj_type(Register obj, Register mdo_addr
   ld(tmp, mdo_addr_offs, mdo_addr_base);
 
   // Set null_seen if obj is 0.
-  cmpdi(CCR0, obj, 0);
+  cmpdi(CR0, obj, 0);
   ori(R0, tmp, TypeEntries::null_seen);
-  beq(CCR0, do_update);
+  beq(CR0, do_update);
 
   load_klass(klass, obj);
 
   clrrdi(R0, tmp, exact_log2(-TypeEntries::type_klass_mask));
   // Basically same as andi(R0, tmp, TypeEntries::type_klass_mask);
-  cmpd(CCR1, R0, klass);
+  cmpd(CR1, R0, klass);
   // Klass seen before, nothing to do (regardless of unknown bit).
-  //beq(CCR1, do_nothing);
+  //beq(CR1, do_nothing);
 
   andi_(R0, tmp, TypeEntries::type_unknown);
   // Already unknown. Nothing to do anymore.
-  //bne(CCR0, do_nothing);
-  crorc(CCR0, Assembler::equal, CCR1, Assembler::equal); // cr0 eq = cr1 eq or cr0 ne
-  beq(CCR0, do_nothing);
+  //bne(CR0, do_nothing);
+  crorc(CR0, Assembler::equal, CR1, Assembler::equal); // cr0 eq = cr1 eq or cr0 ne
+  beq(CR0, do_nothing);
 
   clrrdi_(R0, tmp, exact_log2(-TypeEntries::type_mask));
   orr(R0, klass, tmp); // Combine klass and null_seen bit (only used if (tmp & type_mask)==0).
-  beq(CCR0, do_update); // First time here. Set profile type.
+  beq(CR0, do_update); // First time here. Set profile type.
 
   // Different than before. Cannot keep accurate profile.
   ori(R0, tmp, TypeEntries::type_unknown);
@@ -1785,8 +1785,8 @@ void InterpreterMacroAssembler::profile_arguments_type(Register callee,
       in_bytes(VirtualCallData::virtual_call_data_size()) : in_bytes(CounterData::counter_data_size());
 
     lbz(tmp1, in_bytes(DataLayout::tag_offset()) - off_to_start, R28_mdx);
-    cmpwi(CCR0, tmp1, is_virtual ? DataLayout::virtual_call_type_data_tag : DataLayout::call_type_data_tag);
-    bne(CCR0, profile_continue);
+    cmpwi(CR0, tmp1, is_virtual ? DataLayout::virtual_call_type_data_tag : DataLayout::call_type_data_tag);
+    bne(CR0, profile_continue);
 
     if (MethodData::profile_arguments()) {
       Label done;
@@ -1797,9 +1797,9 @@ void InterpreterMacroAssembler::profile_arguments_type(Register callee,
         if (i > 0 || MethodData::profile_return()) {
           // If return value type is profiled we may have no argument to profile.
           ld(tmp1, in_bytes(TypeEntriesAtCall::cell_count_offset())-off_to_args, R28_mdx);
-          cmpdi(CCR0, tmp1, (i+1)*TypeStackSlotEntries::per_arg_count());
+          cmpdi(CR0, tmp1, (i+1)*TypeStackSlotEntries::per_arg_count());
           addi(tmp1, tmp1, -i*TypeStackSlotEntries::per_arg_count());
-          blt(CCR0, done);
+          blt(CR0, done);
         }
         ld(tmp1, in_bytes(Method::const_offset()), callee);
         lhz(tmp1, in_bytes(ConstMethod::size_of_parameters_offset()), tmp1);
@@ -1865,12 +1865,12 @@ void InterpreterMacroAssembler::profile_return_type(Register ret, Register tmp1,
       // length.
       lbz(tmp1, 0, R14_bcp);
       lbz(tmp2, in_bytes(Method::intrinsic_id_offset()), R19_method);
-      cmpwi(CCR0, tmp1, Bytecodes::_invokedynamic);
-      cmpwi(CCR1, tmp1, Bytecodes::_invokehandle);
-      cror(CCR0, Assembler::equal, CCR1, Assembler::equal);
-      cmpwi(CCR1, tmp2, static_cast<int>(vmIntrinsics::_compiledLambdaForm));
-      cror(CCR0, Assembler::equal, CCR1, Assembler::equal);
-      bne(CCR0, profile_continue);
+      cmpwi(CR0, tmp1, Bytecodes::_invokedynamic);
+      cmpwi(CR1, tmp1, Bytecodes::_invokehandle);
+      cror(CR0, Assembler::equal, CR1, Assembler::equal);
+      cmpwi(CR1, tmp2, static_cast<int>(vmIntrinsics::_compiledLambdaForm));
+      cror(CR0, Assembler::equal, CR1, Assembler::equal);
+      bne(CR0, profile_continue);
     }
 
     profile_obj_type(ret, R28_mdx, -in_bytes(ReturnTypeEntry::size()), tmp1, tmp2);
@@ -1890,8 +1890,8 @@ void InterpreterMacroAssembler::profile_parameters_type(Register tmp1, Register 
     // Load the offset of the area within the MDO used for
     // parameters. If it's negative we're not profiling any parameters.
     lwz(tmp1, in_bytes(MethodData::parameters_type_data_di_offset()) - in_bytes(MethodData::data_offset()), R28_mdx);
-    cmpwi(CCR0, tmp1, 0);
-    blt(CCR0, profile_continue);
+    cmpwi(CR0, tmp1, 0);
+    blt(CR0, profile_continue);
 
     // Compute a pointer to the area for parameters from the offset
     // and move the pointer to the slot for the last
@@ -1936,9 +1936,9 @@ void InterpreterMacroAssembler::profile_parameters_type(Register tmp1, Register 
 
     // Go to next parameter.
     int delta = TypeStackSlotEntries::per_arg_count() * DataLayout::cell_size + (type_base - off_base);
-    cmpdi(CCR0, entry_offset, off_base + delta);
+    cmpdi(CR0, entry_offset, off_base + delta);
     addi(entry_offset, entry_offset, -delta);
-    bge(CCR0, loop);
+    bge(CR0, loop);
 
     align(32, 12);
     bind(profile_continue);
@@ -1975,7 +1975,7 @@ void InterpreterMacroAssembler::add_monitor_to_stack(bool stack_is_empty, Regist
     subf(n_slots, esp, R26_monitor);
     srdi_(n_slots, n_slots, LogBytesPerWord);          // Compute number of slots to copy.
     assert(LogBytesPerWord == 3, "conflicts assembler instructions");
-    beq(CCR0, copy_slot_finished);                     // Nothing to copy.
+    beq(CR0, copy_slot_finished);                     // Nothing to copy.
 
     mtctr(n_slots);
 
@@ -2115,8 +2115,8 @@ void InterpreterMacroAssembler::check_and_forward_exception(Register Rscratch1, 
   Label Ldone;
   // Get pending exception oop.
   ld(Rexception, thread_(pending_exception));
-  cmpdi(CCR0, Rexception, 0);
-  beq(CCR0, Ldone);
+  cmpdi(CR0, Rexception, 0);
+  beq(CR0, Ldone);
   li(Rtmp, 0);
   mr_if_needed(R3, Rexception);
   std(Rtmp, thread_(pending_exception)); // Clear exception in thread
@@ -2168,7 +2168,7 @@ void InterpreterMacroAssembler::call_VM_preemptable(Register oop_result, address
   Label resume_pc, not_preempted;
 
   DEBUG_ONLY(ld(R0, in_bytes(JavaThread::preempt_alternate_return_offset()), R16_thread));
-  DEBUG_ONLY(cmpdi(CCR0, R0, 0));
+  DEBUG_ONLY(cmpdi(CR0, R0, 0));
   asm_assert_eq("Should not have alternate return address set");
 
   // Preserve 2 registers
@@ -2186,8 +2186,8 @@ void InterpreterMacroAssembler::call_VM_preemptable(Register oop_result, address
 
   // Jump to handler if the call was preempted
   ld(R0, in_bytes(JavaThread::preempt_alternate_return_offset()), R16_thread);
-  cmpdi(CCR0, R0, 0);
-  beq(CCR0, not_preempted);
+  cmpdi(CR0, R0, 0);
+  beq(CR0, not_preempted);
   mtlr(R0);
   li(R0, 0);
   std(R0, in_bytes(JavaThread::preempt_alternate_return_offset()), R16_thread);
@@ -2215,8 +2215,8 @@ void InterpreterMacroAssembler::restore_after_resume(Register fp) {
   {
     Label ok;
     ld(R12_scratch2, 0, R1_SP);  // load fp
-    cmpd(CCR0, R12_scratch2, R11_scratch1);
-    beq(CCR0, ok);
+    cmpd(CR0, R12_scratch2, R11_scratch1);
+    beq(CR0, ok);
     stop(FILE_AND_LINE ": FP is expected in R11_scratch1");
     bind(ok);
   }
@@ -2298,8 +2298,8 @@ void InterpreterMacroAssembler::restore_interpreter_state(Register scratch, bool
   {
     Label Lok;
     subf(R0, R1_SP, scratch);
-    cmpdi(CCR0, R0, frame::top_ijava_frame_abi_size + frame::ijava_state_size);
-    bge(CCR0, Lok);
+    cmpdi(CR0, R0, frame::top_ijava_frame_abi_size + frame::ijava_state_size);
+    bge(CR0, Lok);
     stop("frame too small (restore istate)");
     bind(Lok);
   }
@@ -2312,13 +2312,13 @@ void InterpreterMacroAssembler::get_method_counters(Register method,
   BLOCK_COMMENT("Load and ev. allocate counter object {");
   Label has_counters;
   ld(Rcounters, in_bytes(Method::method_counters_offset()), method);
-  cmpdi(CCR0, Rcounters, 0);
-  bne(CCR0, has_counters);
+  cmpdi(CR0, Rcounters, 0);
+  bne(CR0, has_counters);
   call_VM(noreg, CAST_FROM_FN_PTR(address,
                                   InterpreterRuntime::build_method_counters), method);
   ld(Rcounters, in_bytes(Method::method_counters_offset()), method);
-  cmpdi(CCR0, Rcounters, 0);
-  beq(CCR0, skip); // No MethodCounters, OutOfMemory.
+  cmpdi(CR0, Rcounters, 0);
+  beq(CR0, skip); // No MethodCounters, OutOfMemory.
   BLOCK_COMMENT("} Load and ev. allocate counter object");
 
   bind(has_counters);
@@ -2398,7 +2398,7 @@ void InterpreterMacroAssembler::verify_oop_or_return_address(Register reg, Regis
 
   const int log2_bytecode_size_limit = 16;
   srdi_(Rtmp, reg, log2_bytecode_size_limit);
-  bne(CCR0, test);
+  bne(CR0, test);
 
   address fd = CAST_FROM_FN_PTR(address, verify_return_address);
   const int nbytes_save = MacroAssembler::num_volatile_regs * 8;
@@ -2442,8 +2442,8 @@ void InterpreterMacroAssembler::notify_method_entry() {
     Label jvmti_post_done;
 
     lwz(R0, in_bytes(JavaThread::interp_only_mode_offset()), R16_thread);
-    cmpwi(CCR0, R0, 0);
-    beq(CCR0, jvmti_post_done);
+    cmpwi(CR0, R0, 0);
+    beq(CR0, jvmti_post_done);
     call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::post_method_entry));
 
     bind(jvmti_post_done);
@@ -2476,8 +2476,8 @@ void InterpreterMacroAssembler::notify_method_exit(bool is_native_method, TosSta
     Label jvmti_post_done;
 
     lwz(R0, in_bytes(JavaThread::interp_only_mode_offset()), R16_thread);
-    cmpwi(CCR0, R0, 0);
-    beq(CCR0, jvmti_post_done);
+    cmpwi(CR0, R0, 0);
+    beq(CR0, jvmti_post_done);
     if (!is_native_method) { push(state); } // Expose tos to GC.
     call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::post_method_exit), check_exceptions);
     if (!is_native_method) { pop(state); }

--- a/src/hotspot/cpu/ppc/interpreterRT_ppc.cpp
+++ b/src/hotspot/cpu/ppc/interpreterRT_ppc.cpp
@@ -103,9 +103,9 @@ void InterpreterRuntime::SignatureHandlerGenerator::pass_object() {
   Label do_null;
   if (do_null_check) {
     __ ld(R0, locals_j_arg_at(offset()));
-    __ cmpdi(CCR0, R0, 0);
+    __ cmpdi(CR0, R0, 0);
     __ li(r, 0);
-    __ beq(CCR0, do_null);
+    __ beq(CR0, do_null);
   }
   __ addir(r, locals_j_arg_at(offset()));
   __ bind(do_null);

--- a/src/hotspot/cpu/ppc/jniFastGetField_ppc.cpp
+++ b/src/hotspot/cpu/ppc/jniFastGetField_ppc.cpp
@@ -75,7 +75,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
 
   __ ld(Rcounter, counter_offs, Rcounter_addr);
   __ andi_(R0, Rcounter, 1);
-  __ bne(CCR0, slow);
+  __ bne(CR0, slow);
 
   if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
     // Field may be volatile.
@@ -91,8 +91,8 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
     int fac_offs = __ load_const_optimized(Rtmp, JvmtiExport::get_field_access_count_addr(),
                                            R0, true);
     __ lwa(Rtmp, fac_offs, Rtmp);
-    __ cmpwi(CCR0, Rtmp, 0);
-    __ bne(CCR0, slow);
+    __ cmpwi(CR0, Rtmp, 0);
+    __ bne(CR0, slow);
   }
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
@@ -118,8 +118,8 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   // Order preceding load(s) wrt. succeeding check (LoadStore for volatile field).
   if (is_fp) {
     Label next;
-    __ fcmpu(CCR0, F1_RET, F1_RET);
-    __ bne(CCR0, next);
+    __ fcmpu(CR0, F1_RET, F1_RET);
+    __ bne(CR0, next);
     __ bind(next);
   } else {
     __ twi_0(Rtmp);
@@ -127,8 +127,8 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   __ isync();
 
   __ ld(R0, counter_offs, Rcounter_addr);
-  __ cmpd(CCR0, R0, Rcounter);
-  __ bne(CCR0, slow);
+  __ cmpd(CR0, R0, Rcounter);
+  __ bne(CR0, slow);
 
   if (!is_fp) {
     __ mr(R3_RET, Rtmp);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1303,8 +1303,8 @@ int MacroAssembler::ic_check(int end_alignment) {
     mtctr(tmp1);
 
     if (!implicit_null_checks_available) {
-      cmpdi(CCR0, receiver, 0);
-      beqctr(CCR0);
+      cmpdi(CR0, receiver, 0);
+      beqctr(CR0);
     }
     if (UseCompressedClassPointers) {
       lwz(tmp1, oopDesc::klass_offset_in_bytes(), receiver);
@@ -1312,8 +1312,8 @@ int MacroAssembler::ic_check(int end_alignment) {
       ld(tmp1, oopDesc::klass_offset_in_bytes(), receiver);
     }
     ld(tmp2, in_bytes(CompiledICData::speculated_klass_offset()), data);
-    cmpd(CCR0, tmp1, tmp2);
-    bnectr(CCR0);
+    cmpd(CR0, tmp1, tmp2);
+    bnectr(CR0);
   }
 
   assert((offset() % end_alignment) == 0, "Misaligned verified entry point");
@@ -1527,8 +1527,8 @@ void MacroAssembler::reserved_stack_check(Register return_pc) {
   Label no_reserved_zone_enabling;
 
   ld_ptr(R0, JavaThread::reserved_stack_activation_offset(), R16_thread);
-  cmpld(CCR0, R1_SP, R0);
-  blt_predict_taken(CCR0, no_reserved_zone_enabling);
+  cmpld(CR0, R1_SP, R0);
+  blt_predict_taken(CR0, no_reserved_zone_enabling);
 
   // Enable reserved zone again, throw stack overflow exception.
   push_frame_reg_args(0, R0);
@@ -1551,9 +1551,9 @@ void MacroAssembler::getandsetd(Register dest_current_value, Register exchange_v
   ldarx(dest_current_value, addr_base, cmpxchgx_hint);
   stdcx_(exchange_value, addr_base);
   if (UseStaticBranchPredictionInCompareAndSwapPPC64) {
-    bne_predict_not_taken(CCR0, retry); // StXcx_ sets CCR0.
+    bne_predict_not_taken(CR0, retry); // StXcx_ sets CR0.
   } else {
-    bne(                  CCR0, retry); // StXcx_ sets CCR0.
+    bne(                  CR0, retry); // StXcx_ sets CR0.
   }
 }
 
@@ -1565,9 +1565,9 @@ void MacroAssembler::getandaddd(Register dest_current_value, Register inc_value,
   add(tmp, dest_current_value, inc_value);
   stdcx_(tmp, addr_base);
   if (UseStaticBranchPredictionInCompareAndSwapPPC64) {
-    bne_predict_not_taken(CCR0, retry); // StXcx_ sets CCR0.
+    bne_predict_not_taken(CR0, retry); // StXcx_ sets CR0.
   } else {
-    bne(                  CCR0, retry); // StXcx_ sets CCR0.
+    bne(                  CR0, retry); // StXcx_ sets CR0.
   }
 }
 
@@ -1638,9 +1638,9 @@ void MacroAssembler::atomic_get_and_modify_generic(Register dest_current_value, 
   }
 
   if (UseStaticBranchPredictionInCompareAndSwapPPC64) {
-    bne_predict_not_taken(CCR0, retry); // StXcx_ sets CCR0.
+    bne_predict_not_taken(CR0, retry); // StXcx_ sets CR0.
   } else {
-    bne(                  CCR0, retry); // StXcx_ sets CCR0.
+    bne(                  CR0, retry); // StXcx_ sets CR0.
   }
 
   // l?arx zero-extends, but Java wants byte/short values sign-extended.
@@ -1744,7 +1744,7 @@ void MacroAssembler::cmpxchg_generic(ConditionRegister flag, Register dest_curre
   bool preset_result_reg = (int_flag_success != dest_current_value && int_flag_success != compare_value.register_or_noreg() &&
                             int_flag_success != exchange_value && int_flag_success != addr_base &&
                             int_flag_success != tmp1 && int_flag_success != tmp2);
-  assert(!weak || flag == CCR0, "weak only supported with CCR0");
+  assert(!weak || flag == CR0, "weak only supported with CR0");
   assert(int_flag_success == noreg || failed_ext == nullptr, "cannot have both");
   assert(size == 1 || size == 2 || size == 4, "unsupported");
 
@@ -1773,9 +1773,9 @@ void MacroAssembler::cmpxchg_generic(ConditionRegister flag, Register dest_curre
                     retry, failed, cmpxchgx_hint, size);
   if (!weak || use_result_reg || failed_ext) {
     if (UseStaticBranchPredictionInCompareAndSwapPPC64) {
-      bne_predict_not_taken(CCR0, weak ? failed : retry); // StXcx_ sets CCR0.
+      bne_predict_not_taken(CR0, weak ? failed : retry); // StXcx_ sets CR0.
     } else {
-      bne(                  CCR0, weak ? failed : retry); // StXcx_ sets CCR0.
+      bne(                  CR0, weak ? failed : retry); // StXcx_ sets CR0.
     }
   }
   // fall through    => (flag == eq), (dest_current_value == compare_value), (swapped)
@@ -1837,7 +1837,7 @@ void MacroAssembler::cmpxchgd(ConditionRegister flag, Register dest_current_valu
   bool use_result_reg    = (int_flag_success!=noreg);
   bool preset_result_reg = (int_flag_success!=dest_current_value && int_flag_success!=compare_value.register_or_noreg() &&
                             int_flag_success!=exchange_value && int_flag_success!=addr_base);
-  assert(!weak || flag == CCR0, "weak only supported with CCR0");
+  assert(!weak || flag == CR0, "weak only supported with CR0");
   assert(int_flag_success == noreg || failed_ext == nullptr, "cannot have both");
 
   if (use_result_reg && preset_result_reg) {
@@ -1870,9 +1870,9 @@ void MacroAssembler::cmpxchgd(ConditionRegister flag, Register dest_current_valu
   stdcx_(exchange_value, addr_base);
   if (!weak || use_result_reg || failed_ext) {
     if (UseStaticBranchPredictionInCompareAndSwapPPC64) {
-      bne_predict_not_taken(CCR0, weak ? failed : retry); // stXcx_ sets CCR0
+      bne_predict_not_taken(CR0, weak ? failed : retry); // stXcx_ sets CR0
     } else {
-      bne(                  CCR0, weak ? failed : retry); // stXcx_ sets CCR0
+      bne(                  CR0, weak ? failed : retry); // stXcx_ sets CR0
     }
   }
 
@@ -1960,12 +1960,12 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
     // Check that this entry is non-null. A null entry means that
     // the receiver class doesn't implement the interface, and wasn't the
     // same as when the caller was compiled.
-    cmpd(CCR0, temp2, intf_klass);
+    cmpd(CR0, temp2, intf_klass);
 
     if (peel) {
-      beq(CCR0, found_method);
+      beq(CR0, found_method);
     } else {
-      bne(CCR0, search);
+      bne(CR0, search);
       // (invert the test to fall through to found_method...)
     }
 
@@ -1973,8 +1973,8 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
 
     bind(search);
 
-    cmpdi(CCR0, temp2, 0);
-    beq(CCR0, L_no_such_interface);
+    cmpdi(CR0, temp2, 0);
+    beq(CR0, L_no_such_interface);
     addi(scan_temp, scan_temp, scan_step);
   }
 
@@ -2044,8 +2044,8 @@ void MacroAssembler::check_klass_subtype_fast_path(Register sub_klass,
   // We move this check to the front of the fast path because many
   // type checks are in fact trivially successful in this manner,
   // so we get a nicely predicted branch right at the start of the check.
-  cmpd(CCR0, sub_klass, super_klass);
-  beq(CCR0, *L_success);
+  cmpd(CR0, sub_klass, super_klass);
+  beq(CR0, *L_success);
 
   // Check the supertype display:
   if (must_load_sco) {
@@ -2058,7 +2058,7 @@ void MacroAssembler::check_klass_subtype_fast_path(Register sub_klass,
   // The loaded value is the offset from Klass.
 
   ld(cached_super, super_check_offset, sub_klass);
-  cmpd(CCR0, cached_super, super_klass);
+  cmpd(CR0, cached_super, super_klass);
 
   // This check has worked decisively for primary supers.
   // Secondary supers are sought in the super_cache ('super_cache_addr').
@@ -2074,29 +2074,29 @@ void MacroAssembler::check_klass_subtype_fast_path(Register sub_klass,
 #define FINAL_JUMP(label) if (&(label) != &L_fallthrough) { b(label); }
 
   if (super_check_offset.is_register()) {
-    beq(CCR0, *L_success);
-    cmpwi(CCR0, super_check_offset.as_register(), sc_offset);
+    beq(CR0, *L_success);
+    cmpwi(CR0, super_check_offset.as_register(), sc_offset);
     if (L_failure == &L_fallthrough) {
-      beq(CCR0, *L_slow_path);
+      beq(CR0, *L_slow_path);
     } else {
-      bne(CCR0, *L_failure);
+      bne(CR0, *L_failure);
       FINAL_JUMP(*L_slow_path);
     }
   } else {
     if (super_check_offset.as_constant() == sc_offset) {
       // Need a slow path; fast failure is impossible.
       if (L_slow_path == &L_fallthrough) {
-        beq(CCR0, *L_success);
+        beq(CR0, *L_success);
       } else {
-        bne(CCR0, *L_slow_path);
+        bne(CR0, *L_slow_path);
         FINAL_JUMP(*L_success);
       }
     } else {
       // No slow path; it's a fast decision.
       if (L_failure == &L_fallthrough) {
-        beq(CCR0, *L_success);
+        beq(CR0, *L_success);
       } else {
-        bne(CCR0, *L_failure);
+        bne(CR0, *L_failure);
         FINAL_JUMP(*L_success);
       }
     }
@@ -2130,16 +2130,16 @@ void MacroAssembler::check_klass_subtype_slow_path_linear(Register sub_klass,
 
   // TODO: PPC port: assert(4 == arrayOopDesc::length_length_in_bytes(), "precondition violated.");
   lwz(temp, length_offset, array_ptr);
-  cmpwi(CCR0, temp, 0);
-  beq(CCR0, (L_success == nullptr) ? failure : fallthru); // indicate failure if length 0
+  cmpwi(CR0, temp, 0);
+  beq(CR0, (L_success == nullptr) ? failure : fallthru); // indicate failure if length 0
 
   mtctr(temp); // load ctr
 
   bind(loop);
   // Oops in table are NO MORE compressed.
   ld(temp, base_offset, array_ptr);
-  cmpd(CCR0, temp, super_klass);
-  beq(CCR0, hit);
+  cmpd(CR0, temp, super_klass);
+  beq(CR0, hit);
   addi(array_ptr, array_ptr, BytesPerWord);
   bdnz(loop);
 
@@ -2147,7 +2147,7 @@ void MacroAssembler::check_klass_subtype_slow_path_linear(Register sub_klass,
   if (result_reg != noreg) {
     li(result_reg, 1); // load non-zero result (indicates a miss)
   } else if (L_success == nullptr) {
-    crandc(CCR0, Assembler::equal, CCR0, Assembler::equal); // miss indicated by CR0.ne
+    crandc(CR0, Assembler::equal, CR0, Assembler::equal); // miss indicated by CR0.ne
   }
   b(fallthru);
 
@@ -2224,14 +2224,14 @@ void MacroAssembler::check_klass_subtype_slow_path_table(Register sub_klass,
 
   if (L_success != nullptr || !result_reg_provided) {
     // result_reg may get overwritten by pop_set
-    cmpdi(CCR0, result_reg, 0);
+    cmpdi(CR0, result_reg, 0);
   }
 
   // Unspill the temp. registers:
   pop_set(pushed_regs);
 
   if (L_success != nullptr) {
-    beq(CCR0, *L_success);
+    beq(CR0, *L_success);
   }
 }
 
@@ -2270,8 +2270,8 @@ void MacroAssembler::repne_scan(Register addr, Register value, Register count, R
 #ifdef ASSERT
   {
     Label ok;
-    cmpdi(CCR0, count, 0);
-    bgt(CCR0, ok);
+    cmpdi(CR0, count, 0);
+    bgt(CR0, ok);
     stop("count must be positive");
     bind(ok);
   }
@@ -2282,7 +2282,7 @@ void MacroAssembler::repne_scan(Register addr, Register value, Register count, R
   bind(Lloop);
   ld(scratch, 0 , addr);
   xor_(scratch, scratch, value);
-  beq(CCR0, Lexit);
+  beq(CR0, Lexit);
   addi(addr, addr, wordSize);
   bdnz(Lloop);
 
@@ -2336,7 +2336,7 @@ void MacroAssembler::lookup_secondary_supers_table_const(Register r_sub_klass,
 
   li(result, 1); // failure
   // We test the MSB of r_array_index, i.e. its sign bit
-  bge(CCR0, L_done);
+  bge(CR0, L_done);
 
   // We will consult the secondary-super array.
   ld(r_array_base, in_bytes(Klass::secondary_supers_offset()), r_sub_klass);
@@ -2360,11 +2360,11 @@ void MacroAssembler::lookup_secondary_supers_table_const(Register r_sub_klass,
   }
 
   xor_(result, result, r_super_klass);
-  beq(CCR0, L_done); // Found a match (result == 0)
+  beq(CR0, L_done); // Found a match (result == 0)
 
   // Is there another entry to check? Consult the bitmap.
-  testbitdi(CCR0, /* temp */ r_array_length, r_bitmap, (bit + 1) & Klass::SECONDARY_SUPERS_TABLE_MASK);
-  beq(CCR0, L_done); // (result != 0)
+  testbitdi(CR0, /* temp */ r_array_length, r_bitmap, (bit + 1) & Klass::SECONDARY_SUPERS_TABLE_MASK);
+  beq(CR0, L_done); // (result != 0)
 
   // Linear probe. Rotate the bitmap so that the next bit to test is
   // in Bit 2 for the look-ahead check in the slow path.
@@ -2428,7 +2428,7 @@ void MacroAssembler::lookup_secondary_supers_table_var(Register r_sub_klass,
   sld_(r_array_index, r_bitmap, R0); // shift left by 63-slot
 
   // We test the MSB of r_array_index, i.e. its sign bit
-  bge(CCR0, L_done);
+  bge(CR0, L_done);
 
   // We will consult the secondary-super array.
   ld(r_array_base, in_bytes(Klass::secondary_supers_offset()), r_sub_klass);
@@ -2446,7 +2446,7 @@ void MacroAssembler::lookup_secondary_supers_table_var(Register r_sub_klass,
 
   ldx(R0, r_array_base, r_array_index);
   xor_(result, R0, r_super_klass);
-  beq(CCR0, L_done); // found a match, result is 0 in this case
+  beq(CR0, L_done); // found a match, result is 0 in this case
 
   // Linear probe. Rotate the bitmap so that the next bit to test is
   // in Bit 1.
@@ -2454,7 +2454,7 @@ void MacroAssembler::lookup_secondary_supers_table_var(Register r_sub_klass,
   rldcl(r_bitmap, r_bitmap, R0, 0);
   Register temp = slot;
   andi_(temp, r_bitmap, 2);
-  beq(CCR0, L_done); // fail (result != 0)
+  beq(CR0, L_done); // fail (result != 0)
 
   // The slot we just inspected is at secondary_supers[r_array_index - 1].
   // The next slot to be inspected, by the logic we're about to call,
@@ -2503,8 +2503,8 @@ void MacroAssembler::lookup_secondary_supers_table_slow_path(Register r_super_kl
 
   // The bitmap is full to bursting.
   // Implicit invariant: BITMAP_FULL implies (length > 0)
-  cmpwi(CCR0, r_array_length, (int32_t)Klass::SECONDARY_SUPERS_TABLE_SIZE - 2);
-  bgt(CCR0, L_huge);
+  cmpwi(CR0, r_array_length, (int32_t)Klass::SECONDARY_SUPERS_TABLE_SIZE - 2);
+  bgt(CR0, L_huge);
 
   // NB! Our caller has checked bits 0 and 1 in the bitmap. The
   // current slot (at secondary_supers[r_array_index]) has not yet
@@ -2522,8 +2522,8 @@ void MacroAssembler::lookup_secondary_supers_table_slow_path(Register r_super_kl
       // We should only reach here after having found a bit in the bitmap.
       // Invariant: array_length == popcount(bitmap)
       Label ok;
-      cmpdi(CCR0, r_array_length, 0);
-      bgt(CCR0, ok);
+      cmpdi(CR0, r_array_length, 0);
+      bgt(CR0, ok);
       stop("array_length must be positive");
       bind(ok);
     }
@@ -2537,16 +2537,16 @@ void MacroAssembler::lookup_secondary_supers_table_slow_path(Register r_super_kl
     bind(L_loop);
 
     // Check for wraparound.
-    cmpd(CCR0, r_array_index, r_array_length);
-    isel_0(r_array_index, CCR0, Assembler::greater);
+    cmpd(CR0, r_array_index, r_array_length);
+    isel_0(r_array_index, CR0, Assembler::greater);
 
     ldx(result, r_array_base, r_array_index);
     xor_(result, result, r_super_klass);
-    beq(CCR0, L_done); // success (result == 0)
+    beq(CR0, L_done); // success (result == 0)
 
     // look-ahead check (Bit 2); result is non-zero
-    testbitdi(CCR0, R0, r_bitmap, 2);
-    beq(CCR0, L_done); // fail (result != 0)
+    testbitdi(CR0, R0, r_bitmap, 2);
+    beq(CR0, L_done); // fail (result != 0)
 
     rldicl(r_bitmap, r_bitmap, 64 - 1, 0);
     addi(r_array_index, r_array_index, BytesPerWord);
@@ -2594,16 +2594,16 @@ void MacroAssembler::verify_secondary_supers_table(Register r_sub_klass,
   normalize_bool(result, R0, true);
   const Register linear_result = r_array_index; // reuse
   li(linear_result, 1);
-  cmpdi(CCR0, r_array_length, 0);
-  ble(CCR0, failure);
+  cmpdi(CR0, r_array_length, 0);
+  ble(CR0, failure);
   repne_scan(r_array_base, r_super_klass, r_array_length, linear_result);
   bind(failure);
 
   // convert !=0 to 1
   normalize_bool(linear_result, R0, true);
 
-  cmpd(CCR0, result, linear_result);
-  beq(CCR0, passed);
+  cmpd(CR0, result, linear_result);
+  beq(CR0, passed);
 
   // report fatal error and terminate VM
 
@@ -2639,19 +2639,19 @@ void MacroAssembler::clinit_barrier(Register klass, Register thread, Label* L_fa
   // Fast path check: class is fully initialized
   lbz(R0, in_bytes(InstanceKlass::init_state_offset()), klass);
   // acquire by cmp-branch-isync if fully_initialized
-  cmpwi(CCR0, R0, InstanceKlass::fully_initialized);
-  bne(CCR0, L_check_thread);
+  cmpwi(CR0, R0, InstanceKlass::fully_initialized);
+  bne(CR0, L_check_thread);
   isync();
   b(*L_fast_path);
 
   // Fast path check: current thread is initializer thread
   bind(L_check_thread);
   ld(R0, in_bytes(InstanceKlass::init_thread_offset()), klass);
-  cmpd(CCR0, thread, R0);
+  cmpd(CR0, thread, R0);
   if (L_slow_path == &L_fallthrough) {
-    beq(CCR0, *L_fast_path);
+    beq(CR0, *L_fast_path);
   } else if (L_fast_path == &L_fallthrough) {
-    bne(CCR0, *L_slow_path);
+    bne(CR0, *L_slow_path);
   } else {
     Unimplemented();
   }
@@ -2699,15 +2699,15 @@ void MacroAssembler::tlab_allocate(
   } else {
     add(new_top, obj, var_size_in_bytes);
   }
-  cmpld(CCR0, new_top, R0);
-  bc_far_optimized(Assembler::bcondCRbiIs1, bi0(CCR0, Assembler::greater), slow_case);
+  cmpld(CR0, new_top, R0);
+  bc_far_optimized(Assembler::bcondCRbiIs1, bi0(CR0, Assembler::greater), slow_case);
 
 #ifdef ASSERT
   // make sure new free pointer is properly aligned
   {
     Label L;
     andi_(R0, new_top, MinObjAlignmentInBytesMask);
-    beq(CCR0, L);
+    beq(CR0, L);
     stop("updated TLAB free is not properly aligned");
     bind(L);
   }
@@ -2784,7 +2784,7 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
   // Handle existing monitor.
   // The object has an existing monitor iff (mark & monitor_value) != 0.
   andi_(temp, displaced_header, markWord::monitor_value);
-  bne(CCR0, object_has_monitor);
+  bne(CR0, object_has_monitor);
 
   if (LockingMode == LM_MONITOR) {
     // Set NE to indicate 'failure' -> take slow-path.
@@ -2830,10 +2830,10 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
     // displaced header in the box, which indicates that it is a recursive lock.
     std(R0/*==0, perhaps*/, BasicLock::displaced_header_offset_in_bytes(), box);
 
-    if (flag != CCR0) {
-      mcrf(flag, CCR0);
+    if (flag != CR0) {
+      mcrf(flag, CR0);
     }
-    beq(CCR0, success);
+    beq(CR0, success);
     b(failure);
   }
 
@@ -2906,7 +2906,7 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
   // The object has an existing monitor iff (mark & monitor_value) != 0.
   ld(current_header, oopDesc::mark_offset_in_bytes(), oop);
   andi_(R0, current_header, markWord::monitor_value);
-  bne(CCR0, object_has_monitor);
+  bne(CR0, object_has_monitor);
 
   if (LockingMode == LM_MONITOR) {
     // Set NE to indicate 'failure' -> take slow-path.
@@ -2937,12 +2937,12 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
 
   ld(displaced_header, in_bytes(ObjectMonitor::recursions_offset()), current_header);
   addic_(displaced_header, displaced_header, -1);
-  blt(CCR0, not_recursive); // Not recursive if negative after decrement.
+  blt(CR0, not_recursive); // Not recursive if negative after decrement.
 
   // Recursive unlock
   std(displaced_header, in_bytes(ObjectMonitor::recursions_offset()), current_header);
-  if (flag == CCR0) { // Otherwise, flag is already EQ, here.
-    crorc(CCR0, Assembler::equal, CCR0, Assembler::equal); // Set CCR0 EQ
+  if (flag == CR0) { // Otherwise, flag is already EQ, here.
+    crorc(CR0, Assembler::equal, CR0, Assembler::equal); // Set CR0 EQ
   }
   b(success);
 
@@ -3001,7 +3001,7 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(ConditionRegister fla
                                                            Register tmp1, Register tmp2, Register tmp3) {
   assert_different_registers(obj, box, tmp1, tmp2, tmp3);
   assert(UseObjectMonitorTable || tmp3 == noreg, "tmp3 not needed");
-  assert(flag == CCR0, "bad condition register");
+  assert(flag == CR0, "bad condition register");
 
   // Handle inflated monitor.
   Label inflated;
@@ -3019,8 +3019,8 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(ConditionRegister fla
   if (DiagnoseSyncOnValueBasedClasses != 0) {
     load_klass(tmp1, obj);
     lbz(tmp1, in_bytes(Klass::misc_flags_offset()), tmp1);
-    testbitdi(CCR0, R0, tmp1, exact_log2(KlassFlags::_misc_is_value_based_class));
-    bne(CCR0, slow_path);
+    testbitdi(CR0, R0, tmp1, exact_log2(KlassFlags::_misc_is_value_based_class));
+    bne(CR0, slow_path);
   }
 
   Register mark = tmp1;
@@ -3034,8 +3034,8 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(ConditionRegister fla
 
     // Check if lock-stack is full.
     lwz(top, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
-    cmplwi(CCR0, top, LockStack::end_offset() - 1);
-    bgt(CCR0, slow_path);
+    cmplwi(CR0, top, LockStack::end_offset() - 1);
+    bgt(CR0, slow_path);
 
     // The underflow check is elided. The recursive check will always fail
     // when the lock stack is empty because of the _bad_oop_sentinel field.
@@ -3043,15 +3043,15 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(ConditionRegister fla
     // Check if recursive.
     subi(R0, top, oopSize);
     ldx(R0, R16_thread, R0);
-    cmpd(CCR0, obj, R0);
-    beq(CCR0, push);
+    cmpd(CR0, obj, R0);
+    beq(CR0, push);
 
     // Check for monitor (0b10) or locked (0b00).
     ld(mark, oopDesc::mark_offset_in_bytes(), obj);
     andi_(R0, mark, markWord::lock_mask_in_place);
-    cmpldi(CCR0, R0, markWord::unlocked_value);
-    bgt(CCR0, inflated);
-    bne(CCR0, slow_path);
+    cmpldi(CR0, R0, markWord::unlocked_value);
+    bgt(CR0, inflated);
+    bne(CR0, slow_path);
 
     // Not inflated.
 
@@ -3091,8 +3091,8 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(ConditionRegister fla
       const int num_unrolled = 2;
       for (int i = 0; i < num_unrolled; i++) {
         ld(R0, 0, cache_addr);
-        cmpd(CCR0, R0, obj);
-        beq(CCR0, monitor_found);
+        cmpd(CR0, R0, obj);
+        beq(CR0, monitor_found);
         addi(cache_addr, cache_addr, in_bytes(OMCache::oop_to_oop_difference()));
       }
 
@@ -3103,14 +3103,14 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(ConditionRegister fla
 
       // Check for match.
       ld(R0, 0, cache_addr);
-      cmpd(CCR0, R0, obj);
-      beq(CCR0, monitor_found);
+      cmpd(CR0, R0, obj);
+      beq(CR0, monitor_found);
 
       // Search until null encountered, guaranteed _null_sentinel at end.
       addi(cache_addr, cache_addr, in_bytes(OMCache::oop_to_oop_difference()));
-      cmpdi(CCR1, R0, 0);
-      bne(CCR1, loop);
-      // Cache Miss, CCR0.NE set from cmp above
+      cmpdi(CR1, R0, 0);
+      bne(CR1, loop);
+      // Cache Miss, CR0.NE set from cmp above
       b(slow_path);
 
       bind(monitor_found);
@@ -3123,18 +3123,18 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(ConditionRegister fla
     // Try to CAS owner (no owner => current thread's _monitor_owner_id).
     assert_different_registers(thread_id, monitor, owner_addr, box, R0);
     ld(thread_id, in_bytes(JavaThread::monitor_owner_id_offset()), R16_thread);
-    cmpxchgd(/*flag=*/CCR0,
+    cmpxchgd(/*flag=*/CR0,
             /*current_value=*/R0,
             /*compare_value=*/(intptr_t)0,
             /*exchange_value=*/thread_id,
             /*where=*/owner_addr,
             MacroAssembler::MemBarRel | MacroAssembler::MemBarAcq,
             MacroAssembler::cmpxchgx_hint_acquire_lock());
-    beq(CCR0, monitor_locked);
+    beq(CR0, monitor_locked);
 
     // Check if recursive.
-    cmpd(CCR0, R0, thread_id);
-    bne(CCR0, slow_path);
+    cmpd(CR0, R0, thread_id);
+    bne(CR0, slow_path);
 
     // Recursive.
     if (!UseObjectMonitorTable) {
@@ -3160,13 +3160,13 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(ConditionRegister fla
 #ifdef ASSERT
   // Check that locked label is reached with flag == EQ.
   Label flag_correct;
-  beq(CCR0, flag_correct);
+  beq(CR0, flag_correct);
   stop("Fast Lock Flag != EQ");
 #endif
   bind(slow_path);
 #ifdef ASSERT
   // Check that slow_path label is reached with flag == NE.
-  bne(CCR0, flag_correct);
+  bne(CR0, flag_correct);
   stop("Fast Lock Flag != NE");
   bind(flag_correct);
 #endif
@@ -3176,7 +3176,7 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(ConditionRegister fla
 void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister flag, Register obj, Register box,
                                                              Register tmp1, Register tmp2, Register tmp3) {
   assert_different_registers(obj, tmp1, tmp2, tmp3);
-  assert(flag == CCR0, "bad condition register");
+  assert(flag == CR0, "bad condition register");
 
   // Handle inflated monitor.
   Label inflated, inflated_load_monitor;
@@ -3196,9 +3196,9 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
     lwz(top, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
     subi(top, top, oopSize);
     ldx(t, R16_thread, top);
-    cmpd(CCR0, obj, t);
+    cmpd(CR0, obj, t);
     // Top of lock stack was not obj. Must be monitor.
-    bne(CCR0, inflated_load_monitor);
+    bne(CR0, inflated_load_monitor);
 
     // Pop lock-stack.
     DEBUG_ONLY(li(t, 0);)
@@ -3211,8 +3211,8 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
     // Check if recursive.
     subi(t, top, oopSize);
     ldx(t, R16_thread, t);
-    cmpd(CCR0, obj, t);
-    beq(CCR0, unlocked);
+    cmpd(CR0, obj, t);
+    beq(CR0, unlocked);
 
     // Not recursive.
 
@@ -3220,16 +3220,16 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
     ld(mark, oopDesc::mark_offset_in_bytes(), obj);
     andi_(t, mark, markWord::monitor_value);
     if (!UseObjectMonitorTable) {
-      bne(CCR0, inflated);
+      bne(CR0, inflated);
     } else {
-      bne(CCR0, push_and_slow);
+      bne(CR0, push_and_slow);
     }
 
 #ifdef ASSERT
     // Check header not unlocked (0b01).
     Label not_unlocked;
     andi_(t, mark, markWord::unlocked_value);
-    beq(CCR0, not_unlocked);
+    beq(CR0, not_unlocked);
     stop("lightweight_unlock already unlocked");
     bind(not_unlocked);
 #endif
@@ -3251,7 +3251,7 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
     ld(mark, oopDesc::mark_offset_in_bytes(), obj);
 #ifdef ASSERT
     andi_(t, mark, markWord::monitor_value);
-    bne(CCR0, inflated);
+    bne(CR0, inflated);
     stop("Fast Unlock not monitor");
 #endif
 
@@ -3260,11 +3260,11 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
 #ifdef ASSERT
     Label check_done;
     subi(top, top, oopSize);
-    cmplwi(CCR0, top, in_bytes(JavaThread::lock_stack_base_offset()));
-    blt(CCR0, check_done);
+    cmplwi(CR0, top, in_bytes(JavaThread::lock_stack_base_offset()));
+    blt(CR0, check_done);
     ldx(t, R16_thread, top);
-    cmpd(CCR0, obj, t);
-    bne(CCR0, inflated);
+    cmpd(CR0, obj, t);
+    bne(CR0, inflated);
     stop("Fast Unlock lock on stack");
     bind(check_done);
 #endif
@@ -3279,8 +3279,8 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
     } else {
       ld(monitor, BasicLock::object_monitor_cache_offset_in_bytes(), box);
       // null check with Flags == NE, no valid pointer below alignof(ObjectMonitor*)
-      cmpldi(CCR0, monitor, checked_cast<uint8_t>(alignof(ObjectMonitor*)));
-      blt(CCR0, slow_path);
+      cmpldi(CR0, monitor, checked_cast<uint8_t>(alignof(ObjectMonitor*)));
+      blt(CR0, slow_path);
     }
 
     const Register recursions = tmp2;
@@ -3289,11 +3289,11 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
     // Check if recursive.
     ld(recursions, in_bytes(ObjectMonitor::recursions_offset()), monitor);
     addic_(recursions, recursions, -1);
-    blt(CCR0, not_recursive);
+    blt(CR0, not_recursive);
 
     // Recursive unlock.
     std(recursions, in_bytes(ObjectMonitor::recursions_offset()), monitor);
-    crorc(CCR0, Assembler::equal, CCR0, Assembler::equal);
+    crorc(CR0, Assembler::equal, CR0, Assembler::equal);
     b(unlocked);
 
     bind(not_recursive);
@@ -3313,15 +3313,15 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
     ld(t, in_bytes(ObjectMonitor::EntryList_offset()), monitor);
     ld(t2, in_bytes(ObjectMonitor::cxq_offset()), monitor);
     orr(t, t, t2);
-    cmpdi(CCR0, t, 0);
-    beq(CCR0, unlocked); // If so we are done.
+    cmpdi(CR0, t, 0);
+    beq(CR0, unlocked); // If so we are done.
 
     // Check if there is a successor.
     ld(t, in_bytes(ObjectMonitor::succ_offset()), monitor);
-    cmpdi(CCR0, t, 0);
+    cmpdi(CR0, t, 0);
     // Invert equal bit
     crnand(flag, Assembler::equal, flag, Assembler::equal);
-    beq(CCR0, unlocked); // If there is a successor we are done.
+    beq(CR0, unlocked); // If there is a successor we are done.
 
     // Save the monitor pointer in the current thread, so we can try
     // to reacquire the lock in SharedRuntime::monitor_exit_helper().
@@ -3334,13 +3334,13 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
 #ifdef ASSERT
   // Check that unlocked label is reached with flag == EQ.
   Label flag_correct;
-  beq(CCR0, flag_correct);
+  beq(CR0, flag_correct);
   stop("Fast Lock Flag != EQ");
 #endif
   bind(slow_path);
 #ifdef ASSERT
   // Check that slow_path label is reached with flag == NE.
-  bne(CCR0, flag_correct);
+  bne(CR0, flag_correct);
   stop("Fast Lock Flag != NE");
   bind(flag_correct);
 #endif
@@ -3357,21 +3357,21 @@ void MacroAssembler::safepoint_poll(Label& slow_path, Register temp, bool at_ret
         relocate(relocInfo::poll_return_type);
         td(traptoGreaterThanUnsigned, R1_SP, temp);
       } else {
-        cmpld(CCR0, R1_SP, temp);
+        cmpld(CR0, R1_SP, temp);
         // Stub may be out of range for short conditional branch.
-        bc_far_optimized(Assembler::bcondCRbiIs1, bi0(CCR0, Assembler::greater), slow_path);
+        bc_far_optimized(Assembler::bcondCRbiIs1, bi0(CR0, Assembler::greater), slow_path);
       }
     } else { // Not in nmethod.
       // Frame still on stack, need to get fp.
       Register fp = R0;
       ld(fp, _abi0(callers_sp), R1_SP);
-      cmpld(CCR0, fp, temp);
-      bgt(CCR0, slow_path);
+      cmpld(CR0, fp, temp);
+      bgt(CR0, slow_path);
     }
   } else { // Normal safepoint poll. Not at return.
     assert(!in_nmethod, "should use load_from_polling_page");
     andi_(temp, temp, SafepointMechanism::poll_bit());
-    bne(CCR0, slow_path);
+    bne(CR0, slow_path);
   }
 }
 
@@ -3612,8 +3612,8 @@ void MacroAssembler::resolve_weak_handle(Register result, Register tmp1, Registe
   Label resolved;
 
   // A null weak handle resolves to null.
-  cmpdi(CCR0, result, 0);
-  beq(CCR0, resolved);
+  cmpdi(CR0, result, 0);
+  beq(CR0, resolved);
 
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF, result, noreg, result, tmp1, tmp2,
                  preservation_level);
@@ -3674,11 +3674,11 @@ void MacroAssembler::clear_memory_doubleword(Register base_ptr, Register cnt_dwo
     load_const_optimized(cnt_dwords, const_cnt, tmp);
   } else {
     // cnt_dwords already loaded in register. Need to check size.
-    cmpdi(CCR1, cnt_dwords, min_cnt); // Big enough? (ensure >= dcbz_min lines included).
-    blt(CCR1, small_rest);
+    cmpdi(CR1, cnt_dwords, min_cnt); // Big enough? (ensure >= dcbz_min lines included).
+    blt(CR1, small_rest);
   }
     rldicl_(tmp, base_ptr, 64-3, 64-cl_dw_addr_bits); // Extract dword offset within first cache line.
-    beq(CCR0, fast);                                  // Already 128byte aligned.
+    beq(CR0, fast);                                  // Already 128byte aligned.
 
     subfic(tmp, tmp, cl_dwords);
     mtctr(tmp);                        // Set ctr to hit 128byte boundary (0<ctr<cl_dwords).
@@ -3701,8 +3701,8 @@ void MacroAssembler::clear_memory_doubleword(Register base_ptr, Register cnt_dwo
     bdnz(fastloop);
 
   bind(small_rest);
-    cmpdi(CCR0, cnt_dwords, 0);        // size 0?
-    beq(CCR0, done);                   // rest == 0
+    cmpdi(CR0, cnt_dwords, 0);        // size 0?
+    beq(CR0, done);                   // rest == 0
     li(tmp, 0);
     mtctr(cnt_dwords);                 // Load counter.
 
@@ -3824,7 +3824,7 @@ void MacroAssembler::update_byteLoop_crc32(Register crc, Register buf, Register 
 
   // Process all bytes in a single-byte loop.
   clrldi_(len, len, 32);                         // Enforce 32 bit. Anything to do?
-  beq(CCR0, L_done);
+  beq(CR0, L_done);
 
   mtctr(len);
   align(mainLoop_alignment);
@@ -3915,8 +3915,8 @@ void MacroAssembler::kernel_crc32_1word(Register crc, Register buf, Register len
   }
 
   // Check for short (<mainLoop_stepping) buffer.
-  cmpdi(CCR0, len, complexThreshold);
-  blt(CCR0, L_tail);
+  cmpdi(CR0, len, complexThreshold);
+  blt(CR0, L_tail);
 
   // Pre-mainLoop alignment did show a slight (1%) positive effect on performance.
   // We leave the code in for reference. Maybe we need alignment when we exploit vector instructions.
@@ -3929,8 +3929,8 @@ void MacroAssembler::kernel_crc32_1word(Register crc, Register buf, Register len
       sub(len, len, tmp2);                       // Remaining bytes for main loop (>=mainLoop_stepping is guaranteed).
     } else {
       sub(tmp, len, tmp2);                       // Remaining bytes for main loop.
-      cmpdi(CCR0, tmp, mainLoop_stepping);
-      blt(CCR0, L_tail);                         // For less than one mainloop_stepping left, do only tail processing
+      cmpdi(CR0, tmp, mainLoop_stepping);
+      blt(CR0, L_tail);                         // For less than one mainloop_stepping left, do only tail processing
       mr(len, tmp);                              // remaining bytes for main loop (>=mainLoop_stepping is guaranteed).
     }
     update_byteLoop_crc32(crc, buf, tmp2, table, data, false);
@@ -4007,8 +4007,8 @@ void MacroAssembler::kernel_crc32_vpmsum(Register crc, Register buf, Register le
   neg(prealign, buf);
   addi(t1, len, -threshold);
   andi(prealign, prealign, alignment - 1);
-  cmpw(CCR0, t1, prealign);
-  blt(CCR0, L_tail); // len - prealign < threshold?
+  cmpw(CR0, t1, prealign);
+  blt(CR0, L_tail); // len - prealign < threshold?
 
   subf(len, prealign, len);
   update_byteLoop_crc32(crc, buf, prealign, constants, t2, false);
@@ -4132,8 +4132,8 @@ void MacroAssembler::kernel_crc32_vpmsum_aligned(Register crc, Register buf, Reg
 #define BE_swap_bytes(x) vperm(x, x, x, swap_bytes)
 #endif
 
-  cmpd(CCR0, len, num_bytes);
-  blt(CCR0, L_last);
+  cmpd(CR0, len, num_bytes);
+  blt(CR0, L_last);
 
   addi(cur_const, constants, outer_consts_size); // Point to consts for inner loop
   load_const_optimized(loop_count, unroll_factor / (2 * unroll_factor2) - 1); // One double-iteration peeled off.
@@ -4220,8 +4220,8 @@ void MacroAssembler::kernel_crc32_vpmsum_aligned(Register crc, Register buf, Reg
       vxor(data0[j], data0[j], data0[j+i]);
     }
   }
-  cmpd(CCR0, len, num_bytes);
-  bge(CCR0, L_outer_loop);
+  cmpd(CR0, len, num_bytes);
+  bge(CR0, L_outer_loop);
 
   // Last chance with lower num_bytes.
   bind(L_last);
@@ -4233,7 +4233,7 @@ void MacroAssembler::kernel_crc32_vpmsum_aligned(Register crc, Register buf, Reg
   subf(cur_const, R0, cur_const); // Point to constant to be used first.
 
   addic_(loop_count, loop_count, -1); // One double-iteration peeled off.
-  bgt(CCR0, L_outer_loop);
+  bgt(CR0, L_outer_loop);
   // ********** Main loop end **********
 
   // Restore DSCR pre-fetch value.
@@ -4248,7 +4248,7 @@ void MacroAssembler::kernel_crc32_vpmsum_aligned(Register crc, Register buf, Reg
 
     srdi_(t0, len, 4); // 16 bytes per iteration
     clrldi(len, len, 64-4);
-    beq(CCR0, L_done);
+    beq(CR0, L_done);
 
     // Point to const (same as last const for inner loop).
     add_const_optimized(cur_const, constants, outer_consts_size + inner_consts_size - 16);
@@ -4367,7 +4367,7 @@ void MacroAssembler::multiply_64_x_64_loop(Register x, Register xstart,
   Label L_one_x, L_one_y, L_multiply;
 
   addic_(xstart, xstart, -1);
-  blt(CCR0, L_one_x);   // Special case: length of x is 1.
+  blt(CR0, L_one_x);   // Special case: length of x is 1.
 
   // Load next two integers of x.
   sldi(tmp, xstart, LogBytesPerInt);
@@ -4379,10 +4379,10 @@ void MacroAssembler::multiply_64_x_64_loop(Register x, Register xstart,
   align(32, 16);
   bind(L_first_loop);
 
-  cmpdi(CCR0, idx, 1);
-  blt(CCR0, L_first_loop_exit);
+  cmpdi(CR0, idx, 1);
+  blt(CR0, L_first_loop_exit);
   addi(idx, idx, -2);
-  beq(CCR0, L_one_y);
+  beq(CR0, L_one_y);
 
   // Load next two integers of y.
   sldi(tmp, idx, LogBytesPerInt);
@@ -4490,7 +4490,7 @@ void MacroAssembler::multiply_128_x_128_loop(Register x_xstart,
 
   // Scale the index.
   srdi_(jdx, idx, 2);
-  beq(CCR0, L_third_loop_exit);
+  beq(CR0, L_third_loop_exit);
   mtctr(jdx);
 
   align(32, 16);
@@ -4508,12 +4508,12 @@ void MacroAssembler::multiply_128_x_128_loop(Register x_xstart,
   bind(L_third_loop_exit);  // Handle any left-over operand parts.
 
   andi_(idx, idx, 0x3);
-  beq(CCR0, L_post_third_loop_done);
+  beq(CR0, L_post_third_loop_done);
 
   Label L_check_1;
 
   addic_(idx, idx, -2);
-  blt(CCR0, L_check_1);
+  blt(CR0, L_check_1);
 
   multiply_add_128_x_128(x_xstart, y, z, yz_idx, idx, carry, product_high, product, tmp, 0);
   mr_if_needed(carry, product_high);
@@ -4523,7 +4523,7 @@ void MacroAssembler::multiply_128_x_128_loop(Register x_xstart,
   addi(idx, idx, 0x2);
   andi_(idx, idx, 0x1);
   addic_(idx, idx, -1);
-  blt(CCR0, L_post_third_loop_done);
+  blt(CR0, L_post_third_loop_done);
 
   sldi(tmp, idx, LogBytesPerInt);
   lwzx(yz_idx, y, tmp);
@@ -4551,12 +4551,12 @@ void MacroAssembler::muladd(Register out, Register in,
   Label LOOP, SKIP;
 
   // Make sure length is positive.
-  cmpdi  (CCR0,    len,     0);
+  cmpdi  (CR0,    len,     0);
 
   // Prepare variables
   subi   (offset,  offset,  4);
   li     (carry,   0);
-  ble    (CCR0,    SKIP);
+  ble    (CR0,    SKIP);
 
   mtctr  (len);
   subi   (len,     len,     1    );
@@ -4628,20 +4628,20 @@ void MacroAssembler::multiply_to_len(Register x, Register xlen,
   Label L_done;
 
   addic_(xstart, xlen, -1);
-  blt(CCR0, L_done);
+  blt(CR0, L_done);
 
   multiply_64_x_64_loop(x, xstart, x_xstart, y, y_idx, z,
                         carry, product_high, product, idx, kdx, tmp);
 
   Label L_second_loop;
 
-  cmpdi(CCR0, kdx, 0);
-  beq(CCR0, L_second_loop);
+  cmpdi(CR0, kdx, 0);
+  beq(CR0, L_second_loop);
 
   Label L_carry;
 
   addic_(kdx, kdx, -1);
-  beq(CCR0, L_carry);
+  beq(CR0, L_carry);
 
   // Store lower 32 bits of carry.
   sldi(tmp, kdx, LogBytesPerInt);
@@ -4676,7 +4676,7 @@ void MacroAssembler::multiply_to_len(Register x, Register xlen,
   li(carry, 0);                   // carry = 0;
 
   addic_(xstart, xstart, -1);     // i = xstart-1;
-  blt(CCR0, L_done);
+  blt(CR0, L_done);
 
   Register zsave = tmp10;
 
@@ -4689,7 +4689,7 @@ void MacroAssembler::multiply_to_len(Register x, Register xlen,
   add(z, z, tmp);                 // z = z + k - j
   addi(z, z, 4);
   addic_(xstart, xstart, -1);     // i = xstart-1;
-  blt(CCR0, L_last_x);
+  blt(CR0, L_last_x);
 
   sldi(tmp, xstart, LogBytesPerInt);
   ldx(x_xstart, x, tmp);
@@ -4723,7 +4723,7 @@ void MacroAssembler::multiply_to_len(Register x, Register xlen,
   sldi(tmp, tmp3, LogBytesPerInt);
   stwx(carry, z, tmp);
   addic_(tmp3, tmp3, -1);
-  blt(CCR0, L_done);
+  blt(CR0, L_done);
 
   srdi(carry, carry, 32);
   sldi(tmp, tmp3, LogBytesPerInt);
@@ -4743,9 +4743,9 @@ void MacroAssembler::asm_assert(bool check_equal, const char *msg) {
 #ifdef ASSERT
   Label ok;
   if (check_equal) {
-    beq(CCR0, ok);
+    beq(CR0, ok);
   } else {
-    bne(CCR0, ok);
+    bne(CR0, ok);
   }
   stop(msg);
   bind(ok);
@@ -4758,11 +4758,11 @@ void MacroAssembler::asm_assert_mems_zero(bool check_equal, int size, int mem_of
   switch (size) {
     case 4:
       lwz(R0, mem_offset, mem_base);
-      cmpwi(CCR0, R0, 0);
+      cmpwi(CR0, R0, 0);
       break;
     case 8:
       ld(R0, mem_offset, mem_base);
-      cmpdi(CCR0, R0, 0);
+      cmpdi(CR0, R0, 0);
       break;
     default:
       ShouldNotReachHere();
@@ -4884,8 +4884,8 @@ void MacroAssembler::zap_from_to(Register low, int before, Register high, int af
     bind(loop);
     std(val, 0, addr);
     addi(addr, addr, 8);
-    cmpd(CCR6, addr, high);
-    ble(CCR6, loop);
+    cmpd(CR6, addr, high);
+    ble(CR6, loop);
     if (after) addi(high, high, -after * BytesPerWord);  // Correct back to old value.
   }
   BLOCK_COMMENT("} zap memory region");
@@ -4917,8 +4917,8 @@ void MacroAssembler::push_cont_fastpath() {
 
   Label done;
   ld_ptr(R0, JavaThread::cont_fastpath_offset(), R16_thread);
-  cmpld(CCR0, R1_SP, R0);
-  ble(CCR0, done);
+  cmpld(CR0, R1_SP, R0);
+  ble(CR0, done);
   st_ptr(R1_SP, JavaThread::cont_fastpath_offset(), R16_thread);
   bind(done);
 }
@@ -4928,48 +4928,48 @@ void MacroAssembler::pop_cont_fastpath() {
 
   Label done;
   ld_ptr(R0, JavaThread::cont_fastpath_offset(), R16_thread);
-  cmpld(CCR0, R1_SP, R0);
-  ble(CCR0, done);
+  cmpld(CR0, R1_SP, R0);
+  ble(CR0, done);
   li(R0, 0);
   st_ptr(R0, JavaThread::cont_fastpath_offset(), R16_thread);
   bind(done);
 }
 
-// Note: Must preserve CCR0 EQ (invariant).
+// Note: Must preserve CR0 EQ (invariant).
 void MacroAssembler::inc_held_monitor_count(Register tmp) {
   assert(LockingMode == LM_LEGACY, "");
   ld(tmp, in_bytes(JavaThread::held_monitor_count_offset()), R16_thread);
 #ifdef ASSERT
   Label ok;
-  cmpdi(CCR0, tmp, 0);
-  bge_predict_taken(CCR0, ok);
+  cmpdi(CR0, tmp, 0);
+  bge_predict_taken(CR0, ok);
   stop("held monitor count is negativ at increment");
   bind(ok);
-  crorc(CCR0, Assembler::equal, CCR0, Assembler::equal); // Restore CCR0 EQ
+  crorc(CR0, Assembler::equal, CR0, Assembler::equal); // Restore CR0 EQ
 #endif
   addi(tmp, tmp, 1);
   std(tmp, in_bytes(JavaThread::held_monitor_count_offset()), R16_thread);
 }
 
-// Note: Must preserve CCR0 EQ (invariant).
+// Note: Must preserve CR0 EQ (invariant).
 void MacroAssembler::dec_held_monitor_count(Register tmp) {
   assert(LockingMode == LM_LEGACY, "");
   ld(tmp, in_bytes(JavaThread::held_monitor_count_offset()), R16_thread);
 #ifdef ASSERT
   Label ok;
-  cmpdi(CCR0, tmp, 0);
-  bgt_predict_taken(CCR0, ok);
+  cmpdi(CR0, tmp, 0);
+  bgt_predict_taken(CR0, ok);
   stop("held monitor count is <= 0 at decrement");
   bind(ok);
-  crorc(CCR0, Assembler::equal, CCR0, Assembler::equal); // Restore CCR0 EQ
+  crorc(CR0, Assembler::equal, CR0, Assembler::equal); // Restore CR0 EQ
 #endif
   addi(tmp, tmp, -1);
   std(tmp, in_bytes(JavaThread::held_monitor_count_offset()), R16_thread);
 }
 
 // Function to flip between unlocked and locked state (fast locking).
-// Branches to failed if the state is not as expected with CCR0 NE.
-// Falls through upon success with CCR0 EQ.
+// Branches to failed if the state is not as expected with CR0 NE.
+// Falls through upon success with CR0 EQ.
 // This requires fewer instructions and registers and is easier to use than the
 // cmpxchg based implementation.
 void MacroAssembler::atomically_flip_locked_state(bool is_unlock, Register obj, Register tmp, Label& failed, int semantics) {
@@ -4986,15 +4986,15 @@ void MacroAssembler::atomically_flip_locked_state(bool is_unlock, Register obj, 
     ldarx(tmp, obj, MacroAssembler::cmpxchgx_hint_acquire_lock());
     xori(tmp, tmp, markWord::unlocked_value); // flip unlocked bit
     andi_(R0, tmp, markWord::lock_mask_in_place);
-    bne(CCR0, failed); // failed if new header doesn't contain locked_value (which is 0)
+    bne(CR0, failed); // failed if new header doesn't contain locked_value (which is 0)
   } else {
     ldarx(tmp, obj, MacroAssembler::cmpxchgx_hint_release_lock());
     andi_(R0, tmp, markWord::lock_mask_in_place);
-    bne(CCR0, failed); // failed if old header doesn't contain locked_value (which is 0)
+    bne(CR0, failed); // failed if old header doesn't contain locked_value (which is 0)
     ori(tmp, tmp, markWord::unlocked_value); // set unlocked bit
   }
   stdcx_(tmp, obj);
-  bne(CCR0, retry);
+  bne(CR0, retry);
 
   if (semantics & MemBarFenceAfter) {
     fence();
@@ -5024,8 +5024,8 @@ void MacroAssembler::lightweight_lock(Register box, Register obj, Register t1, R
 
   // Check if the lock-stack is full.
   lwz(top, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
-  cmplwi(CCR0, top, LockStack::end_offset());
-  bge(CCR0, slow);
+  cmplwi(CR0, top, LockStack::end_offset());
+  bge(CR0, slow);
 
   // The underflow check is elided. The recursive check will always fail
   // when the lock stack is empty because of the _bad_oop_sentinel field.
@@ -5033,14 +5033,14 @@ void MacroAssembler::lightweight_lock(Register box, Register obj, Register t1, R
   // Check for recursion.
   subi(t, top, oopSize);
   ldx(t, R16_thread, t);
-  cmpd(CCR0, obj, t);
-  beq(CCR0, push);
+  cmpd(CR0, obj, t);
+  beq(CR0, push);
 
   // Check header for monitor (0b10) or locked (0b00).
   ld(mark, oopDesc::mark_offset_in_bytes(), obj);
   xori(t, mark, markWord::unlocked_value);
   andi_(t, t, markWord::lock_mask_in_place);
-  bne(CCR0, slow);
+  bne(CR0, slow);
 
   // Try to lock. Transition lock bits 0b01 => 0b00
   atomically_flip_locked_state(/* is_unlock */ false, obj, mark, slow, MacroAssembler::MemBarAcq);
@@ -5069,8 +5069,8 @@ void MacroAssembler::lightweight_unlock(Register obj, Register t1, Label& slow) 
     // Check for lock-stack underflow.
     Label stack_ok;
     lwz(t1, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
-    cmplwi(CCR0, t1, LockStack::start_offset());
-    bge(CCR0, stack_ok);
+    cmplwi(CR0, t1, LockStack::start_offset());
+    bge(CR0, stack_ok);
     stop("Lock-stack underflow");
     bind(stack_ok);
   }
@@ -5085,8 +5085,8 @@ void MacroAssembler::lightweight_unlock(Register obj, Register t1, Label& slow) 
   lwz(top, in_bytes(JavaThread::lock_stack_top_offset()), R16_thread);
   subi(top, top, oopSize);
   ldx(t, R16_thread, top);
-  cmpd(CCR0, obj, t);
-  bne(CCR0, slow);
+  cmpd(CR0, obj, t);
+  bne(CR0, slow);
 
   // Pop lock-stack.
   DEBUG_ONLY(li(t, 0);)
@@ -5099,8 +5099,8 @@ void MacroAssembler::lightweight_unlock(Register obj, Register t1, Label& slow) 
   // Check if recursive.
   subi(t, top, oopSize);
   ldx(t, R16_thread, t);
-  cmpd(CCR0, obj, t);
-  beq(CCR0, unlocked);
+  cmpd(CR0, obj, t);
+  beq(CR0, unlocked);
 
   // Use top as tmp
   t = top;
@@ -5108,13 +5108,13 @@ void MacroAssembler::lightweight_unlock(Register obj, Register t1, Label& slow) 
   // Not recursive. Check header for monitor (0b10).
   ld(mark, oopDesc::mark_offset_in_bytes(), obj);
   andi_(t, mark, markWord::monitor_value);
-  bne(CCR0, push_and_slow);
+  bne(CR0, push_and_slow);
 
 #ifdef ASSERT
   // Check header not unlocked (0b01).
   Label not_unlocked;
   andi_(t, mark, markWord::unlocked_value);
-  beq(CCR0, not_unlocked);
+  beq(CR0, not_unlocked);
   stop("lightweight_unlock already unlocked");
   bind(not_unlocked);
 #endif

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -179,8 +179,8 @@ class MacroAssembler: public Assembler {
   //
   // branch, jump
   //
-  // set dst to -1, 0, +1 as follows: if CCR0bi is "greater than", dst is set to 1,
-  // if CCR0bi is "equal", dst is set to 0, otherwise it's set to -1.
+  // set dst to -1, 0, +1 as follows: if CR0bi is "greater than", dst is set to 1,
+  // if CR0bi is "equal", dst is set to 0, otherwise it's set to -1.
   void inline set_cmp3(Register dst);
   // set dst to (treat_unordered_like_less ? -1 : +1)
   void inline set_cmpu3(Register dst, bool treat_unordered_like_less);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.inline.hpp
@@ -248,14 +248,14 @@ inline bool MacroAssembler::is_bc_far_variant3_at(address instruction_addr) {
          is_endgroup(instruction_2);
 }
 
-// set dst to -1, 0, +1 as follows: if CCR0bi is "greater than", dst is set to 1,
-// if CCR0bi is "equal", dst is set to 0, otherwise it's set to -1.
+// set dst to -1, 0, +1 as follows: if CR0bi is "greater than", dst is set to 1,
+// if CR0bi is "equal", dst is set to 0, otherwise it's set to -1.
 inline void MacroAssembler::set_cmp3(Register dst) {
   assert_different_registers(dst, R0);
   // P10, prefer using setbc instructions
   if (VM_Version::has_brw()) {
-    setbc(R0, CCR0, Assembler::greater); // Set 1 to R0 if CCR0bi is "greater than", otherwise 0
-    setnbc(dst, CCR0, Assembler::less); // Set -1 to dst if CCR0bi is "less than", otherwise 0
+    setbc(R0, CR0, Assembler::greater); // Set 1 to R0 if CR0bi is "greater than", otherwise 0
+    setnbc(dst, CR0, Assembler::less); // Set -1 to dst if CR0bi is "less than", otherwise 0
   } else {
     mfcr(R0); // copy CR register to R0
     srwi(dst, R0, 30); // copy the first two bits to dst
@@ -267,9 +267,9 @@ inline void MacroAssembler::set_cmp3(Register dst) {
 // set dst to (treat_unordered_like_less ? -1 : +1)
 inline void MacroAssembler::set_cmpu3(Register dst, bool treat_unordered_like_less) {
   if (treat_unordered_like_less) {
-    cror(CCR0, Assembler::less, CCR0, Assembler::summary_overflow); // treat unordered like less
+    cror(CR0, Assembler::less, CR0, Assembler::summary_overflow); // treat unordered like less
   } else {
-    cror(CCR0, Assembler::greater, CCR0, Assembler::summary_overflow); // treat unordered like greater
+    cror(CR0, Assembler::greater, CR0, Assembler::summary_overflow); // treat unordered like greater
   }
   set_cmp3(dst);
 }
@@ -280,11 +280,11 @@ inline void MacroAssembler::normalize_bool(Register dst, Register temp, bool is_
 
   if (VM_Version::has_brw()) {
     if (is_64bit) {
-      cmpdi(CCR0, dst, 0);
+      cmpdi(CR0, dst, 0);
     } else {
-      cmpwi(CCR0, dst, 0);
+      cmpwi(CR0, dst, 0);
     }
-    setbcr(dst, CCR0, Assembler::equal);
+    setbcr(dst, CR0, Assembler::equal);
   } else {
     assert_different_registers(temp, dst);
     neg(temp, dst);
@@ -373,8 +373,8 @@ inline void MacroAssembler::null_check_throw(Register a, int offset, Register te
       trap_null_check(a);
     } else {
       Label ok;
-      cmpdi(CCR0, a, 0);
-      bne(CCR0, ok);
+      cmpdi(CR0, a, 0);
+      bne(CR0, ok);
       load_const_optimized(temp_reg, exception_entry);
       mtctr(temp_reg);
       bctr();
@@ -390,8 +390,8 @@ inline void MacroAssembler::null_check(Register a, int offset, Label *Lis_null) 
       trap_null_check(a);
     } else if (Lis_null){
       Label ok;
-      cmpdi(CCR0, a, 0);
-      beq(CCR0, *Lis_null);
+      cmpdi(CR0, a, 0);
+      beq(CR0, *Lis_null);
     }
   }
 }
@@ -468,14 +468,14 @@ inline Register MacroAssembler::encode_heap_oop_not_null(Register d, Register sr
 inline Register MacroAssembler::encode_heap_oop(Register d, Register src) {
   if (CompressedOops::base() != nullptr) {
     if (VM_Version::has_isel()) {
-      cmpdi(CCR0, src, 0);
+      cmpdi(CR0, src, 0);
       Register co = encode_heap_oop_not_null(d, src);
       assert(co == d, "sanity");
-      isel_0(d, CCR0, Assembler::equal);
+      isel_0(d, CR0, Assembler::equal);
     } else {
       Label isNull;
       or_(d, src, src); // move and compare 0
-      beq(CCR0, isNull);
+      beq(CR0, isNull);
       encode_heap_oop_not_null(d, src);
       bind(isNull);
     }
@@ -509,16 +509,16 @@ inline void MacroAssembler::decode_heap_oop(Register d) {
   Label isNull;
   bool use_isel = false;
   if (CompressedOops::base() != nullptr) {
-    cmpwi(CCR0, d, 0);
+    cmpwi(CR0, d, 0);
     if (VM_Version::has_isel()) {
       use_isel = true;
     } else {
-      beq(CCR0, isNull);
+      beq(CR0, isNull);
     }
   }
   decode_heap_oop_not_null(d);
   if (use_isel) {
-    isel_0(d, CCR0, Assembler::equal);
+    isel_0(d, CR0, Assembler::equal);
   }
   bind(isNull);
 }

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc_sha.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc_sha.cpp
@@ -93,7 +93,7 @@ void MacroAssembler::sha256_load_h_vec(const VectorRegister a,
   lvx    (a,    hptr);
   addi   (tmp,  hptr, 16);
   lvx    (e,    tmp);
-  beq    (CCR0, sha256_aligned);
+  beq    (CR0, sha256_aligned);
 
   // handle unaligned accesses
   load_perm(vRb, hptr);
@@ -121,7 +121,7 @@ void MacroAssembler::sha256_load_w_plus_k_vec(const Register buf_in,
   VectorRegister vRb = VR6;
 
   andi_ (tmp, buf_in, 0xF);
-  beq   (CCR0, w_aligned); // address ends with 0x0, not 0x8
+  beq   (CR0, w_aligned); // address ends with 0x0, not 0x8
 
   // deal with unaligned addresses
   lvx    (ws[0], buf_in);
@@ -318,7 +318,7 @@ void MacroAssembler::sha256_update_sha_state(const VectorRegister a,
   li      (of16, 16);
   lvx     (vt0, hptr);
   lvx     (vt5, of16, hptr);
-  beq     (CCR0, state_load_aligned);
+  beq     (CR0, state_load_aligned);
 
   // handle unaligned accesses
   li      (of32, 32);
@@ -538,8 +538,8 @@ void MacroAssembler::sha256(bool multi_block) {
   if (multi_block) {
     addi(buf_in, buf_in, buf_size);
     addi(ofs, ofs, buf_size);
-    cmplw(CCR0, ofs, limit);
-    ble(CCR0, sha_loop);
+    cmplw(CR0, ofs, limit);
+    ble(CR0, sha_loop);
 
     // return ofs
     mr(R3_RET, ofs);
@@ -567,7 +567,7 @@ void MacroAssembler::sha512_load_w_vec(const Register buf_in,
   Label is_aligned, after_alignment;
 
   andi_  (tmp, buf_in, 0xF);
-  beq    (CCR0, is_aligned); // address ends with 0x0, not 0x8
+  beq    (CR0, is_aligned); // address ends with 0x0, not 0x8
 
   // deal with unaligned addresses
   lvx    (ws[0], buf_in);
@@ -623,7 +623,7 @@ void MacroAssembler::sha512_update_sha_state(const Register state,
   VectorRegister aux = VR9;
 
   andi_(tmp, state, 0xf);
-  beq(CCR0, state_save_aligned);
+  beq(CR0, state_save_aligned);
   // deal with unaligned addresses
 
   {
@@ -860,7 +860,7 @@ void MacroAssembler::sha512_load_h_vec(const Register state,
   Label state_aligned, after_state_aligned;
 
   andi_(tmp, state, 0xf);
-  beq(CCR0, state_aligned);
+  beq(CR0, state_aligned);
 
   // deal with unaligned addresses
   VectorRegister aux = VR9;
@@ -1121,8 +1121,8 @@ void MacroAssembler::sha512(bool multi_block) {
   if (multi_block) {
     addi(buf_in, buf_in, buf_size);
     addi(ofs, ofs, buf_size);
-    cmplw(CCR0, ofs, limit);
-    ble(CCR0, sha_loop);
+    cmplw(CR0, ofs, limit);
+    ble(CR0, sha_loop);
 
     // return ofs
     mr(R3_RET, ofs);

--- a/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
+++ b/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
@@ -83,16 +83,16 @@ void MethodHandles::verify_klass(MacroAssembler* _masm,
   Label L_ok, L_bad;
   BLOCK_COMMENT("verify_klass {");
   __ verify_oop(obj_reg, FILE_AND_LINE);
-  __ cmpdi(CCR0, obj_reg, 0);
-  __ beq(CCR0, L_bad);
+  __ cmpdi(CR0, obj_reg, 0);
+  __ beq(CR0, L_bad);
   __ load_klass(temp_reg, obj_reg);
   __ load_const_optimized(temp2_reg, (address) klass_addr);
   __ ld(temp2_reg, 0, temp2_reg);
-  __ cmpd(CCR0, temp_reg, temp2_reg);
-  __ beq(CCR0, L_ok);
+  __ cmpd(CR0, temp_reg, temp2_reg);
+  __ beq(CR0, L_ok);
   __ ld(temp_reg, klass->super_check_offset(), temp_reg);
-  __ cmpd(CCR0, temp_reg, temp2_reg);
-  __ beq(CCR0, L_ok);
+  __ cmpd(CR0, temp_reg, temp2_reg);
+  __ beq(CR0, L_ok);
   __ BIND(L_bad);
   __ stop(error_message);
   __ BIND(L_ok);
@@ -107,8 +107,8 @@ void MethodHandles::verify_ref_kind(MacroAssembler* _masm, int ref_kind, Registe
   // assert(sizeof(u4) == sizeof(java.lang.invoke.MemberName.flags), "");
   __ srwi( temp, temp, java_lang_invoke_MemberName::MN_REFERENCE_KIND_SHIFT);
   __ andi(temp, temp, java_lang_invoke_MemberName::MN_REFERENCE_KIND_MASK);
-  __ cmpwi(CCR1, temp, ref_kind);
-  __ beq(CCR1, L);
+  __ cmpwi(CR1, temp, ref_kind);
+  __ beq(CR1, L);
   { char* buf = NEW_C_HEAP_ARRAY(char, 100, mtInternal);
     jio_snprintf(buf, 100, "verify_ref_kind expected %x", ref_kind);
     if (ref_kind == JVM_REF_invokeVirtual ||
@@ -135,11 +135,11 @@ void MethodHandles::jump_from_method_handle(MacroAssembler* _masm, Register meth
     // compiled code in threads for which the event is enabled.  Check here for
     // interp_only_mode if these events CAN be enabled.
     __ lwz(temp, in_bytes(JavaThread::interp_only_mode_offset()), R16_thread);
-    __ cmplwi(CCR0, temp, 0);
-    __ beq(CCR0, run_compiled_code);
+    __ cmplwi(CR0, temp, 0);
+    __ beq(CR0, run_compiled_code);
     // Null method test is replicated below in compiled case.
-    __ cmplwi(CCR0, R19_method, 0);
-    __ beq(CCR0, L_no_such_method);
+    __ cmplwi(CR0, R19_method, 0);
+    __ beq(CR0, L_no_such_method);
     __ ld(target, in_bytes(Method::interpreter_entry_offset()), R19_method);
     __ mtctr(target);
     __ bctr();
@@ -147,8 +147,8 @@ void MethodHandles::jump_from_method_handle(MacroAssembler* _masm, Register meth
   }
 
   // Compiled case, either static or fall-through from runtime conditional
-  __ cmplwi(CCR0, R19_method, 0);
-  __ beq(CCR0, L_no_such_method);
+  __ cmplwi(CR0, R19_method, 0);
+  __ beq(CR0, L_no_such_method);
 
   const ByteSize entry_offset = for_compiler_entry ? Method::from_compiled_offset() :
                                                      Method::from_interpreted_offset();
@@ -200,8 +200,8 @@ void MethodHandles::jump_to_lambda_form(MacroAssembler* _masm,
     // assert(sizeof(u2) == sizeof(ConstMethod::_size_of_parameters), "");
     Label L;
     __ ld(temp2, __ argument_offset(temp2, temp2, 0), R15_esp);
-    __ cmpd(CCR1, temp2, recv);
-    __ beq(CCR1, L);
+    __ cmpd(CR1, temp2, recv);
+    __ beq(CR1, L);
     __ stop("receiver not on stack");
     __ BIND(L);
   }
@@ -248,8 +248,8 @@ address MethodHandles::generate_method_handle_interpreter_entry(MacroAssembler* 
     BLOCK_COMMENT("verify_intrinsic_id {");
     __ load_sized_value(R30_tmp1, in_bytes(Method::intrinsic_id_offset()), R19_method,
                         sizeof(u2), /*is_signed*/ false);
-    __ cmpwi(CCR1, R30_tmp1, (int) iid);
-    __ beq(CCR1, L);
+    __ cmpwi(CR1, R30_tmp1, (int) iid);
+    __ beq(CR1, L);
     if (iid == vmIntrinsics::_linkToVirtual ||
         iid == vmIntrinsics::_linkToSpecial) {
       // could do this for all kinds, but would explode assembly code size
@@ -425,8 +425,8 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
 
       if (VerifyMethodHandles) {
         Label L_index_ok;
-        __ cmpdi(CCR1, temp2_index, 0);
-        __ bge(CCR1, L_index_ok);
+        __ cmpdi(CR1, temp2_index, 0);
+        __ bge(CR1, L_index_ok);
         __ stop("no virtual index");
         __ BIND(L_index_ok);
       }
@@ -457,8 +457,8 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
       __ ld(vtable_index, NONZERO(java_lang_invoke_MemberName::vmindex_offset()), member_reg);
       if (VerifyMethodHandles) {
         Label L_index_ok;
-        __ cmpdi(CCR1, vtable_index, 0);
-        __ bge(CCR1, L_index_ok);
+        __ cmpdi(CR1, vtable_index, 0);
+        __ bge(CR1, L_index_ok);
         __ stop("invalid vtable index for MH.invokeInterface");
         __ BIND(L_index_ok);
       }

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -236,14 +236,14 @@ register %{
   // in the CR register.
 
   // types: v = volatile, nv = non-volatile, s = system
-  reg_def CCR0(SOC, SOC, Op_RegFlags, 0, CCR0->as_VMReg());  // v
-  reg_def CCR1(SOC, SOC, Op_RegFlags, 1, CCR1->as_VMReg());  // v
-  reg_def CCR2(SOC, SOC, Op_RegFlags, 2, CCR2->as_VMReg());  // nv
-  reg_def CCR3(SOC, SOC, Op_RegFlags, 3, CCR3->as_VMReg());  // nv
-  reg_def CCR4(SOC, SOC, Op_RegFlags, 4, CCR4->as_VMReg());  // nv
-  reg_def CCR5(SOC, SOC, Op_RegFlags, 5, CCR5->as_VMReg());  // v
-  reg_def CCR6(SOC, SOC, Op_RegFlags, 6, CCR6->as_VMReg());  // v
-  reg_def CCR7(SOC, SOC, Op_RegFlags, 7, CCR7->as_VMReg());  // v
+  reg_def CR0(SOC, SOC, Op_RegFlags, 0, CR0->as_VMReg());  // v
+  reg_def CR1(SOC, SOC, Op_RegFlags, 1, CR1->as_VMReg());  // v
+  reg_def CR2(SOC, SOC, Op_RegFlags, 2, CR2->as_VMReg());  // nv
+  reg_def CR3(SOC, SOC, Op_RegFlags, 3, CR3->as_VMReg());  // nv
+  reg_def CR4(SOC, SOC, Op_RegFlags, 4, CR4->as_VMReg());  // nv
+  reg_def CR5(SOC, SOC, Op_RegFlags, 5, CR5->as_VMReg());  // v
+  reg_def CR6(SOC, SOC, Op_RegFlags, 6, CR6->as_VMReg());  // v
+  reg_def CR7(SOC, SOC, Op_RegFlags, 7, CR7->as_VMReg());  // v
 
   // Special registers of PPC64
 
@@ -443,14 +443,14 @@ alloc_class chunk1 (
 alloc_class chunk2 (
   // Chunk2 contains *all* 8 condition code registers.
 
-  CCR0,
-  CCR1,
-  CCR2,
-  CCR3,
-  CCR4,
-  CCR5,
-  CCR6,
-  CCR7
+  CR0,
+  CR1,
+  CR2,
+  CR3,
+  CR4,
+  CR5,
+  CR6,
+  CR7
 );
 
 alloc_class chunk3 (
@@ -803,30 +803,30 @@ reg_class bits64_reg_ro(
 // Special Class for Condition Code Flags Register
 
 reg_class int_flags(
-/*CCR0*/             // scratch
-/*CCR1*/             // scratch
-/*CCR2*/             // nv!
-/*CCR3*/             // nv!
-/*CCR4*/             // nv!
-  CCR5,
-  CCR6,
-  CCR7
+/*CR0*/             // scratch
+/*CR1*/             // scratch
+/*CR2*/             // nv!
+/*CR3*/             // nv!
+/*CR4*/             // nv!
+  CR5,
+  CR6,
+  CR7
 );
 
 reg_class int_flags_ro(
-  CCR0,
-  CCR1,
-  CCR2,
-  CCR3,
-  CCR4,
-  CCR5,
-  CCR6,
-  CCR7
+  CR0,
+  CR1,
+  CR2,
+  CR3,
+  CR4,
+  CR5,
+  CR6,
+  CR7
 );
 
-reg_class int_flags_CR0(CCR0);
-reg_class int_flags_CR1(CCR1);
-reg_class int_flags_CR6(CCR6);
+reg_class int_flags_CR0(CR0);
+reg_class int_flags_CR1(CR1);
+reg_class int_flags_CR6(CR6);
 reg_class ctr_reg(SR_CTR);
 
 // ----------------------------
@@ -5568,8 +5568,8 @@ instruct loadF_ac(regF dst, memory mem, flagsRegCR0 cr0) %{
     int Idisp = $mem$$disp + frame_slots_bias($mem$$base, ra_);
     Label next;
     __ lfs($dst$$FloatRegister, Idisp, $mem$$base$$Register);
-    __ fcmpu(CCR0, $dst$$FloatRegister, $dst$$FloatRegister);
-    __ bne(CCR0, next);
+    __ fcmpu(CR0, $dst$$FloatRegister, $dst$$FloatRegister);
+    __ bne(CR0, next);
     __ bind(next);
     __ isync();
   %}
@@ -5604,8 +5604,8 @@ instruct loadD_ac(regD dst, memory mem, flagsRegCR0 cr0) %{
     int Idisp = $mem$$disp + frame_slots_bias($mem$$base, ra_);
     Label next;
     __ lfd($dst$$FloatRegister, Idisp, $mem$$base$$Register);
-    __ fcmpu(CCR0, $dst$$FloatRegister, $dst$$FloatRegister);
-    __ bne(CCR0, next);
+    __ fcmpu(CR0, $dst$$FloatRegister, $dst$$FloatRegister);
+    __ bne(CR0, next);
     __ bind(next);
     __ isync();
   %}
@@ -7394,8 +7394,8 @@ instruct compareAndSwapB_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, iRegIsrc
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "CMPXCHGB $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgb(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgb(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 $res$$Register, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7413,8 +7413,8 @@ instruct compareAndSwapB4_regP_regI_regI(iRegIdst res, rarg3RegP mem_ptr, iRegIs
   effect(TEMP_DEF res, USE_KILL src2, USE_KILL mem_ptr, TEMP tmp1, TEMP tmp2, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "CMPXCHGB $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgb(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgb(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 $res$$Register, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7432,8 +7432,8 @@ instruct compareAndSwapS_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, iRegIsrc
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "CMPXCHGH $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgh(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgh(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 $res$$Register, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7451,8 +7451,8 @@ instruct compareAndSwapS4_regP_regI_regI(iRegIdst res, rarg3RegP mem_ptr, iRegIs
   effect(TEMP_DEF res, USE_KILL src2, USE_KILL mem_ptr, TEMP tmp1, TEMP tmp2, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "CMPXCHGH $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgh(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgh(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 $res$$Register, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7469,8 +7469,8 @@ instruct compareAndSwapI_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, iRegIsrc
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "CMPXCHGW $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgw(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgw(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 $res$$Register, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7488,8 +7488,8 @@ instruct compareAndSwapN_regP_regN_regN(iRegIdst res, iRegPdst mem_ptr, iRegNsrc
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "CMPXCHGW $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgw(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgw(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 $res$$Register, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7506,8 +7506,8 @@ instruct compareAndSwapL_regP_regL_regL(iRegIdst res, iRegPdst mem_ptr, iRegLsrc
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "CMPXCHGD $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgd(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 $res$$Register, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7525,8 +7525,8 @@ instruct compareAndSwapP_regP_regP_regP(iRegIdst res, iRegPdst mem_ptr, iRegPsrc
   predicate(n->as_LoadStore()->barrier_data() == 0);
   format %{ "CMPXCHGD $res, $mem_ptr, $src1, $src2; as bool; ptr" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgd(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 $res$$Register, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7546,8 +7546,8 @@ instruct weakCompareAndSwapB_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGB $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgb(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgb(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
                 MacroAssembler::MemBarNone,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7560,8 +7560,8 @@ instruct weakCompareAndSwapB4_regP_regI_regI(iRegIdst res, rarg3RegP mem_ptr, iR
   effect(TEMP_DEF res, USE_KILL src2, USE_KILL mem_ptr, TEMP tmp1, TEMP tmp2, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGB $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgb(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgb(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
                 MacroAssembler::MemBarNone,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7574,8 +7574,8 @@ instruct weakCompareAndSwapB_acq_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGB acq $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgb(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgb(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
                 support_IRIW_for_not_multiple_copy_atomic_cpu ? MacroAssembler::MemBarAcq : MacroAssembler::MemBarFenceAfter,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7588,8 +7588,8 @@ instruct weakCompareAndSwapB4_acq_regP_regI_regI(iRegIdst res, rarg3RegP mem_ptr
   effect(TEMP_DEF res, USE_KILL src2, USE_KILL mem_ptr, TEMP tmp1, TEMP tmp2, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGB acq $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgb(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgb(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
                 support_IRIW_for_not_multiple_copy_atomic_cpu ? MacroAssembler::MemBarAcq : MacroAssembler::MemBarFenceAfter,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7602,8 +7602,8 @@ instruct weakCompareAndSwapS_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGH $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgh(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgh(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
                 MacroAssembler::MemBarNone,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7616,8 +7616,8 @@ instruct weakCompareAndSwapS4_regP_regI_regI(iRegIdst res, rarg3RegP mem_ptr, iR
   effect(TEMP_DEF res, USE_KILL src2, USE_KILL mem_ptr, TEMP tmp1, TEMP tmp2, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGH $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgh(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgh(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
                 MacroAssembler::MemBarNone,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7630,8 +7630,8 @@ instruct weakCompareAndSwapS_acq_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGH acq $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgh(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgh(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
                 support_IRIW_for_not_multiple_copy_atomic_cpu ? MacroAssembler::MemBarAcq : MacroAssembler::MemBarFenceAfter,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7644,8 +7644,8 @@ instruct weakCompareAndSwapS4_acq_regP_regI_regI(iRegIdst res, rarg3RegP mem_ptr
   effect(TEMP_DEF res, USE_KILL src2, USE_KILL mem_ptr, TEMP tmp1, TEMP tmp2, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGH acq $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgh(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgh(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, $tmp2$$Register,
                 support_IRIW_for_not_multiple_copy_atomic_cpu ? MacroAssembler::MemBarAcq : MacroAssembler::MemBarFenceAfter,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7658,8 +7658,8 @@ instruct weakCompareAndSwapI_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGW $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgw(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgw(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7672,10 +7672,10 @@ instruct weakCompareAndSwapI_acq_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGW acq $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     // Acquire only needed in successful case. Weak node is allowed to report unsuccessful in additional rare cases and
     // value is never passed to caller.
-    __ cmpxchgw(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    __ cmpxchgw(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 support_IRIW_for_not_multiple_copy_atomic_cpu ? MacroAssembler::MemBarAcq : MacroAssembler::MemBarFenceAfter,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7688,8 +7688,8 @@ instruct weakCompareAndSwapN_regP_regN_regN(iRegIdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGW $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgw(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgw(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7702,10 +7702,10 @@ instruct weakCompareAndSwapN_acq_regP_regN_regN(iRegIdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGW acq $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     // Acquire only needed in successful case. Weak node is allowed to report unsuccessful in additional rare cases and
     // value is never passed to caller.
-    __ cmpxchgw(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    __ cmpxchgw(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 support_IRIW_for_not_multiple_copy_atomic_cpu ? MacroAssembler::MemBarAcq : MacroAssembler::MemBarFenceAfter,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7718,9 +7718,9 @@ instruct weakCompareAndSwapL_regP_regL_regL(iRegIdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGD $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     // value is never passed to caller.
-    __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    __ cmpxchgd(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7733,10 +7733,10 @@ instruct weakCompareAndSwapL_acq_regP_regL_regL(iRegIdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGD acq $res, $mem_ptr, $src1, $src2; as bool" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     // Acquire only needed in successful case. Weak node is allowed to report unsuccessful in additional rare cases and
     // value is never passed to caller.
-    __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    __ cmpxchgd(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 support_IRIW_for_not_multiple_copy_atomic_cpu ? MacroAssembler::MemBarAcq : MacroAssembler::MemBarFenceAfter,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7749,8 +7749,8 @@ instruct weakCompareAndSwapP_regP_regP_regP(iRegIdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGD $res, $mem_ptr, $src1, $src2; as bool; ptr" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgd(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7763,10 +7763,10 @@ instruct weakCompareAndSwapP_acq_regP_regP_regP(iRegIdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0); // TEMP_DEF to avoid jump
   format %{ "weak CMPXCHGD acq $res, $mem_ptr, $src1, $src2; as bool; ptr" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     // Acquire only needed in successful case. Weak node is allowed to report unsuccessful in additional rare cases and
     // value is never passed to caller.
-    __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    __ cmpxchgd(CR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 support_IRIW_for_not_multiple_copy_atomic_cpu ? MacroAssembler::MemBarAcq : MacroAssembler::MemBarFenceAfter,
                 MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
@@ -7781,8 +7781,8 @@ instruct compareAndExchangeB_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGB $res, $mem_ptr, $src1, $src2; as int" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgb(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgb(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
   %}
@@ -7795,8 +7795,8 @@ instruct compareAndExchangeB4_regP_regI_regI(iRegIdst res, rarg3RegP mem_ptr, iR
   effect(TEMP_DEF res, USE_KILL src2, USE_KILL mem_ptr, TEMP tmp1, TEMP cr0);
   format %{ "CMPXCHGB $res, $mem_ptr, $src1, $src2; as int" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgb(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, R0,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgb(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, R0,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
   %}
@@ -7809,8 +7809,8 @@ instruct compareAndExchangeB_acq_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGB acq $res, $mem_ptr, $src1, $src2; as int" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgb(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgb(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7829,8 +7829,8 @@ instruct compareAndExchangeB4_acq_regP_regI_regI(iRegIdst res, rarg3RegP mem_ptr
   effect(TEMP_DEF res, USE_KILL src2, USE_KILL mem_ptr, TEMP tmp1, TEMP cr0);
   format %{ "CMPXCHGB acq $res, $mem_ptr, $src1, $src2; as int" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgb(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, R0,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgb(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, R0,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7849,8 +7849,8 @@ instruct compareAndExchangeS_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGH $res, $mem_ptr, $src1, $src2; as int" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgh(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgh(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
   %}
@@ -7863,8 +7863,8 @@ instruct compareAndExchangeS4_regP_regI_regI(iRegIdst res, rarg3RegP mem_ptr, iR
   effect(TEMP_DEF res, USE_KILL src2, USE_KILL mem_ptr, TEMP tmp1, TEMP cr0);
   format %{ "CMPXCHGH $res, $mem_ptr, $src1, $src2; as int" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgh(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, R0,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgh(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, R0,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
   %}
@@ -7877,8 +7877,8 @@ instruct compareAndExchangeS_acq_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGH acq $res, $mem_ptr, $src1, $src2; as int" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgh(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgh(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, noreg, noreg,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7897,8 +7897,8 @@ instruct compareAndExchangeS4_acq_regP_regI_regI(iRegIdst res, rarg3RegP mem_ptr
   effect(TEMP_DEF res, USE_KILL src2, USE_KILL mem_ptr, TEMP tmp1, TEMP cr0);
   format %{ "CMPXCHGH acq $res, $mem_ptr, $src1, $src2; as int" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgh(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, R0,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgh(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register, $tmp1$$Register, R0,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7917,8 +7917,8 @@ instruct compareAndExchangeI_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGW $res, $mem_ptr, $src1, $src2; as int" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgw(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgw(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
   %}
@@ -7931,8 +7931,8 @@ instruct compareAndExchangeI_acq_regP_regI_regI(iRegIdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGW acq $res, $mem_ptr, $src1, $src2; as int" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgw(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgw(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7951,8 +7951,8 @@ instruct compareAndExchangeN_regP_regN_regN(iRegNdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGW $res, $mem_ptr, $src1, $src2; as narrow oop" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgw(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgw(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
   %}
@@ -7965,8 +7965,8 @@ instruct compareAndExchangeN_acq_regP_regN_regN(iRegNdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGW acq $res, $mem_ptr, $src1, $src2; as narrow oop" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgw(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgw(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -7985,8 +7985,8 @@ instruct compareAndExchangeL_regP_regL_regL(iRegLdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGD $res, $mem_ptr, $src1, $src2; as long" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgd(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgd(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
   %}
@@ -7999,8 +7999,8 @@ instruct compareAndExchangeL_acq_regP_regL_regL(iRegLdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGD acq $res, $mem_ptr, $src1, $src2; as long" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgd(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgd(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -8020,8 +8020,8 @@ instruct compareAndExchangeP_regP_regP_regP(iRegPdst res, iRegPdst mem_ptr, iReg
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGD $res, $mem_ptr, $src1, $src2; as ptr; ptr" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgd(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgd(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
   %}
@@ -8035,8 +8035,8 @@ instruct compareAndExchangeP_acq_regP_regP_regP(iRegPdst res, iRegPdst mem_ptr, 
   effect(TEMP_DEF res, TEMP cr0);
   format %{ "CMPXCHGD acq $res, $mem_ptr, $src1, $src2; as ptr; ptr" %}
   ins_encode %{
-    // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
-    __ cmpxchgd(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
+    // CmpxchgX sets CR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
+    __ cmpxchgd(CR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
                 noreg, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
@@ -11389,7 +11389,7 @@ instruct cmpL3_reg_reg(iRegIdst dst, iRegLsrc src1, iRegLsrc src2, flagsRegCR0 c
   format %{ "cmpL3_reg_reg $dst, $src1, $src2" %}
 
   ins_encode %{
-    __ cmpd(CCR0, $src1$$Register, $src2$$Register);
+    __ cmpd(CR0, $src1$$Register, $src2$$Register);
     __ set_cmp3($dst$$Register);
   %}
   ins_pipe(pipe_class_default);
@@ -11661,11 +11661,11 @@ instruct cmpF_reg_reg_Ex(flagsReg crx, regF src1, regF src2) %{
   //
   // block BXX:
   // 0: instruct cmpFUnordered_reg_reg (cmpF_reg_reg-0):
-  //    cmpFUrd CCR6, F11, F9
+  //    cmpFUrd CR6, F11, F9
   // 4: instruct cmov_bns_less (cmpF_reg_reg-1):
-  //    cmov CCR6
+  //    cmov CR6
   // 8: instruct branchConSched:
-  //    B_FARle CCR6, B56  P=0.500000 C=-1.000000
+  //    B_FARle CR6, B56  P=0.500000 C=-1.000000
   match(Set crx (CmpF src1 src2));
   ins_cost(DEFAULT_COST+BRANCH_COST);
 
@@ -11724,7 +11724,7 @@ instruct cmpF3_reg_reg(iRegIdst dst, regF src1, regF src2, flagsRegCR0 cr0) %{
   format %{ "cmpF3_reg_reg $dst, $src1, $src2" %}
 
   ins_encode %{
-    __ fcmpu(CCR0, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ fcmpu(CR0, $src1$$FloatRegister, $src2$$FloatRegister);
     __ set_cmpu3($dst$$Register, true); // C2 requires unordered to get treated like less
   %}
   ins_pipe(pipe_class_default);
@@ -11808,7 +11808,7 @@ instruct cmpD3_reg_reg(iRegIdst dst, regD src1, regD src2, flagsRegCR0 cr0) %{
   format %{ "cmpD3_reg_reg $dst, $src1, $src2" %}
 
   ins_encode %{
-    __ fcmpu(CCR0, $src1$$FloatRegister, $src2$$FloatRegister);
+    __ fcmpu(CR0, $src1$$FloatRegister, $src2$$FloatRegister);
     __ set_cmpu3($dst$$Register, true); // C2 requires unordered to get treated like less
   %}
   ins_pipe(pipe_class_default);
@@ -12770,7 +12770,7 @@ instruct string_inflate(Universe dummy, rarg1RegP src, rarg2RegP dst, iRegIsrc l
     __ string_inflate_16($src$$Register, $dst$$Register, $len$$Register, $tmp1$$Register,
                          $tmp2$$Register, $tmp3$$Register, $tmp4$$Register, $tmp5$$Register);
     __ rldicl_($tmp1$$Register, $len$$Register, 0, 64-3); // Remaining characters.
-    __ beq(CCR0, Ldone);
+    __ beq(CR0, Ldone);
     __ string_inflate($src$$Register, $dst$$Register, $tmp1$$Register, $tmp2$$Register);
     __ bind(Ldone);
   %}
@@ -12854,8 +12854,8 @@ instruct minI_reg_reg_isel(iRegIdst dst, iRegIsrc src1, iRegIsrc src2, flagsRegC
   ins_cost(DEFAULT_COST*2);
 
   ins_encode %{
-    __ cmpw(CCR0, $src1$$Register, $src2$$Register);
-    __ isel($dst$$Register, CCR0, Assembler::less, /*invert*/false, $src1$$Register, $src2$$Register);
+    __ cmpw(CR0, $src1$$Register, $src2$$Register);
+    __ isel($dst$$Register, CR0, Assembler::less, /*invert*/false, $src1$$Register, $src2$$Register);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -12887,8 +12887,8 @@ instruct maxI_reg_reg_isel(iRegIdst dst, iRegIsrc src1, iRegIsrc src2, flagsRegC
   ins_cost(DEFAULT_COST*2);
 
   ins_encode %{
-    __ cmpw(CCR0, $src1$$Register, $src2$$Register);
-    __ isel($dst$$Register, CCR0, Assembler::greater, /*invert*/false, $src1$$Register, $src2$$Register);
+    __ cmpw(CR0, $src1$$Register, $src2$$Register);
+    __ isel($dst$$Register, CR0, Assembler::greater, /*invert*/false, $src1$$Register, $src2$$Register);
   %}
   ins_pipe(pipe_class_default);
 %}

--- a/src/hotspot/cpu/ppc/register_ppc.hpp
+++ b/src/hotspot/cpu/ppc/register_ppc.hpp
@@ -179,14 +179,14 @@ inline constexpr ConditionRegister as_ConditionRegister(int encoding) {
   return ConditionRegister(encoding);
 }
 
-constexpr ConditionRegister CCR0 = as_ConditionRegister(0);
-constexpr ConditionRegister CCR1 = as_ConditionRegister(1);
-constexpr ConditionRegister CCR2 = as_ConditionRegister(2);
-constexpr ConditionRegister CCR3 = as_ConditionRegister(3);
-constexpr ConditionRegister CCR4 = as_ConditionRegister(4);
-constexpr ConditionRegister CCR5 = as_ConditionRegister(5);
-constexpr ConditionRegister CCR6 = as_ConditionRegister(6);
-constexpr ConditionRegister CCR7 = as_ConditionRegister(7);
+constexpr ConditionRegister CR0 = as_ConditionRegister(0);
+constexpr ConditionRegister CR1 = as_ConditionRegister(1);
+constexpr ConditionRegister CR2 = as_ConditionRegister(2);
+constexpr ConditionRegister CR3 = as_ConditionRegister(3);
+constexpr ConditionRegister CR4 = as_ConditionRegister(4);
+constexpr ConditionRegister CR5 = as_ConditionRegister(5);
+constexpr ConditionRegister CR6 = as_ConditionRegister(6);
+constexpr ConditionRegister CR7 = as_ConditionRegister(7);
 
 
 class VectorSRegister;

--- a/src/hotspot/cpu/ppc/runtime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/runtime_ppc.cpp
@@ -101,7 +101,7 @@ void OptoRuntime::generate_exception_blob() {
   __ call_c((address) OptoRuntime::handle_exception_C);
   address calls_return_pc = __ last_calls_return_pc();
 # ifdef ASSERT
-  __ cmpdi(CCR0, R3_RET, 0);
+  __ cmpdi(CR0, R3_RET, 0);
   __ asm_assert_ne("handle_exception_C must not return null");
 # endif
 

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -908,9 +908,9 @@ static address gen_c2i_adapter(MacroAssembler *masm,
 
   // Does compiled code exists? If yes, patch the caller's callsite.
   __ ld(code, method_(code));
-  __ cmpdi(CCR0, code, 0);
+  __ cmpdi(CR0, code, 0);
   __ ld(ientry, method_(interpreter_entry)); // preloaded
-  __ beq(CCR0, call_interpreter);
+  __ beq(CR0, call_interpreter);
 
 
   // Patch caller's callsite, method_(code) was not null which means that
@@ -1184,9 +1184,9 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
   // Argument is valid and klass is as expected, continue.
 
   __ ld(code, method_(code));
-  __ cmpdi(CCR0, code, 0);
+  __ cmpdi(CR0, code, 0);
   __ ld(ientry, method_(interpreter_entry)); // preloaded
-  __ beq_predict_taken(CCR0, call_interpreter);
+  __ beq_predict_taken(CR0, call_interpreter);
 
   // Branch to ic_miss_stub.
   __ b64_patchable((address)SharedRuntime::get_ic_miss_stub(), relocInfo::runtime_call_type);
@@ -1203,7 +1203,7 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
     { // Bypass the barrier for non-static methods
       __ lhz(R0, in_bytes(Method::access_flags_offset()), R19_method);
       __ andi_(R0, R0, JVM_ACC_STATIC);
-      __ beq(CCR0, L_skip_barrier); // non-static
+      __ beq(CR0, L_skip_barrier); // non-static
     }
 
     Register klass = R11_scratch1;
@@ -1251,8 +1251,8 @@ static void object_move(MacroAssembler* masm,
 
     __ addi(r_handle, r_caller_sp, reg2offset(src.first()));
     __ ld(  r_temp_2, reg2offset(src.first()), r_caller_sp);
-    __ cmpdi(CCR0, r_temp_2, 0);
-    __ bne(CCR0, skip);
+    __ cmpdi(CR0, r_temp_2, 0);
+    __ bne(CR0, skip);
     // Use a null handle if oop is null.
     __ li(r_handle, 0);
     __ bind(skip);
@@ -1281,8 +1281,8 @@ static void object_move(MacroAssembler* masm,
     __ std( r_oop,    oop_offset, R1_SP);
     __ addi(r_handle, R1_SP, oop_offset);
 
-    __ cmpdi(CCR0, r_oop, 0);
-    __ bne(CCR0, skip);
+    __ cmpdi(CR0, r_oop, 0);
+    __ bne(CR0, skip);
     // Use a null handle if oop is null.
     __ li(r_handle, 0);
     __ bind(skip);
@@ -1642,7 +1642,7 @@ static void continuation_enter_cleanup(MacroAssembler* masm) {
 #ifdef ASSERT
   __ block_comment("clean {");
   __ ld_ptr(tmp1, JavaThread::cont_entry_offset(), R16_thread);
-  __ cmpd(CCR0, R1_SP, tmp1);
+  __ cmpd(CR0, R1_SP, tmp1);
   __ asm_assert_eq(FILE_AND_LINE ": incorrect R1_SP");
 #endif
 
@@ -1653,15 +1653,15 @@ static void continuation_enter_cleanup(MacroAssembler* masm) {
     // Check if this is a virtual thread continuation
     Label L_skip_vthread_code;
     __ lwz(R0, in_bytes(ContinuationEntry::flags_offset()), R1_SP);
-    __ cmpwi(CCR0, R0, 0);
-    __ beq(CCR0, L_skip_vthread_code);
+    __ cmpwi(CR0, R0, 0);
+    __ beq(CR0, L_skip_vthread_code);
 
     // If the held monitor count is > 0 and this vthread is terminating then
     // it failed to release a JNI monitor. So we issue the same log message
     // that JavaThread::exit does.
     __ ld(R0, in_bytes(JavaThread::jni_monitor_count_offset()), R16_thread);
-    __ cmpdi(CCR0, R0, 0);
-    __ beq(CCR0, L_skip_vthread_code);
+    __ cmpdi(CR0, R0, 0);
+    __ beq(CR0, L_skip_vthread_code);
 
     // Save return value potentially containing the exception oop
     Register ex_oop = R15_esp;   // nonvolatile register
@@ -1683,8 +1683,8 @@ static void continuation_enter_cleanup(MacroAssembler* masm) {
     // Check if this is a virtual thread continuation
     Label L_skip_vthread_code;
     __ lwz(R0, in_bytes(ContinuationEntry::flags_offset()), R1_SP);
-    __ cmpwi(CCR0, R0, 0);
-    __ beq(CCR0, L_skip_vthread_code);
+    __ cmpwi(CR0, R0, 0);
+    __ beq(CR0, L_skip_vthread_code);
 
     // See comment just above. If not checking JNI calls the JNI count is only
     // needed for assertion checking.
@@ -1749,8 +1749,8 @@ static void gen_continuation_enter(MacroAssembler* masm,
 #ifdef ASSERT
     Label is_interp_only;
     __ lwz(R0, in_bytes(JavaThread::interp_only_mode_offset()), R16_thread);
-    __ cmpwi(CCR0, R0, 0);
-    __ bne(CCR0, is_interp_only);
+    __ cmpwi(CR0, R0, 0);
+    __ bne(CR0, is_interp_only);
     __ stop("enterSpecial interpreter entry called when not in interp_only_mode");
     __ bind(is_interp_only);
 #endif
@@ -1770,8 +1770,8 @@ static void gen_continuation_enter(MacroAssembler* masm,
     fill_continuation_entry(masm, reg_cont_obj, reg_is_virtual);
 
     // If isContinue, call to thaw. Otherwise, call Continuation.enter(Continuation c, boolean isContinue)
-    __ cmpwi(CCR0, reg_is_cont, 0);
-    __ bne(CCR0, L_thaw);
+    __ cmpwi(CR0, reg_is_cont, 0);
+    __ bne(CR0, L_thaw);
 
     // --- call Continuation.enter(Continuation c, boolean isContinue)
 
@@ -1818,8 +1818,8 @@ static void gen_continuation_enter(MacroAssembler* masm,
   fill_continuation_entry(masm, reg_cont_obj, reg_is_virtual);
 
   // If isContinue, call to thaw. Otherwise, call Continuation.enter(Continuation c, boolean isContinue)
-  __ cmpwi(CCR0, reg_is_cont, 0);
-  __ bne(CCR0, L_thaw);
+  __ cmpwi(CR0, reg_is_cont, 0);
+  __ bne(CR0, L_thaw);
 
   // --- call Continuation.enter(Continuation c, boolean isContinue)
 
@@ -1869,7 +1869,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
   // Pop frame and return
   DEBUG_ONLY(__ ld_ptr(R0, 0, R1_SP));
   __ addi(R1_SP, R1_SP, framesize_words*wordSize);
-  DEBUG_ONLY(__ cmpd(CCR0, R0, R1_SP));
+  DEBUG_ONLY(__ cmpd(CR0, R0, R1_SP));
   __ asm_assert_eq(FILE_AND_LINE ": inconsistent frame size");
   __ ld(R0, _abi0(lr), R1_SP); // Return pc
   __ mtlr(R0);
@@ -1937,8 +1937,8 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
   Label L_pinned;
 
-  __ cmpwi(CCR0, R3_RET, 0);
-  __ bne(CCR0, L_pinned);
+  __ cmpwi(CR0, R3_RET, 0);
+  __ bne(CR0, L_pinned);
 
   // yield succeeded
 
@@ -1961,8 +1961,8 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
   // handle pending exception thrown by freeze
   __ ld(tmp, in_bytes(JavaThread::pending_exception_offset()), R16_thread);
-  __ cmpdi(CCR0, tmp, 0);
-  __ beq(CCR0, L_return); // return if no exception is pending
+  __ cmpdi(CR0, tmp, 0);
+  __ beq(CR0, L_return); // return if no exception is pending
   __ pop_frame();
   __ ld(R0, _abi0(lr), R1_SP); // Return pc
   __ mtlr(R0);
@@ -2398,12 +2398,12 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
     if (LockingMode == LM_LIGHTWEIGHT) {
       // fast_lock kills r_temp_1, r_temp_2, r_temp_3.
       Register r_temp_3_or_noreg = UseObjectMonitorTable ? r_temp_3 : noreg;
-      __ compiler_fast_lock_lightweight_object(CCR0, r_oop, r_box, r_temp_1, r_temp_2, r_temp_3_or_noreg);
+      __ compiler_fast_lock_lightweight_object(CR0, r_oop, r_box, r_temp_1, r_temp_2, r_temp_3_or_noreg);
     } else {
       // fast_lock kills r_temp_1, r_temp_2, r_temp_3.
-      __ compiler_fast_lock_object(CCR0, r_oop, r_box, r_temp_1, r_temp_2, r_temp_3);
+      __ compiler_fast_lock_object(CR0, r_oop, r_box, r_temp_1, r_temp_2, r_temp_3);
     }
-    __ beq(CCR0, locked);
+    __ beq(CR0, locked);
 
     // None of the above fast optimizations worked so we have to get into the
     // slow case of monitor enter. Inline a special case of call_VM that
@@ -2538,8 +2538,8 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
     // Not suspended.
     // TODO: PPC port assert(4 == Thread::sz_suspend_flags(), "unexpected field size");
     __ lwz(suspend_flags, thread_(suspend_flags));
-    __ cmpwi(CCR1, suspend_flags, 0);
-    __ beq(CCR1, no_block);
+    __ cmpwi(CR1, suspend_flags, 0);
+    __ beq(CR1, no_block);
 
     // Block. Save any potential method result value before the operation and
     // use a leaf call to leave the last_Java_frame setup undisturbed. Doing this
@@ -2572,8 +2572,8 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
     if (LockingMode != LM_LEGACY && method->is_object_wait0()) {
       Label not_preempted;
       __ ld(R0, in_bytes(JavaThread::preempt_alternate_return_offset()), R16_thread);
-      __ cmpdi(CCR0, R0, 0);
-      __ beq(CCR0, not_preempted);
+      __ cmpdi(CR0, R0, 0);
+      __ beq(CR0, not_preempted);
       __ mtlr(R0);
       __ li(R0, 0);
       __ std(R0, in_bytes(JavaThread::preempt_alternate_return_offset()), R16_thread);
@@ -2591,8 +2591,8 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
 
   Label no_reguard;
   __ lwz(r_temp_1, thread_(stack_guard_state));
-  __ cmpwi(CCR0, r_temp_1, StackOverflow::stack_guard_yellow_reserved_disabled);
-  __ bne(CCR0, no_reguard);
+  __ cmpwi(CR0, r_temp_1, StackOverflow::stack_guard_yellow_reserved_disabled);
+  __ bne(CR0, no_reguard);
 
   save_native_result(masm, ret_type, workspace_slot_offset);
   __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages));
@@ -2622,11 +2622,11 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
 
     // Try fastpath for unlocking.
     if (LockingMode == LM_LIGHTWEIGHT) {
-      __ compiler_fast_unlock_lightweight_object(CCR0, r_oop, r_box, r_temp_1, r_temp_2, r_temp_3);
+      __ compiler_fast_unlock_lightweight_object(CR0, r_oop, r_box, r_temp_1, r_temp_2, r_temp_3);
     } else {
-      __ compiler_fast_unlock_object(CCR0, r_oop, r_box, r_temp_1, r_temp_2, r_temp_3);
+      __ compiler_fast_unlock_object(CR0, r_oop, r_box, r_temp_1, r_temp_2, r_temp_3);
     }
-    __ beq(CCR0, done);
+    __ beq(CR0, done);
 
     // Save and restore any potential method result value around the unlocking operation.
     save_native_result(masm, ret_type, workspace_slot_offset);
@@ -2693,8 +2693,8 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
   // Check for pending exceptions.
   // --------------------------------------------------------------------------
   __ ld(r_temp_2, thread_(pending_exception));
-  __ cmpdi(CCR0, r_temp_2, 0);
-  __ bne(CCR0, handle_pending_exception);
+  __ cmpdi(CR0, r_temp_2, 0);
+  __ bne(CR0, handle_pending_exception);
 
   // Return
   // --------------------------------------------------------------------------
@@ -2851,7 +2851,7 @@ static void push_skeleton_frames(MacroAssembler* masm, bool deopt,
 
 #ifdef ASSERT
   // Make sure that there is at least one entry in the array.
-  __ cmpdi(CCR0, number_of_frames_reg, 0);
+  __ cmpdi(CR0, number_of_frames_reg, 0);
   __ asm_assert_ne("array_size must be > 0");
 #endif
 
@@ -2866,8 +2866,8 @@ static void push_skeleton_frames(MacroAssembler* masm, bool deopt,
                       pcs_reg,
                       frame_size_reg,
                       pc_reg);
-  __ cmpdi(CCR0, number_of_frames_reg, 0);
-  __ bne(CCR0, loop);
+  __ cmpdi(CR0, number_of_frames_reg, 0);
+  __ bne(CR0, loop);
 
   // Get the return address pointing into the frame manager.
   __ ld(R0, 0, pcs_reg);
@@ -3014,8 +3014,8 @@ void SharedRuntime::generate_deopt_blob() {
   // stored in the thread during exception entry above. The exception
   // oop will be the return value of this stub.
   Label skip_restore_excp;
-  __ cmpdi(CCR0, exec_mode_reg, Deoptimization::Unpack_exception);
-  __ bne(CCR0, skip_restore_excp);
+  __ cmpdi(CR0, exec_mode_reg, Deoptimization::Unpack_exception);
+  __ bne(CR0, skip_restore_excp);
   __ ld(R3_RET, in_bytes(JavaThread::exception_oop_offset()), R16_thread);
   __ ld(R4_ARG2, in_bytes(JavaThread::exception_pc_offset()), R16_thread);
   __ li(R0, 0);
@@ -3165,7 +3165,7 @@ void OptoRuntime::generate_uncommon_trap_blob() {
 
 #ifdef ASSERT
   __ lwz(R22_tmp2, in_bytes(Deoptimization::UnrollBlock::unpack_kind_offset()), unroll_block_reg);
-  __ cmpdi(CCR0, R22_tmp2, (unsigned)Deoptimization::Unpack_uncommon_trap);
+  __ cmpdi(CR0, R22_tmp2, (unsigned)Deoptimization::Unpack_uncommon_trap);
   __ asm_assert_eq("OptoRuntime::generate_uncommon_trap_blob: expected Unpack_uncommon_trap");
 #endif
 
@@ -3295,8 +3295,8 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
   BLOCK_COMMENT("  Check pending exception.");
   const Register pending_exception = R0;
   __ ld(pending_exception, thread_(pending_exception));
-  __ cmpdi(CCR0, pending_exception, 0);
-  __ beq(CCR0, noException);
+  __ cmpdi(CR0, pending_exception, 0);
+  __ beq(CR0, noException);
 
   // Exception pending
   RegisterSaver::restore_live_registers_and_pop_frame(masm,
@@ -3315,8 +3315,8 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
     Label no_adjust;
     // If our stashed return pc was modified by the runtime we avoid touching it
     __ ld(R0, frame_size_in_bytes + _abi0(lr), R1_SP);
-    __ cmpd(CCR0, R0, R31);
-    __ bne(CCR0, no_adjust);
+    __ cmpd(CR0, R0, R31);
+    __ bne(CR0, no_adjust);
 
     // Adjust return pc forward to step over the safepoint poll instruction
     __ addi(R31, R31, 4);
@@ -3395,8 +3395,8 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
   BLOCK_COMMENT("Check for pending exceptions.");
   Label pending;
   __ ld(R11_scratch1, thread_(pending_exception));
-  __ cmpdi(CCR0, R11_scratch1, 0);
-  __ bne(CCR0, pending);
+  __ cmpdi(CR0, R11_scratch1, 0);
+  __ bne(CR0, pending);
 
   __ mtctr(R3_RET); // Ctr will not be touched by restore_live_registers_and_pop_frame.
 
@@ -3499,8 +3499,8 @@ RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address ru
     __ ld(R0,
           in_bytes(Thread::pending_exception_offset()),
           R16_thread);
-    __ cmpdi(CCR0, R0, 0);
-    __ bne(CCR0, L);
+    __ cmpdi(CR0, R0, 0);
+    __ bne(CR0, L);
     __ stop("SharedRuntime::throw_exception: no pending exception");
     __ bind(L);
   }

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -194,8 +194,8 @@ class StubGenerator: public StubCodeGenerator {
              r_top_of_arguments_addr, r_frame_alignment_in_bytes);
 
       // any arguments to copy?
-      __ cmpdi(CCR0, r_arg_argument_count, 0);
-      __ beq(CCR0, arguments_copied);
+      __ cmpdi(CR0, r_arg_argument_count, 0);
+      __ beq(CR0, arguments_copied);
 
       // prepare loop and copy arguments in reverse order
       {
@@ -334,10 +334,10 @@ class StubGenerator: public StubCodeGenerator {
 
       // Store result depending on type. Everything that is not
       // T_OBJECT, T_LONG, T_FLOAT, or T_DOUBLE is treated as T_INT.
-      __ cmpwi(CCR0, r_arg_result_type, T_OBJECT);
-      __ cmpwi(CCR1, r_arg_result_type, T_LONG);
-      __ cmpwi(CCR5, r_arg_result_type, T_FLOAT);
-      __ cmpwi(CCR6, r_arg_result_type, T_DOUBLE);
+      __ cmpwi(CR0, r_arg_result_type, T_OBJECT);
+      __ cmpwi(CR1, r_arg_result_type, T_LONG);
+      __ cmpwi(CR5, r_arg_result_type, T_FLOAT);
+      __ cmpwi(CR6, r_arg_result_type, T_DOUBLE);
 
       // restore non-volatile registers
       __ restore_nonvolatile_gprs(R1_SP, _spill_nonvolatiles_neg(r14));
@@ -353,10 +353,10 @@ class StubGenerator: public StubCodeGenerator {
       // All non-volatiles have been restored at this point!!
       assert(R3_RET == R3, "R3_RET should be R3");
 
-      __ beq(CCR0, ret_is_object);
-      __ beq(CCR1, ret_is_long);
-      __ beq(CCR5, ret_is_float);
-      __ beq(CCR6, ret_is_double);
+      __ beq(CR0, ret_is_object);
+      __ beq(CR1, ret_is_long);
+      __ beq(CR5, ret_is_float);
+      __ beq(CR6, ret_is_double);
 
       // default:
       __ stw(R3_RET, 0, r_arg_result_addr);
@@ -458,8 +458,8 @@ class StubGenerator: public StubCodeGenerator {
       // Make sure that this code is only executed if there is a pending exception.
       {
         Label L;
-        __ cmpdi(CCR0, R3_ARG1, 0);
-        __ bne(CCR0, L);
+        __ cmpdi(CR0, R3_ARG1, 0);
+        __ bne(CR0, L);
         __ stop("StubRoutines::forward exception: no pending exception (1)");
         __ bind(L);
       }
@@ -496,8 +496,8 @@ class StubGenerator: public StubCodeGenerator {
     // Make sure exception is set.
     {
       Label L;
-      __ cmpdi(CCR0, R3_ARG1, 0);
-      __ bne(CCR0, L);
+      __ cmpdi(CR0, R3_ARG1, 0);
+      __ bne(CR0, L);
       __ stop("StubRoutines::forward exception: no pending exception (2)");
       __ bind(L);
     }
@@ -551,16 +551,16 @@ class StubGenerator: public StubCodeGenerator {
     __ srdi_(tmp1_reg, cnt_dwords_reg, 1);      // number of double dwords
     __ load_const_optimized(zero_reg, 0L);      // Use as zero register.
 
-    __ cmpdi(CCR1, tmp2_reg, 0);                // cnt_dwords even?
-    __ beq(CCR0, lastdword);                    // size <= 1
+    __ cmpdi(CR1, tmp2_reg, 0);                // cnt_dwords even?
+    __ beq(CR0, lastdword);                    // size <= 1
     __ mtctr(tmp1_reg);                         // Speculatively preload counter for rest loop (>0).
-    __ cmpdi(CCR0, cnt_dwords_reg, (min_dcbz+1)*cl_dwords-1); // Big enough to ensure >=min_dcbz cache lines are included?
+    __ cmpdi(CR0, cnt_dwords_reg, (min_dcbz+1)*cl_dwords-1); // Big enough to ensure >=min_dcbz cache lines are included?
     __ neg(tmp1_reg, base_ptr_reg);             // bit 0..58: bogus, bit 57..60: (16-(base>>3))%16, bit 61..63: 000
 
-    __ blt(CCR0, restloop);                     // Too small. (<31=(2*cl_dwords)-1 is sufficient, but bigger performs better.)
+    __ blt(CR0, restloop);                     // Too small. (<31=(2*cl_dwords)-1 is sufficient, but bigger performs better.)
     __ rldicl_(tmp1_reg, tmp1_reg, 64-3, 64-cl_dwordaddr_bits); // Extract number of dwords to 128byte boundary=(16-(base>>3))%16.
 
-    __ beq(CCR0, fast);                         // already 128byte aligned
+    __ beq(CR0, fast);                         // already 128byte aligned
     __ mtctr(tmp1_reg);                         // Set ctr to hit 128byte boundary (0<ctr<cnt).
     __ subf(cnt_dwords_reg, tmp1_reg, cnt_dwords_reg); // rest (>0 since size>=256-8)
 
@@ -576,7 +576,7 @@ class StubGenerator: public StubCodeGenerator {
     __ andi(tmp2_reg, cnt_dwords_reg, 1);       // to check if rest even
 
     __ mtctr(tmp1_reg);                         // load counter
-    __ cmpdi(CCR1, tmp2_reg, 0);                // rest even?
+    __ cmpdi(CR1, tmp2_reg, 0);                // rest even?
     __ rldicl_(tmp1_reg, cnt_dwords_reg, 63, 65-cl_dwordaddr_bits); // rest in double dwords
 
     __ bind(fastloop);
@@ -585,7 +585,7 @@ class StubGenerator: public StubCodeGenerator {
     __ bdnz(fastloop);
 
     //__ dcbtst(base_ptr_reg);                  // Indicate write access to last cache line.
-    __ beq(CCR0, lastdword);                    // rest<=1
+    __ beq(CR0, lastdword);                    // rest<=1
     __ mtctr(tmp1_reg);                         // load counter
 
     // Clear rest.
@@ -596,7 +596,7 @@ class StubGenerator: public StubCodeGenerator {
     __ bdnz(restloop);
 
     __ bind(lastdword);
-    __ beq(CCR1, done);
+    __ beq(CR1, done);
     __ std(zero_reg, 0, base_ptr_reg);
     __ bind(done);
     __ blr();                                   // return
@@ -667,21 +667,21 @@ class StubGenerator: public StubCodeGenerator {
         shift = 2;
         // Clone bytes (zero extend not needed because store instructions below ignore high order bytes).
         __ rldimi(value, value, 8, 48);     // 8 bit -> 16 bit
-        __ cmpdi(CCR0, count, 2<<shift);    // Short arrays (< 8 bytes) fill by element.
-        __ blt(CCR0, L_fill_elements);
+        __ cmpdi(CR0, count, 2<<shift);    // Short arrays (< 8 bytes) fill by element.
+        __ blt(CR0, L_fill_elements);
         __ rldimi(value, value, 16, 32);    // 16 bit -> 32 bit
         break;
        case T_SHORT:
         shift = 1;
         // Clone bytes (zero extend not needed because store instructions below ignore high order bytes).
         __ rldimi(value, value, 16, 32);    // 16 bit -> 32 bit
-        __ cmpdi(CCR0, count, 2<<shift);    // Short arrays (< 8 bytes) fill by element.
-        __ blt(CCR0, L_fill_elements);
+        __ cmpdi(CR0, count, 2<<shift);    // Short arrays (< 8 bytes) fill by element.
+        __ blt(CR0, L_fill_elements);
         break;
       case T_INT:
         shift = 0;
-        __ cmpdi(CCR0, count, 2<<shift);    // Short arrays (< 8 bytes) fill by element.
-        __ blt(CCR0, L_fill_4_bytes);
+        __ cmpdi(CR0, count, 2<<shift);    // Short arrays (< 8 bytes) fill by element.
+        __ blt(CR0, L_fill_4_bytes);
         break;
       default: ShouldNotReachHere();
     }
@@ -691,7 +691,7 @@ class StubGenerator: public StubCodeGenerator {
       if (t == T_BYTE) {
         // One byte misalignment happens only for byte arrays.
         __ andi_(temp, to, 1);
-        __ beq(CCR0, L_skip_align1);
+        __ beq(CR0, L_skip_align1);
         __ stb(value, 0, to);
         __ addi(to, to, 1);
         __ addi(count, count, -1);
@@ -699,7 +699,7 @@ class StubGenerator: public StubCodeGenerator {
       }
       // Two bytes misalignment happens only for byte and short (char) arrays.
       __ andi_(temp, to, 2);
-      __ beq(CCR0, L_skip_align2);
+      __ beq(CR0, L_skip_align2);
       __ sth(value, 0, to);
       __ addi(to, to, 2);
       __ addi(count, count, -(1 << (shift - 1)));
@@ -709,7 +709,7 @@ class StubGenerator: public StubCodeGenerator {
     if (!aligned) {
       // Align to 8 bytes, we know we are 4 byte aligned to start.
       __ andi_(temp, to, 7);
-      __ beq(CCR0, L_fill_32_bytes);
+      __ beq(CR0, L_fill_32_bytes);
       __ stw(value, 0, to);
       __ addi(to, to, 4);
       __ addi(count, count, -(1 << shift));
@@ -723,7 +723,7 @@ class StubGenerator: public StubCodeGenerator {
     Label L_check_fill_8_bytes;
     // Fill 32-byte chunks.
     __ subf_(count, temp, count);
-    __ blt(CCR0, L_check_fill_8_bytes);
+    __ blt(CR0, L_check_fill_8_bytes);
 
     Label L_fill_32_bytes_loop;
     __ align(32);
@@ -736,13 +736,13 @@ class StubGenerator: public StubCodeGenerator {
     __ std(value, 24, to);
 
     __ addi(to, to, 32);
-    __ bge(CCR0, L_fill_32_bytes_loop);
+    __ bge(CR0, L_fill_32_bytes_loop);
 
     __ bind(L_check_fill_8_bytes);
     __ add_(count, temp, count);
-    __ beq(CCR0, L_exit);
+    __ beq(CR0, L_exit);
     __ addic_(count, count, -(2 << shift));
-    __ blt(CCR0, L_fill_4_bytes);
+    __ blt(CR0, L_fill_4_bytes);
 
     //
     // Length is too short, just fill 8 bytes at a time.
@@ -752,12 +752,12 @@ class StubGenerator: public StubCodeGenerator {
     __ std(value, 0, to);
     __ addic_(count, count, -(2 << shift));
     __ addi(to, to, 8);
-    __ bge(CCR0, L_fill_8_bytes_loop);
+    __ bge(CR0, L_fill_8_bytes_loop);
 
     // Fill trailing 4 bytes.
     __ bind(L_fill_4_bytes);
     __ andi_(temp, count, 1<<shift);
-    __ beq(CCR0, L_fill_2_bytes);
+    __ beq(CR0, L_fill_2_bytes);
 
     __ stw(value, 0, to);
     if (t == T_BYTE || t == T_SHORT) {
@@ -765,14 +765,14 @@ class StubGenerator: public StubCodeGenerator {
       // Fill trailing 2 bytes.
       __ bind(L_fill_2_bytes);
       __ andi_(temp, count, 1<<(shift-1));
-      __ beq(CCR0, L_fill_byte);
+      __ beq(CR0, L_fill_byte);
       __ sth(value, 0, to);
       if (t == T_BYTE) {
         __ addi(to, to, 2);
         // Fill trailing byte.
         __ bind(L_fill_byte);
         __ andi_(count, count, 1);
-        __ beq(CCR0, L_exit);
+        __ beq(CR0, L_exit);
         __ stb(value, 0, to);
       } else {
         __ bind(L_fill_byte);
@@ -788,18 +788,18 @@ class StubGenerator: public StubCodeGenerator {
       __ bind(L_fill_elements);
       Label L_fill_2, L_fill_4;
       __ andi_(temp, count, 1);
-      __ beq(CCR0, L_fill_2);
+      __ beq(CR0, L_fill_2);
       __ stb(value, 0, to);
       __ addi(to, to, 1);
       __ bind(L_fill_2);
       __ andi_(temp, count, 2);
-      __ beq(CCR0, L_fill_4);
+      __ beq(CR0, L_fill_4);
       __ stb(value, 0, to);
       __ stb(value, 0, to);
       __ addi(to, to, 2);
       __ bind(L_fill_4);
       __ andi_(temp, count, 4);
-      __ beq(CCR0, L_exit);
+      __ beq(CR0, L_exit);
       __ stb(value, 0, to);
       __ stb(value, 1, to);
       __ stb(value, 2, to);
@@ -811,12 +811,12 @@ class StubGenerator: public StubCodeGenerator {
       Label L_fill_2;
       __ bind(L_fill_elements);
       __ andi_(temp, count, 1);
-      __ beq(CCR0, L_fill_2);
+      __ beq(CR0, L_fill_2);
       __ sth(value, 0, to);
       __ addi(to, to, 2);
       __ bind(L_fill_2);
       __ andi_(temp, count, 2);
-      __ beq(CCR0, L_exit);
+      __ beq(CR0, L_exit);
       __ sth(value, 0, to);
       __ sth(value, 2, to);
       __ blr();
@@ -846,12 +846,12 @@ class StubGenerator: public StubCodeGenerator {
 
     __ subf(tmp1, R3_ARG1, R4_ARG2); // distance in bytes
     __ sldi(tmp2, R5_ARG3, log2_elem_size); // size in bytes
-    __ cmpld(CCR0, R3_ARG1, R4_ARG2); // Use unsigned comparison!
-    __ cmpld(CCR1, tmp1, tmp2);
-    __ crnand(CCR0, Assembler::less, CCR1, Assembler::less);
+    __ cmpld(CR0, R3_ARG1, R4_ARG2); // Use unsigned comparison!
+    __ cmpld(CR1, tmp1, tmp2);
+    __ crnand(CR0, Assembler::less, CR1, Assembler::less);
     // Overlaps if Src before dst and distance smaller than size.
     // Branch to forward copy routine otherwise (within range of 32kB).
-    __ bc(Assembler::bcondCRbiIs1, Assembler::bi0(CCR0, Assembler::less), no_overlap_target);
+    __ bc(Assembler::bcondCRbiIs1, Assembler::bi0(CR0, Assembler::less), no_overlap_target);
 
     // need to copy backwards
   }
@@ -913,18 +913,18 @@ class StubGenerator: public StubCodeGenerator {
 
       // Don't try anything fancy if arrays don't have many elements.
       __ li(tmp3, 0);
-      __ cmpwi(CCR0, R5_ARG3, 17);
-      __ ble(CCR0, l_6); // copy 4 at a time
+      __ cmpwi(CR0, R5_ARG3, 17);
+      __ ble(CR0, l_6); // copy 4 at a time
 
       if (!aligned) {
         __ xorr(tmp1, R3_ARG1, R4_ARG2);
         __ andi_(tmp1, tmp1, 3);
-        __ bne(CCR0, l_6); // If arrays don't have the same alignment mod 4, do 4 element copy.
+        __ bne(CR0, l_6); // If arrays don't have the same alignment mod 4, do 4 element copy.
 
         // Copy elements if necessary to align to 4 bytes.
         __ neg(tmp1, R3_ARG1); // Compute distance to alignment boundary.
         __ andi_(tmp1, tmp1, 3);
-        __ beq(CCR0, l_2);
+        __ beq(CR0, l_2);
 
         __ subf(R5_ARG3, tmp1, R5_ARG3);
         __ bind(l_9);
@@ -933,7 +933,7 @@ class StubGenerator: public StubCodeGenerator {
         __ stb(tmp2, 0, R4_ARG2);
         __ addi(R3_ARG1, R3_ARG1, 1);
         __ addi(R4_ARG2, R4_ARG2, 1);
-        __ bne(CCR0, l_9);
+        __ bne(CR0, l_9);
 
         __ bind(l_2);
       }
@@ -941,11 +941,11 @@ class StubGenerator: public StubCodeGenerator {
       // copy 8 elements at a time
       __ xorr(tmp2, R3_ARG1, R4_ARG2); // skip if src & dest have differing alignment mod 8
       __ andi_(tmp1, tmp2, 7);
-      __ bne(CCR0, l_7); // not same alignment -> to or from is aligned -> copy 8
+      __ bne(CR0, l_7); // not same alignment -> to or from is aligned -> copy 8
 
       // copy a 2-element word if necessary to align to 8 bytes
       __ andi_(R0, R3_ARG1, 7);
-      __ beq(CCR0, l_7);
+      __ beq(CR0, l_7);
 
       __ lwzx(tmp2, R3_ARG1, tmp3);
       __ addi(R5_ARG3, R5_ARG3, -4);
@@ -957,8 +957,8 @@ class StubGenerator: public StubCodeGenerator {
       __ bind(l_7);
 
       { // FasterArrayCopy
-        __ cmpwi(CCR0, R5_ARG3, 31);
-        __ ble(CCR0, l_6); // copy 2 at a time if less than 32 elements remain
+        __ cmpwi(CR0, R5_ARG3, 31);
+        __ ble(CR0, l_6); // copy 2 at a time if less than 32 elements remain
 
         __ srdi(tmp1, R5_ARG3, 5);
         __ andi_(R5_ARG3, R5_ARG3, 31);
@@ -1023,8 +1023,8 @@ class StubGenerator: public StubCodeGenerator {
       __ bind(l_6);
 
       // copy 4 elements at a time
-      __ cmpwi(CCR0, R5_ARG3, 4);
-      __ blt(CCR0, l_1);
+      __ cmpwi(CR0, R5_ARG3, 4);
+      __ blt(CR0, l_1);
       __ srdi(tmp1, R5_ARG3, 2);
       __ mtctr(tmp1); // is > 0
       __ andi_(R5_ARG3, R5_ARG3, 3);
@@ -1042,8 +1042,8 @@ class StubGenerator: public StubCodeGenerator {
 
       // do single element copy
       __ bind(l_1);
-      __ cmpwi(CCR0, R5_ARG3, 0);
-      __ beq(CCR0, l_4);
+      __ cmpwi(CR0, R5_ARG3, 0);
+      __ beq(CR0, l_4);
 
       { // FasterArrayCopy
         __ mtctr(R5_ARG3);
@@ -1098,7 +1098,7 @@ class StubGenerator: public StubCodeGenerator {
       __ bind(l_2);
       __ addic_(R5_ARG3, R5_ARG3, -1);
       __ lbzx(tmp1, R3_ARG1, R5_ARG3);
-      __ bge(CCR0, l_1);
+      __ bge(CR0, l_1);
     }
     __ li(R3_RET, 0); // return 0
     __ blr();
@@ -1181,19 +1181,19 @@ class StubGenerator: public StubCodeGenerator {
       UnsafeMemoryAccessMark umam(this, !aligned, false);
       // don't try anything fancy if arrays don't have many elements
       __ li(tmp3, 0);
-      __ cmpwi(CCR0, R5_ARG3, 9);
-      __ ble(CCR0, l_6); // copy 2 at a time
+      __ cmpwi(CR0, R5_ARG3, 9);
+      __ ble(CR0, l_6); // copy 2 at a time
 
       if (!aligned) {
         __ xorr(tmp1, R3_ARG1, R4_ARG2);
         __ andi_(tmp1, tmp1, 3);
-        __ bne(CCR0, l_6); // if arrays don't have the same alignment mod 4, do 2 element copy
+        __ bne(CR0, l_6); // if arrays don't have the same alignment mod 4, do 2 element copy
 
         // At this point it is guaranteed that both, from and to have the same alignment mod 4.
 
         // Copy 1 element if necessary to align to 4 bytes.
         __ andi_(tmp1, R3_ARG1, 3);
-        __ beq(CCR0, l_2);
+        __ beq(CR0, l_2);
 
         __ lhz(tmp2, 0, R3_ARG1);
         __ addi(R3_ARG1, R3_ARG1, 2);
@@ -1208,11 +1208,11 @@ class StubGenerator: public StubCodeGenerator {
         // Align to 8 bytes, but only if both, from and to, have same alignment mod 8.
         __ xorr(tmp2, R3_ARG1, R4_ARG2);
         __ andi_(tmp1, tmp2, 7);
-        __ bne(CCR0, l_7); // not same alignment mod 8 -> copy 4, either from or to will be unaligned
+        __ bne(CR0, l_7); // not same alignment mod 8 -> copy 4, either from or to will be unaligned
 
         // Copy a 2-element word if necessary to align to 8 bytes.
         __ andi_(R0, R3_ARG1, 7);
-        __ beq(CCR0, l_7);
+        __ beq(CR0, l_7);
 
         __ lwzx(tmp2, R3_ARG1, tmp3);
         __ addi(R5_ARG3, R5_ARG3, -2);
@@ -1229,8 +1229,8 @@ class StubGenerator: public StubCodeGenerator {
       // be unaligned if aligned == false.
 
       { // FasterArrayCopy
-        __ cmpwi(CCR0, R5_ARG3, 15);
-        __ ble(CCR0, l_6); // copy 2 at a time if less than 16 elements remain
+        __ cmpwi(CR0, R5_ARG3, 15);
+        __ ble(CR0, l_6); // copy 2 at a time if less than 16 elements remain
 
         __ srdi(tmp1, R5_ARG3, 4);
         __ andi_(R5_ARG3, R5_ARG3, 15);
@@ -1294,8 +1294,8 @@ class StubGenerator: public StubCodeGenerator {
 
       // copy 2 elements at a time
       { // FasterArrayCopy
-        __ cmpwi(CCR0, R5_ARG3, 2);
-        __ blt(CCR0, l_1);
+        __ cmpwi(CR0, R5_ARG3, 2);
+        __ blt(CR0, l_1);
         __ srdi(tmp1, R5_ARG3, 1);
         __ andi_(R5_ARG3, R5_ARG3, 1);
 
@@ -1314,8 +1314,8 @@ class StubGenerator: public StubCodeGenerator {
 
       // do single element copy
       __ bind(l_1);
-      __ cmpwi(CCR0, R5_ARG3, 0);
-      __ beq(CCR0, l_4);
+      __ cmpwi(CR0, R5_ARG3, 0);
+      __ beq(CR0, l_4);
 
       { // FasterArrayCopy
         __ mtctr(R5_ARG3);
@@ -1370,7 +1370,7 @@ class StubGenerator: public StubCodeGenerator {
       __ bind(l_2);
       __ addic_(tmp1, tmp1, -2);
       __ lhzx(tmp2, R3_ARG1, tmp1);
-      __ bge(CCR0, l_1);
+      __ bge(CR0, l_1);
     }
     __ li(R3_RET, 0); // return 0
     __ blr();
@@ -1399,19 +1399,19 @@ class StubGenerator: public StubCodeGenerator {
 
     // for short arrays, just do single element copy
     __ li(tmp3, 0);
-    __ cmpwi(CCR0, R5_ARG3, 5);
-    __ ble(CCR0, l_2);
+    __ cmpwi(CR0, R5_ARG3, 5);
+    __ ble(CR0, l_2);
 
     if (!aligned) {
         // check if arrays have same alignment mod 8.
         __ xorr(tmp1, R3_ARG1, R4_ARG2);
         __ andi_(R0, tmp1, 7);
         // Not the same alignment, but ld and std just need to be 4 byte aligned.
-        __ bne(CCR0, l_4); // to OR from is 8 byte aligned -> copy 2 at a time
+        __ bne(CR0, l_4); // to OR from is 8 byte aligned -> copy 2 at a time
 
         // copy 1 element to align to and from on an 8 byte boundary
         __ andi_(R0, R3_ARG1, 7);
-        __ beq(CCR0, l_4);
+        __ beq(CR0, l_4);
 
         __ lwzx(tmp2, R3_ARG1, tmp3);
         __ addi(R5_ARG3, R5_ARG3, -1);
@@ -1424,8 +1424,8 @@ class StubGenerator: public StubCodeGenerator {
       }
 
     { // FasterArrayCopy
-      __ cmpwi(CCR0, R5_ARG3, 7);
-      __ ble(CCR0, l_2); // copy 1 at a time if less than 8 elements remain
+      __ cmpwi(CR0, R5_ARG3, 7);
+      __ ble(CR0, l_2); // copy 1 at a time if less than 8 elements remain
 
       __ srdi(tmp1, R5_ARG3, 3);
       __ andi_(R5_ARG3, R5_ARG3, 7);
@@ -1489,8 +1489,8 @@ class StubGenerator: public StubCodeGenerator {
 
     // copy 1 element at a time
     __ bind(l_2);
-    __ cmpwi(CCR0, R5_ARG3, 0);
-    __ beq(CCR0, l_1);
+    __ cmpwi(CR0, R5_ARG3, 0);
+    __ beq(CR0, l_1);
 
     { // FasterArrayCopy
       __ mtctr(R5_ARG3);
@@ -1553,8 +1553,8 @@ class StubGenerator: public StubCodeGenerator {
     VectorSRegister tmp_vsr2  = VSR2;
 
     { // FasterArrayCopy
-      __ cmpwi(CCR0, R5_ARG3, 0);
-      __ beq(CCR0, l_6);
+      __ cmpwi(CR0, R5_ARG3, 0);
+      __ beq(CR0, l_6);
 
       __ sldi(R5_ARG3, R5_ARG3, 2);
       __ add(R3_ARG1, R3_ARG1, R5_ARG3);
@@ -1566,11 +1566,11 @@ class StubGenerator: public StubCodeGenerator {
         __ xorr(tmp1, R3_ARG1, R4_ARG2);
         __ andi_(R0, tmp1, 7);
         // Not the same alignment, but ld and std just need to be 4 byte aligned.
-        __ bne(CCR0, l_7); // to OR from is 8 byte aligned -> copy 2 at a time
+        __ bne(CR0, l_7); // to OR from is 8 byte aligned -> copy 2 at a time
 
         // copy 1 element to align to and from on an 8 byte boundary
         __ andi_(R0, R3_ARG1, 7);
-        __ beq(CCR0, l_7);
+        __ beq(CR0, l_7);
 
         __ addi(R3_ARG1, R3_ARG1, -4);
         __ addi(R4_ARG2, R4_ARG2, -4);
@@ -1580,8 +1580,8 @@ class StubGenerator: public StubCodeGenerator {
         __ bind(l_7);
       }
 
-      __ cmpwi(CCR0, R5_ARG3, 7);
-      __ ble(CCR0, l_5); // copy 1 at a time if less than 8 elements remain
+      __ cmpwi(CR0, R5_ARG3, 7);
+      __ ble(CR0, l_5); // copy 1 at a time if less than 8 elements remain
 
       __ srdi(tmp1, R5_ARG3, 3);
       __ andi(R5_ARG3, R5_ARG3, 7);
@@ -1638,8 +1638,8 @@ class StubGenerator: public StubCodeGenerator {
       }
      }
 
-      __ cmpwi(CCR0, R5_ARG3, 0);
-      __ beq(CCR0, l_6);
+      __ cmpwi(CR0, R5_ARG3, 0);
+      __ beq(CR0, l_6);
 
       __ bind(l_5);
       __ mtctr(R5_ARG3);
@@ -1704,8 +1704,8 @@ class StubGenerator: public StubCodeGenerator {
     VectorSRegister tmp_vsr2  = VSR2;
 
     { // FasterArrayCopy
-      __ cmpwi(CCR0, R5_ARG3, 3);
-      __ ble(CCR0, l_3); // copy 1 at a time if less than 4 elements remain
+      __ cmpwi(CR0, R5_ARG3, 3);
+      __ ble(CR0, l_3); // copy 1 at a time if less than 4 elements remain
 
       __ srdi(tmp1, R5_ARG3, 2);
       __ andi_(R5_ARG3, R5_ARG3, 3);
@@ -1768,8 +1768,8 @@ class StubGenerator: public StubCodeGenerator {
 
     // copy 1 element at a time
     __ bind(l_3);
-    __ cmpwi(CCR0, R5_ARG3, 0);
-    __ beq(CCR0, l_1);
+    __ cmpwi(CR0, R5_ARG3, 0);
+    __ beq(CR0, l_1);
 
     { // FasterArrayCopy
       __ mtctr(R5_ARG3);
@@ -1828,8 +1828,8 @@ class StubGenerator: public StubCodeGenerator {
 
     Label l_1, l_2, l_3, l_4, l_5;
 
-    __ cmpwi(CCR0, R5_ARG3, 0);
-    __ beq(CCR0, l_1);
+    __ cmpwi(CR0, R5_ARG3, 0);
+    __ beq(CR0, l_1);
 
     { // FasterArrayCopy
       __ sldi(R5_ARG3, R5_ARG3, 3);
@@ -1837,8 +1837,8 @@ class StubGenerator: public StubCodeGenerator {
       __ add(R4_ARG2, R4_ARG2, R5_ARG3);
       __ srdi(R5_ARG3, R5_ARG3, 3);
 
-      __ cmpwi(CCR0, R5_ARG3, 3);
-      __ ble(CCR0, l_5); // copy 1 at a time if less than 4 elements remain
+      __ cmpwi(CR0, R5_ARG3, 3);
+      __ ble(CR0, l_5); // copy 1 at a time if less than 4 elements remain
 
       __ srdi(tmp1, R5_ARG3, 2);
       __ andi(R5_ARG3, R5_ARG3, 3);
@@ -1895,8 +1895,8 @@ class StubGenerator: public StubCodeGenerator {
       }
      }
 
-      __ cmpwi(CCR0, R5_ARG3, 0);
-      __ beq(CCR0, l_1);
+      __ cmpwi(CR0, R5_ARG3, 0);
+      __ beq(CR0, l_1);
 
       __ bind(l_5);
       __ mtctr(R5_ARG3);
@@ -2093,12 +2093,12 @@ class StubGenerator: public StubCodeGenerator {
     Label no_overlap;
     __ subf(tmp1, R3_ARG1, R4_ARG2); // distance in bytes
     __ sldi(tmp2, R5_ARG3, LogBytesPerHeapOop); // size in bytes
-    __ cmpld(CCR0, R3_ARG1, R4_ARG2); // Use unsigned comparison!
-    __ cmpld(CCR1, tmp1, tmp2);
-    __ crnand(CCR0, Assembler::less, CCR1, Assembler::less);
+    __ cmpld(CR0, R3_ARG1, R4_ARG2); // Use unsigned comparison!
+    __ cmpld(CR1, tmp1, tmp2);
+    __ crnand(CR0, Assembler::less, CR1, Assembler::less);
     // Overlaps if Src before dst and distance smaller than size.
     // Branch to forward copy routine otherwise.
-    __ blt(CCR0, no_overlap);
+    __ blt(CR0, no_overlap);
     __ stop("overlap in checkcast_copy");
     __ bind(no_overlap);
     }
@@ -2117,7 +2117,7 @@ class StubGenerator: public StubCodeGenerator {
     Label load_element, store_element, store_null, success, do_epilogue;
     __ or_(R9_remain, R5_count, R5_count); // Initialize loop index, and test it.
     __ li(R8_offset, 0);                   // Offset from start of arrays.
-    __ bne(CCR0, load_element);
+    __ bne(CR0, load_element);
 
     // Empty array: Nothing to do.
     __ li(R3_RET, 0);           // Return 0 on (trivial) success.
@@ -2145,7 +2145,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ addi(R8_offset, R8_offset, heapOopSize);   // Step to next offset.
     __ addic_(R9_remain, R9_remain, -1);          // Decrement the count.
-    __ beq(CCR0, success);
+    __ beq(CR0, success);
 
     // ======== loop entry is here ========
     __ bind(load_element);
@@ -2175,7 +2175,7 @@ class StubGenerator: public StubCodeGenerator {
     // and report their number to the caller.
     __ subf_(R5_count, R9_remain, R5_count);
     __ nand(R3_RET, R5_count, R5_count);   // report (-1^K) to caller
-    __ bne(CCR0, do_epilogue);
+    __ bne(CR0, do_epilogue);
     __ blr();
 
     __ bind(success);
@@ -2226,13 +2226,13 @@ class StubGenerator: public StubCodeGenerator {
     __ orr(R6_bits, R3_from, R4_to);
     __ orr(R6_bits, R6_bits, R5_count);
     __ andi_(R0, R6_bits, (BytesPerLong-1));
-    __ beq(CCR0, long_copy);
+    __ beq(CR0, long_copy);
 
     __ andi_(R0, R6_bits, (BytesPerInt-1));
-    __ beq(CCR0, int_copy);
+    __ beq(CR0, int_copy);
 
     __ andi_(R0, R6_bits, (BytesPerShort-1));
-    __ beq(CCR0, short_copy);
+    __ beq(CR0, short_copy);
 
     // byte_copy:
     __ b(byte_copy_entry);
@@ -2271,14 +2271,14 @@ class StubGenerator: public StubCodeGenerator {
     //  if (src_pos + length > arrayOop(src)->length() ) FAIL;
     __ lwa(array_length, arrayOopDesc::length_offset_in_bytes(), src);
     __ add(end_pos, src_pos, length);  // src_pos + length
-    __ cmpd(CCR0, end_pos, array_length);
-    __ bgt(CCR0, L_failed);
+    __ cmpd(CR0, end_pos, array_length);
+    __ bgt(CR0, L_failed);
 
     //  if (dst_pos + length > arrayOop(dst)->length() ) FAIL;
     __ lwa(array_length, arrayOopDesc::length_offset_in_bytes(), dst);
     __ add(end_pos, dst_pos, length);  // src_pos + length
-    __ cmpd(CCR0, end_pos, array_length);
-    __ bgt(CCR0, L_failed);
+    __ cmpd(CR0, end_pos, array_length);
+    __ bgt(CR0, L_failed);
 
     BLOCK_COMMENT("arraycopy_range_checks done");
   }
@@ -2344,16 +2344,16 @@ class StubGenerator: public StubCodeGenerator {
     // (8) dst_pos + length must not exceed length of dst.
     BLOCK_COMMENT("arraycopy initial argument checks");
 
-    __ cmpdi(CCR1, src, 0);      // if (src == nullptr) return -1;
+    __ cmpdi(CR1, src, 0);      // if (src == nullptr) return -1;
     __ extsw_(src_pos, src_pos); // if (src_pos < 0) return -1;
-    __ cmpdi(CCR5, dst, 0);      // if (dst == nullptr) return -1;
-    __ cror(CCR1, Assembler::equal, CCR0, Assembler::less);
+    __ cmpdi(CR5, dst, 0);      // if (dst == nullptr) return -1;
+    __ cror(CR1, Assembler::equal, CR0, Assembler::less);
     __ extsw_(dst_pos, dst_pos); // if (src_pos < 0) return -1;
-    __ cror(CCR5, Assembler::equal, CCR0, Assembler::less);
+    __ cror(CR5, Assembler::equal, CR0, Assembler::less);
     __ extsw_(length, length);   // if (length < 0) return -1;
-    __ cror(CCR1, Assembler::equal, CCR5, Assembler::equal);
-    __ cror(CCR1, Assembler::equal, CCR0, Assembler::less);
-    __ beq(CCR1, L_failed);
+    __ cror(CR1, Assembler::equal, CR5, Assembler::equal);
+    __ cror(CR1, Assembler::equal, CR0, Assembler::less);
+    __ beq(CR1, L_failed);
 
     BLOCK_COMMENT("arraycopy argument klass checks");
     __ load_klass(src_klass, src);
@@ -2375,22 +2375,22 @@ class StubGenerator: public StubCodeGenerator {
     // Handle objArrays completely differently...
     jint objArray_lh = Klass::array_layout_helper(T_OBJECT);
     __ load_const_optimized(temp, objArray_lh, R0);
-    __ cmpw(CCR0, lh, temp);
-    __ beq(CCR0, L_objArray);
+    __ cmpw(CR0, lh, temp);
+    __ beq(CR0, L_objArray);
 
-    __ cmpd(CCR5, src_klass, dst_klass);          // if (src->klass() != dst->klass()) return -1;
-    __ cmpwi(CCR6, lh, Klass::_lh_neutral_value); // if (!src->is_Array()) return -1;
+    __ cmpd(CR5, src_klass, dst_klass);          // if (src->klass() != dst->klass()) return -1;
+    __ cmpwi(CR6, lh, Klass::_lh_neutral_value); // if (!src->is_Array()) return -1;
 
-    __ crnand(CCR5, Assembler::equal, CCR6, Assembler::less);
-    __ beq(CCR5, L_failed);
+    __ crnand(CR5, Assembler::equal, CR6, Assembler::less);
+    __ beq(CR5, L_failed);
 
     // At this point, it is known to be a typeArray (array_tag 0x3).
 #ifdef ASSERT
     { Label L;
       jint lh_prim_tag_in_place = (Klass::_lh_array_tag_type_value << Klass::_lh_array_tag_shift);
       __ load_const_optimized(temp, lh_prim_tag_in_place, R0);
-      __ cmpw(CCR0, lh, temp);
-      __ bge(CCR0, L);
+      __ cmpw(CR0, lh, temp);
+      __ bge(CR0, L);
       __ stop("must be a primitive array");
       __ bind(L);
     }
@@ -2430,17 +2430,17 @@ class StubGenerator: public StubCodeGenerator {
 
     BLOCK_COMMENT("choose copy loop based on element size");
     // Using conditional branches with range 32kB.
-    const int bo = Assembler::bcondCRbiIs1, bi = Assembler::bi0(CCR0, Assembler::equal);
-    __ cmpwi(CCR0, elsize, 0);
+    const int bo = Assembler::bcondCRbiIs1, bi = Assembler::bi0(CR0, Assembler::equal);
+    __ cmpwi(CR0, elsize, 0);
     __ bc(bo, bi, entry_jbyte_arraycopy);
-    __ cmpwi(CCR0, elsize, LogBytesPerShort);
+    __ cmpwi(CR0, elsize, LogBytesPerShort);
     __ bc(bo, bi, entry_jshort_arraycopy);
-    __ cmpwi(CCR0, elsize, LogBytesPerInt);
+    __ cmpwi(CR0, elsize, LogBytesPerInt);
     __ bc(bo, bi, entry_jint_arraycopy);
 #ifdef ASSERT
     { Label L;
-      __ cmpwi(CCR0, elsize, LogBytesPerLong);
-      __ beq(CCR0, L);
+      __ cmpwi(CR0, elsize, LogBytesPerLong);
+      __ beq(CR0, L);
       __ stop("must be long copy, but elsize is wrong");
       __ bind(L);
     }
@@ -2453,8 +2453,8 @@ class StubGenerator: public StubCodeGenerator {
 
     Label L_disjoint_plain_copy, L_checkcast_copy;
     //  test array classes for subtyping
-    __ cmpd(CCR0, src_klass, dst_klass);         // usual case is exact equality
-    __ bne(CCR0, L_checkcast_copy);
+    __ cmpd(CR0, src_klass, dst_klass);         // usual case is exact equality
+    __ bne(CR0, L_checkcast_copy);
 
     // Identically typed arrays can be copied without element-wise checks.
     arraycopy_range_checks(src, src_pos, dst, dst_pos, length,
@@ -2474,8 +2474,8 @@ class StubGenerator: public StubCodeGenerator {
     {
       // Before looking at dst.length, make sure dst is also an objArray.
       __ lwz(temp, lh_offset, dst_klass);
-      __ cmpw(CCR0, lh, temp);
-      __ bne(CCR0, L_failed);
+      __ cmpw(CR0, lh, temp);
+      __ bne(CR0, L_failed);
 
       // It is safe to examine both src.length and dst.length.
       arraycopy_range_checks(src, src_pos, dst, dst_pos, length,
@@ -2652,8 +2652,8 @@ class StubGenerator: public StubCodeGenerator {
     __ vec_perm        (vKey2, vTmp1, keyPerm);
 
     // if all round keys are loaded, skip next 4 rounds
-    __ cmpwi           (CCR0, keylen, 44);
-    __ beq             (CCR0, L_doLast);
+    __ cmpwi           (CR0, keylen, 44);
+    __ beq             (CR0, L_doLast);
 
     // 10th - 11th rounds
     __ vcipher         (vRet, vRet, vKey1);
@@ -2670,12 +2670,12 @@ class StubGenerator: public StubCodeGenerator {
     __ vec_perm        (vKey2, vTmp1, keyPerm);
 
     // if all round keys are loaded, skip next 2 rounds
-    __ cmpwi           (CCR0, keylen, 52);
-    __ beq             (CCR0, L_doLast);
+    __ cmpwi           (CR0, keylen, 52);
+    __ beq             (CR0, L_doLast);
 
 #ifdef ASSERT
-    __ cmpwi           (CCR0, keylen, 60);
-    __ bne             (CCR0, L_error);
+    __ cmpwi           (CR0, keylen, 60);
+    __ bne             (CR0, L_error);
 #endif
 
     // 12th - 13th rounds
@@ -2789,15 +2789,15 @@ class StubGenerator: public StubCodeGenerator {
     __ vsldoi          (keyPerm, keyPerm, keyPerm, 8);
 #endif
 
-    __ cmpwi           (CCR0, keylen, 44);
-    __ beq             (CCR0, L_do44);
+    __ cmpwi           (CR0, keylen, 44);
+    __ beq             (CR0, L_do44);
 
-    __ cmpwi           (CCR0, keylen, 52);
-    __ beq             (CCR0, L_do52);
+    __ cmpwi           (CR0, keylen, 52);
+    __ beq             (CR0, L_do52);
 
 #ifdef ASSERT
-    __ cmpwi           (CCR0, keylen, 60);
-    __ bne             (CCR0, L_error);
+    __ cmpwi           (CR0, keylen, 60);
+    __ bne             (CR0, L_error);
 #endif
 
     // load the 15th round key to vKey1
@@ -3010,7 +3010,7 @@ class StubGenerator: public StubCodeGenerator {
     address start = __ pc();
 
     __ andi_(temp, is_presync, 1);
-    __ bne(CCR0, SKIP);
+    __ bne(CR0, SKIP);
     __ cache_wbsync(false); // post sync => emit 'sync'
     __ bind(SKIP);          // pre sync => emit nothing
     __ blr();
@@ -3267,10 +3267,10 @@ class StubGenerator: public StubCodeGenerator {
     // Store the squares, right shifted one bit (i.e., divided by 2)
     __ subi   (out_aux,   out,       8);
     __ subi   (in_aux,    in,        4);
-    __ cmpwi  (CCR0,      in_len,    0);
+    __ cmpwi  (CR0,      in_len,    0);
     // Initialize lplw outside of the loop
     __ xorr   (lplw,      lplw,      lplw);
-    __ ble    (CCR0,      SKIP_LOOP_SQUARE);    // in_len <= 0
+    __ ble    (CR0,      SKIP_LOOP_SQUARE);    // in_len <= 0
     __ mtctr  (in_len);
 
     __ bind(LOOP_SQUARE);
@@ -3293,8 +3293,8 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(SKIP_LOOP_SQUARE);
 
     // Add in off-diagonal sums
-    __ cmpwi  (CCR0,      in_len,    0);
-    __ ble    (CCR0,      SKIP_DIAGONAL_SUM);
+    __ cmpwi  (CR0,      in_len,    0);
+    __ ble    (CR0,      SKIP_DIAGONAL_SUM);
     // Avoid CTR usage here in order to use it at mulAdd
     __ subi   (i_minus1,  in_len,    1);
     __ li     (offset,    4);
@@ -3325,25 +3325,25 @@ class StubGenerator: public StubCodeGenerator {
 
     // if (((uint64_t)s >> 32) != 0) {
     __ srdi_  (a,         b,         32);
-    __ beq    (CCR0,      SKIP_ADDONE);
+    __ beq    (CR0,      SKIP_ADDONE);
 
     // while (--mlen >= 0) {
     __ bind(LOOP_ADDONE);
     __ subi   (mlen,      mlen,      4);
-    __ cmpwi  (CCR0,      mlen,      0);
-    __ beq    (CCR0,      SKIP_ADDONE);
+    __ cmpwi  (CR0,      mlen,      0);
+    __ beq    (CR0,      SKIP_ADDONE);
 
     // if (--offset_aux < 0) { // Carry out of number
     __ subi   (off_aux,   off_aux,   4);
-    __ cmpwi  (CCR0,      off_aux,   0);
-    __ blt    (CCR0,      SKIP_ADDONE);
+    __ cmpwi  (CR0,      off_aux,   0);
+    __ blt    (CR0,      SKIP_ADDONE);
 
     // } else {
     __ lwzx   (b,         off_aux,   out);
     __ addi   (b,         b,         1);
     __ stwx   (b,         off_aux,   out);
-    __ cmpwi  (CCR0,      b,         0);
-    __ bne    (CCR0,      SKIP_ADDONE);
+    __ cmpwi  (CR0,      b,         0);
+    __ bne    (CR0,      SKIP_ADDONE);
     __ b      (LOOP_ADDONE);
 
     __ bind(SKIP_ADDONE);
@@ -3351,16 +3351,16 @@ class StubGenerator: public StubCodeGenerator {
 
     __ addi   (offset,    offset,    8);
     __ subi   (i_minus1,  i_minus1,  1);
-    __ cmpwi  (CCR0,      i_minus1,  0);
-    __ bge    (CCR0,      LOOP_DIAGONAL_SUM);
+    __ cmpwi  (CR0,      i_minus1,  0);
+    __ bge    (CR0,      LOOP_DIAGONAL_SUM);
 
     __ bind(SKIP_DIAGONAL_SUM);
 
     // Shift back up and set low bit
     // Shifts 1 bit left up to len positions. Assumes no leading zeros
     // begin<primitiveLeftShift>
-    __ cmpwi  (CCR0,      out_len,   0);
-    __ ble    (CCR0,      SKIP_LSHIFT);
+    __ cmpwi  (CR0,      out_len,   0);
+    __ ble    (CR0,      SKIP_LSHIFT);
     __ li     (i,         0);
     __ lwz    (c,         0,         out);
     __ subi   (b,         out_len,   1);
@@ -3493,10 +3493,10 @@ class StubGenerator: public StubCodeGenerator {
     __ restore_LR(R3_RET /* used as tmp register */);
     __ restore_volatile_gprs(R1_SP, -nbytes_save, true);
 
-    __ cmpdi(CCR0, R0, 0);
+    __ cmpdi(CR0, R0, 0);
 
     // Return to prologue if no deoptimization is required (bnelr)
-    __ bclr(Assembler::bcondCRbiIs1, Assembler::bi0(CCR0, Assembler::equal), Assembler::bhintIsTaken);
+    __ bclr(Assembler::bcondCRbiIs1, Assembler::bi0(CR0, Assembler::equal), Assembler::bhintIsTaken);
 
     // Deoptimization required.
     // For actually handling the deoptimization, the 'wrong method stub' is invoked.
@@ -3777,7 +3777,7 @@ class StubGenerator: public StubCodeGenerator {
     // = sl >> block_size_shift.  After the shift, if sl <= 0, there's too
     // little data to be processed by this intrinsic.
     __ srawi_(sl, sl, block_size_shift);
-    __ ble(CCR0, return_zero);
+    __ ble(CR0, return_zero);
     __ mtctr(sl);
 
     // Clear the other two parameter registers upper 32 bits.
@@ -3816,8 +3816,8 @@ class StubGenerator: public StubCodeGenerator {
 
     // The rest of the constants use different values depending on the
     // setting of isURL
-    __ cmpwi(CCR0, isURL, 0);
-    __ beq(CCR0, not_URL);
+    __ cmpwi(CR0, isURL, 0);
+    __ beq(CR0, not_URL);
 
     // isURL != 0 (true)
     if (PowerArchitecturePPC64 >= 10) {
@@ -3907,11 +3907,11 @@ class StubGenerator: public StubCodeGenerator {
       //
       __ vcmpequb_(non_match, non_match, vec_0s);
     }
-    // vmcmpequb_ sets the EQ bit of CCR6 if no elements compare equal.
+    // vmcmpequb_ sets the EQ bit of CR6 if no elements compare equal.
     // Any element comparing equal to zero means there is an error in
     // that element.  Note that the comparison result register
-    // non_match is not referenced again.  Only CCR6-EQ matters.
-    __ bne_predict_not_taken(CCR6, loop_exit);
+    // non_match is not referenced again.  Only CR6-EQ matters.
+    __ bne_predict_not_taken(CR6, loop_exit);
 
     // The Base64 characters had no errors, so add the offsets, which in
     // the case of Power10 is a constant vector of all 0x80's (see earlier
@@ -4311,8 +4311,8 @@ class StubGenerator: public StubCodeGenerator {
 
     // Use a different translation lookup table depending on the
     // setting of isURL
-    __ cmpdi(CCR0, isURL, 0);
-    __ beq(CCR0, not_URL);
+    __ cmpdi(CR0, isURL, 0);
+    __ beq(CR0, not_URL);
     __ lxv(vec_base64_48_63->to_vsr(), BLK_OFFSETOF(base64_48_63_URL_val), const_ptr);
     __ b(calculate_size);
 
@@ -4329,8 +4329,8 @@ class StubGenerator: public StubCodeGenerator {
     //
     __ sub(size, sl, sp);
     __ subi(size, size, 4);
-    __ cmpdi(CCR7, size, block_size);
-    __ bgt(CCR7, calculate_blocked_size);
+    __ cmpdi(CR7, size, block_size);
+    __ bgt(CR7, calculate_blocked_size);
     __ mr(remaining, size);
     // Add the 4 back into remaining again
     __ addi(remaining, remaining, 4);
@@ -4388,8 +4388,8 @@ class StubGenerator: public StubCodeGenerator {
     __ addi(bytes_to_write, bytes_to_write, 2);
     __ divwu(bytes_to_write, bytes_to_write, three);
 
-    __ cmpwi(CCR7, bytes_to_write, 16);
-    __ ble_predict_taken(CCR7, le_16_to_write);
+    __ cmpwi(CR7, bytes_to_write, 16);
+    __ ble_predict_taken(CR7, le_16_to_write);
     __ stxv(expanded->to_vsr(), 0, out);
 
     // We've processed 12 of the 13-15 data bytes, so advance the pointers,
@@ -4410,7 +4410,7 @@ class StubGenerator: public StubCodeGenerator {
     __ add(out, out, bytes_to_write);
 
     __ li(pad_char, '=');
-    __ rlwinm_(modulo_chars, bytes_to_write, 0, 30, 31); // bytes_to_write % 4, set CCR0
+    __ rlwinm_(modulo_chars, bytes_to_write, 0, 30, 31); // bytes_to_write % 4, set CR0
     // Examples:
     //    remaining  bytes_to_write  modulo_chars  num pad chars
     //        0            0               0            0
@@ -4424,9 +4424,9 @@ class StubGenerator: public StubCodeGenerator {
     //       13           18               2            2
     //       14           19               3            1
     //       15           20               0            0
-    __ beq(CCR0, no_pad);
-    __ cmpwi(CCR7, modulo_chars, 3);
-    __ beq(CCR7, one_pad_char);
+    __ beq(CR0, no_pad);
+    __ cmpwi(CR7, modulo_chars, 3);
+    __ beq(CR7, one_pad_char);
 
     // two pad chars
     __ stb(pad_char, out);
@@ -4509,13 +4509,13 @@ address generate_lookup_secondary_supers_table_stub(u1 super_klass_index) {
       __ ld_ptr(R1_SP, JavaThread::cont_entry_offset(), R16_thread);
 #ifdef ASSERT
       __ ld_ptr(tmp2, _abi0(callers_sp), R1_SP);
-      __ cmpd(CCR0, tmp1, tmp2);
+      __ cmpd(CR0, tmp1, tmp2);
       __ asm_assert_eq(FILE_AND_LINE ": callers sp is corrupt");
 #endif
     }
 #ifdef ASSERT
     __ ld_ptr(tmp1, JavaThread::cont_entry_offset(), R16_thread);
-    __ cmpd(CCR0, R1_SP, tmp1);
+    __ cmpd(CR0, R1_SP, tmp1);
     __ asm_assert_eq(FILE_AND_LINE ": incorrect R1_SP");
 #endif
 
@@ -4524,14 +4524,14 @@ address generate_lookup_secondary_supers_table_stub(u1 super_klass_index) {
 
 #ifdef ASSERT
     DEBUG_ONLY(__ ld_ptr(tmp1, JavaThread::cont_entry_offset(), R16_thread));
-    DEBUG_ONLY(__ cmpd(CCR0, R1_SP, tmp1));
+    DEBUG_ONLY(__ cmpd(CR0, R1_SP, tmp1));
     __ asm_assert_eq(FILE_AND_LINE ": incorrect R1_SP");
 #endif
 
     // R3_RET contains the size of the frames to thaw, 0 if overflow or no more frames
     Label thaw_success;
-    __ cmpdi(CCR0, R3_RET, 0);
-    __ bne(CCR0, thaw_success);
+    __ cmpdi(CR0, R3_RET, 0);
+    __ bne(CR0, thaw_success);
     __ load_const_optimized(tmp1, (SharedRuntime::throw_StackOverflowError_entry()), R0);
     __ mtctr(tmp1); __ bctr();
     __ bind(thaw_success);
@@ -4605,8 +4605,8 @@ address generate_lookup_secondary_supers_table_stub(u1 super_klass_index) {
 
     Label preemption_cancelled;
     __ lbz(R11_scratch1, in_bytes(JavaThread::preemption_cancelled_offset()), R16_thread);
-    __ cmpwi(CCR0, R11_scratch1, 0);
-    __ bne(CCR0, preemption_cancelled);
+    __ cmpwi(CR0, R11_scratch1, 0);
+    __ bne(CR0, preemption_cancelled);
 
     // Remove enterSpecial frame from the stack and return to Continuation.run() to unmount.
     SharedRuntime::continuation_enter_cleanup(_masm);

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -147,8 +147,8 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
     assert(sizeof(AccessFlags) == 2, "wrong size");
     __ lhz(R11_scratch1/*access_flags*/, method_(access_flags));
     // testbit with condition register.
-    __ testbitdi(CCR0, R0, R11_scratch1/*access_flags*/, JVM_ACC_STATIC_BIT);
-    __ btrue(CCR0, L);
+    __ testbitdi(CR0, R0, R11_scratch1/*access_flags*/, JVM_ACC_STATIC_BIT);
+    __ btrue(CR0, L);
     // For non-static functions, pass "this" in R4_ARG2 and copy it
     // to 2nd C-arg slot.
     // We need to box the Java object here, so we use arg_java
@@ -175,8 +175,8 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
   // signature points to '(' at entry
 #ifdef ASSERT
   __ lbz(sig_byte, 0, signature);
-  __ cmplwi(CCR0, sig_byte, '(');
-  __ bne(CCR0, do_dontreachhere);
+  __ cmplwi(CR0, sig_byte, '(');
+  __ bne(CR0, do_dontreachhere);
 #endif
 
   __ bind(loop_start);
@@ -184,41 +184,41 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
   __ addi(argcnt, argcnt, 1);
   __ lbzu(sig_byte, 1, signature);
 
-  __ cmplwi(CCR0, sig_byte, ')'); // end of signature
-  __ beq(CCR0, loop_end);
+  __ cmplwi(CR0, sig_byte, ')'); // end of signature
+  __ beq(CR0, loop_end);
 
-  __ cmplwi(CCR0, sig_byte, 'B'); // byte
-  __ beq(CCR0, do_int);
+  __ cmplwi(CR0, sig_byte, 'B'); // byte
+  __ beq(CR0, do_int);
 
-  __ cmplwi(CCR0, sig_byte, 'C'); // char
-  __ beq(CCR0, do_int);
+  __ cmplwi(CR0, sig_byte, 'C'); // char
+  __ beq(CR0, do_int);
 
-  __ cmplwi(CCR0, sig_byte, 'D'); // double
-  __ beq(CCR0, do_double);
+  __ cmplwi(CR0, sig_byte, 'D'); // double
+  __ beq(CR0, do_double);
 
-  __ cmplwi(CCR0, sig_byte, 'F'); // float
-  __ beq(CCR0, do_float);
+  __ cmplwi(CR0, sig_byte, 'F'); // float
+  __ beq(CR0, do_float);
 
-  __ cmplwi(CCR0, sig_byte, 'I'); // int
-  __ beq(CCR0, do_int);
+  __ cmplwi(CR0, sig_byte, 'I'); // int
+  __ beq(CR0, do_int);
 
-  __ cmplwi(CCR0, sig_byte, 'J'); // long
-  __ beq(CCR0, do_long);
+  __ cmplwi(CR0, sig_byte, 'J'); // long
+  __ beq(CR0, do_long);
 
-  __ cmplwi(CCR0, sig_byte, 'S'); // short
-  __ beq(CCR0, do_int);
+  __ cmplwi(CR0, sig_byte, 'S'); // short
+  __ beq(CR0, do_int);
 
-  __ cmplwi(CCR0, sig_byte, 'Z'); // boolean
-  __ beq(CCR0, do_int);
+  __ cmplwi(CR0, sig_byte, 'Z'); // boolean
+  __ beq(CR0, do_int);
 
-  __ cmplwi(CCR0, sig_byte, 'L'); // object
-  __ beq(CCR0, do_object);
+  __ cmplwi(CR0, sig_byte, 'L'); // object
+  __ beq(CR0, do_object);
 
-  __ cmplwi(CCR0, sig_byte, '['); // array
-  __ beq(CCR0, do_array);
+  __ cmplwi(CR0, sig_byte, '['); // array
+  __ beq(CR0, do_array);
 
-  //  __ cmplwi(CCR0, sig_byte, 'V'); // void cannot appear since we do not parse the return type
-  //  __ beq(CCR0, do_void);
+  //  __ cmplwi(CR0, sig_byte, 'V'); // void cannot appear since we do not parse the return type
+  //  __ beq(CR0, do_void);
 
   __ bind(do_dontreachhere);
 
@@ -231,16 +231,16 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
 
     __ bind(start_skip);
     __ lbzu(sig_byte, 1, signature);
-    __ cmplwi(CCR0, sig_byte, '[');
-    __ beq(CCR0, start_skip); // skip further brackets
-    __ cmplwi(CCR0, sig_byte, '9');
-    __ bgt(CCR0, end_skip);   // no optional size
-    __ cmplwi(CCR0, sig_byte, '0');
-    __ bge(CCR0, start_skip); // skip optional size
+    __ cmplwi(CR0, sig_byte, '[');
+    __ beq(CR0, start_skip); // skip further brackets
+    __ cmplwi(CR0, sig_byte, '9');
+    __ bgt(CR0, end_skip);   // no optional size
+    __ cmplwi(CR0, sig_byte, '0');
+    __ bge(CR0, start_skip); // skip optional size
     __ bind(end_skip);
 
-    __ cmplwi(CCR0, sig_byte, 'L');
-    __ beq(CCR0, do_object);  // for arrays of objects, the name of the object must be skipped
+    __ cmplwi(CR0, sig_byte, 'L');
+    __ beq(CR0, do_object);  // for arrays of objects, the name of the object must be skipped
     __ b(do_boxed);          // otherwise, go directly to do_boxed
   }
 
@@ -249,8 +249,8 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
     Label L;
     __ bind(L);
     __ lbzu(sig_byte, 1, signature);
-    __ cmplwi(CCR0, sig_byte, ';');
-    __ bne(CCR0, L);
+    __ cmplwi(CR0, sig_byte, ';');
+    __ bne(CR0, L);
    }
   // Need to box the Java object here, so we use arg_java (address of
   // current Java stack slot) as argument and don't dereference it as
@@ -258,16 +258,16 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
   Label do_null;
   __ bind(do_boxed);
   __ ld(R0,0, arg_java);
-  __ cmpdi(CCR0, R0, 0);
+  __ cmpdi(CR0, R0, 0);
   __ li(intSlot,0);
-  __ beq(CCR0, do_null);
+  __ beq(CR0, do_null);
   __ mr(intSlot, arg_java);
   __ bind(do_null);
   __ std(intSlot, 0, arg_c);
   __ addi(arg_java, arg_java, -BytesPerWord);
   __ addi(arg_c, arg_c, BytesPerWord);
-  __ cmplwi(CCR0, argcnt, max_int_register_arguments);
-  __ blt(CCR0, move_intSlot_to_ARG);
+  __ cmplwi(CR0, argcnt, max_int_register_arguments);
+  __ blt(CR0, move_intSlot_to_ARG);
   __ b(loop_start);
 
   __ bind(do_int);
@@ -275,8 +275,8 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
   __ std(intSlot, 0, arg_c);
   __ addi(arg_java, arg_java, -BytesPerWord);
   __ addi(arg_c, arg_c, BytesPerWord);
-  __ cmplwi(CCR0, argcnt, max_int_register_arguments);
-  __ blt(CCR0, move_intSlot_to_ARG);
+  __ cmplwi(CR0, argcnt, max_int_register_arguments);
+  __ blt(CR0, move_intSlot_to_ARG);
   __ b(loop_start);
 
   __ bind(do_long);
@@ -284,8 +284,8 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
   __ std(intSlot, 0, arg_c);
   __ addi(arg_java, arg_java, - 2 * BytesPerWord);
   __ addi(arg_c, arg_c, BytesPerWord);
-  __ cmplwi(CCR0, argcnt, max_int_register_arguments);
-  __ blt(CCR0, move_intSlot_to_ARG);
+  __ cmplwi(CR0, argcnt, max_int_register_arguments);
+  __ blt(CR0, move_intSlot_to_ARG);
   __ b(loop_start);
 
   __ bind(do_float);
@@ -293,8 +293,8 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
   __ stfs(floatSlot, Argument::float_on_stack_offset_in_bytes_c, arg_c);
   __ addi(arg_java, arg_java, -BytesPerWord);
   __ addi(arg_c, arg_c, BytesPerWord);
-  __ cmplwi(CCR0, fpcnt, max_fp_register_arguments);
-  __ blt(CCR0, move_floatSlot_to_FARG);
+  __ cmplwi(CR0, fpcnt, max_fp_register_arguments);
+  __ blt(CR0, move_floatSlot_to_FARG);
   __ b(loop_start);
 
   __ bind(do_double);
@@ -302,8 +302,8 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
   __ stfd(floatSlot, 0, arg_c);
   __ addi(arg_java, arg_java, - 2 * BytesPerWord);
   __ addi(arg_c, arg_c, BytesPerWord);
-  __ cmplwi(CCR0, fpcnt, max_fp_register_arguments);
-  __ blt(CCR0, move_floatSlot_to_FARG);
+  __ cmplwi(CR0, fpcnt, max_fp_register_arguments);
+  __ blt(CR0, move_floatSlot_to_FARG);
   __ b(loop_start);
 
   __ bind(loop_end);
@@ -510,8 +510,8 @@ address TemplateInterpreterGenerator::generate_Reference_get_entry(void) {
   __ ld(R3_RET, Interpreter::stackElementSize, R15_esp); // get receiver
 
   // Check if receiver == nullptr and go the slow path.
-  __ cmpdi(CCR0, R3_RET, 0);
-  __ beq(CCR0, slow_path);
+  __ cmpdi(CR0, R3_RET, 0);
+  __ beq(CR0, slow_path);
 
   __ load_heap_oop(R3_RET, referent_offset, R3_RET,
                    /* non-volatile temp */ R31, R11_scratch1,
@@ -725,8 +725,8 @@ void TemplateInterpreterGenerator::generate_counter_incr(Label* overflow) {
   if (ProfileInterpreter) {
     const Register Rmdo = R3_counters;
     __ ld(Rmdo, in_bytes(Method::method_data_offset()), R19_method);
-    __ cmpdi(CCR0, Rmdo, 0);
-    __ beq(CCR0, no_mdo);
+    __ cmpdi(CR0, Rmdo, 0);
+    __ beq(CR0, no_mdo);
 
     // Increment invocation counter in the MDO.
     const int mdo_ic_offs = in_bytes(MethodData::invocation_counter_offset()) + in_bytes(InvocationCounter::counter_offset());
@@ -735,7 +735,7 @@ void TemplateInterpreterGenerator::generate_counter_incr(Label* overflow) {
     __ addi(Rscratch2, Rscratch2, increment);
     __ stw(Rscratch2, mdo_ic_offs, Rmdo);
     __ and_(Rscratch1, Rscratch2, Rscratch1);
-    __ bne(CCR0, done);
+    __ bne(CR0, done);
     __ b(*overflow);
   }
 
@@ -748,7 +748,7 @@ void TemplateInterpreterGenerator::generate_counter_incr(Label* overflow) {
   __ addi(Rscratch2, Rscratch2, increment);
   __ stw(Rscratch2, mo_ic_offs, R3_counters);
   __ and_(Rscratch1, Rscratch2, Rscratch1);
-  __ beq(CCR0, *overflow);
+  __ beq(CR0, *overflow);
 
   __ bind(done);
 }
@@ -789,8 +789,8 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(Register Rmem_f
   BLOCK_COMMENT("stack_overflow_check_with_compare {");
   __ sub(Rmem_frame_size, R1_SP, Rmem_frame_size);
   __ ld(Rscratch1, thread_(stack_overflow_limit));
-  __ cmpld(CCR0/*is_stack_overflow*/, Rmem_frame_size, Rscratch1);
-  __ bgt(CCR0/*is_stack_overflow*/, done);
+  __ cmpld(CR0/*is_stack_overflow*/, Rmem_frame_size, Rscratch1);
+  __ bgt(CR0/*is_stack_overflow*/, done);
 
   // The stack overflows. Load target address of the runtime stub and call it.
   assert(SharedRuntime::throw_StackOverflowError_entry() != nullptr, "generated in wrong order");
@@ -799,13 +799,13 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(Register Rmem_f
   // Restore caller_sp (c2i adapter may exist, but no shrinking of interpreted caller frame).
 #ifdef ASSERT
   Label frame_not_shrunk;
-  __ cmpld(CCR0, R1_SP, R21_sender_SP);
-  __ ble(CCR0, frame_not_shrunk);
+  __ cmpld(CR0, R1_SP, R21_sender_SP);
+  __ ble(CR0, frame_not_shrunk);
   __ stop("frame shrunk");
   __ bind(frame_not_shrunk);
   __ ld(Rscratch1, 0, R1_SP);
   __ ld(R0, 0, R21_sender_SP);
-  __ cmpd(CCR0, R0, Rscratch1);
+  __ cmpd(CR0, R0, Rscratch1);
   __ asm_assert_eq("backlink");
 #endif // ASSERT
   __ mr(R1_SP, R21_sender_SP);
@@ -829,8 +829,8 @@ void TemplateInterpreterGenerator::lock_method(Register Rflags, Register Rscratc
     // Check if methods needs synchronization.
     {
       Label Lok;
-      __ testbitdi(CCR0, R0, Rflags, JVM_ACC_SYNCHRONIZED_BIT);
-      __ btrue(CCR0,Lok);
+      __ testbitdi(CR0, R0, Rflags, JVM_ACC_SYNCHRONIZED_BIT);
+      __ btrue(CR0,Lok);
       __ stop("method doesn't need synchronization");
       __ bind(Lok);
     }
@@ -842,8 +842,8 @@ void TemplateInterpreterGenerator::lock_method(Register Rflags, Register Rscratc
     Label Lstatic;
     Label Ldone;
 
-    __ testbitdi(CCR0, R0, Rflags, JVM_ACC_STATIC_BIT);
-    __ btrue(CCR0, Lstatic);
+    __ testbitdi(CR0, R0, Rflags, JVM_ACC_STATIC_BIT);
+    __ btrue(CR0, Lstatic);
 
     // Non-static case: load receiver obj from stack and we're done.
     __ ld(Robj_to_lock, R18_locals);
@@ -950,8 +950,8 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call, Regist
     // environment and one for a possible native mirror.
     Label skip_native_calculate_max_stack;
     __ addi(Rtop_frame_size, Rsize_of_parameters, 2);
-    __ cmpwi(CCR0, Rtop_frame_size, Argument::n_int_register_parameters_c);
-    __ bge(CCR0, skip_native_calculate_max_stack);
+    __ cmpwi(CR0, Rtop_frame_size, Argument::n_int_register_parameters_c);
+    __ bge(CR0, skip_native_calculate_max_stack);
     __ li(Rtop_frame_size, Argument::n_int_register_parameters_c);
     __ bind(skip_native_calculate_max_stack);
     __ sldi(Rsize_of_parameters, Rsize_of_parameters, Interpreter::logStackElementSize);
@@ -999,8 +999,8 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call, Regist
   if (ProfileInterpreter) {
     Label zero_continue;
     __ ld(R28_mdx, method_(method_data));
-    __ cmpdi(CCR0, R28_mdx, 0);
-    __ beq(CCR0, zero_continue);
+    __ cmpdi(CR0, R28_mdx, 0);
+    __ beq(CR0, zero_continue);
     __ addi(R28_mdx, R28_mdx, in_bytes(MethodData::data_offset()));
     __ bind(zero_continue);
   }
@@ -1330,8 +1330,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   __ ld(signature_handler_fd, method_(signature_handler));
   Label call_signature_handler;
 
-  __ cmpdi(CCR0, signature_handler_fd, 0);
-  __ bne(CCR0, call_signature_handler);
+  __ cmpdi(CR0, signature_handler_fd, 0);
+  __ bne(CR0, call_signature_handler);
 
   // Method has never been called. Either generate a specialized
   // handler or point to the slow one.
@@ -1342,8 +1342,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // Check for an exception while looking up the target method. If we
   // incurred one, bail.
   __ ld(pending_exception, thread_(pending_exception));
-  __ cmpdi(CCR0, pending_exception, 0);
-  __ bne(CCR0, exception_return_sync_check); // Has pending exception.
+  __ cmpdi(CR0, pending_exception, 0);
+  __ bne(CR0, exception_return_sync_check); // Has pending exception.
 
   // Reload signature handler, it may have been created/assigned in the meanwhile.
   __ ld(signature_handler_fd, method_(signature_handler));
@@ -1398,8 +1398,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     // Access_flags is non-volatile and still, no need to restore it.
 
     // Restore access flags.
-    __ testbitdi(CCR0, R0, access_flags, JVM_ACC_STATIC_BIT);
-    __ bfalse(CCR0, method_is_not_static);
+    __ testbitdi(CR0, R0, access_flags, JVM_ACC_STATIC_BIT);
+    __ bfalse(CR0, method_is_not_static);
 
     // Load mirror from interpreter frame (FP in R11_scratch1)
     __ ld(R21_tmp1, _ijava_state_neg(mirror), R11_scratch1);
@@ -1508,8 +1508,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // Not suspended.
   // TODO PPC port assert(4 == Thread::sz_suspend_flags(), "unexpected field size");
   __ lwz(suspend_flags, thread_(suspend_flags));
-  __ cmpwi(CCR1, suspend_flags, 0);
-  __ beq(CCR1, sync_check_done);
+  __ cmpwi(CR1, suspend_flags, 0);
+  __ beq(CR1, sync_check_done);
 
   __ bind(do_safepoint);
   __ isync();
@@ -1552,8 +1552,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     // Check preemption for Object.wait()
     Label not_preempted;
     __ ld(R0, in_bytes(JavaThread::preempt_alternate_return_offset()), R16_thread);
-    __ cmpdi(CCR0, R0, 0);
-    __ beq(CCR0, not_preempted);
+    __ cmpdi(CR0, R0, 0);
+    __ beq(CR0, not_preempted);
     __ mtlr(R0);
     __ li(R0, 0);
     __ std(R0, in_bytes(JavaThread::preempt_alternate_return_offset()), R16_thread);
@@ -1611,8 +1611,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
   Label exception_return_sync_check_already_unlocked;
   __ ld(R0/*pending_exception*/, thread_(pending_exception));
-  __ cmpdi(CCR0, R0/*pending_exception*/, 0);
-  __ bne(CCR0, exception_return_sync_check_already_unlocked);
+  __ cmpdi(CR0, R0/*pending_exception*/, 0);
+  __ bne(CR0, exception_return_sync_check_already_unlocked);
 
   //-----------------------------------------------------------------------------
   // No exception pending.
@@ -1706,7 +1706,7 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
   __ subf(Rnum, Rsize_of_parameters, Rsize_of_locals);
   __ subf(Rslot_addr, Rsize_of_parameters, R18_locals);
   __ srdi_(Rnum, Rnum, Interpreter::logStackElementSize);
-  __ beq(CCR0, Lno_locals);
+  __ beq(CR0, Lno_locals);
   __ li(R0, 0);
   __ mtctr(Rnum);
 
@@ -2080,8 +2080,8 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
     __ ld(return_pc, 0, R1_SP);
     __ ld(return_pc, _abi0(lr), return_pc);
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::interpreter_contains), return_pc);
-    __ cmpdi(CCR0, R3_RET, 0);
-    __ bne(CCR0, Lcaller_not_deoptimized);
+    __ cmpdi(CR0, R3_RET, 0);
+    __ bne(CR0, Lcaller_not_deoptimized);
 
     // The deoptimized case.
     // In this case, we can't call dispatch_next() after the frame is
@@ -2127,16 +2127,16 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
     Label L_done;
 
     __ lbz(R11_scratch1, 0, R14_bcp);
-    __ cmpwi(CCR0, R11_scratch1, Bytecodes::_invokestatic);
-    __ bne(CCR0, L_done);
+    __ cmpwi(CR0, R11_scratch1, Bytecodes::_invokestatic);
+    __ bne(CR0, L_done);
 
     // The member name argument must be restored if _invokestatic is re-executed after a PopFrame call.
     // Detect such a case in the InterpreterRuntime function and return the member name argument, or null.
     __ ld(R4_ARG2, 0, R18_locals);
     __ call_VM(R4_ARG2, CAST_FROM_FN_PTR(address, InterpreterRuntime::member_name_arg_or_null), R4_ARG2, R19_method, R14_bcp);
 
-    __ cmpdi(CCR0, R4_ARG2, 0);
-    __ beq(CCR0, L_done);
+    __ cmpdi(CR0, R4_ARG2, 0);
+    __ beq(CR0, L_done);
     __ std(R4_ARG2, wordSize, R15_esp);
     __ bind(L_done);
 #endif // INCLUDE_JVMTI
@@ -2321,8 +2321,8 @@ address TemplateInterpreterGenerator::generate_trace_code(TosState state) {
     int offs2 = __ load_const_optimized(R12_scratch2, (address) &BytecodeCounter::_counter_value, R0, true);
     __ ld(R11_scratch1, offs1, R11_scratch1);
     __ lwa(R12_scratch2, offs2, R12_scratch2);
-    __ cmpd(CCR0, R12_scratch2, R11_scratch1);
-    __ blt(CCR0, Lskip_vm_call);
+    __ cmpd(CR0, R12_scratch2, R11_scratch1);
+    __ blt(CR0, Lskip_vm_call);
   }
 
   __ push(state);
@@ -2396,8 +2396,8 @@ void TemplateInterpreterGenerator::stop_interpreter_at() {
   int offs2 = __ load_const_optimized(R12_scratch2, (address) &BytecodeCounter::_counter_value, R0, true);
   __ ld(R11_scratch1, offs1, R11_scratch1);
   __ lwa(R12_scratch2, offs2, R12_scratch2);
-  __ cmpd(CCR0, R12_scratch2, R11_scratch1);
-  __ bne(CCR0, L);
+  __ cmpd(CR0, R12_scratch2, R11_scratch1);
+  __ bne(CR0, L);
   __ illtrap();
   __ bind(L);
 }

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -123,9 +123,9 @@ void TemplateTable::patch_bytecode(Bytecodes::Code new_bc, Register Rnew_bc, Reg
       int code_offset = (byte_no == f1_byte) ? in_bytes(ResolvedFieldEntry::get_code_offset())
                                              : in_bytes(ResolvedFieldEntry::put_code_offset());
       __ lbz(Rnew_bc, code_offset, Rtemp);
-      __ cmpwi(CCR0, Rnew_bc, 0);
+      __ cmpwi(CR0, Rnew_bc, 0);
       __ li(Rnew_bc, (unsigned int)(unsigned char)new_bc);
-      __ beq(CCR0, L_patch_done);
+      __ beq(CR0, L_patch_done);
       // __ isync(); // acquire not needed
       break;
     }
@@ -140,8 +140,8 @@ void TemplateTable::patch_bytecode(Bytecodes::Code new_bc, Register Rnew_bc, Reg
   if (JvmtiExport::can_post_breakpoint()) {
     Label L_fast_patch;
     __ lbz(Rtemp, 0, R14_bcp);
-    __ cmpwi(CCR0, Rtemp, (unsigned int)(unsigned char)Bytecodes::_breakpoint);
-    __ bne(CCR0, L_fast_patch);
+    __ cmpwi(CR0, Rtemp, (unsigned int)(unsigned char)Bytecodes::_breakpoint);
+    __ bne(CR0, L_fast_patch);
     // Perform the quickening, slowly, in the bowels of the breakpoint table.
     __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::set_original_bytecode_at), R19_method, R14_bcp, Rnew_bc);
     __ b(L_patch_done);
@@ -261,14 +261,14 @@ void TemplateTable::ldc(LdcType type) {
   __ addi(Rscratch2, Rscratch2, tags_offset);
   __ lbzx(Rscratch2, Rscratch2, Rscratch1);
 
-  __ cmpwi(CCR0, Rscratch2, JVM_CONSTANT_UnresolvedClass); // Unresolved class?
-  __ cmpwi(CCR1, Rscratch2, JVM_CONSTANT_UnresolvedClassInError); // Unresolved class in error state?
-  __ cror(CCR0, Assembler::equal, CCR1, Assembler::equal);
+  __ cmpwi(CR0, Rscratch2, JVM_CONSTANT_UnresolvedClass); // Unresolved class?
+  __ cmpwi(CR1, Rscratch2, JVM_CONSTANT_UnresolvedClassInError); // Unresolved class in error state?
+  __ cror(CR0, Assembler::equal, CR1, Assembler::equal);
 
   // Resolved class - need to call vm to get java mirror of the class.
-  __ cmpwi(CCR1, Rscratch2, JVM_CONSTANT_Class);
-  __ crnor(CCR0, Assembler::equal, CCR1, Assembler::equal); // Neither resolved class nor unresolved case from above?
-  __ beq(CCR0, notClass);
+  __ cmpwi(CR1, Rscratch2, JVM_CONSTANT_Class);
+  __ crnor(CR0, Assembler::equal, CR1, Assembler::equal); // Neither resolved class nor unresolved case from above?
+  __ beq(CR0, notClass);
 
   __ li(R4, is_ldc_wide(type) ? 1 : 0);
   call_VM(R17_tos, CAST_FROM_FN_PTR(address, InterpreterRuntime::ldc), R4);
@@ -279,16 +279,16 @@ void TemplateTable::ldc(LdcType type) {
   __ bind(notClass);
   __ addi(Rcpool, Rcpool, base_offset);
   __ sldi(Rscratch1, Rscratch1, LogBytesPerWord);
-  __ cmpdi(CCR0, Rscratch2, JVM_CONSTANT_Integer);
-  __ bne(CCR0, notInt);
+  __ cmpdi(CR0, Rscratch2, JVM_CONSTANT_Integer);
+  __ bne(CR0, notInt);
   __ lwax(R17_tos, Rcpool, Rscratch1);
   __ push(itos);
   __ b(exit);
 
   __ align(32, 12);
   __ bind(notInt);
-  __ cmpdi(CCR0, Rscratch2, JVM_CONSTANT_Float);
-  __ bne(CCR0, notFloat);
+  __ cmpdi(CR0, Rscratch2, JVM_CONSTANT_Float);
+  __ bne(CR0, notFloat);
   __ lfsx(F15_ftos, Rcpool, Rscratch1);
   __ push(ftos);
   __ b(exit);
@@ -318,12 +318,12 @@ void TemplateTable::fast_aldc(LdcType type) {
   int simm16_rest = __ load_const_optimized(R11_scratch1, Universe::the_null_sentinel_addr(), R0, true);
   __ ld(R31, simm16_rest, R11_scratch1);
   __ resolve_oop_handle(R31, R11_scratch1, R12_scratch2, MacroAssembler::PRESERVATION_NONE);
-  __ cmpld(CCR0, R17_tos, R31);
+  __ cmpld(CR0, R17_tos, R31);
   if (VM_Version::has_isel()) {
-    __ isel_0(R17_tos, CCR0, Assembler::equal);
+    __ isel_0(R17_tos, CR0, Assembler::equal);
   } else {
     Label not_sentinel;
-    __ bne(CCR0, not_sentinel);
+    __ bne(CR0, not_sentinel);
     __ li(R17_tos, 0);
     __ bind(not_sentinel);
   }
@@ -359,15 +359,15 @@ void TemplateTable::ldc2_w() {
   __ lbzx(Rtag, Rtag, Rindex);
   __ sldi(Rindex, Rindex, LogBytesPerWord);
 
-  __ cmpdi(CCR0, Rtag, JVM_CONSTANT_Double);
-  __ bne(CCR0, not_double);
+  __ cmpdi(CR0, Rtag, JVM_CONSTANT_Double);
+  __ bne(CR0, not_double);
   __ lfdx(F15_ftos, Rcpool, Rindex);
   __ push(dtos);
   __ b(exit);
 
   __ bind(not_double);
-  __ cmpdi(CCR0, Rtag, JVM_CONSTANT_Long);
-  __ bne(CCR0, not_long);
+  __ cmpdi(CR0, Rtag, JVM_CONSTANT_Long);
+  __ bne(CR0, not_long);
   __ ldx(R17_tos, Rcpool, Rindex);
   __ push(ltos);
   __ b(exit);
@@ -401,32 +401,32 @@ void TemplateTable::condy_helper(Label& Done) {
     {
       // tos in (itos, ftos, stos, btos, ctos, ztos)
       Label notInt, notFloat, notShort, notByte, notChar, notBool;
-      __ cmplwi(CCR0, flags, itos);
-      __ bne(CCR0, notInt);
+      __ cmplwi(CR0, flags, itos);
+      __ bne(CR0, notInt);
       // itos
       __ lwax(R17_tos, obj, off);
       __ push(itos);
       __ b(Done);
 
       __ bind(notInt);
-      __ cmplwi(CCR0, flags, ftos);
-      __ bne(CCR0, notFloat);
+      __ cmplwi(CR0, flags, ftos);
+      __ bne(CR0, notFloat);
       // ftos
       __ lfsx(F15_ftos, obj, off);
       __ push(ftos);
       __ b(Done);
 
       __ bind(notFloat);
-      __ cmplwi(CCR0, flags, stos);
-      __ bne(CCR0, notShort);
+      __ cmplwi(CR0, flags, stos);
+      __ bne(CR0, notShort);
       // stos
       __ lhax(R17_tos, obj, off);
       __ push(stos);
       __ b(Done);
 
       __ bind(notShort);
-      __ cmplwi(CCR0, flags, btos);
-      __ bne(CCR0, notByte);
+      __ cmplwi(CR0, flags, btos);
+      __ bne(CR0, notByte);
       // btos
       __ lbzx(R17_tos, obj, off);
       __ extsb(R17_tos, R17_tos);
@@ -434,16 +434,16 @@ void TemplateTable::condy_helper(Label& Done) {
       __ b(Done);
 
       __ bind(notByte);
-      __ cmplwi(CCR0, flags, ctos);
-      __ bne(CCR0, notChar);
+      __ cmplwi(CR0, flags, ctos);
+      __ bne(CR0, notChar);
       // ctos
       __ lhzx(R17_tos, obj, off);
       __ push(ctos);
       __ b(Done);
 
       __ bind(notChar);
-      __ cmplwi(CCR0, flags, ztos);
-      __ bne(CCR0, notBool);
+      __ cmplwi(CR0, flags, ztos);
+      __ bne(CR0, notBool);
       // ztos
       __ lbzx(R17_tos, obj, off);
       __ push(ztos);
@@ -456,16 +456,16 @@ void TemplateTable::condy_helper(Label& Done) {
   case Bytecodes::_ldc2_w:
     {
       Label notLong, notDouble;
-      __ cmplwi(CCR0, flags, ltos);
-      __ bne(CCR0, notLong);
+      __ cmplwi(CR0, flags, ltos);
+      __ bne(CR0, notLong);
       // ltos
       __ ldx(R17_tos, obj, off);
       __ push(ltos);
       __ b(Done);
 
       __ bind(notLong);
-      __ cmplwi(CCR0, flags, dtos);
-      __ bne(CCR0, notDouble);
+      __ cmplwi(CR0, flags, dtos);
+      __ bne(CR0, notDouble);
       // dtos
       __ lfdx(F15_ftos, obj, off);
       __ push(dtos);
@@ -517,16 +517,16 @@ void TemplateTable::iload_internal(RewriteControl rc) {
     // last two iloads in a pair. Comparing against fast_iload means that
     // the next bytecode is neither an iload or a caload, and therefore
     // an iload pair.
-    __ cmpwi(CCR0, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_iload);
-    __ beq(CCR0, Ldone);
+    __ cmpwi(CR0, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_iload);
+    __ beq(CR0, Ldone);
 
-    __ cmpwi(CCR1, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_fast_iload);
+    __ cmpwi(CR1, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_fast_iload);
     __ li(Rrewrite_to, (unsigned int)(unsigned char)Bytecodes::_fast_iload2);
-    __ beq(CCR1, Lrewrite);
+    __ beq(CR1, Lrewrite);
 
-    __ cmpwi(CCR0, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_caload);
+    __ cmpwi(CR0, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_caload);
     __ li(Rrewrite_to, (unsigned int)(unsigned char)Bytecodes::_fast_icaload);
-    __ beq(CCR0, Lrewrite);
+    __ beq(CR0, Lrewrite);
 
     __ li(Rrewrite_to, (unsigned int)(unsigned char)Bytecodes::_fast_iload);
 
@@ -812,20 +812,20 @@ void TemplateTable::aload_0_internal(RewriteControl rc) {
     __ lbz(Rnext_byte, Bytecodes::length_for(Bytecodes::_aload_0), R14_bcp);
 
     // If _getfield, wait to rewrite. We only want to rewrite the last two bytecodes in a pair.
-    __ cmpwi(CCR0, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_getfield);
-    __ beq(CCR0, Ldont_rewrite);
+    __ cmpwi(CR0, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_getfield);
+    __ beq(CR0, Ldont_rewrite);
 
-    __ cmpwi(CCR1, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_fast_igetfield);
+    __ cmpwi(CR1, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_fast_igetfield);
     __ li(Rrewrite_to, (unsigned int)(unsigned char)Bytecodes::_fast_iaccess_0);
-    __ beq(CCR1, Lrewrite);
+    __ beq(CR1, Lrewrite);
 
-    __ cmpwi(CCR0, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_fast_agetfield);
+    __ cmpwi(CR0, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_fast_agetfield);
     __ li(Rrewrite_to, (unsigned int)(unsigned char)Bytecodes::_fast_aaccess_0);
-    __ beq(CCR0, Lrewrite);
+    __ beq(CR0, Lrewrite);
 
-    __ cmpwi(CCR1, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_fast_fgetfield);
+    __ cmpwi(CR1, Rnext_byte, (unsigned int)(unsigned char)Bytecodes::_fast_fgetfield);
     __ li(Rrewrite_to, (unsigned int)(unsigned char)Bytecodes::_fast_faccess_0);
-    __ beq(CCR1, Lrewrite);
+    __ beq(CR1, Lrewrite);
 
     __ li(Rrewrite_to, (unsigned int)(unsigned char)Bytecodes::_fast_aload_0);
 
@@ -997,8 +997,8 @@ void TemplateTable::aastore() {
   Register Rscratch3 = Rindex;
 
   // Do array store check - check for null value first.
-  __ cmpdi(CCR0, R17_tos, 0);
-  __ beq(CCR0, Lis_null);
+  __ cmpdi(CR0, R17_tos, 0);
+  __ beq(CR0, Lis_null);
 
   __ load_klass(Rarray_klass, Rarray);
   __ load_klass(Rvalue_klass, R17_tos);
@@ -1045,9 +1045,9 @@ void TemplateTable::bastore() {
   __ load_klass(Rscratch, Rarray);
   __ lwz(Rscratch, in_bytes(Klass::layout_helper_offset()), Rscratch);
   int diffbit = exact_log2(Klass::layout_helper_boolean_diffbit());
-  __ testbitdi(CCR0, R0, Rscratch, diffbit);
+  __ testbitdi(CR0, R0, Rscratch, diffbit);
   Label L_skip;
-  __ bfalse(CCR0, L_skip);
+  __ bfalse(CR0, L_skip);
   __ andi(R17_tos, R17_tos, 1);  // if it is a T_BOOLEAN array, mask the stored value to 0/1
   __ bind(L_skip);
 
@@ -1262,11 +1262,11 @@ void TemplateTable::idiv() {
   Register Rdividend = R11_scratch1; // Used by irem.
 
   __ addi(R0, R17_tos, 1);
-  __ cmplwi(CCR0, R0, 2);
-  __ bgt(CCR0, Lnormal); // divisor <-1 or >1
+  __ cmplwi(CR0, R0, 2);
+  __ bgt(CR0, Lnormal); // divisor <-1 or >1
 
-  __ cmpwi(CCR1, R17_tos, 0);
-  __ beq(CCR1, Lexception); // divisor == 0
+  __ cmpwi(CR1, R17_tos, 0);
+  __ beq(CR1, Lexception); // divisor == 0
 
   __ pop_i(Rdividend);
   __ mullw(R17_tos, Rdividend, R17_tos); // div by +/-1
@@ -1307,11 +1307,11 @@ void TemplateTable::ldiv() {
   Register Rdividend = R11_scratch1; // Used by lrem.
 
   __ addi(R0, R17_tos, 1);
-  __ cmpldi(CCR0, R0, 2);
-  __ bgt(CCR0, Lnormal); // divisor <-1 or >1
+  __ cmpldi(CR0, R0, 2);
+  __ bgt(CR0, Lnormal); // divisor <-1 or >1
 
-  __ cmpdi(CCR1, R17_tos, 0);
-  __ beq(CCR1, Lexception); // divisor == 0
+  __ cmpdi(CR1, R17_tos, 0);
+  __ beq(CR1, Lexception); // divisor == 0
 
   __ pop_l(Rdividend);
   __ mulld(R17_tos, Rdividend, R17_tos); // div by +/-1
@@ -1565,18 +1565,18 @@ void TemplateTable::convert() {
 
     case Bytecodes::_d2i:
     case Bytecodes::_f2i:
-      __ fcmpu(CCR0, F15_ftos, F15_ftos);
+      __ fcmpu(CR0, F15_ftos, F15_ftos);
       __ li(R17_tos, 0); // 0 in case of NAN
-      __ bso(CCR0, done);
+      __ bso(CR0, done);
       __ fctiwz(F15_ftos, F15_ftos);
       __ move_d_to_l();
       break;
 
     case Bytecodes::_d2l:
     case Bytecodes::_f2l:
-      __ fcmpu(CCR0, F15_ftos, F15_ftos);
+      __ fcmpu(CR0, F15_ftos, F15_ftos);
       __ li(R17_tos, 0); // 0 in case of NAN
-      __ bso(CCR0, done);
+      __ bso(CR0, done);
       __ fctidz(F15_ftos, F15_ftos);
       __ move_d_to_l();
       break;
@@ -1593,7 +1593,7 @@ void TemplateTable::lcmp() {
   const Register Rscratch = R11_scratch1;
   __ pop_l(Rscratch); // first operand, deeper in stack
 
-  __ cmpd(CCR0, Rscratch, R17_tos); // compare
+  __ cmpd(CR0, Rscratch, R17_tos); // compare
   __ set_cmp3(R17_tos); // set result as follows: <: -1, =: 0, >: 1
 }
 
@@ -1611,7 +1611,7 @@ void TemplateTable::float_cmp(bool is_float, int unordered_result) {
     __ pop_d(Rfirst);
   }
 
-  __ fcmpu(CCR0, Rfirst, Rsecond); // compare
+  __ fcmpu(CR0, Rfirst, Rsecond); // compare
   // if unordered_result is 1, treat unordered_result like 'greater than'
   assert(unordered_result == 1 || unordered_result == -1, "unordered_result can be either 1 or -1");
   __ set_cmpu3(R17_tos, unordered_result != 1);
@@ -1683,8 +1683,8 @@ void TemplateTable::branch(bool is_jsr, bool is_wide) {
     Label Lforward;
 
     // Check branch direction.
-    __ cmpdi(CCR0, Rdisp, 0);
-    __ bgt(CCR0, Lforward);
+    __ cmpdi(CR0, Rdisp, 0);
+    __ bgt(CR0, Lforward);
 
     __ get_method_counters(R19_method, R4_counters, Lforward);
 
@@ -1695,8 +1695,8 @@ void TemplateTable::branch(bool is_jsr, bool is_wide) {
 
       // If no method data exists, go to profile_continue.
       __ ld(Rmdo, in_bytes(Method::method_data_offset()), R19_method);
-      __ cmpdi(CCR0, Rmdo, 0);
-      __ beq(CCR0, Lno_mdo);
+      __ cmpdi(CR0, Rmdo, 0);
+      __ beq(CR0, Lno_mdo);
 
       // Increment backedge counter in the MDO.
       const int mdo_bc_offs = in_bytes(MethodData::backedge_counter_offset()) + in_bytes(InvocationCounter::counter_offset());
@@ -1706,7 +1706,7 @@ void TemplateTable::branch(bool is_jsr, bool is_wide) {
       __ stw(Rscratch2, mdo_bc_offs, Rmdo);
       if (UseOnStackReplacement) {
         __ and_(Rscratch3, Rscratch2, Rscratch3);
-        __ bne(CCR0, Lforward);
+        __ bne(CR0, Lforward);
         __ b(Loverflow);
       } else {
         __ b(Lforward);
@@ -1722,7 +1722,7 @@ void TemplateTable::branch(bool is_jsr, bool is_wide) {
     __ stw(Rscratch2, mo_bc_offs, R4_counters);
     if (UseOnStackReplacement) {
       __ and_(Rscratch3, Rscratch2, Rscratch3);
-      __ bne(CCR0, Lforward);
+      __ bne(CR0, Lforward);
     } else {
       __ b(Lforward);
     }
@@ -1733,13 +1733,13 @@ void TemplateTable::branch(bool is_jsr, bool is_wide) {
     __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::frequency_counter_overflow), R4_ARG2, true);
 
     // Was an OSR adapter generated?
-    __ cmpdi(CCR0, R3_RET, 0);
-    __ beq(CCR0, Lforward);
+    __ cmpdi(CR0, R3_RET, 0);
+    __ beq(CR0, Lforward);
 
     // Has the nmethod been invalidated already?
     __ lbz(R0, in_bytes(nmethod::state_offset()), R3_RET);
-    __ cmpwi(CCR0, R0, nmethod::in_use);
-    __ bne(CCR0, Lforward);
+    __ cmpwi(CR0, R0, nmethod::in_use);
+    __ bne(CR0, Lforward);
 
     // Migrate the interpreter frame off of the stack.
     // We can use all registers because we will not return to interpreter from this point.
@@ -1775,18 +1775,18 @@ void TemplateTable::if_cmp_common(Register Rfirst, Register Rsecond, Register Rs
 
   if (is_jint) {
     if (cmp0) {
-      __ cmpwi(CCR0, Rfirst, 0);
+      __ cmpwi(CR0, Rfirst, 0);
     } else {
-      __ cmpw(CCR0, Rfirst, Rsecond);
+      __ cmpw(CR0, Rfirst, Rsecond);
     }
   } else {
     if (cmp0) {
-      __ cmpdi(CCR0, Rfirst, 0);
+      __ cmpdi(CR0, Rfirst, 0);
     } else {
-      __ cmpd(CCR0, Rfirst, Rsecond);
+      __ cmpd(CR0, Rfirst, Rsecond);
     }
   }
-  branch_conditional(CCR0, cc, Lnot_taken, /*invert*/ true);
+  branch_conditional(CR0, cc, Lnot_taken, /*invert*/ true);
 
   // Conition is false => Jump!
   branch(false, false);
@@ -1885,10 +1885,10 @@ void TemplateTable::tableswitch() {
   __ get_u4(Rhigh_byte, Rdef_offset_addr, 2 *BytesPerInt, InterpreterMacroAssembler::Unsigned);
 
   // Check for default case (=index outside [low,high]).
-  __ cmpw(CCR0, R17_tos, Rlow_byte);
-  __ cmpw(CCR1, R17_tos, Rhigh_byte);
-  __ blt(CCR0, Ldefault_case);
-  __ bgt(CCR1, Ldefault_case);
+  __ cmpw(CR0, R17_tos, Rlow_byte);
+  __ cmpw(CR1, R17_tos, Rhigh_byte);
+  __ blt(CR0, Ldefault_case);
+  __ bgt(CR1, Ldefault_case);
 
   // Lookup dispatch offset.
   __ sub(Rindex, R17_tos, Rlow_byte);
@@ -1944,8 +1944,8 @@ void TemplateTable::fast_linearswitch() {
   __ addi(Rcurrent_pair, Rdef_offset_addr, 2 * BytesPerInt); // Rcurrent_pair now points to first pair.
 
   __ mtctr(Rcount);
-  __ cmpwi(CCR0, Rcount, 0);
-  __ bne(CCR0, Lloop_entry);
+  __ cmpwi(CR0, Rcount, 0);
+  __ bne(CR0, Lloop_entry);
 
   // Default case
   __ bind(Ldefault_case);
@@ -1961,8 +1961,8 @@ void TemplateTable::fast_linearswitch() {
   __ addi(Rcurrent_pair, Rcurrent_pair, 2 * BytesPerInt);
   __ bind(Lloop_entry);
   __ get_u4(Rvalue, Rcurrent_pair, 0, InterpreterMacroAssembler::Unsigned);
-  __ cmpw(CCR0, Rvalue, Rcmp_value);
-  __ bne(CCR0, Lsearch_loop);
+  __ cmpw(CR0, Rvalue, Rcmp_value);
+  __ bne(CR0, Lsearch_loop);
 
   // Found, load offset.
   __ get_u4(Roffset, Rcurrent_pair, BytesPerInt, InterpreterMacroAssembler::Signed);
@@ -2057,8 +2057,8 @@ void TemplateTable::fast_binaryswitch() {
     // else
     //   Rh = Ri
     Label Lgreater;
-    __ cmpw(CCR0, Rkey, Rscratch);
-    __ bge(CCR0, Lgreater);
+    __ cmpw(CR0, Rkey, Rscratch);
+    __ bge(CR0, Lgreater);
     __ mr(Rj, Rh);
     __ b(entry);
     __ bind(Lgreater);
@@ -2067,10 +2067,10 @@ void TemplateTable::fast_binaryswitch() {
     // while (i+1 < j)
     __ bind(entry);
     __ addi(Rscratch, Ri, 1);
-    __ cmpw(CCR0, Rscratch, Rj);
+    __ cmpw(CR0, Rscratch, Rj);
     __ add(Rh, Ri, Rj); // start h = i + j >> 1;
 
-    __ blt(CCR0, loop);
+    __ blt(CR0, loop);
   }
 
   // End of binary search, result index is i (must check again!).
@@ -2086,8 +2086,8 @@ void TemplateTable::fast_binaryswitch() {
 
   Label not_found;
   // Ri = offset offset
-  __ cmpw(CCR0, Rkey, Rscratch);
-  __ beq(CCR0, not_found);
+  __ cmpw(CR0, Rkey, Rscratch);
+  __ beq(CR0, not_found);
   // entry not found -> j = default offset
   __ get_u4(Rj, Rarray, -2 * BytesPerInt, InterpreterMacroAssembler::Unsigned);
   __ b(default_case);
@@ -2130,8 +2130,8 @@ void TemplateTable::_return(TosState state) {
     // Load klass of this obj.
     __ load_klass(Rklass, R17_tos);
     __ lbz(Rklass_flags, in_bytes(Klass::misc_flags_offset()), Rklass);
-    __ testbitdi(CCR0, R0, Rklass_flags, exact_log2(KlassFlags::_misc_has_finalizer));
-    __ bfalse(CCR0, Lskip_register_finalizer);
+    __ testbitdi(CR0, R0, Rklass_flags, exact_log2(KlassFlags::_misc_has_finalizer));
+    __ bfalse(CR0, Lskip_register_finalizer);
 
     __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::register_finalizer), R17_tos /* obj */);
 
@@ -2143,7 +2143,7 @@ void TemplateTable::_return(TosState state) {
     Label no_safepoint;
     __ ld(R11_scratch1, in_bytes(JavaThread::polling_word_offset()), R16_thread);
     __ andi_(R11_scratch1, R11_scratch1, SafepointMechanism::poll_bit());
-    __ beq(CCR0, no_safepoint);
+    __ beq(CR0, no_safepoint);
     __ push(state);
     __ push_cont_fastpath();
     __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::at_safepoint));
@@ -2214,8 +2214,8 @@ void TemplateTable::resolve_cache_and_index_for_method(int byte_no, Register Rca
   // Load-acquire the bytecode to match store-release in InterpreterRuntime
   __ lbz(Rscratch, bytecode_offset, Rcache);
   // Acquire by cmp-br-isync (see below).
-  __ cmpdi(CCR0, Rscratch, (int)code);
-  __ beq(CCR0, Lresolved);
+  __ cmpdi(CR0, Rscratch, (int)code);
+  __ beq(CR0, Lresolved);
 
   // Class initialization barrier slow path lands here as well.
   __ bind(L_clinit_barrier_slow);
@@ -2263,8 +2263,8 @@ void TemplateTable::resolve_cache_and_index_for_field(int byte_no,
   int code_offset = (byte_no == f1_byte) ? in_bytes(ResolvedFieldEntry::get_code_offset())
                                          : in_bytes(ResolvedFieldEntry::put_code_offset());
   __ lbz(R0, code_offset, Rcache);
-  __ cmpwi(CCR0, R0, (int)code); // have we resolved this bytecode?
-  __ beq(CCR0, resolved);
+  __ cmpwi(CR0, R0, (int)code); // have we resolved this bytecode?
+  __ beq(CR0, resolved);
 
   // resolve first time through
   address entry = CAST_FROM_FN_PTR(address, InterpreterRuntime::resolve_from_cache);
@@ -2332,8 +2332,8 @@ void TemplateTable::load_resolved_method_entry_handle(Register cache,
 
   // maybe push appendix to arguments (just before return address)
   Label L_no_push;
-  __ testbitdi(CCR0, R0, flags, ResolvedMethodEntry::has_appendix_shift);
-  __ bfalse(CCR0, L_no_push);
+  __ testbitdi(CR0, R0, flags, ResolvedMethodEntry::has_appendix_shift);
+  __ bfalse(CR0, L_no_push);
   // invokehandle uses an index into the resolved references array
   __ lhz(ref_index, in_bytes(ResolvedMethodEntry::resolved_references_index_offset()), cache);
   // Push the appendix as a trailing parameter.
@@ -2395,8 +2395,8 @@ void TemplateTable::load_invokedynamic_entry(Register method) {
   __ ld_ptr(method, in_bytes(ResolvedIndyEntry::method_offset()), cache);
 
   // The invokedynamic is unresolved iff method is null
-  __ cmpdi(CCR0, method, 0);
-  __ bne(CCR0, resolved);
+  __ cmpdi(CR0, method, 0);
+  __ bne(CR0, resolved);
 
   Bytecodes::Code code = bytecode();
 
@@ -2408,7 +2408,7 @@ void TemplateTable::load_invokedynamic_entry(Register method) {
   __ load_resolved_indy_entry(cache, index);
   __ ld_ptr(method, in_bytes(ResolvedIndyEntry::method_offset()), cache);
 
-  DEBUG_ONLY(__ cmpdi(CCR0, method, 0));
+  DEBUG_ONLY(__ cmpdi(CR0, method, 0));
   __ asm_assert_ne("Should be resolved by now");
   __ bind(resolved);
   __ isync(); // Order load wrt. succeeding loads.
@@ -2417,7 +2417,7 @@ void TemplateTable::load_invokedynamic_entry(Register method) {
   // Check if there is an appendix
   __ lbz(index, in_bytes(ResolvedIndyEntry::flags_offset()), cache);
   __ rldicl_(R0, index, 64-ResolvedIndyEntry::has_appendix_shift, 63);
-  __ beq(CCR0, L_no_push);
+  __ beq(CR0, L_no_push);
 
   // Get appendix
   __ lhz(index, in_bytes(ResolvedIndyEntry::resolved_references_index_offset()), cache);
@@ -2489,8 +2489,8 @@ void TemplateTable::jvmti_post_field_access(Register Rcache, Register Rscratch, 
     int offs = __ load_const_optimized(Rscratch, JvmtiExport::get_field_access_count_addr(), R0, true);
     __ lwz(Rscratch, offs, Rscratch);
 
-    __ cmpwi(CCR0, Rscratch, 0);
-    __ beq(CCR0, Lno_field_access_post);
+    __ cmpwi(CR0, Rscratch, 0);
+    __ beq(CR0, Lno_field_access_post);
 
     // Post access enabled - do it!
     if (is_static) {
@@ -2574,13 +2574,13 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
 
 #ifdef ASSERT
   Label LFlagInvalid;
-  __ cmpldi(CCR0, Rtos_state, number_of_states);
-  __ bge(CCR0, LFlagInvalid);
+  __ cmpldi(CR0, Rtos_state, number_of_states);
+  __ bge(CR0, LFlagInvalid);
 #endif
 
   // Load from branch table and dispatch (volatile case: one instruction ahead).
   __ sldi(Rtos_state, Rtos_state, LogBytesPerWord);
-  __ cmpwi(CCR2, Rscratch, 1); // Volatile?
+  __ cmpwi(CR2, Rscratch, 1); // Volatile?
   if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
     __ sldi(Rscratch, Rscratch, exact_log2(BytesPerInstWord)); // Volatile ? size of 1 instruction : 0.
   }
@@ -2631,12 +2631,12 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   }
   {
     Label acquire_double;
-    __ beq(CCR2, acquire_double); // Volatile?
+    __ beq(CR2, acquire_double); // Volatile?
     __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
     __ bind(acquire_double);
-    __ fcmpu(CCR0, F15_ftos, F15_ftos); // Acquire by cmp-br-isync.
-    __ beq_predict_taken(CCR0, Lisync);
+    __ fcmpu(CR0, F15_ftos, F15_ftos); // Acquire by cmp-br-isync.
+    __ beq_predict_taken(CR0, Lisync);
     __ b(Lisync); // In case of NAN.
   }
 
@@ -2652,12 +2652,12 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   }
   {
     Label acquire_float;
-    __ beq(CCR2, acquire_float); // Volatile?
+    __ beq(CR2, acquire_float); // Volatile?
     __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
     __ bind(acquire_float);
-    __ fcmpu(CCR0, F15_ftos, F15_ftos); // Acquire by cmp-br-isync.
-    __ beq_predict_taken(CCR0, Lisync);
+    __ fcmpu(CR0, F15_ftos, F15_ftos); // Acquire by cmp-br-isync.
+    __ beq_predict_taken(CR0, Lisync);
     __ b(Lisync); // In case of NAN.
   }
 
@@ -2671,7 +2671,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_igetfield, Rbc, Rscratch);
   }
-  __ beq(CCR2, Lacquire); // Volatile?
+  __ beq(CR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2684,7 +2684,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_lgetfield, Rbc, Rscratch);
   }
-  __ beq(CCR2, Lacquire); // Volatile?
+  __ beq(CR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2698,7 +2698,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_bgetfield, Rbc, Rscratch);
   }
-  __ beq(CCR2, Lacquire); // Volatile?
+  __ beq(CR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2712,7 +2712,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
     // use btos rewriting, no truncating to t/f bit is needed for getfield.
     patch_bytecode(Bytecodes::_fast_bgetfield, Rbc, Rscratch);
   }
-  __ beq(CCR2, Lacquire); // Volatile?
+  __ beq(CR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2725,7 +2725,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_cgetfield, Rbc, Rscratch);
   }
-  __ beq(CCR2, Lacquire); // Volatile?
+  __ beq(CR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2738,7 +2738,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_sgetfield, Rbc, Rscratch);
   }
-  __ beq(CCR2, Lacquire); // Volatile?
+  __ beq(CR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 28, 28); // Align load.
@@ -2753,7 +2753,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   if (!is_static && rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_agetfield, Rbc, Rscratch);
   }
-  __ beq(CCR2, Lacquire); // Volatile?
+  __ beq(CR2, Lacquire); // Volatile?
   __ dispatch_epilog(vtos, Bytecodes::length_for(bytecode()));
 
   __ align(32, 12);
@@ -2796,8 +2796,8 @@ void TemplateTable::jvmti_post_field_mod(Register Rcache, Register Rscratch, boo
     int offs = __ load_const_optimized(Rscratch, JvmtiExport::get_field_modification_count_addr(), R0, true);
     __ lwz(Rscratch, offs, Rscratch);
 
-    __ cmpwi(CCR0, Rscratch, 0);
-    __ beq(CCR0, Lno_field_mod_post);
+    __ cmpwi(CR0, Rscratch, 0);
+    __ beq(CR0, Lno_field_mod_post);
 
     // Do the post
     const Register Robj = Rscratch;
@@ -2830,11 +2830,11 @@ void TemplateTable::jvmti_post_field_mod(Register Rcache, Register Rscratch, boo
           // the type to determine where the object is.
           __ lbz(Rtos_state, in_bytes(ResolvedFieldEntry::type_offset()), Rcache);
 
-          __ cmpwi(CCR0, Rtos_state, ltos);
-          __ cmpwi(CCR1, Rtos_state, dtos);
+          __ cmpwi(CR0, Rtos_state, ltos);
+          __ cmpwi(CR1, Rtos_state, dtos);
           __ addi(base, R15_esp, Interpreter::expr_offset_in_bytes(1));
-          __ crnor(CCR0, Assembler::equal, CCR1, Assembler::equal);
-          __ beq(CCR0, is_one_slot);
+          __ crnor(CR0, Assembler::equal, CR1, Assembler::equal);
+          __ beq(CR0, is_one_slot);
           __ addi(base, R15_esp, Interpreter::expr_offset_in_bytes(2));
           __ bind(is_one_slot);
           break;
@@ -2881,7 +2881,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
                  Rscratch2     = R12_scratch2, // used by load_field_cp_cache_entry
                  Rscratch3     = R6_ARG4,
                  Rbc           = Rscratch3;
-  const ConditionRegister CR_is_vol = CCR2; // Non-volatile condition register (survives runtime call in do_oop_store).
+  const ConditionRegister CR_is_vol = CR2; // Non-volatile condition register (survives runtime call in do_oop_store).
 
   static address field_rw_branch_table[number_of_states],
                  field_norw_branch_table[number_of_states],
@@ -2907,8 +2907,8 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
 
 #ifdef ASSERT
   Label LFlagInvalid;
-  __ cmpldi(CCR0, Rtos_state, number_of_states);
-  __ bge(CCR0, LFlagInvalid);
+  __ cmpldi(CR0, Rtos_state, number_of_states);
+  __ bge(CR0, LFlagInvalid);
 #endif
 
   // Load from branch table and dispatch (volatile case: one instruction ahead).
@@ -3124,7 +3124,7 @@ void TemplateTable::fast_storefield(TosState state) {
                  Rscratch      = R11_scratch1, // used by load_field_cp_cache_entry
                  Rscratch2     = R12_scratch2, // used by load_field_cp_cache_entry
                  Rscratch3     = R4_ARG2;
-  const ConditionRegister CR_is_vol = CCR2; // Non-volatile condition register (survives runtime call in do_oop_store).
+  const ConditionRegister CR_is_vol = CR2; // Non-volatile condition register (survives runtime call in do_oop_store).
 
   // Constant pool already resolved => Load flags and offset of field.
   __ load_field_entry(Rcache, Rscratch);
@@ -3139,7 +3139,7 @@ void TemplateTable::fast_storefield(TosState state) {
   if (!support_IRIW_for_not_multiple_copy_atomic_cpu) { __ cmpdi(CR_is_vol, Rscratch, 1); }
   {
     Label LnotVolatile;
-    __ beq(CCR0, LnotVolatile);
+    __ beq(CR0, LnotVolatile);
     __ release();
     __ align(32, 12);
     __ bind(LnotVolatile);
@@ -3219,7 +3219,7 @@ void TemplateTable::fast_accessfield(TosState state) {
 
   // Get volatile flag.
   __ rldicl_(Rscratch, Rflags, 64-ResolvedFieldEntry::is_volatile_shift, 63); // Extract volatile bit.
-  __ bne(CCR0, LisVolatile);
+  __ bne(CR0, LisVolatile);
 
   switch(bytecode()) {
     case Bytecodes::_fast_agetfield:
@@ -3307,8 +3307,8 @@ void TemplateTable::fast_accessfield(TosState state) {
       Label Ldummy;
       if (support_IRIW_for_not_multiple_copy_atomic_cpu) { __ fence(); }
       __ lfsx(F15_ftos, Rclass_or_obj, Roffset);
-      __ fcmpu(CCR0, F15_ftos, F15_ftos); // Acquire by cmp-br-isync.
-      __ bne_predict_not_taken(CCR0, Ldummy);
+      __ fcmpu(CR0, F15_ftos, F15_ftos); // Acquire by cmp-br-isync.
+      __ bne_predict_not_taken(CR0, Ldummy);
       __ bind(Ldummy);
       __ isync();
       break;
@@ -3322,8 +3322,8 @@ void TemplateTable::fast_accessfield(TosState state) {
       Label Ldummy;
       if (support_IRIW_for_not_multiple_copy_atomic_cpu) { __ fence(); }
       __ lfdx(F15_ftos, Rclass_or_obj, Roffset);
-      __ fcmpu(CCR0, F15_ftos, F15_ftos); // Acquire by cmp-br-isync.
-      __ bne_predict_not_taken(CCR0, Ldummy);
+      __ fcmpu(CR0, F15_ftos, F15_ftos); // Acquire by cmp-br-isync.
+      __ bne_predict_not_taken(CR0, Ldummy);
       __ bind(Ldummy);
       __ isync();
       break;
@@ -3360,7 +3360,7 @@ void TemplateTable::fast_xaccess(TosState state) {
 
   // Get volatile flag.
   __ rldicl_(Rscratch, Rflags, 64-ResolvedFieldEntry::is_volatile_shift, 63); // Extract volatile bit.
-  __ bne(CCR0, LisVolatile);
+  __ bne(CR0, LisVolatile);
 
   switch(state) {
   case atos:
@@ -3398,8 +3398,8 @@ void TemplateTable::fast_xaccess(TosState state) {
       Label Ldummy;
       if (support_IRIW_for_not_multiple_copy_atomic_cpu) { __ fence(); }
       __ lfsx(F15_ftos, Rclass_or_obj, Roffset);
-      __ fcmpu(CCR0, F15_ftos, F15_ftos); // Acquire by cmp-br-isync.
-      __ bne_predict_not_taken(CCR0, Ldummy);
+      __ fcmpu(CR0, F15_ftos, F15_ftos); // Acquire by cmp-br-isync.
+      __ bne_predict_not_taken(CR0, Ldummy);
       __ bind(Ldummy);
       __ isync();
       break;
@@ -3480,8 +3480,8 @@ void TemplateTable::invokevirtual(int byte_no) {
   load_resolved_method_entry_virtual(Rcache, noreg, Rflags);
 
   // Handle final method separately.
-  __ testbitdi(CCR0, R0, Rflags, ResolvedMethodEntry::is_vfinal_shift);
-  __ bfalse(CCR0, LnotFinal);
+  __ testbitdi(CR0, R0, Rflags, ResolvedMethodEntry::is_vfinal_shift);
+  __ bfalse(CR0, LnotFinal);
 
   if (RewriteBytecodes && !CDSConfig::is_using_archive() && !CDSConfig::is_dumping_static_archive()) {
     patch_bytecode(Bytecodes::_fast_invokevfinal, Rnew_bc, R12_scratch2);
@@ -3587,8 +3587,8 @@ void TemplateTable::invokeinterface_object_method(Register Rrecv_klass,
   Label LnotFinal;
 
   // Check for vfinal.
-  __ testbitdi(CCR0, R0, Rflags, ResolvedMethodEntry::is_vfinal_shift);
-  __ bfalse(CCR0, LnotFinal);
+  __ testbitdi(CR0, R0, Rflags, ResolvedMethodEntry::is_vfinal_shift);
+  __ bfalse(CR0, LnotFinal);
 
   Register Rscratch = Rflags, // Rflags is dead now.
            Rmethod  = Rtemp2,
@@ -3641,8 +3641,8 @@ void TemplateTable::invokeinterface(int byte_no) {
   // to handle this corner case.
 
   Label LnotObjectMethod, Lthrow_ame;
-  __ testbitdi(CCR0, R0, Rflags, ResolvedMethodEntry::is_forced_virtual_shift);
-  __ bfalse(CCR0, LnotObjectMethod);
+  __ testbitdi(CR0, R0, Rflags, ResolvedMethodEntry::is_forced_virtual_shift);
+  __ bfalse(CR0, LnotObjectMethod);
   invokeinterface_object_method(Rrecv_klass, Rret_addr, Rflags, Rcache, Rscratch1, Rscratch2);
   __ bind(LnotObjectMethod);
 
@@ -3652,8 +3652,8 @@ void TemplateTable::invokeinterface(int byte_no) {
   // Check for private method invocation - indicated by vfinal
   Label LnotVFinal, L_no_such_interface, L_subtype;
 
-  __ testbitdi(CCR0, R0, Rflags, ResolvedMethodEntry::is_vfinal_shift);
-  __ bfalse(CCR0, LnotVFinal);
+  __ testbitdi(CR0, R0, Rflags, ResolvedMethodEntry::is_vfinal_shift);
+  __ bfalse(CR0, LnotVFinal);
 
   __ check_klass_subtype(Rrecv_klass, Rinterface_klass, Rscratch1, Rscratch2, L_subtype);
   // If we get here the typecheck failed
@@ -3687,8 +3687,8 @@ void TemplateTable::invokeinterface(int byte_no) {
   __ lookup_interface_method(Rrecv_klass, Rinterface_klass, Rindex, Rmethod2, Rscratch1, Rscratch2,
                              L_no_such_interface);
 
-  __ cmpdi(CCR0, Rmethod2, 0);
-  __ beq(CCR0, Lthrow_ame);
+  __ cmpdi(CR0, Rmethod2, 0);
+  __ beq(CR0, Lthrow_ame);
   // Found entry. Jump off!
   // Argument and return type profiling.
   __ profile_arguments_type(Rmethod2, Rscratch1, Rscratch2, true);
@@ -3795,8 +3795,8 @@ void TemplateTable::_new() {
     __ addi(Rtags, Rtags, Array<u1>::base_offset_in_bytes());
     __ lbzx(Rtags, Rindex, Rtags);
 
-    __ cmpdi(CCR0, Rtags, JVM_CONSTANT_Class);
-    __ bne(CCR0, Lslow_case);
+    __ cmpdi(CR0, Rtags, JVM_CONSTANT_Class);
+    __ bne(CR0, Lslow_case);
 
     // Get instanceKlass
     __ sldi(Roffset, Rindex, LogBytesPerWord);
@@ -3810,7 +3810,7 @@ void TemplateTable::_new() {
 
     // Make sure klass is not abstract, or interface or java/lang/Class.
     __ andi_(R0, Rinstance_size, Klass::_lh_instance_slow_path_bit); // slow path bit equals 0?
-    __ bne(CCR0, Lslow_case);
+    __ bne(CR0, Lslow_case);
 
     // --------------------------------------------------------------------------
     // Fast case:
@@ -3829,8 +3829,8 @@ void TemplateTable::_new() {
     __ add(RnewTopValue, Rinstance_size, RoldTopValue);
 
     // If there is enough space, we do not CAS and do not clear.
-    __ cmpld(CCR0, RnewTopValue, RendValue);
-    __ bgt(CCR0, Lslow_case);
+    __ cmpld(CR0, RnewTopValue, RendValue);
+    __ bgt(CR0, Lslow_case);
 
     __ std(RnewTopValue, in_bytes(JavaThread::tlab_top_offset()), R16_thread);
 
@@ -3947,8 +3947,8 @@ void TemplateTable::checkcast() {
            Rtags           = R12_scratch2;
 
   // Null does not pass.
-  __ cmpdi(CCR0, R17_tos, 0);
-  __ beq(CCR0, Lis_null);
+  __ cmpdi(CR0, R17_tos, 0);
+  __ beq(CR0, Lis_null);
 
   // Get constant pool tag to find out if the bytecode has already been "quickened".
   __ get_cpool_and_tags(Rcpool, Rtags);
@@ -3958,8 +3958,8 @@ void TemplateTable::checkcast() {
   __ addi(Rtags, Rtags, Array<u1>::base_offset_in_bytes());
   __ lbzx(Rtags, Rtags, Roffset);
 
-  __ cmpdi(CCR0, Rtags, JVM_CONSTANT_Class);
-  __ beq(CCR0, Lquicked);
+  __ cmpdi(CR0, Rtags, JVM_CONSTANT_Class);
+  __ beq(CR0, Lquicked);
 
   // Call into the VM to "quicken" instanceof.
   __ push_ptr();  // for GC
@@ -4009,8 +4009,8 @@ void TemplateTable::instanceof() {
            Rtags           = R12_scratch2;
 
   // Null does not pass.
-  __ cmpdi(CCR0, R17_tos, 0);
-  __ beq(CCR0, Lis_null);
+  __ cmpdi(CR0, R17_tos, 0);
+  __ beq(CR0, Lis_null);
 
   // Get constant pool tag to find out if the bytecode has already been "quickened".
   __ get_cpool_and_tags(Rcpool, Rtags);
@@ -4020,8 +4020,8 @@ void TemplateTable::instanceof() {
   __ addi(Rtags, Rtags, Array<u1>::base_offset_in_bytes());
   __ lbzx(Rtags, Rtags, Roffset);
 
-  __ cmpdi(CCR0, Rtags, JVM_CONSTANT_Class);
-  __ beq(CCR0, Lquicked);
+  __ cmpdi(CR0, Rtags, JVM_CONSTANT_Class);
+  __ beq(CR0, Lquicked);
 
   // Call into the VM to "quicken" instanceof.
   __ push_ptr();  // for GC
@@ -4127,8 +4127,8 @@ void TemplateTable::monitorenter() {
   __ null_check_throw(Robj_to_lock, -1, Rscratch1);
 
   // Check if any slot is present => short cut to allocation if not.
-  __ cmpld(CCR0, Rcurrent_monitor, Rbot);
-  __ beq(CCR0, Lallocate_new);
+  __ cmpld(CR0, Rcurrent_monitor, Rbot);
+  __ beq(CR0, Lallocate_new);
 
   // ------------------------------------------------------------------------------
   // Find a free slot in the monitor block.
@@ -4141,24 +4141,24 @@ void TemplateTable::monitorenter() {
     __ ld(Rcurrent_obj, in_bytes(BasicObjectLock::obj_offset()), Rcurrent_monitor);
     // Exit if current entry is for same object; this guarantees, that new monitor
     // used for recursive lock is above the older one.
-    __ cmpd(CCR0, Rcurrent_obj, Robj_to_lock);
-    __ beq(CCR0, Lexit); // recursive locking
+    __ cmpd(CR0, Rcurrent_obj, Robj_to_lock);
+    __ beq(CR0, Lexit); // recursive locking
 
-    __ cmpdi(CCR0, Rcurrent_obj, 0);
-    __ bne(CCR0, LnotFree);
+    __ cmpdi(CR0, Rcurrent_obj, 0);
+    __ bne(CR0, LnotFree);
     __ mr(Rfree_slot, Rcurrent_monitor); // remember free slot closest to the bottom
     __ bind(LnotFree);
 
     __ addi(Rcurrent_monitor, Rcurrent_monitor, frame::interpreter_frame_monitor_size_in_bytes());
-    __ cmpld(CCR0, Rcurrent_monitor, Rbot);
-    __ bne(CCR0, Lloop);
+    __ cmpld(CR0, Rcurrent_monitor, Rbot);
+    __ bne(CR0, Lloop);
     __ bind(Lexit);
   }
 
   // ------------------------------------------------------------------------------
   // Check if we found a free slot.
-  __ cmpdi(CCR0, Rfree_slot, 0);
-  __ bne(CCR0, Lfound);
+  __ cmpdi(CR0, Rfree_slot, 0);
+  __ bne(CR0, Lfound);
 
   // We didn't find a free BasicObjLock => allocate one.
   __ bind(Lallocate_new);
@@ -4206,8 +4206,8 @@ void TemplateTable::monitorexit() {
   __ null_check_throw(Robj_to_lock, -1, Rscratch);
 
   // Check corner case: unbalanced monitorEnter / Exit.
-  __ cmpld(CCR0, Rcurrent_monitor, Rbot);
-  __ beq(CCR0, Lillegal_monitor_state);
+  __ cmpld(CR0, Rcurrent_monitor, Rbot);
+  __ beq(CR0, Lillegal_monitor_state);
 
   // Find the corresponding slot in the monitors stack section.
   {
@@ -4216,12 +4216,12 @@ void TemplateTable::monitorexit() {
     __ bind(Lloop);
     __ ld(Rcurrent_obj, in_bytes(BasicObjectLock::obj_offset()), Rcurrent_monitor);
     // Is this entry for same obj?
-    __ cmpd(CCR0, Rcurrent_obj, Robj_to_lock);
-    __ beq(CCR0, Lfound);
+    __ cmpd(CR0, Rcurrent_obj, Robj_to_lock);
+    __ beq(CR0, Lfound);
 
     __ addi(Rcurrent_monitor, Rcurrent_monitor, frame::interpreter_frame_monitor_size_in_bytes());
-    __ cmpld(CCR0, Rcurrent_monitor, Rbot);
-    __ bne(CCR0, Lloop);
+    __ cmpld(CR0, Rcurrent_monitor, Rbot);
+    __ bne(CR0, Lloop);
   }
 
   // Fell through without finding the basic obj lock => throw up!

--- a/src/hotspot/cpu/ppc/vtableStubs_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/vtableStubs_ppc_64.cpp
@@ -91,8 +91,8 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index) {
     // Check offset vs vtable length.
     const Register vtable_len = R12_scratch2;
     __ lwz(vtable_len, in_bytes(Klass::vtable_length_offset()), rcvr_klass);
-    __ cmpwi(CCR0, vtable_len, vtable_index*vtableEntry::size());
-    __ bge(CCR0, L);
+    __ cmpwi(CR0, vtable_len, vtable_index*vtableEntry::size());
+    __ bge(CR0, L);
     __ li(R12_scratch2, vtable_index);
     __ call_VM(noreg, CAST_FROM_FN_PTR(address, bad_compiled_vtable_index), R3_ARG1, R12_scratch2, false);
     __ bind(L);
@@ -108,8 +108,8 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index) {
 #ifndef PRODUCT
   if (DebugVtables) {
     Label L;
-    __ cmpdi(CCR0, R19_method, 0);
-    __ bne(CCR0, L);
+    __ cmpdi(CR0, R19_method, 0);
+    __ bne(CR0, L);
     __ stop("Vtable entry is ZERO");
     __ bind(L);
   }
@@ -194,8 +194,8 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
 #ifndef PRODUCT
   if (DebugVtables) {
     Label ok;
-    __ cmpdi(CCR0, R19_method, 0);
-    __ bne(CCR0, ok);
+    __ cmpdi(CR0, R19_method, 0);
+    __ bne(CR0, ok);
     __ stop("method is null");
     __ bind(ok);
   }


### PR DESCRIPTION
PPC64 currently uses the names CCR0 to CCR7 for Condition Registers. This PR renames them as CR0 to CR7 matching the ISA. Build(release debug level) and testing are successful.

JBS Issue: [JDK-8344983](https://bugs.openjdk.org/browse/JDK-8344983)