### PR TITLE
8349006: File.getCanonicalPath should remove "(on UNIX platforms)" from its specification

### DIFF
--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1518,7 +1518,7 @@ public class File
      * virtual machine with special privileges that allow it to execute files
      * that are not marked executable.
      *
-     * <p>An invocation of this method of the form {@code file.setExcutable(arg)}
+     * <p>An invocation of this method of the form {@code file.setExecutable(arg)}
      * behaves in exactly the same way as the invocation
      *
      * {@snippet lang=java :

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -588,8 +588,8 @@ public class File
      * {@link #getAbsolutePath} method, and then maps it to its unique form in a
      * system-dependent way.  This typically involves removing redundant names
      * such as {@code "."} and {@code ".."} from the pathname, resolving
-     * symbolic links (on UNIX platforms), and converting drive letters to a
-     * standard case (on Microsoft Windows platforms).
+     * symbolic links, and converting drive letters to a standard case (on
+     * Microsoft Windows platforms).
      *
      * <p> Every pathname that denotes an existing file or directory has a
      * unique canonical form.  Every pathname that denotes a nonexistent file


### PR DESCRIPTION
The change made for [JDK-8003887](https://bugs.openjdk.org/browse/JDK-8003887) updated `File.getCanonicalPath` to resolve symbolic links on Windows, but its specification was not modified to reflect this. Here it is proposed to correct that omission.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8349104](https://bugs.openjdk.org/browse/JDK-8349104) to be approved

### Issues
 * [JDK-8349006](https://bugs.openjdk.org/browse/JDK-8349006): File.getCanonicalPath should remove "(on UNIX platforms)" from its specification (**Bug** - P4)
 * [JDK-8349104](https://bugs.openjdk.org/browse/JDK-8349104): File.getCanonicalPath should remove "(on UNIX platforms)" from its specification (**CSR**)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23371/head:pull/23371` \
`$ git checkout pull/23371`

Update a local copy of the PR: \
`$ git checkout pull/23371` \
`$ git pull https://git.openjdk.org/jdk.git pull/23371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23371`

View PR using the GUI difftool: \
`$ git pr show -t 23371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23371.diff">https://git.openjdk.org/jdk/pull/23371.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23371#issuecomment-2624865742)
</details>
