### PR TITLE
8349206: Fix for synchronization in j.u.l Handlers.

### DIFF
--- a/src/java.logging/share/classes/java/util/logging/Formatter.java
+++ b/src/java.logging/share/classes/java/util/logging/Formatter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, 2025, Oracle and/or its affiliates.
+ * All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +37,9 @@ package java.util.logging;
  * Some formatters (such as the XMLFormatter) need to wrap head
  * and tail strings around a set of formatted records. The getHeader
  * and getTail methods can be used to obtain these strings.
+ * <p>
+ * See individual method documentation for information about object
+ * locking and synchronization for implementations of this class.
  *
  * @since 1.4
  */
@@ -55,6 +59,9 @@ public abstract class Formatter {
      * localized and formatted version of the LogRecord's message field.
      * It is recommended to use the {@link Formatter#formatMessage}
      * convenience method to localize and format the message field.
+     * <p>
+     * This method is expected to be invoked without any logging
+     * related locks held (since is calls back to user code).
      *
      * @param record the log record to be formatted.
      * @return the formatted log record
@@ -67,6 +74,10 @@ public abstract class Formatter {
      * <p>
      * This base class returns an empty string, but this may be
      * overridden by subclasses.
+     * <p>
+     * This method may be invoked with handler related locks held
+     * and must not be implemented in such a way as to risk
+     * deadlocks, such as by calling back into user code.
      *
      * @param   h  The target handler (can be null)
      * @return  header string
@@ -80,6 +91,10 @@ public abstract class Formatter {
      * <p>
      * This base class returns an empty string, but this may be
      * overridden by subclasses.
+     * <p>
+     * This method may be invoked with handler related locks held
+     * and must not be implemented in such a way as to risk
+     * deadlocks, such as by calling back into user code.
      *
      * @param   h  The target handler (can be null)
      * @return  tail string
@@ -106,6 +121,12 @@ public abstract class Formatter {
      *     java.text.MessageFormat is used to format the string.
      * <li>Otherwise no formatting is performed.
      * </ul>
+     * <p>
+     * This method is expected to be invoked without any logging
+     * related locks held (since is calls back to user code). Any
+     * overridden implementation of this method must avoid locking
+     * around any calls to {@link Object#toString()} on parameters, or
+     * {@code super.formatMessage()}.
      *
      * @param  record  the log record containing the raw message
      * @return   a localized and formatted message

--- a/src/java.logging/share/classes/java/util/logging/Handler.java
+++ b/src/java.logging/share/classes/java/util/logging/Handler.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, 2025, Oracle and/or its affiliates.
+ * All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,6 +124,10 @@ public abstract class Handler {
      * <p>
      * The {@code Handler}  is responsible for formatting the message, when and
      * if necessary.  The formatting should include localization.
+     * <p>
+     * To avoid deadlock risk, this method should not be invoked with any
+     * logging related locks held, and must not be implemented as a synchronized
+     * method.
      *
      * @param  record  description of the log event. A null record is
      *                 silently ignored and is not published

--- a/src/java.logging/share/classes/java/util/logging/SocketHandler.java
+++ b/src/java.logging/share/classes/java/util/logging/SocketHandler.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, 2025, Oracle and/or its affiliates.
+ * All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,10 +173,11 @@ public class SocketHandler extends StreamHandler {
      *                 silently ignored and is not published
      */
     @Override
-    public synchronized void publish(LogRecord record) {
+    public void publish(LogRecord record) {
         if (!isLoggable(record)) {
             return;
         }
+        // JDK-8349206: Do NOT synchronize around the parent's publish() method.
         super.publish(record);
         flush();
     }

--- a/test/jdk/java/util/logging/LoggingDeadlock5.java
+++ b/test/jdk/java/util/logging/LoggingDeadlock5.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8349206
+ * @summary j.u.l.Handler classes create deadlock risk via synchronized publish() method.
+ * @modules java.base/sun.util.logging
+ *          java.logging
+ * @compile -XDignore.symbol.file LoggingDeadlock5.java
+ * @run main/othervm/timeout=10 LoggingDeadlock5
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.Semaphore;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.StreamHandler;
+
+/**
+ * This test verifies that logging Handler implementations no longer suffer
+ * from the deadlock risk outlined in JDK-8349206.
+ *
+ * <p>This test should reliably cause, and detect, deadlocks in a timely
+ * manner if the problem occurs, and SHOULD NOT time out.
+ */
+public class LoggingDeadlock5 {
+
+    // Formatter which calls toString() on all arguments.
+    private static final Formatter TEST_FORMATTER = new Formatter() {
+        @Override
+        public String format(LogRecord record) {
+            // All we care about is that our formatter will invoke toString() on user arguments.
+            for (Object p : record.getParameters()) {
+                var unused = p.toString();
+            }
+            return "<formatted string>";
+        }
+    };
+
+    // A handler which *should* cause a deadlock by synchronizing publish().
+    private static final Handler SELF_TEST_HANDLER = new Handler() {
+        @Override
+        public synchronized void publish(LogRecord record) {
+            TEST_FORMATTER.formatMessage(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    };
+
+    public static void main(String[] args) throws InterruptedException, IOException {
+        // Self test that deadlocks are correct caught (and don't lock the entire test).
+        new DeadLocker(SELF_TEST_HANDLER).checkDeadlock(true);
+
+        // In theory, we should test FileHandler and SocketHandler here as well
+        // because, while they are just subclasses of StreamHandler, they could
+        // be adding locking around the call to super.publish(). However, they
+        // are quite problematic in a test environment since they need to create
+        // files and open sockets. They are not being tested for now.
+        StreamHandler streamHandler = new StreamHandler(new ByteArrayOutputStream(0), TEST_FORMATTER);
+        streamHandler.setEncoding(StandardCharsets.UTF_8.name());
+        new DeadLocker(streamHandler).checkDeadlock(false);
+
+        // Any other problematic handler classes can be easily added here if
+        // they are simple enough to be constructed in a test environment.
+    }
+
+    private static class DeadLocker {
+        private final static Duration JOIN_WAIT = Duration.ofMillis(500);
+
+        private final Semaphore readyToDeadlock = new Semaphore(0);
+        private final Semaphore userLockIsHeld = new Semaphore(0);
+        private final Logger logger = Logger.getAnonymousLogger();
+        private final Handler handlerUnderTest;
+        private final Object userLock = new Object();
+        private boolean deadlockEncountered = true;
+
+        DeadLocker(Handler handlerUnderTest) {
+            this.handlerUnderTest = handlerUnderTest;
+
+            this.logger.setUseParentHandlers(false);
+            this.logger.addHandler(handlerUnderTest);
+            this.logger.setLevel(Level.INFO);
+            this.handlerUnderTest.setLevel(Level.INFO);
+        }
+
+        void checkDeadlock(boolean expectDeadlock) throws InterruptedException {
+            // Note: Even though the message format string isn't used in the
+            // test formatter, it must be a valid log format string (Logger
+            // detects if there are no "{n}" placeholders and skips calling
+            // the formatter otherwise).
+            Thread t1 = runAsDaemon(() -> logger.log(Level.INFO, "Hello {0}", new Argument()));
+            readyToDeadlock.acquireUninterruptibly();
+            // First thread is blocked until userLockIsHeld is released in t2.
+            Thread t2 = runAsDaemon(this::locksThenLogs);
+
+            // If deadlock occurs, the join() calls both return false.
+            int threadsBlocked = 0;
+            if (!t1.join(JOIN_WAIT)) {
+                threadsBlocked += 1;
+            }
+            if (!t2.join(JOIN_WAIT)) {
+                threadsBlocked += 1;
+            }
+            // These indicate test problems, not a failure of the code under test.
+            errorIf(threadsBlocked == 1, "Inconsistent number of blocked threads.");
+            errorIf(deadlockEncountered != (threadsBlocked == 2),
+                    "Deadlock reporting should coincide with number of blocked threads.");
+
+            // This is the actual test assertion.
+            if (expectDeadlock != deadlockEncountered) {
+                String issue = expectDeadlock ? "Expected deadlock but none occurred" : "Unexpected deadlock";
+                throw new AssertionError(errorMsg(issue));
+            }
+        }
+
+        void locksThenLogs() {
+            synchronized (userLock) {
+                userLockIsHeld.release();
+                logger.log(Level.INFO, "This will cause a deadlock if the Handler locks!");
+            }
+        }
+
+        void calledFromToString() {
+            this.readyToDeadlock.release();
+            this.userLockIsHeld.acquireUninterruptibly();
+            synchronized (userLock) {
+                this.deadlockEncountered = false;
+            }
+        }
+
+        class Argument {
+            @Override
+            public String toString() {
+                calledFromToString();
+                return "<to string>";
+            }
+        }
+
+        String errorMsg(String msg) {
+            return String.format("Handler deadlock test [%s]: %s", handlerUnderTest.getClass().getName(), msg);
+        }
+
+        void errorIf(boolean condition, String msg) {
+            if (condition) {
+                throw new RuntimeException(errorMsg("TEST ERROR - " + msg));
+            }
+        }
+    }
+
+    static Thread runAsDaemon(Runnable job) {
+        Thread thread = new Thread(job);
+        thread.setDaemon(true);
+        thread.start();
+        return thread;
+    }
+}


### PR DESCRIPTION
1. Remove synchronization of calls to publish() in Handlers in java.util.logging package.
2. Add explanatory comments to various affected methods.
3. Add a test to ensure deadlocks no longer occur.

Note that this change does not address issue in MemoryHandler (see JDK-8349208).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8349206](https://bugs.openjdk.org/browse/JDK-8349206)

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8349206: Fix for synchronization in j.u.l Handlers.`

### Issue
 * [JDK-8349206](https://bugs.openjdk.org/browse/JDK-8349206): j.u.l.Handler classes create deadlock risk via synchronized publish() method. (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23488/head:pull/23488` \
`$ git checkout pull/23488`

Update a local copy of the PR: \
`$ git checkout pull/23488` \
`$ git pull https://git.openjdk.org/jdk.git pull/23488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23488`

View PR using the GUI difftool: \
`$ git pr show -t 23488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23488.diff">https://git.openjdk.org/jdk/pull/23488.diff</a>

</details>
