### PR TITLE
8349193: compiler/intrinsics/TestContinuationPinningAndEA.java missing @requires vm.continuations

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestContinuationPinningAndEA.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @requires vm.continuations
  * @bug 8347997
  * @summary Test that Continuation.pin() and unpin() intrinsics work with EA.
  * @modules java.base/jdk.internal.vm


### PR DESCRIPTION
As title says, test is missing require vm.continuations, as continuations are not yet supported on s390x, I saw this test failure in my recent builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349193](https://bugs.openjdk.org/browse/JDK-8349193): compiler/intrinsics/TestContinuationPinningAndEA.java missing @<!---->requires vm.continuations (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23412/head:pull/23412` \
`$ git checkout pull/23412`

Update a local copy of the PR: \
`$ git checkout pull/23412` \
`$ git pull https://git.openjdk.org/jdk.git pull/23412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23412`

View PR using the GUI difftool: \
`$ git pr show -t 23412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23412.diff">https://git.openjdk.org/jdk/pull/23412.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23412#issuecomment-2629795328)
</details>
