### PR TITLE
8319055: JCMD should not buffer the whole output of commands

### DIFF
--- a/src/hotspot/os/posix/attachListener_posix.cpp
+++ b/src/hotspot/os/posix/attachListener_posix.cpp
@@ -114,6 +114,7 @@ public:
 
   void close() {
     if (opened()) {
+      ::shutdown(_socket, SHUT_RDWR);
       ::close(_socket);
       _socket = -1;
     }
@@ -132,9 +133,8 @@ public:
     RESTARTABLE(::write(_socket, buffer, size), n);
     return checked_cast<int>(n);
   }
-  // called after writing all data
+
   void flush() override {
-    ::shutdown(_socket, SHUT_RDWR);
   }
 };
 
@@ -144,13 +144,17 @@ class PosixAttachOperation: public AttachOperation {
   SocketChannel _socket_channel;
 
  public:
-  void complete(jint res, bufferedStream* st) override;
-
   PosixAttachOperation(int socket) : AttachOperation(), _socket_channel(socket) {
   }
 
+  void complete(jint res, bufferedStream* st) override;
+
+  virtual ReplyWriter* get_reply_writer() override {
+      return &_socket_channel;
+  }
+
   bool read_request() {
-    return AttachOperation::read_request(&_socket_channel, &_socket_channel);
+    return _socket_channel.read_request(this, &_socket_channel);
   }
 };
 
@@ -318,11 +322,6 @@ PosixAttachOperation* PosixAttachListener::dequeue() {
 // socket could be made non-blocking and a timeout could be used.
 
 void PosixAttachOperation::complete(jint result, bufferedStream* st) {
-  JavaThread* thread = JavaThread::current();
-  ThreadBlockInVM tbivm(thread);
-
-  write_reply(&_socket_channel, result, st);
-
   delete this;
 }
 

--- a/src/hotspot/os/posix/attachListener_posix.cpp
+++ b/src/hotspot/os/posix/attachListener_posix.cpp
@@ -144,13 +144,12 @@ class PosixAttachOperation: public AttachOperation {
   SocketChannel _socket_channel;
 
  public:
-  PosixAttachOperation(int socket) : AttachOperation(), _socket_channel(socket) {
-  }
+  PosixAttachOperation(int socket) : AttachOperation(), _socket_channel(socket) {}
 
   void complete(jint res, bufferedStream* st) override;
 
-  virtual ReplyWriter* get_reply_writer() override {
-      return &_socket_channel;
+  ReplyWriter* get_reply_writer() override {
+    return &_socket_channel;
   }
 
   bool read_request() {

--- a/src/hotspot/os/windows/attachListener_windows.cpp
+++ b/src/hotspot/os/windows/attachListener_windows.cpp
@@ -156,7 +156,7 @@ public:
 public:
   void complete(jint result, bufferedStream* result_stream) override;
 
-  virtual ReplyWriter* get_reply_writer() override {
+  ReplyWriter* get_reply_writer() override {
     return &_pipe;
   }
 };

--- a/src/hotspot/os/windows/attachListener_windows.cpp
+++ b/src/hotspot/os/windows/attachListener_windows.cpp
@@ -92,6 +92,7 @@ public:
 
   void close() {
     if (opened()) {
+      FlushFileBuffers(_hPipe);
       CloseHandle(_hPipe);
       _hPipe = INVALID_HANDLE_VALUE;
     }
@@ -123,15 +124,13 @@ public:
                               &written,
                               nullptr);  // not overlapped
     if (!fSuccess) {
-        log_error(attach)("pipe write error (%d)", GetLastError());
-        return -1;
+      log_error(attach)("pipe write error (%d)", GetLastError());
+      return -1;
     }
     return (int)written;
   }
 
   void flush() override {
-    assert(opened(), "must be");
-    FlushFileBuffers(_hPipe);
   }
 };
 
@@ -151,11 +150,15 @@ public:
   }
 
   bool read_request() {
-    return AttachOperation::read_request(&_pipe, &_pipe);
+    return _pipe.read_request(this, &_pipe);
   }
 
 public:
   void complete(jint result, bufferedStream* result_stream) override;
+
+  virtual ReplyWriter* get_reply_writer() override {
+    return &_pipe;
+  }
 };
 
 
@@ -432,11 +435,6 @@ Win32AttachOperation* Win32AttachListener::dequeue() {
 }
 
 void Win32AttachOperation::complete(jint result, bufferedStream* result_stream) {
-  JavaThread* thread = JavaThread::current();
-  ThreadBlockInVM tbivm(thread);
-
-  write_reply(&_pipe, result, result_stream);
-
   delete this;
 }
 

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -127,6 +127,8 @@ public:
   // Called after the operation is completed.
   // If reply_writer is provided, writes the results.
   void complete() {
+    JavaThread* thread = JavaThread::current();
+    ThreadBlockInVM tbivm(thread);
     flush_reply();
   }
 

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -369,7 +369,7 @@ static jint jcmd(AttachOperation* op, attachStream* out) {
   // Special case for ManagementAgent.start and ManagementAgent.start_local commands
   // used by HotSpotVirtualMachine.startManagementAgent and startLocalManagementAgent.
   // The commands report error if the agent failed to load, so we need to disable streaming output.
-  const char jmx_prefix[] = "ManagementAgent.";
+  const char* jmx_prefix = "ManagementAgent.";
   if (strncmp(op->arg(0), jmx_prefix, strlen(jmx_prefix)) == 0) {
     allow_streaming_output = false;
   }
@@ -393,8 +393,8 @@ static jint jcmd(AttachOperation* op, attachStream* out) {
   executor.parse_and_execute(op->arg(0), ' ', THREAD);
   if (HAS_PENDING_EXCEPTION) {
     // We can get an exception during command execution.
-    // In the case _attach_stream->set_result() is already called and operation result code is send
-    // to the client.
+    // In the case _attach_stream->set_result() is already called and the operation result code
+    // is sent to the client.
     // Repeated out->set_result() is a no-op, just report exception message.
     java_lang_Throwable::print(PENDING_EXCEPTION, out);
     out->cr();

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -54,7 +54,7 @@
 //
 // To support streaming output platform implementation need to implement AttachOperation::get_reply_writer() method
 // and ctor allow_streaming argument should be set to true.
-// 
+//
 // Initially attachStream works in buffered mode.
 // To switch to the streaming mode attach command handler need to call attachStream::set_result().
 // The method flushes buffered output and consequent printing goes directly to ReplyWriter.
@@ -357,7 +357,7 @@ static void thread_dump(AttachOperation* op, attachStream* out) {
 // dispatch to the diagnostic commands used for serviceability functions.
 static void jcmd(AttachOperation* op, attachStream* out) {
   JavaThread* THREAD = JavaThread::current(); // For exception macros.
-  
+
   // All the supplied jcmd arguments are stored as a single
   // string (op->arg(0)). This is parsed by the Dcmd framework.
 

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -627,9 +627,10 @@ void AttachListenerThread::thread_entry(JavaThread* thread, TRAPS) {
       }
 
       if (info != nullptr) {
-        log_debug(attach)("executing command %s, streaming output: %d",
+        log_debug(attach)("executing command %s, streaming output: %d (supported by impl: %d)",
                          op->name(),
-                         (op->get_reply_writer() != nullptr && op->streaming_output()) ? 1 : 0);
+                         op->streaming_output() ? 1 : 0,
+                         op->get_reply_writer() != nullptr ? 1 : 0);
         // dispatch to the function that implements this operation
         info->func(op, &st);
         // If the operation handler hasn't set result, set it to JNI_OK now.

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -50,10 +50,10 @@
 
 
 // Stream for printing attach operation results.
-// Supports buffered and streaming output for commands which can produce lenghtly reply.
+// Supports buffered and streaming output for commands which can produce lengthy reply.
 //
-// To support streaming output platform implementation need to implement AttachOperation::get_reply_writer() method
-// and ctor allow_streaming argument should be set to true.
+// A platform implementation supports streaming output if it implements AttachOperation::get_reply_writer().
+// Streaming is enabled if the allow_streaming in the constructor is set to true.
 //
 // Initially attachStream works in buffered mode.
 // To switch to the streaming mode attach command handler need to call attachStream::set_result().
@@ -136,10 +136,6 @@ public:
         _error = !_reply_writer->write_fully(str, (int)len);
       }
     } else {
-      /* TODO: handle buffer overflow
-      if (size() + len > MAXIMUM_BUFFER_SIZE) {
-      }
-      */
       bufferedStream::write(str, len);
     }
   }

--- a/src/hotspot/share/services/diagnosticFramework.cpp
+++ b/src/hotspot/share/services/diagnosticFramework.cpp
@@ -386,7 +386,7 @@ void DCmd::Executor::parse_and_execute(const char* cmdline, char delim, TRAPS) {
 
   int count = 0;
   while (iter.has_next()) {
-    if(_source == DCmd_Source_MBean && count > 0) {
+    if (_source == DCmd_Source_MBean && count > 0) {
       // When diagnostic commands are invoked via JMX, each command line
       // must contains one and only one command because of the Permission
       // checks performed by the DiagnosticCommandMBean

--- a/src/hotspot/share/services/diagnosticFramework.cpp
+++ b/src/hotspot/share/services/diagnosticFramework.cpp
@@ -379,15 +379,14 @@ GrowableArray<DCmdArgumentInfo*>* DCmdParser::argument_info_array() const {
 DCmdFactory* DCmdFactory::_DCmdFactoryList = nullptr;
 bool DCmdFactory::_has_pending_jmx_notification = false;
 
-void DCmd::parse_and_execute(DCmdSource source, outputStream* out,
-                             const char* cmdline, char delim, TRAPS) {
+void DCmd::Executor::parse_and_execute(const char* cmdline, char delim, TRAPS) {
 
   if (cmdline == nullptr) return; // Nothing to do!
   DCmdIter iter(cmdline, '\n');
 
   int count = 0;
   while (iter.has_next()) {
-    if(source == DCmd_Source_MBean && count > 0) {
+    if(_source == DCmd_Source_MBean && count > 0) {
       // When diagnostic commands are invoked via JMX, each command line
       // must contains one and only one command because of the Permission
       // checks performed by the DiagnosticCommandMBean
@@ -408,14 +407,23 @@ void DCmd::parse_and_execute(DCmdSource source, outputStream* out,
         line = updated_cmd;
       }
 
-      DCmd* command = DCmdFactory::create_local_DCmd(source, line, out, CHECK);
+      DCmd* command = DCmdFactory::create_local_DCmd(_source, line, _out, CHECK);
       assert(command != nullptr, "command error must be handled before this line");
       DCmdMark mark(command);
       command->parse(&line, delim, CHECK);
-      command->execute(source, CHECK);
+      execute(command, CHECK);
     }
     count++;
   }
+}
+
+void DCmd::Executor::execute(DCmd* command, TRAPS) {
+  command->execute(_source, CHECK);
+}
+
+void DCmd::parse_and_execute(DCmdSource source, outputStream* out,
+                             const char* cmdline, char delim, TRAPS) {
+  Executor(source, out).parse_and_execute(cmdline, delim, CHECK);
 }
 
 bool DCmd::reorder_help_cmd(CmdLine line, stringStream &updated_line) {

--- a/src/hotspot/share/services/diagnosticFramework.hpp
+++ b/src/hotspot/share/services/diagnosticFramework.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -277,6 +277,19 @@ public:
     GrowableArray<DCmdArgumentInfo*>* array = new GrowableArray<DCmdArgumentInfo*>(0);
     return array;
   }
+
+  // helper class to invoke the framework
+  class Executor : public StackObj {
+    DCmdSource _source;
+    outputStream* _out;
+  public:
+    Executor(DCmdSource source, outputStream* out): _source(source), _out(out) {}
+
+    void parse_and_execute(const char* cmdline, char delim, TRAPS);
+
+  protected:
+    virtual void execute(DCmd* command, TRAPS);
+  };
 
   // main method to invoke the framework
   static void parse_and_execute(DCmdSource source, outputStream* out, const char* cmdline,

--- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
     private static final Path ROOT_TMP = Path.of("root/tmp");
 
     String socket_path;
-    private int ver = VERSION_1;        // updated in ctor depending on detectVersion result
+    private OperationProperties props = new OperationProperties(VERSION_1); // updated in ctor
 
     /**
      * Attaches to the target VM
@@ -124,7 +124,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         checkPermissions(socket_path);
 
         if (isAPIv2Enabled()) {
-            ver = detectVersion();
+            props = getDefaultProps();
         } else {
             // Check that we can connect to the process
             // - this ensures we throw the permission denied error now rather than
@@ -178,7 +178,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         // connected - write request
         try {
             SocketOutputStream writer = new SocketOutputStream(s);
-            writeCommand(writer, ver, cmd, args);
+            writeCommand(writer, props, cmd, args);
         } catch (IOException x) {
             ioe = x;
         }

--- a/src/jdk.attach/macosx/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/macosx/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -48,7 +48,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
     // Any changes to this needs to be synchronized with HotSpot.
     private static final String tmpdir;
     String socket_path;
-    private int ver = VERSION_1;        // updated in ctor depending on detectVersion result
+    private OperationProperties props = new OperationProperties(VERSION_1); // updated in ctor
 
     /**
      * Attaches to the target VM
@@ -109,7 +109,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         checkPermissions(socket_path);
 
         if (isAPIv2Enabled()) {
-            ver = detectVersion();
+            props = getDefaultProps();
         } else {
             // Check that we can connect to the process
             // - this ensures we throw the permission denied error now rather than
@@ -161,10 +161,9 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         IOException ioe = null;
 
         // connected - write request
-        // <ver> <cmd> <args...>
         try {
             SocketOutputStream writer = new SocketOutputStream(s);
-            writeCommand(writer, ver, cmd, args);
+            writeCommand(writer, props, cmd, args);
         } catch (IOException x) {
             ioe = x;
         }

--- a/src/jdk.attach/share/classes/sun/tools/attach/HotSpotVirtualMachine.java
+++ b/src/jdk.attach/share/classes/sun/tools/attach/HotSpotVirtualMachine.java
@@ -345,7 +345,7 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
         public final static String STREAMING = "streaming";
 
         private int ver;
-		private Map<String, String> options = new HashMap<>();
+        private Map<String, String> options = new HashMap<>();
 
         OperationProperties(int ver) {
             this.ver = ver;
@@ -356,11 +356,11 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
         }
 
         void setOption(String name, String value) {
-			options.put(name, value);
+            options.put(name, value);
         }
 
         String options() {
-			return options.entrySet().stream()
+            return options.entrySet().stream()
                           .map(e -> e.getKey() + "=" + e.getValue())
                           .collect(Collectors.joining(","));
         }

--- a/src/jdk.attach/share/classes/sun/tools/attach/HotSpotVirtualMachine.java
+++ b/src/jdk.attach/share/classes/sun/tools/attach/HotSpotVirtualMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -57,10 +59,16 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
     }
 
     private static final boolean ALLOW_ATTACH_SELF;
+    private static final boolean ALLOW_STREAMING_OUTPUT;
     static {
         String s = VM.getSavedProperty("jdk.attach.allowAttachSelf");
         ALLOW_ATTACH_SELF = "".equals(s) || Boolean.parseBoolean(s);
+        // For now the default is false.
+        String s2 = VM.getSavedProperty("jdk.attach.allowStreamingOutput");
+        ALLOW_STREAMING_OUTPUT = "".equals(s2) || Boolean.parseBoolean(s2);
     }
+
+    private final boolean selfAttach;
 
     HotSpotVirtualMachine(AttachProvider provider, String id)
         throws AttachNotSupportedException, IOException
@@ -74,9 +82,10 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
             throw new AttachNotSupportedException("Invalid process identifier: " + id);
         }
 
+        selfAttach = pid == 0 || pid == CURRENT_PID;
         // The tool should be a different VM to the target. This check will
         // eventually be enforced by the target VM.
-        if (!ALLOW_ATTACH_SELF && (pid == 0 || pid == CURRENT_PID)) {
+        if (!ALLOW_ATTACH_SELF && selfAttach) {
             throw new IOException("Can not attach to current VM");
         }
     }
@@ -331,27 +340,67 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
     protected static final int VERSION_1 = 1;
     protected static final int VERSION_2 = 2;
 
+    // Attach operation properties.
+    protected static class OperationProperties {
+        public final static String STREAMING = "streaming";
+
+        private int ver;
+		private Map<String, String> options = new HashMap<>();
+
+        OperationProperties(int ver) {
+            this.ver = ver;
+        }
+
+        int version() {
+            return ver;
+        }
+
+        void setOption(String name, String value) {
+			options.put(name, value);
+        }
+
+        String options() {
+			return options.entrySet().stream()
+                          .map(e -> e.getKey() + "=" + e.getValue())
+                          .collect(Collectors.joining(","));
+        }
+    }
+
     /*
-     * Detects Attach API version supported by target VM.
+     * Detects Attach API properties supported by target VM.
      */
-    protected int detectVersion() throws IOException {
+    protected OperationProperties getDefaultProps() throws IOException {
         try {
-            InputStream reply = execute("getversion");
+            InputStream reply = execute("getversion", "options");
             String message = readMessage(reply);
             reply.close();
-            try {
-                int supportedVersion = Integer.parseUnsignedInt(message);
-                // we expect only VERSION_2
-                if (supportedVersion == VERSION_2) {
-                    return VERSION_2;
+
+            // Reply is "<ver> option1,option2...".
+            int delimPos = message.indexOf(' ');
+            String ver = delimPos < 0 ? message : message.substring(0, delimPos);
+
+            int supportedVersion = Integer.parseUnsignedInt(ver);
+
+            // VERSION_2 supports options.
+            if (supportedVersion == VERSION_2) {
+                OperationProperties result = new OperationProperties(supportedVersion);
+                // Parse known options, ignore unknown.
+                String options = delimPos < 0 ? "" : message.substring(delimPos + 1);
+                String[] parts = options.split(",");
+                for (String s: parts) {
+                    if (OperationProperties.STREAMING.equals(s)) {
+                        result.setOption(OperationProperties.STREAMING,
+                                         (isStreamingEnabled() ? "1" : "0"));
+                    }
                 }
-            } catch (NumberFormatException nfe) {
-                // bad reply - fallback to VERSION_1
+                return result;
             }
         } catch (AttachOperationFailedException | AgentLoadException ex) {
             // the command is not supported, the VM supports VERSION_1 only
+        } catch (NumberFormatException nfe) {
+            // bad version number - fallback to VERSION_1
         }
-        return VERSION_1;
+        return new OperationProperties(VERSION_1);
     }
 
     /*
@@ -360,6 +409,17 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
     protected boolean isAPIv2Enabled() {
         // if "jdk.attach.compat" property is set, only v1 is enabled.
         return !Boolean.getBoolean("jdk.attach.compat");
+    }
+
+    /*
+     * Streaming output.
+     */
+    protected boolean isStreamingEnabled() {
+        // Disable streaming for self-attach.
+        if (selfAttach) {
+            return false;
+        }
+        return ALLOW_STREAMING_OUTPUT;
     }
 
     /*
@@ -478,9 +538,15 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
         writer.write(b, 0, 1);
     }
 
-    protected void writeCommand(AttachOutputStream writer, int ver, String cmd, Object ... args) throws IOException {
-        writeString(writer, ver);
-        if (ver == VERSION_2) {
+    protected void writeCommand(AttachOutputStream writer, OperationProperties props,
+                                String cmd, Object ... args) throws IOException {
+        writeString(writer, props.version());
+        if (props.version() == VERSION_2) {
+            // add options to the command name (if specified)
+            String options = props.options();
+            if (!options.isEmpty()) {
+                cmd += " " + options;
+            }
             // for v2 write size of the data
             int size = dataSize(cmd);
             for (Object arg: args) {
@@ -490,7 +556,7 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
         }
         writeString(writer, cmd);
         // v1 commands always write 3 arguments
-        int argNumber = ver == VERSION_1 ? 3 : args.length;
+        int argNumber = props.version() == VERSION_1 ? 3 : args.length;
         for (int i = 0; i < argNumber; i++) {
             writeString(writer, i < args.length ? args[i] : null);
         }

--- a/src/jdk.attach/windows/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/windows/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
     private static byte[] stub;
 
     private volatile long hProcess;     // handle to the process
-    private int ver = VERSION_1;        // updated in ctor depending on detectVersion result
+    private OperationProperties props = new OperationProperties(VERSION_1); // updated in ctor
 
     VirtualMachineImpl(AttachProvider provider, String id)
         throws AttachNotSupportedException, IOException
@@ -55,7 +55,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
 
         try {
             if (isAPIv2Enabled()) {
-                ver = detectVersion();
+                props = getDefaultProps();
             } else {
                 // The target VM might be a pre-6.0 VM so we enqueue a "null" command
                 // which minimally tests that the enqueue function exists in the target
@@ -88,12 +88,12 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         String pipename = pipeprefix + r;
         long hPipe;
         try {
-            hPipe = createPipe(ver, pipename);
+            hPipe = createPipe(props.version(), pipename);
         } catch (IOException ce) {
             // Retry with another random pipe name.
             r = rnd.nextInt();
             pipename = pipeprefix + r;
-            hPipe = createPipe(ver, pipename);
+            hPipe = createPipe(props.version(), pipename);
         }
 
         // check if we are detached - in theory it's possible that detach is invoked
@@ -105,11 +105,11 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
 
         try {
             // enqueue the command to the process.
-            if (ver == VERSION_1) {
-                enqueue(hProcess, stub, ver, cmd, pipename, args);
+            if (props.version() == VERSION_1) {
+                enqueue(hProcess, stub, props.version(), cmd, pipename, args);
             } else {
                 // for v2 operations request contains only pipe name.
-                enqueue(hProcess, stub, ver, null, pipename);
+                enqueue(hProcess, stub, props.version(), null, pipename);
             }
 
             // wait for the target VM to connect to the pipe.
@@ -117,11 +117,11 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
 
             IOException ioe = null;
 
-            if (ver == VERSION_2) {
+            if (props.version() == VERSION_2) {
                 PipeOutputStream writer = new PipeOutputStream(hPipe);
 
                 try {
-                    writeCommand(writer, ver, cmd, args);
+                    writeCommand(writer, props, cmd, args);
                 } catch (IOException x) {
                     ioe = x;
                 }

--- a/test/hotspot/jtreg/serviceability/attach/AttachAPIv2/StreamingOutputTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/AttachAPIv2/StreamingOutputTest.java
@@ -59,35 +59,35 @@ public class StreamingOutputTest {
         } finally {
             LingeredApp.stopApp(app);
         }
-		
-		verify(clientStreaming, vmStreaming, app.getProcessStdout());
-		
+        
+        verify(clientStreaming, vmStreaming, app.getProcessStdout());
+        
         System.out.println("Testing: end");
         System.out.println();
-	}
-	
+    }
+    
     private static void attach(LingeredApp app, boolean clientStreaming, boolean vmStreaming) throws Exception {
         HotSpotVirtualMachine vm = (HotSpotVirtualMachine)VirtualMachine.attach(String.valueOf(app.getPid()));
         try {
-			try (BufferedReader replyReader = new BufferedReader(
-			        new InputStreamReader(vm.setFlag("HeapDumpPath", "the_path")))) {
-				System.out.println("vm.setFlag reply:");
+            try (BufferedReader replyReader = new BufferedReader(
+                    new InputStreamReader(vm.setFlag("HeapDumpPath", "the_path")))) {
+                System.out.println("vm.setFlag reply:");
                 String line;
                 while ((line = replyReader.readLine()) != null) {
                     System.out.println("setFlag reply: " + line);
                 }
-			}
+            }
         } finally {
             vm.detach();
         }
     }
 
-	private static void verify(boolean clientStreaming, boolean vmStreaming, String out) throws Exception {
-		System.out.println("Target VM output:");
-		System.out.println(out);
-		String expected = "executing command setflag, streaming output: " + (clientStreaming ? "1" : "0");
-		if (!out.contains(expected)) {
-			throw new Exception("VM did not logged expected '" + expected + "'");
-		}
-	}
+    private static void verify(boolean clientStreaming, boolean vmStreaming, String out) throws Exception {
+        System.out.println("Target VM output:");
+        System.out.println(out);
+        String expected = "executing command setflag, streaming output: " + (clientStreaming ? "1" : "0");
+        if (!out.contains(expected)) {
+            throw new Exception("VM did not logged expected '" + expected + "'");
+        }
+    }
 }

--- a/test/hotspot/jtreg/serviceability/attach/AttachAPIv2/StreamingOutputTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/AttachAPIv2/StreamingOutputTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Sanity test for streaming output support
+ * @bug 8319055
+ * @library /test/lib
+ * @modules jdk.attach/sun.tools.attach
+ *
+ * @run main/othervm -Djdk.attach.allowStreamingOutput=true StreamingOutputTest
+ * @run main/othervm -Djdk.attach.allowStreamingOutput=false StreamingOutputTest
+ */
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+import com.sun.tools.attach.VirtualMachine;
+import sun.tools.attach.HotSpotVirtualMachine;
+
+import jdk.test.lib.apps.LingeredApp;
+
+public class StreamingOutputTest {
+
+    public static void main(String[] args) throws Exception {
+        boolean clientStreaming = System.getProperty("jdk.attach.allowStreamingOutput").equals("true");
+        test(clientStreaming, false);
+        test(clientStreaming, true);
+    }
+
+    private static void test(boolean clientStreaming, boolean vmStreaming) throws Exception {
+        System.out.println("Testing: clientStreaming=" + clientStreaming + ", vmStreaming=" + vmStreaming);
+        LingeredApp app = null;
+        try {
+            app = LingeredApp.startApp("-Xlog:attach=trace",
+                                       "-Djdk.attach.vm.streaming=" + String.valueOf(vmStreaming));
+            attach(app, clientStreaming, vmStreaming);
+        } finally {
+            LingeredApp.stopApp(app);
+        }
+		
+		verify(clientStreaming, vmStreaming, app.getProcessStdout());
+		
+        System.out.println("Testing: end");
+        System.out.println();
+	}
+	
+    private static void attach(LingeredApp app, boolean clientStreaming, boolean vmStreaming) throws Exception {
+        HotSpotVirtualMachine vm = (HotSpotVirtualMachine)VirtualMachine.attach(String.valueOf(app.getPid()));
+        try {
+			try (BufferedReader replyReader = new BufferedReader(
+			        new InputStreamReader(vm.setFlag("HeapDumpPath", "the_path")))) {
+				System.out.println("vm.setFlag reply:");
+                String line;
+                while ((line = replyReader.readLine()) != null) {
+                    System.out.println("setFlag reply: " + line);
+                }
+			}
+        } finally {
+            vm.detach();
+        }
+    }
+
+	private static void verify(boolean clientStreaming, boolean vmStreaming, String out) throws Exception {
+		System.out.println("Target VM output:");
+		System.out.println(out);
+		String expected = "executing command setflag, streaming output: " + (clientStreaming ? "1" : "0");
+		if (!out.contains(expected)) {
+			throw new Exception("VM did not logged expected '" + expected + "'");
+		}
+	}
+}

--- a/test/hotspot/jtreg/serviceability/attach/AttachAPIv2/StreamingOutputTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/AttachAPIv2/StreamingOutputTest.java
@@ -55,7 +55,7 @@ public class StreamingOutputTest {
         try {
             app = LingeredApp.startApp("-Xlog:attach=trace",
                                        "-Djdk.attach.vm.streaming=" + String.valueOf(vmStreaming));
-            attach(app, clientStreaming, vmStreaming);
+            attach(app);
         } finally {
             LingeredApp.stopApp(app);
         }
@@ -66,7 +66,7 @@ public class StreamingOutputTest {
         System.out.println();
     }
 
-    private static void attach(LingeredApp app, boolean clientStreaming, boolean vmStreaming) throws Exception {
+    private static void attach(LingeredApp app) throws Exception {
         HotSpotVirtualMachine vm = (HotSpotVirtualMachine)VirtualMachine.attach(String.valueOf(app.getPid()));
         try {
             try (BufferedReader replyReader = new BufferedReader(
@@ -86,6 +86,10 @@ public class StreamingOutputTest {
         System.out.println("Target VM output:");
         System.out.println(out);
         String expected = "executing command setflag, streaming output: " + (clientStreaming ? "1" : "0");
+        if (!out.contains(expected)) {
+            throw new Exception("VM did not logged expected '" + expected + "'");
+        }
+        expected = "default streaming output: " + (vmStreaming ? "1" : "0");
         if (!out.contains(expected)) {
             throw new Exception("VM did not logged expected '" + expected + "'");
         }

--- a/test/hotspot/jtreg/serviceability/attach/AttachAPIv2/StreamingOutputTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/AttachAPIv2/StreamingOutputTest.java
@@ -59,13 +59,13 @@ public class StreamingOutputTest {
         } finally {
             LingeredApp.stopApp(app);
         }
-        
+
         verify(clientStreaming, vmStreaming, app.getProcessStdout());
-        
+
         System.out.println("Testing: end");
         System.out.println();
     }
-    
+
     private static void attach(LingeredApp app, boolean clientStreaming, boolean vmStreaming) throws Exception {
         HotSpotVirtualMachine vm = (HotSpotVirtualMachine)VirtualMachine.attach(String.valueOf(app.getPid()));
         try {

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeHeapAnalyticsParams.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeHeapAnalyticsParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import jdk.test.lib.dcmd.PidJcmdExecutor;
 
 /*
  * @test CodeHeapAnalyticsParams
+ * @bug 8225388
  * @summary Test the Compiler.CodeHeap_Analytics command
  * @requires vm.flagless
  * @library /test/lib
@@ -38,7 +39,8 @@ public class CodeHeapAnalyticsParams {
     public static void main(String args[]) throws Exception {
         PidJcmdExecutor executor = new PidJcmdExecutor();
         executor.execute("Compiler.CodeHeap_Analytics all 1").shouldHaveExitValue(0);
-        executor.execute("Compiler.CodeHeap_Analytics all 0").shouldHaveExitValue(1);
-        executor.execute("Compiler.CodeHeap_Analytics all k").shouldHaveExitValue(1);
+        // invalid argument should report exception, and don't crash
+        executor.execute("Compiler.CodeHeap_Analytics all 0").shouldContain("IllegalArgumentException");
+        executor.execute("Compiler.CodeHeap_Analytics all k").shouldContain("IllegalArgumentException");
     }
 }


### PR DESCRIPTION
The fix implements streaming output support for attach protocol.
See JBS issue for evaluation, summary of the changes in the 1st comment.
Testing: tier1..4,hs-tier5-svc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319055](https://bugs.openjdk.org/browse/JDK-8319055): JCMD should not buffer the whole output of commands (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) Review applies to [2a3d4346](https://git.openjdk.org/jdk/pull/23405/files/2a3d4346b02af679217e2ff82ae673d13ca91de4)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23405/head:pull/23405` \
`$ git checkout pull/23405`

Update a local copy of the PR: \
`$ git checkout pull/23405` \
`$ git pull https://git.openjdk.org/jdk.git pull/23405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23405`

View PR using the GUI difftool: \
`$ git pr show -t 23405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23405.diff">https://git.openjdk.org/jdk/pull/23405.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23405#issuecomment-2628572639)
</details>
