### PR TITLE
8348658: [AArch64] The node limit in compiler/codegen/TestMatcherClone.java is too strict

### DIFF
--- a/test/hotspot/jtreg/compiler/codegen/TestMatcherClone.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestMatcherClone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class TestMatcherClone {
     }
 
     @Test(compLevel = CompLevel.C2)
-    @IR(counts = {IRNode.ADD_P_OF, "reg_imm", "<200"},
+    @IR(counts = {IRNode.ADD_P_OF, "reg_imm", "<400"},
         phase = CompilePhase.MATCHING)
     public void test() {
         iArr = new int[] {x % 2};


### PR DESCRIPTION
### Issue Summary

On some aarch64 machines, the node limit in the test `compiler/codegen/TestMatcherClone.java` is too strict.

### Changeset

On the aarch64 machine I used when developing the fix for [JDK-8331295](https://bugs.openjdk.org/browse/JDK-8331295), the fix caused the node count in the test to decrease from 522 to 174. As a result, I set the IR framework node count limit to <200 to capture this. @shipilev now reports that on another aarch64 machine, the fix instead results in a decrease from 696 to 350. Since the fix for [JDK-8331295](https://bugs.openjdk.org/browse/JDK-8331295) still applies (the node count indeed decreases as expected), we should adjust the limit to somewhere in between 350 and 522 to capture both cases. 400 seems like a reasonable value and is what I propose in this PR.

### Testing

- [GitHub Actions](https://github.com/dlunde/jdk/actions/runs/13014279125)
- `tier1` and HotSpot parts of `tier2` and `tier3` on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64.
- Extra testing of `TestMatcherClone.java` with various flag combinations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348658](https://bugs.openjdk.org/browse/JDK-8348658): [AArch64] The node limit in compiler/codegen/TestMatcherClone.java is too strict (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Contributors
 * Aleksey Shipilev `<shade@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23349/head:pull/23349` \
`$ git checkout pull/23349`

Update a local copy of the PR: \
`$ git checkout pull/23349` \
`$ git pull https://git.openjdk.org/jdk.git pull/23349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23349`

View PR using the GUI difftool: \
`$ git pr show -t 23349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23349.diff">https://git.openjdk.org/jdk/pull/23349.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23349#issuecomment-2622000156)
</details>
