### PR TITLE
8347428: Avoid using secret-key in specifications

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
@@ -820,7 +820,7 @@ public final class JceKeyStore extends KeyStoreSpi {
                         // Add the entry to the list
                         entries.put(alias, entry);
 
-                    } else if (tag == 3) { // secret-key entry
+                    } else if (tag == 3) { // secret key entry
                         secretKeyCount++;
                         SecretKeyEntry entry = new SecretKeyEntry();
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -566,7 +566,7 @@ public final class SunJCE extends Provider {
                 null);
 
         /*
-         * Secret-key factories
+         * Secret key factories
          */
         ps("SecretKeyFactory", "DES",
                 "com.sun.crypto.provider.DESKeyFactory");

--- a/src/java.base/share/classes/javax/crypto/SecretKeyFactory.java
+++ b/src/java.base/share/classes/javax/crypto/SecretKeyFactory.java
@@ -52,7 +52,7 @@ import sun.security.jca.GetInstance.Instance;
  * {@link #generateSecret(java.security.spec.KeySpec) generateSecret} and
  * {@link #getKeySpec(javax.crypto.SecretKey, java.lang.Class) getKeySpec}
  * methods.
- * For example, the DESede (Triple DES) secret-key factory supplied by the
+ * For example, the DESede (Triple DES) secret key factory supplied by the
  * "SunJCE" provider supports {@code DESedeKeySpec} as a transparent
  * representation of Triple DES keys.
  *
@@ -100,7 +100,7 @@ public class SecretKeyFactory {
      *
      * @param keyFacSpi the delegate
      * @param provider the provider
-     * @param algorithm the secret-key algorithm
+     * @param algorithm the secret key algorithm
      */
     protected SecretKeyFactory(SecretKeyFactorySpi keyFacSpi,
                                Provider provider, String algorithm) {
@@ -140,7 +140,7 @@ public class SecretKeyFactory {
      * may be different from the order of providers returned by
      * {@link Security#getProviders() Security.getProviders()}.
      *
-     * @param algorithm the standard name of the requested secret-key
+     * @param algorithm the standard name of the requested secret key
      * algorithm.
      * See the SecretKeyFactory section in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#secretkeyfactory-algorithms">
@@ -176,7 +176,7 @@ public class SecretKeyFactory {
      * <p> Note that the list of registered providers may be retrieved via
      * the {@link Security#getProviders() Security.getProviders()} method.
      *
-     * @param algorithm the standard name of the requested secret-key
+     * @param algorithm the standard name of the requested secret key
      * algorithm.
      * See the SecretKeyFactory section in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#secretkeyfactory-algorithms">
@@ -221,7 +221,7 @@ public class SecretKeyFactory {
      * object is returned.  Note that the specified provider object
      * does not have to be registered in the provider list.
      *
-     * @param algorithm the standard name of the requested secret-key
+     * @param algorithm the standard name of the requested secret key
      * algorithm.
      * See the SecretKeyFactory section in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#secretkeyfactory-algorithms">
@@ -327,7 +327,7 @@ public class SecretKeyFactory {
      * @return the secret key
      *
      * @exception InvalidKeySpecException if the given key specification
-     * is inappropriate for this secret-key factory to produce a secret key.
+     * is inappropriate for this secret key factory to produce a secret key.
      */
     public final SecretKey generateSecret(KeySpec keySpec)
             throws InvalidKeySpecException {
@@ -371,7 +371,7 @@ public class SecretKeyFactory {
      * whereas {@code keySpec} is the specification of a software-based
      * key), or the given key cannot be dealt with
      * (e.g., the given key has an algorithm or format not supported by this
-     * secret-key factory).
+     * secret key factory).
      */
     public final KeySpec getKeySpec(SecretKey key, Class<?> keySpec)
             throws InvalidKeySpecException {
@@ -399,14 +399,14 @@ public class SecretKeyFactory {
 
     /**
      * Translates a key object, whose provider may be unknown or potentially
-     * untrusted, into a corresponding key object of this secret-key factory.
+     * untrusted, into a corresponding key object of this secret key factory.
      *
      * @param key the key whose provider is unknown or untrusted
      *
      * @return the translated key
      *
      * @exception InvalidKeyException if the given key cannot be processed
-     * by this secret-key factory.
+     * by this secret key factory.
      */
     public final SecretKey translateKey(SecretKey key)
             throws InvalidKeyException {

--- a/src/java.base/share/classes/javax/crypto/SecretKeyFactorySpi.java
+++ b/src/java.base/share/classes/javax/crypto/SecretKeyFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/crypto/SecretKeyFactorySpi.java
+++ b/src/java.base/share/classes/javax/crypto/SecretKeyFactorySpi.java
@@ -33,13 +33,13 @@ import java.security.spec.*;
  * for the {@code SecretKeyFactory} class.
  * All the abstract methods in this class must be implemented by each
  * cryptographic service provider who wishes to supply the implementation
- * of a secret-key factory for a particular algorithm.
+ * of a secret key factory for a particular algorithm.
  *
  * <P> A provider should document all the key specifications supported by its
  * secret key factory.
- * For example, the DES secret-key factory supplied by the "SunJCE" provider
+ * For example, the DES secret key factory supplied by the "SunJCE" provider
  * supports {@code DESKeySpec} as a transparent representation of DES
- * keys, and that provider's secret-key factory for Triple DES keys supports
+ * keys, and that provider's secret key factory for Triple DES keys supports
  * {@code DESedeKeySpec} as a transparent representation of Triple DES
  * keys.
  *
@@ -67,7 +67,7 @@ public abstract class SecretKeyFactorySpi {
      * @return the secret key
      *
      * @exception InvalidKeySpecException if the given key specification
-     * is inappropriate for this secret-key factory to produce a secret key.
+     * is inappropriate for this secret key factory to produce a secret key.
      */
     protected abstract SecretKey engineGenerateSecret(KeySpec keySpec)
         throws InvalidKeySpecException;
@@ -91,7 +91,7 @@ public abstract class SecretKeyFactorySpi {
      * whereas {@code keySpec} is the specification of a software-based
      * key), or the given key cannot be dealt with
      * (e.g., the given key has an algorithm or format not supported by this
-     * secret-key factory).
+     * secret key factory).
      */
     protected abstract KeySpec engineGetKeySpec(SecretKey key, Class<?> keySpec)
         throws InvalidKeySpecException;
@@ -99,14 +99,14 @@ public abstract class SecretKeyFactorySpi {
     /**
      * Translates a key object, whose provider may be unknown or
      * potentially untrusted, into a corresponding key object of this
-     * secret-key factory.
+     * secret key factory.
      *
      * @param key the key whose provider is unknown or untrusted
      *
      * @return the translated key
      *
      * @exception InvalidKeyException if the given key cannot be processed
-     * by this secret-key factory.
+     * by this secret key factory.
      */
     protected abstract SecretKey engineTranslateKey(SecretKey key)
         throws InvalidKeyException;

--- a/src/java.base/share/classes/javax/crypto/spec/PBEKeySpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/PBEKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/crypto/spec/PBEKeySpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/PBEKeySpec.java
@@ -42,9 +42,9 @@ import java.util.Arrays;
  * PKCS #12 looks at all 16 bits of each character.
  *
  * <p>You convert the password characters to a PBE key by creating an
- * instance of the appropriate secret-key factory. For example, a secret-key
+ * instance of the appropriate secret key factory. For example, a secret key
  * factory for PKCS #5 will construct a PBE key from only the low order 8 bits
- * of each password character, whereas a secret-key factory for PKCS #12 will
+ * of each password character, whereas a secret key factory for PKCS #12 will
  * take all 16 bits of each character.
  *
  * <p>Also note that this class stores passwords as char arrays instead of

--- a/src/java.base/share/classes/javax/crypto/spec/SecretKeySpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/SecretKeySpec.java
@@ -91,7 +91,7 @@ public class SecretKeySpec implements KeySpec, SecretKey {
      *
      * @param key the key material of the secret key. The contents of
      * the array are copied to protect against subsequent modification.
-     * @param algorithm the name of the secret-key algorithm to be associated
+     * @param algorithm the name of the secret key algorithm to be associated
      * with the given key material.
      * See the SecretKey Algorithms section in the
      * <a href="{@docRoot}/../specs/security/standard-names.html#secretkey-algorithms">
@@ -136,7 +136,7 @@ public class SecretKeySpec implements KeySpec, SecretKey {
      * @param offset the offset in <code>key</code> where the key material
      * starts.
      * @param len the length of the key material.
-     * @param algorithm the name of the secret-key algorithm to be associated
+     * @param algorithm the name of the secret key algorithm to be associated
      * with the given key material.
      * See the SecretKey Algorithms section in the
      * <a href="{@docRoot}/../specs/security/standard-names.html#secretkey-algorithms">

--- a/test/jdk/com/sun/crypto/provider/CICO/PBEFunc/AbstractPBEWrapper.java
+++ b/test/jdk/com/sun/crypto/provider/CICO/PBEFunc/AbstractPBEWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/crypto/provider/CICO/PBEFunc/AbstractPBEWrapper.java
+++ b/test/jdk/com/sun/crypto/provider/CICO/PBEFunc/AbstractPBEWrapper.java
@@ -43,7 +43,7 @@ public abstract class AbstractPBEWrapper {
     protected final String transformation;
 
     /**
-     * the standard name of the requested secret-key algorithm.
+     * the standard name of the requested secret key algorithm.
      */
     protected final String baseAlgo;
 


### PR DESCRIPTION
There are quite some places in API specifications that use the term "secret-key". This is not a formal term. Consider replacing them with "secret key".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347428](https://bugs.openjdk.org/browse/JDK-8347428): Avoid using secret-key in specifications (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23342/head:pull/23342` \
`$ git checkout pull/23342`

Update a local copy of the PR: \
`$ git checkout pull/23342` \
`$ git pull https://git.openjdk.org/jdk.git pull/23342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23342`

View PR using the GUI difftool: \
`$ git pr show -t 23342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23342.diff">https://git.openjdk.org/jdk/pull/23342.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23342#issuecomment-2619975382)
</details>
