### PR TITLE
8349132: javac Analyzers should handle non-deferrable errors

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Analyzer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Analyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -735,7 +735,7 @@ public class Analyzer {
                     erroneous = true;
                 }
                 return true;
-            });
+            }, false);
         }
     }
 

--- a/test/langtools/tools/javac/analyzer/Diamond.java
+++ b/test/langtools/tools/javac/analyzer/Diamond.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8349132
+ * @summary Check behavior of the diamond analyzer
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main Diamond
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+
+import toolbox.TestRunner;
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class Diamond extends TestRunner {
+
+    private final ToolBox tb;
+
+    public static void main(String... args) throws Exception {
+        new Diamond().runTests();
+    }
+
+    Diamond() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public void runTests() throws Exception {
+        runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    @Test //JDK-8349132:
+    public void testMissingClassfileForConstructorParamType(Path base) throws Exception {
+        Path current = base.resolve(".");
+        Path lib = current.resolve("lib");
+        Path libSrc = lib.resolve("src");
+        Path libClasses = lib.resolve("classes");
+        tb.writeJavaFiles(libSrc,
+                          """
+                          package test;
+                          public class Utils {
+                              public static void run(Task<Param> uat) {
+                              }
+                          }
+                          """,
+                          """
+                          package test;
+                          public interface Task<T> {
+                              public void run(T t) throws Exception;
+                          }
+                          """,
+                          """
+                          package test;
+                          public class Param {
+                          }
+                          """);
+
+        Files.createDirectories(libClasses);
+
+        new JavacTask(tb)
+            .outdir(libClasses)
+            .files(tb.findJavaFiles(libSrc))
+            .run(Task.Expect.SUCCESS)
+            .writeAll();
+
+        Files.delete(libClasses.resolve("test").resolve("Param.class"));
+
+        Path src = current.resolve("src");
+        Path classes = current.resolve("classes");
+        tb.writeJavaFiles(src,
+                          """
+                          package test;
+                          public class Test {
+                              private static void test() {
+                                  Utils.run(new Task<Param>() {
+                                      @Override
+                                      public void run(Param parameter) throws Exception {
+                                      }
+                                  });
+                              }
+                          }
+                          """);
+
+        Files.createDirectories(classes);
+
+        var out = new JavacTask(tb)
+            .options("-XDfind=diamond",
+                     "-XDshould-stop.at=FLOW",
+                     "-XDrawDiagnostics")
+            .classpath(libClasses)
+            .outdir(classes)
+            .files(tb.findJavaFiles(src))
+            .run(Task.Expect.FAIL)
+            .writeAll()
+            .getOutputLines(Task.OutputKind.DIRECT);
+
+        var expectedOut = List.of(
+            "Test.java:4:28: compiler.err.cant.resolve.location: kindname.class, Param, , , (compiler.misc.location: kindname.class, test.Test, null)",
+            "Test.java:6:29: compiler.err.cant.resolve: kindname.class, Param, , ",
+            "2 errors"
+        );
+
+        if (!Objects.equals(expectedOut, out)) {
+            throw new AssertionError("Incorrect Output, expected: " + expectedOut +
+                                      ", actual: " + out);
+
+        }
+    }
+
+}


### PR DESCRIPTION
Consider this test script:
```
$ cat JDK8349132.sh 
mkdir -p JDK-8349132
cd JDK-8349132
cat >Utils.java <<EOF
package test;
public class Utils {
    public static void run(Task<Param> uat) {}
}
interface Task<T> {
    public void run(T t) throws Exception;
}
class Param {}
EOF
cat >Test.java <<EOF
package test;
public class Test {
    private static void test() {
        Utils.run(new Task<Param>() {
            @Override
            public void run(Param parameter) throws Exception {
            }
        });
    }
}
EOF

javac -d out Utils.java
rm out/test/Param.class
javac -XDfind=diamond -XDshould-stop.at=FLOW -classpath out Test.java
```

It fails with:
```
$ bash JDK8349132.sh 
Test.java:4: error: cannot find symbol
        Utils.run(new Task<Param>() {
                           ^
  symbol:   class Param
  location: class Test
Test.java:6: error: cannot find symbol
            public void run(Param parameter) throws Exception {
                            ^
  symbol: class Param
Test.java:4: error: cannot access Param
        Utils.run(new Task<Param>() {
             ^
  class file for test.Param not found
3 errors
An exception has occurred in the compiler (21.0.5). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.AssertionError: Analyzer error when processing: Utils.run(new Task<Param>(){
    
    () {
        super();
    }
    
    @Override
    public void run(Param parameter) throws Exception {
    }
});:java.lang.NullPointerException: Cannot invoke "com.sun.tools.javac.code.Type.getTypeArguments()" because "com.sun.tools.javac.util.List.get(int).type" is null
jdk.compiler/com.sun.tools.javac.comp.Analyzer$DiamondInitializer.process(Analyzer.java:258)
jdk.compiler/com.sun.tools.javac.comp.Analyzer$DiamondInitializer.process(Analyzer.java:228)
jdk.compiler/com.sun.tools.javac.comp.Analyzer.doAnalysis(Analyzer.java:577)
jdk.compiler/com.sun.tools.javac.comp.Analyzer$2.flush(Analyzer.java:547)
jdk.compiler/com.sun.tools.javac.comp.Analyzer.flush(Analyzer.java:591)
jdk.compiler/com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1425)
jdk.compiler/com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1393)
jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:976)
jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:319)
jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:178)
jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:64)
jdk.compiler/com.sun.tools.javac.Main.main(Main.java:50)
        at jdk.compiler/com.sun.tools.javac.util.Assert.error(Assert.java:162)
        at jdk.compiler/com.sun.tools.javac.comp.Analyzer.doAnalysis(Analyzer.java:579)
        at jdk.compiler/com.sun.tools.javac.comp.Analyzer$2.flush(Analyzer.java:547)
        at jdk.compiler/com.sun.tools.javac.comp.Analyzer.flush(Analyzer.java:591)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1425)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1393)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:976)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:319)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:178)
        at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:64)
        at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:50)
printing javac parameters to: /tmp/JDK-8349132/javac.20250131_133856.args
```

The reason for this is as follows: Some errors reported by javac have the "NON_DEFERRABLE" flag, which means the error should not be stored in `DeferredDiagnosticHandler`, but rather should be reported immediately.

This is particularly the case when e.g. entering the sources before annotation processing - the errors found during this enter run may be resolved by the AP. So, ordinary errors are stored in `DeferredDiagnosticHandler` and reported later if needed. Non-deferrable errors are not stored, but reported immediately, as those are typically serious errors that cannot be fixed by AP.

javac also has an `Analyzer`, which looks for code simplifications by speculatively simplifying the code, and re-attributing it to see if it would still compile. It is using `DeferredDiagnosticHandler`, so that if any errors are found during the speculative attribution, the code simplification is rejected.

But, if a non-deferrable error is reported during the speculative attribution, it is passed through `DeferredDiagnosticHandler` undetected, and the `Analyzer` may try to do further evaluations - which may crash the compiler.

The proposal in the PR is to catch all errors while doing this speculative attribution for the `Analyzer`. As a consequence, the speculative code rewrite is found to be problematic, is rejected, and there's no crash.

Note this will also avoid the third error reported in the above case - that error comes directly from the speculative attribution, and it seems incorrect to report it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8349132: javac Analyzers should handle non-deferrable errors`

### Issue
 * [JDK-8349132](https://bugs.openjdk.org/browse/JDK-8349132): javac Analyzers should handle non-deferrable errors (**Bug** - P4)


### Reviewers
 * [Aggelos Biboudis](https://openjdk.org/census#abimpoudis) (@biboudis - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23387/head:pull/23387` \
`$ git checkout pull/23387`

Update a local copy of the PR: \
`$ git checkout pull/23387` \
`$ git pull https://git.openjdk.org/jdk.git pull/23387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23387`

View PR using the GUI difftool: \
`$ git pr show -t 23387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23387.diff">https://git.openjdk.org/jdk/pull/23387.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23387#issuecomment-2627230376)
</details>
