### PR TITLE
8348830: LIBFONTMANAGER optimization is always HIGHEST

### DIFF
--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -360,8 +360,6 @@ else
   LIBFONTMANAGER_JDK_LIBS += libfreetype
 endif
 
-LIBFONTMANAGER_OPTIMIZATION := HIGHEST
-
 ifneq ($(filter $(TOOLCHAIN_TYPE), gcc clang), )
   # gcc (and to an extent clang) is particularly bad at optimizing these files,
   # causing a massive spike in compile time. We don't care about these
@@ -372,7 +370,6 @@ endif
 
 ifeq ($(call isTargetOs, windows), true)
   LIBFONTMANAGER_EXCLUDE_FILES += X11FontScaler.c X11TextRenderer.c
-  LIBFONTMANAGER_OPTIMIZATION := HIGHEST
 else ifeq ($(call isTargetOs, macosx), true)
   LIBFONTMANAGER_EXCLUDE_FILES += X11FontScaler.c X11TextRenderer.c \
       fontpath.c lcdglyph.c
@@ -393,7 +390,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
         AccelGlyphCache.c, \
     CFLAGS := $(LIBFONTMANAGER_CFLAGS), \
     CXXFLAGS := $(LIBFONTMANAGER_CFLAGS), \
-    OPTIMIZATION := $(LIBFONTMANAGER_OPTIMIZATION), \
+    OPTIMIZATION := HIGHEST, \
     CFLAGS_windows = -DCC_NOEX, \
     EXTRA_HEADER_DIRS := $(LIBFONTMANAGER_EXTRA_HEADER_DIRS), \
     EXTRA_SRC := $(LIBFONTMANAGER_EXTRA_SRC), \


### PR DESCRIPTION
In the makefile we reset LIBFONTMANAGER optimization, but is always set to HIGHEST so we can avoid the resetting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348830](https://bugs.openjdk.org/browse/JDK-8348830): LIBFONTMANAGER optimization is always HIGHEST (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23332/head:pull/23332` \
`$ git checkout pull/23332`

Update a local copy of the PR: \
`$ git checkout pull/23332` \
`$ git pull https://git.openjdk.org/jdk.git pull/23332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23332`

View PR using the GUI difftool: \
`$ git pr show -t 23332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23332.diff">https://git.openjdk.org/jdk/pull/23332.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23332#issuecomment-2619034007)
</details>
