### PR TITLE
8349214: Improve size optimization flags for MSVC builds

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -347,7 +347,7 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
     C_O_FLAG_DEBUG="-Od"
     C_O_FLAG_DEBUG_JVM=""
     C_O_FLAG_NONE="-Od"
-    C_O_FLAG_SIZE="-Os"
+    C_O_FLAG_SIZE="-O1"
   fi
 
   # Now copy to C++ flags


### PR DESCRIPTION
Looks like the binary size optimization flags are not ideal when compiling with MSVC.
On other compilers (gcc/clang) the current size optimization flags lead in most cases to smaller libraries. On MSVC this seems to be not the case, the libs often get larger when optimizing for SIZE.

For example jvm.dll (build with VS2022) with current -Os size optimization
20M images/jdk/bin/server/jvm.dll

with -O1 set for size optimization
13M images/jdk/bin/server/jvm.dll

See the doc from MSVC about "optimize for size"
https://learn.microsoft.com/en-us/cpp/build/reference/o1-o2-minimize-size-maximize-speed?view=msvc-170
"The /O1 option sets the individual optimization options that create the smallest code in the majority of cases."
The Os option is only a part of the size minimization flag set :
/O1 (Minimize Size) equivalent to /Og /Os /Oy /Ob2 /GF /Gy

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349214](https://bugs.openjdk.org/browse/JDK-8349214): Improve size optimization flags for MSVC builds (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23432/head:pull/23432` \
`$ git checkout pull/23432`

Update a local copy of the PR: \
`$ git checkout pull/23432` \
`$ git pull https://git.openjdk.org/jdk.git pull/23432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23432`

View PR using the GUI difftool: \
`$ git pr show -t 23432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23432.diff">https://git.openjdk.org/jdk/pull/23432.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23432#issuecomment-2633268788)
</details>
