### PR TITLE
8349374: [JVMCI] concurrent use of HotSpotSpeculationLog can crash

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
@@ -77,7 +77,7 @@ public class HotSpotSpeculationLog implements SpeculationLog {
     }
 
     /**
-     * Gets the address of the pointer to the native failed speculations list.
+     * Gets the address of the pointer to the native failed speculations list.  This always returns a non-zero address.
      *
      * @see #managesFailedSpeculations()
      */

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
@@ -173,11 +173,15 @@ public class HotSpotSpeculationLog implements SpeculationLog {
     @Override
     public void collectFailedSpeculations() {
         if (failedSpeculationsAddress == 0) {
+            // If no memory has been allocated then don't force its creation
             return;
         }
 
-        if (UnsafeAccess.UNSAFE.getLong(getFailedSpeculationsAddress()) != 0) {
-            failedSpeculations = compilerToVM().getFailedSpeculations(failedSpeculationsAddress, failedSpeculations);
+        // Go through getFailedSpeculationsAddress() to ensure that any concurrent
+        // initialization of failedSpeculationsAddress is seen by this thread.
+        long address = getFailedSpeculationsAddress();
+        if (UnsafeAccess.UNSAFE.getLong(address) != 0) {
+            failedSpeculations = compilerToVM().getFailedSpeculations(address, failedSpeculations);
             assert failedSpeculations.getClass() == byte[][].class;
         }
     }


### PR DESCRIPTION
This ensures that collectFailedSpeculations sees the initialization of the recently allocated failedSpeculationsAddress memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349374](https://bugs.openjdk.org/browse/JDK-8349374): [JVMCI] concurrent use of HotSpotSpeculationLog can crash (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**) Review applies to [aefc1dfd](https://git.openjdk.org/jdk/pull/23444/files/aefc1dfd282e1e7c0eaf4eec90fc6cab03e34bde)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23444/head:pull/23444` \
`$ git checkout pull/23444`

Update a local copy of the PR: \
`$ git checkout pull/23444` \
`$ git pull https://git.openjdk.org/jdk.git pull/23444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23444`

View PR using the GUI difftool: \
`$ git pr show -t 23444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23444.diff">https://git.openjdk.org/jdk/pull/23444.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23444#issuecomment-2634498820)
</details>
