### PR TITLE
8348910: Broken links in the JDK 24 JavaDoc API documentation, build 33

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -432,7 +432,7 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *     prefix {@code 'T'} forces this output to upper case.
  *
  * <tr><th scope="row" style="vertical-align:top">{@code 'z'}
- *     <td> <a href="http://www.ietf.org/rfc/rfc0822.txt">RFC&nbsp;822</a>
+ *     <td> <a href="https://www.ietf.org/rfc/rfc822.txt">RFC&nbsp;822</a>
  *     style numeric time zone offset from GMT, e.g. {@code -0800}.  This
  *     value will be adjusted as necessary for Daylight Saving Time.  For
  *     {@code long}, {@link Long}, and {@link Date} the time zone used is
@@ -1720,7 +1720,7 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <tr><th scope="row" style="vertical-align:top">{@code 'z'}
  *     <td style="vertical-align:top"> <code>'&#92;u007a'</code>
- *     <td> <a href="http://www.ietf.org/rfc/rfc0822.txt">RFC&nbsp;822</a>
+ *     <td> <a href="https://www.ietf.org/rfc/rfc822.txt">RFC&nbsp;822</a>
  *     style numeric time zone offset from GMT, e.g. {@code -0800}.  This
  *     value will be adjusted as necessary for Daylight Saving Time.  For
  *     {@code long}, {@link Long}, and {@link Date} the time zone used is

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/DefaultResponseControlFactory.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/DefaultResponseControlFactory.java
@@ -36,7 +36,7 @@ import javax.naming.ldap.*;
  * <ul>
  * <li>
  * Paged results, as defined in
- * <a href="http://www.ietf.org/rfc/rfc2696.txt">RFC 2696</a>.
+ * <a href="https://www.ietf.org/rfc/rfc2696.txt">RFC 2696</a>.
  * <li>
  * Server-side sorting, as defined in
  * <a href="http://www.ietf.org/rfc/rfc2891.txt">RFC 2891</a>.

--- a/src/java.naming/share/classes/javax/naming/ldap/PagedResultsControl.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/PagedResultsControl.java
@@ -92,7 +92,7 @@ import com.sun.jndi.ldap.BerEncoder;
  * } </pre>
  * <p>
  * This class implements the LDAPv3 Control for paged-results as defined in
- * <a href="http://www.ietf.org/rfc/rfc2696.txt">RFC 2696</a>.
+ * <a href="https://www.ietf.org/rfc/rfc2696.txt">RFC 2696</a>.
  *
  * The control's value has the following ASN.1 definition:
  * <pre>{@code

--- a/src/java.naming/share/classes/javax/naming/ldap/PagedResultsResponseControl.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/PagedResultsResponseControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import com.sun.jndi.ldap.BerDecoder;
  * <p>
  * This class implements the LDAPv3 Response Control for
  * paged-results as defined in
- * <a href="http://www.ietf.org/rfc/rfc2696">RFC 2696</a>.
+ * <a href="https://www.ietf.org/rfc/rfc2696.txt">RFC 2696</a>.
  *
  * The control's value has the following ASN.1 definition:
  * <pre>

--- a/src/jdk.jdi/share/classes/com/sun/jdi/connect/spi/TransportService.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/connect/spi/TransportService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ import com.sun.jdi.connect.TransportTimeoutException;
  * but may involve techniques such as the <i>positive
  * acknowledgment with retransmission</i> technique used in
  * protocols such as the Transmission Control Protocol (TCP)
- * (see <a href="http://www.ietf.org/rfc/rfc0793.txt"> RFC 793
+ * (see <a href="https://www.ietf.org/rfc/rfc793.txt"> RFC 793
  * </a>).
  *
  * <p> A transport service can be used to initiate a connection

--- a/test/docs/jdk/javadoc/doccheck/ExtLinksJdk.txt
+++ b/test/docs/jdk/javadoc/doccheck/ExtLinksJdk.txt
@@ -43,8 +43,8 @@ http://www.iana.org/assignments/character-sets/character-sets.xhtml
 http://www.iana.org/assignments/media-types/
 http://www.iana.org/assignments/uri-schemes.html
 http://www.ietf.org/
-http://www.ietf.org/rfc/rfc0793.txt
-http://www.ietf.org/rfc/rfc0822.txt
+https://www.ietf.org/rfc/rfc793.txt
+https://www.ietf.org/rfc/rfc822.txt
 http://www.ietf.org/rfc/rfc1122.txt
 http://www.ietf.org/rfc/rfc1123.txt
 http://www.ietf.org/rfc/rfc1323.txt
@@ -83,8 +83,7 @@ http://www.ietf.org/rfc/rfc2440.txt
 http://www.ietf.org/rfc/rfc2474.txt
 http://www.ietf.org/rfc/rfc2609.txt
 http://www.ietf.org/rfc/rfc2616.txt
-http://www.ietf.org/rfc/rfc2696
-http://www.ietf.org/rfc/rfc2696.txt
+https://www.ietf.org/rfc/rfc2696.txt
 http://www.ietf.org/rfc/rfc2710.txt
 http://www.ietf.org/rfc/rfc2732.txt
 http://www.ietf.org/rfc/rfc2743.txt


### PR DESCRIPTION
Contacted ietf, these are the new links to use.
This will need to be backported to JDK 24.

Note: the change to `ExtLinksJdk.txt` is because we partly use it to check external links, so it needs to be updated alongside the docs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8348910`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8348910`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23350/head:pull/23350` \
`$ git checkout pull/23350`

Update a local copy of the PR: \
`$ git checkout pull/23350` \
`$ git pull https://git.openjdk.org/jdk.git pull/23350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23350`

View PR using the GUI difftool: \
`$ git pr show -t 23350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23350.diff">https://git.openjdk.org/jdk/pull/23350.diff</a>

</details>
