### PR TITLE
8348905: Add support to specify the JDK for compiling Jtreg tests

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -78,6 +78,9 @@ $(eval $(call IncludeCustomExtension, RunTests.gmk))
 
 # This is the JDK that we will test
 JDK_UNDER_TEST := $(JDK_IMAGE_DIR)
+# The JDK used to compile jtreg test code. By default it is the same as
+# JDK_UNDER_TEST.
+JDK_FOR_COMPILE := $(JDK_IMAGE_DIR)
 
 TEST_RESULTS_DIR := $(OUTPUTDIR)/test-results
 TEST_SUPPORT_DIR := $(OUTPUTDIR)/test-support
@@ -979,6 +982,7 @@ define SetupRunJtregTestBody
       $$(JTREG_JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
           -Dprogram=jtreg -jar $$(JT_HOME)/lib/jtreg.jar \
           $$($1_JTREG_BASIC_OPTIONS) \
+          -compilejdk:$$(JDK_FOR_COMPILE) \
           -testjdk:$$(JDK_UNDER_TEST) \
           -dir:$$(JTREG_TOPDIR) \
           -reportDir:$$($1_TEST_RESULTS_DIR) \


### PR DESCRIPTION
This adds `-compilejdk:$$(JDK_FOR_COMPILE)` to the jtreg run command. By default `JDK_FOR_COMPILE` is set to `$(JDK_IMAGE_DIR)`, which is the same as `JDK_UNDER_TEST`. `JDK_FOR_COMPILE` can be set to an alternative JDK directory that is different from the JDK running the tests. For jtreg testing on the new `static-jdk` image (the static JDK built by `static-jdk-image`), this becomes useful. The `static-jdk` binary is a subset of the regular `jdk` and only contain the needed files for the `static` Java launcher. `JDK_FOR_COMPILE` can be set to a JDK directory containing the full JDK binary. For example:

`$ make test-tier1 JDK_IMAGE_DIR=/.../JDK-8348905/build/linux-x86_64-server-release/images/static-jdk JDK_FOR_COMPILE=/.../JDK-8348905/build/linux-x86_64-server-release/images/jdk`

Without the support, when running jtreg tests on `static-jdk` it produces following error:

```
Running test 'jtreg:test/hotspot/jtreg:tier1'
Error: Compilation of extra property definition files failed.
Finished running test 'jtreg:test/hotspot/jtreg:tier1'
Test report is stored in build/linux-x86_64-server-release/test-results/jtreg_test_hotspot_jtreg_tier1
Clean up dirs for jtreg_test_jdk_tier1
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348905](https://bugs.openjdk.org/browse/JDK-8348905): Add support to specify the JDK for compiling Jtreg tests (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23345/head:pull/23345` \
`$ git checkout pull/23345`

Update a local copy of the PR: \
`$ git checkout pull/23345` \
`$ git pull https://git.openjdk.org/jdk.git pull/23345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23345`

View PR using the GUI difftool: \
`$ git pr show -t 23345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23345.diff">https://git.openjdk.org/jdk/pull/23345.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23345#issuecomment-2620385596)
</details>
