### PR TITLE
8348610: GenShen: TestShenandoahEvacuationInformationEvent failed with setRegions >= regionsFreed: expected 1 >= 57

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGenerationalHeuristics.cpp
@@ -237,7 +237,7 @@ void ShenandoahGenerationalHeuristics::choose_collection_set(ShenandoahCollectio
     evacInfo.set_regular_promoted_free(regular_regions_promoted_free);
     evacInfo.set_regions_immediate(immediate_regions);
     evacInfo.set_immediate_size(immediate_garbage);
-    evacInfo.set_regions_freed(free_regions);
+    evacInfo.set_free_regions(free_regions);
 
     ShenandoahTracer().report_evacuation_info(&evacInfo);
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacInfo.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacInfo.hpp
@@ -35,20 +35,20 @@ class ShenandoahEvacuationInformation : public StackObj {
   size_t _collected_old;
   size_t _collected_promoted;
   size_t _collected_young;
+  size_t _free_regions;
   size_t _regions_promoted_humongous;
   size_t _regions_promoted_regular;
   size_t _regular_promoted_garbage;
   size_t _regular_promoted_free;
-  size_t _regions_freed;
   size_t _regions_immediate;
   size_t _immediate_size;
 
 public:
   ShenandoahEvacuationInformation() :
     _collection_set_regions(0), _collection_set_used_before(0), _collection_set_used_after(0),
-    _collected_old(0), _collected_promoted(0), _collected_young(0), _regions_promoted_humongous(0),
-    _regions_promoted_regular(0), _regular_promoted_garbage(0), _regular_promoted_free(0),
-    _regions_freed(0), _regions_immediate(0), _immediate_size(0) { }
+    _collected_old(0), _collected_promoted(0), _collected_young(0), _free_regions(0),
+    _regions_promoted_humongous(0), _regions_promoted_regular(0), _regular_promoted_garbage(0),
+    _regular_promoted_free(0), _regions_immediate(0), _immediate_size(0) { }
 
   void set_collection_set_regions(size_t collection_set_regions) {
     _collection_set_regions = collection_set_regions;
@@ -74,8 +74,8 @@ public:
     _collected_young = collected;
   }
 
-  void set_regions_freed(size_t freed) {
-    _regions_freed = freed;
+  void set_free_regions(size_t freed) {
+    _free_regions = freed;
   }
 
   void set_regions_promoted_humongous(size_t humongous) {
@@ -112,7 +112,7 @@ public:
   size_t regions_promoted_regular()   { return _regions_promoted_regular; }
   size_t regular_promoted_garbage()   { return _regular_promoted_garbage; }
   size_t regular_promoted_free()      { return _regular_promoted_free; }
-  size_t regions_freed()              { return _regions_freed; }
+  size_t free_regions()               { return _free_regions; }
   size_t regions_immediate()          { return _regions_immediate; }
   size_t immediate_size()             { return _immediate_size; }
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahTrace.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahTrace.cpp
@@ -44,7 +44,7 @@ void ShenandoahTracer::send_evacuation_info_event(ShenandoahEvacuationInformatio
     e.set_regionsPromotedRegular(info->regions_promoted_regular());
     e.set_regularPromotedGarbage(info->regular_promoted_garbage());
     e.set_regularPromotedFree(info->regular_promoted_free());
-    e.set_regionsFreed(info->regions_freed());
+    e.set_freeRegions(info->free_regions());
     e.set_regionsImmediate(info->regions_immediate());
     e.set_immediateBytes(info->immediate_size());
 

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1220,7 +1220,7 @@
     <Field type="ulong" name="regionsPromotedRegular" label="Regions Promoted Regular" />
     <Field type="ulong" contentType="bytes" name="regularPromotedGarbage" label="Regular Promoted Garbage" description="Garbage memory of in place promoted regular regions" />
     <Field type="ulong" contentType="bytes" name="regularPromotedFree" label="Regular Promoted Free" description="Free memory of in place promoted regular regions" />
-    <Field type="ulong" name="regionsFreed" label="Regions Freed" description="Free regions prior to determining collection set" />
+    <Field type="ulong" name="freeRegions" label="Free Regions" description="Free regions prior to collection" />
     <Field type="ulong" name="regionsImmediate" label="Regions Immediate" />
     <Field type="ulong" contentType="bytes" name="immediateBytes" label="Immediate Bytes" />
   </Event>

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestShenandoahEvacuationInformationEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestShenandoahEvacuationInformationEvent.java
@@ -49,6 +49,7 @@ public class TestShenandoahEvacuationInformationEvent {
 
     public static void main(String[] args) throws Exception {
         final long shenandoahHeapRegionSize = 1024 * 1024;
+        final long shenandoahMaxHeapRegionCount = 64;
         Recording recording = new Recording();
         recording.enable(EVENT_NAME).withThreshold(Duration.ofMillis(0));
         recording.start();
@@ -63,14 +64,14 @@ public class TestShenandoahEvacuationInformationEvent {
             }
             System.out.println("Event: " + event);
 
-            long setRegions = Events.assertField(event, "cSetRegions").atLeast(0L).getValue();
+            long cSetRegions = Events.assertField(event, "cSetRegions").atLeast(0L).getValue();
             long setUsedAfter = Events.assertField(event, "cSetUsedAfter").atLeast(0L).getValue();
             long setUsedBefore = Events.assertField(event, "cSetUsedBefore").atLeast(setUsedAfter).getValue();
-            long regionsFreed = Events.assertField(event, "regionsFreed").atLeast(0L).getValue();
+            long freeRegions = Events.assertField(event, "freeRegions").atLeast(0L).getValue();
             Events.assertField(event, "collectedOld").atLeast(0L).getValue();
             Events.assertField(event, "collectedYoung").atLeast(0L).getValue();
 
-            Asserts.assertGreaterThanOrEqual(setRegions, regionsFreed, "setRegions >= regionsFreed");
+            Asserts.assertGreaterThanOrEqual(shenandoahMaxHeapRegionCount, freeRegions + cSetRegions, "numRegions >= freeRegions + cSetRegions");
             Asserts.assertGreaterThanOrEqual(shenandoahHeapRegionSize * setRegions, setUsedAfter, "ShenandoahHeapRegionSize * setRegions >= setUsedAfter");
             Asserts.assertGreaterThanOrEqual(shenandoahHeapRegionSize * setRegions, setUsedBefore, "ShenandoahHeapRegionSize * setRegions >= setUsedBefore");
 


### PR DESCRIPTION
Renaming `ShenandoahEvacuationInformation.freedRegions` to `ShenandoahEvacuationInformation.freeRegions` for clarity, and fixing incorrect assertion in  TestShenandoahEvacuationInformationEvent.cpp

Tested with tier 1, tier 2, and tier 3 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348610](https://bugs.openjdk.org/browse/JDK-8348610): GenShen: TestShenandoahEvacuationInformationEvent failed with setRegions &gt;= regionsFreed: expected 1 &gt;= 57 (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23362/head:pull/23362` \
`$ git checkout pull/23362`

Update a local copy of the PR: \
`$ git checkout pull/23362` \
`$ git pull https://git.openjdk.org/jdk.git pull/23362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23362`

View PR using the GUI difftool: \
`$ git pr show -t 23362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23362.diff">https://git.openjdk.org/jdk/pull/23362.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23362#issuecomment-2623512448)
</details>
