### PR TITLE
8349200: [JMH] time.format.ZonedDateTimeFormatterBenchmark fails

### DIFF
--- a/test/micro/org/openjdk/bench/java/time/format/ZonedDateTimeFormatterBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/time/format/ZonedDateTimeFormatterBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class ZonedDateTimeFormatterBenchmark {
     private static final DateTimeFormatter df = new DateTimeFormatterBuilder()
             .appendPattern("yyyy:MM:dd:HH:mm:v")
             .toFormatter();
-    private static final String TEXT = "2015:03:10:12:13:ECT";
+    private static final String TEXT = "2015:03:10:12:13:Z";
 
     @Setup
     public void setUp() {

--- a/test/micro/org/openjdk/bench/java/time/format/ZonedDateTimeFormatterBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/time/format/ZonedDateTimeFormatterBenchmark.java
@@ -40,7 +40,7 @@ public class ZonedDateTimeFormatterBenchmark {
     private static final DateTimeFormatter df = new DateTimeFormatterBuilder()
             .appendPattern("yyyy:MM:dd:HH:mm:v")
             .toFormatter();
-    private static final String TEXT = "2015:03:10:12:13:Z";
+    private static final String TEXT = "2015:03:10:12:13:PST";
 
     @Setup
     public void setUp() {


### PR DESCRIPTION
Hi all,
The JMH test "org.openjdk.bench.java.time.format.ZonedDateTimeFormatterBenchmark.parse" fails "java.time.format.DateTimeParseException: Text '2015:03:10:12:13:ECT' could not be parsed at index 17".
The `ECT` standard for "America/Guayaquil" - "Ecuador Time", and since jdk23 the `ECT` TimeZone.SHORT doesn't support anymore. Below code snippet shows the difference between jdk22 and jdk23:

```java
        TimeZone tz = TimeZone.getTimeZone("America/Guayaquil");
        System.out.println(tz.getDisplayName());
        System.out.println(tz.getDisplayName(true, TimeZone.SHORT));
        System.out.println(tz.getDisplayName(false, TimeZone.SHORT));
```

- Java 22 output:

```
~/software/jdk/temurin/jdk-22.0.2+9/bin/java ~/compiler-test/zzkk/TimeZoneTest.java 
Ecuador Time
ECST
ECT
```

- Java 23 output:

```
~/software/jdk/temurin/jdk-23+37/bin/java ~/compiler-test/zzkk/TimeZoneTest.java 
Ecuador Time
GMT-04:00
GMT-05:00
```

This PR use `Z` TimeZone.SHORT instead of `ECT` will make this test more generic. Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349200](https://bugs.openjdk.org/browse/JDK-8349200): [JMH] time.format.ZonedDateTimeFormatterBenchmark fails (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) Review applies to [56fde9bc](https://git.openjdk.org/jdk/pull/23414/files/56fde9bcdcd1c2703457b96f5d1870997f3b8a07)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23414/head:pull/23414` \
`$ git checkout pull/23414`

Update a local copy of the PR: \
`$ git checkout pull/23414` \
`$ git pull https://git.openjdk.org/jdk.git pull/23414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23414`

View PR using the GUI difftool: \
`$ git pr show -t 23414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23414.diff">https://git.openjdk.org/jdk/pull/23414.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23414#issuecomment-2630299686)
</details>
