### PR TITLE
8344925: translet-name ignored when package-name is also set

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -57,7 +57,7 @@ import org.xml.sax.XMLReader;
  * @author G. Todd Miller
  * @author Morten Jorgensen
  * @author John Howard (johnh@schemasoft.com)
- * @LastModified: Dec 2024
+ * @LastModified: Feb 2025
  */
 public final class XSLTC {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
@@ -734,7 +734,6 @@ public final class XSLTC {
      */
     public void setPackageName(String packageName) {
         _packageName = Objects.requireNonNull(packageName);
-        if (_className != null) setClassName(_className);
     }
 
     /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
@@ -999,9 +999,6 @@ public class TransformerFactoryImpl
         // Set the attributes for translet generation
         int outputType = XSLTC.BYTEARRAY_OUTPUT;
         if (_generateTranslet || _autoTranslet) {
-            // Set the translet name
-            xsltc.setClassName(getTransletBaseName(source));
-
             if (_destinationDirectory != null)
                 xsltc.setDestDirectory(_destinationDirectory);
             else {
@@ -1015,8 +1012,11 @@ public class TransformerFactoryImpl
                 }
             }
 
+            // set package name
             if (_packageName != null)
                 xsltc.setPackageName(_packageName);
+            // Set the translet name
+            xsltc.setClassName(getTransletBaseName(source));
 
             if (_jarFileName != null) {
                 xsltc.setJarFileName(_jarFileName);

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -87,7 +87,7 @@ import org.xml.sax.XMLReader;
  * @author G. Todd Miller
  * @author Morten Jorgensen
  * @author Santiago Pericas-Geertsen
- * @LastModified: Dec 2024
+ * @LastModified: Feb 2025
  */
 public class TransformerFactoryImpl
     extends SAXTransformerFactory implements SourceLoader

--- a/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JUnitTestUtil.java
+++ b/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JUnitTestUtil.java
@@ -26,11 +26,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import jdk.test.lib.Platform;
 
 public class JUnitTestUtil {
     public static final String CLS_DIR = System.getProperty("test.classes");
     public static final String SRC_DIR = System.getProperty("test.src");
-    public static final boolean isWindows = System.getProperty("os.name").contains("Windows");
 
     /**
      * Returns the System identifier (URI) of the source.
@@ -40,7 +40,7 @@ public class JUnitTestUtil {
     public static String getSystemId(String path) {
         if (path == null) return null;
         String xmlSysId = "file://" + path;
-        if (isWindows) {
+        if (Platform.isWindows()) {
             path = path.replace('\\', '/');
             xmlSysId = "file:///" + path;
         }

--- a/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JUnitTestUtil.java
+++ b/test/jaxp/javax/xml/jaxp/libs/jaxp/library/JUnitTestUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jaxp.library;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+public class JUnitTestUtil {
+    public static final String CLS_DIR = System.getProperty("test.classes");
+    public static final String SRC_DIR = System.getProperty("test.src");
+    public static final boolean isWindows = System.getProperty("os.name").contains("Windows");
+
+    /**
+     * Returns the System identifier (URI) of the source.
+     * @param path the path to the source
+     * @return the System identifier
+     */
+    public static String getSystemId(String path) {
+        if (path == null) return null;
+        String xmlSysId = "file://" + path;
+        if (isWindows) {
+            path = path.replace('\\', '/');
+            xmlSysId = "file:///" + path;
+        }
+        return xmlSysId;
+    }
+
+    /**
+     * Copies a file.
+     * @param src the path of the source file
+     * @param target the path of the target file
+     * @throws Exception if the process fails
+     */
+    public static void copyFile(String src, String target) throws Exception {
+        try {
+            Files.copy(Path.of(src), Path.of(target), StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException x) {
+            throw new Exception(x.getMessage());
+        }
+    }
+}

--- a/test/jaxp/javax/xml/jaxp/unittest/transform/PropertiesTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/transform/PropertiesTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package transform;
+
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamSource;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import jaxp.library.JUnitTestUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * @test
+ * @bug 8344925
+ * @summary Transformer properties tests
+ * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
+ * @run junit/othervm transform.PropertiesTest
+ */
+public class PropertiesTest {
+    private static final String USER_DIR = System.getProperty("user.dir");
+    private static final String TEST_DIR = System.getProperty("test.src");
+    // Test parameters:
+    // generate-translet: indicates whether to generate translet
+    // translet-name: the name of the translet
+    // package-name: the package name
+    // destination-directory: the destination
+    // expected: the class path
+    private static Stream<Arguments> testData() {
+        String destination = JUnitTestUtil.CLS_DIR + "/testdir";
+        return Stream.of(
+                Arguments.of(true, "MyTranslet", "org.myorg", destination, "/org/myorg/MyTranslet.class"),
+                Arguments.of(false, "Translet", "not.generate", destination, "/not/generate/Translet.class"),
+                // translet named after the stylesheet
+                Arguments.of(true, null, "org.myorg", destination, "/org/myorg/transform.class"),
+                // default package name die.verwandlung since JDK 9
+                Arguments.of(true, "MyTranslet", null, destination, "/die/verwandlung/MyTranslet.class"),
+                Arguments.of(true, "MyTranslet", "org.myorg", null, "/org/myorg/MyTranslet.class")
+                );
+    }
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        // so that the translet is generated under test.classes
+        JUnitTestUtil.copyFile(JUnitTestUtil.SRC_DIR + "/transform.xsl", JUnitTestUtil.CLS_DIR + "/transform.xsl");
+    }
+
+    @ParameterizedTest
+    @MethodSource("testData")
+    public void test(boolean generateTranslet, String name, String packageName,
+                     String destination, String expected)
+            throws Exception {
+        TransformerFactory tf = TransformerFactory.newInstance();
+
+        tf.setAttribute("generate-translet", generateTranslet);
+        if (name != null) tf.setAttribute("translet-name", name);
+        if (packageName != null) tf.setAttribute("package-name", packageName);
+        if (destination != null) tf.setAttribute("destination-directory", destination);
+
+        String xslFile = JUnitTestUtil.CLS_DIR + "/transform.xsl";
+        String xslSysId = JUnitTestUtil.getSystemId(xslFile);
+        StreamSource xsl = new StreamSource(xslSysId);
+        tf.newTemplates(xsl);
+
+        String path = (destination != null) ? destination + expected : new File(xslFile).getParent() + expected;
+
+        if (generateTranslet) {
+            //Files.list(Path.of(path)).forEach(System.out::println);
+            assertTrue(Files.exists(Path.of(path)), "Translet is expected at " + expected);
+        } else {
+            assertTrue(Files.notExists(Path.of(path)), "Translet is not to be generated.");
+        }
+    }
+}

--- a/test/jaxp/javax/xml/jaxp/unittest/transform/PropertiesTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/transform/PropertiesTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @test
  * @bug 8344925
  * @summary Transformer properties tests
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
+ * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest /test/lib
  * @run junit/othervm transform.PropertiesTest
  */
 public class PropertiesTest {
@@ -91,7 +91,6 @@ public class PropertiesTest {
         String path = (destination != null) ? destination + expected : new File(xslFile).getParent() + expected;
 
         if (generateTranslet) {
-            //Files.list(Path.of(path)).forEach(System.out::println);
             assertTrue(Files.exists(Path.of(path)), "Translet is expected at " + expected);
         } else {
             assertTrue(Files.notExists(Path.of(path)), "Translet is not to be generated.");


### PR DESCRIPTION
Fix an issue where the translet-name is incorrectly set when the package-name is also specified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344925](https://bugs.openjdk.org/browse/JDK-8344925): translet-name ignored when package-name is also set (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) Review applies to [df9b015a](https://git.openjdk.org/jdk/pull/23446/files/df9b015afa06c5385c4a90001d37caa7ce91e4b0)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23446/head:pull/23446` \
`$ git checkout pull/23446`

Update a local copy of the PR: \
`$ git checkout pull/23446` \
`$ git pull https://git.openjdk.org/jdk.git pull/23446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23446`

View PR using the GUI difftool: \
`$ git pr show -t 23446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23446.diff">https://git.openjdk.org/jdk/pull/23446.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23446#issuecomment-2634768436)
</details>
