### PR TITLE
8349102: Test compiler/arguments/TestCodeEntryAlignment.java failed: …

### DIFF
--- a/src/hotspot/cpu/x86/stubDeclarations_x86.hpp
+++ b/src/hotspot/cpu/x86/stubDeclarations_x86.hpp
@@ -85,7 +85,7 @@
                                        do_arch_blob,                    \
                                        do_arch_entry,                   \
                                        do_arch_entry_init)              \
-  do_arch_blob(compiler, 20000 LP64_ONLY(+60000) WINDOWS_ONLY(+2000))   \
+  do_arch_blob(compiler, 20000 LP64_ONLY(+64000) WINDOWS_ONLY(+2000))   \
   do_stub(compiler, vector_float_sign_mask)                             \
   do_arch_entry(x86, compiler, vector_float_sign_mask,                  \
                 vector_float_sign_mask, vector_float_sign_mask)         \

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -77,8 +77,6 @@ compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 
 compiler/interpreter/Test6833129.java 8335266 generic-i586
 
-compiler/arguments/TestCodeEntryAlignment.java 8349102 generic-all
-
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
…assert(allocates2(pc)) failed: not in CodeBuffer memory

The StubGenenerator compiler blob runs out of space when TestCodeEntryAlignment is run on macos/x86_64 on an avx2-only CPU. This only happens in the worst case with command line options `-XX:CodeCacheSegmentSize=1024 -XX:CodeEntryAlignment=1024`.

On linux/x86_64 the test succeeds in that worst case when run on an avx512-enabled CPU but with only 980 bytes of headroom.

This patch increments the buffer size on x86_64 to ensure both the avx2 and avx3 cases have enough headroom.

n.b. the increment has deliberately been made x86_64-specific rather than macos-specific, even though this problem manifests when testing MacOS and does not manifest when testing Linux. The disparity in generated stubs size actually relates to the capabilities of the CPU and is independent of OS.