### PR TITLE
8348976: MemorySegment::reinretpret should be force inlined

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -129,6 +129,7 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @Override
     @CallerSensitive
+    @ForceInline
     public final MemorySegment reinterpret(long newSize, Arena arena, Consumer<MemorySegment> cleanup) {
         Objects.requireNonNull(arena);
         return reinterpretInternal(Reflection.getCallerClass(), newSize,
@@ -137,12 +138,14 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @Override
     @CallerSensitive
+    @ForceInline
     public final MemorySegment reinterpret(long newSize) {
         return reinterpretInternal(Reflection.getCallerClass(), newSize, scope, null);
     }
 
     @Override
     @CallerSensitive
+    @ForceInline
     public final MemorySegment reinterpret(Arena arena, Consumer<MemorySegment> cleanup) {
         Objects.requireNonNull(arena);
         return reinterpretInternal(Reflection.getCallerClass(), byteSize(),


### PR DESCRIPTION
See the JBS issue.

Mark the implementation of `MemorySegment::reinterpret` with `@ForceInline` so that we prevent `Reflection.getCallerClass` from falling back to a slow stack walk.

This is a leftover from an earlier performance investigation, in which we observed `reinterpret` not being inlined, causing significant slowdowns.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348976](https://bugs.openjdk.org/browse/JDK-8348976): MemorySegment::reinretpret should be force inlined (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23352/head:pull/23352` \
`$ git checkout pull/23352`

Update a local copy of the PR: \
`$ git checkout pull/23352` \
`$ git pull https://git.openjdk.org/jdk.git pull/23352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23352`

View PR using the GUI difftool: \
`$ git pr show -t 23352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23352.diff">https://git.openjdk.org/jdk/pull/23352.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23352#issuecomment-2624737870)
</details>
