### PR TITLE
8348752: Enable -XX:+AOTClassLinking by default when -XX:AOTMode is specified

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -420,6 +420,11 @@ void CDSConfig::check_flag_aliases() {
 bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_flag_cmd_line) {
   check_flag_aliases();
 
+  if (!FLAG_IS_DEFAULT(AOTMode)) {
+    // Using any form of the new AOTMode switch enables enhanced optimizations.
+    FLAG_SET_ERGO_IF_DEFAULT(AOTClassLinking, true);
+  }
+
   if (AOTClassLinking) {
     // If AOTClassLinking is specified, enable all AOT optimizations by default.
     FLAG_SET_ERGO_IF_DEFAULT(AOTInvokeDynamicLinking, true);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d266ca96](https://github.com/openjdk/jdk/commit/d266ca965d214f54c1ab16c1863f87728542b3e0) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ioi Lam on 29 Jan 2025 and was reviewed by Aleksey Shipilev and Dan Heidinga.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348752](https://bugs.openjdk.org/browse/JDK-8348752): Enable -XX:+AOTClassLinking by default when -XX:AOTMode is specified (**Bug** - P2)


### Reviewers
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23354/head:pull/23354` \
`$ git checkout pull/23354`

Update a local copy of the PR: \
`$ git checkout pull/23354` \
`$ git pull https://git.openjdk.org/jdk.git pull/23354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23354`

View PR using the GUI difftool: \
`$ git pr show -t 23354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23354.diff">https://git.openjdk.org/jdk/pull/23354.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23354#issuecomment-2622333088)
</details>
