### PR TITLE
8301875: java.util.TimeZone.getSystemTimeZoneID uses C library default file mode 

### DIFF
--- a/src/java.base/windows/native/libjava/TimeZone_md.c
+++ b/src/java.base/windows/native/libjava/TimeZone_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ static char *matchJavaTZ(const char *java_home_dir, char *tzName)
     strcpy(mapFileName, java_home_dir);
     strcat(mapFileName, MAPPINGS_FILE);
 
-    if ((fp = fopen(mapFileName, "r")) == NULL) {
+    if (fopen_s(&fp, mapFileName, "rt") != 0) {
         jio_fprintf(stderr, "can't open %s.\n", mapFileName);
         free((void *) mapFileName);
         return NULL;


### PR DESCRIPTION
Force opening "tzmappings" file in text mode. Confirmed the fix with customer provided test case. Also replaced the file open function with the safer one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301875](https://bugs.openjdk.org/browse/JDK-8301875): java.util.TimeZone.getSystemTimeZoneID uses C library default file mode (**Bug** - P3)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23356/head:pull/23356` \
`$ git checkout pull/23356`

Update a local copy of the PR: \
`$ git checkout pull/23356` \
`$ git pull https://git.openjdk.org/jdk.git pull/23356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23356`

View PR using the GUI difftool: \
`$ git pr show -t 23356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23356.diff">https://git.openjdk.org/jdk/pull/23356.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23356#issuecomment-2622817063)
</details>
