### PR TITLE
8349462: Gatherers.mapConcurrent could support async interrupts

### DIFF
--- a/test/jdk/java/util/stream/GatherersMapConcurrentTest.java
+++ b/test/jdk/java/util/stream/GatherersMapConcurrentTest.java
@@ -336,7 +336,7 @@ public class GatherersMapConcurrentTest {
                 () -> {
                     throw assertThrows(
                         RuntimeException.class,
-                        () -> c.stream().sequential() // Force sequential
+                        () -> c.stream()
                             .gather(Gatherers.mapConcurrent(c.streamSize() / 2, x -> {
                                 vts.offer(Thread.currentThread()); // Remember these for later
                                 currentThread.interrupt(); // Make sure caller gets interrupted


### PR DESCRIPTION
This change is likely going to need some extra verbiage in the spec for mapConcurrent, and thus a CSR.
This behavior aligns mapConcurrent with how parallel streams work in conjunction with interruptions of the caller thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349462](https://bugs.openjdk.org/browse/JDK-8349462): Gatherers.mapConcurrent could support async interrupts (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23467/head:pull/23467` \
`$ git checkout pull/23467`

Update a local copy of the PR: \
`$ git checkout pull/23467` \
`$ git pull https://git.openjdk.org/jdk.git pull/23467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23467`

View PR using the GUI difftool: \
`$ git pr show -t 23467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23467.diff">https://git.openjdk.org/jdk/pull/23467.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23467#issuecomment-2637403087)
</details>
