### PR TITLE
8349579: jsvml.dll incorrect RDATA SEGMENT specification

### DIFF
--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_acos_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_acos_windows_x86.S
@@ -2456,7 +2456,7 @@ _unwind___jsvml_dacos_ha_cout_rare_internal_B1_B21:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dacos_ha_data_internal
 __jsvml_dacos_ha_data_internal  DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_asin_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_asin_windows_x86.S
@@ -2386,7 +2386,7 @@ _unwind___jsvml_dasin_ha_cout_rare_internal_B1_B13:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dasin_ha_data_internal
 __jsvml_dasin_ha_data_internal  DD      4294967295

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_atan2_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_atan2_windows_x86.S
@@ -4431,7 +4431,7 @@ _unwind___jsvml_datan2_ha_cout_rare_internal_B1_B57:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_datan2_ha_data_internal
 __jsvml_datan2_ha_data_internal DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_atan_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_atan_windows_x86.S
@@ -2436,7 +2436,7 @@ _unwind___jsvml_datan_ha_cout_rare_internal_B1_B15:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_datan_ha_data_internal_avx512
 __jsvml_datan_ha_data_internal_avx512   DD      4294967295

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_cbrt_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_cbrt_windows_x86.S
@@ -419,7 +419,7 @@ _unwind___jsvml_cbrt4_ha_l9_B6_B10:
         DD      imagerel _unwind___jsvml_cbrt4_ha_l9_B6_B10
 
 .pdata  ENDS
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
 __VUNPACK_ODD_ind1_2671_0_2     DD      0
         DD      0
@@ -2063,7 +2063,7 @@ _unwind___jsvml_dcbrt_ha_cout_rare_internal_B1_B9:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ  'DATA'
+_RDATA  SEGMENT     READONLY  'DATA'
         DD 8 DUP (0H)
         PUBLIC __jsvml_dcbrt_ha_data_internal_avx512
 __jsvml_dcbrt_ha_data_internal_avx512   DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_cos_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_cos_windows_x86.S
@@ -3963,7 +3963,7 @@ _unwind___jsvml_dcos_ha_cout_rare_internal_B1_B6:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dcos_ha_reduction_data_internal
 __jsvml_dcos_ha_reduction_data_internal DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_cosh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_cosh_windows_x86.S
@@ -2040,7 +2040,7 @@ _unwind___jsvml_dcosh_ha_cout_rare_internal_B1_B12:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dcosh_ha_data_internal
 __jsvml_dcosh_ha_data_internal  DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_exp_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_exp_windows_x86.S
@@ -1783,7 +1783,7 @@ _unwind___jsvml_dexp_ha_cout_rare_internal_B1_B21:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dexp_ha_data_internal_avx512
 __jsvml_dexp_ha_data_internal_avx512    DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_expm1_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_expm1_windows_x86.S
@@ -2191,7 +2191,7 @@ _unwind___jsvml_dexpm1_ha_cout_rare_internal_B1_B23:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dexpm1_ha_data_internal_avx512
 __jsvml_dexpm1_ha_data_internal_avx512  DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_hypot_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_hypot_windows_x86.S
@@ -2198,7 +2198,7 @@ _unwind___jsvml_dhypot_ha_cout_rare_internal_B1_B22:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dhypot_ha_data_internal
 __jsvml_dhypot_ha_data_internal DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_log10_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_log10_windows_x86.S
@@ -1778,7 +1778,7 @@ _unwind___jsvml_dlog10_ha_cout_rare_internal_B1_B16:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dlog10_ha_data_internal_avx512
 __jsvml_dlog10_ha_data_internal_avx512  DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_log1p_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_log1p_windows_x86.S
@@ -2135,7 +2135,7 @@ _unwind___jsvml_dlog1p_ha_cout_rare_internal_B1_B16:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dlog1p_ha_data_internal_avx512
 __jsvml_dlog1p_ha_data_internal_avx512  DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_log_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_log_windows_x86.S
@@ -1704,7 +1704,7 @@ _unwind___jsvml_dlog_ha_cout_rare_internal_B1_B16:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dlog_ha_data_internal_avx512
 __jsvml_dlog_ha_data_internal_avx512    DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_pow_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_pow_windows_x86.S
@@ -3509,7 +3509,7 @@ _unwind___jsvml_dpow_ha_cout_rare_internal_B1_B76:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dpow_ha_data_internal_avx512
 __jsvml_dpow_ha_data_internal_avx512    DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_sin_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_sin_windows_x86.S
@@ -4022,7 +4022,7 @@ _unwind___jsvml_dsin_ha_cout_rare_internal_B1_B6:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dsin_ha_reduction_data_internal
 __jsvml_dsin_ha_reduction_data_internal DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_sinh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_sinh_windows_x86.S
@@ -2469,7 +2469,7 @@ _unwind___jsvml_dsinh_ha_cout_rare_internal_B1_B17:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dsinh_ha_data_internal
 __jsvml_dsinh_ha_data_internal  DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_tan_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_tan_windows_x86.S
@@ -4331,7 +4331,7 @@ _unwind___jsvml_tan4_ha_l9_B12_B12:
         DD      imagerel _unwind___jsvml_tan4_ha_l9_B12_B12
 
 .pdata  ENDS
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
 __VUNPACK_EVEN_ind1_3308_0_10   DD      0
         DD      0
@@ -4443,7 +4443,7 @@ _unwind___jsvml_dtan_ha_cout_rare_internal_B1_B6:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ  'DATA'
+_RDATA  SEGMENT     READONLY  'DATA'
         DD 8 DUP (0H)
         PUBLIC __jsvml_dtan_ha_reduction_data_internal
 __jsvml_dtan_ha_reduction_data_internal DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_tanh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_tanh_windows_x86.S
@@ -2253,7 +2253,7 @@ _TEXT   ENDS
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_dtanh_ha_data_internal
 __jsvml_dtanh_ha_data_internal  DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_acos_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_acos_windows_x86.S
@@ -1795,7 +1795,7 @@ _unwind___jsvml_sacos_ha_cout_rare_internal_B1_B20:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_sacos_ha_data_internal
 __jsvml_sacos_ha_data_internal  DD      2147483648

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_asin_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_asin_windows_x86.S
@@ -1726,7 +1726,7 @@ _unwind___jsvml_sasin_ha_cout_rare_internal_B1_B12:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_sasin_ha_data_internal
 __jsvml_sasin_ha_data_internal  DD      2147483647

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_atan2_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_atan2_windows_x86.S
@@ -3240,7 +3240,7 @@ _DATA   SEGMENT      'DATA'
 ione    DD      1065353216
         DD      -1082130432
 _DATA   ENDS
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_satan2_ha_data_internal
 __jsvml_satan2_ha_data_internal DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_atan_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_atan_windows_x86.S
@@ -1824,7 +1824,7 @@ _unwind___jsvml_satan_ha_cout_rare_internal_B1_B14:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_satan_ha_data_internal_avx512
 __jsvml_satan_ha_data_internal_avx512   DD      2147483647

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_cbrt_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_cbrt_windows_x86.S
@@ -1447,7 +1447,7 @@ _DATA   SEGMENT      'DATA'
 ione    DD      1065353216
         DD      -1082130432
 _DATA   ENDS
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
 vscbrt_ha_cout_data     DD      3212578753
         DD      3212085645

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_cos_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_cos_windows_x86.S
@@ -1786,7 +1786,7 @@ _unwind___jsvml_scos_ha_cout_rare_internal_B1_B17:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_scos_ha_data_internal
 __jsvml_scos_ha_data_internal   DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_cosh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_cosh_windows_x86.S
@@ -1643,7 +1643,7 @@ _unwind___jsvml_scosh_ha_cout_rare_internal_B1_B12:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_scosh_ha_data_internal
 __jsvml_scosh_ha_data_internal  DD      1056964608

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_exp_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_exp_windows_x86.S
@@ -1323,7 +1323,7 @@ _unwind___jsvml_sexp_ha_cout_rare_internal_B1_B20:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_sexp_ha_data_internal_avx512
 __jsvml_sexp_ha_data_internal_avx512    DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_expm1_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_expm1_windows_x86.S
@@ -1731,7 +1731,7 @@ _unwind___jsvml_sexpm1_ha_cout_rare_internal_B1_B22:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_sexpm1_ha_data_internal_avx512
 __jsvml_sexpm1_ha_data_internal_avx512  DD      1065353216

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_hypot_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_hypot_windows_x86.S
@@ -1631,7 +1631,7 @@ _unwind___jsvml_shypot_ha_cout_rare_internal_B1_B18:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_shypot_ha_data_internal
 __jsvml_shypot_ha_data_internal DD      4294443008

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_log10_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_log10_windows_x86.S
@@ -1312,7 +1312,7 @@ _unwind___jsvml_slog10_ha_cout_rare_internal_B1_B15:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_slog10_ha_data_internal_avx512
 __jsvml_slog10_ha_data_internal_avx512  DD      1050288128

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_log1p_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_log1p_windows_x86.S
@@ -1682,7 +1682,7 @@ _unwind___jsvml_slog1p_ha_cout_rare_internal_B1_B18:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_slog1p_ha_data_internal_avx512
 __jsvml_slog1p_ha_data_internal_avx512  DD      1060205056

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_log_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_log_windows_x86.S
@@ -1202,7 +1202,7 @@ _unwind___jsvml_slog_ha_cout_rare_internal_B1_B15:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_slog_ha_data_internal_avx512
 __jsvml_slog_ha_data_internal_avx512    DD      131072

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_pow_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_pow_windows_x86.S
@@ -654,7 +654,7 @@ _unwind___jsvml_powf8_ha_l9_B6_B10:
         DD      imagerel _unwind___jsvml_powf8_ha_l9_B6_B10
 
 .pdata  ENDS
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
 __VPACK_ODD_ind_2742_0_4        DD      1
         DD      3
@@ -2703,7 +2703,7 @@ _unwind___jsvml_spow_ha_cout_rare_internal_B1_B64:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ  'DATA'
+_RDATA  SEGMENT     READONLY  'DATA'
         DD 8 DUP (0H)
         PUBLIC __jsvml_spow_ha_data_internal_avx512
 __jsvml_spow_ha_data_internal_avx512    DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_sin_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_sin_windows_x86.S
@@ -1814,7 +1814,7 @@ _unwind___jsvml_ssin_ha_cout_rare_internal_B1_B20:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_ssin_ha_data_internal
 __jsvml_ssin_ha_data_internal   DD      0

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_sinh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_sinh_windows_x86.S
@@ -1932,7 +1932,7 @@ _unwind___jsvml_ssinh_ha_cout_rare_internal_B1_B17:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_ssinh_ha_data_internal
 __jsvml_ssinh_ha_data_internal  DD      1056964608

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_tan_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_tan_windows_x86.S
@@ -2060,7 +2060,7 @@ _unwind___jsvml_stan_ha_cout_rare_internal_B1_B20:
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_stan_ha_data_internal
 __jsvml_stan_ha_data_internal   DD      1092811139

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_tanh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_tanh_windows_x86.S
@@ -1537,7 +1537,7 @@ _TEXT   ENDS
 _DATA   SEGMENT      'DATA'
 _DATA   ENDS
 
-_RDATA  SEGMENT     READ PAGE   'DATA'
+_RDATA  SEGMENT     READONLY PAGE   'DATA'
         ALIGN  32
         PUBLIC __jsvml_stanh_ha_data_internal
 __jsvml_stanh_ha_data_internal  DD      0


### PR DESCRIPTION
A fix for incorrectly defined program segments in Windows SVML assembly.

- Changes _READ_ to _READONLY_ in all math functions
- Now compliant with MASM x86 and x86_64 program segment [specification](https://learn.microsoft.com/en-us/cpp/assembler/masm/segment?view=msvc-170)

The tier1 tests show the changes didn't introduce new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349579](https://bugs.openjdk.org/browse/JDK-8349579): jsvml.dll incorrect RDATA SEGMENT specification (**Bug** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23503/head:pull/23503` \
`$ git checkout pull/23503`

Update a local copy of the PR: \
`$ git checkout pull/23503` \
`$ git pull https://git.openjdk.org/jdk.git pull/23503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23503`

View PR using the GUI difftool: \
`$ git pr show -t 23503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23503.diff">https://git.openjdk.org/jdk/pull/23503.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23503#issuecomment-2649233758)
</details>
