### PR TITLE
8349003: NativeCallStack::print_on() output is unreadable

### DIFF
--- a/src/hotspot/share/utilities/nativeCallStack.cpp
+++ b/src/hotspot/share/utilities/nativeCallStack.cpp
@@ -115,5 +115,4 @@ void NativeCallStack::print_on(outputStream* out) const {
     print_frame(out, _stack[i]);
     out->cr();
   }
-  out->cr();
 }

--- a/src/hotspot/share/utilities/nativeCallStack.cpp
+++ b/src/hotspot/share/utilities/nativeCallStack.cpp
@@ -113,6 +113,7 @@ void NativeCallStack::print_on(outputStream* out) const {
   DEBUG_ONLY(assert_not_fake();)
   for (int i = 0; i < NMT_TrackingStackDepth && _stack[i] != nullptr; i++) {
     print_frame(out, _stack[i]);
+    out->cr();
   }
   out->cr();
 }


### PR DESCRIPTION
Please review this trivial change that improves output readability.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349003](https://bugs.openjdk.org/browse/JDK-8349003): NativeCallStack::print_on() output is unreadable (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [2cd05aea](https://git.openjdk.org/jdk/pull/23359/files/2cd05aea4ba689a45476ef02c2b3b52d845ab892)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23359/head:pull/23359` \
`$ git checkout pull/23359`

Update a local copy of the PR: \
`$ git checkout pull/23359` \
`$ git pull https://git.openjdk.org/jdk.git pull/23359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23359`

View PR using the GUI difftool: \
`$ git pr show -t 23359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23359.diff">https://git.openjdk.org/jdk/pull/23359.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23359#issuecomment-2622964184)
</details>
