### PR TITLE
8349157: Unnecessary Hashtable usage in XKeysym.javaKeycode2KeysymHash

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XKeysym.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XKeysym.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,9 @@
  */
 
 package sun.awt.X11;
+
 import java.util.Hashtable;
+import java.util.Map;
 import jdk.internal.misc.Unsafe;
 
 import sun.util.logging.PlatformLogger;
@@ -68,7 +70,12 @@ public class XKeysym {
     // for robot only it seems to me. After that, we can remove lookup table
     // from XWindow.c altogether.
     // Another use for reverse lookup: query keyboard state, for some keys.
-    static Hashtable<Integer, Long> javaKeycode2KeysymHash = new Hashtable<Integer, Long>();
+    private static final Map<Integer, Long> javaKeycode2KeysymHash = Map.of(
+            java.awt.event.KeyEvent.VK_CAPS_LOCK, XKeySymConstants.XK_Caps_Lock,
+            java.awt.event.KeyEvent.VK_NUM_LOCK, XKeySymConstants.XK_Num_Lock,
+            java.awt.event.KeyEvent.VK_SCROLL_LOCK, XKeySymConstants.XK_Scroll_Lock,
+            java.awt.event.KeyEvent.VK_KANA_LOCK, XKeySymConstants.XK_Kana_Lock
+    );
     static long keysym_lowercase = unsafe.allocateMemory(Native.getLongSize());
     static long keysym_uppercase = unsafe.allocateMemory(Native.getLongSize());
     static Keysym2JavaKeycode kanaLock = new Keysym2JavaKeycode(java.awt.event.KeyEvent.VK_KANA_LOCK,
@@ -289,9 +296,8 @@ public class XKeysym {
         Keysym2JavaKeycode jkc = getJavaKeycode( keysym );
         return jkc == null ? java.awt.event.KeyEvent.VK_UNDEFINED : jkc.getJavaKeycode();
     }
-    static long javaKeycode2Keysym( int jkey ) {
-        Long ks = javaKeycode2KeysymHash.get( jkey );
-        return  (ks == null ? 0 : ks.longValue());
+    static long javaKeycode2Keysym(int jkey) {
+        return javaKeycode2KeysymHash.getOrDefault(jkey, 0L);
     }
     /**
         Return keysym derived from a keycode and modifiers.
@@ -1716,14 +1722,6 @@ public class XKeysym {
         keysym2JavaKeycodeHash.put( Long.valueOf(XKeySymConstants.hpXK_mute_asciitilde),     new Keysym2JavaKeycode(java.awt.event.KeyEvent.VK_DEAD_TILDE, java.awt.event.KeyEvent.KEY_LOCATION_STANDARD));
 
         keysym2JavaKeycodeHash.put( Long.valueOf(XConstants.NoSymbol),     new Keysym2JavaKeycode(java.awt.event.KeyEvent.VK_UNDEFINED, java.awt.event.KeyEvent.KEY_LOCATION_UNKNOWN));
-
-        /* Reverse search of keysym by keycode. */
-
-        /* Add keyboard locking codes. */
-        javaKeycode2KeysymHash.put( java.awt.event.KeyEvent.VK_CAPS_LOCK, XKeySymConstants.XK_Caps_Lock);
-        javaKeycode2KeysymHash.put( java.awt.event.KeyEvent.VK_NUM_LOCK, XKeySymConstants.XK_Num_Lock);
-        javaKeycode2KeysymHash.put( java.awt.event.KeyEvent.VK_SCROLL_LOCK, XKeySymConstants.XK_Scroll_Lock);
-        javaKeycode2KeysymHash.put( java.awt.event.KeyEvent.VK_KANA_LOCK, XKeySymConstants.XK_Kana_Lock);
     }
 
 }


### PR DESCRIPTION
There is a field `sun.awt.X11.XKeysym#javaKeycode2KeysymHash` which uses legacy Hashtable class.
As this map is read-only and all its content is initialized in `<clinit>` we can safely use immutable Map instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349157](https://bugs.openjdk.org/browse/JDK-8349157): Unnecessary Hashtable usage in XKeysym.javaKeycode2KeysymHash (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23347/head:pull/23347` \
`$ git checkout pull/23347`

Update a local copy of the PR: \
`$ git checkout pull/23347` \
`$ git pull https://git.openjdk.org/jdk.git pull/23347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23347`

View PR using the GUI difftool: \
`$ git pr show -t 23347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23347.diff">https://git.openjdk.org/jdk/pull/23347.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23347#issuecomment-2627996328)
</details>
