### PR TITLE
8349184: [JMH] jdk.incubator.vector.ColumnFilterBenchmark.filterDoubleColumn fails on linux-aarch64

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/ColumnFilterBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/ColumnFilterBenchmark.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector", "-XX:UseAVX=2"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:UseAVX=2"})
 public class ColumnFilterBenchmark {
     @Param({"1024", "2047", "4096"})
     int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/ColumnFilterBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/ColumnFilterBenchmark.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,
Several JMH tests fails "Unrecognized VM option 'UseAVX=2'" on linux-aarch64. The VM option '-XX:UseAVX=2' only support on x86_64 platform. This PR add option '-XX:+IgnoreUnrecognizedVMOptions' to make test run normally on non x86_64 platform.
Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349184](https://bugs.openjdk.org/browse/JDK-8349184): [JMH] jdk.incubator.vector.ColumnFilterBenchmark.filterDoubleColumn fails on linux-aarch64 (**Bug** - P4)


### Reviewers
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Committer)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23409/head:pull/23409` \
`$ git checkout pull/23409`

Update a local copy of the PR: \
`$ git checkout pull/23409` \
`$ git pull https://git.openjdk.org/jdk.git pull/23409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23409`

View PR using the GUI difftool: \
`$ git pr show -t 23409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23409.diff">https://git.openjdk.org/jdk/pull/23409.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23409#issuecomment-2628979246)
</details>
