### PR TITLE
8349142: [JMH] compiler.MergeLoadBench.getCharBV fails

### DIFF
--- a/test/micro/org/openjdk/bench/vm/compiler/MergeLoadBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeLoadBench.java
@@ -357,7 +357,7 @@ public class MergeLoadBench {
     public void getCharLV(Blackhole BH) {
         long sum = 0;
         for (int i = 0; i < longs.length; i++) {
-            char c = (char) CHAR_L.get(bytes4, Unsafe.ARRAY_BYTE_BASE_OFFSET + i * 2);
+            char c = (char) CHAR_L.get(bytes4, i * 2);
             sum += c;
         }
         BH.consume(sum);

--- a/test/micro/org/openjdk/bench/vm/compiler/MergeLoadBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeLoadBench.java
@@ -317,7 +317,7 @@ public class MergeLoadBench {
     public void getCharBV(Blackhole BH) {
         long sum = 0;
         for (int i = 0; i < longs.length; i++) {
-            char c = (char) CHAR_B.get(bytes4, Unsafe.ARRAY_BYTE_BASE_OFFSET + i * 2);
+            char c = (char) CHAR_B.get(bytes4, i * 2);
             sum += c;
         }
         BH.consume(sum);


### PR DESCRIPTION
Fix the BUG caused by PR #22095 Change Unsafe base offset from int to long

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349142](https://bugs.openjdk.org/browse/JDK-8349142): [JMH] compiler.MergeLoadBench.getCharBV fails (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23392/head:pull/23392` \
`$ git checkout pull/23392`

Update a local copy of the PR: \
`$ git checkout pull/23392` \
`$ git pull https://git.openjdk.org/jdk.git pull/23392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23392`

View PR using the GUI difftool: \
`$ git pr show -t 23392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23392.diff">https://git.openjdk.org/jdk/pull/23392.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23392#issuecomment-2627584208)
</details>
