### PR TITLE
8348880: Replace ConcurrentMap with AtomicReferenceArray for ZoneOffset.QUARTER_CACHE

### DIFF
--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -428,11 +428,10 @@ public final class ZoneOffset
         }
         int quarters = totalSeconds / SECONDS_PER_QUARTER;
         if (totalSeconds - quarters * SECONDS_PER_QUARTER == 0) {
-            int cacheIndex = quarters & 0xff;
-            ZoneOffset result = QUARTER_CACHE.getOpaque(cacheIndex);
+            ZoneOffset result = QUARTER_CACHE.getOpaque(quarters & 0xff);
             if (result == null) {
                 result = new ZoneOffset(totalSeconds);
-                var existing = QUARTER_CACHE.compareAndExchange(cacheIndex, null, result);
+                var existing = QUARTER_CACHE.compareAndExchange(quarters & 0xff, null, result);
                 if (existing != null) {
                     result = existing;
                 }

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -135,7 +135,7 @@ public final class ZoneOffset
         extends ZoneId
         implements TemporalAccessor, TemporalAdjuster, Comparable<ZoneOffset>, Serializable {
 
-    /** Cache of time-zone offset by offset in seconds. */
+    /** Cache of time-zone offset by offset in quarters. */
     private static final int SECONDS_PER_QUARTER = 15 * SECONDS_PER_MINUTE;
     private static final AtomicReferenceArray<ZoneOffset> QUARTER_CACHE = new AtomicReferenceArray<>(256);
 

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -136,7 +136,7 @@ public final class ZoneOffset
         implements TemporalAccessor, TemporalAdjuster, Comparable<ZoneOffset>, Serializable {
 
     /** Cache of time-zone offset by offset in seconds. */
-    private static final int MINUTES_15_SECONDS = 15 * SECONDS_PER_MINUTE;
+    private static final int SECONDS_PER_QUARTER = 15 * SECONDS_PER_MINUTE;
     private static final AtomicReferenceArray<ZoneOffset> MINUTES_15_CACHE = new AtomicReferenceArray<>(256);
 
     /** Cache of time-zone offset by ID. */
@@ -426,9 +426,9 @@ public final class ZoneOffset
         if (totalSeconds < -MAX_SECONDS || totalSeconds > MAX_SECONDS) {
             throw new DateTimeException("Zone offset not in valid range: -18:00 to +18:00");
         }
-        int minutes15Rem = totalSeconds / MINUTES_15_SECONDS;
-        if (totalSeconds - minutes15Rem * MINUTES_15_SECONDS == 0) {
-            int cacheIndex = minutes15Rem & 0xff;
+        int quarters = totalSeconds / SECONDS_PER_QUARTER;
+        if (totalSeconds - quarters * SECONDS_PER_QUARTER == 0) {
+            int cacheIndex = quarters & 0xff;
             ZoneOffset result = MINUTES_15_CACHE.getOpaque(cacheIndex);
             if (result == null) {
                 result = new ZoneOffset(totalSeconds);

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -137,7 +137,7 @@ public final class ZoneOffset
 
     /** Cache of time-zone offset by offset in seconds. */
     private static final int SECONDS_PER_QUARTER = 15 * SECONDS_PER_MINUTE;
-    private static final AtomicReferenceArray<ZoneOffset> MINUTES_15_CACHE = new AtomicReferenceArray<>(256);
+    private static final AtomicReferenceArray<ZoneOffset> QUARTER_CACHE = new AtomicReferenceArray<>(256);
 
     /** Cache of time-zone offset by ID. */
     private static final ConcurrentMap<String, ZoneOffset> ID_CACHE = new ConcurrentHashMap<>(16, 0.75f, 4);
@@ -429,10 +429,10 @@ public final class ZoneOffset
         int quarters = totalSeconds / SECONDS_PER_QUARTER;
         if (totalSeconds - quarters * SECONDS_PER_QUARTER == 0) {
             int cacheIndex = quarters & 0xff;
-            ZoneOffset result = MINUTES_15_CACHE.getOpaque(cacheIndex);
+            ZoneOffset result = QUARTER_CACHE.getOpaque(cacheIndex);
             if (result == null) {
                 result = new ZoneOffset(totalSeconds);
-                var existing = MINUTES_15_CACHE.compareAndExchange(cacheIndex, null, result);
+                var existing = QUARTER_CACHE.compareAndExchange(cacheIndex, null, result);
                 if (existing != null) {
                     result = existing;
                 }

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -428,10 +428,12 @@ public final class ZoneOffset
         }
         int quarters = totalSeconds / SECONDS_PER_QUARTER;
         if (totalSeconds - quarters * SECONDS_PER_QUARTER == 0) {
-            ZoneOffset result = QUARTER_CACHE.getOpaque(quarters & 0xff);
+            // quarters range from -72 to 72, & 0xff maps them to 0-72 and 184-255.
+            int key = quarters & 0xff;
+            ZoneOffset result = QUARTER_CACHE.getOpaque(key);
             if (result == null) {
                 result = new ZoneOffset(totalSeconds);
-                var existing = QUARTER_CACHE.compareAndExchange(quarters & 0xff, null, result);
+                var existing = QUARTER_CACHE.compareAndExchange(key, null, result);
                 if (existing != null) {
                     result = existing;
                 }

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -432,7 +432,7 @@ public final class ZoneOffset
             ZoneOffset result = MINUTES_15_CACHE.getOpaque(cacheIndex);
             if (result == null) {
                 result = new ZoneOffset(totalSeconds);
-                var existing = MINUTES_15_CACHE.getAndSet(cacheIndex, result);
+                var existing = MINUTES_15_CACHE.compareAndExchange(cacheIndex, null, result);
                 if (existing != null) {
                     result = existing;
                 }

--- a/test/jdk/java/time/test/java/time/TestZoneOffset.java
+++ b/test/jdk/java/time/test/java/time/TestZoneOffset.java
@@ -85,15 +85,16 @@ public class TestZoneOffset extends AbstractTest {
 
     @Test
     public void test_quarter_cache() throws Exception {
-        for (int hour = -18; hour < 18; hour++) {
-            for (int minutes = 0; minutes < 60; minutes += 15) {
-                int totalSeconds = hour * 3600 + minutes * 60;
-                var offset0 = ZoneOffset.ofTotalSeconds(totalSeconds);
-                var offset1 = ZoneOffset.ofTotalSeconds(totalSeconds);
-                var offset2 = ZoneOffset.ofTotalSeconds(totalSeconds);
-                assertSame(offset0, offset1);
-                assertSame(offset1, offset2);
-            }
+        // [-18:00, +18:00]
+        int quarter = 15 * 60;
+        int start = -18 * 3600,
+            end   =  18 * 3600;
+        for (int totalSeconds = start; totalSeconds <= end; totalSeconds += quarter) {
+            var offset0 = ZoneOffset.ofTotalSeconds(totalSeconds);
+            var offset1 = ZoneOffset.ofTotalSeconds(totalSeconds);
+            var offset2 = ZoneOffset.ofTotalSeconds(totalSeconds);
+            assertSame(offset0, offset1);
+            assertSame(offset1, offset2);
         }
     }
 

--- a/test/jdk/java/time/test/java/time/TestZoneOffset.java
+++ b/test/jdk/java/time/test/java/time/TestZoneOffset.java
@@ -60,11 +60,13 @@
 package test.java.time;
 
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertEquals;
 
 import java.util.Set;
 import java.time.ZoneOffset;
 
 import org.testng.annotations.Test;
+import java.util.IdentityHashMap;
 
 /**
  * Test ZoneOffset.
@@ -80,6 +82,33 @@ public class TestZoneOffset extends AbstractTest {
     @Test
     public void test_factory_ofTotalSecondsSame() {
         assertSame(ZoneOffset.ofTotalSeconds(0), ZoneOffset.UTC);
+    }
+
+    @Test
+    public void test() throws Exception {
+        Object PRESENT = new Object();
+        IdentityHashMap<ZoneOffset, Object> map = new IdentityHashMap();
+        for (int i = 0; i < 10; i++) {
+            for (int hour = 0; hour < 18; hour++) {
+                for (int minutes = 0; minutes < 60; minutes += 15) {
+                    ZoneOffset zoneOffset = ZoneOffset.ofHoursMinutes(hour, minutes);
+                    map.put(zoneOffset, PRESENT);
+                }
+            }
+        }
+        assertEquals(18 * 4, map.size());
+
+        for (int i = 0; i < 10; i++) {
+            for (int hour = -18; hour < 18; hour++) {
+                for (int minutes = 0; minutes < 60; minutes += 15) {
+                    int totalSeconds = hour * 3600 + minutes * 60;
+                    ZoneOffset zoneOffset = ZoneOffset.ofTotalSeconds(totalSeconds);
+                    map.put(zoneOffset, PRESENT);
+                }
+            }
+        }
+
+        assertEquals(36 * 4, map.size());
     }
 
 }

--- a/test/jdk/java/time/test/java/time/TestZoneOffset.java
+++ b/test/jdk/java/time/test/java/time/TestZoneOffset.java
@@ -83,7 +83,7 @@ public class TestZoneOffset extends AbstractTest {
     }
 
     @Test
-    public void test() throws Exception {
+    public void test_quarter_cache() throws Exception {
         for (int hour = -18; hour < 18; hour++) {
             for (int minutes = 0; minutes < 60; minutes += 15) {
                 int totalSeconds = hour * 3600 + minutes * 60;

--- a/test/jdk/java/time/test/java/time/TestZoneOffset.java
+++ b/test/jdk/java/time/test/java/time/TestZoneOffset.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/time/test/java/time/TestZoneOffset.java
+++ b/test/jdk/java/time/test/java/time/TestZoneOffset.java
@@ -60,13 +60,11 @@
 package test.java.time;
 
 import static org.testng.Assert.assertSame;
-import static org.testng.Assert.assertEquals;
 
 import java.util.Set;
 import java.time.ZoneOffset;
 
 import org.testng.annotations.Test;
-import java.util.IdentityHashMap;
 
 /**
  * Test ZoneOffset.
@@ -86,29 +84,16 @@ public class TestZoneOffset extends AbstractTest {
 
     @Test
     public void test() throws Exception {
-        Object PRESENT = new Object();
-        IdentityHashMap<ZoneOffset, Object> map = new IdentityHashMap();
-        for (int i = 0; i < 10; i++) {
-            for (int hour = 0; hour < 18; hour++) {
-                for (int minutes = 0; minutes < 60; minutes += 15) {
-                    ZoneOffset zoneOffset = ZoneOffset.ofHoursMinutes(hour, minutes);
-                    map.put(zoneOffset, PRESENT);
-                }
+        for (int hour = -18; hour < 18; hour++) {
+            for (int minutes = 0; minutes < 60; minutes += 15) {
+                int totalSeconds = hour * 3600 + minutes * 60;
+                var offset0 = ZoneOffset.ofTotalSeconds(totalSeconds);
+                var offset1 = ZoneOffset.ofTotalSeconds(totalSeconds);
+                var offset2 = ZoneOffset.ofTotalSeconds(totalSeconds);
+                assertSame(offset0, offset1);
+                assertSame(offset1, offset2);
             }
         }
-        assertEquals(18 * 4, map.size());
-
-        for (int i = 0; i < 10; i++) {
-            for (int hour = -18; hour < 18; hour++) {
-                for (int minutes = 0; minutes < 60; minutes += 15) {
-                    int totalSeconds = hour * 3600 + minutes * 60;
-                    ZoneOffset zoneOffset = ZoneOffset.ofTotalSeconds(totalSeconds);
-                    map.put(zoneOffset, PRESENT);
-                }
-            }
-        }
-
-        assertEquals(36 * 4, map.size());
     }
 
 }


### PR DESCRIPTION
ZoneOffset.MINUTES_15_CACHE uses AtomicReferenceArray to replace ConcurrentMap to avoid object allocation caused by boxing from int to Integer during access.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348880](https://bugs.openjdk.org/browse/JDK-8348880): Replace ConcurrentMap with AtomicReferenceArray for ZoneOffset.QUARTER_CACHE (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [2765c4da](https://git.openjdk.org/jdk/pull/23337/files/2765c4daa8ba2afce6730b09f223c388c817fc2b)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23337/head:pull/23337` \
`$ git checkout pull/23337`

Update a local copy of the PR: \
`$ git checkout pull/23337` \
`$ git pull https://git.openjdk.org/jdk.git pull/23337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23337`

View PR using the GUI difftool: \
`$ git pr show -t 23337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23337.diff">https://git.openjdk.org/jdk/pull/23337.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23337#issuecomment-2619506557)
</details>
