### PR TITLE
8348106: Catch C++ exception in Java_sun_awt_windows_WTaskbarPeer_setOverlayIcon

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
@@ -124,7 +124,7 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_WTaskbarPeer_flashWindow
  * Signature: (J[III)V
  */
 JNIEXPORT void JNICALL Java_sun_awt_windows_WTaskbarPeer_setOverlayIcon
-(JNIEnv* env, jobject, jlong window, jintArray buf, jint w, jint h)
+(JNIEnv *env, jobject, jlong window, jintArray buf, jint w, jint h)
 {
     try
     {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
@@ -124,7 +124,7 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_WTaskbarPeer_flashWindow
  * Signature: (J[III)V
  */
 JNIEXPORT void JNICALL Java_sun_awt_windows_WTaskbarPeer_setOverlayIcon
-(JNIEnv *env, jobject, jlong window, jintArray buf, jint w, jint h)
+  (JNIEnv *env, jobject, jlong window, jintArray buf, jint w, jint h)
 {
     try
     {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
@@ -126,14 +126,13 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_WTaskbarPeer_flashWindow
 JNIEXPORT void JNICALL Java_sun_awt_windows_WTaskbarPeer_setOverlayIcon
   (JNIEnv *env, jobject, jlong window, jintArray buf, jint w, jint h)
 {
-    try {
-        HICON icon = CreateIconFromRaster(env, buf, w, h);
-        m_Taskbar->SetOverlayIcon((HWND)window, icon, NULL);
-        ::DestroyIcon(icon);
-    }
-    catch (const std::bad_alloc&) {
-        return;
-    }
+    TRY;
+
+    HICON icon = CreateIconFromRaster(env, buf, w, h);
+    m_Taskbar->SetOverlayIcon((HWND)window, icon, NULL);
+    ::DestroyIcon(icon);
+
+    CATCH_BAD_ALLOC;
 }
 #ifdef __cplusplus
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
@@ -124,11 +124,17 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_WTaskbarPeer_flashWindow
  * Signature: (J[III)V
  */
 JNIEXPORT void JNICALL Java_sun_awt_windows_WTaskbarPeer_setOverlayIcon
-  (JNIEnv *env, jobject, jlong window, jintArray buf, jint w, jint h)
+(JNIEnv* env, jobject, jlong window, jintArray buf, jint w, jint h)
 {
-    HICON icon = CreateIconFromRaster(env, buf, w, h);
-    m_Taskbar->SetOverlayIcon((HWND)window, icon, NULL);
-    ::DestroyIcon(icon);
+    try
+    {
+        HICON icon = CreateIconFromRaster(env, buf, w, h);
+        m_Taskbar->SetOverlayIcon((HWND)window, icon, NULL);
+        ::DestroyIcon(icon);
+    }
+    catch (...) {
+        return;
+    }
 }
 #ifdef __cplusplus
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
@@ -131,7 +131,7 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_WTaskbarPeer_setOverlayIcon
         m_Taskbar->SetOverlayIcon((HWND)window, icon, NULL);
         ::DestroyIcon(icon);
     }
-    catch (...) {
+    catch (const std::bad_alloc&) {
         return;
     }
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
@@ -126,8 +126,7 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_WTaskbarPeer_flashWindow
 JNIEXPORT void JNICALL Java_sun_awt_windows_WTaskbarPeer_setOverlayIcon
   (JNIEnv *env, jobject, jlong window, jintArray buf, jint w, jint h)
 {
-    try
-    {
+    try {
         HICON icon = CreateIconFromRaster(env, buf, w, h);
         m_Taskbar->SetOverlayIcon((HWND)window, icon, NULL);
         ::DestroyIcon(icon);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Taskbar.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
**Issue:**
The JNI method `Java_sun_awt_windows_WTaskbarPeer_setOverlayIcon `calls `CreateIconFromRaster `that can throw a C++ exception.

The C++ exception must be caught and must not be allowed to escape the JNI method. The call to `CreateIconFromRaster `has to wrapped into a try-catch block.

**Solution:**

Added exception handling to make sure any exception from `CreateIconFromRaster `is handled properly.

Testing done.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348106](https://bugs.openjdk.org/browse/JDK-8348106): Catch C++ exception in Java_sun_awt_windows_WTaskbarPeer_setOverlayIcon (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**) Review applies to [5a7cd348](https://git.openjdk.org/jdk/pull/23470/files/5a7cd348cd0798045bc92572120fd0244c52fa97)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23470/head:pull/23470` \
`$ git checkout pull/23470`

Update a local copy of the PR: \
`$ git checkout pull/23470` \
`$ git pull https://git.openjdk.org/jdk.git pull/23470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23470`

View PR using the GUI difftool: \
`$ git pr show -t 23470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23470.diff">https://git.openjdk.org/jdk/pull/23470.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23470#issuecomment-2637746751)
</details>
