### PR TITLE
8346049: jdk/test/lib/security/timestamp/TsaServer.java warnings

### DIFF
--- a/test/lib/jdk/test/lib/security/timestamp/TsaServer.java
+++ b/test/lib/jdk/test/lib/security/timestamp/TsaServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class TsaServer implements AutoCloseable {
      *
      * @param handler a {@link TsaHandler}
      */
-    public void setHandler(TsaHandler handler) {
+    public final void setHandler(TsaHandler handler) {
         server.createContext("/", handler);
     }
 
@@ -113,7 +113,7 @@ public class TsaServer implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         stop();
     }
 }


### PR DESCRIPTION
When compiling the test class: jdk/test/lib/security/timestamp/TsaServer.java


Two warning are shown: 

```
test/lib/security/timestamp/TsaServer.java:56: warning: [this-escape] possible 'this' escape before subclass is fully initialized
            setHandler(handler);
```
- setHandler is called in the constructor and a subclass may override it. It is fixed by making the method 'final'

```
test/lib/security/timestamp/TsaServer.java:42: warning: [try] auto-closeable resource TsaServer has a member method close() that could throw InterruptedException
```
- Remove `throws Exception` from TsaServer.close()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346049](https://bugs.openjdk.org/browse/JDK-8346049): jdk/test/lib/security/timestamp/TsaServer.java warnings (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23463/head:pull/23463` \
`$ git checkout pull/23463`

Update a local copy of the PR: \
`$ git checkout pull/23463` \
`$ git pull https://git.openjdk.org/jdk.git pull/23463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23463`

View PR using the GUI difftool: \
`$ git pr show -t 23463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23463.diff">https://git.openjdk.org/jdk/pull/23463.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23463#issuecomment-2636922863)
</details>
