### PR TITLE
8349559: Compiler interface doesn't need to store protection domain

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -89,14 +89,10 @@ ciInstanceKlass::ciInstanceKlass(Klass* k) :
   JavaThread *thread = JavaThread::current();
   if (ciObjectFactory::is_initialized()) {
     _loader = JNIHandles::make_local(thread, ik->class_loader());
-    _protection_domain = JNIHandles::make_local(thread,
-                                                ik->protection_domain());
     _is_shared = false;
   } else {
     Handle h_loader(thread, ik->class_loader());
-    Handle h_protection_domain(thread, ik->protection_domain());
     _loader = JNIHandles::make_global(h_loader);
-    _protection_domain = JNIHandles::make_global(h_protection_domain);
     _is_shared = true;
   }
 
@@ -118,7 +114,7 @@ ciInstanceKlass::ciInstanceKlass(Klass* k) :
 
 // Version for unloaded classes:
 ciInstanceKlass::ciInstanceKlass(ciSymbol* name,
-                                 jobject loader, jobject protection_domain)
+                                 jobject loader)
   : ciKlass(name, T_OBJECT)
 {
   assert(name->char_at(0) != JVM_SIGNATURE_ARRAY, "not an instance klass");
@@ -129,7 +125,6 @@ ciInstanceKlass::ciInstanceKlass(ciSymbol* name,
   _is_hidden = false;
   _is_record = false;
   _loader = loader;
-  _protection_domain = protection_domain;
   _is_shared = false;
   _super = nullptr;
   _java_mirror = nullptr;
@@ -169,19 +164,6 @@ oop ciInstanceKlass::loader() {
 // ciInstanceKlass::loader_handle
 jobject ciInstanceKlass::loader_handle() {
   return _loader;
-}
-
-// ------------------------------------------------------------------
-// ciInstanceKlass::protection_domain
-oop ciInstanceKlass::protection_domain() {
-  ASSERT_IN_VM;
-  return JNIHandles::resolve(_protection_domain);
-}
-
-// ------------------------------------------------------------------
-// ciInstanceKlass::protection_domain_handle
-jobject ciInstanceKlass::protection_domain_handle() {
-  return _protection_domain;
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,6 @@ private:
   enum SubklassValue { subklass_unknown, subklass_false, subklass_true };
 
   jobject                _loader;
-  jobject                _protection_domain;
 
   InstanceKlass::ClassState _init_state;           // state of class
   bool                   _is_shared;
@@ -84,7 +83,7 @@ private:
 
 protected:
   ciInstanceKlass(Klass* k);
-  ciInstanceKlass(ciSymbol* name, jobject loader, jobject protection_domain);
+  ciInstanceKlass(ciSymbol* name, jobject loader);
 
   InstanceKlass* get_instanceKlass() const {
     return InstanceKlass::cast(get_Klass());
@@ -92,9 +91,6 @@ protected:
 
   oop loader();
   jobject loader_handle();
-
-  oop protection_domain();
-  jobject protection_domain_handle();
 
   const char* type_string() { return "ciInstanceKlass"; }
 

--- a/src/hotspot/share/ci/ciKlass.hpp
+++ b/src/hotspot/share/ci/ciKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,9 +64,6 @@ protected:
   // Certain subklasses have an associated class loader.
   virtual oop loader()             { return nullptr; }
   virtual jobject loader_handle()  { return nullptr; }
-
-  virtual oop protection_domain()             { return nullptr; }
-  virtual jobject protection_domain_handle()  { return nullptr; }
 
   const char* type_string() { return "ciKlass"; }
 

--- a/src/hotspot/share/ci/ciObjArrayKlass.hpp
+++ b/src/hotspot/share/ci/ciObjArrayKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,10 +57,6 @@ protected:
 
   oop     loader()        { return _base_element_klass->loader(); }
   jobject loader_handle() { return _base_element_klass->loader_handle(); }
-
-  oop     protection_domain()        { return _base_element_klass->protection_domain(); }
-  jobject protection_domain_handle() { return _base_element_klass->protection_domain_handle(); }
-
 
 public:
   // The one-level type of the array elements.

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -173,7 +173,7 @@ void ciObjectFactory::init_shared_objects() {
 
   ciEnv::_unloaded_cisymbol = ciObjectFactory::get_symbol(vmSymbols::dummy_symbol());
   // Create dummy InstanceKlass and ObjArrayKlass object and assign them idents
-  ciEnv::_unloaded_ciinstance_klass = new (_arena) ciInstanceKlass(ciEnv::_unloaded_cisymbol, nullptr, nullptr);
+  ciEnv::_unloaded_ciinstance_klass = new (_arena) ciInstanceKlass(ciEnv::_unloaded_cisymbol, nullptr);
   init_ident_of(ciEnv::_unloaded_ciinstance_klass);
   ciEnv::_unloaded_ciobjarrayklass = new (_arena) ciObjArrayKlass(ciEnv::_unloaded_cisymbol, ciEnv::_unloaded_ciinstance_klass, 1);
   init_ident_of(ciEnv::_unloaded_ciobjarrayklass);
@@ -467,13 +467,11 @@ ciKlass* ciObjectFactory::get_unloaded_klass(ciKlass* accessing_klass,
   oop domain = nullptr;
   if (accessing_klass != nullptr) {
     loader = accessing_klass->loader();
-    domain = accessing_klass->protection_domain();
   }
   for (int i = 0; i < _unloaded_klasses.length(); i++) {
     ciKlass* entry = _unloaded_klasses.at(i);
     if (entry->name()->equals(name) &&
-        entry->loader() == loader &&
-        entry->protection_domain() == domain) {
+        entry->loader() == loader) {
       // We've found a match.
       return entry;
     }
@@ -512,12 +510,10 @@ ciKlass* ciObjectFactory::get_unloaded_klass(ciKlass* accessing_klass,
     new_klass = new (arena()) ciObjArrayKlass(name, element_klass, dimension);
   } else {
     jobject loader_handle = nullptr;
-    jobject domain_handle = nullptr;
     if (accessing_klass != nullptr) {
       loader_handle = accessing_klass->loader_handle();
-      domain_handle = accessing_klass->protection_domain_handle();
     }
-    new_klass = new (arena()) ciInstanceKlass(name, loader_handle, domain_handle);
+    new_klass = new (arena()) ciInstanceKlass(name, loader_handle);
   }
   init_ident_of(new_klass);
   _unloaded_klasses.append(new_klass);


### PR DESCRIPTION
The compiler interface has a protection_domain field that it uses for matching in its version of not-yet loaded classes, but class loading only uses (class, class-loader) as an identifier for loaded classes so the compiler interface should do the same.  From the code, I can't see any situation where the protection_domain wouldn't match if name and class loader match.  Actually I think the code was for this case: if you match (name, classLoader) with a calling class with the same classLoader and a different protectionDomain, the code should not match the class without going through the SystemDictionary to call checkPackageAccess() for the second protectionDomain.  Since checkPackageAccess is now removed with the security manager, this extra lookup is now unnecessary and we match just class name, classLoader pairs.

Tested with tier1-7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349559](https://bugs.openjdk.org/browse/JDK-8349559): Compiler interface doesn't need to store protection domain (**Enhancement** - P4)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23496/head:pull/23496` \
`$ git checkout pull/23496`

Update a local copy of the PR: \
`$ git checkout pull/23496` \
`$ git pull https://git.openjdk.org/jdk.git pull/23496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23496`

View PR using the GUI difftool: \
`$ git pr show -t 23496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23496.diff">https://git.openjdk.org/jdk/pull/23496.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23496#issuecomment-2640519466)
</details>
