### PR TITLE
8349284: Make libExplicitAttach work on static JDK

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -80,7 +80,6 @@ else
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerModule := -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := -pthread
 
-  BUILD_JDK_JTREG_LIBRARIES_JDK_LIBS_libExplicitAttach := java.base:libjvm
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libExplicitAttach := -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libImplicitAttach := -pthread
   BUILD_JDK_JTREG_EXCLUDE += exerevokeall.c

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libExplicitAttach.c
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libExplicitAttach.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libExplicitAttach.c
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libExplicitAttach.c
@@ -38,8 +38,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void* reserved) {
  */
 void* thread_main(void* arg) {
     JNIEnv *env;
-    JavaVMInitArgs vm_args;
-    jsize count;
     jint res;
 
     res = (*vm)->AttachCurrentThread(vm, (void **) &env, NULL);


### PR DESCRIPTION
This is similar to https://github.com/openjdk/jdk/pull/23431 change. It removes libjvm.so as a recorded dependency for libExplicitAttach.so by not explicitly link libExplicitAttach.so with libjvm.so at build time. To do that, it also changes libExplicitAttach.c to dynamically lookup the JNI_GetCreatedJavaVMs symbol then invokes the function using the obtained address. The change makes the test to work on both regular 'jdk' image and the 'static-jdk' image.

There are discussions in https://github.com/openjdk/jdk/pull/23431 comment thread among @dholmes-ora, @AlanBateman and myself. Based on my understanding, we are converging on the approach to fix just these few tests, and both @dholmes-ora and @AlanBateman are okay with that. So I'm sending out this PR for libExplicitAttach's fix as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349284](https://bugs.openjdk.org/browse/JDK-8349284): Make libExplicitAttach work on static JDK (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [317d2315](https://git.openjdk.org/jdk/pull/23500/files/317d2315728d5ed4aaac1038745aa4dad17876ac)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23500/head:pull/23500` \
`$ git checkout pull/23500`

Update a local copy of the PR: \
`$ git checkout pull/23500` \
`$ git pull https://git.openjdk.org/jdk.git pull/23500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23500`

View PR using the GUI difftool: \
`$ git pr show -t 23500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23500.diff">https://git.openjdk.org/jdk/pull/23500.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23500#issuecomment-2640908888)
</details>
