### PR TITLE
8348892: Properly fix compilation error for zip_util.c on Windows

### DIFF
--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -74,9 +74,7 @@ static jint INITIAL_META_COUNT = 2;   /* initial number of entries in meta name 
 /*
  * Declare library specific JNI_Onload entry
  */
-#ifndef WIN32
 DEF_STATIC_JNI_OnLoad
-#endif
 
 /*
  * The ZFILE_* functions exist to provide some platform-independence with


### PR DESCRIPTION
Reapply [JDK-8348348](https://bugs.openjdk.org/browse/JDK-8348348)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348892](https://bugs.openjdk.org/browse/JDK-8348892): Properly fix compilation error for zip_util.c on Windows (**Sub-task** - P2) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Jiangli Zhou](https://openjdk.org/census#jiangli) (@jianglizhou - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23344/head:pull/23344` \
`$ git checkout pull/23344`

Update a local copy of the PR: \
`$ git checkout pull/23344` \
`$ git pull https://git.openjdk.org/jdk.git pull/23344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23344`

View PR using the GUI difftool: \
`$ git pr show -t 23344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23344.diff">https://git.openjdk.org/jdk/pull/23344.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23344#issuecomment-2620219816)
</details>
