### PR TITLE
8333386: TestAbortOnVMOperationTimeout test fails for client VM

### DIFF
--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -68,6 +68,7 @@ public class TestAbortOnVMOperationTimeout {
                 "-XX:+AbortVMOnVMOperationTimeout",
                 "-XX:AbortVMOnVMOperationTimeoutDelay=" + delay,
                 "-Xmx256m",
+                "-XX:NewSize=64m",
                 "-XX:+UseSerialGC",
                 "-XX:-CreateCoredumpOnCrash",
                 "-Xlog:gc*=info",


### PR DESCRIPTION
Hi all,

The test case `TestAbortOnVMOperationTimeout.java` fails on client VM, 
because the default new generation size is low and the new size can't be expanded when allocating. 
It is good to set the new size explicitly so that the test case can pass on the client VM.

Thanks for your review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333386](https://bugs.openjdk.org/browse/JDK-8333386): TestAbortOnVMOperationTimeout test fails for client VM (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23334/head:pull/23334` \
`$ git checkout pull/23334`

Update a local copy of the PR: \
`$ git checkout pull/23334` \
`$ git pull https://git.openjdk.org/jdk.git pull/23334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23334`

View PR using the GUI difftool: \
`$ git pr show -t 23334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23334.diff">https://git.openjdk.org/jdk/pull/23334.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23334#issuecomment-2619123695)
</details>
