### PR TITLE
8349508: runtime/cds/appcds/TestParallelGCWithCDS.java should not check for specific output

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,13 +146,6 @@ public class TestParallelGCWithCDS {
                     out.shouldContain(HELLO);
                     out.shouldNotContain(errMsg);
                 } else {
-                    String pattern = "((Too small maximum heap)" +
-                                     "|(GC triggered before VM initialization completed)" +
-                                     "|(CDS archive has aot-linked classes but the archived heap objects cannot be loaded)" +
-                                     "|(Initial heap size set to a larger value than the maximum heap size)" +
-                                     "|(java.lang.OutOfMemoryError)" +
-                                     "|(Error: A JNI error has occurred, please check your installation and try again))";
-                    out.shouldMatch(pattern);
                     out.shouldNotHaveFatalError();
                 }
                 n++;

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -163,12 +163,7 @@ public class TestSerialGCWithCDS {
                 if (out.getExitValue() == 0) {
                     out.shouldNotContain(errMsg);
                 } else {
-                    String output = out.getStdout() + out.getStderr();
-                    String exp1 = "Too small maximum heap";
-                    String exp2 = "GC triggered before VM initialization completed";
-                    if (!output.contains(exp1) && !output.contains(exp2)) {
-                        throw new RuntimeException("Either '" + exp1 + "' or '" + exp2 + "' must be in stdout/stderr \n");
-                    }
+                    out.shouldNotHaveFatalError();
                 }
                 n++;
             }


### PR DESCRIPTION
The `TestParallelGCWithCDS.java` test runs with small max heap and failed intermittently due to the expected output is missing. Instead of keep adding the expected output, the fix is just check that the JVM hasn't crashed. Also updating the `TestSerialGCWithCDS.java` test with similar fix.

Passed tier3 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349508](https://bugs.openjdk.org/browse/JDK-8349508): runtime/cds/appcds/TestParallelGCWithCDS.java should not check for specific output (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23485/head:pull/23485` \
`$ git checkout pull/23485`

Update a local copy of the PR: \
`$ git checkout pull/23485` \
`$ git pull https://git.openjdk.org/jdk.git pull/23485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23485`

View PR using the GUI difftool: \
`$ git pr show -t 23485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23485.diff">https://git.openjdk.org/jdk/pull/23485.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23485#issuecomment-2639025787)
</details>
