### PR TITLE
8349554: [UBSAN] os::attempt_reserve_memory_between reported applying non-zero offset to non-null pointer produced null pointer

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2016,11 +2016,11 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
     return nullptr; // overflow
   }
 
-  const size_t hi_end = p2u(MIN2(max, absolute_max));
-  if (hi_end < bytes) {
+  char* const hi_end = MIN2(max, absolute_max);
+  if ((uintptr_t)hi_end <= bytes) {
     return nullptr; // no need to go on
   }
-  char* const hi_att = align_down((char*)(hi_end - bytes), alignment_adjusted);
+  char* const hi_att = align_down(hi_end - bytes, alignment_adjusted);
   if (hi_att > max) {
     return nullptr; // overflow
   }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2016,11 +2016,11 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
     return nullptr; // overflow
   }
 
-  char* const hi_end = MIN2(max, absolute_max);
-  if ((uintptr_t)hi_end < bytes) {
+  const size_t hi_end = p2u(MIN2(max, absolute_max));
+  if (hi_end < bytes) {
     return nullptr; // no need to go on
   }
-  char* const hi_att = align_down(hi_end - bytes, alignment_adjusted);
+  char* const hi_att = align_down((char*)(hi_end - bytes), alignment_adjusted);
   if (hi_att > max) {
     return nullptr; // overflow
   }


### PR DESCRIPTION
Hi all,

Function 'os::attempt_reserve_memory_between(char*, char*, size_t, size_t, bool)' 'src/hotspot/share/runtime/os.cpp' reported "runtime error: applying non-zero offset to non-null pointer 0x000000001000 produced null pointer" by address sanitizer. Gtest in function 'os_attempt_reserve_memory_between_combos_vm_Test::TestBody'  at file test/hotspot/gtest/runtime/test_os_reserve_between.cpp call 'os::attempt_reserve_memory_between (min=0x0, max=0x1000, bytes=4096, alignment=4096, randomize=true)' trigger this failure. Before this PR, the pointer var `hi_end` get value from `max` 0x1000, and then apply offset `bytes`, and `max` equals `bytes`, thus address sanitizer report this failure.

This PR change from `hi_end < bytes` to `hi_end <= bytes` will eliminate the undefined behaviour. Risk is low.

Additional testing:

- [x] jtreg tests(which include tier1/2/3 etc.) on linux-x64
- [x] jtreg tests(which include tier1/2/3 etc.) on linux-aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349554](https://bugs.openjdk.org/browse/JDK-8349554): [UBSAN] os::attempt_reserve_memory_between reported applying non-zero offset to non-null pointer produced null pointer (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23508/head:pull/23508` \
`$ git checkout pull/23508`

Update a local copy of the PR: \
`$ git checkout pull/23508` \
`$ git pull https://git.openjdk.org/jdk.git pull/23508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23508`

View PR using the GUI difftool: \
`$ git pr show -t 23508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23508.diff">https://git.openjdk.org/jdk/pull/23508.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23508#issuecomment-2641780444)
</details>
