### PR TITLE
8349039: Adjust exception No type named <ThreadType> in database

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/types/basic/BasicTypeDataBase.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/types/basic/BasicTypeDataBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ public class BasicTypeDataBase implements TypeDataBase {
   public Type lookupType(String cTypeName, boolean throwException) {
     Type type = nameToTypeMap.get(cTypeName);
     if (type == null && throwException) {
-      throw new RuntimeException("No type named \"" + cTypeName + "\" in database");
+      throw new RuntimeException("No type named \"" + cTypeName + "\" present in type database");
     }
     return type;
   }


### PR DESCRIPTION
We should the exception message from
Caused by: java.lang.RuntimeException: No type named "DeoptimizeObjectsALotThread" in database
to
Caused by: java.lang.RuntimeException: No type named "DeoptimizeObjectsALotThread" present in type database

(like we have in some other exceptions in the same class)

error was (from [JDK-8348800](https://bugs.openjdk.org/browse/JDK-8348800)) :
serviceability/sa/CDSJMapClstats.java

at jdk.hotspot.agent/sun.jvm.hotspot.runtime.Threads.createJavaThreadWrapper(Threads.java:196)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.Threads.getJavaThreadAt(Threads.java:178)
at jdk.hotspot.agent/sun.jvm.hotspot.oops.ObjectHeap.collectLiveRegions(ObjectHeap.java:320)
at jdk.hotspot.agent/sun.jvm.hotspot.oops.ObjectHeap.iterateSubtypes(ObjectHeap.java:216)
at jdk.hotspot.agent/sun.jvm.hotspot.oops.ObjectHeap.iterateObjectsOfKlass(ObjectHeap.java:116)
at jdk.hotspot.agent/sun.jvm.hotspot.oops.ObjectHeap.iterateObjectsOfKlass(ObjectHeap.java:128)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.ClassLoaderStats.printClassLoaderStatistics(ClassLoaderStats.java:95)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.ClassLoaderStats.run(ClassLoaderStats.java:78)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.JMap.run(JMap.java:121)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.startInternal(Tool.java:278)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.start(Tool.java:241)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.execute(Tool.java:134)
at jdk.hotspot.agent/sun.jvm.hotspot.tools.JMap.main(JMap.java:202)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.runJMAP(SALauncher.java:344)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.main(SALauncher.java:507)
Caused by: java.lang.RuntimeException: No type named "DeoptimizeObjectsALotThread" in database
at jdk.hotspot.agent/sun.jvm.hotspot.types.basic.BasicTypeDataBase.lookupType(BasicTypeDataBase.java:86)
at jdk.hotspot.agent/sun.jvm.hotspot.HotSpotTypeDataBase.lookupType(HotSpotTypeDataBase.java:137)
at jdk.hotspot.agent/sun.jvm.hotspot.types.basic.BasicTypeDataBase.lookupType(BasicTypeDataBase.java:80)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.VirtualConstructor.instantiateWrapperFor(VirtualConstructor.java:75)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.Threads.createJavaThreadWrapper(Threads.java:192)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349039](https://bugs.openjdk.org/browse/JDK-8349039): Adjust exception No type named &lt;ThreadType&gt; in database (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23365/head:pull/23365` \
`$ git checkout pull/23365`

Update a local copy of the PR: \
`$ git checkout pull/23365` \
`$ git pull https://git.openjdk.org/jdk.git pull/23365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23365`

View PR using the GUI difftool: \
`$ git pr show -t 23365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23365.diff">https://git.openjdk.org/jdk/pull/23365.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23365#issuecomment-2624097248)
</details>
