### PR TITLE
JDK-8349002: GenShen: Deadlock during shutdown

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -317,6 +317,8 @@ void ShenandoahGenerationalControlThread::run_service() {
     }
   }
 
+  set_gc_mode(stopped);
+
   // Wait for the actual stop(), can't leave run_service() earlier.
   while (!should_terminate()) {
     os::naked_short_sleep(ShenandoahControlIntervalMin);
@@ -812,6 +814,7 @@ const char* ShenandoahGenerationalControlThread::gc_mode_name(ShenandoahGenerati
     case stw_full:          return "full";
     case servicing_old:     return "old";
     case bootstrapping_old: return "bootstrap";
+    case stopped:           return "stopped";
     default:                return "unknown";
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
@@ -48,7 +48,8 @@ public:
     stw_degenerated,
     stw_full,
     bootstrapping_old,
-    servicing_old
+    servicing_old,
+    stopped
   } GCMode;
 
 private:


### PR DESCRIPTION
[JDK-8345970](https://bugs.openjdk.org/browse/JDK-8345970) changed the order in which the control thread and regulator thread are shutdown. The new order (in which the control thread is shutdown first), may leave the regulator thread waiting indefinitely for a gc cycle that will never start.