### PR TITLE
JDK-8349150: Support precompiled headers on AIX

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -125,9 +125,7 @@ else ifeq ($(call And, $(call isTargetOs, linux) $(call isTargetCpu, aarch64)), 
   endif
 endif
 
-ifeq ($(call isTargetOs, linux macosx windows), true)
-  JVM_PRECOMPILED_HEADER := $(TOPDIR)/src/hotspot/share/precompiled/precompiled.hpp
-endif
+JVM_PRECOMPILED_HEADER := $(TOPDIR)/src/hotspot/share/precompiled/precompiled.hpp
 
 ifeq ($(call isTargetCpu, x86), true)
   JVM_EXCLUDE_PATTERNS += x86_64

--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -118,11 +118,7 @@ else ifeq ($(call isTargetOs, macosx), true)
   endif
 
 else ifeq ($(call isTargetOs, aix), true)
-  ifeq ($(TOOLCHAIN_TYPE), clang)
-    BUILD_LIBJVM_synchronizer.cpp_CXXFLAGS := -fno-inline
-  else
-    BUILD_LIBJVM_synchronizer.cpp_CXXFLAGS := -qnoinline
-  endif
+  BUILD_LIBJVM_synchronizer.cpp_CXXFLAGS := -fno-inline
   BUILD_LIBJVM_sharedRuntimeTrans.cpp_CXXFLAGS := $(CXX_O_FLAG_NONE)
   # Disable aggressive optimizations for functions in sharedRuntimeTrig.cpp
   # and sharedRuntimeTrans.cpp on ppc64.
@@ -145,6 +141,13 @@ else ifeq ($(call isTargetOs, aix), true)
 
   # Disable ELF decoder on AIX (AIX uses XCOFF).
   JVM_EXCLUDE_PATTERNS += elf
+
+  JVM_PRECOMPILED_HEADER_EXCLUDE := \
+      sharedRuntimeTrig.cpp \
+      sharedRuntimeTrans.cpp \
+      synchronizer.cpp \
+      $(OPT_SPEED_SRC) \
+      #
 
 else ifeq ($(call isTargetOs, windows), true)
   JVM_PRECOMPILED_HEADER_EXCLUDE := \


### PR DESCRIPTION
The clang compiler currently used on AIX should be able to support precompiled headers in the HS build (same as on Linux or macOS where clang is used).
However currently the precompiled headers feature is disabled on AIX (probably because the old xlc had issues with this feature).