### PR TITLE
8349000: Performance improvement for Currency.isPastCutoverDate(String)

### DIFF
--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -1179,7 +1179,7 @@ public final class Currency implements Serializable {
         // cutOver adheres to ISO8601 Local Date Time format (excluding nano secs)
         private static boolean isPastCutoverDate(String cutOver) {
             return System.currentTimeMillis() >
-                    LocalDateTime.parse(cutOver.trim(), DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                    LocalDateTime.parse(cutOver, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
                             .toInstant(ZoneOffset.UTC)
                             .toEpochMilli();
         }

--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -1176,7 +1176,7 @@ public final class Currency implements Serializable {
                     || prop.fraction != fractionDigit);
         }
 
-        // cutOver adheres to: "yyyy-MM-ddTHH:mm:ss"
+        // cutOver adheres to ISO8601 Local Date Time format (excluding nano secs)
         private static boolean isPastCutoverDate(String cutOver) {
             return System.currentTimeMillis() >
                     LocalDateTime.parse(cutOver.trim(), DateTimeFormatter.ISO_LOCAL_DATE_TIME)

--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -32,8 +32,10 @@ import java.io.FileReader;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.Serializable;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
@@ -1134,7 +1136,7 @@ public final class Currency implements Serializable {
                                 && !isPastCutoverDate(prop.date)) {
                             prop = null;
                         }
-                    } catch (ParseException ex) {
+                    } catch (DateTimeParseException ex) {
                         prop = null;
                     }
                 }
@@ -1174,15 +1176,12 @@ public final class Currency implements Serializable {
                     || prop.fraction != fractionDigit);
         }
 
-        private static boolean isPastCutoverDate(String s)
-                throws ParseException {
-            SimpleDateFormat format = new SimpleDateFormat(
-                    "yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT);
-            format.setTimeZone(TimeZone.getTimeZone("UTC"));
-            format.setLenient(false);
-            long time = format.parse(s.trim()).getTime();
-            return System.currentTimeMillis() > time;
-
+        // cutOver adheres to: "yyyy-MM-ddTHH:mm:ss"
+        private static boolean isPastCutoverDate(String cutOver) {
+            return System.currentTimeMillis() >
+                    LocalDateTime.parse(cutOver.trim(), DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                            .toInstant(ZoneOffset.UTC)
+                            .toEpochMilli();
         }
 
         private static void info(String message, Throwable t) {


### PR DESCRIPTION
Please review this PR which improves the performance of cut-over date checking when the user supplies a properties override via the `java.util.currency.data` sys prop. Replacing the `SimpleDateFormat` with a _java.time_ alternative has better performance. It should be noted that this method is only entered when the string `s` is confirmed to adhere to the format: `yyyy-MM-ddTHH:mm:ss`.

An alternative is using `LocalDateTime.of(..)` and extracting the date/time values ourselves from `s` with the known positions which is considerably faster but not as concise.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349000](https://bugs.openjdk.org/browse/JDK-8349000): Performance improvement for Currency.isPastCutoverDate(String) (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23374/head:pull/23374` \
`$ git checkout pull/23374`

Update a local copy of the PR: \
`$ git checkout pull/23374` \
`$ git pull https://git.openjdk.org/jdk.git pull/23374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23374`

View PR using the GUI difftool: \
`$ git pr show -t 23374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23374.diff">https://git.openjdk.org/jdk/pull/23374.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23374#issuecomment-2625400488)
</details>
