### PR TITLE
8348855: G1: Implement G1BarrierSetC2::estimate_stub_size

### DIFF
--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -546,8 +546,7 @@ int G1BarrierSetC2::estimate_stub_size() const {
     size += cb.insts_size();
   }
 
-  // Add slop to avoid expansion during emit_stubs.
-  return size + PhaseOutput::MAX_inst_size;
+  return size;
 }
 
 void G1BarrierSetC2::emit_stubs(CodeBuffer& cb) const {

--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.hpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.hpp
@@ -118,6 +118,7 @@ public:
   virtual void* create_barrier_state(Arena* comp_arena) const;
   virtual void emit_stubs(CodeBuffer& cb) const;
   virtual void late_barrier_analysis() const;
+  virtual int estimate_stub_size() const;
 
 #ifndef PRODUCT
   virtual void dump_barrier_data(const MachNode* mach, outputStream* st) const;

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1361,8 +1361,10 @@ CodeBuffer* PhaseOutput::init_buffer() {
 
   int pad_req   = NativeCall::byte_size();
 
+  // Despite the name "stub", GC barrier stubs are emitted into
+  // the insn section, and should be counted in code_req.
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-  stub_req += bs->estimate_stub_size();
+  code_req += bs->estimate_stub_size();
 
   // nmethod and CodeBuffer count stubs & constants as part of method's code.
   // class HandlerImpl is platform-specific and defined in the *.ad files.

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1361,10 +1361,8 @@ CodeBuffer* PhaseOutput::init_buffer() {
 
   int pad_req   = NativeCall::byte_size();
 
-  // Despite the name "stub", GC barrier stubs are emitted into
-  // the insn section, and should be counted in code_req.
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-  code_req += bs->estimate_stub_size();
+  stub_req += bs->estimate_stub_size();
 
   // nmethod and CodeBuffer count stubs & constants as part of method's code.
   // class HandlerImpl is platform-specific and defined in the *.ad files.


### PR DESCRIPTION
We run into peculiar problem in Leyden: due to current prototype limitation, we cannot yet store the generated code that has the expanded code buffer. The code buffer expansion routinely happens with late G1 barrier expansion, as `G1BarrierSetC2` does not report any estimate for stub sizes.

So a method rich in these G1 stubs would blow the initial code size estimate, force the buffer resize, and thus disqualify itself from storing C2 code in Leyden. Whoops. Fortunately, we just need to implement `G1BarrierSetC2::estimate_stub_size()` in mainline to avoid a significant part of this problem. 

I also fixed the misattribution of "stub" sizes in insn section, this part is also important to get the stub sizes right. I can do that separately, but it would only matter for ZGC without G1 stub size estimation implemented.

You can see the impact it has on Leyden here:
https://github.com/openjdk/leyden/pull/28#issuecomment-2619077625

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`
 - [x] Linux AArch64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348855](https://bugs.openjdk.org/browse/JDK-8348855): G1: Implement G1BarrierSetC2::estimate_stub_size (**Enhancement** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**) 🔄 Re-review required (review applies to [bec7c5c1](https://git.openjdk.org/jdk/pull/23333/files/bec7c5c128aa2ef9159470373b70dbbf33ce985e))
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) 🔄 Re-review required (review applies to [bec7c5c1](https://git.openjdk.org/jdk/pull/23333/files/bec7c5c128aa2ef9159470373b70dbbf33ce985e))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23333/head:pull/23333` \
`$ git checkout pull/23333`

Update a local copy of the PR: \
`$ git checkout pull/23333` \
`$ git pull https://git.openjdk.org/jdk.git pull/23333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23333`

View PR using the GUI difftool: \
`$ git pr show -t 23333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23333.diff">https://git.openjdk.org/jdk/pull/23333.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23333#issuecomment-2619352659)
</details>
