### PR TITLE
8349465: [UBSAN] test_os_reserve_between.cpp reported applying non-zero offset to null pointer

### DIFF
--- a/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
+++ b/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
@@ -284,7 +284,7 @@ TEST_VM(os, attempt_reserve_memory_between_combos) {
   for (size_t range_size = allocation_granularity(); range_size <= large_end; range_size *= 2) {
     for (size_t start_offset = 0; start_offset <= large_end; start_offset += (large_end / 2)) {
       char* const min = (char*)(uintptr_t)start_offset;
-      char* const max = min + range_size;
+      char* const max = (char*)(p2u(min) + range_size);
       for (size_t bytes = os::vm_page_size(); bytes < large_end; bytes *= 2) {
         for (size_t alignment = allocation_granularity(); alignment < large_end; alignment *= 2) {
           test_attempt_reserve_memory_between(min, max, bytes, alignment, true, Expect::dontcare(), __LINE__);


### PR DESCRIPTION
Hi all,
Test function `os_attempt_reserve_memory_between_combos_vm_Test::TestBody()` in "test/hotspot/gtest/runtime/test_os_reserve_between.cpp" file reported "applying non-zero offset 4096 to null pointer" by UndefinedBehaviorSanitizer. The var `min` cast from 0 to pointer and then apply non-zero offset `range_size` is undefined behavior.

This PR cast pointer `min` to uintptr_t before add the offset `range_size`, and the cast back to pointer. This solution similar to [JDK-8346714](https://github.com/openjdk/jdk/pull/22848). This PR do not change the original logic but eliminate the undefined behaviour in code.

Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349465](https://bugs.openjdk.org/browse/JDK-8349465): [UBSAN] test_os_reserve_between.cpp reported applying non-zero offset to null pointer (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23462/head:pull/23462` \
`$ git checkout pull/23462`

Update a local copy of the PR: \
`$ git checkout pull/23462` \
`$ git pull https://git.openjdk.org/jdk.git pull/23462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23462`

View PR using the GUI difftool: \
`$ git pr show -t 23462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23462.diff">https://git.openjdk.org/jdk/pull/23462.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23462#issuecomment-2636626194)
</details>
