### PR TITLE
8349106: Change ChaCha20 intrinsic to use quarter-round parallel implementation on aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -4354,7 +4354,7 @@ class StubGenerator: public StubCodeGenerator {
     // onto SIMD registers.  The first 128 bits are a counter add overlay
     // that adds +1/+0/+0/+0 to the vectors holding replicated state[12].
     // The second 128-bits is a table constant used for 8-bit left rotations.
-	// on 32-bit lanes within a SIMD register.
+    // on 32-bit lanes within a SIMD register.
     __ BIND(L_Q_cc20_const);
     __ emit_int64(0x0000000000000001UL);
     __ emit_int64(0x0000000000000000UL);
@@ -4380,7 +4380,7 @@ class StubGenerator: public StubCodeGenerator {
     const FloatRegister b1Vec = v5;
     const FloatRegister c1Vec = v6;
     const FloatRegister d1Vec = v7;
-	// Skip the callee-saved registers v8 - v15
+    // Skip the callee-saved registers v8 - v15
     const FloatRegister a2Vec = v16;
     const FloatRegister b2Vec = v17;
     const FloatRegister c2Vec = v18;
@@ -4400,11 +4400,11 @@ class StubGenerator: public StubCodeGenerator {
     // Load the initial state in the first 4 quadword registers,
     // then copy the initial state into the next 4 quadword registers
     // that will be used for the working state.
-	__ ld1(aState, bState, cState, dState, __ T16B, Address(state));
+    __ ld1(aState, bState, cState, dState, __ T16B, Address(state));
 
     // Load the index register for 2 constant 128-bit data fields.
-	// The first represents the +1/+0/+0/+0 add mask.  The second is
-	// the 8-bit left rotation.
+    // The first represents the +1/+0/+0/+0 add mask.  The second is
+    // the 8-bit left rotation.
     __ adr(tmpAddr, L_Q_cc20_const);
     __ ldpq(addMask, lrot8Tbl, Address(tmpAddr));
 
@@ -4438,17 +4438,17 @@ class StubGenerator: public StubCodeGenerator {
     //  Qround(state, 1, 5, 9,13)
     //  Qround(state, 2, 6,10,14)
     //  Qround(state, 3, 7,11,15)
-	__ cc20_quarter_round(a1Vec, b1Vec, c1Vec, d1Vec, scratch, lrot8Tbl);
-	__ cc20_quarter_round(a2Vec, b2Vec, c2Vec, d2Vec, scratch, lrot8Tbl);
-	__ cc20_quarter_round(a3Vec, b3Vec, c3Vec, d3Vec, scratch, lrot8Tbl);
-	__ cc20_quarter_round(a4Vec, b4Vec, c4Vec, d4Vec, scratch, lrot8Tbl);
+    __ cc20_quarter_round(a1Vec, b1Vec, c1Vec, d1Vec, scratch, lrot8Tbl);
+    __ cc20_quarter_round(a2Vec, b2Vec, c2Vec, d2Vec, scratch, lrot8Tbl);
+    __ cc20_quarter_round(a3Vec, b3Vec, c3Vec, d3Vec, scratch, lrot8Tbl);
+    __ cc20_quarter_round(a4Vec, b4Vec, c4Vec, d4Vec, scratch, lrot8Tbl);
 
     // Shuffle the b1Vec/c1Vec/d1Vec to reorganize the state vectors to
     // diagonals. The a1Vec does not need to change orientation.
-	__ cc20_shift_lane_org(b1Vec, c1Vec, d1Vec, true);
-	__ cc20_shift_lane_org(b2Vec, c2Vec, d2Vec, true);
-	__ cc20_shift_lane_org(b3Vec, c3Vec, d3Vec, true);
-	__ cc20_shift_lane_org(b4Vec, c4Vec, d4Vec, true);
+    __ cc20_shift_lane_org(b1Vec, c1Vec, d1Vec, true);
+    __ cc20_shift_lane_org(b2Vec, c2Vec, d2Vec, true);
+    __ cc20_shift_lane_org(b3Vec, c3Vec, d3Vec, true);
+    __ cc20_shift_lane_org(b4Vec, c4Vec, d4Vec, true);
 
     // The second set of operations on the vectors covers the second 4 quarter
     // round operations, now acting on the diagonals:
@@ -4456,18 +4456,18 @@ class StubGenerator: public StubCodeGenerator {
     //  Qround(state, 1, 6,11,12)
     //  Qround(state, 2, 7, 8,13)
     //  Qround(state, 3, 4, 9,14)
-	__ cc20_quarter_round(a1Vec, b1Vec, c1Vec, d1Vec, scratch, lrot8Tbl);
-	__ cc20_quarter_round(a2Vec, b2Vec, c2Vec, d2Vec, scratch, lrot8Tbl);
-	__ cc20_quarter_round(a3Vec, b3Vec, c3Vec, d3Vec, scratch, lrot8Tbl);
-	__ cc20_quarter_round(a4Vec, b4Vec, c4Vec, d4Vec, scratch, lrot8Tbl);
+    __ cc20_quarter_round(a1Vec, b1Vec, c1Vec, d1Vec, scratch, lrot8Tbl);
+    __ cc20_quarter_round(a2Vec, b2Vec, c2Vec, d2Vec, scratch, lrot8Tbl);
+    __ cc20_quarter_round(a3Vec, b3Vec, c3Vec, d3Vec, scratch, lrot8Tbl);
+    __ cc20_quarter_round(a4Vec, b4Vec, c4Vec, d4Vec, scratch, lrot8Tbl);
 
     // Before we start the next iteration, we need to perform shuffles
     // on the b/c/d vectors to move them back to columnar organizations
     // from their current diagonal orientation.
-	__ cc20_shift_lane_org(b1Vec, c1Vec, d1Vec, false);
-	__ cc20_shift_lane_org(b2Vec, c2Vec, d2Vec, false);
-	__ cc20_shift_lane_org(b3Vec, c3Vec, d3Vec, false);
-	__ cc20_shift_lane_org(b4Vec, c4Vec, d4Vec, false);
+    __ cc20_shift_lane_org(b1Vec, c1Vec, d1Vec, false);
+    __ cc20_shift_lane_org(b2Vec, c2Vec, d2Vec, false);
+    __ cc20_shift_lane_org(b3Vec, c3Vec, d3Vec, false);
+    __ cc20_shift_lane_org(b4Vec, c4Vec, d4Vec, false);
 
     // Decrement and iterate
     __ sub(loopCtr, loopCtr, 1);
@@ -4501,17 +4501,14 @@ class StubGenerator: public StubCodeGenerator {
     __ addv(d4Vec, __ T4S, d4Vec, dState);
 
     // Write the final state back to the result buffer
-	__ st1(a1Vec, b1Vec, c1Vec, d1Vec, __ T16B, __ post(keystream, 64));
-	__ st1(a2Vec, b2Vec, c2Vec, d2Vec, __ T16B, __ post(keystream, 64));
-	__ st1(a3Vec, b3Vec, c3Vec, d3Vec, __ T16B, __ post(keystream, 64));
-	__ st1(a4Vec, b4Vec, c4Vec, d4Vec, __ T16B, __ post(keystream, 64));
+    __ st1(a1Vec, b1Vec, c1Vec, d1Vec, __ T16B, __ post(keystream, 64));
+    __ st1(a2Vec, b2Vec, c2Vec, d2Vec, __ T16B, __ post(keystream, 64));
+    __ st1(a3Vec, b3Vec, c3Vec, d3Vec, __ T16B, __ post(keystream, 64));
+    __ st1(a4Vec, b4Vec, c4Vec, d4Vec, __ T16B, __ post(keystream, 64));
 
     __ mov(r0, 256);             // Return length of output keystream
     __ leave();
     __ ret(lr);
-
-    #undef SHIFT_LANES
-    #undef FOUR_QTR_ROUND
 
     return start;
   }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -4351,7 +4351,7 @@ class StubGenerator: public StubCodeGenerator {
   address generate_chacha20Block_qrpar() {
     Label L_Q_twoRounds, L_Q_cc20_const;
     // The constant data is broken into two 128-bit segments to be loaded
-    // onto FloatRegisters.  The first 128 bits are a counter add overlay
+    // onto SIMD registers.  The first 128 bits are a counter add overlay
     // that adds +1/+0/+0/+0 to the vectors holding replicated state[12].
     // The second 128-bits is a table constant used for 8-bit left rotations.
 	// on 32-bit lanes within a SIMD register.
@@ -4400,12 +4400,6 @@ class StubGenerator: public StubCodeGenerator {
     // Load the initial state in the first 4 quadword registers,
     // then copy the initial state into the next 4 quadword registers
     // that will be used for the working state.
-#if 0
-    __ ldrq(aState, Address(state, 0));
-    __ ldrq(bState, Address(state, 16));
-    __ ldrq(cState, Address(state, 32));
-    __ ldrq(dState, Address(state, 48));
-#endif
 	__ ld1(aState, bState, cState, dState, __ T16B, Address(state));
 
     // Load the index register for 2 constant 128-bit data fields.
@@ -4506,20 +4500,7 @@ class StubGenerator: public StubCodeGenerator {
     __ addv(dState, __ T4S, dState, addMask);
     __ addv(d4Vec, __ T4S, d4Vec, dState);
 
-    // Now write the final state back to the result buffer
-#if 0
-    __ stpq(a1Vec, b1Vec, Address(keystream, 0));
-    __ stpq(c1Vec, d1Vec, Address(keystream, 32));
-
-    __ stpq(a2Vec, b2Vec, Address(keystream, 64));
-    __ stpq(c2Vec, d2Vec, Address(keystream, 96));
-
-    __ stpq(a3Vec, b3Vec, Address(keystream, 128));
-    __ stpq(c3Vec, d3Vec, Address(keystream, 160));
-
-    __ stpq(a4Vec, b4Vec, Address(keystream, 192));
-    __ stpq(c4Vec, d4Vec, Address(keystream, 224));
-#endif
+    // Write the final state back to the result buffer
 	__ st1(a1Vec, b1Vec, c1Vec, d1Vec, __ T16B, __ post(keystream, 64));
 	__ st1(a2Vec, b2Vec, c2Vec, d2Vec, __ T16B, __ post(keystream, 64));
 	__ st1(a3Vec, b3Vec, c3Vec, d3Vec, __ T16B, __ post(keystream, 64));
@@ -4531,136 +4512,6 @@ class StubGenerator: public StubCodeGenerator {
 
     #undef SHIFT_LANES
     #undef FOUR_QTR_ROUND
-
-    return start;
-  }
-
-
-
-
-  // ChaCha20 block function.  This version parallelizes by loading
-  // individual 32-bit state elements into vectors for four blocks
-  // (e.g. all four blocks' worth of state[0] in one register, etc.)
-  //
-  // state (int[16]) = c_rarg0
-  // keystream (byte[1024]) = c_rarg1
-  // return - number of bytes of keystream (always 256)
-  address generate_chacha20Block_blockpar() {
-    Label L_twoRounds, L_cc20_const;
-    // The constant data is broken into two 128-bit segments to be loaded
-    // onto FloatRegisters.  The first 128 bits are a counter add overlay
-    // that adds +0/+1/+2/+3 to the vector holding replicated state[12].
-    // The second 128-bits is a table constant used for 8-bit left rotations.
-    __ BIND(L_cc20_const);
-    __ emit_int64(0x0000000100000000UL);
-    __ emit_int64(0x0000000300000002UL);
-    __ emit_int64(0x0605040702010003UL);
-    __ emit_int64(0x0E0D0C0F0A09080BUL);
-
-    __ align(CodeEntryAlignment);
-    StubGenStubId stub_id = StubGenStubId::chacha20Block_id;
-    StubCodeMark mark(this, stub_id);
-    address start = __ pc();
-    __ enter();
-
-    int i, j;
-    const Register state = c_rarg0;
-    const Register keystream = c_rarg1;
-    const Register loopCtr = r10;
-    const Register tmpAddr = r11;
-
-    const FloatRegister stateFirst = v0;
-    const FloatRegister stateSecond = v1;
-    const FloatRegister stateThird = v2;
-    const FloatRegister stateFourth = v3;
-    const FloatRegister origCtrState = v28;
-    const FloatRegister scratch = v29;
-    const FloatRegister lrot8Tbl = v30;
-
-    // Organize SIMD registers in an array that facilitates
-    // putting repetitive opcodes into loop structures.  It is
-    // important that each grouping of 4 registers is monotonically
-    // increasing to support the requirements of multi-register
-    // instructions (e.g. ld4r, st4, etc.)
-    const FloatRegister workSt[16] = {
-         v4,  v5,  v6,  v7, v16, v17, v18, v19,
-        v20, v21, v22, v23, v24, v25, v26, v27
-    };
-
-    // Load from memory and interlace across 16 SIMD registers,
-    // With each word from memory being broadcast to all lanes of
-    // each successive SIMD register.
-    //      Addr(0) -> All lanes in workSt[i]
-    //      Addr(4) -> All lanes workSt[i + 1], etc.
-    __ mov(tmpAddr, state);
-    for (i = 0; i < 16; i += 4) {
-      __ ld4r(workSt[i], workSt[i + 1], workSt[i + 2], workSt[i + 3], __ T4S,
-          __ post(tmpAddr, 16));
-    }
-
-    // Pull in constant data.  The first 16 bytes are the add overlay
-    // which is applied to the vector holding the counter (state[12]).
-    // The second 16 bytes is the index register for the 8-bit left
-    // rotation tbl instruction.
-    __ adr(tmpAddr, L_cc20_const);
-    __ ldpq(origCtrState, lrot8Tbl, Address(tmpAddr));
-    __ addv(workSt[12], __ T4S, workSt[12], origCtrState);
-
-    // Set up the 10 iteration loop and perform all 8 quarter round ops
-    __ mov(loopCtr, 10);
-    __ BIND(L_twoRounds);
-
-    __ cc20_quarter_round(workSt[0], workSt[4], workSt[8], workSt[12],
-        scratch, lrot8Tbl);
-    __ cc20_quarter_round(workSt[1], workSt[5], workSt[9], workSt[13],
-        scratch, lrot8Tbl);
-    __ cc20_quarter_round(workSt[2], workSt[6], workSt[10], workSt[14],
-        scratch, lrot8Tbl);
-    __ cc20_quarter_round(workSt[3], workSt[7], workSt[11], workSt[15],
-        scratch, lrot8Tbl);
-
-    __ cc20_quarter_round(workSt[0], workSt[5], workSt[10], workSt[15],
-        scratch, lrot8Tbl);
-    __ cc20_quarter_round(workSt[1], workSt[6], workSt[11], workSt[12],
-        scratch, lrot8Tbl);
-    __ cc20_quarter_round(workSt[2], workSt[7], workSt[8], workSt[13],
-        scratch, lrot8Tbl);
-    __ cc20_quarter_round(workSt[3], workSt[4], workSt[9], workSt[14],
-        scratch, lrot8Tbl);
-
-    // Decrement and iterate
-    __ sub(loopCtr, loopCtr, 1);
-    __ cbnz(loopCtr, L_twoRounds);
-
-    __ mov(tmpAddr, state);
-
-    // Add the starting state back to the post-loop keystream
-    // state.  We read/interlace the state array from memory into
-    // 4 registers similar to what we did in the beginning.  Then
-    // add the counter overlay onto workSt[12] at the end.
-    for (i = 0; i < 16; i += 4) {
-      __ ld4r(stateFirst, stateSecond, stateThird, stateFourth, __ T4S,
-          __ post(tmpAddr, 16));
-      __ addv(workSt[i], __ T4S, workSt[i], stateFirst);
-      __ addv(workSt[i + 1], __ T4S, workSt[i + 1], stateSecond);
-      __ addv(workSt[i + 2], __ T4S, workSt[i + 2], stateThird);
-      __ addv(workSt[i + 3], __ T4S, workSt[i + 3], stateFourth);
-    }
-    __ addv(workSt[12], __ T4S, workSt[12], origCtrState);    // Add ctr mask
-
-    // Write to key stream, storing the same element out of workSt[0..15]
-    // to consecutive 4-byte offsets in the key stream buffer, then repeating
-    // for the next element position.
-    for (i = 0; i < 4; i++) {
-      for (j = 0; j < 16; j += 4) {
-        __ st4(workSt[j], workSt[j + 1], workSt[j + 2], workSt[j + 3], __ S, i,
-            __ post(keystream, 16));
-      }
-    }
-
-    __ mov(r0, 256);             // Return length of output keystream
-    __ leave();
-    __ ret(lr);
 
     return start;
   }
@@ -9064,7 +8915,6 @@ class StubGenerator: public StubCodeGenerator {
 
     if (UseChaCha20Intrinsics) {
       StubRoutines::_chacha20Block = generate_chacha20Block_qrpar();
-      //StubRoutines::_chacha20Block = generate_chacha20Block_blockpar();
     }
 
     if (UseBASE64Intrinsics) {


### PR DESCRIPTION
This enhancement makes a change to the ChaCha20 block function intrinsic on aarch64, moving away from the block parallel implementation and to the quarter-round parallel implementation that was done on x86_64.  Assembly language profiling yielded an 11% improvement in throughput.  When put together as an intrinsic and hooked into the JCE ChaCha20 cipher, the gains are more modest, somewhere in the 2-4% range depending on job size, but still an improvement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349106](https://bugs.openjdk.org/browse/JDK-8349106): Change ChaCha20 intrinsic to use quarter-round parallel implementation on aarch64 (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23397/head:pull/23397` \
`$ git checkout pull/23397`

Update a local copy of the PR: \
`$ git checkout pull/23397` \
`$ git pull https://git.openjdk.org/jdk.git pull/23397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23397`

View PR using the GUI difftool: \
`$ git pr show -t 23397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23397.diff">https://git.openjdk.org/jdk/pull/23397.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23397#issuecomment-2627848991)
</details>
