### PR TITLE
8349241: Fix the concurrent execution JVM crash of StringBuilder::append(int/long)

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -272,7 +272,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * unless the given minimum capacity is greater than that.
      *
      * @param  minCapacity the desired minimum capacity
-     * @param  oldLength current length
+     * @param  oldLength the raw length of the current value array, without being processed using coder.
      * @param  coder the coder to be used when calculating the capacity length
      * @throws OutOfMemoryError if minCapacity is less than zero or
      *         greater than (Integer.MAX_VALUE >> coder)

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -239,20 +239,10 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * If {@code minimumCapacity} is non positive due to numeric
      * overflow, this method throws {@code OutOfMemoryError}.
      */
-    private void ensureCapacityInternal(int minimumCapacity) {
-        ensureCapacityInternal(minimumCapacity, getCoder());
-    }
-
-    /**
-     * For positive values of {@code minimumCapacity}, this method
-     * behaves like {@code ensureCapacity}, however it is never
-     * synchronized.
-     * If {@code minimumCapacity} is non positive due to numeric
-     * overflow, this method throws {@code OutOfMemoryError}.
-     */
-    private byte[] ensureCapacityInternal(int minimumCapacity, byte coder) {
+    private byte[] ensureCapacityInternal(int minimumCapacity) {
         // overflow-conscious code
         byte[] value = this.value;
+        byte coder = this.coder;
         int oldCapacity = value.length >> coder;
         if (minimumCapacity - oldCapacity > 0) {
             value = Arrays.copyOf(value,
@@ -852,9 +842,8 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     public AbstractStringBuilder append(int i) {
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(i);
-        byte coder = getCoder();
-        byte[] value = ensureCapacityInternal(spaceNeeded, coder);
-        if (coder == LATIN1) {
+        byte[] value = ensureCapacityInternal(spaceNeeded);
+        if (isLatin1()) {
             DecimalDigits.getCharsLatin1(i, spaceNeeded, value);
         } else {
             DecimalDigits.getCharsUTF16(i, spaceNeeded, value);
@@ -878,9 +867,8 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     public AbstractStringBuilder append(long l) {
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(l);
-        byte coder = getCoder();
-        byte[] value = ensureCapacityInternal(spaceNeeded, coder);
-        if (coder == LATIN1) {
+        byte[] value = ensureCapacityInternal(spaceNeeded);
+        if (isLatin1()) {
             DecimalDigits.getCharsLatin1(l, spaceNeeded, value);
         } else {
             DecimalDigits.getCharsUTF16(l, spaceNeeded, value);

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -253,14 +253,14 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      */
     private byte[] ensureCapacityInternal(int minimumCapacity, byte coder) {
         // overflow-conscious code
-        byte[] value = this.value;
-        int oldCapacity = value.length >> coder;
+        byte[] val = this.value;
+        int oldCapacity = val.length >> coder;
         if (minimumCapacity - oldCapacity > 0) {
-            value = Arrays.copyOf(value,
-                    newCapacity(minimumCapacity, value, coder) << coder);
-            this.value = value;
+            val = Arrays.copyOf(val,
+                    newCapacity(minimumCapacity, val, coder) << coder);
+            this.value = val;
         }
-        return value;
+        return val;
     }
 
     /**
@@ -272,6 +272,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * unless the given minimum capacity is greater than that.
      *
      * @param  minCapacity the desired minimum capacity
+     * @param  coder the coder to be used when calculating the capacity length
      * @throws OutOfMemoryError if minCapacity is less than zero or
      *         greater than (Integer.MAX_VALUE >> coder)
      */

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -250,6 +250,10 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * synchronized.
      * If {@code minimumCapacity} is non positive due to numeric
      * overflow, this method throws {@code OutOfMemoryError}.
+     *
+     * @param   minimumCapacity   the minimum desired capacity.
+     * @param   coder the coder to be used when calculating the capacity length.
+     * @return  Returns the value that ensures the capacity
      */
     private byte[] ensureCapacityInternal(int minimumCapacity, byte coder) {
         // overflow-conscious code

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -239,13 +239,16 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * If {@code minimumCapacity} is non positive due to numeric
      * overflow, this method throws {@code OutOfMemoryError}.
      */
-    private void ensureCapacityInternal(int minimumCapacity) {
+    private byte[] ensureCapacityInternal(int minimumCapacity) {
         // overflow-conscious code
+        byte[] value = this.value;
         int oldCapacity = value.length >> coder;
         if (minimumCapacity - oldCapacity > 0) {
             value = Arrays.copyOf(value,
                     newCapacity(minimumCapacity) << coder);
+            this.value = value;
         }
+        return value;
     }
 
     /**
@@ -838,7 +841,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     public AbstractStringBuilder append(int i) {
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(i);
-        ensureCapacityInternal(spaceNeeded);
+        byte[] value = ensureCapacityInternal(spaceNeeded);
         if (isLatin1()) {
             DecimalDigits.getCharsLatin1(i, spaceNeeded, value);
         } else {
@@ -863,7 +866,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     public AbstractStringBuilder append(long l) {
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(l);
-        ensureCapacityInternal(spaceNeeded);
+        byte[] value = ensureCapacityInternal(spaceNeeded);
         if (isLatin1()) {
             DecimalDigits.getCharsLatin1(l, spaceNeeded, value);
         } else {

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -239,10 +239,21 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * If {@code minimumCapacity} is non positive due to numeric
      * overflow, this method throws {@code OutOfMemoryError}.
      */
-    private byte[] ensureCapacityInternal(int minimumCapacity) {
+    private void ensureCapacityInternal(int minimumCapacity) {
+        // overflow-conscious code
+        ensureCapacityInternal(minimumCapacity, coder);
+    }
+
+    /**
+     * For positive values of {@code minimumCapacity}, this method
+     * behaves like {@code ensureCapacity}, however it is never
+     * synchronized.
+     * If {@code minimumCapacity} is non positive due to numeric
+     * overflow, this method throws {@code OutOfMemoryError}.
+     */
+    private byte[] ensureCapacityInternal(int minimumCapacity, byte coder) {
         // overflow-conscious code
         byte[] value = this.value;
-        byte coder = this.coder;
         int oldCapacity = value.length >> coder;
         if (minimumCapacity - oldCapacity > 0) {
             value = Arrays.copyOf(value,
@@ -842,8 +853,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     public AbstractStringBuilder append(int i) {
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(i);
-        byte[] value = ensureCapacityInternal(spaceNeeded);
-        if (isLatin1()) {
+        byte coder = this.coder;
+        byte[] value = ensureCapacityInternal(spaceNeeded, coder);
+        if (coder == LATIN1) {
             DecimalDigits.getCharsLatin1(i, spaceNeeded, value);
         } else {
             DecimalDigits.getCharsUTF16(i, spaceNeeded, value);
@@ -867,8 +879,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     public AbstractStringBuilder append(long l) {
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(l);
-        byte[] value = ensureCapacityInternal(spaceNeeded);
-        if (isLatin1()) {
+        byte coder = this.coder;
+        byte[] value = ensureCapacityInternal(spaceNeeded, coder);
+        if (coder == LATIN1) {
             DecimalDigits.getCharsLatin1(l, spaceNeeded, value);
         } else {
             DecimalDigits.getCharsUTF16(l, spaceNeeded, value);

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -257,7 +257,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         int oldCapacity = val.length >> coder;
         if (minimumCapacity - oldCapacity > 0) {
             val = Arrays.copyOf(val,
-                    newCapacity(minimumCapacity, val, coder) << coder);
+                    newCapacity(minimumCapacity, val.length, coder) << coder);
             this.value = val;
         }
         return val;
@@ -272,12 +272,12 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * unless the given minimum capacity is greater than that.
      *
      * @param  minCapacity the desired minimum capacity
+     * @param  oldLength current length
      * @param  coder the coder to be used when calculating the capacity length
      * @throws OutOfMemoryError if minCapacity is less than zero or
      *         greater than (Integer.MAX_VALUE >> coder)
      */
-    private static int newCapacity(int minCapacity, byte[] value, byte coder) {
-        int oldLength = value.length;
+    private static int newCapacity(int minCapacity, int oldLength, byte coder) {
         int newLength = minCapacity << coder;
         int growth = newLength - oldLength;
         int length = ArraysSupport.newLength(oldLength, growth, oldLength + (2 << coder));

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -240,7 +240,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * overflow, this method throws {@code OutOfMemoryError}.
      */
     private void ensureCapacityInternal(int minimumCapacity) {
-        ensureCapacityInternal(minimumCapacity, value, getCoder());
+        ensureCapacityInternal(minimumCapacity, getCoder());
     }
 
     /**
@@ -250,8 +250,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * If {@code minimumCapacity} is non positive due to numeric
      * overflow, this method throws {@code OutOfMemoryError}.
      */
-    private byte[] ensureCapacityInternal(int minimumCapacity, byte[] value, byte coder) {
+    private byte[] ensureCapacityInternal(int minimumCapacity, byte coder) {
         // overflow-conscious code
+        byte[] value = this.value;
         int oldCapacity = value.length >> coder;
         if (minimumCapacity - oldCapacity > 0) {
             value = Arrays.copyOf(value,
@@ -852,7 +853,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(i);
         byte coder = getCoder();
-        byte[] value = ensureCapacityInternal(spaceNeeded, this.value, coder);
+        byte[] value = ensureCapacityInternal(spaceNeeded, coder);
         if (coder == LATIN1) {
             DecimalDigits.getCharsLatin1(i, spaceNeeded, value);
         } else {
@@ -878,7 +879,7 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
         int count = this.count;
         int spaceNeeded = count + DecimalDigits.stringSize(l);
         byte coder = getCoder();
-        byte[] value = ensureCapacityInternal(spaceNeeded, this.value, coder);
+        byte[] value = ensureCapacityInternal(spaceNeeded, coder);
         if (coder == LATIN1) {
             DecimalDigits.getCharsLatin1(l, spaceNeeded, value);
         } else {


### PR DESCRIPTION
The following code can reproduce the problem, writing out of bounds causes JVM Crash

```java
         StringBuilder buf = new StringBuilder();
        buf.append('中');

        Thread[] threads = new Thread[40];
        final CountDownLatch latch = new CountDownLatch(threads.length);
        Runnable r = () -> {
            for (int i = 0; i < 1000000; i++) {
                buf.setLength(0);
                buf.trimToSize();
                buf.append(123456789123456789L);
            }
            latch.countDown();
        };

        for (int i = 0; i < threads.length; i++) {
            threads[i] = new Thread(r);
        }
        for (Thread t : threads) {
            t.start();
        }
        latch.await();
```

This problem can be avoided by using the value of ensureCapacityInternal directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8349241](https://bugs.openjdk.org/browse/JDK-8349241): Fix the concurrent execution JVM crash of StringBuilder::append(int/long) (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23427/head:pull/23427` \
`$ git checkout pull/23427`

Update a local copy of the PR: \
`$ git checkout pull/23427` \
`$ git pull https://git.openjdk.org/jdk.git pull/23427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23427`

View PR using the GUI difftool: \
`$ git pr show -t 23427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23427.diff">https://git.openjdk.org/jdk/pull/23427.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23427#issuecomment-2631817922)
</details>
