### PR TITLE
8292700: Add date stamps to logs by default

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -24,6 +24,7 @@
 #ifndef SHARE_LOGGING_LOGCONFIGURATION_HPP
 #define SHARE_LOGGING_LOGCONFIGURATION_HPP
 
+#include "logging/logFileOutput.hpp"
 #include "logging/logFileStreamOutput.hpp"
 #include "logging/logLevel.hpp"
 #include "memory/allStatic.hpp"
@@ -65,7 +66,7 @@ class LogConfiguration : public AllStatic {
   static bool                       _async_mode;
 
   // Create a new output. Returns null if failed.
-  static LogOutput* new_output(const char* name, const char* options, outputStream* errstream);
+  static LogFileOutput* new_output(const char* name, const char* options, outputStream* errstream);
 
   // Add an output to the list of configured outputs. Returns the assigned index.
   static size_t add_output(LogOutput* out);

--- a/src/hotspot/share/logging/logFileOutput.hpp
+++ b/src/hotspot/share/logging/logFileOutput.hpp
@@ -80,7 +80,7 @@ class LogFileOutput : public LogFileStreamOutput {
     }
   }
 
- public:
+public:
   LogFileOutput(const char *name);
   virtual ~LogFileOutput();
   virtual bool initialize(const char* options, outputStream* errstream);
@@ -98,6 +98,8 @@ class LogFileOutput : public LogFileStreamOutput {
   const char* cur_log_file_name();
   static const char* const Prefix;
   static void set_file_name_parameters(jlong start_time);
+
+  void write_file_unique_time_message(const char* message);
 };
 
 #endif // SHARE_LOGGING_LOGFILEOUTPUT_HPP

--- a/src/hotspot/share/logging/logTagSet.hpp
+++ b/src/hotspot/share/logging/logTagSet.hpp
@@ -116,6 +116,10 @@ class LogTagSet {
     _output_list.set_output_level(output, level);
   }
 
+  const LogDecorators& decorators() {
+    return _decorators;
+  }
+
   // Refresh the decorators for this tagset to contain the decorators for all
   // of its current outputs combined with the given decorators.
   void update_decorators(const LogDecorators& decorator = LogDecorators::None);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1868,6 +1868,9 @@ const int ObjectAlignmentInBytes = 8;
              "Use the FP register for holding the frame pointer "           \
              "and not as a general purpose register.")                      \
                                                                             \
+  product(bool, LogDateInFileOnStartAndRotation, true,                      \
+          "When a new log file is created by Unified Logging, log the "     \
+          "current date and time inside the file as a ISO8601 timestamp.")  \
   product(size_t, AsyncLogBufferSize, 2*M,                                  \
           "Memory budget (in bytes) for the buffer of Asynchronous "        \
           "Logging (-Xlog:async).")                                         \

--- a/test/hotspot/jtreg/runtime/logging/FileLocalLogOnStartAndRotation.java
+++ b/test/hotspot/jtreg/runtime/logging/FileLocalLogOnStartAndRotation.java
@@ -36,6 +36,10 @@
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
+import java.util.regex.*;
+import java.io.File;
+import java.util.stream.*;
+
 public class FileLocalLogOnStartAndRotation {
     private static Pattern startLogRegex = Pattern.compile("^.*Started logging for file at.*$");
     private static Pattern rotateLogRegex = Pattern.compile("^.*Rotated file at.*$");
@@ -43,7 +47,7 @@ public class FileLocalLogOnStartAndRotation {
     // Match default decorations, ex: [0.001s][info][logging]
     private static Pattern decorationRegex = Pattern.compile("^\\[.*\\]\\[.*\\]\\[.*\\].*$");
 
-    private static void analyzeFile(File f, bool shouldHaveDecorations) {
+    private static void analyzeFile(File f, boolean shouldHaveDecorations) {
         String content = new String(Files.readAllBytes(f), StandardCharsets.UTF_8);
 
         Matcher matchStart = startLogRegex.matcher(content);

--- a/test/hotspot/jtreg/runtime/logging/FileLocalLogOnStartAndRotation.java
+++ b/test/hotspot/jtreg/runtime/logging/FileLocalLogOnStartAndRotation.java
@@ -51,7 +51,7 @@ public class FileLocalLogOnStartAndRotation {
     private static Pattern decorationRegex = Pattern.compile("^\\[.*\\]\\[.*\\]\\[.*\\].*$");
 
     private static void analyzeFile(File f, boolean shouldHaveDecorations) {
-        String content = new String(Files.readAllBytes(f), StandardCharsets.UTF_8);
+        String content = new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
 
         Matcher matchStart = startLogRegex.matcher(content);
         Matcher matchRotate = rotateLogRegex.matcher(content);

--- a/test/hotspot/jtreg/runtime/logging/FileLocalLogOnStartAndRotation.java
+++ b/test/hotspot/jtreg/runtime/logging/FileLocalLogOnStartAndRotation.java
@@ -39,6 +39,9 @@ import jdk.test.lib.process.OutputAnalyzer;
 import java.util.regex.*;
 import java.io.File;
 import java.util.stream.*;
+import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
+
 
 public class FileLocalLogOnStartAndRotation {
     private static Pattern startLogRegex = Pattern.compile("^.*Started logging for file at.*$");

--- a/test/hotspot/jtreg/runtime/logging/FileLocalLogOnStartAndRotation.java
+++ b/test/hotspot/jtreg/runtime/logging/FileLocalLogOnStartAndRotation.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8349755
+ * @summary UL should put ISO8601 date stamp on file creation and file rotation
+ * @requires vm.flagless
+ * @requires vm.debug
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver FileLocalLogOnStartAndRotation
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class FileLocalLogOnStartAndRotation {
+    private static Pattern startLogRegex = Pattern.compile("^.*Started logging for file at.*$");
+    private static Pattern rotateLogRegex = Pattern.compile("^.*Rotated file at.*$");
+
+    // Match default decorations, ex: [0.001s][info][logging]
+    private static Pattern decorationRegex = Pattern.compile("^\\[.*\\]\\[.*\\]\\[.*\\].*$");
+
+    private static void analyzeFile(File f, bool shouldHaveDecorations) {
+        String content = new String(Files.readAllBytes(f), StandardCharsets.UTF_8);
+
+        Matcher matchStart = startLogRegex.matcher(content);
+        Matcher matchRotate = rotateLogRegex.matcher(content);
+        long startMatchCount = matchStart.results().count();
+        long rotateMatchCount = matchRotate.results().count();
+        if (startMatchCount > 0 && rotateMatchCount > 0) {
+            throw new RuntimeException("Should only have either start or log rotate message");
+        }
+        if (startMatchCount == 0 && rotateMatchCount == 0) {
+            throw new RuntimeException("Must have either start or log rotate message");
+        }
+
+
+        Stream<Boolean> linesWithDecorations =
+            content
+                .lines()
+                .map((l) -> decorationRegex.matcher(l))
+                .map((m) -> m.find());
+        if (shouldHaveDecorations) {
+            boolean eachLineHasADecoration = linesWithDecorations.reduce(true, (a, b) -> a && b);
+            if (!eachLineHasADecoration) {
+                throw new RuntimeException("Expected that each line has decoration, but doesn't");
+            }
+        } else {
+            boolean someLineHasADecoration = linesWithDecorations.reduce(false, (a, b) -> a || b);
+            if (someLineHasADecoration) {
+                throw new RuntimeException("Expected that no line has decoration, but some do");
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        /*
+        Run two tests:
+        1. With file rotation and decorations
+        2. With file rotations, but without decorations
+        Check that in both of these cases we get log start and log rotate messages inside of the files.
+
+        For case #2, ensure that the start and rotate messages also runs without decorations.
+        This is a way for us to test that the file-local messages also abide by the decorator options specified.
+        */
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:os=all:file=default.FileLocalLogOnStartAndRotationDecorations.log::filesize=100", "--version");
+        Process p = pb.start();
+        p.waitFor();
+
+        File directory = new File(".");
+        String fileRegex = ".*FileLocalLogOnStartAndRotationDecorations\\.log\\.[0-9]*";
+        File[] files = directory.listFiles((dir, name) -> name.matches(fileRegex));
+
+        for (File f : files) {
+            analyzeFile(f, true);
+        }
+
+        // Re-do the same test, but this time run without any decorations.
+        ProcessBuilder pb2 = ProcessTools.createLimitedTestJavaProcessBuilder(
+                "-Xlog:os=all:file=default.FileLocalLogOnStartAndRotation.log:none:filesize=100", "--version");
+        Process p2 = pb2.start();
+        p2.waitFor();
+
+        String fileRegexNoDecs = ".*FileLocalLogOnStartAndRotation\\.log\\.[0-9]*";
+        File[] filesNoDecs = directory.listFiles((dir, name) -> name.matches(fileRegexNoDecs));
+
+        for (File f : filesNoDecs) {
+            analyzeFile(f, false);
+        }
+    }
+}


### PR DESCRIPTION
Hi,

This PR adds file-local messages for when a log file is opened and when it is rotated. The messages are published for the `logging` tag at the `Info` level regardless of any specified UL options.

The intention with this change is to help with correlating log events with the date that they occurred.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292700](https://bugs.openjdk.org/browse/JDK-8292700): Add date stamps to logs by default (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23502/head:pull/23502` \
`$ git checkout pull/23502`

Update a local copy of the PR: \
`$ git checkout pull/23502` \
`$ git pull https://git.openjdk.org/jdk.git pull/23502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23502`

View PR using the GUI difftool: \
`$ git pr show -t 23502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23502.diff">https://git.openjdk.org/jdk/pull/23502.diff</a>

</details>
