### PR TITLE
8349058: 'internal proprietary API' warnings make javac warnings unusable

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
@@ -241,7 +241,7 @@ public class ClassFinder {
      * available from the module system.
      */
     long getSupplementaryFlags(ClassSymbol c) {
-        if (c.name == names.module_info) {
+        if (jrtIndex == null || !jrtIndex.isInJRT(c.classfile) || c.name == names.module_info) {
             return 0;
         }
 
@@ -257,22 +257,17 @@ public class ClassFinder {
             try {
                 ModuleSymbol owningModule = packge.modle;
                 if (owningModule == syms.noModule) {
-                    if (jrtIndex != null && jrtIndex.isInJRT(c.classfile)) {
-                        JRTIndex.CtSym ctSym = jrtIndex.getCtSym(packge.flatName());
-                        Profile minProfile = Profile.DEFAULT;
-                        if (ctSym.proprietary)
-                            newFlags |= PROPRIETARY;
-                        if (ctSym.minProfile != null)
-                            minProfile = Profile.lookup(ctSym.minProfile);
-                        if (profile != Profile.DEFAULT && minProfile.value > profile.value) {
-                            newFlags |= NOT_IN_PROFILE;
-                        }
+                    JRTIndex.CtSym ctSym = jrtIndex.getCtSym(packge.flatName());
+                    Profile minProfile = Profile.DEFAULT;
+                    if (ctSym.proprietary)
+                        newFlags |= PROPRIETARY;
+                    if (ctSym.minProfile != null)
+                        minProfile = Profile.lookup(ctSym.minProfile);
+                    if (profile != Profile.DEFAULT && minProfile.value > profile.value) {
+                        newFlags |= NOT_IN_PROFILE;
                     }
                 } else if (owningModule.name == names.jdk_unsupported) {
                     newFlags |= PROPRIETARY;
-                } else {
-                    // don't accumulate user modules in supplementaryFlags
-                    return 0;
                 }
             } catch (IOException ignore) {
             }

--- a/test/langtools/tools/javac/options/system/SystemSunProprietary.java
+++ b/test/langtools/tools/javac/options/system/SystemSunProprietary.java
@@ -23,14 +23,18 @@
 
 /**
  * @test
- * @bug 8331081
+ * @bug 8331081 8349058
  * @summary Verify 'internal proprietary API' diagnostics if --system is configured
  * @library /tools/lib
- * @modules jdk.compiler/com.sun.tools.javac.api jdk.compiler/com.sun.tools.javac.main
- *     jdk.compiler/com.sun.tools.javac.jvm jdk.jdeps/com.sun.tools.javap
+ * @modules jdk.compiler/com.sun.tools.javac.api jdk.compiler/com.sun.tools.javac.file
+ *     jdk.compiler/com.sun.tools.javac.jvm jdk.compiler/com.sun.tools.javac.main
+ *     jdk.compiler/com.sun.tools.javac.util jdk.jdeps/com.sun.tools.javap
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask toolbox.JavapTask toolbox.TestRunner
  * @run main SystemSunProprietary
  */
+import com.sun.tools.javac.file.JavacFileManager;
+import com.sun.tools.javac.util.Context;
+
 import toolbox.JavacTask;
 import toolbox.Task;
 import toolbox.Task.Expect;
@@ -41,12 +45,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
 
 public class SystemSunProprietary extends TestRunner {
 
     private final ToolBox tb = new ToolBox();
+
+    private Path src;
+    private Path classes;
 
     public SystemSunProprietary() {
         super(System.err);
@@ -58,45 +64,14 @@ public class SystemSunProprietary extends TestRunner {
 
     @Test
     public void testUnsafe(Path base) throws IOException {
-        Path src = base.resolve("src");
+        src = base.resolve("src");
         tb.writeJavaFiles(
                 src,
                 "module m { requires jdk.unsupported; }",
                 "package test; public class Test { sun.misc.Unsafe unsafe; } ");
-        Path classes = base.resolve("classes");
+
+        classes = base.resolve("classes");
         tb.createDirectories(classes);
-
-        List<String> log;
-        List<String> expected =
-                Arrays.asList(
-                        "Test.java:1:43: compiler.warn.sun.proprietary: sun.misc.Unsafe",
-                        "1 warning");
-
-        log =
-                new JavacTask(tb)
-                        .options("-XDrawDiagnostics")
-                        .outdir(classes)
-                        .files(tb.findJavaFiles(src))
-                        .run(Expect.SUCCESS)
-                        .writeAll()
-                        .getOutputLines(Task.OutputKind.DIRECT);
-
-        if (!expected.equals(log)) {
-            throw new AssertionError("Unexpected output: " + log);
-        }
-
-        log =
-                new JavacTask(tb)
-                        .options("-XDrawDiagnostics", "--system", System.getProperty("java.home"))
-                        .outdir(classes)
-                        .files(tb.findJavaFiles(src))
-                        .run(Expect.SUCCESS)
-                        .writeAll()
-                        .getOutputLines(Task.OutputKind.DIRECT);
-
-        if (!expected.equals(log)) {
-            throw new AssertionError("Unexpected output: " + log);
-        }
 
         // Create a valid argument to system that isn't the current java.home
         Path originalSystem = Path.of(System.getProperty("java.home"));
@@ -107,17 +82,39 @@ public class SystemSunProprietary extends TestRunner {
             Files.copy(originalSystem.resolve(path), to);
         }
 
-        log =
+        expectSunapi(true, false, "-XDrawDiagnostics");
+        expectSunapi(true, false, "-XDrawDiagnostics", "--system", System.getProperty("java.home"));
+
+        // non-default --system arguments disable sunapi, see JDK-8349058
+        expectSunapi(false, false, "-XDrawDiagnostics", "--system", system.toString());
+
+        // -XDignore.symbol.file disables sunapi diagnostics, see JDK-8349058
+        expectSunapi(false, true, "-XDrawDiagnostics");
+        expectSunapi(false, true, "-XDrawDiagnostics", "--system", System.getProperty("java.home"));
+        expectSunapi(false, true, "-XDrawDiagnostics", "--system", system.toString());
+    }
+
+    private void expectSunapi(boolean expectDiagnostic, boolean ignoreSymbolFile, String... options)
+            throws IOException {
+        List<String> expected =
+                expectDiagnostic
+                        ? List.of(
+                                "Test.java:1:43: compiler.warn.sun.proprietary: sun.misc.Unsafe",
+                                "1 warning")
+                        : List.of("");
+        JavacFileManager fm = new JavacFileManager(new Context(), false, null);
+        fm.setSymbolFileEnabled(!ignoreSymbolFile);
+        List<String> log =
                 new JavacTask(tb)
-                        .options("-XDrawDiagnostics", "--system", system.toString())
+                        .fileManager(fm)
+                        .options(options)
                         .outdir(classes)
                         .files(tb.findJavaFiles(src))
                         .run(Expect.SUCCESS)
                         .writeAll()
                         .getOutputLines(Task.OutputKind.DIRECT);
-
-        if (!expected.equals(log)) {
-            throw new AssertionError("Unexpected output: " + log);
+        if (!log.equals(expected)) {
+            throw new AssertionError("expected: " + expected + "\nactual: " + log + "\n");
         }
     }
 


### PR DESCRIPTION
This change is a partial backout of [JDK-8332744](https://bugs.openjdk.org/browse/JDK-8332744). The logic was reverted, but the test was preserved and updated to reflect the updated behaviour, and some cleanups to benchmark code were kept.

This restores the ability to use `-XDignore.symbol.file` as an ad-hoc suppression mechanism for `sunapi` diagnostics, see discussion in [JDK-8349058](https://bugs.openjdk.org/browse/JDK-8349058).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349058](https://bugs.openjdk.org/browse/JDK-8349058): 'internal proprietary API' warnings make javac warnings unusable (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23448/head:pull/23448` \
`$ git checkout pull/23448`

Update a local copy of the PR: \
`$ git checkout pull/23448` \
`$ git pull https://git.openjdk.org/jdk.git pull/23448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23448`

View PR using the GUI difftool: \
`$ git pr show -t 23448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23448.diff">https://git.openjdk.org/jdk/pull/23448.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23448#issuecomment-2635350007)
</details>
