### PR TITLE
8349543: LinkedBlockingDeque does not immediately throw InterrruptedException in put/take

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedBlockingDeque.java
@@ -367,7 +367,7 @@ public class LinkedBlockingDeque<E>
         if (e == null) throw new NullPointerException();
         Node<E> node = new Node<E>(e);
         final ReentrantLock lock = this.lock;
-        lock.lock();
+        lock.lockInterruptibly();
         try {
             while (!linkFirst(node))
                 notFull.await();
@@ -384,7 +384,7 @@ public class LinkedBlockingDeque<E>
         if (e == null) throw new NullPointerException();
         Node<E> node = new Node<E>(e);
         final ReentrantLock lock = this.lock;
-        lock.lock();
+        lock.lockInterruptibly();
         try {
             while (!linkLast(node))
                 notFull.await();
@@ -479,7 +479,7 @@ public class LinkedBlockingDeque<E>
 
     public E takeFirst() throws InterruptedException {
         final ReentrantLock lock = this.lock;
-        lock.lock();
+        lock.lockInterruptibly();
         try {
             E x;
             while ( (x = unlinkFirst()) == null)
@@ -492,7 +492,7 @@ public class LinkedBlockingDeque<E>
 
     public E takeLast() throws InterruptedException {
         final ReentrantLock lock = this.lock;
-        lock.lock();
+        lock.lockInterruptibly();
         try {
             E x;
             while ( (x = unlinkLast()) == null)


### PR DESCRIPTION
The LinkedBlockingDeque does not behave consistently with other concurrency components. If we call putFirst(), putLast(), takeFirst(), or takeLast() with a thread that is interrupted, it does not immediately throw an InterruptedException, the way that ArrayBlockingQueue and LInkedBlockingQueue does, because instead of lockInterruptibly(), we call lock(). It will only throw an InterruptedException if the queue is full (on put) or empty (on take). Since interruptions are frequently used as a shutdown mechanism, this might prevent code from ever shutting down.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8349543](https://bugs.openjdk.org/browse/JDK-8349543)

### Issue
 * [JDK-8349543](https://bugs.openjdk.org/browse/JDK-8349543): LinkedBlockingDeque does not immediately throw InterruptedException in put/take (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23464/head:pull/23464` \
`$ git checkout pull/23464`

Update a local copy of the PR: \
`$ git checkout pull/23464` \
`$ git pull https://git.openjdk.org/jdk.git pull/23464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23464`

View PR using the GUI difftool: \
`$ git pr show -t 23464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23464.diff">https://git.openjdk.org/jdk/pull/23464.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23464#issuecomment-2640170000)
</details>
