### PR TITLE
8349040: Test compiler/inlining/LateInlinePrinting.java fails after JDK-8319850

### DIFF
--- a/test/hotspot/jtreg/compiler/inlining/LateInlinePrinting.java
+++ b/test/hotspot/jtreg/compiler/inlining/LateInlinePrinting.java
@@ -76,7 +76,7 @@ public class LateInlinePrinting {
             "-XX:+PrintCompilation",
             "-XX:CompileCommand=compileonly,compiler.inlining.LateInlinePrinting$TestLateInlining::test1",
             "-XX:CompileCommand=compileonly,compiler.inlining.LateInlinePrinting$TestLateInlining::test2",
-            "-XX:CompileCommand=quiet", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining", "-XX:+AlwaysIncrementalInline",
+            "-XX:CompileCommand=quiet", "-XX:+PrintInlining", "-XX:+AlwaysIncrementalInline",
             "-XX:CompileCommand=dontinline,compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline",
             TestLateInlining.class.getName()
         );

--- a/test/hotspot/jtreg/compiler/inlining/LateInlinePrinting.java
+++ b/test/hotspot/jtreg/compiler/inlining/LateInlinePrinting.java
@@ -29,6 +29,7 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @requires vm.flagless
+ * @requires vm.debug == true
  *
  * @run driver compiler.inlining.LateInlinePrinting
  */
@@ -75,7 +76,7 @@ public class LateInlinePrinting {
             "-XX:+PrintCompilation",
             "-XX:CompileCommand=compileonly,compiler.inlining.LateInlinePrinting$TestLateInlining::test1",
             "-XX:CompileCommand=compileonly,compiler.inlining.LateInlinePrinting$TestLateInlining::test2",
-            "-XX:CompileCommand=quiet", "-XX:+PrintInlining", "-XX:+AlwaysIncrementalInline",
+            "-XX:CompileCommand=quiet", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining", "-XX:+AlwaysIncrementalInline",
             "-XX:CompileCommand=dontinline,compiler.inlining.LateInlinePrinting$TestLateInlining::testFailInline",
             TestLateInlining.class.getName()
         );


### PR DESCRIPTION
Hi all,

This PR fix the test bug which report "VM option 'AlwaysIncrementalInline' is develop and is available only in debug version of VM". Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349040](https://bugs.openjdk.org/browse/JDK-8349040): Test compiler/inlining/LateInlinePrinting.java fails after JDK-8319850 (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23364/head:pull/23364` \
`$ git checkout pull/23364`

Update a local copy of the PR: \
`$ git checkout pull/23364` \
`$ git pull https://git.openjdk.org/jdk.git pull/23364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23364`

View PR using the GUI difftool: \
`$ git pr show -t 23364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23364.diff">https://git.openjdk.org/jdk/pull/23364.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23364#issuecomment-2624053163)
</details>
