### PR TITLE
8323158: HotSpot Style Guide should specify more include ordering

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -207,23 +207,31 @@ the simple "getter".</p></li>
 <ul>
 <li><p>All source files must have a globally unique basename. The build
 system depends on this uniqueness.</p></li>
+<li><p>Keep the include lines within a section alphabetically sorted.</p></li>
+<li><p>Put conditional inclusions (`#if ...`) at the end of the section of HotSpot
+include lines. This also applies to macro-expanded includes of platform
+dependent files.</p></li>
+<li><p>Put system includes in a section after the HotSpot include lines with a blank
+line separating the two sections.</p></li>
 <li><p>Do not put non-trivial function implementations in .hpp files. If
-the implementation depends on other .hpp files, put it in a .cpp or a
-.inline.hpp file.</p></li>
+the implementation depends on other .hpp files, put it in a .cpp or
+a .inline.hpp file.</p></li>
 <li><p>.inline.hpp files should only be included in .cpp or .inline.hpp
 files.</p></li>
-<li><p>All .inline.hpp files should include their corresponding .hpp
-file as the first include line. Declarations needed by other files
-should be put in the .hpp file, and not in the .inline.hpp file. This
-rule exists to resolve problems with circular dependencies between
-.inline.hpp files.</p></li>
+<li><p>All .inline.hpp files should include their corresponding .hpp file as
+the first include line with blank line separating it from the rest of the
+include lines. Declarations needed by other files should be put in the .hpp
+file, and not in the .inline.hpp file. This rule exists to resolve problems
+with circular dependencies between .inline.hpp files.</p></li>
+<li><p>Do not include a .hpp file if the corresponding .inline.hpp file is included.</p></li>
+<li><p>Use include guards for .hpp and .inline.hpp files. The name of the defined
+guard should be derived from the full search path of the file relative to the
+hotspot source directory. The define should be all upper case with all paths
+separators and periods replaced by underscores.</p></li>
 <li><p>Some build configurations use precompiled headers to speed up the
 build times. The precompiled headers are included in the precompiled.hpp
 file. Note that precompiled.hpp is just a build time optimization, so
 don't rely on it to resolve include problems.</p></li>
-<li><p>Keep the include lines alphabetically sorted.</p></li>
-<li><p>Put conditional inclusions (<code>#if ...</code>) at the end of
-the include list.</p></li>
 </ul>
 <h3 id="jtreg-tests">JTReg Tests</h3>
 <ul>

--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -219,14 +219,14 @@ a .inline.hpp file.</p></li>
 <li><p>.inline.hpp files should only be included in .cpp or .inline.hpp
 files.</p></li>
 <li><p>All .inline.hpp files should include their corresponding .hpp file as
-the first include line with blank line separating it from the rest of the
+the first include line with a blank line separating it from the rest of the
 include lines. Declarations needed by other files should be put in the .hpp
 file, and not in the .inline.hpp file. This rule exists to resolve problems
 with circular dependencies between .inline.hpp files.</p></li>
 <li><p>Do not include a .hpp file if the corresponding .inline.hpp file is included.</p></li>
 <li><p>Use include guards for .hpp and .inline.hpp files. The name of the defined
 guard should be derived from the full search path of the file relative to the
-hotspot source directory. The define should be all upper case with all paths
+hotspot source directory. The guard should be all upper case with all paths
 separators and periods replaced by underscores.</p></li>
 <li><p>Some build configurations use precompiled headers to speed up the
 build times. The precompiled headers are included in the precompiled.hpp

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -135,8 +135,17 @@ change should be done with a "setter" accessor matched to the simple
 
 ### Source Files
 
-* All source files must have a globally unique basename.  The build
+* All source files must have a globally unique basename. The build
 system depends on this uniqueness.
+
+* Keep the include lines within a section alphabetically sorted.
+
+* Put conditional inclusions (`#if ...`) at the end of the section of HotSpot
+include lines. This also applies to macro-expanded includes of platform
+dependent files.
+
+* Put system includes in a section after the HotSpot include lines with a blank
+line separating the two sections.
 
 * Do not put non-trivial function implementations in .hpp files. If
 the implementation depends on other .hpp files, put it in a .cpp or
@@ -146,18 +155,22 @@ a .inline.hpp file.
 files.
 
 * All .inline.hpp files should include their corresponding .hpp file as
-the first include line. Declarations needed by other files should be put
-in the .hpp file, and not in the .inline.hpp file. This rule exists to
-resolve problems with circular dependencies between .inline.hpp files.
+the first include line with blank line separating it from the rest of the
+include lines. Declarations needed by other files should be put in the .hpp
+file, and not in the .inline.hpp file. This rule exists to resolve problems
+with circular dependencies between .inline.hpp files.
+
+* Do not include a .hpp file if the corresponding .inline.hpp file is included.
+
+* Use include guards for .hpp and .inline.hpp files. The name of the defined
+guard should be derived from the full search path of the file relative to the
+hotspot source directory. The define should be all upper case with all paths
+separators and periods replaced by underscores.
 
 * Some build configurations use precompiled headers to speed up the
 build times. The precompiled headers are included in the precompiled.hpp
 file. Note that precompiled.hpp is just a build time optimization, so
 don't rely on it to resolve include problems.
-
-* Keep the include lines alphabetically sorted.
-
-* Put conditional inclusions (`#if ...`) at the end of the include list.
 
 ### JTReg Tests
 

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -155,7 +155,7 @@ a .inline.hpp file.
 files.
 
 * All .inline.hpp files should include their corresponding .hpp file as
-the first include line with blank line separating it from the rest of the
+the first include line with a blank line separating it from the rest of the
 include lines. Declarations needed by other files should be put in the .hpp
 file, and not in the .inline.hpp file. This rule exists to resolve problems
 with circular dependencies between .inline.hpp files.
@@ -164,7 +164,7 @@ with circular dependencies between .inline.hpp files.
 
 * Use include guards for .hpp and .inline.hpp files. The name of the defined
 guard should be derived from the full search path of the file relative to the
-hotspot source directory. The define should be all upper case with all paths
+hotspot source directory. The guard should be all upper case with all paths
 separators and periods replaced by underscores.
 
 * Some build configurations use precompiled headers to speed up the


### PR DESCRIPTION
The HotSpot Style Guide has a section about source files and includes. The style used for includes have mostly been introduced by scripts when includeDB was replaced, but also when various other enhancements to our includes were made. Some of the introduced styles were never written down in the style guide.

I propose a couple of changes to the HotSpot Style Guide to reflect some of these implicit styles that we have. While updating the text I also took the liberty to order the items in an order that I felt was good.

Note that JDK-8323158 contains a few more suggestions, but I've only addressed the items that I think can be accepted without much contention. Either I extract the items that have not been address into a new RFE, or I create a new RFE for this PR.

There a some small whitespace tweaks that I made so that the .md and .html had a similar layout.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323158](https://bugs.openjdk.org/browse/JDK-8323158): HotSpot Style Guide should specify more include ordering (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [51913afa](https://git.openjdk.org/jdk/pull/23388/files/51913afa259692ddff2324fe9702c19c6af202c6)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23388/head:pull/23388` \
`$ git checkout pull/23388`

Update a local copy of the PR: \
`$ git checkout pull/23388` \
`$ git pull https://git.openjdk.org/jdk.git pull/23388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23388`

View PR using the GUI difftool: \
`$ git pr show -t 23388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23388.diff">https://git.openjdk.org/jdk/pull/23388.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23388#issuecomment-2627430685)
</details>
