### PR TITLE
8349417: Fix NULL usage from JDK-8346433

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4433,8 +4433,8 @@ bool os::message_box(const char* title, const char* message) {
 void os::init(void) {
   if (is_vm_statically_linked()) {
     // Mimick what is done in DllMain for non-static builds
-    HMODULE hModule = NULL;
-    GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, NULL, &hModule);
+    HMODULE hModule = nullptr;
+    GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, nullptr, &hModule);
     windows_preinit(hModule);
     atexit(windows_atexit);
   }


### PR DESCRIPTION
Trivial replacement of NULL with nullptr

Testing: Windows build

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349417](https://bugs.openjdk.org/browse/JDK-8349417): Fix NULL usage from JDK-8346433 (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23483/head:pull/23483` \
`$ git checkout pull/23483`

Update a local copy of the PR: \
`$ git checkout pull/23483` \
`$ git pull https://git.openjdk.org/jdk.git pull/23483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23483`

View PR using the GUI difftool: \
`$ git pr show -t 23483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23483.diff">https://git.openjdk.org/jdk/pull/23483.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23483#issuecomment-2638827215)
</details>
