### PR TITLE
8348800: Many serviceability/sa tests failing after JDK-8348239

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -155,7 +155,13 @@ public class Threads {
         virtualConstructor.addMapping("NotificationThread", NotificationThread.class);
         virtualConstructor.addMapping("StringDedupThread", StringDedupThread.class);
         virtualConstructor.addMapping("AttachListenerThread", AttachListenerThread.class);
-        virtualConstructor.addMapping("DeoptimizeObjectsALotThread", DeoptimizeObjectsALotThread.class);
+
+        /* Only add DeoptimizeObjectsALotThread if it is actually present in the type database. */
+        try {
+            db.lookupType("DeoptimizeObjectsALotThread");
+            virtualConstructor.addMapping("DeoptimizeObjectsALotThread", DeoptimizeObjectsALotThread.class);
+        } catch (RuntimeException e) {
+        }
     }
 
     public Threads() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -157,10 +157,8 @@ public class Threads {
         virtualConstructor.addMapping("AttachListenerThread", AttachListenerThread.class);
 
         /* Only add DeoptimizeObjectsALotThread if it is actually present in the type database. */
-        try {
-            db.lookupType("DeoptimizeObjectsALotThread");
+        if (db.lookupType("DeoptimizeObjectsALotThread", false) != null) {
             virtualConstructor.addMapping("DeoptimizeObjectsALotThread", DeoptimizeObjectsALotThread.class);
-        } catch (RuntimeException e) {
         }
     }
 


### PR DESCRIPTION
DeoptimizeObjectsALotThread was being unconditionally added to the mapping table:

       virtualConstructor.addMapping("DeoptimizeObjectsALotThread", DeoptimizeObjectsALotThread.class);

But is conditionally included in VMStructs:

         DEBUG_ONLY(COMPILER2_OR_JVMCI_PRESENT( \
          declare_type(DeoptimizeObjectsALotThread, JavaThread))) \ 

There is code that iterates over all the mapping table entries and calls db.lookupType() on each. This results in a RuntimeException if the type is not present in the type database:

 Caused by: java.lang.RuntimeException: No type named "DeoptimizeObjectsALotThread" in database 

The fix is to not add it to the mapping table if it is not present in the database.

Testing is in progresses. I did test locally with a debug build using TEST_VM_OPTS=-XX:+DeoptimizeObjectsALot to make sure the original DeoptimizeObjectsALotThread issue is still fixed, and then tested a release build without TEST_VM_OPTS=-XX:+DeoptimizeObjectsALot to make sure this new issue did not reproduce.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348800](https://bugs.openjdk.org/browse/JDK-8348800): Many serviceability/sa tests failing after JDK-8348239 (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23339/head:pull/23339` \
`$ git checkout pull/23339`

Update a local copy of the PR: \
`$ git checkout pull/23339` \
`$ git pull https://git.openjdk.org/jdk.git pull/23339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23339`

View PR using the GUI difftool: \
`$ git pr show -t 23339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23339.diff">https://git.openjdk.org/jdk/pull/23339.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23339#issuecomment-2619869228)
</details>
