### PR TITLE
8349183: [BACKOUT] Optimization for StringBuilder append boolean & null

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -640,11 +640,14 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         int count = this.count;
         byte[] val = this.value;
         if (isLatin1()) {
-            StringLatin1.putCharsAt(val, count, 'n', 'u', 'l', 'l');
+            val[count++] = 'n';
+            val[count++] = 'u';
+            val[count++] = 'l';
+            val[count++] = 'l';
         } else {
-            StringUTF16.putCharsAt(val, count, 'n', 'u', 'l', 'l');
+            count = StringUTF16.putCharsAt(val, count, 'n', 'u', 'l', 'l');
         }
-        this.count = count + 4;
+        this.count = count;
         return this;
     }
 
@@ -769,18 +772,25 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         byte[] val = this.value;
         if (isLatin1()) {
             if (b) {
-                StringLatin1.putCharsAt(val, count, 't', 'r', 'u', 'e');
+                val[count++] = 't';
+                val[count++] = 'r';
+                val[count++] = 'u';
+                val[count++] = 'e';
             } else {
-                StringLatin1.putCharsAt(val, count, 'f', 'a', 'l', 's', 'e');
+                val[count++] = 'f';
+                val[count++] = 'a';
+                val[count++] = 'l';
+                val[count++] = 's';
+                val[count++] = 'e';
             }
         } else {
             if (b) {
-                StringUTF16.putCharsAt(val, count, 't', 'r', 'u', 'e');
+                count = StringUTF16.putCharsAt(val, count, 't', 'r', 'u', 'e');
             } else {
-                StringUTF16.putCharsAt(val, count, 'f', 'a', 'l', 's', 'e');
+                count = StringUTF16.putCharsAt(val, count, 'f', 'a', 'l', 's', 'e');
             }
         }
-        this.count = count + (b ? 4 : 5);
+        this.count = count;
         return this;
     }
 

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -236,10 +236,17 @@ final class StringConcatHelper {
         if (indexCoder < UTF16) {
             if (value) {
                 index -= 4;
-                StringLatin1.putCharsAt(buf, index, 't', 'r', 'u', 'e');
+                buf[index] = 't';
+                buf[index + 1] = 'r';
+                buf[index + 2] = 'u';
+                buf[index + 3] = 'e';
             } else {
                 index -= 5;
-                StringLatin1.putCharsAt(buf, index, 'f', 'a', 'l', 's', 'e');
+                buf[index] = 'f';
+                buf[index + 1] = 'a';
+                buf[index + 2] = 'l';
+                buf[index + 3] = 's';
+                buf[index + 4] = 'e';
             }
             index -= prefix.length();
             prefix.getBytes(buf, index, String.LATIN1);
@@ -247,10 +254,17 @@ final class StringConcatHelper {
         } else {
             if (value) {
                 index -= 4;
-                StringUTF16.putCharsAt(buf, index, 't', 'r', 'u', 'e');
+                StringUTF16.putChar(buf, index, 't');
+                StringUTF16.putChar(buf, index + 1, 'r');
+                StringUTF16.putChar(buf, index + 2, 'u');
+                StringUTF16.putChar(buf, index + 3, 'e');
             } else {
                 index -= 5;
-                StringUTF16.putCharsAt(buf, index, 'f', 'a', 'l', 's', 'e');
+                StringUTF16.putChar(buf, index, 'f');
+                StringUTF16.putChar(buf, index + 1, 'a');
+                StringUTF16.putChar(buf, index + 2, 'l');
+                StringUTF16.putChar(buf, index + 3, 's');
+                StringUTF16.putChar(buf, index + 4, 'e');
             }
             index -= prefix.length();
             prefix.getBytes(buf, index, String.UTF16);
@@ -624,20 +638,34 @@ final class StringConcatHelper {
         if (coder == String.LATIN1) {
             if (value) {
                 index -= 4;
-                StringLatin1.putCharsAt(buf, index, 't', 'r', 'u', 'e');
+                buf[index] = 't';
+                buf[index + 1] = 'r';
+                buf[index + 2] = 'u';
+                buf[index + 3] = 'e';
             } else {
                 index -= 5;
-                StringLatin1.putCharsAt(buf, index, 'f', 'a', 'l', 's', 'e');
+                buf[index] = 'f';
+                buf[index + 1] = 'a';
+                buf[index + 2] = 'l';
+                buf[index + 3] = 's';
+                buf[index + 4] = 'e';
             }
             index -= prefix.length();
             prefix.getBytes(buf, index, String.LATIN1);
         } else {
             if (value) {
                 index -= 4;
-                StringUTF16.putCharsAt(buf, index, 't', 'r', 'u', 'e');
+                StringUTF16.putChar(buf, index, 't');
+                StringUTF16.putChar(buf, index + 1, 'r');
+                StringUTF16.putChar(buf, index + 2, 'u');
+                StringUTF16.putChar(buf, index + 3, 'e');
             } else {
                 index -= 5;
-                StringUTF16.putCharsAt(buf, index, 'f', 'a', 'l', 's', 'e');
+                StringUTF16.putChar(buf, index, 'f');
+                StringUTF16.putChar(buf, index + 1, 'a');
+                StringUTF16.putChar(buf, index + 2, 'l');
+                StringUTF16.putChar(buf, index + 3, 's');
+                StringUTF16.putChar(buf, index + 4, 'e');
             }
             index -= prefix.length();
             prefix.getBytes(buf, index, String.UTF16);

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -32,7 +32,6 @@ import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import jdk.internal.misc.Unsafe;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.util.DecimalDigits;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
@@ -43,8 +42,6 @@ import static java.lang.String.checkIndex;
 import static java.lang.String.checkOffset;
 
 final class StringLatin1 {
-    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
-
     public static char charAt(byte[] value, int index) {
         checkIndex(index, value.length);
         return (char)(value[index] & 0xff);
@@ -825,27 +822,6 @@ final class StringLatin1 {
 
     static Stream<String> lines(byte[] value) {
         return StreamSupport.stream(LinesSpliterator.spliterator(value), false);
-    }
-
-    static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4) {
-        assert index >= 0 && index + 3 < length(val) : "Trusted caller missed bounds check";
-        // Don't use the putChar method, Its instrinsic will cause C2 unable to combining values into larger stores.
-        long offset = (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
-        UNSAFE.putByte(val, offset    , (byte)(c1));
-        UNSAFE.putByte(val, offset + 1, (byte)(c2));
-        UNSAFE.putByte(val, offset + 2, (byte)(c3));
-        UNSAFE.putByte(val, offset + 3, (byte)(c4));
-    }
-
-    static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4, int c5) {
-        assert index >= 0 && index + 4 < length(val) : "Trusted caller missed bounds check";
-        // Don't use the putChar method, Its instrinsic will cause C2 unable to combining values into larger stores.
-        long offset  = (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
-        UNSAFE.putByte(val, offset    , (byte)(c1));
-        UNSAFE.putByte(val, offset + 1, (byte)(c2));
-        UNSAFE.putByte(val, offset + 2, (byte)(c3));
-        UNSAFE.putByte(val, offset + 3, (byte)(c4));
-        UNSAFE.putByte(val, offset + 4, (byte)(c5));
     }
 
     public static void putChar(byte[] val, int index, int c) {

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -43,6 +43,7 @@ import static java.lang.String.UTF16;
 import static java.lang.String.LATIN1;
 
 final class StringUTF16 {
+
     // Return a new byte array for a UTF16-coded string for len chars
     // Throw an exception if out of range
     public static byte[] newBytesFor(int len) {
@@ -1547,20 +1548,27 @@ final class StringUTF16 {
         return true;
     }
 
-    static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4) {
-        assert index >= 0 && index + 3 < length(val) : "Trusted caller missed bounds check";
-        putChar(val, index    , c1);
-        putChar(val, index + 1, c2);
-        putChar(val, index + 2, c3);
-        putChar(val, index + 3, c4);
+    public static int putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
+        int end = i + 4;
+        checkBoundsBeginEnd(i, end, value);
+        putChar(value, i++, c1);
+        putChar(value, i++, c2);
+        putChar(value, i++, c3);
+        putChar(value, i++, c4);
+        assert(i == end);
+        return end;
     }
 
-    static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4, int c5) {
-        putChar(val, index    , c1);
-        putChar(val, index + 1, c2);
-        putChar(val, index + 2, c3);
-        putChar(val, index + 3, c4);
-        putChar(val, index + 4, c5);
+    public static int putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
+        int end = i + 5;
+        checkBoundsBeginEnd(i, end, value);
+        putChar(value, i++, c1);
+        putChar(value, i++, c2);
+        putChar(value, i++, c3);
+        putChar(value, i++, c4);
+        putChar(value, i++, c5);
+        assert(i == end);
+        return end;
     }
 
     public static char charAt(byte[] value, int index) {

--- a/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
+++ b/test/hotspot/jtreg/compiler/patches/java.base/java/lang/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,17 +133,11 @@ public class Helper {
     }
 
     public static int putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4) {
-        int end = i + 4;
-        StringUTF16.checkBoundsBeginEnd(i, end, value);
-        StringUTF16.putCharsAt(value, i, c1, c2, c3, c4);
-        return end;
+        return StringUTF16.putCharsAt(value, i, c1, c2, c3, c4);
     }
 
     public static int putCharsAt(byte[] value, int i, char c1, char c2, char c3, char c4, char c5) {
-        int end = i + 5;
-        StringUTF16.checkBoundsBeginEnd(i, end, value);
-        StringUTF16.putCharsAt(value, i, c1, c2, c3, c4, c5);
-        return end;
+        return StringUTF16.putCharsAt(value, i, c1, c2, c3, c4, c5);
     }
 
     public static char charAt(byte[] value, int index) {

--- a/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
@@ -226,66 +226,17 @@ public class StringBuilders {
 
 
     @Benchmark
-    public int appendWithBool8Latin1() {
-        StringBuilder buf = sbLatin1;
-        buf.setLength(0);
-        buf.append(true);
-        buf.append(false);
-        buf.append(true);
-        buf.append(true);
-        buf.append(false);
-        buf.append(true);
-        buf.append(false);
-        buf.append(false);
-        return buf.length();
-    }
-
-
-    @Benchmark
-    public int appendWithBool8Utf16() {
-        StringBuilder buf = sbUtf16;
-        buf.setLength(0);
-        buf.append(true);
-        buf.append(false);
-        buf.append(true);
-        buf.append(true);
-        buf.append(false);
-        buf.append(true);
-        buf.append(false);
-        buf.append(false);
-        return buf.length();
-    }
-
-
-    @Benchmark
-    public int appendWithNull8Latin1() {
-        StringBuilder buf = sbLatin1;
-        buf.setLength(0);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        return buf.length();
-    }
-
-
-    @Benchmark
-    public int appendWithNull8Utf16() {
-        StringBuilder buf = sbUtf16;
-        buf.setLength(0);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        buf.append((String) null);
-        return buf.length();
+    public String toStringCharWithBool8() {
+        StringBuilder result = new StringBuilder();
+        result.append(true);
+        result.append(false);
+        result.append(true);
+        result.append(true);
+        result.append(false);
+        result.append(true);
+        result.append(false);
+        result.append(false);
+        return result.toString();
     }
 
 


### PR DESCRIPTION
Can I please get a review of this backport of https://github.com/openjdk/jdk/pull/23420 into jdk24?

This proposes to bring in those same backouts into `jdk24` to prevent the issue noted in that PR description. jdk24 is in rampdown and this backport will require an approval. A approval request has been raised in https://bugs.openjdk.org/browse/JDK-8349183?focusedId=14746841&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14746841.

This backport into jdk24 wasn't clean due to a trivial merge conflict in `StringLatin1.java` file. That merge conflict was manually resolved (just like it was done against mainline). The git commands used to create this backport against jdk24 branch are:

```
<checkout fresh jdk24 branch>
git cherry-pick --no-commit 618c5eb27b4c719afd577b690e6bcb21a45fcb0d
<resolve merge conflict in StringLatin1.java>
git commit -m 'Backport 618c5eb27b4c719afd577b690e6bcb21a45fcb0d'
```

tier1, tier2 and tier3 testing is currently in progress with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8349183](https://bugs.openjdk.org/browse/JDK-8349183): [BACKOUT] Optimization for StringBuilder append boolean &amp; null (**Sub-task** - P2)
 * [JDK-8349239](https://bugs.openjdk.org/browse/JDK-8349239): [BACKOUT] Reuse StringLatin1::putCharsAt and StringUTF16::putCharsAt (**Bug** - P2)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23425/head:pull/23425` \
`$ git checkout pull/23425`

Update a local copy of the PR: \
`$ git checkout pull/23425` \
`$ git pull https://git.openjdk.org/jdk.git pull/23425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23425`

View PR using the GUI difftool: \
`$ git pr show -t 23425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23425.diff">https://git.openjdk.org/jdk/pull/23425.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23425#issuecomment-2631792140)
</details>
