### PR TITLE
8349512: Duplicate PermittedSubclasses entries with doclint enabled

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1353,8 +1353,8 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             int index = Collections.binarySearch(permitted, element, java.util.Comparator.comparing(PermittedClassWithPos::pos));
             if (index < 0) {
                 index = -index - 1;
+                permitted.add(index, element);
             }
-            permitted.add(index, element);
         }
 
         public boolean isPermittedSubclass(Symbol csym) {

--- a/test/langtools/tools/javac/sealed/SealedDiffConfigurationsTest.java
+++ b/test/langtools/tools/javac/sealed/SealedDiffConfigurationsTest.java
@@ -132,7 +132,10 @@ public class SealedDiffConfigurationsTest extends TestRunner {
         ClassModel sealedCF = ClassFile.of().parse(out.resolve(cfName));
         Assert.check((sealedCF.flags().flagsMask() & ClassFile.ACC_FINAL) == 0, String.format("class at file %s must not be final", cfName));
         PermittedSubclassesAttribute permittedSubclasses = sealedCF.findAttribute(Attributes.permittedSubclasses()).orElseThrow();
-        Assert.check(permittedSubclasses.permittedSubclasses().size() == expectedSubTypeNames.size());
+        Assert.check(permittedSubclasses.permittedSubclasses().size() == expectedSubTypeNames.size(),
+                String.format("%s != %s",
+                        permittedSubclasses.permittedSubclasses(),
+                        expectedSubTypeNames));
         List<String> subtypeNames = new ArrayList<>();
         permittedSubclasses.permittedSubclasses().forEach(i -> {
             try {
@@ -725,5 +728,34 @@ public class SealedDiffConfigurationsTest extends TestRunner {
                 .files(fooUser, foo)
                 .run();
         checkSealedClassFile(out, "Foo.class", List.of("Foo$R1", "Foo$R2"));
+    }
+
+    @Test
+    public void testDuplicatePermittedSubclassesDoclint(Path base) throws Exception {
+        Path src = base.resolve("src");
+        Path foo = src.resolve("Foo.java");
+
+        tb.writeFile(foo,
+                """
+                public class Foo {
+                  private enum E {
+                    INSTANCE {
+                      /** foo {@link E} */
+                      void f() {}
+                    };
+                    void f() {}
+                  }
+                }
+                """);
+
+        Path out = base.resolve("out");
+        Files.createDirectories(out);
+
+        new JavacTask(tb)
+                .options("-Xdoclint:html,syntax")
+                .outdir(out)
+                .files(foo)
+                .run();
+        checkSealedClassFile(out, "Foo$E.class", List.of("Foo$E$1"));
     }
 }

--- a/test/langtools/tools/javac/sealed/SealedDiffConfigurationsTest.java
+++ b/test/langtools/tools/javac/sealed/SealedDiffConfigurationsTest.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test 8247352 8293348
+ * @test 8247352 8293348 8349512
  * @summary test different configurations of sealed classes, same compilation unit, diff pkg or mdl, etc
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api


### PR DESCRIPTION
This change avoids emitting duplicate `PermittedSubclasses` entries when `-Xdoclint` is enabled.

`-Xdoclint` causes some trees to be re-attributed, and the second attribution was resulting in permitted subclasses being added again, and those side effects were not discarded. This fix causes `addPermittedSubclass` to not insert duplicate entries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349512](https://bugs.openjdk.org/browse/JDK-8349512): Duplicate PermittedSubclasses entries with doclint enabled (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23507/head:pull/23507` \
`$ git checkout pull/23507`

Update a local copy of the PR: \
`$ git checkout pull/23507` \
`$ git pull https://git.openjdk.org/jdk.git pull/23507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23507`

View PR using the GUI difftool: \
`$ git pr show -t 23507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23507.diff">https://git.openjdk.org/jdk/pull/23507.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23507#issuecomment-2641520689)
</details>
