### PR TITLE
8346777: Add missing const declarations and rename variables

### DIFF
--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -69,7 +69,7 @@ bool AssertionPredicate::has_halt(const Node* success_proj) {
 }
 
 // Returns the Parse Predicate node if the provided node is a Parse Predicate success proj. Otherwise, return null.
-ParsePredicateNode* ParsePredicate::init_parse_predicate(Node* parse_predicate_proj,
+ParsePredicateNode* ParsePredicate::init_parse_predicate(const Node* parse_predicate_proj,
                                                          Deoptimization::DeoptReason deopt_reason) {
   assert(parse_predicate_proj != nullptr, "must not be null");
   if (parse_predicate_proj->is_IfTrue() && parse_predicate_proj->in(0)->is_ParsePredicate()) {
@@ -100,7 +100,7 @@ void ParsePredicate::trace_cloned_parse_predicate(const bool is_true_path_loop,
 }
 #endif // NOT PRODUCT
 
-Deoptimization::DeoptReason RuntimePredicate::uncommon_trap_reason(IfProjNode* if_proj) {
+Deoptimization::DeoptReason RuntimePredicate::uncommon_trap_reason(const IfProjNode* if_proj) {
     CallStaticJavaNode* uct_call = if_proj->is_uncommon_trap_if_pattern();
     if (uct_call == nullptr) {
       return Deoptimization::Reason_none;
@@ -108,7 +108,7 @@ Deoptimization::DeoptReason RuntimePredicate::uncommon_trap_reason(IfProjNode* i
     return Deoptimization::trap_request_reason(uct_call->uncommon_trap_request());
 }
 
-bool RuntimePredicate::is_predicate(Node* maybe_success_proj) {
+bool RuntimePredicate::is_predicate(const Node* maybe_success_proj) {
   if (RegularPredicate::may_be_predicate_if(maybe_success_proj)) {
     return has_valid_uncommon_trap(maybe_success_proj);
   } else {
@@ -150,7 +150,7 @@ bool RegularPredicate::may_be_predicate_if(const Node* node) {
 // Template Assertion Predicate) to the 'target_predicate' based on the 'data_in_loop_body' check.
 void TemplateAssertionPredicate::rewire_loop_data_dependencies(IfTrueNode* target_predicate,
                                                                const NodeInLoopBody& data_in_loop_body,
-                                                               PhaseIdealLoop* phase) const {
+                                                               const PhaseIdealLoop* phase) const {
   for (DUIterator i = _success_proj->outs(); _success_proj->has_out(i); i++) {
     Node* output = _success_proj->out(i);
     if (!output->is_CFG() && data_in_loop_body.check_node_in_loop_body(output)) {
@@ -161,7 +161,7 @@ void TemplateAssertionPredicate::rewire_loop_data_dependencies(IfTrueNode* targe
 }
 
 // Template Assertion Predicates always have the dedicated OpaqueTemplateAssertionPredicate to identify them.
-bool TemplateAssertionPredicate::is_predicate(Node* node) {
+bool TemplateAssertionPredicate::is_predicate(const Node* node) {
   if (!may_be_assertion_predicate_if(node)) {
     return false;
   }
@@ -294,7 +294,7 @@ void InitializedAssertionPredicate::verify() const {
 
 // Initialized Assertion Predicates always have the dedicated OpaqueInitiailizedAssertionPredicate node to identify
 // them.
-bool InitializedAssertionPredicate::is_predicate(Node* node) {
+bool InitializedAssertionPredicate::is_predicate(const Node* node) {
   if (!may_be_assertion_predicate_if(node)) {
     return false;
   }
@@ -310,7 +310,7 @@ void InitializedAssertionPredicate::kill(PhaseIdealLoop* phase) const {
 #ifdef ASSERT
 // Check that the block has at most one Parse Predicate and that we only find Regular Predicate nodes (i.e. IfProj,
 // If, or RangeCheck nodes).
-void RegularPredicateBlock::verify_block(Node* tail) {
+void RegularPredicateBlock::verify_block(Node* tail) const {
   Node* next = tail;
   while (next != _entry) {
     assert(!next->is_ParsePredicate(), "can only have one Parse Predicate in a block");
@@ -326,33 +326,33 @@ void RegularPredicateBlock::verify_block(Node* tail) {
 // This strategy clones the OpaqueLoopInit and OpaqueLoopStride nodes.
 class CloneStrategy : public TransformStrategyForOpaqueLoopNodes {
   PhaseIdealLoop* const _phase;
-  Node* const _new_ctrl;
+  Node* const _new_control;
 
  public:
-  CloneStrategy(PhaseIdealLoop* phase, Node* new_ctrl)
+  CloneStrategy(PhaseIdealLoop* phase, Node* new_control)
       : _phase(phase),
-        _new_ctrl(new_ctrl) {}
+        _new_control(new_control) {}
   NONCOPYABLE(CloneStrategy);
 
   Node* transform_opaque_init(OpaqueLoopInitNode* opaque_init) const override {
-    return _phase->clone_and_register(opaque_init, _new_ctrl)->as_OpaqueLoopInit();
+    return _phase->clone_and_register(opaque_init, _new_control)->as_OpaqueLoopInit();
   }
 
   Node* transform_opaque_stride(OpaqueLoopStrideNode* opaque_stride) const override {
-    return _phase->clone_and_register(opaque_stride, _new_ctrl)->as_OpaqueLoopStride();
+    return _phase->clone_and_register(opaque_stride, _new_control)->as_OpaqueLoopStride();
   }
 };
 
 // This strategy replaces the OpaqueLoopInitNode with the provided init node and clones the OpaqueLoopStrideNode.
 class ReplaceInitAndCloneStrideStrategy : public TransformStrategyForOpaqueLoopNodes {
   Node* const _new_init;
-  Node* const _new_ctrl;
+  Node* const _new_control;
   PhaseIdealLoop* const _phase;
 
  public:
-  ReplaceInitAndCloneStrideStrategy(Node* new_init, Node* new_ctrl, PhaseIdealLoop* phase)
+  ReplaceInitAndCloneStrideStrategy(Node* new_control, Node* new_init, PhaseIdealLoop* phase)
       : _new_init(new_init),
-        _new_ctrl(new_ctrl),
+        _new_control(new_control),
         _phase(phase) {}
   NONCOPYABLE(ReplaceInitAndCloneStrideStrategy);
 
@@ -361,54 +361,24 @@ class ReplaceInitAndCloneStrideStrategy : public TransformStrategyForOpaqueLoopN
   }
 
   Node* transform_opaque_stride(OpaqueLoopStrideNode* opaque_stride) const override {
-    return _phase->clone_and_register(opaque_stride, _new_ctrl)->as_OpaqueLoopStride();
-  }
-};
-
-// This strategy replaces the OpaqueLoopInit and OpaqueLoopStride nodes with the provided init and stride nodes,
-// respectively.
-class ReplaceInitAndStrideStrategy : public TransformStrategyForOpaqueLoopNodes {
-  Node* const _new_init;
-  Node* const _new_stride;
-
- public:
-  ReplaceInitAndStrideStrategy(Node* new_init, Node* new_stride)
-      : _new_init(new_init),
-        _new_stride(new_stride) {}
-  NONCOPYABLE(ReplaceInitAndStrideStrategy);
-
-  Node* transform_opaque_init(OpaqueLoopInitNode* opaque_init) const override {
-    return _new_init;
-  }
-
-  Node* transform_opaque_stride(OpaqueLoopStrideNode* opaque_stride) const override {
-    return _new_stride;
+    return _phase->clone_and_register(opaque_stride, _new_control)->as_OpaqueLoopStride();
   }
 };
 
 // Creates an identical clone of this Template Assertion Expression (i.e.cloning all nodes from the
 // OpaqueTemplateAssertionPredicate to and including the OpaqueLoop* nodes). The cloned nodes are rewired to reflect the
-// same graph structure as found for this Template Assertion Expression. The cloned nodes get 'new_ctrl' as ctrl. There
-// is no other update done for the cloned nodes. Return the newly cloned OpaqueTemplateAssertionPredicate.
-OpaqueTemplateAssertionPredicateNode* TemplateAssertionExpression::clone(Node* new_control, PhaseIdealLoop* phase) {
+// same graph structure as found for this Template Assertion Expression. The cloned nodes get 'new_control' as control.
+// There is no other update done for the cloned nodes. Return the newly cloned OpaqueTemplateAssertionPredicate.
+OpaqueTemplateAssertionPredicateNode* TemplateAssertionExpression::clone(Node* new_control, PhaseIdealLoop* phase) const {
   CloneStrategy clone_init_and_stride_strategy(phase, new_control);
   return clone(clone_init_and_stride_strategy, new_control, phase);
 }
 
 // Same as clone() but instead of cloning the OpaqueLoopInitNode, we replace it with the provided 'new_init' node.
 OpaqueTemplateAssertionPredicateNode*
-TemplateAssertionExpression::clone_and_replace_init(Node* new_control, Node* new_init, PhaseIdealLoop* phase) {
-  ReplaceInitAndCloneStrideStrategy replace_init_and_clone_stride_strategy(new_init, new_control, phase);
+TemplateAssertionExpression::clone_and_replace_init(Node* new_control, Node* new_init, PhaseIdealLoop* phase) const {
+  ReplaceInitAndCloneStrideStrategy replace_init_and_clone_stride_strategy(new_control, new_init, phase);
   return clone(replace_init_and_clone_stride_strategy, new_control, phase);
-}
-
-// Same as clone() but instead of cloning the OpaqueLoopInit and OpaqueLoopStride node, we replace them with the provided
-// 'new_init' and 'new_stride' nodes, respectively.
-OpaqueTemplateAssertionPredicateNode*
-TemplateAssertionExpression::clone_and_replace_init_and_stride(Node* new_control, Node* new_init, Node* new_stride,
-                                                               PhaseIdealLoop* phase) {
-  ReplaceInitAndStrideStrategy replace_init_and_stride_strategy(new_init, new_stride);
-  return clone(replace_init_and_stride_strategy, new_control, phase);
 }
 
 // Class to collect data nodes from a source to target nodes by following the inputs of the source node recursively.
@@ -490,8 +460,8 @@ class DataNodesOnPathsToTargets : public StackObj {
 
 // Clones this Template Assertion Expression and applies the given strategy to transform the OpaqueLoop* nodes.
 OpaqueTemplateAssertionPredicateNode*
-TemplateAssertionExpression::clone(const TransformStrategyForOpaqueLoopNodes& transform_strategy, Node* new_ctrl,
-                                   PhaseIdealLoop* phase) {
+TemplateAssertionExpression::clone(const TransformStrategyForOpaqueLoopNodes& transform_strategy, Node* new_control,
+                                   PhaseIdealLoop* phase) const {
   ResourceMark rm;
   auto is_opaque_loop_node = [](const Node* node) {
     return node->is_Opaque1();
@@ -500,7 +470,8 @@ TemplateAssertionExpression::clone(const TransformStrategyForOpaqueLoopNodes& tr
                                                           is_opaque_loop_node);
   const Unique_Node_List& collected_nodes = data_nodes_on_path_to_targets.collect(_opaque_node);
   DataNodeGraph data_node_graph(collected_nodes, phase);
-  const OrigToNewHashtable& orig_to_new = data_node_graph.clone_with_opaque_loop_transform_strategy(transform_strategy, new_ctrl);
+  const OrigToNewHashtable& orig_to_new = data_node_graph.clone_with_opaque_loop_transform_strategy(transform_strategy,
+                                                                                                    new_control);
   assert(orig_to_new.contains(_opaque_node), "must exist");
   Node* opaque_node_clone = *orig_to_new.get(_opaque_node);
   return opaque_node_clone->as_OpaqueTemplateAssertionPredicate();
@@ -537,7 +508,7 @@ class ReplaceOpaqueStrideInput : public BFSActions {
 };
 
 // Replace the input to OpaqueLoopStrideNode with 'new_stride' and leave the other nodes unchanged.
-void TemplateAssertionExpression::replace_opaque_stride_input(Node* new_stride, PhaseIterGVN& igvn) {
+void TemplateAssertionExpression::replace_opaque_stride_input(Node* new_stride, PhaseIterGVN& igvn) const {
   ReplaceOpaqueStrideInput replace_opaque_stride_input(new_stride, igvn);
   replace_opaque_stride_input.replace_for(_opaque_node);
 }
@@ -555,7 +526,7 @@ class RemoveOpaqueLoopNodesStrategy : public TransformStrategyForOpaqueLoopNodes
 };
 
 OpaqueInitializedAssertionPredicateNode*
-TemplateAssertionExpression::clone_and_fold_opaque_loop_nodes(Node* new_control, PhaseIdealLoop* phase) {
+TemplateAssertionExpression::clone_and_fold_opaque_loop_nodes(Node* new_control, PhaseIdealLoop* phase) const {
   RemoveOpaqueLoopNodesStrategy remove_opaque_loop_nodes_strategy;
   OpaqueTemplateAssertionPredicateNode* cloned_template_opaque = clone(remove_opaque_loop_nodes_strategy, new_control,
                                                                        phase);
@@ -583,7 +554,7 @@ bool TemplateAssertionExpressionNode::is_in_expression(Node* node) {
   return false;
 }
 
-bool TemplateAssertionExpressionNode::is_template_assertion_predicate(Node* node) {
+bool TemplateAssertionExpressionNode::is_template_assertion_predicate(const Node* node) {
   return node->is_If() && node->in(1)->is_OpaqueTemplateAssertionPredicate();
 }
 
@@ -644,7 +615,7 @@ class AssertionPredicateExpressionCreator : public StackObj {
 // create_for_initialized() is that we use a template specific Halt message on the fail path.
 IfTrueNode* AssertionPredicateIfCreator::create_for_template(Node* new_control, const int if_opcode,
                                                              Node* assertion_expression,
-                                                             const AssertionPredicateType assertion_predicate_type) {
+                                                             const AssertionPredicateType assertion_predicate_type) const {
   const char* halt_message = "Template Assertion Predicates are always removed before code generation";
   return create(new_control, if_opcode, assertion_expression, halt_message, assertion_predicate_type);
 }
@@ -653,7 +624,7 @@ IfTrueNode* AssertionPredicateIfCreator::create_for_template(Node* new_control, 
 // create_for_template() is that we use a initialized specific Halt message on the fail path.
 IfTrueNode* AssertionPredicateIfCreator::create_for_initialized(Node* new_control, const int if_opcode,
                                                                 Node* assertion_expression,
-                                                                const AssertionPredicateType assertion_predicate_type) {
+                                                                const AssertionPredicateType assertion_predicate_type) const {
   const char* halt_message = "Initialized Assertion Predicate cannot fail";
   return create(new_control, if_opcode, assertion_expression, halt_message, assertion_predicate_type);
 }
@@ -669,7 +640,7 @@ IfTrueNode* AssertionPredicateIfCreator::create_for_initialized(Node* new_contro
 //
 IfTrueNode* AssertionPredicateIfCreator::create(Node* new_control, const int if_opcode, Node* assertion_expression,
                                                 const char* halt_message,
-                                                const AssertionPredicateType assertion_predicate_type) {
+                                                const AssertionPredicateType assertion_predicate_type) const {
   assert(assertion_expression->is_OpaqueTemplateAssertionPredicate() ||
          assertion_expression->is_OpaqueInitializedAssertionPredicate(), "not a valid assertion expression");
   IdealLoopTree* loop = _phase->get_loop(new_control);
@@ -680,7 +651,7 @@ IfTrueNode* AssertionPredicateIfCreator::create(Node* new_control, const int if_
 
 IfNode* AssertionPredicateIfCreator::create_if_node(Node* new_control, const int if_opcode, Node* assertion_expression,
                                                     IdealLoopTree* loop,
-                                                    const AssertionPredicateType assertion_predicate_type) {
+                                                    const AssertionPredicateType assertion_predicate_type) const {
   IfNode* if_node;
   if (if_opcode == Op_If) {
     if_node = new IfNode(new_control, assertion_expression, PROB_MAX, COUNT_UNKNOWN, assertion_predicate_type);
@@ -692,20 +663,20 @@ IfNode* AssertionPredicateIfCreator::create_if_node(Node* new_control, const int
   return if_node;
 }
 
-IfTrueNode* AssertionPredicateIfCreator::create_success_path(IfNode* if_node, IdealLoopTree* loop) {
+IfTrueNode* AssertionPredicateIfCreator::create_success_path(IfNode* if_node, IdealLoopTree* loop) const {
   IfTrueNode* success_proj = new IfTrueNode(if_node);
   _phase->register_control(success_proj, loop, if_node);
   return success_proj;
 }
 
-void AssertionPredicateIfCreator::create_fail_path(IfNode* if_node, IdealLoopTree* loop, const char* halt_message) {
+void AssertionPredicateIfCreator::create_fail_path(IfNode* if_node, IdealLoopTree* loop, const char* halt_message) const {
   IfFalseNode* fail_proj = new IfFalseNode(if_node);
   _phase->register_control(fail_proj, loop, if_node);
   create_halt_node(fail_proj, loop, halt_message);
 }
 
 void AssertionPredicateIfCreator::create_halt_node(IfFalseNode* fail_proj, IdealLoopTree* loop,
-                                                   const char* halt_message) {
+                                                   const char* halt_message) const {
   StartNode* start_node = _phase->C->start();
   Node* frame = new ParmNode(start_node, TypeFunc::FramePtr);
   _phase->register_new_node(frame, start_node);
@@ -714,7 +685,7 @@ void AssertionPredicateIfCreator::create_halt_node(IfFalseNode* fail_proj, Ideal
   _phase->register_control(halt, loop, fail_proj);
 }
 
-OpaqueLoopInitNode* TemplateAssertionPredicateCreator::create_opaque_init(Node* new_control) {
+OpaqueLoopInitNode* TemplateAssertionPredicateCreator::create_opaque_init(Node* new_control) const {
   OpaqueLoopInitNode* opaque_init = new OpaqueLoopInitNode(_phase->C, _loop_head->init_trip());
   _phase->register_new_node(opaque_init, new_control);
   return opaque_init;
@@ -760,7 +731,7 @@ IfTrueNode* TemplateAssertionPredicateCreator::create_if_node(
 
 // Creates an init and last value Template Assertion Predicate connected together with a Halt node on the failing path.
 // Returns the success projection of the last value Template Assertion Predicate latter.
-IfTrueNode* TemplateAssertionPredicateCreator::create(Node* new_control) {
+IfTrueNode* TemplateAssertionPredicateCreator::create(Node* new_control) const {
   OpaqueLoopInitNode* opaque_init = create_opaque_init(new_control);
   bool does_overflow;
   OpaqueTemplateAssertionPredicateNode* template_assertion_predicate_expression =
@@ -803,9 +774,9 @@ InitializedAssertionPredicateCreator::InitializedAssertionPredicateCreator(Phase
 //                           proj    (Halt or UCT)                       proj
 //
 InitializedAssertionPredicate InitializedAssertionPredicateCreator::create_from_template(
-    IfNode* template_assertion_predicate, Node* new_control, Node* new_init, Node* new_stride) const {
+    const IfNode* template_assertion_predicate, Node* new_control, Node* new_init) const {
   OpaqueInitializedAssertionPredicateNode* assertion_expression =
-      create_assertion_expression_from_template(template_assertion_predicate, new_control, new_init, new_stride);
+      create_assertion_expression_from_template(template_assertion_predicate, new_control, new_init);
    IfTrueNode* success_proj = create_control_nodes(new_control,
                                                    template_assertion_predicate->Opcode(),
                                                    assertion_expression,
@@ -856,14 +827,13 @@ IfTrueNode* InitializedAssertionPredicateCreator::create_control_nodes(
 // Create a new Assertion Expression based from the given template to be used as bool input for the Initialized
 // Assertion Predicate IfNode.
 OpaqueInitializedAssertionPredicateNode*
-InitializedAssertionPredicateCreator::create_assertion_expression_from_template(IfNode* template_assertion_predicate,
-                                                                                Node* new_control, Node* new_init,
-                                                                                Node* new_stride) const {
+InitializedAssertionPredicateCreator::create_assertion_expression_from_template(const IfNode* template_assertion_predicate,
+                                                                                Node* new_control, Node* new_init) const {
   OpaqueTemplateAssertionPredicateNode* template_opaque =
       template_assertion_predicate->in(1)->as_OpaqueTemplateAssertionPredicate();
   TemplateAssertionExpression template_assertion_expression(template_opaque);
   OpaqueTemplateAssertionPredicateNode* tmp_opaque =
-      template_assertion_expression.clone_and_replace_init_and_stride(new_control, new_init, new_stride, _phase);
+      template_assertion_expression.clone_and_replace_init(new_control, new_init, _phase);
   OpaqueInitializedAssertionPredicateNode* assertion_expression =
       new OpaqueInitializedAssertionPredicateNode(tmp_opaque->in(1)->as_Bool(), _phase->C);
   _phase->register_new_node(assertion_expression, new_control);
@@ -918,7 +888,6 @@ CreateAssertionPredicatesVisitor::CreateAssertionPredicatesVisitor(CountedLoopNo
                                                                    const NodeInLoopBody& node_in_loop_body,
                                                                    const bool clone_template)
     : _init(target_loop_head->init_trip()),
-      _stride(target_loop_head->stride()),
       _old_target_loop_entry(target_loop_head->skip_strip_mined()->in(LoopNode::EntryControl)),
       _current_predicate_chain_head(target_loop_head->skip_strip_mined()), // Initially no predicates, yet.
       _phase(phase),
@@ -960,8 +929,7 @@ InitializedAssertionPredicate CreateAssertionPredicatesVisitor::initialize_from_
   IfNode* template_head = template_assertion_predicate.head();
   InitializedAssertionPredicateCreator initialized_assertion_predicate_creator(_phase);
   InitializedAssertionPredicate initialized_assertion_predicate =
-      initialized_assertion_predicate_creator.create_from_template(template_head, new_control, _init, _stride);
-
+      initialized_assertion_predicate_creator.create_from_template(template_head, new_control, _init);
   DEBUG_ONLY(initialized_assertion_predicate.verify();)
   template_assertion_predicate.rewire_loop_data_dependencies(initialized_assertion_predicate.tail(),
                                                              _node_in_loop_body, _phase);

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -492,6 +492,8 @@ class TemplateAssertionExpression : public StackObj {
   OpaqueTemplateAssertionPredicateNode* clone(Node* new_control, PhaseIdealLoop* phase) const;
   OpaqueTemplateAssertionPredicateNode* clone_and_replace_init(Node* new_control, Node* new_init,
                                                                PhaseIdealLoop* phase) const;
+  OpaqueTemplateAssertionPredicateNode* clone_and_replace_init_and_stride(Node* new_control, Node* new_init,
+                                                                          Node* new_stride, PhaseIdealLoop* phase) const;
   void replace_opaque_stride_input(Node* new_stride, PhaseIterGVN& igvn) const;
   OpaqueInitializedAssertionPredicateNode* clone_and_fold_opaque_loop_nodes(Node* new_control, PhaseIdealLoop* phase) const;
 };
@@ -632,7 +634,7 @@ class InitializedAssertionPredicateCreator : public StackObj {
   NONCOPYABLE(InitializedAssertionPredicateCreator);
 
   InitializedAssertionPredicate create_from_template(const IfNode* template_assertion_predicate, Node* new_control,
-                                                     Node* new_init) const;
+                                                     Node* new_init, Node* new_stride) const;
 
   InitializedAssertionPredicate
   create_from_template_and_insert_below(const TemplateAssertionPredicate& template_assertion_predicate) const;
@@ -641,7 +643,8 @@ class InitializedAssertionPredicateCreator : public StackObj {
 
  private:
   OpaqueInitializedAssertionPredicateNode* create_assertion_expression_from_template(const IfNode* template_assertion_predicate,
-                                                                                     Node* new_control, Node* new_init) const;
+                                                                                     Node* new_control, Node* new_init,
+                                                                                     Node* new_stride) const;
   IfTrueNode* create_control_nodes(Node* new_control, int if_opcode,
                                    OpaqueInitializedAssertionPredicateNode* assertion_expression,
                                    AssertionPredicateType assertion_predicate_type) const;
@@ -1032,6 +1035,7 @@ class NodeInClonedLoopBody : public NodeInLoopBody {
 // loop. This visitor can be used in combination with a PredicateIterator.
 class CreateAssertionPredicatesVisitor : public PredicateVisitor {
   Node* const _init;
+  Node* const _stride;
   Node* const _old_target_loop_entry;
   Node* _current_predicate_chain_head;
   PhaseIdealLoop* const _phase;

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -295,7 +295,7 @@ class ParsePredicate : public Predicate {
     return parse_predicate_proj->isa_IfTrue();
   }
 
-  static ParsePredicateNode* init_parse_predicate(Node* parse_predicate_proj, Deoptimization::DeoptReason deopt_reason);
+  static ParsePredicateNode* init_parse_predicate(const Node* parse_predicate_proj, Deoptimization::DeoptReason deopt_reason);
   NOT_PRODUCT(static void trace_cloned_parse_predicate(bool is_true_path_loop,
                                                        const ParsePredicateSuccessProj* success_proj);)
 
@@ -351,9 +351,9 @@ class RuntimePredicate : public Predicate {
   NONCOPYABLE(RuntimePredicate);
 
  private:
-  static bool is_predicate(Node* maybe_success_proj);
+  static bool is_predicate(const Node* maybe_success_proj);
   static bool has_valid_uncommon_trap(const Node* success_proj);
-  static Deoptimization::DeoptReason uncommon_trap_reason(IfProjNode* if_proj);
+  static Deoptimization::DeoptReason uncommon_trap_reason(const IfProjNode* if_proj);
 
  public:
   Node* entry() const override {
@@ -409,9 +409,9 @@ class TemplateAssertionPredicate : public Predicate {
   void replace_opaque_stride_input(Node* new_stride, PhaseIterGVN& igvn) const;
   InitializedAssertionPredicate initialize(PhaseIdealLoop* phase) const;
   void rewire_loop_data_dependencies(IfTrueNode* target_predicate, const NodeInLoopBody& data_in_loop_body,
-                                     PhaseIdealLoop* phase) const;
+                                     const PhaseIdealLoop* phase) const;
   void kill(PhaseIdealLoop* phase) const;
-  static bool is_predicate(Node* node);
+  static bool is_predicate(const Node* node);
 
 #ifdef ASSERT
   static void verify(IfTrueNode* template_assertion_predicate_success_proj) {
@@ -457,7 +457,7 @@ class InitializedAssertionPredicate : public Predicate {
   }
 
   void kill(PhaseIdealLoop* phase) const;
-  static bool is_predicate(Node* node);
+  static bool is_predicate(const Node* node);
 
 #ifdef ASSERT
   static void verify(IfTrueNode* initialized_assertion_predicate_success_proj) {
@@ -486,16 +486,14 @@ class TemplateAssertionExpression : public StackObj {
 
  private:
   OpaqueTemplateAssertionPredicateNode* clone(const TransformStrategyForOpaqueLoopNodes& transform_strategy,
-                                              Node* new_ctrl, PhaseIdealLoop* phase);
+                                              Node* new_control, PhaseIdealLoop* phase) const;
 
  public:
-  OpaqueTemplateAssertionPredicateNode* clone(Node* new_control, PhaseIdealLoop* phase);
+  OpaqueTemplateAssertionPredicateNode* clone(Node* new_control, PhaseIdealLoop* phase) const;
   OpaqueTemplateAssertionPredicateNode* clone_and_replace_init(Node* new_control, Node* new_init,
-                                                               PhaseIdealLoop* phase);
-  OpaqueTemplateAssertionPredicateNode* clone_and_replace_init_and_stride(Node* new_control, Node* new_init,
-                                                                          Node* new_stride, PhaseIdealLoop* phase);
-  void replace_opaque_stride_input(Node* new_stride, PhaseIterGVN& igvn);
-  OpaqueInitializedAssertionPredicateNode* clone_and_fold_opaque_loop_nodes(Node* new_ctrl, PhaseIdealLoop* phase);
+                                                               PhaseIdealLoop* phase) const;
+  void replace_opaque_stride_input(Node* new_stride, PhaseIterGVN& igvn) const;
+  OpaqueInitializedAssertionPredicateNode* clone_and_fold_opaque_loop_nodes(Node* new_control, PhaseIdealLoop* phase) const;
 };
 
 // Class to represent a node being part of a Template Assertion Expression. Note that this is not an IR node.
@@ -514,7 +512,7 @@ class TemplateAssertionExpressionNode : public StackObj {
   NONCOPYABLE(TemplateAssertionExpressionNode);
 
  private:
-  static bool is_template_assertion_predicate(Node* node);
+  static bool is_template_assertion_predicate(const Node* node);
 
  public:
   // Check whether the provided node is part of a Template Assertion Expression or not.
@@ -581,17 +579,17 @@ class AssertionPredicateIfCreator : public StackObj {
   NONCOPYABLE(AssertionPredicateIfCreator);
 
   IfTrueNode* create_for_initialized(Node* new_control, int if_opcode, Node* assertion_expression,
-                                     AssertionPredicateType assertion_predicate_type);
+                                     AssertionPredicateType assertion_predicate_type) const;
   IfTrueNode* create_for_template(Node* new_control, int if_opcode, Node* assertion_expression,
-                                  AssertionPredicateType assertion_predicate_type);
+                                  AssertionPredicateType assertion_predicate_type) const;
  private:
   IfTrueNode* create(Node* new_control, int if_opcode, Node* assertion_expression, const char* halt_message,
-                     AssertionPredicateType assertion_predicate_type);
+                     AssertionPredicateType assertion_predicate_type) const;
   IfNode* create_if_node(Node* new_control, int if_opcode, Node* assertion_expression, IdealLoopTree* loop,
-                         AssertionPredicateType assertion_predicate_type);
-  IfTrueNode* create_success_path(IfNode* if_node, IdealLoopTree* loop);
-  void create_fail_path(IfNode* if_node, IdealLoopTree* loop, const char* halt_message);
-  void create_halt_node(IfFalseNode* fail_proj, IdealLoopTree* loop, const char* halt_message);
+                         AssertionPredicateType assertion_predicate_type) const;
+  IfTrueNode* create_success_path(IfNode* if_node, IdealLoopTree* loop) const;
+  void create_fail_path(IfNode* if_node, IdealLoopTree* loop, const char* halt_message) const;
+  void create_halt_node(IfFalseNode* fail_proj, IdealLoopTree* loop, const char* halt_message) const;
 };
 
 // This class is used to create a Template Assertion Predicate either with a Halt Node from scratch.
@@ -602,7 +600,7 @@ class TemplateAssertionPredicateCreator : public StackObj {
   Node* const _range;
   PhaseIdealLoop* const _phase;
 
-  OpaqueLoopInitNode* create_opaque_init(Node* new_control);
+  OpaqueLoopInitNode* create_opaque_init(Node* new_control) const;
   OpaqueTemplateAssertionPredicateNode* create_for_init_value(Node* new_control, OpaqueLoopInitNode* opaque_init,
                                                               bool& does_overflow) const;
   OpaqueTemplateAssertionPredicateNode* create_for_last_value(Node* new_control, OpaqueLoopInitNode* opaque_init,
@@ -622,7 +620,7 @@ class TemplateAssertionPredicateCreator : public StackObj {
         _phase(phase) {}
   NONCOPYABLE(TemplateAssertionPredicateCreator);
 
-  IfTrueNode* create(Node* new_control);
+  IfTrueNode* create(Node* new_control) const;
 };
 
 // This class creates a new Initialized Assertion Predicate either from a template or from scratch.
@@ -633,8 +631,8 @@ class InitializedAssertionPredicateCreator : public StackObj {
   explicit InitializedAssertionPredicateCreator(PhaseIdealLoop* phase);
   NONCOPYABLE(InitializedAssertionPredicateCreator);
 
-  InitializedAssertionPredicate create_from_template(IfNode* template_assertion_predicate, Node* new_control,
-                                                     Node* new_init, Node* new_stride) const;
+  InitializedAssertionPredicate create_from_template(const IfNode* template_assertion_predicate, Node* new_control,
+                                                     Node* new_init) const;
 
   InitializedAssertionPredicate
   create_from_template_and_insert_below(const TemplateAssertionPredicate& template_assertion_predicate) const;
@@ -642,9 +640,8 @@ class InitializedAssertionPredicateCreator : public StackObj {
                      AssertionPredicateType assertion_predicate_type) const;
 
  private:
-  OpaqueInitializedAssertionPredicateNode* create_assertion_expression_from_template(IfNode* template_assertion_predicate,
-                                                                                     Node* new_control, Node* new_init,
-                                                                                     Node* new_stride) const;
+  OpaqueInitializedAssertionPredicateNode* create_assertion_expression_from_template(const IfNode* template_assertion_predicate,
+                                                                                     Node* new_control, Node* new_init) const;
   IfTrueNode* create_control_nodes(Node* new_control, int if_opcode,
                                    OpaqueInitializedAssertionPredicateNode* assertion_expression,
                                    AssertionPredicateType assertion_predicate_type) const;
@@ -792,7 +789,7 @@ class RegularPredicateBlock : public StackObj {
     return iterator.skip_all();
   }
 
-  DEBUG_ONLY(void verify_block(Node* tail);)
+  DEBUG_ONLY(void verify_block(Node* tail) const;)
 
  public:
   Node* entry() const {
@@ -1035,7 +1032,6 @@ class NodeInClonedLoopBody : public NodeInLoopBody {
 // loop. This visitor can be used in combination with a PredicateIterator.
 class CreateAssertionPredicatesVisitor : public PredicateVisitor {
   Node* const _init;
-  Node* const _stride;
   Node* const _old_target_loop_entry;
   Node* _current_predicate_chain_head;
   PhaseIdealLoop* const _phase;


### PR DESCRIPTION
This simple patch adds some missing `const` and applies variable renamings and parameter reorderings

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346777](https://bugs.openjdk.org/browse/JDK-8346777): Add missing const declarations and rename variables (**Sub-task** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23434/head:pull/23434` \
`$ git checkout pull/23434`

Update a local copy of the PR: \
`$ git checkout pull/23434` \
`$ git pull https://git.openjdk.org/jdk.git pull/23434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23434`

View PR using the GUI difftool: \
`$ git pr show -t 23434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23434.diff">https://git.openjdk.org/jdk/pull/23434.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23434#issuecomment-2633388880)
</details>
