### PR TITLE
8349537: Bad copyright in TestArrayStructs.java

### DIFF
--- a/test/jdk/java/foreign/arraystructs/TestArrayStructs.java
+++ b/test/jdk/java/foreign/arraystructs/TestArrayStructs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/loaderLookup/TestSymbolLookupFindOrThrow.java
+++ b/test/jdk/java/foreign/loaderLookup/TestSymbolLookupFindOrThrow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Added missing comma.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349537](https://bugs.openjdk.org/browse/JDK-8349537): Bad copyright in TestArrayStructs.java (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23489/head:pull/23489` \
`$ git checkout pull/23489`

Update a local copy of the PR: \
`$ git checkout pull/23489` \
`$ git pull https://git.openjdk.org/jdk.git pull/23489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23489`

View PR using the GUI difftool: \
`$ git pr show -t 23489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23489.diff">https://git.openjdk.org/jdk/pull/23489.diff</a>

</details>
