### PR TITLE
8349509: [macos] Clean up macOS dead code in jpackage

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
-import jdk.internal.util.OperatingSystem;
 import jdk.internal.util.OSVersion;
 import static jdk.jpackage.internal.MacAppBundler.BUNDLE_ID_SIGNING_PREFIX;
 import static jdk.jpackage.internal.MacAppBundler.DEVELOPER_ID_APP_SIGNING_KEY;
@@ -419,12 +418,8 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
                 signAppBundle(params, root, "-", null, null);
             }
             restoreKeychainList(params);
-        } else if (OperatingSystem.isMacOS()) {
-            signAppBundle(params, root, "-", null, null);
         } else {
-            // Calling signAppBundle() without signingIdentity will result in
-            // unsigning app bundle
-            signAppBundle(params, root, null, null, null);
+            signAppBundle(params, root, "-", null, null);
         }
     }
 

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,13 +64,6 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
     static final String TEMPLATE_BUNDLE_ICON = "JavaApp.icns";
 
     static final String DEFAULT_LICENSE_PLIST="lic_template.plist";
-
-    public static final BundlerParamInfo<String> INSTALLER_SUFFIX =
-            new StandardBundlerParam<> (
-            "mac.dmg.installerName.suffix",
-            String.class,
-            params -> "",
-            (s, p) -> s);
 
     public Path bundle(Map<String, ? super Object> params,
             Path outdir) throws PackagerException {
@@ -276,9 +269,10 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
             Files.createDirectories(imagesRoot);
         }
 
-        Path protoDMG = imagesRoot.resolve(APP_NAME.fetchFrom(params) +"-tmp.dmg");
+        Path protoDMG = imagesRoot.resolve(APP_NAME.fetchFrom(params)
+                + "-tmp.dmg");
         Path finalDMG = outdir.resolve(MAC_INSTALLER_NAME.fetchFrom(params)
-                + INSTALLER_SUFFIX.fetchFrom(params) + ".dmg");
+                + ".dmg");
 
         Path srcFolder = appLocation.getParent();
         if (StandardBundlerParam.isRuntimeInstaller(params)) {

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,13 +138,6 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
 
                     return result;
                 },
-            (s, p) -> s);
-
-    public static final BundlerParamInfo<String> INSTALLER_SUFFIX =
-            new StandardBundlerParam<> (
-            "mac.pkg.installerName.suffix",
-            String.class,
-            params -> "",
             (s, p) -> s);
 
     public Path bundle(Map<String, ? super Object> params,
@@ -593,7 +586,6 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
 
             // build final package
             Path finalPKG = outdir.resolve(MAC_INSTALLER_NAME.fetchFrom(params)
-                    + INSTALLER_SUFFIX.fetchFrom(params)
                     + ".pkg");
             Files.createDirectories(outdir);
 


### PR DESCRIPTION
- Removed unused `INSTALLER_SUFFIX` bundler param.
- Removed unreachable if branch in `MacAppImageBuilder`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349509](https://bugs.openjdk.org/browse/JDK-8349509): [macos] Clean up macOS dead code in jpackage (**Enhancement** - P4)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23504/head:pull/23504` \
`$ git checkout pull/23504`

Update a local copy of the PR: \
`$ git checkout pull/23504` \
`$ git pull https://git.openjdk.org/jdk.git pull/23504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23504`

View PR using the GUI difftool: \
`$ git pr show -t 23504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23504.diff">https://git.openjdk.org/jdk/pull/23504.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23504#issuecomment-2641354262)
</details>
