### PR TITLE
8349648: Test tools/jpackage/share/JLinkOptionsTest.java fails with --enable-linkable-runtime set after JDK-8346434

### DIFF
--- a/test/jdk/tools/jpackage/share/JLinkOptionsTest.java
+++ b/test/jdk/tools/jpackage/share/JLinkOptionsTest.java
@@ -58,6 +58,7 @@ public final class JLinkOptionsTest {
                     new String[]{"jdk.jartool", "jdk.unsupported"},
                     null,
                     },
+
             // multiple jlink-options
             {"com.other/com.other.Hello", new String[]{
                     "--jlink-options",
@@ -69,6 +70,7 @@ public final class JLinkOptionsTest {
                     new String[]{"java.smartcardio", "jdk.crypto.cryptoki"},
                     null,
                     },
+
             // bind-services
             {"Hello", new String[]{
                     "--jlink-options",
@@ -139,8 +141,8 @@ public final class JLinkOptionsTest {
 
     @Test
     public void testNoBindServicesByDefault() {
-        final var defaultModules = getModulesInRuntime();
-        final var modulesWithBindServices = getModulesInRuntime("--bind-services");
+        final var defaultModules = getModulesInRuntime("--limit-modules java.smartcardio,jdk.crypto.cryptoki,java.desktop");
+        final var modulesWithBindServices = getModulesInRuntime("--bind-services --limit-modules java.smartcardio,jdk.crypto.cryptoki,java.desktop");
 
         final var moduleComm = Comm.compare(defaultModules, modulesWithBindServices);
 

--- a/test/jdk/tools/jpackage/share/JLinkOptionsTest.java
+++ b/test/jdk/tools/jpackage/share/JLinkOptionsTest.java
@@ -148,6 +148,7 @@ public final class JLinkOptionsTest {
 
         TKit.assertStringListEquals(List.of(), moduleComm.unique1().stream().toList(),
                 "Check '--bind-services' option doesn't remove modules");
+        // with the limited set of modules, we expect that jdk.crypto.cryptoki be added through --bind-services
         TKit.assertNotEquals("", moduleComm.unique2().stream().sorted().collect(Collectors.joining(",")),
                 "Check '--bind-services' option adds modules");
     }


### PR DESCRIPTION
The change for JDK-8346434 added a new test case to tools/jpackage/share/JLinkOptionsTest.java which does not respect the constraint of the linkable runtime (JEP 493) that no jdk.jlink module can be part of the target image.
This can be circumvented by limiting the modules.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349648](https://bugs.openjdk.org/browse/JDK-8349648): Test tools/jpackage/share/JLinkOptionsTest.java fails with --enable-linkable-runtime set after JDK-8346434 (**Bug** - P4)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**) Review applies to [e606244c](https://git.openjdk.org/jdk/pull/23514/files/e606244c1bd5e930676517690354aafdec0d82fb)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23514/head:pull/23514` \
`$ git checkout pull/23514`

Update a local copy of the PR: \
`$ git checkout pull/23514` \
`$ git pull https://git.openjdk.org/jdk.git pull/23514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23514`

View PR using the GUI difftool: \
`$ git pr show -t 23514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23514.diff">https://git.openjdk.org/jdk/pull/23514.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23514#issuecomment-2642884506)
</details>
