### PR TITLE
8333569: jpackage tests must run app launchers with retries on Linux only

### DIFF
--- a/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
+++ b/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Executor;
-import static jdk.jpackage.test.HelloApp.configureEnvironment;
+import static jdk.jpackage.test.HelloApp.configureAndExecute;
 import jdk.jpackage.test.TKit;
 
 /**
@@ -62,16 +62,12 @@ public class AppLauncherEnvTest {
 
         final String envVarName = envVarName();
 
-        final int attempts = 3;
-        final int waitBetweenAttemptsSeconds = 5;
-        List<String> output = configureEnvironment(new Executor())
+        List<String> output = configureAndExecute(0, new Executor()
                 .saveOutput()
                 .setExecutable(cmd.appLauncherPath().toAbsolutePath())
                 .addArguments("--print-env-var=" + envVarName)
                 .addArguments("--print-sys-prop=" + testAddDirProp)
-                .addArguments("--print-sys-prop=" + "java.library.path")
-                .executeAndRepeatUntilExitCode(0, attempts,
-                        waitBetweenAttemptsSeconds).getOutput();
+                .addArguments("--print-sys-prop=" + "java.library.path")).getOutput();
 
         BiFunction<Integer, String, String> getValue = (idx, name) -> {
             return  output.get(idx).substring((name + "=").length());

--- a/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
+++ b/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 import java.nio.file.Path;
 
 import jdk.jpackage.test.JPackageCommand;
-import static jdk.jpackage.test.HelloApp.configureEnvironment;
+import static jdk.jpackage.test.HelloApp.configureAndExecute;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Executor;
 import jdk.jpackage.test.TKit;
@@ -63,9 +63,9 @@ public class WinChildProcessTest {
 
             // Start the third party application launcher and dump and save the
             // output of the application
-            List<String> output = configureEnvironment(new Executor()).saveOutput().dumpOutput()
-                    .setExecutable(cmd.appLauncherPath().toAbsolutePath())
-                    .execute(0).getOutput();
+            List<String> output = configureAndExecute(0, new Executor().saveOutput().dumpOutput()
+                    .setExecutable(cmd.appLauncherPath().toAbsolutePath()))
+                            .getOutput();
             String pidStr = output.get(0);
 
             // parse child PID


### PR DESCRIPTION
Run app launchers in jpackage tests with retries on Linux only. Run them without retries on other platforms.

Supplementary remove `HelloApp.AppOutputVerifier.removePathEnvVar()` function. It sets an unused member field and is a leftover from [JDK-8347300](https://bugs.openjdk.org/browse/JDK-8347300) fix. This change has no functional impact; it cleans unused code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8333569: jpackage tests must run app launchers with retries on Linux only`

### Issue
 * [JDK-8333569](https://bugs.openjdk.org/browse/JDK-8333569): jpackage tests must run app launchers with retries on Linux only (**Enhancement** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23454/head:pull/23454` \
`$ git checkout pull/23454`

Update a local copy of the PR: \
`$ git checkout pull/23454` \
`$ git pull https://git.openjdk.org/jdk.git pull/23454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23454`

View PR using the GUI difftool: \
`$ git pr show -t 23454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23454.diff">https://git.openjdk.org/jdk/pull/23454.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23454#issuecomment-2635631259)
</details>
