### PR TITLE
8348309: MultiNST tests need more debugging and timing

### DIFF
--- a/test/jdk/javax/net/ssl/templates/TLSBase.java
+++ b/test/jdk/javax/net/ssl/templates/TLSBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,7 @@ import java.security.cert.PKIXBuilderParameters;
 import java.security.cert.X509CertSelector;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 /**
  * This is a base setup for creating a server and clients.  All clients will
@@ -84,14 +81,16 @@ abstract public class TLSBase {
     byte[] read(SSLSocket sock) throws Exception {
         BufferedInputStream is = new BufferedInputStream(sock.getInputStream());
         byte[] b = is.readNBytes(5);
-        System.err.println("(read) " + Thread.currentThread().getName() + ": " + new String(b));
+        System.err.println("(read) " + Thread.currentThread().getName() + ": " +
+            new String(b));
         return b;
     }
 
     // Base write operation
     public void write(SSLSocket sock, byte[] data) throws Exception {
         sock.getOutputStream().write(data);
-        System.err.println("(write)" + Thread.currentThread().getName() + ": " + new String(data));
+        System.err.println("(write)" + Thread.currentThread().getName() + ": " +
+            new String(data));
     }
 
     private static KeyManager[] getKeyManager(boolean empty) throws Exception {
@@ -148,14 +147,10 @@ abstract public class TLSBase {
         // Clients sockets are kept in a hash table with the port as the key.
         ConcurrentHashMap<Integer, SSLSocket> clientMap =
                 new ConcurrentHashMap<>();
-        Thread t;
         List<Exception> exceptionList = new ArrayList<>();
         ExecutorService threadPool = Executors.newFixedThreadPool(1,
-            r -> {
-                Thread t = Executors.defaultThreadFactory().newThread(r);
-                return t;
-            });
-
+            r -> Executors.defaultThreadFactory().newThread(r));
+        CountDownLatch serverLatch = new CountDownLatch(1);
         Server(ServerBuilder builder) {
             super();
             name = "server";
@@ -168,27 +163,28 @@ abstract public class TLSBase {
                 ssock.setReuseAddress(true);
                 ssock.setNeedClientAuth(builder.clientauth);
                 serverPort = ssock.getLocalPort();
-                System.out.println("Server Port: " + serverPort);
+                System.err.println("Server Port: " + serverPort);
             } catch (Exception e) {
                 System.err.println("Failure during server initialization");
                 e.printStackTrace();
             }
 
             // Thread to allow multiple clients to connect
-            t = new Thread(() -> {
+            new Thread(() -> {
                 try {
-                    while (true) {
+                    System.err.println("Server starting to accept");
+                    serverLatch.countDown();
+                    do {
                         SSLSocket sock = (SSLSocket)ssock.accept();
                         threadPool.submit(new ServerThread(sock));
-                    }
+                    } while (true);
                 } catch (Exception ex) {
                     System.err.println("Server Down");
                     ex.printStackTrace();
                 } finally {
                     threadPool.close();
                 }
-            });
-            t.start();
+            }).start();
         }
 
         class ServerThread extends Thread {
@@ -196,7 +192,8 @@ abstract public class TLSBase {
 
             ServerThread(SSLSocket s) {
                 this.sock = s;
-                System.err.println("ServerThread("+sock.getPort()+")");
+                System.err.println("(Server) client connection on port " +
+                    sock.getPort());
                 clientMap.put(sock.getPort(), sock);
             }
 
@@ -204,7 +201,7 @@ abstract public class TLSBase {
                 try {
                     write(sock, read(sock));
                 } catch (Exception e) {
-                    System.out.println("Caught " + e.getMessage());
+                    System.err.println("Caught " + e.getMessage());
                     e.printStackTrace();
                     exceptionList.add(e);
                 }
@@ -289,7 +286,8 @@ abstract public class TLSBase {
             this.tm = tm;
             try {
                 sslContext = SSLContext.getInstance("TLS");
-                sslContext.init(TLSBase.getKeyManager(km), TLSBase.getTrustManager(tm), null);
+                sslContext.init(TLSBase.getKeyManager(km),
+                    TLSBase.getTrustManager(tm), null);
                 socket = createSocket();
             } catch (Exception ex) {
                 ex.printStackTrace();
@@ -312,9 +310,12 @@ abstract public class TLSBase {
 
         public SSLSocket connect() {
             try {
-                socket.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), serverPort));
-                System.err.println("Client (" + Thread.currentThread().getName() + ") connected using port " +
-                    socket.getLocalPort() + " to " + socket.getPort());
+                socket.connect(new InetSocketAddress(
+                    InetAddress.getLoopbackAddress(), serverPort));
+                System.err.println("Client (" +
+                    Thread.currentThread().getName() +
+                    ") connected using port " + socket.getLocalPort() + " to " +
+                    socket.getPort());
                 writeRead();
             } catch (Exception ex) {
                 ex.printStackTrace();

--- a/test/jdk/javax/net/ssl/templates/TLSBase.java
+++ b/test/jdk/javax/net/ssl/templates/TLSBase.java
@@ -148,8 +148,7 @@ abstract public class TLSBase {
         ConcurrentHashMap<Integer, SSLSocket> clientMap =
                 new ConcurrentHashMap<>();
         List<Exception> exceptionList = new ArrayList<>();
-        ExecutorService threadPool = Executors.newFixedThreadPool(1,
-            r -> Executors.defaultThreadFactory().newThread(r));
+        ExecutorService threadPool = Executors.newFixedThreadPool(1);
         CountDownLatch serverLatch = new CountDownLatch(1);
         Server(ServerBuilder builder) {
             super();

--- a/test/jdk/javax/net/ssl/templates/TLSBase.java
+++ b/test/jdk/javax/net/ssl/templates/TLSBase.java
@@ -31,7 +31,10 @@ import java.security.cert.PKIXBuilderParameters;
 import java.security.cert.X509CertSelector;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This is a base setup for creating a server and clients.  All clients will

--- a/test/jdk/javax/net/ssl/templates/TLSBase.java
+++ b/test/jdk/javax/net/ssl/templates/TLSBase.java
@@ -31,10 +31,7 @@ import java.security.cert.PKIXBuilderParameters;
 import java.security.cert.X509CertSelector;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 /**
  * This is a base setup for creating a server and clients.  All clients will

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTClient.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTClient.java
@@ -81,7 +81,6 @@ public class MultiNSTClient {
                 Utils.addTestJavaOpts("MultiNSTClient", "p"));
 
             OutputAnalyzer output = ProcessTools.executeProcess(pb);
-            System.out.println("I'm here");
             boolean pass = true;
             try {
                 List<String> list = output.stderrShouldContain("MultiNST PSK").

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTClient.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTClient.java
@@ -127,8 +127,8 @@ public class MultiNSTClient {
         }
 
         TLSBase.Server server = new TLSBase.Server();
-
-        System.out.println("------  Start connection");
+        server.serverLatch.await();
+        System.out.println("------  Server ready, starting original client.");
         TLSBase.Client initial = new TLSBase.Client();
         SSLSession initialSession = initial.connect().getSession();
         System.out.println("id = " + hex.formatHex(initialSession.getId()));

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTClient.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTClient.java
@@ -99,10 +99,12 @@ public class MultiNSTClient {
                 for (int i = 0; i < 2; i++) {
                     String svr = serverPSK.getFirst();
                     String cli = clientPSK.getFirst();
-                    if (svr.regionMatches(svr.length() - 16, cli, cli.length() - 16, 16)) {
+                    if (svr.regionMatches(svr.length() - 16, cli,
+                        cli.length() - 16, 16)) {
                         System.out.println("entry " + (i + 1) + " match.");
                     } else {
-                        System.out.println("entry " + (i + 1) + " server and client PSK didn't match:");
+                        System.out.println("entry " + (i + 1) +
+                            " server and client PSK didn't match:");
                         System.out.println("  server: " + svr);
                         System.out.println("  client: " + cli);
                         pass = false;

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTNoSessionCreation.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTNoSessionCreation.java
@@ -76,8 +76,8 @@ public class MultiNSTNoSessionCreation {
         }
 
         TLSBase.Server server = new TLSBase.Server();
-
-        System.out.println("------  Initial connection");
+        server.serverLatch.await();
+        System.out.println("------  Server ready, starting initial client.");
         TLSBase.Client initial = new TLSBase.Client();
         initial.connect();
         System.out.println(

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTSequence.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTSequence.java
@@ -115,8 +115,8 @@ public class MultiNSTSequence {
         }
 
         TLSBase.Server server = new TLSBase.Server();
-
-        System.out.println("------  Initial connection");
+        server.serverLatch.await();
+        System.out.println("------  Server ready, starting initial client.");
         TLSBase.Client initial = new TLSBase.Client();
 
         SSLSession initialSession = initial.connect().getSession();

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTSequence.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/MultiNSTSequence.java
@@ -64,8 +64,7 @@ public class MultiNSTSequence {
                 " -Dtest.src=" + System.getProperty("test.src") +
                     " -Dtest.jdk=" + System.getProperty("test.jdk") +
                     " -Dtest.root=" + System.getProperty("test.root") +
-                    " -Djavax.net.debug=ssl,handshake " + params
-                              );
+                    " -Djavax.net.debug=ssl,handshake " + params);
 
             System.out.println("test.java.opts: " +
                 System.getProperty("test.java.opts"));


### PR DESCRIPTION
I need a review of this change that adds new timing controls for the initial server setup.  On rare occasions, more so on certain architectures, the server may not fully start before the client tries to connect.  Additional debugging is added to help identify if there are other timing issues.

Thanks

Tony

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348309](https://bugs.openjdk.org/browse/JDK-8348309): MultiNST tests need more debugging and timing (**Bug** - P4)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23407/head:pull/23407` \
`$ git checkout pull/23407`

Update a local copy of the PR: \
`$ git checkout pull/23407` \
`$ git pull https://git.openjdk.org/jdk.git pull/23407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23407`

View PR using the GUI difftool: \
`$ git pr show -t 23407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23407.diff">https://git.openjdk.org/jdk/pull/23407.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23407#issuecomment-2632120597)
</details>
