### PR TITLE
8348936: [Accessibility,macOS,VoiceOver] VoiceOver doesn't announce untick on toggling the checkbox with "space" key on macOS

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -28,6 +28,7 @@ package sun.lwawt.macosx;
 import java.awt.Component;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.Objects;
 
 import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleContext;
@@ -182,8 +183,7 @@ class CAccessible extends CFRetainedResource implements Accessible {
 
                     // Do send check box state changes to native side
                     if (thisRole == AccessibleRole.CHECK_BOX) {
-                        if ((newValue != null && !newValue.equals(oldValue)) ||
-                                oldValue != null && !oldValue.equals(newValue)) {
+                        if (!Objects.equals(newValue, oldValue)) {
                             valueChanged(ptr);
                         }
 
@@ -209,8 +209,7 @@ class CAccessible extends CFRetainedResource implements Accessible {
 
                     // Do send toggle button state changes to native side
                     if (thisRole == AccessibleRole.TOGGLE_BUTTON) {
-                        if ((newValue != null && !newValue.equals(oldValue)) ||
-                                oldValue != null && !oldValue.equals(newValue)) {
+                        if (!Objects.equals(newValue, oldValue)) {
                             valueChanged(ptr);
                         }
                     }

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -182,7 +182,8 @@ class CAccessible extends CFRetainedResource implements Accessible {
 
                     // Do send check box state changes to native side
                     if (thisRole == AccessibleRole.CHECK_BOX) {
-                        if (newValue != null && !newValue.equals(oldValue)) {
+                        if ((newValue != null && !newValue.equals(oldValue)) ||
+                                oldValue != null && !oldValue.equals(newValue)) {
                             valueChanged(ptr);
                         }
 
@@ -208,7 +209,8 @@ class CAccessible extends CFRetainedResource implements Accessible {
 
                     // Do send toggle button state changes to native side
                     if (thisRole == AccessibleRole.TOGGLE_BUTTON) {
-                        if (newValue != null && !newValue.equals(oldValue)) {
+                        if ((newValue != null && !newValue.equals(oldValue)) ||
+                                oldValue != null && !oldValue.equals(newValue)) {
                             valueChanged(ptr);
                         }
                     }

--- a/test/jdk/javax/accessibility/TestJCheckBoxToggleAccessibility.java
+++ b/test/jdk/javax/accessibility/TestJCheckBoxToggleAccessibility.java
@@ -67,9 +67,9 @@ public class TestJCheckBoxToggleAccessibility {
                 <ol style="margin-bottom: 0">
                   <li>Enable Screen magnifier on the Mac:
                    <b>System Settings</b> -> <b>Accessibility</b> ->
-                   <b>Hover Text</b> -> <b>Enable Hover Text</b><br>
-                   Default Hover Text Activation Modifier is <kbd>Command</kbd> key.
-                  <li>Move focus back to test application
+                   <b>Hover Text</b> -> Enable <b>Hover Text</b><br>
+                   Default Hover Text Activation Modifier is <kbd>Command</kbd> key
+                  <li>Move focus back to the test application and perform the following tests
 
                   <ul style="margin-bottom: 0">
                     <li>Test <i>CheckBox</i> states with Screen Magnifier
@@ -97,6 +97,7 @@ public class TestJCheckBoxToggleAccessibility {
                         <li>If Screen Magnifier behaviour is incorrect, press <b>Fail</b>
                       </ol>
                   </ul>
+                  <li>Disable <b>Hover Text</b> (optionally) in the Settings
                 </ol>
 
                 <p>Press <b>Pass</b> if you are able to hear correct VoiceOver announcements and

--- a/test/jdk/javax/accessibility/TestJCheckBoxToggleAccessibility.java
+++ b/test/jdk/javax/accessibility/TestJCheckBoxToggleAccessibility.java
@@ -44,9 +44,9 @@ import javax.swing.JToggleButton;
 public class TestJCheckBoxToggleAccessibility {
     public static void main(String[] args) throws Exception {
         String INSTRUCTIONS = """
-                
+
                 Testing with VoiceOver
-                
+
                 1. Start the VoiceOver application (Press Command + F5)
                 2. Click on Frame with CheckBox and ToggleButton window to move focus
                 3. Press Spacebar
@@ -56,9 +56,9 @@ public class TestJCheckBoxToggleAccessibility {
                 7. Press Tab to move focus to ToggleButton
                 8. Repeat steps 3 to 6 and listen the announcement
                 9. If announcements are incorrect, Press Fail
-                
+
                 Stop the VoiceOver application (Press Command + F5)
-                
+
                 Testing with Screen Magnifier
                 1. Enable Screen magnifier on the Mac
                    System Preference -> Accessibility -> Hover Text -> Enable Hover Text
@@ -67,26 +67,24 @@ public class TestJCheckBoxToggleAccessibility {
 
                     Test CheckBox states with Screen Magnifier
                         a. Click on CheckBox to select
-                        b. Press Command key and hover mouse over CheckBox 
+                        b. Press Command key and hover mouse over CheckBox
                         c. CheckBox ticked state along with label should be magnified
                         d. Keep Command button pressed and click CheckBox to deselect
                         e. CheckBox unticked state along with label should be magnified
                         f. Release Command key
                         g. If Screen Magnifier behaviour is incorrect, Press Fail
-                        
+
                     Test ToggleButton states with Screen Magnifier
                         a. Click on ToggleButton to select
-                        b. Press Command key and hover mouse over ToggleButton 
+                        b. Press Command key and hover mouse over ToggleButton
                         c. Ticked state along with label should be magnified
                         d. Keep Command button pressed and click ToggleButton to deselect
                         e. Unticked state along with label should be magnified
                         f. Release Command key
                         g. If Screen Magnifier behaviour is incorrect, Press Fail
-                
+
                 Press Pass if you are able to hear correct VoiceOver announcements and
-                able to see the correct screen magnifier behaviour.
-                
-                """;
+                able to see the correct screen magnifier behaviour. """;
 
         PassFailJFrame.builder()
                 .title("TestJCheckBoxToggleAccessibility Instruction")

--- a/test/jdk/javax/accessibility/TestJCheckBoxToggleAccessibility.java
+++ b/test/jdk/javax/accessibility/TestJCheckBoxToggleAccessibility.java
@@ -44,47 +44,63 @@ import javax.swing.JToggleButton;
 public class TestJCheckBoxToggleAccessibility {
     public static void main(String[] args) throws Exception {
         String INSTRUCTIONS = """
+                <html><body>
+                <p><b>Testing with VoiceOver</b></p>
 
-                Testing with VoiceOver
+                <ol>
+                  <li>Start the VoiceOver application
+                      (Press <kbd>Command</kbd> + <kbd>F5</kbd>)
+                  <li>Click on the <i>Frame with CheckBox and ToggleButton</i>
+                      window to move focus
+                  <li>Press <kbd>Spacebar</kbd>
+                  <li>VO should announce the checked state
+                  <li>Press <kbd>Spacebar</kbd> again
+                  <li>VO should announce the unchecked state
+                  <li>Press <kbd>Tab</kbd> to move focus to <i>ToggleButton</i>
+                  <li>Repeat steps 3 to 6 and listen the announcement
+                  <li>If announcements are incorrect, press <b>Fail</b>
+                  <li>Stop the VoiceOver application
+                      (Press <kbd>Command</kbd> + <kbd>F5</kbd> again)
+                </ol>
 
-                1. Start the VoiceOver application (Press Command + F5)
-                2. Click on Frame with CheckBox and ToggleButton window to move focus
-                3. Press Spacebar
-                4. VO should announce the checked state
-                5. Press Spacebar again
-                6. VO should announce the unchecked state
-                7. Press Tab to move focus to ToggleButton
-                8. Repeat steps 3 to 6 and listen the announcement
-                9. If announcements are incorrect, press Fail
+                <p><b>Testing with Screen Magnifier</b></p>
+                <ol style="margin-bottom: 0">
+                  <li>Enable Screen magnifier on the Mac:
+                   <b>System Settings</b> -> <b>Accessibility</b> ->
+                   <b>Hover Text</b> -> <b>Enable Hover Text</b><br>
+                   Default Hover Text Activation Modifier is <kbd>Command</kbd> key.
+                  <li>Move focus back to test application
 
-                Stop the VoiceOver application (Press Command + F5)
+                  <ul style="margin-bottom: 0">
+                    <li>Test <i>CheckBox</i> states with Screen Magnifier
+                      <ol style="list-style-type: lower-alpha; margin-top: 0; margin-bottom: 0">
+                        <li>Click on <i>CheckBox</i> to select it
+                        <li>Press the <kbd>Command</kbd> key and
+                            hover mouse over <i>CheckBox</i>
+                        <li>CheckBox ticked state along with its label should be magnified
+                        <li>Keep the <kbd>Command</kbd> key pressed and
+                            click <i>CheckBox</i> to deselect it
+                        <li>CheckBox unticked state along with its label should be magnified
+                        <li>Release the <kbd>Command</kbd> key
+                        <li>If Screen Magnifier behaviour is incorrect, press <b>Fail</b>
+                      </ol>
+                    <li>Test <i>ToggleButton</i> states with Screen Magnifier
+                      <ol style="list-style-type: lower-alpha; margin-top: 0; margin-bottom: 0">
+                        <li>Click on <i>ToggleButton</i> to select it
+                        <li>Press the <kbd>Command</kbd> key and
+                            hover mouse over <i>ToggleButton</i>
+                        <li>Ticked state along with label should be magnified
+                        <li>Keep the <kbd>Command</kbd> button pressed and
+                            click <i>ToggleButton</i> to deselect it
+                        <li>Unticked state along with its label should be magnified
+                        <li>Release the <kbd>Command</kbd> key
+                        <li>If Screen Magnifier behaviour is incorrect, press <b>Fail</b>
+                      </ol>
+                  </ul>
+                </ol>
 
-                Testing with Screen Magnifier
-                1. Enable Screen magnifier on the Mac
-                   System Preference -> Accessibility -> Hover Text -> Enable Hover Text
-                   Default Hover Text Activation Modifier is "Command" key.
-                2. Move focus back to test application
-
-                    Test CheckBox states with Screen Magnifier
-                        a. Click on CheckBox to select
-                        b. Press Command key and hover mouse over CheckBox
-                        c. CheckBox ticked state along with label should be magnified
-                        d. Keep Command button pressed and click CheckBox to deselect
-                        e. CheckBox unticked state along with label should be magnified
-                        f. Release Command key
-                        g. If Screen Magnifier behaviour is incorrect, press Fail
-
-                    Test ToggleButton states with Screen Magnifier
-                        a. Click on ToggleButton to select
-                        b. Press Command key and hover mouse over ToggleButton
-                        c. Ticked state along with label should be magnified
-                        d. Keep Command button pressed and click ToggleButton to deselect
-                        e. Unticked state along with label should be magnified
-                        f. Release Command key
-                        g. If Screen Magnifier behaviour is incorrect, press Fail
-
-                Press Pass if you are able to hear correct VoiceOver announcements and
-                able to see the correct screen magnifier behaviour. """;
+                <p>Press <b>Pass</b> if you are able to hear correct VoiceOver announcements and
+                able to see the correct screen magnifier behaviour.</p></body></html>""";
 
         PassFailJFrame.builder()
                 .title("TestJCheckBoxToggleAccessibility Instruction")

--- a/test/jdk/javax/accessibility/TestJCheckBoxToggleAccessibility.java
+++ b/test/jdk/javax/accessibility/TestJCheckBoxToggleAccessibility.java
@@ -31,7 +31,7 @@ import javax.swing.JToggleButton;
 
 /*
  * @test
- * @bug 8348936
+ * @bug 8348936 8345728
  * @summary Verifies that VoiceOver announces the untick state of CheckBox and
  *          ToggleButton when space key is pressed. Also verifies that CheckBox
  *          and ToggleButton untick state is magnified with Screen Magnifier.
@@ -55,7 +55,7 @@ public class TestJCheckBoxToggleAccessibility {
                 6. VO should announce the unchecked state
                 7. Press Tab to move focus to ToggleButton
                 8. Repeat steps 3 to 6 and listen the announcement
-                9. If announcements are incorrect, Press Fail
+                9. If announcements are incorrect, press Fail
 
                 Stop the VoiceOver application (Press Command + F5)
 
@@ -72,7 +72,7 @@ public class TestJCheckBoxToggleAccessibility {
                         d. Keep Command button pressed and click CheckBox to deselect
                         e. CheckBox unticked state along with label should be magnified
                         f. Release Command key
-                        g. If Screen Magnifier behaviour is incorrect, Press Fail
+                        g. If Screen Magnifier behaviour is incorrect, press Fail
 
                     Test ToggleButton states with Screen Magnifier
                         a. Click on ToggleButton to select
@@ -81,7 +81,7 @@ public class TestJCheckBoxToggleAccessibility {
                         d. Keep Command button pressed and click ToggleButton to deselect
                         e. Unticked state along with label should be magnified
                         f. Release Command key
-                        g. If Screen Magnifier behaviour is incorrect, Press Fail
+                        g. If Screen Magnifier behaviour is incorrect, press Fail
 
                 Press Pass if you are able to hear correct VoiceOver announcements and
                 able to see the correct screen magnifier behaviour. """;
@@ -92,7 +92,6 @@ public class TestJCheckBoxToggleAccessibility {
                 .columns(40)
                 .rows(25)
                 .testUI(TestJCheckBoxToggleAccessibility::createUI)
-                .logArea(8)
                 .testTimeOut(8)
                 .build()
                 .awaitAndCheck();

--- a/test/jdk/javax/accessibility/TestJCheckBoxToggleAccessibility.java
+++ b/test/jdk/javax/accessibility/TestJCheckBoxToggleAccessibility.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.GridLayout;
+
+import javax.swing.JCheckBox;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JToggleButton;
+
+/*
+ * @test
+ * @bug 8348936
+ * @summary Verifies that VoiceOver announces the untick state of CheckBox and
+ *          ToggleButton when space key is pressed. Also verifies that CheckBox
+ *          and ToggleButton untick state is magnified with Screen Magnifier.
+ * @requires os.family == "mac"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestJCheckBoxToggleAccessibility
+ */
+
+public class TestJCheckBoxToggleAccessibility {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                
+                Testing with VoiceOver
+                
+                1. Start the VoiceOver application (Press Command + F5)
+                2. Click on Frame with CheckBox and ToggleButton window to move focus
+                3. Press Spacebar
+                4. VO should announce the checked state
+                5. Press Spacebar again
+                6. VO should announce the unchecked state
+                7. Press Tab to move focus to ToggleButton
+                8. Repeat steps 3 to 6 and listen the announcement
+                9. If announcements are incorrect, Press Fail
+                
+                Stop the VoiceOver application (Press Command + F5)
+                
+                Testing with Screen Magnifier
+                1. Enable Screen magnifier on the Mac
+                   System Preference -> Accessibility -> Hover Text -> Enable Hover Text
+                   Default Hover Text Activation Modifier is "Command" key.
+                2. Move focus back to test application
+
+                    Test CheckBox states with Screen Magnifier
+                        a. Click on CheckBox to select
+                        b. Press Command key and hover mouse over CheckBox 
+                        c. CheckBox ticked state along with label should be magnified
+                        d. Keep Command button pressed and click CheckBox to deselect
+                        e. CheckBox unticked state along with label should be magnified
+                        f. Release Command key
+                        g. If Screen Magnifier behaviour is incorrect, Press Fail
+                        
+                    Test ToggleButton states with Screen Magnifier
+                        a. Click on ToggleButton to select
+                        b. Press Command key and hover mouse over ToggleButton 
+                        c. Ticked state along with label should be magnified
+                        d. Keep Command button pressed and click ToggleButton to deselect
+                        e. Unticked state along with label should be magnified
+                        f. Release Command key
+                        g. If Screen Magnifier behaviour is incorrect, Press Fail
+                
+                Press Pass if you are able to hear correct VoiceOver announcements and
+                able to see the correct screen magnifier behaviour.
+                
+                """;
+
+        PassFailJFrame.builder()
+                .title("TestJCheckBoxToggleAccessibility Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .rows(25)
+                .testUI(TestJCheckBoxToggleAccessibility::createUI)
+                .logArea(8)
+                .testTimeOut(8)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createUI() {
+        JFrame frame = new JFrame("A Frame with CheckBox and ToggleButton");
+        JCheckBox cb = new JCheckBox("CheckBox", false);
+        JToggleButton tb = new JToggleButton("ToggleButton");
+
+        JPanel p = new JPanel(new GridLayout(2, 1));
+        p.add(cb);
+        p.add(tb);
+        frame.getContentPane().add(p, BorderLayout.CENTER);
+        frame.setSize(400, 400);
+        return frame;
+    }
+}


### PR DESCRIPTION
VoiceOver doesn't announce the _untick state_ when Checkbox is `deselected` using **space** key. When CheckBox is deselected, the state change is not notified to a11y client (VoiceOver) and so the state is not announced by VO. 

Screen Magnifier is also unable to magnify the unchecked state of JCheckBox due to same reason and is captured as separate bug [JDK-8345728](https://bugs.openjdk.org/browse/JDK-8345728).

Proposed fix is to send the state change notification to a11y client when checkbox is deselected, this resolves the problem for VoiceOver and Screen Magnifier.

Similar issue observed for JToggleButton. So, I extended the fix for JToggleButton as well.

The proposed change can be verified the manual test in the PR.

CI pipeline testing is `OK`, link posted in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8348936](https://bugs.openjdk.org/browse/JDK-8348936): [Accessibility,macOS,VoiceOver] VoiceOver doesn't announce untick on toggling the checkbox with "space" key on macOS (**Bug** - P3)
 * [JDK-8345728](https://bugs.openjdk.org/browse/JDK-8345728): [Accessibility,macOS,Screen Magnifier]: JCheckbox unchecked state does not magnify but works for checked state (**Bug** - P3)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Artem Semenov](https://openjdk.org/census#asemenov) (@savoptik - Committer) Review applies to [1bfa6d98](https://git.openjdk.org/jdk/pull/23436/files/1bfa6d984703c5e8c4a7566ae0f07cb9e940fcec)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23436/head:pull/23436` \
`$ git checkout pull/23436`

Update a local copy of the PR: \
`$ git checkout pull/23436` \
`$ git pull https://git.openjdk.org/jdk.git pull/23436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23436`

View PR using the GUI difftool: \
`$ git pr show -t 23436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23436.diff">https://git.openjdk.org/jdk/pull/23436.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23436#issuecomment-2633586071)
</details>
