### PR TITLE
8348675: TrayIcon tests fail in Ubuntu 24.10 Wayland

### DIFF
--- a/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
+++ b/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
@@ -86,7 +86,7 @@ public class ActionCommand {
         } else if (SystemTrayIconHelper.isOel7orLater()) {
             System.out.println("OEL 7 doesn't support double click in " +
                     "systray. Skipped");
-            throw new SkippedException("Skipped on OEL 7");
+            throw new SkippedException("Skipped on OEL 7+");
         }
         new ActionCommand().doTest();
     }

--- a/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
+++ b/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
@@ -37,7 +37,6 @@ import java.awt.image.BufferedImage;
  * @summary Check the return value of the getActionCommand method
  *          of the ActionEvent triggered when TrayIcon is double clicked
  *          (single clicked, on Mac)
- * @author Dmitriy Ermashov (dmitriy.ermashov@oracle.com)
  * @modules java.desktop/java.awt:open
  * @library
  *          /java/awt/patchlib
@@ -69,25 +68,27 @@ public class ActionCommand {
             // The current robot implementation does not support
             // clicking in the system tray area.
             throw new SkippedException("Skipped on Wayland");
-        } else if (!SystemTray.isSupported()) {
-            throw new SkippedException("SystemTray is not supported on this platform.");
-        } else {
-            if (System.getProperty("os.name").toLowerCase().startsWith("win")) {
-                System.err.println("Test can fail if the icon hides to a tray icons pool " +
-                        "in Windows 7, which is behavior by default.\n" +
-                        "Set \"Right mouse click\" -> \"Customize notification icons\" -> " +
-                        "\"Always show all icons and notifications on the taskbar\" true to " +
-                        "avoid this problem. Or change behavior only for Java SE tray icon " +
-                        "and rerun test.");
-            } else  if (System.getProperty("os.name").toLowerCase().startsWith("mac")){
-                isMacOS = true;
-            } else if (SystemTrayIconHelper.isOel7orLater()) {
-                System.out.println("OEL 7 doesn't support double click in " +
-                        "systray. Skipped");
-                return;
-            }
-            new ActionCommand().doTest();
         }
+
+        if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray is not supported on this platform.");
+        }
+
+        if (Platform.isWindows()) {
+            System.err.println("Test can fail if the icon hides to a tray icons pool " +
+                    "in Windows 7, which is behavior by default.\n" +
+                    "Set \"Right mouse click\" -> \"Customize notification icons\" -> " +
+                    "\"Always show all icons and notifications on the taskbar\" true to " +
+                    "avoid this problem. Or change behavior only for Java SE tray icon " +
+                    "and rerun test.");
+        } else if (Platform.isOSX()){
+            isMacOS = true;
+        } else if (SystemTrayIconHelper.isOel7orLater()) {
+            System.out.println("OEL 7 doesn't support double click in " +
+                    "systray. Skipped");
+            throw new SkippedException("Skipped on OEL 7");
+        }
+        new ActionCommand().doTest();
     }
 
     void doTest() throws Exception {

--- a/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
+++ b/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,11 @@
  * questions.
  */
 
-import java.awt.*;
+import java.awt.AWTException;
+import java.awt.EventQueue;
+import java.awt.Point;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
 import java.awt.image.BufferedImage;
 
 /*
@@ -32,7 +36,7 @@ import java.awt.image.BufferedImage;
  *          (single clicked, on Mac)
  * @author Dmitriy Ermashov (dmitriy.ermashov@oracle.com)
  * @modules java.desktop/java.awt:open
- * @library /lib/client ../
+ * @library /lib/client /java/awt/TrayIcon
  * @library /java/awt/patchlib
  * @build java.desktop/java.awt.Helper
  * @build ExtendedRobot SystemTrayIconHelper
@@ -44,13 +48,14 @@ public class ActionCommand {
     TrayIcon icon;
     ExtendedRobot robot;
 
-    boolean actionPerformed = false;
-    Object actionLock = new Object();
-    String actionCommand = null;
+    volatile boolean actionPerformed = false;
+    volatile String actionCommand = null;
+    final Object actionLock = new Object();
+
     static boolean isMacOS = false;
 
     public static void main(String[] args) throws Exception {
-        if (! SystemTray.isSupported()) {
+        if (!SystemTray.isSupported()) {
             System.out.println("SystemTray not supported on the platform under test. " +
                     "Marking the test passed");
         } else {
@@ -95,7 +100,7 @@ public class ActionCommand {
 
             icon.setActionCommand("Sample Command");
 
-            if (! "Sample Command".equals(icon.getActionCommand()))
+            if (!"Sample Command".equals(icon.getActionCommand()))
                 throw new RuntimeException("FAIL: getActionCommand did not return the correct value. " +
                         icon.getActionCommand() + " Expected: Sample Command");
 
@@ -117,7 +122,7 @@ public class ActionCommand {
         actionPerformed = false;
         SystemTrayIconHelper.doubleClick(robot);
 
-        if (! actionPerformed) {
+        if (!actionPerformed) {
             synchronized (actionLock) {
                 try {
                     actionLock.wait(3000);
@@ -125,7 +130,7 @@ public class ActionCommand {
                 }
             }
         }
-        if (! actionPerformed) {
+        if (!actionPerformed) {
             throw new RuntimeException("FAIL: ActionEvent not triggered when TrayIcon is "+(isMacOS? "" : "double ")+"clicked");
         } else if (! "Sample Command".equals(actionCommand)) {
             throw new RuntimeException("FAIL: ActionEvent.getActionCommand did not return the correct " +
@@ -149,7 +154,7 @@ public class ActionCommand {
         actionCommand = null;
         SystemTrayIconHelper.doubleClick(robot);
 
-        if (! actionPerformed) {
+        if (!actionPerformed) {
             synchronized (actionLock) {
                 try {
                     actionLock.wait(3000);
@@ -157,7 +162,7 @@ public class ActionCommand {
                 }
             }
         }
-        if (! actionPerformed) {
+        if (!actionPerformed) {
             throw new RuntimeException("FAIL: ActionEvent not triggered when ActionCommand set to " +
                     "null and then TrayIcon is "+(isMacOS? "" : "double ")+ "clicked");
         } else if (actionCommand != null) {

--- a/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
+++ b/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
@@ -21,6 +21,9 @@
  * questions.
  */
 
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
+
 import java.awt.AWTException;
 import java.awt.EventQueue;
 import java.awt.Point;
@@ -36,10 +39,17 @@ import java.awt.image.BufferedImage;
  *          (single clicked, on Mac)
  * @author Dmitriy Ermashov (dmitriy.ermashov@oracle.com)
  * @modules java.desktop/java.awt:open
- * @library /lib/client /java/awt/TrayIcon
- * @library /java/awt/patchlib
- * @build java.desktop/java.awt.Helper
- * @build ExtendedRobot SystemTrayIconHelper
+ * @library
+ *          /java/awt/patchlib
+ *          /java/awt/TrayIcon
+ *          /lib/client
+ *          /test/lib
+ * @build
+ *          java.desktop/java.awt.Helper
+ *          jdk.test.lib.Platform
+ *          jtreg.SkippedException
+ *          ExtendedRobot
+ *          SystemTrayIconHelper
  * @run main ActionCommand
  */
 
@@ -55,9 +65,12 @@ public class ActionCommand {
     static boolean isMacOS = false;
 
     public static void main(String[] args) throws Exception {
-        if (!SystemTray.isSupported()) {
-            System.out.println("SystemTray not supported on the platform under test. " +
-                    "Marking the test passed");
+        if (Platform.isOnWayland()) {
+            // The current robot implementation does not support
+            // clicking in the system tray area.
+            throw new SkippedException("Skipped on Wayland");
+        } else if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray is not supported on this platform.");
         } else {
             if (System.getProperty("os.name").toLowerCase().startsWith("win")) {
                 System.err.println("Test can fail if the icon hides to a tray icons pool " +

--- a/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
+++ b/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
@@ -158,7 +158,7 @@ public class ActionCommand {
             }
         });
 
-        robot.mouseMove(0, 0);
+        robot.mouseMove(100, 0);
         robot.waitForIdle();
         robot.mouseMove(iconPosition.x, iconPosition.y);
         robot.waitForIdle();

--- a/test/jdk/java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import java.awt.image.BufferedImage;
  *          or single clicked with button 1 on rest.
  * @modules java.desktop/java.awt:open
  * @library /java/awt/patchlib
- * @library /lib/client ../
+ * @library /lib/client /java/awt/TrayIcon
  * @build java.desktop/java.awt.Helper
  * @build ExtendedRobot SystemTrayIconHelper
  * @run main TrayIconMouseTest
@@ -48,16 +48,18 @@ public class TrayIconMouseTest {
 
     TrayIcon icon;
     ExtendedRobot robot;
-    boolean actionPerformed = false;
-    Object actionLock = new Object();
+
+    volatile boolean actionPerformed = false;
+    final Object actionLock = new Object();
+
     static boolean isMacOS = false;
     static boolean isWinOS = false;
     static boolean isOelOS = false;
     String caption = "Sample Icon";
     int[] buttonTypes = {
-        InputEvent.BUTTON1_MASK,
-        InputEvent.BUTTON2_MASK,
-        InputEvent.BUTTON3_MASK
+        InputEvent.BUTTON1_DOWN_MASK,
+        InputEvent.BUTTON2_DOWN_MASK,
+        InputEvent.BUTTON3_DOWN_MASK
     };
     String[] buttonNames = {
         "BUTTON1",

--- a/test/jdk/java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java
@@ -82,19 +82,20 @@ public class TrayIconMouseTest {
             // The current robot implementation does not support
             // clicking in the system tray area.
             throw new SkippedException("Skipped on Wayland");
-        } else if (!SystemTray.isSupported()) {
-            throw new SkippedException("SystemTray is not supported on this platform.");
-        } else {
-            String osName = System.getProperty("os.name").toLowerCase();
-            if (osName.startsWith("mac")) {
-                isMacOS = true;
-            } else if (osName.startsWith("win")) {
-                isWinOS = true;
-            } else {
-                isOelOS = SystemTrayIconHelper.isOel7orLater();
-            }
-            new TrayIconMouseTest().doTest();
         }
+
+        if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray is not supported on this platform.");
+        }
+
+        if (Platform.isOSX()) {
+            isMacOS = true;
+        } else if (Platform.isWindows()) {
+            isWinOS = true;
+        } else {
+            isOelOS = SystemTrayIconHelper.isOel7orLater();
+        }
+        new TrayIconMouseTest().doTest();
     }
 
     TrayIconMouseTest() throws Exception {

--- a/test/jdk/java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java
@@ -21,6 +21,9 @@
  * questions.
  */
 
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
+
 import java.awt.EventQueue;
 import java.awt.Point;
 import java.awt.SystemTray;
@@ -37,10 +40,17 @@ import java.awt.image.BufferedImage;
  *          or single clicked with button 3 on Mac OS X
  *          or single clicked with button 1 on rest.
  * @modules java.desktop/java.awt:open
- * @library /java/awt/patchlib
- * @library /lib/client /java/awt/TrayIcon
- * @build java.desktop/java.awt.Helper
- * @build ExtendedRobot SystemTrayIconHelper
+ * @library
+ *          /java/awt/patchlib
+ *          /java/awt/TrayIcon
+ *          /lib/client
+ *          /test/lib
+ * @build
+ *          java.desktop/java.awt.Helper
+ *          jdk.test.lib.Platform
+ *          jtreg.SkippedException
+ *          ExtendedRobot
+ *          SystemTrayIconHelper
  * @run main TrayIconMouseTest
  */
 
@@ -68,9 +78,12 @@ public class TrayIconMouseTest {
     };
 
     public static void main(String[] args) throws Exception {
-        if (!SystemTray.isSupported()) {
-            System.out.println("SystemTray not supported on the platform "
-                    + "under test. Marking the test passed");
+        if (Platform.isOnWayland()) {
+            // The current robot implementation does not support
+            // clicking in the system tray area.
+            throw new SkippedException("Skipped on Wayland");
+        } else if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray is not supported on this platform.");
         } else {
             String osName = System.getProperty("os.name").toLowerCase();
             if (osName.startsWith("mac")) {

--- a/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupClickTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupClickTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@ import java.awt.EventQueue;
 import java.awt.Point;
 import java.awt.AWTException;
 import java.awt.event.MouseEvent;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.image.BufferedImage;
@@ -40,7 +38,7 @@ import java.awt.image.BufferedImage;
  * @author Shashidhara Veerabhadraiah (shashidhara.veerabhadraiah@oracle.com)
  * @modules java.desktop/java.awt:open
  * @library /java/awt/patchlib
- * @library /lib/client ../
+ * @library /lib/client /java/awt/TrayIcon
  * @build java.desktop/java.awt.Helper
  * @build ExtendedRobot SystemTrayIconHelper
  * @run main TrayIconPopupClickTest
@@ -50,7 +48,7 @@ public class TrayIconPopupClickTest {
 
     TrayIcon icon;
     ExtendedRobot robot;
-    boolean actionPerformed = false;
+    volatile boolean actionPerformed = false;
 
     public static void main(String[] args) throws Exception {
         if (!SystemTray.isSupported()) {
@@ -89,13 +87,7 @@ public class TrayIconPopupClickTest {
             throw new RuntimeException(e);
         }
 
-        icon.getActionCommand();
-        icon.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                actionPerformed = true;
-            }
-        });
+        icon.addActionListener(e -> actionPerformed = true);
     }
 
     void doTest() throws Exception {
@@ -106,16 +98,16 @@ public class TrayIconPopupClickTest {
 
         robot.mouseMove(iconPosition.x, iconPosition.y);
         robot.waitForIdle();
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(50);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(50);
 
         robot.mouseMove(iconPosition.x, iconPosition.y + 10);
         robot.waitForIdle();
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(50);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(50);
 
         if (!actionPerformed)

--- a/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupClickTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupClickTest.java
@@ -20,6 +20,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
+
 import java.awt.TrayIcon;
 import java.awt.SystemTray;
 import java.awt.EventQueue;
@@ -37,10 +40,17 @@ import java.awt.image.BufferedImage;
  *          message is clicked on.
  * @author Shashidhara Veerabhadraiah (shashidhara.veerabhadraiah@oracle.com)
  * @modules java.desktop/java.awt:open
- * @library /java/awt/patchlib
- * @library /lib/client /java/awt/TrayIcon
- * @build java.desktop/java.awt.Helper
- * @build ExtendedRobot SystemTrayIconHelper
+ * @library
+ *          /java/awt/patchlib
+ *          /java/awt/TrayIcon
+ *          /lib/client
+ *          /test/lib
+ * @build
+ *          java.desktop/java.awt.Helper
+ *          jdk.test.lib.Platform
+ *          jtreg.SkippedException
+ *          ExtendedRobot
+ *          SystemTrayIconHelper
  * @run main TrayIconPopupClickTest
  */
 
@@ -51,9 +61,12 @@ public class TrayIconPopupClickTest {
     volatile boolean actionPerformed = false;
 
     public static void main(String[] args) throws Exception {
-        if (!SystemTray.isSupported()) {
-            System.out.println("SystemTray not supported on the platform under test. " +
-                    "Marking the test passed");
+        if (Platform.isOnWayland()) {
+            // The current robot implementation does not support
+            // clicking in the system tray area.
+            throw new SkippedException("Skipped on Wayland");
+        } else if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray is not supported on this platform.");
         } else {
             if (System.getProperty("os.name").toLowerCase().startsWith("win"))
                 System.err.println("Test can fail if the icon hides to a tray icons pool " +

--- a/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupClickTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupClickTest.java
@@ -38,7 +38,6 @@ import java.awt.image.BufferedImage;
  * @key headful
  * @summary Check if a action performed event is received when TrayIcon display
  *          message is clicked on.
- * @author Shashidhara Veerabhadraiah (shashidhara.veerabhadraiah@oracle.com)
  * @modules java.desktop/java.awt:open
  * @library
  *          /java/awt/patchlib
@@ -65,18 +64,22 @@ public class TrayIconPopupClickTest {
             // The current robot implementation does not support
             // clicking in the system tray area.
             throw new SkippedException("Skipped on Wayland");
-        } else if (!SystemTray.isSupported()) {
-            throw new SkippedException("SystemTray is not supported on this platform.");
-        } else {
-            if (System.getProperty("os.name").toLowerCase().startsWith("win"))
-                System.err.println("Test can fail if the icon hides to a tray icons pool " +
-                        "in Windows 7/10, which is behavior by default.\n" +
-                        "Set \"Right mouse click\" -> \"Customize notification icons\" -> " +
-                        "\"Always show all icons and notifications on the taskbar\" true " +
-                        "to avoid this problem. Or change behavior only for Java SE " +
-                        "tray icon.");
-            new TrayIconPopupClickTest().doTest();
         }
+
+        if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray is not supported on this platform.");
+        }
+
+        if (Platform.isWindows()) {
+            System.err.println("Test can fail if the icon hides to a tray icons pool " +
+                    "in Windows 7/10, which is behavior by default.\n" +
+                    "Set \"Right mouse click\" -> \"Customize notification icons\" -> " +
+                    "\"Always show all icons and notifications on the taskbar\" true " +
+                    "to avoid this problem. Or change behavior only for Java SE " +
+                    "tray icon.");
+        }
+
+        new TrayIconPopupClickTest().doTest();
     }
 
     TrayIconPopupClickTest() throws Exception {
@@ -104,7 +107,6 @@ public class TrayIconPopupClickTest {
     }
 
     void doTest() throws Exception {
-
         Point iconPosition = SystemTrayIconHelper.getTrayIconLocation(icon);
         if (iconPosition == null)
             throw new RuntimeException("Unable to find the icon location!");

--- a/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupTest.java
@@ -21,6 +21,9 @@
  * questions.
  */
 
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
+
 import java.awt.AWTException;
 import java.awt.Dialog;
 import java.awt.EventQueue;
@@ -42,10 +45,17 @@ import java.awt.image.BufferedImage;
  *          right clicked. It uses a JWindow as the parent of the JPopupMenu
  * @author Dmitriy Ermashov (dmitriy.ermashov@oracle.com)
  * @modules java.desktop/java.awt:open
- * @library /java/awt/patchlib
- * @library /lib/client /java/awt/TrayIcon
- * @build java.desktop/java.awt.Helper
- * @build ExtendedRobot SystemTrayIconHelper
+ * @library
+ *          /java/awt/patchlib
+ *          /java/awt/TrayIcon
+ *          /lib/client
+ *          /test/lib
+ * @build
+ *          java.desktop/java.awt.Helper
+ *          jdk.test.lib.Platform
+ *          jtreg.SkippedException
+ *          ExtendedRobot
+ *          SystemTrayIconHelper
  * @run main TrayIconPopupTest
  */
 
@@ -63,9 +73,12 @@ public class TrayIconPopupTest {
     Dialog window;
 
     public static void main(String[] args) throws Exception {
-        if (!SystemTray.isSupported()) {
-            System.out.println("SystemTray not supported on the platform under test. " +
-                    "Marking the test passed");
+        if (Platform.isOnWayland()) {
+            // The current robot implementation does not support
+            // clicking in the system tray area.
+            throw new SkippedException("Skipped on Wayland");
+        } else if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray is not supported on this platform.");
         } else {
             if (System.getProperty("os.name").toLowerCase().startsWith("win"))
                 System.err.println("Test can fail if the icon hides to a tray icons pool " +

--- a/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,8 +20,19 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.awt.*;
-import java.awt.event.*;
+
+import java.awt.AWTException;
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.MenuItem;
+import java.awt.Point;
+import java.awt.PopupMenu;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 
 /*
@@ -32,7 +43,7 @@ import java.awt.image.BufferedImage;
  * @author Dmitriy Ermashov (dmitriy.ermashov@oracle.com)
  * @modules java.desktop/java.awt:open
  * @library /java/awt/patchlib
- * @library /lib/client ../
+ * @library /lib/client /java/awt/TrayIcon
  * @build java.desktop/java.awt.Helper
  * @build ExtendedRobot SystemTrayIconHelper
  * @run main TrayIconPopupTest
@@ -43,8 +54,9 @@ public class TrayIconPopupTest {
     TrayIcon icon;
     ExtendedRobot robot;
 
-    boolean actionPerformed = false;
-    Object actionLock = new Object();
+    volatile boolean actionPerformed = false;
+    final Object actionLock = new Object();
+
     static final int ATTEMPTS = 10;
 
     PopupMenu popup;
@@ -128,15 +140,15 @@ public class TrayIconPopupTest {
 
         robot.mouseMove(iconPosition.x, iconPosition.y);
         robot.waitForIdle();
-        robot.mousePress(InputEvent.BUTTON3_MASK);
+        robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
         robot.delay(50);
-        robot.mouseRelease(InputEvent.BUTTON3_MASK);
+        robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
         robot.delay(6000);
 
         robot.mouseMove(window.getLocation().x + 10, window.getLocation().y + 10);
-        robot.mousePress(InputEvent.BUTTON3_MASK);
+        robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
         robot.delay(50);
-        robot.mouseRelease(InputEvent.BUTTON3_MASK);
+        robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
 
         int attempts = 0;
         while (!actionPerformed && attempts++ < ATTEMPTS) {

--- a/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupTest.java
@@ -43,7 +43,6 @@ import java.awt.image.BufferedImage;
  * @key headful
  * @summary Check if a JPopupMenu can be displayed when TrayIcon is
  *          right clicked. It uses a JWindow as the parent of the JPopupMenu
- * @author Dmitriy Ermashov (dmitriy.ermashov@oracle.com)
  * @modules java.desktop/java.awt:open
  * @library
  *          /java/awt/patchlib
@@ -77,18 +76,21 @@ public class TrayIconPopupTest {
             // The current robot implementation does not support
             // clicking in the system tray area.
             throw new SkippedException("Skipped on Wayland");
-        } else if (!SystemTray.isSupported()) {
-            throw new SkippedException("SystemTray is not supported on this platform.");
-        } else {
-            if (System.getProperty("os.name").toLowerCase().startsWith("win"))
-                System.err.println("Test can fail if the icon hides to a tray icons pool " +
-                        "in Windows 7, which is behavior by default.\n" +
-                        "Set \"Right mouse click\" -> \"Customize notification icons\" -> " +
-                        "\"Always show all icons and notifications on the taskbar\" true " +
-                        "to avoid this problem. Or change behavior only for Java SE " +
-                        "tray icon.");
-            new TrayIconPopupTest().doTest();
         }
+
+        if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray is not supported on this platform.");
+        }
+
+        if (Platform.isWindows()) {
+            System.err.println("Test can fail if the icon hides to a tray icons pool " +
+                    "in Windows 7, which is behavior by default.\n" +
+                    "Set \"Right mouse click\" -> \"Customize notification icons\" -> " +
+                    "\"Always show all icons and notifications on the taskbar\" true " +
+                    "to avoid this problem. Or change behavior only for Java SE " +
+                    "tray icon.");
+        }
+        new TrayIconPopupTest().doTest();
     }
 
     TrayIconPopupTest() throws Exception {


### PR DESCRIPTION
Several TrayIcon tests are trying to click on the system tray icon with Robot using XTest API.

Basically we have the same kind of failures as before, e.g. [JDK-8280990](https://bugs.openjdk.org/browse/JDK-8280990)
>  the reason is this is using XTEST, an X11 protocol which will not work outside of X11.
>
> In other words, the emulated input event reaches the X11 clients, but not the Wayland compositor which is the actual display server but also the X11 window manager in Wayland, the component which is in charge of moving/resizing/stacking the windows. 

I also tested the same tests by clicking manually instead of using the robot, and it works as expected.
So for now, skip those tests on Wayland (and do some minor cleanup).

Testing after modifications is also green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348675](https://bugs.openjdk.org/browse/JDK-8348675): TrayIcon tests fail in Ubuntu 24.10 Wayland (**Bug** - P3)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23329/head:pull/23329` \
`$ git checkout pull/23329`

Update a local copy of the PR: \
`$ git checkout pull/23329` \
`$ git pull https://git.openjdk.org/jdk.git pull/23329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23329`

View PR using the GUI difftool: \
`$ git pr show -t 23329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23329.diff">https://git.openjdk.org/jdk/pull/23329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23329#issuecomment-2618751000)
</details>
