### PR TITLE
8348658: [AArch64] The node limit in compiler/codegen/TestMatcherClone.java is too strict

### DIFF
--- a/test/hotspot/jtreg/compiler/codegen/TestMatcherClone.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestMatcherClone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class TestMatcherClone {
     }
 
     @Test(compLevel = CompLevel.C2)
-    @IR(counts = {IRNode.ADD_P_OF, "reg_imm", "<200"},
+    @IR(counts = {IRNode.ADD_P_OF, "reg_imm", "<400"},
         phase = CompilePhase.MATCHING)
     public void test() {
         iArr = new int[] {x % 2};


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ee87d187](https://github.com/openjdk/jdk/commit/ee87d187d1cab09317b4f0068bfafc68efbbfe56) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Daniel Lundén on 31 Jan 2025 and was reviewed by Aleksey Shipilev and Vladimir Kozlov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348658](https://bugs.openjdk.org/browse/JDK-8348658): [AArch64] The node limit in compiler/codegen/TestMatcherClone.java is too strict (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23390/head:pull/23390` \
`$ git checkout pull/23390`

Update a local copy of the PR: \
`$ git checkout pull/23390` \
`$ git pull https://git.openjdk.org/jdk.git pull/23390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23390`

View PR using the GUI difftool: \
`$ git pr show -t 23390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23390.diff">https://git.openjdk.org/jdk/pull/23390.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23390#issuecomment-2627497372)
</details>
