### PR TITLE
8349375: Cleanup AIX special file build settings

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -122,13 +122,6 @@ else ifeq ($(call isTargetOs, aix), true)
   # mode, so don't optimize sharedRuntimeTrig.cpp at all.
   BUILD_LIBJVM_sharedRuntimeTrig.cpp_CXXFLAGS := $(CXX_O_FLAG_NONE)
 
-  ifneq ($(DEBUG_LEVEL), slowdebug)
-    # Compiling jvmtiEnterTrace.cpp with full optimization needs more than 30min
-    # (mostly because of '-qhot=level=1' and the more than 1300 'log_trace' calls
-    # which cause a lot of template expansion).
-    BUILD_LIBJVM_jvmtiEnterTrace.cpp_OPTIMIZATION := LOW
-  endif
-
   # Disable ELF decoder on AIX (AIX uses XCOFF).
   JVM_EXCLUDE_PATTERNS += elf
 


### PR DESCRIPTION
The special optimization settings for  jvmtiEnterTrace.cpp on AIX can be removed ; the file compiles now some seconds with or without this workaround.
The special settings were needed for ancient versions of xlC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349375](https://bugs.openjdk.org/browse/JDK-8349375): Cleanup AIX special file build settings (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23487/head:pull/23487` \
`$ git checkout pull/23487`

Update a local copy of the PR: \
`$ git checkout pull/23487` \
`$ git pull https://git.openjdk.org/jdk.git pull/23487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23487`

View PR using the GUI difftool: \
`$ git pr show -t 23487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23487.diff">https://git.openjdk.org/jdk/pull/23487.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23487#issuecomment-2639213447)
</details>
