### PR TITLE
8348631: Crash in PredictedCallGenerator::generate after JDK-8347006

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -932,6 +932,9 @@ JVMState* PredictedCallGenerator::generate(JVMState* jvms) {
 
   // Make the hot call:
   JVMState* new_jvms = _if_hit->generate(kit.sync_jvms());
+  if (kit.failing()) {
+    return nullptr;
+  }
   if (new_jvms == nullptr) {
     // Inline failed, so make a direct call.
     assert(_if_hit->is_inline(), "must have been a failed inline");
@@ -1259,6 +1262,9 @@ JVMState* PredicatedIntrinsicGenerator::generate(JVMState* jvms) {
       PreserveJVMState pjvms(&kit);
       // Generate intrinsic code:
       JVMState* new_jvms = _intrinsic->generate(kit.sync_jvms());
+      if (kit.failing()) {
+        return nullptr;
+      }
       if (new_jvms == nullptr) {
         // Intrinsic failed, use normal compilation path for this predicate.
         slow_region->add_req(kit.control());

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4302,7 +4302,10 @@ Node* LibraryCallKit::generate_array_guard_common(Node* kls, RegionNode* region,
   if (obj != nullptr && is_array_ctrl != nullptr && is_array_ctrl != top()) {
     // Keep track of the fact that 'obj' is an array to prevent
     // array specific accesses from floating above the guard.
-    *obj = _gvn.transform(new CastPPNode(is_array_ctrl, *obj, TypeAryPtr::BOTTOM));
+    Node* cast = _gvn.transform(new CastPPNode(is_array_ctrl, *obj, TypeAryPtr::BOTTOM));
+    if (!cast->is_top()) {
+      *obj = cast;
+    }
   }
   return ctrl;
 }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4303,6 +4303,8 @@ Node* LibraryCallKit::generate_array_guard_common(Node* kls, RegionNode* region,
     // Keep track of the fact that 'obj' is an array to prevent
     // array specific accesses from floating above the guard.
     Node* cast = _gvn.transform(new CastPPNode(is_array_ctrl, *obj, TypeAryPtr::BOTTOM));
+    // Check for top because in rare cases, the type system can determine that
+    // the object can't be an array but the layout helper check is not folded.
     if (!cast->is_top()) {
       *obj = cast;
     }

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -106,6 +106,10 @@ class LibraryCallKit : public GraphKit {
   void push_result() {
     // Push the result onto the stack.
     if (!stopped() && result() != nullptr) {
+      if (result()->is_top()) {
+        assert(false, "Can't determine return value.");
+        C->record_method_not_compilable("Can't determine return value.");
+      }
       BasicType bt = result()->bottom_type()->basic_type();
       push_node(bt, result());
     }

--- a/test/hotspot/jtreg/compiler/intrinsics/TestArrayGuardWithInterfaces.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestArrayGuardWithInterfaces.java
@@ -38,7 +38,7 @@ public class TestArrayGuardWithInterfaces {
     public static interface MyInterface { }
 
     public static int test1(Object obj) {
-        // Should be folded, arrays can never imlement 'MyInterface' 
+        // Should be folded, arrays can never imlement 'MyInterface'
         return Array.getLength((MyInterface)obj);
     }
 

--- a/test/hotspot/jtreg/compiler/intrinsics/TestArrayGuardWithInterfaces.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestArrayGuardWithInterfaces.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.reflect.Array;
+import jdk.test.lib.Asserts;
+
+/**
+ * @test
+ * @bug 8348631
+ * @summary Test folding of array guards used by intrinsics.
+ * @library /test/lib
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,TestArrayGuardWithInterfaces::test*
+ *                   TestArrayGuardWithInterfaces
+ */
+public class TestArrayGuardWithInterfaces {
+
+    public static interface MyInterface { }
+
+    public static int test1(Object obj) {
+        // Should be folded, arrays can never imlement 'MyInterface' 
+        return Array.getLength((MyInterface)obj);
+    }
+
+    public static int test2(Object obj) {
+        // Should not be folded, arrays implement 'Cloneable'
+        return Array.getLength((Cloneable)obj);
+    }
+
+    public static void main(String[] args) {
+        // Warmup
+        Class c = MyInterface.class;
+        Array.getLength(args);
+
+        try {
+            test1(null);
+            throw new RuntimeException("No exception thrown");
+        } catch (Exception e) {
+            // Expected
+        }
+        Asserts.assertEQ(test2(new int[1]), 1);
+    }
+}


### PR DESCRIPTION
We crash / assert during C2 compilation of intrinsics like `_getLength` because the cast emitted by the array guard added by [JDK-8347006](https://bugs.openjdk.org/browse/JDK-8347006) is folded to top:
https://github.com/openjdk/jdk/blob/c33c1cfe7349ac657cd7bf54861227709d3c8f1b/src/hotspot/share/opto/library_call.cpp#L4302-L4305

This happens when C2's type system determines that the type of the object that we cast implements an interface other than `Serializable` or `Cloneable` and therefore can't be an array. This is possible since [JDK-8297933](https://bugs.openjdk.org/browse/JDK-8297933). Now unfortunately, control via the layout helper check is not (yet) folded due to:
https://github.com/openjdk/jdk/blob/c33c1cfe7349ac657cd7bf54861227709d3c8f1b/src/hotspot/share/opto/memnode.cpp#L2215-L2223

This is probably an oversight from [JDK-8297933](https://bugs.openjdk.org/browse/JDK-8297933). Given that this is a regression in JDK 24, I'm going with a conservative approach of simply checking the cast for top and not using it if that's the case. In addition, I made the code more robust and added a compilation bailout (assert in debug) if an intrinsic produces a `top` result.

We should then properly fix this by making sure that the layout helper check is folded. I filed [JDK-8348853](https://bugs.openjdk.org/browse/JDK-8348853) for this.

Big thanks to @cushon for reporting this just in time for fixing in JDK 24!

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348631](https://bugs.openjdk.org/browse/JDK-8348631): Crash in PredictedCallGenerator::generate after JDK-8347006 (**Bug** - P2)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**) Review applies to [4cf7f864](https://git.openjdk.org/jdk/pull/23331/files/4cf7f864a9d61120f836670a8768457bb3b2ced2)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23331/head:pull/23331` \
`$ git checkout pull/23331`

Update a local copy of the PR: \
`$ git checkout pull/23331` \
`$ git pull https://git.openjdk.org/jdk.git pull/23331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23331`

View PR using the GUI difftool: \
`$ git pr show -t 23331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23331.diff">https://git.openjdk.org/jdk/pull/23331.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23331#issuecomment-2619361795)
</details>
