### PR TITLE
8349428: RISC-V: "bad alignment" with -XX:-AvoidUnalignedAccesses after JDK-8347489

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1461,12 +1461,14 @@ void C2_MacroAssembler::string_compare(Register str1, Register str2,
   {
     if (str1_isL == str2_isL) { // LL or UU
 #ifdef ASSERT
-      Label align_ok;
-      orr(t0, str1, str2);
-      andi(t0, t0, 0x7);
-      beqz(t0, align_ok);
-      stop("bad alignment");
-      bind(align_ok);
+      if (AvoidUnalignedAccesses) {
+        Label align_ok;
+        orr(t0, str1, str2);
+        andi(t0, t0, 0x7);
+        beqz(t0, align_ok);
+        stop("bad alignment");
+        bind(align_ok);
+      }
 #endif
       // load 8 bytes once to compare
       ld(tmp1, Address(str1));
@@ -1518,7 +1520,7 @@ void C2_MacroAssembler::string_compare(Register str1, Register str2,
     // main loop
     bind(NEXT_WORD);
     if (str1_isL == str2_isL) { // LL or UU
-      // both of the two loads are 8-byte aligned
+      // 8-byte aligned loads when AvoidUnalignedAccesses is enabled
       add(t0, str1, cnt2);
       ld(tmp1, Address(t0));
       add(t0, str2, cnt2);
@@ -1713,12 +1715,14 @@ void C2_MacroAssembler::arrays_equals(Register a1, Register a2,
   bltz(cnt1, SHORT);
 
 #ifdef ASSERT
-  Label align_ok;
-  orr(t0, a1, a2);
-  andi(t0, t0, 0x7);
-  beqz(t0, align_ok);
-  stop("bad alignment");
-  bind(align_ok);
+  if (AvoidUnalignedAccesses) {
+    Label align_ok;
+    orr(t0, a1, a2);
+    andi(t0, t0, 0x7);
+    beqz(t0, align_ok);
+    stop("bad alignment");
+    bind(align_ok);
+  }
 #endif
 
   // Main 8 byte comparison loop.
@@ -1817,12 +1821,14 @@ void C2_MacroAssembler::string_equals(Register a1, Register a2,
   bltz(cnt1, SHORT);
 
 #ifdef ASSERT
-  Label align_ok;
-  orr(t0, a1, a2);
-  andi(t0, t0, 0x7);
-  beqz(t0, align_ok);
-  stop("bad alignment");
-  bind(align_ok);
+  if (AvoidUnalignedAccesses) {
+    Label align_ok;
+    orr(t0, a1, a2);
+    andi(t0, t0, 0x7);
+    beqz(t0, align_ok);
+    stop("bad alignment");
+    bind(align_ok);
+  }
 #endif
 
   // Main 8 byte comparison loop.

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2458,7 +2458,15 @@ class StubGenerator: public StubCodeGenerator {
     assert((base_offset % (UseCompactObjectHeaders ? 4 :
                            (UseCompressedClassPointers ? 8 : 4))) == 0, "Must be");
 
-    // strL is 8-byte aligned
+#ifdef ASSERT
+    if (AvoidUnalignedAccesses) {
+      Label align_ok;
+      andi(t0, strL, 0x7);
+      beqz(t0, align_ok);
+      stop("bad alignment");
+      bind(align_ok);
+    }
+#endif
     __ ld(tmpLval, Address(strL));
     __ addi(strL, strL, wordSize);
 
@@ -2542,7 +2550,7 @@ class StubGenerator: public StubCodeGenerator {
       __ subi(cnt2, cnt2, wordSize / 2);
     }
 
-    // we are now 8-bytes aligned on strL
+    // we are now 8-bytes aligned on strL when AvoidUnalignedAccesses is true
     __ subi(cnt2, cnt2, wordSize * 2);
     __ bltz(cnt2, TAIL);
     __ bind(SMALL_LOOP); // smaller loop

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2461,10 +2461,10 @@ class StubGenerator: public StubCodeGenerator {
 #ifdef ASSERT
     if (AvoidUnalignedAccesses) {
       Label align_ok;
-      andi(t0, strL, 0x7);
-      beqz(t0, align_ok);
-      stop("bad alignment");
-      bind(align_ok);
+      __ andi(t0, strL, 0x7);
+      __ beqz(t0, align_ok);
+      __ stop("bad alignment");
+      __ bind(align_ok);
     }
 #endif
     __ ld(tmpLval, Address(strL));


### PR DESCRIPTION
Hi, please review this small change fixing an assertion error.
As the alignment of the loading addresses is only ensured under -XX:-AvoidUnalignedAccesses, we should only enable the related assersions about the alignment under this option.


### Testing
- [x] Sanity tested with -XX:-AvoidUnalignedAccesses using fastdebug build.
- [ ] Run tier1 tests on SOPHON SG2042 (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349428](https://bugs.openjdk.org/browse/JDK-8349428): RISC-V: "bad alignment" with -XX:-AvoidUnalignedAccesses after JDK-8347489 (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23459/head:pull/23459` \
`$ git checkout pull/23459`

Update a local copy of the PR: \
`$ git checkout pull/23459` \
`$ git pull https://git.openjdk.org/jdk.git pull/23459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23459`

View PR using the GUI difftool: \
`$ git pr show -t 23459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23459.diff">https://git.openjdk.org/jdk/pull/23459.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23459#issuecomment-2636145902)
</details>
