### PR TITLE
8349178: runtime/jni/atExit/TestAtExit.java should be supported on static JDK

### DIFF
--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -880,7 +880,6 @@ endif
 
 
 BUILD_HOTSPOT_JTREG_EXECUTABLES_JDK_LIBS_exesigtest := java.base:libjvm
-BUILD_HOTSPOT_JTREG_LIBRARIES_JDK_LIBS_libatExit := java.base:libjvm
 BUILD_HOTSPOT_JTREG_EXECUTABLES_JDK_LIBS_exedaemonDestroy := java.base:libjvm
 
 ifeq ($(call isTargetOs, windows), true)

--- a/test/hotspot/jtreg/runtime/jni/atExit/libatExit.c
+++ b/test/hotspot/jtreg/runtime/jni/atExit/libatExit.c
@@ -71,7 +71,7 @@ jboolean getJavaVMfunctions() {
 #ifdef WINDOWS
     HMODULE handle;
     handle = GetModuleHandle("jvm.dll");
-    if (handle == NULL) (
+    if (handle == NULL) {
       // No loaded jvm.dll. Get the handle to the executable.
       handle = GetModuleHandle(NULL);
     }

--- a/test/hotspot/jtreg/runtime/jni/atExit/libatExit.c
+++ b/test/hotspot/jtreg/runtime/jni/atExit/libatExit.c
@@ -24,6 +24,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef WINDOWS
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif // WINDOWS
+
 #include "jni.h"
 
 static JavaVM *jvm;
@@ -52,6 +58,48 @@ static void report(const char* func, int ret_actual, int ret_expected) {
 
 static int using_system_exit = 0; // Not System.exit by default
 
+typedef jint (JNICALL *GetDefaultJavaVMInitArgs_t)(void *args);
+typedef jint (JNICALL *GetCreatedJavaVMs_t)(JavaVM **vmBuf, jsize bufLen, jsize *nVMs);
+typedef jint (JNICALL *CreateJavaVM_t)(JavaVM **pvm, void **penv, void *args);
+
+GetDefaultJavaVMInitArgs_t GetDefaultJavaVMInitArgs = NULL;
+GetCreatedJavaVMs_t GetCreatedJavaVMs = NULL;
+CreateJavaVM_t CreateJavaVM = NULL;
+
+// VM is already loaded.
+jboolean getJavaVMfunctions() {
+#ifdef WINDOWS
+    HMODULE handle;
+    handle = GetModuleHandle("jvm.dll");
+    if (handle == NULL) (
+      // No loaded jvm.dll. Get the handle to the executable.
+      handle = GetModuleHandle(NULL);
+    }
+#endif
+
+#ifdef WINDOWS
+#define GET_VM_FUNCTION(f) GetProcAddress(handle, f)
+#else
+#define GET_VM_FUNCTION(f) dlsym(RTLD_DEFAULT, f)
+#endif
+    GetDefaultJavaVMInitArgs = (GetDefaultJavaVMInitArgs_t)GET_VM_FUNCTION("JNI_GetDefaultJavaVMInitArgs");
+    if (GetDefaultJavaVMInitArgs == NULL) {
+      fprintf(stderr, "Failed to find JNI_GetDefaultJavaVMInitArgs");
+      return JNI_FALSE;
+    }
+    GetCreatedJavaVMs = (GetCreatedJavaVMs_t)GET_VM_FUNCTION("JNI_GetCreatedJavaVMs");
+    if (GetCreatedJavaVMs == NULL) {
+      fprintf(stderr, "Failed to find JNI_GetCreatedJavaVMs");
+      return JNI_FALSE;
+    }
+    CreateJavaVM = (CreateJavaVM_t)GET_VM_FUNCTION("JNI_CreateJavaVM");
+    if (CreateJavaVM == NULL) {
+      fprintf(stderr, "Failed to find JNI_CreateJavaVM");
+      return JNI_FALSE;
+    }
+    return JNI_TRUE;
+}
+
 JNIEXPORT
 void JNICALL Java_TestAtExit_00024Tester_setUsingSystemExit(JNIEnv* env, jclass c) {
   using_system_exit = 1;
@@ -59,6 +107,10 @@ void JNICALL Java_TestAtExit_00024Tester_setUsingSystemExit(JNIEnv* env, jclass 
 
 void at_exit_handler(void) {
   printf("In at_exit_handler\n");
+
+  if (!getJavaVMfunctions()) {
+    return;
+  }
 
   // We've saved the JavaVM from OnLoad time so we first try to
   // get a JNIEnv for the current thread.
@@ -78,12 +130,12 @@ void at_exit_handler(void) {
 
     JavaVMInitArgs args;
     args.version = JNI_VERSION_1_2;
-    res = JNI_GetDefaultJavaVMInitArgs(&args);
+    res = (*GetDefaultJavaVMInitArgs)(&args);
     report("JNI_GetDefaultJavaVMInitArgs", res, JNI_OK);
 
     JavaVM* jvm_p[1];
     int nVMs;
-    res = JNI_GetCreatedJavaVMs(jvm_p, 1, &nVMs);
+    res = (*GetCreatedJavaVMs)(jvm_p, 1, &nVMs);
     report("JNI_GetCreatedJavaVMs", res, JNI_OK);
     // Whether nVMs is 0 or 1 depends on the termination path
     if (nVMs == 0 && !using_system_exit) {
@@ -98,7 +150,7 @@ void at_exit_handler(void) {
     report("DestroyJavaVM", res, JNI_ERR);
 
     // Failure mode depends on the termination path
-    res = JNI_CreateJavaVM(jvm_p, (void**)&env, &args);
+    res = (*CreateJavaVM)(jvm_p, (void**)&env, &args);
     report("JNI_CreateJavaVM", res, using_system_exit ? JNI_EEXIST : JNI_ERR);
   }
   // else test has already failed


### PR DESCRIPTION
Please review runtime/jni/atExit/TestAtExit.java test change:

- Remove `BUILD_HOTSPOT_JTREG_LIBRARIES_JDK_LIBS_libatExit := java.base:libjvm`. Don't explicitly link with libjvm, because it adds libjvm.so as a recorded dependency to libatExit.so (on Linux for example). That requires libjvm.so must be resolved and loaded successfully when libatExit.so is loaded. The static JDK (e.g. static-jdk image) does not provide a libjvm.so for runtime usage.
- Instead of calling the following functions directly in libatExit.c, change to look up the functions and calls them using the retrieved function addresses:
  - JNI_GetDefaultJavaVMInitArgs
  - JNI_GetCreatedJavaVMs
  - JNI_CreateJavaVM

On Linux (and similar) platform, there is no need to call `dlopen` for libjvm in libatExit.c explicitly, because the VM must already be loaded by the time when the libatExit native code is executed. Using `RTLD_DEFAULT` can "find symbols in the executable and its dependencies, as well as symbols in shared objects that were dynamically loaded with the RTLD_GLOBAL flag" (see https://man7.org/linux/man-pages/man3/dlsym.3.html).  https://github.com/openjdk/jdk/blob/9b49597244f898400222cfc252f50a2401ca3e2f/src/java.base/unix/native/libjli/java_md.c#L533 is where we `dlopen` libjvm with `RTLD_GLOBAL` for unix platform.

For Windows platform, I added Windows specific code to get the loaded `jvm.dll` first. If it can't find loaded `jvm.dll`, it then get the handle of the executable running the current process. The returned handle is used for finding the function addresses. 

TestAtExit passes with https://github.com/jianglizhou/jdk/actions/runs/13124407248/job/36619759000. TestAtExit also pass on static-jdk with my local jtreg run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349178](https://bugs.openjdk.org/browse/JDK-8349178): runtime/jni/atExit/TestAtExit.java should be supported on static JDK (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23431/head:pull/23431` \
`$ git checkout pull/23431`

Update a local copy of the PR: \
`$ git checkout pull/23431` \
`$ git pull https://git.openjdk.org/jdk.git pull/23431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23431`

View PR using the GUI difftool: \
`$ git pr show -t 23431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23431.diff">https://git.openjdk.org/jdk/pull/23431.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23431#issuecomment-2632539331)
</details>
