### PR TITLE
8258246: sun.net.www.ParseUtil.decode throws java.lang.IllegalArgumentException: Error decoding percent encoded characters

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -239,7 +239,7 @@ public class URLClassPath {
     private static URL toFileURL(String s) {
         try {
             File f = new File(s).getCanonicalFile();
-            return ParseUtil.fileToEncodedURL(f);
+            return f.toPath().toUri().toURL();
         } catch (IOException e) {
             return null;
         }

--- a/src/java.base/share/classes/sun/net/www/ParseUtil.java
+++ b/src/java.base/share/classes/sun/net/www/ParseUtil.java
@@ -229,22 +229,6 @@ public final class ParseUtil {
         return sb.toString();
     }
 
-    public static URL fileToEncodedURL(File file)
-        throws MalformedURLException
-    {
-        String path = file.getAbsolutePath();
-        path = ParseUtil.encodePath(path);
-        if (!path.startsWith("/")) {
-            path = "/" + path;
-        }
-        if (!path.endsWith("/") && file.isDirectory()) {
-            path = path + "/";
-        }
-        @SuppressWarnings("deprecation")
-        var result = new URL("file", "", path);
-        return result;
-    }
-
     public static java.net.URI toURI(URL url) {
         String protocol = url.getProtocol();
         String auth = url.getAuthority();

--- a/test/jdk/jdk/internal/loader/URLClassPath/ClassPathUnicodeChars.java
+++ b/test/jdk/jdk/internal/loader/URLClassPath/ClassPathUnicodeChars.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assumptions.abort;
 
 /*
  * @test
- * @bug 8344908
+ * @bug 8258246
  * @summary verify that when locating resources, the URLClassPath can function properly
  *          when classpath elements contain Unicode characters with two, three or four
  *          byte UTF-8 encodings


### PR DESCRIPTION
`URLClassPath` called into `ParseUtil.fileToEncodedURL`, which misencoded characters with a four byte UTF-8 representation. Replacing that function with `toPath().toUri().toURL()` (and removing it, since its only used once) results in correct encoding for all Unicode characters.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8258246](https://bugs.openjdk.org/browse/JDK-8258246): sun.net.www.ParseUtil.decode throws java.lang.IllegalArgumentException: Error decoding percent encoded characters (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23383/head:pull/23383` \
`$ git checkout pull/23383`

Update a local copy of the PR: \
`$ git checkout pull/23383` \
`$ git pull https://git.openjdk.org/jdk.git pull/23383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23383`

View PR using the GUI difftool: \
`$ git pr show -t 23383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23383.diff">https://git.openjdk.org/jdk/pull/23383.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23383#issuecomment-2627073837)
</details>
