### PR TITLE
8349142: [JMH] compiler.MergeLoadBench.getCharBV fails

### DIFF
--- a/test/micro/org/openjdk/bench/vm/compiler/MergeLoadBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeLoadBench.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -317,7 +317,7 @@ public class MergeLoadBench {
     public void getCharBV(Blackhole BH) {
         long sum = 0;
         for (int i = 0; i < longs.length; i++) {
-            char c = (char) CHAR_B.get(bytes4, Unsafe.ARRAY_BYTE_BASE_OFFSET + i * 2);
+            char c = (char) CHAR_B.get(bytes4, (int)(Unsafe.ARRAY_BYTE_BASE_OFFSET + i * 2));
             sum += c;
         }
         BH.consume(sum);
@@ -357,7 +357,7 @@ public class MergeLoadBench {
     public void getCharLV(Blackhole BH) {
         long sum = 0;
         for (int i = 0; i < longs.length; i++) {
-            char c = (char) CHAR_L.get(bytes4, Unsafe.ARRAY_BYTE_BASE_OFFSET + i * 2);
+            char c = (char) CHAR_L.get(bytes4, (int)(Unsafe.ARRAY_BYTE_BASE_OFFSET + i * 2));
             sum += c;
         }
         BH.consume(sum);

--- a/test/micro/org/openjdk/bench/vm/compiler/MergeLoadBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeLoadBench.java
@@ -317,7 +317,7 @@ public class MergeLoadBench {
     public void getCharBV(Blackhole BH) {
         long sum = 0;
         for (int i = 0; i < longs.length; i++) {
-            char c = (char) CHAR_B.get(bytes4, (int)(Unsafe.ARRAY_BYTE_BASE_OFFSET + i * 2));
+            char c = (char) CHAR_B.get(bytes4, i * 2);
             sum += c;
         }
         BH.consume(sum);
@@ -357,7 +357,7 @@ public class MergeLoadBench {
     public void getCharLV(Blackhole BH) {
         long sum = 0;
         for (int i = 0; i < longs.length; i++) {
-            char c = (char) CHAR_L.get(bytes4, (int)(Unsafe.ARRAY_BYTE_BASE_OFFSET + i * 2));
+            char c = (char) CHAR_L.get(bytes4, i * 2);
             sum += c;
         }
         BH.consume(sum);


### PR DESCRIPTION
Hi all,

There are two JMH tests fails after [JDK-8344168](https://bugs.openjdk.org/browse/JDK-8344168) merged. This PR fix the JMH tests fails similar to https://github.com/oracle/graal/pull/10602, just remove the unnecessary Unsafe.ARRAY_BYTE_BASE_OFFSET at the second argument of VarHandle.get.
Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349142](https://bugs.openjdk.org/browse/JDK-8349142): [JMH] compiler.MergeLoadBench.getCharBV fails (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23393/head:pull/23393` \
`$ git checkout pull/23393`

Update a local copy of the PR: \
`$ git checkout pull/23393` \
`$ git pull https://git.openjdk.org/jdk.git pull/23393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23393`

View PR using the GUI difftool: \
`$ git pr show -t 23393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23393.diff">https://git.openjdk.org/jdk/pull/23393.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23393#issuecomment-2627628390)
</details>
