### PR TITLE
8349092: File.getFreeSpace violates specification if quotas are in effect (win)

### DIFF
--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -584,6 +584,13 @@ final class WinNTFileSystem extends FileSystem {
     @Override
     public long getSpace(File f, int t) {
         if (f.exists()) {
+            // the value for the number of bytes of free space returned by the
+            // native layer is not used here as it represents the number of free
+            // bytes not considering quotas, whereas the value returned for the
+            // number of usable bytes does respect quotas, and it is required
+            // that free space <= total space
+            if (t == SPACE_FREE)
+                t = SPACE_USABLE;
             return getSpace0(f, t);
         }
         return 0;

--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 4057701 6286712 6364377 8181919
+ * @bug 4057701 6286712 6364377 8181919 8349092
  * @requires (os.family == "linux" | os.family == "mac" |
  *            os.family == "windows")
  * @summary Basic functionality of File.get-X-Space methods.
@@ -175,6 +175,12 @@ public class GetXSpace {
         long ts = f.getTotalSpace();
         long fs = f.getFreeSpace();
         long us = f.getUsableSpace();
+
+        // Verify inequalities us <= fs <= ts (JDK-8349092)
+        if (fs > ts)
+            throw new RuntimeException(f + " free space " + fs + " > total space " + ts);
+        if (us > fs)
+            throw new RuntimeException(f + " usable space " + fs + " > free space " + ts);
 
         out.format("%s (%d):%n", s.name(), s.size());
         String fmt = "  %-4s total = %12d free = %12d usable = %12d%n";


### PR DESCRIPTION
On Windows, for `File.getFreeSpace` return the same value as returned by `File.getUsableSpace`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349092](https://bugs.openjdk.org/browse/JDK-8349092): File.getFreeSpace violates specification if quotas are in effect (win) (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23377/head:pull/23377` \
`$ git checkout pull/23377`

Update a local copy of the PR: \
`$ git checkout pull/23377` \
`$ git pull https://git.openjdk.org/jdk.git pull/23377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23377`

View PR using the GUI difftool: \
`$ git pr show -t 23377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23377.diff">https://git.openjdk.org/jdk/pull/23377.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23377#issuecomment-2626015331)
</details>
