### PR TITLE
8349140: Size optimization (opt-size) build fails after recent PCH changes

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -55,21 +55,11 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_LIBJVM_sharedRuntimeTrig.cpp_CXXFLAGS := $(FDLIBM_CFLAGS) $(LIBJVM_FDLIBM_COPY_OPT_FLAG)
   BUILD_LIBJVM_sharedRuntimeTrans.cpp_CXXFLAGS := $(FDLIBM_CFLAGS) $(LIBJVM_FDLIBM_COPY_OPT_FLAG)
 
-  ifeq ($(TOOLCHAIN_TYPE), clang)
-    JVM_PRECOMPILED_HEADER_EXCLUDE := \
-        sharedRuntimeTrig.cpp \
-        sharedRuntimeTrans.cpp \
-        $(OPT_SPEED_SRC) \
-        #
-  endif
-
-  ifeq ($(call isTargetCpu, ppc64le)+$(TOOLCHAIN_TYPE), true+gcc)
-    JVM_PRECOMPILED_HEADER_EXCLUDE := \
-        sharedRuntimeTrig.cpp \
-        sharedRuntimeTrans.cpp \
-        $(OPT_SPEED_SRC) \
-        #
-  endif
+  JVM_PRECOMPILED_HEADER_EXCLUDE := \
+      sharedRuntimeTrig.cpp \
+      sharedRuntimeTrans.cpp \
+      $(OPT_SPEED_SRC) \
+      #
 
   ifeq ($(call isTargetCpu, x86), true)
     # Performance measurements show that by compiling GC related code, we could
@@ -151,13 +141,12 @@ else ifeq ($(call isTargetOs, aix), true)
 
 else ifeq ($(call isTargetOs, windows), true)
   JVM_PRECOMPILED_HEADER_EXCLUDE := \
-      bytecodeInterpreter.cpp \
-      bytecodeInterpreterWithChecks.cpp \
       opcodes.cpp \
       os_windows.cpp \
       os_windows_x86.cpp \
       osThread_windows.cpp \
       jvmciCompilerToVMInit.cpp \
+      $(OPT_SPEED_SRC) \
       #
 
   # Workaround for jvmciCompilerToVM.cpp long compilation time


### PR DESCRIPTION
When using the configure flag --enable-jvm-feature-opt-size (linux x86_64 opt build, gcc 11 devkit) we run into this error after the recent PCH related changes :

```
cc1plus: error: /build_optsize/hotspot/variant-server/libjvm/objs/precompiled/precompiled.hpp.gch: not used because `__OPTIMIZE_SIZE__' not defined [-Werror=invalid-pch]

+ exit 1
gmake[3]: *** [lib/CompileJvm.gmk:170: /build_optsize/hotspot/variant-server/libjvm/objs/allocation.o] Error 1

```
Please note that allocation.cpp is currently in the list of `OPT_SPEED_SRC` files (means - files to be optimized for speed even in case of SIZE optimization) :
https://github.com/openjdk/jdk/blob/master/make/hotspot/lib/JvmFeatures.gmk#L196

Same issue can be observed on Windows x86_64 (VS2022 used).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349140](https://bugs.openjdk.org/browse/JDK-8349140): Size optimization (opt-size) build fails after recent PCH changes (**Bug** - P3)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23442/head:pull/23442` \
`$ git checkout pull/23442`

Update a local copy of the PR: \
`$ git checkout pull/23442` \
`$ git pull https://git.openjdk.org/jdk.git pull/23442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23442`

View PR using the GUI difftool: \
`$ git pr show -t 23442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23442.diff">https://git.openjdk.org/jdk/pull/23442.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23442#issuecomment-2634350667)
</details>
