### PR TITLE
8349344: Clarify documentation of Arena.ofConfined

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -246,9 +246,9 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
     }
 
     /**
-     * {@return a new confined arena} Segments allocated with the confined arena can be
-     *          {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by the thread
-     *          that created the arena, the arena's <em>owner thread</em>.
+     * {@return a new confined arena} Segments allocated with the confined arena can
+     *          only be {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by the
+     *          thread that created the arena, the arena's <em>owner thread</em>.
      * <p>
      * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
      * are zero-initialized.


### PR DESCRIPTION
This PR proposes to clarify the documentation for `Arena.ofConfined()`. It is proposed to say that segments allocated from the returned `Arena` can _only_ be accessed by the thread that created the `Arena` in the first place.