### PR TITLE
8349009: JVM fails to start when AOTClassLinking is used with unverifiable old classes

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -322,6 +322,13 @@ bool SystemDictionaryShared::check_for_exclusion_impl(InstanceKlass* k) {
   if (!k->is_linked()) {
     if (has_class_failed_verification(k)) {
       return warn_excluded(k, "Failed verification");
+    } else if (CDSConfig::is_dumping_aot_linked_classes()) {
+      // Most loaded classes should have been speculatively linked by MetaspaceShared::link_class_for_cds().
+      // However, we do not speculatively link old classes, as they are not recorded by
+      // SystemDictionaryShared::record_linking_constraint(). As a result, such an unlinked
+      // class may fail to verify in AOTLinkedClassBulkLoader::init_required_classes_for_loader(),
+      // causing the JVM to fail at bootstrap.
+      return warn_excluded(k, "Unlinked class not supported by AOTClassLinking");
     }
   } else {
     if (!k->can_be_verified_at_dumptime()) {

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -518,14 +518,21 @@ hotspot_aot_classlinking = \
  -runtime/cds/appcds/cacheObject/ArchivedIntegerCacheTest.java \
  -runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java \
  -runtime/cds/appcds/CDSandJFR.java \
+ -runtime/cds/appcds/customLoader/CustomClassListDump.java \
  -runtime/cds/appcds/customLoader/HelloCustom_JFR.java \
+ -runtime/cds/appcds/customLoader/OldClassAndInf.java \
  -runtime/cds/appcds/customLoader/ParallelTestMultiFP.java \
  -runtime/cds/appcds/customLoader/ParallelTestSingleFP.java \
  -runtime/cds/appcds/customLoader/SameNameInTwoLoadersTest.java \
  -runtime/cds/appcds/DumpClassListWithLF.java \
  -runtime/cds/appcds/dynamicArchive/ModulePath.java \
+ -runtime/cds/appcds/dynamicArchive/LambdaCustomLoader.java \
+ -runtime/cds/appcds/dynamicArchive/LambdaForOldInfInBaseArchive.java \
  -runtime/cds/appcds/dynamicArchive/LambdaInBaseArchive.java \
  -runtime/cds/appcds/dynamicArchive/LambdasInTwoArchives.java \
+ -runtime/cds/appcds/dynamicArchive/OldClassAndInf.java \
+ -runtime/cds/appcds/dynamicArchive/OldClassInBaseArchive.java \
+ -runtime/cds/appcds/dynamicArchive/OldClassVerifierTrouble.java \
  -runtime/cds/appcds/HelloExtTest.java \
  -runtime/cds/appcds/javaldr/GCDuringDump.java \
  -runtime/cds/appcds/javaldr/LockDuringDump.java \
@@ -545,6 +552,13 @@ hotspot_aot_classlinking = \
  -runtime/cds/appcds/jvmti \
  -runtime/cds/appcds/LambdaProxyClasslist.java \
  -runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java \
+ -runtime/cds/appcds/NestHostOldInf.java \
+ -runtime/cds/appcds/OldClassTest.java \
+ -runtime/cds/appcds/OldClassWithjsr.java \
+ -runtime/cds/appcds/OldInfExtendsInfDefMeth.java \
+ -runtime/cds/appcds/OldSuperClass.java \
+ -runtime/cds/appcds/OldSuperInfIndirect.java \
+ -runtime/cds/appcds/OldSuperInf.java \
  -runtime/cds/appcds/redefineClass \
  -runtime/cds/appcds/resolvedConstants/AOTLinkedLambdas.java \
  -runtime/cds/appcds/resolvedConstants/AOTLinkedVarHandles.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClassA.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClassA.jasm
@@ -1,6 +1,25 @@
 /*
  * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
- * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
  */
 
 super public class BadOldClassA

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClassA.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClassA.jasm
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+
+super public class BadOldClassA
+    version 49:0
+{
+
+
+public Method "<init>":"()V"
+    stack 1 locals 1
+{
+        aload_0;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        return;
+}
+
+    /*
+     * The following method tries to return an Object as a String.
+     * Verifier should fail.
+     */
+public Method doit:"()Ljava/lang/String;"
+    stack 2 locals 1
+{
+        new              class java/lang/Object;
+        dup;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        astore_0;
+        aload_0;
+        areturn;   // tries to return an Object as a String
+}
+
+} // end Class BadOldClassA

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClassB.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClassB.jasm
@@ -1,6 +1,25 @@
 /*
  * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
- * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
  */
 
 super public class BadOldClassB

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClassB.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BadOldClassB.jasm
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+
+super public class BadOldClassB
+    version 49:0
+{
+
+
+public Method "<init>":"()V"
+    stack 1 locals 1
+{
+        aload_0;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        return;
+}
+
+    /*
+     * The following method tries to return an Object as a String.
+     * Verifier should fail.
+     */
+public Method doit:"()Ljava/lang/String;"
+    stack 2 locals 1
+{
+        new              class java/lang/Object;
+        dup;
+        invokespecial    Method java/lang/Object."<init>":"()V";
+        astore_0;
+        aload_0;
+        areturn;   // tries to return an Object as a String
+}
+
+} // end Class BadOldClassB

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,9 +32,10 @@
  * @comment work around JDK-8345635
  * @requires !vm.jvmci.enabled
  * @library /test/jdk/lib/testlibrary /test/lib
- * @build InitiatingLoaderTester
+ * @build InitiatingLoaderTester BadOldClassA BadOldClassB
  * @build BulkLoaderTest
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar BulkLoaderTestApp.jar BulkLoaderTestApp MyUtil InitiatingLoaderTester
+ *                 BadOldClassA BadOldClassB
  * @run driver BulkLoaderTest STATIC
  */
 
@@ -44,9 +45,10 @@
  * @comment work around JDK-8345635
  * @requires !vm.jvmci.enabled
  * @library /test/jdk/lib/testlibrary /test/lib
- * @build InitiatingLoaderTester
+ * @build InitiatingLoaderTester BadOldClassA BadOldClassB
  * @build jdk.test.whitebox.WhiteBox BulkLoaderTest
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar BulkLoaderTestApp.jar BulkLoaderTestApp MyUtil InitiatingLoaderTester
+ *                 BadOldClassA BadOldClassB
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. BulkLoaderTest DYNAMIC
  */
@@ -129,6 +131,7 @@ class BulkLoaderTestApp {
     public static void main(String args[]) throws Exception {
         checkClasses();
         checkInitiatingLoader();
+        checkOldClasses();
     }
 
     // Check the ClassLoader/Module/Package/ProtectionDomain/CodeSource of classes that are aot-linked
@@ -228,6 +231,29 @@ class BulkLoaderTestApp {
         }
 
         throw new RuntimeException("Should not have succeeded");
+    }
+
+    static void checkOldClasses() throws Exception {
+        // Resolve BadOldClassA from the constant pool without linking it.
+        // implNote: BadOldClassA will be excluded, so any resolved refereces
+        // to BadOldClassA should be removed from the constant pool.
+        Class c = BadOldClassA.class;
+        Object n = new Object();
+        if (c.isInstance(n)) {
+            throw new RuntimeException("Must not succeed");
+        }
+
+        try {
+            // In dynamic dump, the VM loads BadOldClassB and then attempts to
+            // link it. This will leave BadOldClassB in a "failed verification" state.
+            // All refernces to BadOldClassB from the CP should be purged from the CDS
+            // archive.
+            c = BadOldClassB.class;
+            c.newInstance();
+            throw new RuntimeException("Must not succeed");
+        } catch (VerifyError e) {
+            System.out.println("Caught VerifyError for BadOldClassA: " + e);
+        }
     }
 }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
@@ -252,7 +252,7 @@ class BulkLoaderTestApp {
             c.newInstance();
             throw new RuntimeException("Must not succeed");
         } catch (VerifyError e) {
-            System.out.println("Caught VerifyError for BadOldClassA: " + e);
+            System.out.println("Caught VerifyError for BadOldClassB: " + e);
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
@@ -236,10 +236,10 @@ class BulkLoaderTestApp {
     static void checkOldClasses() throws Exception {
         // Resolve BadOldClassA from the constant pool without linking it.
         // implNote: BadOldClassA will be excluded, so any resolved refereces
-        // to BadOldClassA should be removed from the constant pool.
+        // to BadOldClassA should be removed from the archived constant pool.
         Class c = BadOldClassA.class;
         Object n = new Object();
-        if (c.isInstance(n)) {
+        if (c.isInstance(n)) { // Note that type-testing BadOldClassA here neither links nor initailizes it.
             throw new RuntimeException("Must not succeed");
         }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
@@ -239,7 +239,7 @@ class BulkLoaderTestApp {
         // to BadOldClassA should be removed from the archived constant pool.
         Class c = BadOldClassA.class;
         Object n = new Object();
-        if (c.isInstance(n)) { // Note that type-testing BadOldClassA here neither links nor initailizes it.
+        if (c.isInstance(n)) { // Note that type-testing BadOldClassA here neither links nor initializes it.
             throw new RuntimeException("Must not succeed");
         }
 


### PR DESCRIPTION
During the testing of [JDK-8348752](https://bugs.openjdk.org/browse/JDK-8348752), we notice test failures caused by unverifiable old classes (i.e., classes with bad instructions and major version < 50).

The fix is simple. Simply exclude unlinked classes from the AOTCache when `-XX:+AOTClassLinking` is enabled.

Verified with JCK.

NOTE: I have to exclude some old CDS tests from test tasks that add the `-XX:+AOTClassLinking` flag. These test cases assume that **verifiable but unlinked** classes are archived. However, with this PR, such classes are no longer archived. These tests are now added to `TEST.groups`, along with other old CDS tests that are no longer valid with  `-XX:+AOTClassLinking`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349009](https://bugs.openjdk.org/browse/JDK-8349009): JVM fails to start when AOTClassLinking is used with unverifiable old classes (**Bug** - P2)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewers
 * [John R Rose](https://openjdk.org/census#jrose) (@rose00 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23361/head:pull/23361` \
`$ git checkout pull/23361`

Update a local copy of the PR: \
`$ git checkout pull/23361` \
`$ git pull https://git.openjdk.org/jdk.git pull/23361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23361`

View PR using the GUI difftool: \
`$ git pr show -t 23361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23361.diff">https://git.openjdk.org/jdk/pull/23361.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23361#issuecomment-2623397516)
</details>
