### PR TITLE
8349662: SSLTube SSLSubscriptionWrapper has potential races when switching subscriptions

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLTube.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLTube.java
@@ -119,7 +119,7 @@ public class SSLTube implements FlowTube {
             // Connect the read sink first. That's the left-hand side
             // downstream subscriber from the HttpConnection (or more
             // accurately, the SSLSubscriberWrapper that will wrap it
-            // when SSLTube::connectFlows is called.
+            // when SSLTube::connectFlows is called).
             reader.subscribe(downReader);
 
             // Connect the right hand side tube (the socket tube).
@@ -191,7 +191,7 @@ public class SSLTube implements FlowTube {
     private volatile Flow.Subscription readSubscription;
 
     // The DelegateWrapper wraps a subscribed {@code Flow.Subscriber} and
-    // tracks the subscriber's state. In particular it makes sure that
+    // tracks the subscriber's state. In particular, it makes sure that
     // onComplete/onError are not called before onSubscribed.
     static final class DelegateWrapper implements FlowTube.TubeSubscriber {
         private final FlowTube.TubeSubscriber delegate;
@@ -302,7 +302,7 @@ public class SSLTube implements FlowTube {
 
     // Used to read data from the SSLTube.
     final class SSLSubscriberWrapper implements FlowTube.TubeSubscriber {
-        private AtomicReference<DelegateWrapper> pendingDelegate =
+        private final AtomicReference<DelegateWrapper> pendingDelegate =
                 new AtomicReference<>();
         private volatile DelegateWrapper subscribed;
         private volatile boolean onCompleteReceived;
@@ -353,15 +353,15 @@ public class SSLTube implements FlowTube {
                 return;
             }
             // sslDelegate field should have been initialized by the
-            // the time we reach here, as there can be no subscriber
+            // time we reach here, as there can be no subscriber
             // until SSLTube is fully constructed.
             if (handleNow || !sslDelegate.resumeReader()) {
                 processPendingSubscriber();
             }
         }
 
-        // Can be called outside of the flow if an error has already been
-        // raise. Otherwise, must be called within the SSLFlowDelegate
+        // Can be called outside the flow if an error has already been
+        // raised. Otherwise, must be called within the SSLFlowDelegate
         // downstream reader flow.
         // If there is a subscription, and if there is a pending delegate,
         // calls dropSubscription() on the previous delegate (if any),
@@ -619,32 +619,57 @@ public class SSLTube implements FlowTube {
         private volatile boolean cancelled;
 
         void setSubscription(Flow.Subscription sub) {
-            long demand = writeDemand.get(); // FIXME: isn't it a racy way of passing the demand?
-            delegate = sub;
-            if (debug.on())
-                debug.log("setSubscription: demand=%d, cancelled:%s", demand, cancelled);
+            long demand;
+            // Avoid race condition and requesting demand twice if
+            // request() runs concurrently with setSubscription()
+            boolean cancelled;
+            synchronized (this) {
+                demand = writeDemand.get();
+                delegate = sub;
+                cancelled = this.cancelled;
+            }
+            if (debug.on()) {
+                debug.log("setSubscription: demand=%d, cancelled:%s, new subscription %s",
+                        demand, cancelled, sub);
+            }
 
             if (cancelled)
-                delegate.cancel();
+                sub.cancel();
             else if (demand > 0)
                 sub.request(demand);
         }
 
         @Override
         public void request(long n) {
-            writeDemand.increase(n);
-            if (debug.on()) debug.log("request: n=%d", n);
-            Flow.Subscription sub = delegate;
-            if (sub != null && n > 0) {
-                sub.request(n);
+            final long demand = n;
+            // Avoid race condition and requesting demand twice if
+            // request() runs concurrently with setSubscription()
+            Flow.Subscription sub;
+            long demanded;
+            synchronized (this) {
+                sub = delegate;
+                demanded = writeDemand.get();
+                writeDemand.increase(n);
+            }
+            if (debug.on()) {
+                debug.log("request: n=%s to %s (%s already demanded)",
+                        demand, sub, demanded);
+            }
+            if (sub != null && demand > 0) {
+                if (debug.on()) debug.log("requesting %s from %s", demand, sub);
+                sub.request(demand);
             }
         }
 
         @Override
         public void cancel() {
-            cancelled = true;
-            if (delegate != null)
-                delegate.cancel();
+            Flow.Subscription sub;
+            synchronized (this) {
+                cancelled = true;
+                sub = delegate;
+            }
+            if (debug.on()) debug.log("cancel: cancelling subscription: " + sub);
+            if (sub != null) sub.cancel();
         }
     }
 
@@ -652,10 +677,16 @@ public class SSLTube implements FlowTube {
     @Override
     public void onSubscribe(Flow.Subscription subscription) {
         Objects.requireNonNull(subscription);
-        Flow.Subscription x = writeSubscription.delegate;
-        if (x != null)
-            x.cancel();
+        Flow.Subscription old;
+        synchronized (this) {
+            old = writeSubscription.delegate;
+        }
+        if (old != null && old != subscription) {
+            if (debug.on()) debug.log("onSubscribe: cancelling old subscription: " + old);
+            old.cancel();
+        }
 
+        if (debug.on()) debug.log("onSubscribe: new subscription: " + subscription);
         writeSubscription.setSubscription(subscription);
     }
 
@@ -664,8 +695,10 @@ public class SSLTube implements FlowTube {
         Objects.requireNonNull(item);
         boolean decremented = writeDemand.tryDecrement();
         assert decremented : "Unexpected writeDemand: ";
-        if (debug.on())
-            debug.log("sending %d  buffers to SSL flow delegate", item.size());
+        if (debug.on()) {
+            debug.log("sending %s  buffers to SSL flow delegate (%s bytes)",
+                    item.size(), Utils.remaining(item));
+        }
         sslDelegate.upstreamWriter().onNext(item);
     }
 

--- a/test/jdk/java/net/httpclient/CookieHeaderTest.java
+++ b/test/jdk/java/net/httpclient/CookieHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,9 +33,6 @@
  *       CookieHeaderTest
  */
 
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
-import com.sun.net.httpserver.HttpsServer;
 import jdk.test.lib.net.SimpleSSLContext;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -51,7 +48,6 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.CookieHandler;
-import java.net.CookieManager;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -65,7 +61,6 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -76,7 +71,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Version.HTTP_1_1;


### PR DESCRIPTION
Hi,

Please find here a change that fixes a potential race condition in  SSLTube.SSLSubscriptionWrapper.
Typically the race may get triggered if the  demand increased by request() is not exhausted by the time 
the subscription is switched by setSubscription.

Some synchronization is required to present a consistent view of the subscripton state, so that pending demand can be consistently transferred to the new the subscription.

This mostly affects HTTP/1.1 over TLS since each new exchange will cause the subscription to be switched to the new exchange. The race condition is elusive and hard to reproduce. when it occurs, it mostly causes tests to fail in jtreg timeout as the demand from upstream may not be transferred properly. 

Some additional logging has been added to the DigestClient.java test class (which is used by DigestClientSSL) to help diagnosability of intermittent failures in these tests.