### PR TITLE
8348888: tier1 closed build failure on Windows after JDK-8348348

### DIFF
--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -74,7 +74,9 @@ static jint INITIAL_META_COUNT = 2;   /* initial number of entries in meta name 
 /*
  * Declare library specific JNI_Onload entry
  */
+#ifndef WIN32
 DEF_STATIC_JNI_OnLoad
+#endif
 
 /*
  * The ZFILE_* functions exist to provide some platform-independence with


### PR DESCRIPTION
Please review this workaround for the compiler error on Windows. This error occurs in closed build with custom make logic that uses zip_util.c. The error indicates `DEF_STATIC_JNI_OnLoad` is not defined, thus disable the macro on Windows for now until the cause is fully understood.

```
[2025-01-28T16:57:35,721Z] c:\sb\prod\1738083154\workspace\open\src\java.base\share\native\libzip\zip_util.c(94): error C2054: expected '(' to follow 'DEF_STATIC_JNI_OnLoad'
[2025-01-28T16:57:35,721Z] c:\sb\prod\1738083154\workspace\open\src\java.base\share\native\libzip\zip_util.c(94): error C2085: 'ZFILE_Open': not in formal parameter list
[2025-01-28T16:57:35,737Z] c:\sb\prod\1738083154\workspace\open\src\java.base\share\native\libzip\zip_util.c(94): error C2143: syntax error: missing ';' before '{'
[2025-01-28T16:57:35,737Z] c:\sb\prod\1738083154\workspace\open\src\java.base\share\native\libzip\zip_util.c(776): warning C4013: 'ZFILE_Open' undefined; assuming extern returning int
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8348888](https://bugs.openjdk.org/browse/JDK-8348888): tier1 closed build failure on Windows after JDK-8348348 (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23340/head:pull/23340` \
`$ git checkout pull/23340`

Update a local copy of the PR: \
`$ git checkout pull/23340` \
`$ git pull https://git.openjdk.org/jdk.git pull/23340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23340`

View PR using the GUI difftool: \
`$ git pr show -t 23340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23340.diff">https://git.openjdk.org/jdk/pull/23340.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23340#issuecomment-2619884132)
</details>
