### PR TITLE
8348870: Eliminate array bound checks in DecimalDigits

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -62,7 +62,7 @@ public final class DecimalDigits {
     private static final short[] DIGITS;
 
     static {
-        short[] digits = new short[10 * 10];
+        short[] digits = new short[128];
 
         for (int i = 0; i < 10; i++) {
             short hi = (short) (i + '0');
@@ -394,7 +394,7 @@ public final class DecimalDigits {
      * @param v to convert
      */
     public static void putPair(char[] buf, int charPos, int v) {
-        int packed = DIGITS[v];
+        int packed = DIGITS[v & 0x7f];
         buf[charPos    ] = (char) (packed & 0xFF);
         buf[charPos + 1] = (char) (packed >> 8);
     }
@@ -407,7 +407,7 @@ public final class DecimalDigits {
      * @param v to convert
      */
     public static void putPairLatin1(byte[] buf, int charPos, int v) {
-        int packed = DIGITS[v];
+        int packed = DIGITS[v & 0x7f];
         putCharLatin1(buf, charPos, packed & 0xFF);
         putCharLatin1(buf, charPos + 1, packed >> 8);
     }
@@ -420,7 +420,7 @@ public final class DecimalDigits {
      * @param v to convert
      */
     public static void putPairUTF16(byte[] buf, int charPos, int v) {
-        int packed = DIGITS[v];
+        int packed = DIGITS[v & 0x7f];
         putCharUTF16(buf, charPos, packed & 0xFF);
         putCharUTF16(buf, charPos + 1, packed >> 8);
     }


### PR DESCRIPTION
Expand DIGITS length to 128 and eliminate array bounds checking by using & 0x7F when accessing DIGITS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348870](https://bugs.openjdk.org/browse/JDK-8348870): Eliminate array bound checks in DecimalDigits (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23335/head:pull/23335` \
`$ git checkout pull/23335`

Update a local copy of the PR: \
`$ git checkout pull/23335` \
`$ git pull https://git.openjdk.org/jdk.git pull/23335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23335`

View PR using the GUI difftool: \
`$ git pr show -t 23335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23335.diff">https://git.openjdk.org/jdk/pull/23335.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23335#issuecomment-2619290832)
</details>
