### PR TITLE
StringLatin1 & StringUTF16::putCharsAt checkBoundsBeginEnd

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -829,6 +829,8 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(i);
         ensureCapacityInternal(spaceNeeded);
+        byte[] value = this.value;
+        Preconditions.checkFromToIndex(count, spaceNeeded, value.length >> coder, Preconditions.SIOOBE_FORMATTER);
         if (isLatin1()) {
             DecimalDigits.getCharsLatin1(i, spaceNeeded, value);
         } else {
@@ -854,6 +856,8 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(l);
         ensureCapacityInternal(spaceNeeded);
+        byte[] value = this.value;
+        Preconditions.checkFromToIndex(count, spaceNeeded, value.length >> coder, Preconditions.SIOOBE_FORMATTER);
         if (isLatin1()) {
             DecimalDigits.getCharsLatin1(l, spaceNeeded, value);
         } else {

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -714,7 +714,6 @@ final class StringLatin1 {
 
     static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4) {
         checkBoundsBeginEnd(index, index + 4, val);
-        assert index >= 0 && index + 3 < length(val) : "Trusted caller missed bounds check";
         // Don't use the putChar method, Its instrinsic will cause C2 unable to combining values into larger stores.
         long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
         UNSAFE.putByte(val, offset    , (byte)(c1));

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -713,6 +713,7 @@ final class StringLatin1 {
     }
 
     static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4) {
+        checkBoundsBeginEnd(index, index + 4, val);
         assert index >= 0 && index + 3 < length(val) : "Trusted caller missed bounds check";
         // Don't use the putChar method, Its instrinsic will cause C2 unable to combining values into larger stores.
         long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
@@ -723,7 +724,7 @@ final class StringLatin1 {
     }
 
     static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4, int c5) {
-        assert index >= 0 && index + 4 < length(val) : "Trusted caller missed bounds check";
+        checkBoundsBeginEnd(index, index + 5, val);
         // Don't use the putChar method, Its instrinsic will cause C2 unable to combining values into larger stores.
         long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
         UNSAFE.putByte(val, offset    , (byte)(c1));
@@ -839,5 +840,9 @@ final class StringLatin1 {
         public int characteristics() {
             return cs;
         }
+    }
+
+    public static void checkBoundsBeginEnd(int begin, int end, byte[] val) {
+        String.checkBoundsBeginEnd(begin, end, length(val));
     }
 }

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1533,7 +1533,7 @@ final class StringUTF16 {
     }
 
     static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4) {
-        assert index >= 0 && index + 3 < length(val) : "Trusted caller missed bounds check";
+        checkBoundsBeginEnd(index, index + 4, val);
         putChar(val, index    , c1);
         putChar(val, index + 1, c2);
         putChar(val, index + 2, c3);
@@ -1541,6 +1541,7 @@ final class StringUTF16 {
     }
 
     static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4, int c5) {
+        checkBoundsBeginEnd(index, index + 5, val);
         putChar(val, index    , c1);
         putChar(val, index + 1, c2);
         putChar(val, index + 2, c3);


### PR DESCRIPTION
The comment in the PR review of that issue #19626 (comment) explains what the issue is with the change that was integrated. 

The putCharsAt method of StringLatin1 and StringUTF16 does not perform boundary checking and writes directly without error in concurrent scenarios.


<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23423/head:pull/23423` \
`$ git checkout pull/23423`

Update a local copy of the PR: \
`$ git checkout pull/23423` \
`$ git pull https://git.openjdk.org/jdk.git pull/23423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23423`

View PR using the GUI difftool: \
`$ git pr show -t 23423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23423.diff">https://git.openjdk.org/jdk/pull/23423.diff</a>

</details>
