### PR TITLE
8349580: Do not use address in MemTracker top level functions

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1088,7 +1088,7 @@ static void unmap_shared(char* addr, size_t bytes) {
     MemTracker::NmtVirtualMemoryLocker nvml;
     res = ::munmap(addr, bytes);
     if (res == 0) {
-      MemTracker::record_virtual_memory_release((address)addr, bytes);
+      MemTracker::record_virtual_memory_release(addr, bytes);
     }
   } else {
     res = ::munmap(addr, bytes);

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -1804,7 +1804,7 @@ void PerfMemory::detach(char* addr, size_t bytes) {
     // it does not go through os api, the operation has to record from here
     MemTracker::NmtVirtualMemoryLocker nvml;
     remove_file_mapping(addr);
-    MemTracker::record_virtual_memory_release((address)addr, bytes);
+    MemTracker::record_virtual_memory_release(addr, bytes);
   } else {
     remove_file_mapping(addr);
   }

--- a/src/hotspot/share/nmt/memTracker.hpp
+++ b/src/hotspot/share/nmt/memTracker.hpp
@@ -135,7 +135,7 @@ class MemTracker : AllStatic {
     }
   }
 
-  static inline void record_virtual_memory_release(address addr, size_t size) {
+  static inline void record_virtual_memory_release(void* addr, size_t size) {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {
@@ -143,7 +143,7 @@ class MemTracker : AllStatic {
     }
   }
 
-  static inline void record_virtual_memory_uncommit(address addr, size_t size) {
+  static inline void record_virtual_memory_uncommit(void* addr, size_t size) {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2204,7 +2204,7 @@ bool os::uncommit_memory(char* addr, size_t bytes, bool executable) {
     MemTracker::NmtVirtualMemoryLocker nvml;
     res = pd_uncommit_memory(addr, bytes, executable);
     if (res) {
-      MemTracker::record_virtual_memory_uncommit((address)addr, bytes);
+      MemTracker::record_virtual_memory_uncommit(addr, bytes);
     }
   } else {
     res = pd_uncommit_memory(addr, bytes, executable);
@@ -2226,7 +2226,7 @@ bool os::release_memory(char* addr, size_t bytes) {
     MemTracker::NmtVirtualMemoryLocker nvml;
     res = pd_release_memory(addr, bytes);
     if (res) {
-      MemTracker::record_virtual_memory_release((address)addr, bytes);
+      MemTracker::record_virtual_memory_release(addr, bytes);
     }
   } else {
     res = pd_release_memory(addr, bytes);
@@ -2311,7 +2311,7 @@ bool os::unmap_memory(char *addr, size_t bytes) {
     MemTracker::NmtVirtualMemoryLocker nvml;
     result = pd_unmap_memory(addr, bytes);
     if (result) {
-      MemTracker::record_virtual_memory_release((address)addr, bytes);
+      MemTracker::record_virtual_memory_release(addr, bytes);
     }
   } else {
     result = pd_unmap_memory(addr, bytes);
@@ -2350,7 +2350,7 @@ bool os::release_memory_special(char* addr, size_t bytes) {
     MemTracker::NmtVirtualMemoryLocker nvml;
     res = pd_release_memory_special(addr, bytes);
     if (res) {
-      MemTracker::record_virtual_memory_release((address)addr, bytes);
+      MemTracker::record_virtual_memory_release(addr, bytes);
     }
   } else {
     res = pd_release_memory_special(addr, bytes);


### PR DESCRIPTION
Hi,

Please consider this trivial patch. Note that this gives us consistency with `reserve_memory`.

```c++
  static inline void record_virtual_memory_reserve(void* addr, size_t size, /* ... */);
```

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349580](https://bugs.openjdk.org/browse/JDK-8349580): Do not use address in MemTracker top level functions (**Enhancement** - P4)


### Reviewers
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23497/head:pull/23497` \
`$ git checkout pull/23497`

Update a local copy of the PR: \
`$ git checkout pull/23497` \
`$ git pull https://git.openjdk.org/jdk.git pull/23497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23497`

View PR using the GUI difftool: \
`$ git pr show -t 23497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23497.diff">https://git.openjdk.org/jdk/pull/23497.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23497#issuecomment-2641085246)
</details>
