### PR TITLE
8346659: SnippetTaglet should report an error if provided ambiguous links

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 package jdk.javadoc.internal.doclets.formats.html.taglets;
 
 import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -133,43 +131,39 @@ public class SnippetTaglet extends BaseTaglet {
         if (lang != null && !lang.isBlank()) {
             code.addStyle("language-" + lang);
         }
-
         content.consumeBy((styles, sequence) -> {
             CharSequence text = Text.normalizeNewlines(sequence);
             if (styles.isEmpty()) {
                 code.add(text);
             } else {
                 Element e = null;
-                String t = null;
-                boolean linkEncountered = false;
+                String linkEncountered = null;
                 boolean markupEncountered = false;
                 Set<String> classes = new HashSet<>();
                 for (Style s : styles) {
-                    if (s instanceof Style.Name n) {
-                        classes.add(n.name());
-                    } else if (s instanceof Style.Link l) {
-                        assert !linkEncountered; // TODO: do not assert; pick the first link report on subsequent
-                        linkEncountered = true;
-                        t = l.target();
-                        e = getLinkedElement(element, t);
-                        if (e == null) {
-                            // TODO: diagnostic output
+                    switch (s) {
+                        case Style.Name n -> classes.add(n.name());
+                        case Style.Link l -> {
+                            if (linkEncountered != null) {
+                                messages.error(utils.getCommentHelper(element).getDocTreePath(tag),
+                                        "doclet.error.snippet.ambiguous.link",
+                                        linkEncountered,
+                                        l.target(),
+                                        content.asCharSequence().toString().trim());
+                            }
+                            linkEncountered = l.target();
+                            e = getLinkedElement(element, linkEncountered);
+                            if (e == null) {
+                                // TODO: diagnostic output
+                            }
                         }
-                    } else if (s instanceof Style.Markup) {
-                        markupEncountered = true;
-                        break;
-                    } else {
-                        // TODO: transform this if...else into an exhaustive
-                        // switch over the sealed Style hierarchy when "Pattern
-                        // Matching for switch" has been implemented (JEP 406
-                        // and friends)
-                        throw new AssertionError(styles);
+                        case Style.Markup m -> markupEncountered = true;
                     }
                 }
                 Content c;
                 if (markupEncountered) {
                     return;
-                } else if (linkEncountered) {
+                } else if (linkEncountered != null) {
                     assert e != null;
                     //disable preview tagging inside the snippets:
                     Utils.PreviewFlagProvider prevPreviewProvider = utils.setPreviewFlagProvider(el -> false);
@@ -177,7 +171,7 @@ public class SnippetTaglet extends BaseTaglet {
                         var lt = (LinkTaglet) config.tagletManager.getTaglet(DocTree.Kind.LINK);
                         c = lt.linkSeeReferenceOutput(element,
                                 null,
-                                t,
+                                linkEncountered,
                                 e,
                                 false, // TODO: for now
                                 Text.of(sequence.toString()),

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -432,3 +432,7 @@ doclet.cannot_use_snippet_path=\
 # 0: path; 1: exception
 doclet.error_setting_snippet_path=\
   Error setting snippet path {0}: {1}
+
+# 0: location
+doclet.error.snippet.ambiguous.link=\
+  ambiguous links: {0}, {1} to {2}

--- a/test/langtools/jdk/javadoc/doclet/ReproducibleSnippet/ReproducibleSnippetTest.java
+++ b/test/langtools/jdk/javadoc/doclet/ReproducibleSnippet/ReproducibleSnippetTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug      8346128 8346659
+ * @summary  Check that snippet generation is reproducible
+ * @library  /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build    toolbox.ToolBox javadoc.tester.*
+ * @run main ReproducibleSnippetTest
+ */
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+import java.nio.file.Path;
+
+public class ReproducibleSnippetTest extends JavadocTester {
+    ToolBox tb = new ToolBox();
+
+    public static void main(String... args) throws Exception {
+        var tester = new ReproducibleSnippetTest();
+        tester.runTests();
+    }
+
+    @Test
+    public void test(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                        package p;
+                        public interface One {
+                            /**
+                             * {@code One obj1}
+                             * {@snippet lang = java:
+                             * // @link substring="ab" target="One#ab" :
+                             * obj1.ab(a()); // @link substring="a" target="#a"
+                             *} class comment
+                             */
+                            int a();
+                            void ab(int i);
+                        }
+                        """);
+        javadoc("-d",
+                "out",
+                "-sourcepath",
+                src.toString(),
+                "p");
+        checkExit(Exit.ERROR);
+    }
+}


### PR DESCRIPTION
Some javadoc snippets can match multiple links to the same content, leading to different results in different javadoc runs.
This patch proposes emitting an error when such cases are encountered.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8348569](https://bugs.openjdk.org/browse/JDK-8348569) to be approved

### Issues
 * [JDK-8346659](https://bugs.openjdk.org/browse/JDK-8346659): SnippetTaglet should report an error if provided ambiguous links (**Bug** - P3)
 * [JDK-8348569](https://bugs.openjdk.org/browse/JDK-8348569): SnippetTaglet should report an error if provided ambiguous links (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23327/head:pull/23327` \
`$ git checkout pull/23327`

Update a local copy of the PR: \
`$ git checkout pull/23327` \
`$ git pull https://git.openjdk.org/jdk.git pull/23327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23327`

View PR using the GUI difftool: \
`$ git pr show -t 23327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23327.diff">https://git.openjdk.org/jdk/pull/23327.diff</a>

</details>
