### PR TITLE
8348659: AArch64: IR rule failure with compiler/loopopts/superword/TestSplitPacks.java

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestSplitPacks.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestSplitPacks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.nio.ByteOrder;
 
 /*
  * @test
- * @bug 8326139
+ * @bug 8326139 8348659
  * @summary Test splitting packs in SuperWord
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestSplitPacks nCOH_nAV
@@ -816,7 +816,17 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeature = {"sse4.1", "true"})
+    // aarch64 limits minimum vector size to 8B, thus a vector size of
+    // length 2 for type "short" will not be generated
+    @IR(counts = {IRNode.LOAD_VECTOR_S, IRNode.VECTOR_SIZE_4, "> 0",
+                  IRNode.LOAD_VECTOR_S, IRNode.VECTOR_SIZE_8, "> 0",
+                  IRNode.ADD_VS,        IRNode.VECTOR_SIZE_8, "> 0",
+                  IRNode.ADD_VS,        IRNode.VECTOR_SIZE_4, "> 0",
+                  IRNode.STORE_VECTOR, "> 0"},
+        applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
+        applyIfPlatform = {"64-bit", "true"},
+        applyIfCPUFeature = {"sve", "true"})
     // Split pack into power-of-2 sizes
     static Object[] test5a(short[] a, short[] b, short val) {
         for (int i = 0; i < RANGE; i+=16) {


### PR DESCRIPTION
"test5a" in this file fails on Graviton3 (32B, SVE) as the compiler fails to match IR rules for vector size 2. This is because the minimum vector size for aarch64 machines is 8B and it does not support generation of vectors of 2 short values.

Modified the IR rules to have two separate rules - one for sse4.1 and another for sve.

The test now passes on Graviton3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348659](https://bugs.openjdk.org/browse/JDK-8348659): AArch64: IR rule failure with compiler/loopopts/superword/TestSplitPacks.java (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23385/head:pull/23385` \
`$ git checkout pull/23385`

Update a local copy of the PR: \
`$ git checkout pull/23385` \
`$ git pull https://git.openjdk.org/jdk.git pull/23385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23385`

View PR using the GUI difftool: \
`$ git pr show -t 23385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23385.diff">https://git.openjdk.org/jdk/pull/23385.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23385#issuecomment-2626979460)
</details>
