### PR TITLE
8349623: [ASAN] Gtest os_linux.glibc_mallinfo_wrapper_vm fails

### DIFF
--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -444,26 +444,28 @@ TEST_VM(os_linux, decoder_get_source_info_valid_overflow_minimal) {
 #endif // clang
 
 #ifdef __GLIBC__
+#ifndef ADDRESS_SANITIZER
 TEST_VM(os_linux, glibc_mallinfo_wrapper) {
   // Very basic test. Call it. That proves that resolution and invocation works.
   os::Linux::glibc_mallinfo mi;
   bool did_wrap = false;
 
-  os::Linux::get_mallinfo(&mi, &did_wrap);
-
   void* p = os::malloc(2 * K, mtTest);
   ASSERT_NOT_NULL(p);
+
+  os::Linux::get_mallinfo(&mi, &did_wrap);
 
   // We should see total allocation values > 0
   ASSERT_GE((mi.uordblks + mi.hblkhd), 2 * K);
 
-  // These values also should exceed some reasonable size.
+  // These values also should less than some reasonable size.
   ASSERT_LT(mi.fordblks, 2 * G);
   ASSERT_LT(mi.uordblks, 2 * G);
   ASSERT_LT(mi.hblkhd, 2 * G);
 
   os::free(p);
 }
+#endif // ADDRESS_SANITIZER
 #endif // __GLIBC__
 
 #endif // LINUX


### PR DESCRIPTION
Hi all,

The glibc function `mallinfo()` do do not work with -fsanitize=adddress, maybe it's [limitation or bug](https://github.com/google/sanitizers/issues/1845) of address sanitizer . Should we disable the gtest 'os_linux.glibc_mallinfo_wrapper_vm' when configure and build with address sanitizer. The macro `ADDRESS_SANITIZER` will always pass to gcc/clang/microsoft compiler when enable address sanitizer. So this PR check the macro `ADDRESS_SANITIZER` to enable the test or not.

On the other hand, this test get malloc usage information by call `os::Linux::get_mallinfo` and check "total allocation values" greater than `2K` before allocate the memort by `malloc(2K)`. Call `os::Linux::get_mallinfo` should after `malloc(2K)`.

Below code snippet can demonstrate the glibc function `mallinfo()` do do not work with -fsanitize=adddress.

```c
#include <stdio.h>
#include <malloc.h>

int main() {
    struct mallinfo info;
    info = mallinfo();

    printf("%d, %d, %d, %d, %d, %d, %d, %d, %d, %d\n", info.arena, info.ordblks, info.smblks, info.hblks, info.hblkhd, info.usmblks, info.fsmblks, info.uordblks, info.fordblks, info.keepcost);

    char* ptr = malloc(0x10000);
    info = mallinfo();

    printf("%d, %d, %d, %d, %d, %d, %d, %d, %d, %d\n", info.arena, info.ordblks, info.smblks, info.hblks, info.hblkhd, info.usmblks, info.fsmblks, info.uordblks, info.fordblks, info.keepcost);

    free(ptr);
    return 0;
}
```

- Without -fsanitize=address, mallinfo() works normally.

```
gcc mallinfo.c && ./a.out
0, 1, 0, 0, 0, 0, 0, 0, 0, 0
135168, 1, 0, 0, 0, 0, 0, 67248, 67920, 67920
```

- With -fsanitize=address, mallinfo() works abnormally.

```
gcc -fsanitize=address mallinfo.c && ./a.out
0, 0, 0, 0, 0, 0, 0, 0, 0, 0
0, 0, 0, 0, 0, 0, 0, 0, 0, 0
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349623](https://bugs.openjdk.org/browse/JDK-8349623): [ASAN] Gtest os_linux.glibc_mallinfo_wrapper_vm fails (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23510/head:pull/23510` \
`$ git checkout pull/23510`

Update a local copy of the PR: \
`$ git checkout pull/23510` \
`$ git pull https://git.openjdk.org/jdk.git pull/23510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23510`

View PR using the GUI difftool: \
`$ git pr show -t 23510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23510.diff">https://git.openjdk.org/jdk/pull/23510.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23510#issuecomment-2642100051)
</details>
