### PR TITLE
8349556: RISC-V: improve the performance when -COH and -AvoidUnalignedAccesses for UL and LU string comparison

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1485,10 +1485,10 @@ void C2_MacroAssembler::string_compare(Register str1, Register str2,
       add(str1, str1, cnt2);
       sub(cnt2, zr, cnt2);
     } else if (isLU) { // LU case
-      lwu(tmp1, Address(str1));
-      load_long_misaligned(tmp2, Address(str2), tmp3, (base_offset2 % 8) != 0 ? 4 : 8);
       mv(t0, STUB_THRESHOLD);
       bge(cnt2, t0, STUB);
+      lwu(tmp1, Address(str1));
+      load_long_misaligned(tmp2, Address(str2), tmp3, (base_offset2 % 8) != 0 ? 4 : 8);
       subi(cnt2, cnt2, 4);
       add(str1, str1, cnt2);
       sub(cnt1, zr, cnt2);
@@ -1499,10 +1499,10 @@ void C2_MacroAssembler::string_compare(Register str1, Register str2,
       sub(cnt2, zr, cnt2);
       addi(cnt1, cnt1, 4);
     } else { // UL case
-      load_long_misaligned(tmp1, Address(str1), tmp3, (base_offset2 % 8) != 0 ? 4 : 8);
-      lwu(tmp2, Address(str2));
       mv(t0, STUB_THRESHOLD);
       bge(cnt2, t0, STUB);
+      load_long_misaligned(tmp1, Address(str1), tmp3, (base_offset2 % 8) != 0 ? 4 : 8);
+      lwu(tmp2, Address(str2));
       subi(cnt2, cnt2, 4);
       slli(t0, cnt2, 1);
       sub(cnt1, zr, t0);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2520,23 +2520,12 @@ class StubGenerator: public StubCodeGenerator {
     assert((base_offset2 % (UseCompactObjectHeaders ? 4 :
                             (UseCompressedClassPointers ? 8 : 4))) == 0, "Must be");
 
-    // cnt2 == amount of characters left to compare
-    // Check already loaded first 4 symbols
-    __ inflate_lo32(tmp3, isLU ? tmp1 : tmp2);
-    __ mv(isLU ? tmp1 : tmp2, tmp3);
-    __ addi(str1, str1, isLU ? wordSize / 2 : wordSize);
-    __ addi(str2, str2, isLU ? wordSize : wordSize / 2);
-    __ subi(cnt2, cnt2, wordSize / 2); // Already loaded 4 symbols
-
-    __ xorr(tmp3, tmp1, tmp2);
-    __ bnez(tmp3, CALCULATE_DIFFERENCE);
-
     Register strU = isLU ? str2 : str1,
              strL = isLU ? str1 : str2,
              tmpU = isLU ? tmp2 : tmp1, // where to keep U for comparison
              tmpL = isLU ? tmp1 : tmp2; // where to keep L for comparison
 
-    if (AvoidUnalignedAccesses && (base_offset1 % 8) == 0) {
+    if (AvoidUnalignedAccesses && (base_offset1 % 8) != 0) {
       // Load another 4 bytes from strL to make sure main loop is 8-byte aligned
       // cnt2 is >= 68 here, no need to check it for >= 0
       __ lwu(tmpL, Address(strL));

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2526,7 +2526,7 @@ class StubGenerator: public StubCodeGenerator {
              tmpL = isLU ? tmp1 : tmp2; // where to keep L for comparison
 
     if (AvoidUnalignedAccesses && (base_offset1 % 8) != 0) {
-      // Load another 4 bytes from strL to make sure main loop is 8-byte aligned
+      // Load 4 bytes from strL to make sure main loop is 8-byte aligned
       // cnt2 is >= 68 here, no need to check it for >= 0
       __ lwu(tmpL, Address(strL));
       __ addi(strL, strL, wordSize / 2);


### PR DESCRIPTION
Hi,

Can you help to review the patch?

It tries to improve the string compare when AvoidUnalignedAccesses == false && encoding is LU or UL (i.e. 2 strings encodings are different with each other).
The jmh test shows when `-CompactObjectHeaders` (i.e. -COH) && `-AvoidUnalignedAccesses`, the patch bring much better performance, and in other cases, it does not bring obvious regression. And currently by default it's -COH.

Thanks

### Performance

it's run on bananapi.

-COH-AvoidUnalignedAccesses
<google-sheets-html-origin style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">
“-COH-Avoid” | (delta) | (size) | (utf16) | Mode | Cnt | Score - master | Score - patch | Error | Units | Improvement
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 24 | N/A | avgt | 10 | 6438443.073 | 6383881.891 | 36912.539 | ns/op | 0.009
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 36 | N/A | avgt | 10 | 9421176.34 | 9390907.1 | 21034.266 | ns/op | 0.003
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 72 | N/A | avgt | 10 | 18592342.33 | 16871350.38 | 15550.827 | ns/op | 0.102
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 128 | N/A | avgt | 10 | 30916157.05 | 28646961.11 | 9263.556 | ns/op | 0.079
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 256 | N/A | avgt | 10 | 58945069.17 | 55505097.77 | 8803.847 | ns/op | 0.062
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 512 | N/A | avgt | 10 | 115520355.5 | 110233842.8 | 35056.972 | ns/op | 0.048
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 24 | N/A | avgt | 10 | 7541299.83 | 7481385.995 | 43240.713 | ns/op | 0.008
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 36 | N/A | avgt | 10 | 10295051.77 | 10264978.04 | 38938.956 | ns/op | 0.003
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 72 | N/A | avgt | 10 | 19652419.64 | 17953481.41 | 10987.17 | ns/op | 0.095
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 128 | N/A | avgt | 10 | 32078969.29 | 29532674.32 | 26556.277 | ns/op | 0.086
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 256 | N/A | avgt | 10 | 60265969.7 | 56586871.09 | 137156.033 | ns/op | 0.065
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 512 | N/A | avgt | 10 | 116892685.5 | 111266086.7 | 106542.956 | ns/op | 0.051

</google-sheets-html-origin>



+COH-AvoidUnalignedAccesses
<google-sheets-html-origin style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">
"+COH-Avoid" | (delta) | (size) | (utf16) | Mode | Cnt | Score - master | Score - patch | Error | Units | Improvement
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 24 | N/A | avgt | 10 | 6384145.1 | 6386249.278 | 1018.737 | ns/op | 0
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 36 | N/A | avgt | 10 | 9484748.389 | 9437921.504 | 25184.962 | ns/op | 0.005
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 72 | N/A | avgt | 10 | 18648808.89 | 17610658.36 | 3613.01 | ns/op | 0.059
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 128 | N/A | avgt | 10 | 31130870.72 | 30542644.4 | 136527.281 | ns/op | 0.019
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 256 | N/A | avgt | 10 | 58943258.88 | 59678929.13 | 9247.37 | ns/op | -0.012
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 512 | N/A | avgt | 10 | 115515196.6 | 118941406.1 | 30104.94 | ns/op | -0.029
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 24 | N/A | avgt | 10 | 7640264.164 | 7691120.134 | 8941.255 | ns/op | -0.007
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 36 | N/A | avgt | 10 | 10568117.17 | 10540680.16 | 11225.744 | ns/op | 0.003
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 72 | N/A | avgt | 10 | 19727550.52 | 18982109.53 | 8609.764 | ns/op | 0.039
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 128 | N/A | avgt | 10 | 32125836.11 | 31006763.12 | 13915.357 | ns/op | 0.036
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 256 | N/A | avgt | 10 | 60202330.54 | 59561746.17 | 15817.383 | ns/op | 0.011
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 512 | N/A | avgt | 10 | 116636087.8 | 117264697.5 | 19632.92 | ns/op | -0.005

</google-sheets-html-origin>




-COH+AvoidUnalignedAccesses
<google-sheets-html-origin style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">
“-COH+Avoid” | (delta) | (size) | (utf16) | Mode | Cnt | Score - master | Score - patch | Error | Units | Improvement
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 24 | N/A | avgt | 10 | 7885819.391 | 7886391.597 | 1238.502 | ns/op | 0
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 36 | N/A | avgt | 10 | 10889126.89 | 10891175.03 | 1399.179 | ns/op | 0
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 72 | N/A | avgt | 10 | 16897052.9 | 16774972.05 | 2609.977 | ns/op | 0.007
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 128 | N/A | avgt | 10 | 28922269.1 | 28478100.28 | 66442.357 | ns/op | 0.016
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 256 | N/A | avgt | 10 | 56180868.95 | 55517886.54 | 48061.692 | ns/op | 0.012
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 512 | N/A | avgt | 10 | 110907025.6 | 110201411.8 | 65541.488 | ns/op | 0.006
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 24 | N/A | avgt | 10 | 9160226.336 | 9053922.422 | 30162.696 | ns/op | 0.012
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 36 | N/A | avgt | 10 | 11858619.51 | 11875124.68 | 30883.529 | ns/op | -0.001
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 72 | N/A | avgt | 10 | 18145983.4 | 17975971.55 | 42989.862 | ns/op | 0.009
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 128 | N/A | avgt | 10 | 30239261.15 | 29550149 | 93379.637 | ns/op | 0.023
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 256 | N/A | avgt | 10 | 57340601.37 | 56598661.49 | 63235.889 | ns/op | 0.013
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 512 | N/A | avgt | 10 | 111847228.7 | 111826244.4 | 30457.378 | ns/op | 0

</google-sheets-html-origin>




+COH+AvoidUnalignedAccesses
<google-sheets-html-origin style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">
“+COH+Avoid” | (delta) | (size) | (utf16) | Mode | Cnt | Score - master | Score - patch | Error | Units | Improvement
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 24 | N/A | avgt | 10 | 8824614.771 | 8879669.558 | 1136.78 | ns/op | -0.006
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 36 | N/A | avgt | 10 | 12453700.16 | 12452977.94 | 2412.16 | ns/op | 0
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 72 | N/A | avgt | 10 | 24742973.85 | 24723425.63 | 46396.337 | ns/op | 0.001
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 128 | N/A | avgt | 10 | 39673249.81 | 39681763.05 | 10340.791 | ns/op | 0
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 256 | N/A | avgt | 10 | 74004446.14 | 73731397.09 | 29337.751 | ns/op | 0.004
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 2 | 512 | N/A | avgt | 10 | 142806141.5 | 142275494.2 | 52159.737 | ns/op | 0.004
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 24 | N/A | avgt | 10 | 9935969.372 | 10045152.69 | 70155.123 | ns/op | -0.011
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 36 | N/A | avgt | 10 | 13255244.36 | 13280685.46 | 68940.937 | ns/op | -0.002
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 72 | N/A | avgt | 10 | 25848901.97 | 25887363.77 | 16178.629 | ns/op | -0.001
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 128 | N/A | avgt | 10 | 40859613.95 | 40908567.84 | 54621.931 | ns/op | -0.001
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 256 | N/A | avgt | 10 | 74853691.65 | 74878469.62 | 31639.587 | ns/op | 0
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 2 | 512 | N/A | avgt | 10 | 143431358.1 | 143495718.8 | 60271.214 | ns/op | 0

</google-sheets-html-origin>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349556](https://bugs.openjdk.org/browse/JDK-8349556): RISC-V: improve the performance when -COH and -AvoidUnalignedAccesses for UL and LU string comparison (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23495/head:pull/23495` \
`$ git checkout pull/23495`

Update a local copy of the PR: \
`$ git checkout pull/23495` \
`$ git pull https://git.openjdk.org/jdk.git pull/23495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23495`

View PR using the GUI difftool: \
`$ git pr show -t 23495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23495.diff">https://git.openjdk.org/jdk/pull/23495.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23495#issuecomment-2640250665)
</details>
