### PR TITLE
8349400: Improve startup speed via eliminating nested classes

### DIFF
--- a/src/java.base/share/classes/sun/security/util/KnownOIDs.java
+++ b/src/java.base/share/classes/sun/security/util/KnownOIDs.java
@@ -448,8 +448,7 @@ public enum KnownOIDs {
         } else if (debug != null) {
             debug.println(o.oid + " => " + o.name());
         }
-        // only register the stdName and aliases if o.registerNames
-        // returns true
+        // only register the stdName and aliases if o.registerNames is true
         if (o.registerNames) {
             String stdNameUpper = o.stdName.toUpperCase(Locale.ENGLISH);
             if (Objects.nonNull(name2enum.put(stdNameUpper, o))) {
@@ -483,15 +482,15 @@ public enum KnownOIDs {
     KnownOIDs(String oid, String stdName, String... aliases) {
         this.oid = oid;
         this.stdName = stdName;
-        this.registerNames = true;
         this.aliases = aliases;
+        this.registerNames = true;
     }
 
     KnownOIDs(String oid, String stdName, boolean registerNames) {
         this.oid = oid;
         this.stdName = stdName;
-        this.registerNames = registerNames;
         this.aliases = new String[0];
+        this.registerNames = registerNames;
     }
 
     // returns the oid string associated with this enum

--- a/src/java.base/share/classes/sun/security/util/KnownOIDs.java
+++ b/src/java.base/share/classes/sun/security/util/KnownOIDs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,10 +91,7 @@ public enum KnownOIDs {
     ipsecEndSystem("1.3.6.1.5.5.7.3.5"),
     ipsecTunnel("1.3.6.1.5.5.7.3.6"),
     ipsecUser("1.3.6.1.5.5.7.3.7"),
-    KP_TimeStamping("1.3.6.1.5.5.7.3.8", "timeStamping") {
-        @Override
-        boolean registerNames() { return false; }
-    },
+    KP_TimeStamping("1.3.6.1.5.5.7.3.8", "timeStamping", false),
     OCSPSigning("1.3.6.1.5.5.7.3.9"),
     // access descriptors - PKIX.48.*
     OCSP("1.3.6.1.5.5.7.48.1"),
@@ -102,10 +99,7 @@ public enum KnownOIDs {
     OCSPNonceExt("1.3.6.1.5.5.7.48.1.2"),
     OCSPNoCheck("1.3.6.1.5.5.7.48.1.5"),
     caIssuers("1.3.6.1.5.5.7.48.2"),
-    AD_TimeStamping("1.3.6.1.5.5.7.48.3", "timeStamping") {
-        @Override
-        boolean registerNames() { return false; }
-    },
+    AD_TimeStamping("1.3.6.1.5.5.7.48.3", "timeStamping", false),
     caRepository("1.3.6.1.5.5.7.48.5", "caRepository"),
 
     // NIST --
@@ -189,10 +183,7 @@ public enum KnownOIDs {
 
     // RSASecurity
     // PKCS1 1.2.840.113549.1.1.*
-    PKCS1("1.2.840.113549.1.1", "RSA") { // RSA KeyPairGenerator and KeyFactory
-        @Override
-        boolean registerNames() { return false; }
-    },
+    PKCS1("1.2.840.113549.1.1", "RSA", false), // RSA KeyPairGenerator and KeyFactory
     RSA("1.2.840.113549.1.1.1"), // RSA encryption
 
     MD2withRSA("1.2.840.113549.1.1.2"),
@@ -322,10 +313,7 @@ public enum KnownOIDs {
     SpecifiedSHA2withECDSA("1.2.840.10045.4.3"),
 
     // X9.42 1.2.840.10046.2.*
-    X942_DH("1.2.840.10046.2.1", "DiffieHellman") { // unused by JDK providers
-        @Override
-        boolean registerNames() { return false; }
-    },
+    X942_DH("1.2.840.10046.2.1", "DiffieHellman", false), // unused by JDK providers
 
     // Teletrust 1.3.36.*
     brainpoolP160r1("1.3.36.3.3.2.8.1.1.1"),
@@ -375,34 +363,19 @@ public enum KnownOIDs {
     // OIW secsig 1.3.14.3.*
     OIW_DES_CBC("1.3.14.3.2.7", "DES/CBC", "DES"),
 
-    OIW_DSA("1.3.14.3.2.12", "DSA") {
-        @Override
-        boolean registerNames() { return false; }
-    },
+    OIW_DSA("1.3.14.3.2.12", "DSA", false),
 
-    OIW_JDK_SHA1withDSA("1.3.14.3.2.13", "SHA1withDSA") {
-        @Override
-        boolean registerNames() { return false; }
-    },
+    OIW_JDK_SHA1withDSA("1.3.14.3.2.13", "SHA1withDSA", false),
 
-    OIW_SHA1withRSA_Odd("1.3.14.3.2.15", "SHA1withRSA") {
-        @Override
-        boolean registerNames() { return false; }
-    },
+    OIW_SHA1withRSA_Odd("1.3.14.3.2.15", "SHA1withRSA", false),
 
     DESede("1.3.14.3.2.17", "DESede"),
 
     SHA_1("1.3.14.3.2.26", "SHA-1", "SHA", "SHA1"),
 
-    OIW_SHA1withDSA("1.3.14.3.2.27", "SHA1withDSA") {
-        @Override
-        boolean registerNames() { return false; }
-    },
+    OIW_SHA1withDSA("1.3.14.3.2.27", "SHA1withDSA", false),
 
-    OIW_SHA1withRSA("1.3.14.3.2.29", "SHA1withRSA") {
-        @Override
-        boolean registerNames() { return false; }
-    },
+    OIW_SHA1withRSA("1.3.14.3.2.29", "SHA1withRSA", false),
 
     // Thawte 1.3.101.*
     X25519("1.3.101.110"),
@@ -426,11 +399,9 @@ public enum KnownOIDs {
     // Consider removing them in future releases when their usage
     // have died out
 
-    ITUX509_RSA("2.5.8.1.1", "RSA") { // unused by JDK providers
-                                      // defined in X.509 for RSA keys
-        @Override                     // with modulus length as its parameter
-        boolean registerNames() { return false; }
-    },
+    ITUX509_RSA("2.5.8.1.1", "RSA", false), // unused by JDK providers
+                                            // defined in X.509 for RSA keys
+                                            // with modulus length as its parameter
 
     SkipIPAddress("1.3.6.1.4.1.42.2.11.2.1"),
     JAVASOFT_JDKKeyProtector("1.3.6.1.4.1.42.2.17.1.1"),
@@ -442,6 +413,7 @@ public enum KnownOIDs {
     private final String stdName;
     private final String oid;
     private final String[] aliases;
+    private final boolean registerNames;
 
     // find the matching enum using either name or oid string
     // return null if no match found
@@ -476,9 +448,9 @@ public enum KnownOIDs {
         } else if (debug != null) {
             debug.println(o.oid + " => " + o.name());
         }
-        // only register the stdName and aliases if o.registerNames()
+        // only register the stdName and aliases if o.registerNames
         // returns true
-        if (o.registerNames()) {
+        if (o.registerNames) {
             String stdNameUpper = o.stdName.toUpperCase(Locale.ENGLISH);
             if (Objects.nonNull(name2enum.put(stdNameUpper, o))) {
                 throw new RuntimeException("ERROR: Duplicate " +
@@ -505,12 +477,21 @@ public enum KnownOIDs {
         this.oid = oid;
         this.stdName = name(); // defaults to enum name
         this.aliases = new String[0];
+        this.registerNames = true;
     }
 
     KnownOIDs(String oid, String stdName, String... aliases) {
         this.oid = oid;
         this.stdName = stdName;
+        this.registerNames = true;
         this.aliases = aliases;
+    }
+
+    KnownOIDs(String oid, String stdName, boolean registerNames) {
+        this.oid = oid;
+        this.stdName = stdName;
+        this.registerNames = registerNames;
+        this.aliases = new String[0];
     }
 
     // returns the oid string associated with this enum
@@ -526,9 +507,5 @@ public enum KnownOIDs {
     // return the internal aliases
     public String[] aliases() {
         return aliases;
-    }
-
-    boolean registerNames() {
-        return true;
     }
 }


### PR DESCRIPTION
During JVM startup, the class KnownOIDs is loaded. KnownOIDs has 10 anonymous classes, which slows down the startup. This PR is to improve KnownOIDs and eliminate unnecessary embedded classes.


Here's how to reproduce this:

```java
public class Startup {
    public static void main(String[] args) {}
}
```

```sh
java -verbose:class Startup
```

```
[0.665s][info][class,load] sun.security.util.KnownOIDs
[0.666s][info][class,load] sun.security.util.KnownOIDs$1
[0.667s][info][class,load] sun.security.util.KnownOIDs$2
[0.667s][info][class,load] sun.security.util.KnownOIDs$3
[0.668s][info][class,load] sun.security.util.KnownOIDs$4
[0.668s][info][class,load] sun.security.util.KnownOIDs$5
[0.668s][info][class,load] sun.security.util.KnownOIDs$6
[0.668s][info][class,load] sun.security.util.KnownOIDs$7
[0.669s][info][class,load] sun.security.util.KnownOIDs$8
[0.669s][info][class,load] sun.security.util.KnownOIDs$9
[0.669s][info][class,load] sun.security.util.KnownOIDs$10
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8349400](https://bugs.openjdk.org/browse/JDK-8349400): Improve startup speed via eliminating nested classes (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23411/head:pull/23411` \
`$ git checkout pull/23411`

Update a local copy of the PR: \
`$ git checkout pull/23411` \
`$ git pull https://git.openjdk.org/jdk.git pull/23411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23411`

View PR using the GUI difftool: \
`$ git pr show -t 23411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23411.diff">https://git.openjdk.org/jdk/pull/23411.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23411#issuecomment-2635268984)
</details>
