### PR TITLE
8347408: Create an internal method handle adapter for system calls with errno

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -27,6 +27,7 @@ package java.lang.foreign;
 
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.ArenaImpl;
+import jdk.internal.foreign.NoInitSegmentAllocator;
 import jdk.internal.foreign.SlicingAllocator;
 import jdk.internal.foreign.StringSupport;
 import jdk.internal.vm.annotation.ForceInline;
@@ -720,22 +721,22 @@ public interface SegmentAllocator {
 
     @ForceInline
     private MemorySegment allocateNoInit(long byteSize) {
-        return this instanceof ArenaImpl arenaImpl ?
-                arenaImpl.allocateNoInit(byteSize, 1) :
+        return this instanceof NoInitSegmentAllocator noInit ?
+                noInit.allocateNoInit(byteSize, 1) :
                 allocate(byteSize);
     }
 
     @ForceInline
     private MemorySegment allocateNoInit(MemoryLayout layout) {
-        return this instanceof ArenaImpl arenaImpl ?
-                arenaImpl.allocateNoInit(layout.byteSize(), layout.byteAlignment()) :
+        return this instanceof NoInitSegmentAllocator noInit ?
+                noInit.allocateNoInit(layout.byteSize(), layout.byteAlignment()) :
                 allocate(layout);
     }
 
     @ForceInline
     private MemorySegment allocateNoInit(MemoryLayout layout, long size) {
-        return this instanceof ArenaImpl arenaImpl ?
-                arenaImpl.allocateNoInit(layout.byteSize() * size, layout.byteAlignment()) :
+        return this instanceof NoInitSegmentAllocator noInit ?
+                noInit.allocateNoInit(layout.byteSize() * size, layout.byteAlignment()) :
                 allocate(layout, size);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/CaptureStateUtil.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/CaptureStateUtil.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.foreign;
+
+import jdk.internal.invoke.MhUtil;
+import jdk.internal.vm.annotation.ForceInline;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public final class CaptureStateUtil {
+
+    private static final MemoryLayout CAPTURE_LAYOUT = Linker.Option.captureStateLayout();
+    //private static final CarrierLocalArenaPools POOL = CarrierLocalArenaPools.create(CAPTURE_LAYOUT);
+    private static final CarrierLocalArenaPools POOL = CarrierLocalArenaPools.create(16);
+
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+    private static final MethodHandle NON_NEGATIVE_INT_MH =
+            MhUtil.findStatic(LOOKUP, "nonNegative",
+                    MethodType.methodType(boolean.class, int.class));
+
+    private static final MethodHandle SUCCESS_INT_MH =
+            MhUtil.findStatic(LOOKUP, "success",
+                    MethodType.methodType(int.class, int.class, MemorySegment.class));
+
+    private static final MethodHandle ERROR_INT_MH =
+            MhUtil.findStatic(LOOKUP, "error",
+                    MethodType.methodType(int.class, MethodHandle.class, int.class, MemorySegment.class));
+
+    private static final MethodHandle NON_NEGATIVE_LONG_MH =
+            MhUtil.findStatic(LOOKUP, "nonNegative",
+                    MethodType.methodType(boolean.class, long.class));
+
+    private static final MethodHandle SUCCESS_LONG_MH =
+            MhUtil.findStatic(LOOKUP, "success",
+                    MethodType.methodType(long.class, long.class, MemorySegment.class));
+
+    private static final MethodHandle ERROR_LONG_MH =
+            MhUtil.findStatic(LOOKUP, "error",
+                    MethodType.methodType(long.class, MethodHandle.class, long.class, MemorySegment.class));
+
+    private static final MethodHandle ACQUIRE_ARENA_MH =
+            MhUtil.findStatic(LOOKUP, "acquireArena",
+                    MethodType.methodType(Arena.class));
+
+    private static final MethodHandle ALLOCATE_MH =
+            MhUtil.findStatic(LOOKUP, "allocate",
+                    MethodType.methodType(MemorySegment.class, Arena.class));
+
+    private static final MethodHandle ARENA_CLOSE_MH =
+            MhUtil.findVirtual(LOOKUP, Arena.class, "close",
+                    MethodType.methodType(void.class));
+
+    // (int.class | long.class) ->
+    //   ({"GetLastError" | "WSAGetLastError"} | "errno") ->
+    //     MethodHandle
+    private static final Map<Class<?>, Map<String, MethodHandle>> INNER_HANDLES;
+
+    static {
+
+        final StructLayout stateLayout = Linker.Option.captureStateLayout();
+        final Map<Class<?>, Map<String, MethodHandle>> classMap = new HashMap<>();
+        for (var returnType : new Class<?>[]{int.class, long.class}) {
+            Map<String, MethodHandle> handles = stateLayout
+                    .memberLayouts().stream()
+                    .collect(Collectors.toUnmodifiableMap(
+                            member -> member.name().orElseThrow(),
+                            member -> {
+                                VarHandle vh = stateLayout.varHandle(MemoryLayout.PathElement.groupElement(member.name().orElseThrow()));
+                                // (MemorySegment, long)int
+                                MethodHandle intExtractor = vh.toMethodHandle(VarHandle.AccessMode.GET);
+                                // (MemorySegment)int
+                                intExtractor = MethodHandles.insertArguments(intExtractor, 1, 0L);
+
+                                if (returnType.equals(int.class)) {
+                                    // (int, MemorySegment)int
+                                    return MethodHandles.guardWithTest(
+                                            NON_NEGATIVE_INT_MH,
+                                            SUCCESS_INT_MH,
+                                            ERROR_INT_MH.bindTo(intExtractor));
+                                } else {
+                                    // (long, MemorySegment)long
+                                    return MethodHandles.guardWithTest(
+                                            NON_NEGATIVE_LONG_MH,
+                                            SUCCESS_LONG_MH,
+                                            ERROR_LONG_MH.bindTo(intExtractor));
+                                }
+                            }
+                    ));
+            classMap.put(returnType, handles);
+        }
+        INNER_HANDLES = Map.copyOf(classMap);
+    }
+
+    private CaptureStateUtil() {
+    }
+
+    /**
+     * {@return a new MethodHandle that adapts the provided {@code target} so that it
+     *          directly returns the same value as the {@code target} if it is
+     *          non-negative, otherwise returns the negated errno}
+     * <p>
+     * This method is suitable for adapting system-call method handles(e.g.
+     * {@code open()}, {@code read()}, and {@code close()}). Clients can check the return
+     * value as shown in this example:
+     * {@snippet lang = java:
+     *       // (MemorySegment capture, MemorySegment pathname, int flags)int
+     *       static final MethodHandle CAPTURING_OPEN = ...
+     *
+     *      // (MemorySegment pathname, int flags)int
+     *      static final MethodHandle OPEN = CaptureStateUtil.adaptSystemCall(Pooling.GLOBAL, CAPTURING_OPEN, "errno");
+     *
+     *      try {
+     *         int fh = (int)OPEN.invoke(pathName, flags);
+     *         if (fh < 0) {
+     *             throw new IOException("Error opening file: errno = " + (-fh));
+     *         }
+     *         processFile(fh);
+     *      } catch (Throwable t) {
+     *           throw new RuntimeException(t);
+     *      }
+     *
+     *}
+     * For a method handle that takes a MemorySegment and two int parameters using GLOBAL,
+     * the method combinators are doing the equivalent of:
+     *
+     * {@snippet lang = java:
+     *         public int invoke(int a, int b) {
+     *             final MemorySegment segment = acquireSegment();
+     *             final int result = (int) handle.invoke(segment, a, b);
+     *             if (result >= 0) {
+     *                 return result;
+     *             }
+     *             return -(int) errorHandle.get(segment);
+     *         }
+     *}
+     * Where {@code handle} is the original method handle with the coordinated
+     * {@code (MemorySegment, int, int)int} and {@code errnoHandle} is a method handle
+     * that retrieves the error code from the capturing segment.
+     *
+     *
+     * @param target    method handle that returns an {@code int} or a {@code long} and has
+     *                  a capturing state MemorySegment as its first parameter
+     * @param stateName the name of the capturing state member layout
+     *                  (i.e. "errno","GetLastError", or "WSAGetLastError")
+     * @throws IllegalArgumentException if the provided {@code target}'s return type is
+     *                                  not {@code int} or {@code long}
+     * @throws IllegalArgumentException if the provided {@code target}'s first parameter
+     *                                  type is not {@linkplain MemorySegment}
+     * @throws IllegalArgumentException if the provided {@code stateName} is unknown
+     *                                  on the current platform
+     */
+    public static MethodHandle adaptSystemCall(MethodHandle target,
+                                               String stateName) {
+        // Implicit null check
+        final Class<?> returnType = target.type().returnType();
+        Objects.requireNonNull(stateName);
+
+        if (!(returnType.equals(int.class) || returnType.equals(long.class))) {
+            throw illegalArgDoesNot(target, "return an int or a long");
+        }
+        if (target.type().parameterCount() == 0 || target.type().parameterType(0) != MemorySegment.class) {
+            throw illegalArgDoesNot(target, "have a MemorySegment as the first parameter");
+        }
+
+        // ((int | long), MemorySegment)(int | long)
+        MethodHandle inner = INNER_HANDLES
+                .get(returnType)
+                .get(stateName);
+        if (inner == null) {
+            throw new IllegalArgumentException("Unknown state name: " + stateName +
+                    ". Known on this platform: " + Linker.Option.captureStateLayout());
+        }
+
+        // Make `target` specific adaptations
+
+        // (C0=MemorySegment, C1-Cn, MemorySegment)(int|long)
+        inner = MethodHandles.collectArguments(inner, 0, target);
+
+        int[] perm = new int[target.type().parameterCount() + 1];
+        for (int i = 0; i < target.type().parameterCount(); i++) {
+            perm[i] = i;
+        }
+        perm[target.type().parameterCount()] = 0;
+        // Deduplicate the first and last coordinate and only use the first
+        // (C0=MemorySegment, C1-Cn)(int|long)
+        inner = MethodHandles.permuteArguments(inner, target.type(), perm);
+        // (C0=Arena, C1-Cn)(int|long)
+        inner = MethodHandles.collectArguments(inner, 0, ALLOCATE_MH);
+
+        // ((int|long))(int|long)
+        MethodHandle cleanup = MethodHandles.identity(returnType);
+        // (Throwable, (int|long))(int|long)
+        cleanup = MethodHandles.dropArguments(cleanup, 0, Throwable.class);
+        // (Throwable, (int|long), Arena)(int|long)
+        // Cleanup does not have to have all parameters. It can have zero or more.
+        cleanup = MethodHandles.collectArguments(cleanup, 2, ARENA_CLOSE_MH);
+
+        // (Arena, C1-Cn)(int|long)
+        MethodHandle tryFinally = MethodHandles.tryFinally(inner, cleanup);
+
+        // Finally we arrive at (C1-Cn)(int|long)
+        return MethodHandles.collectArguments(tryFinally, 0, ACQUIRE_ARENA_MH);
+    }
+
+    private static IllegalArgumentException illegalArgDoesNot(MethodHandle target, String info) {
+        return new IllegalArgumentException("The provided target " + target
+                + " does not " + info);
+    }
+
+    // The methods below are reflective used via static MethodHandles
+
+    @ForceInline
+    private static Arena acquireArena() {
+        return POOL.take();
+    }
+
+    @ForceInline
+    private static MemorySegment allocate(Arena arena) {
+        // We do not need to zero out the segment.
+        return ((NoInitSegmentAllocator) arena)
+                .allocateNoInit(CAPTURE_LAYOUT.byteSize(), CAPTURE_LAYOUT.byteAlignment());
+    }
+
+    @ForceInline
+    private static boolean nonNegative(int value) {
+        return value >= 0;
+    }
+
+    @ForceInline
+    private static int success(int value, MemorySegment segment) {
+        return value;
+    }
+
+    @ForceInline
+    private static int error(MethodHandle errorHandle, int value, MemorySegment segment) throws Throwable {
+        return -(int) errorHandle.invokeExact(segment);
+    }
+
+    @ForceInline
+    private static boolean nonNegative(long value) {
+        return value >= 0L;
+    }
+
+    @ForceInline
+    private static long success(long value, MemorySegment segment) {
+        return value;
+    }
+
+    @ForceInline
+    private static long error(MethodHandle errorHandle, long value, MemorySegment segment) throws Throwable {
+        return -(int) errorHandle.invokeExact(segment);
+    }
+
+}

--- a/src/java.base/share/classes/jdk/internal/foreign/CarrierLocalArenaPools.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/CarrierLocalArenaPools.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.foreign;
+
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.misc.CarrierThread;
+import jdk.internal.misc.TerminatingThreadLocal;
+import jdk.internal.misc.Unsafe;
+import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.Stable;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.util.Objects;
+
+public final class CarrierLocalArenaPools {
+
+    @Stable
+    private final TerminatingThreadLocal<LocalArenaPoolImpl> tl;
+
+    private CarrierLocalArenaPools(long byteSize, long byteAlignment) {
+        this.tl = new TerminatingThreadLocal<>() {
+
+            private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
+            @Override
+            protected LocalArenaPoolImpl initialValue() {
+                if (JLA.currentCarrierThread() instanceof CarrierThread) {
+                    // Only a carrier thread that is an instance of `CarrierThread` can
+                    // ever carry virtual threads. (Notably, a `CarrierThread` can also
+                    // carry a platform thread.) This means a `CarrierThread` can carry
+                    // any number of virtual threads, and they can be mounted/unmounted
+                    // from the carrier thread at almost any time. Therefore, we must use
+                    // stronger-than-plain semantics when dealing with mutual exclusion
+                    // of thread local resources.
+                    return new LocalArenaPoolImpl.OfCarrier(byteSize, byteAlignment);
+                } else {
+                    // A carrier thread that is not an instance of `CarrierThread` can
+                    // never carry a virtual thread. Because of this, only one thread will
+                    // be mounted on such a carrier thread. Therefore, we can use plain
+                    // memory semantics when dealing with mutual exclusion of thread local
+                    // resources.
+                    return new LocalArenaPoolImpl.OfPlatform(byteSize, byteAlignment);
+                }
+            }
+
+            @Override
+            protected void threadTerminated(LocalArenaPoolImpl stack) {
+                stack.close();
+            }
+        };
+    }
+
+    @ForceInline
+    public Arena take() {
+        return tl.get()
+                .take();
+    }
+
+    private static sealed abstract class LocalArenaPoolImpl {
+
+        static final int AVAILABLE = 0;
+        static final int TAKEN = 1;
+
+        @Stable
+        private final Arena pooledArena;
+        @Stable
+        private final MemorySegment segment;
+        // Used both directly and reflectively
+        int segmentAvailability;
+
+        private LocalArenaPoolImpl(long byteSize,
+                                   long byteAlignment) {
+            this.pooledArena = Arena.ofConfined();
+            this.segment = pooledArena.allocate(byteSize, byteAlignment);
+        }
+
+        @ForceInline
+        public final Arena take() {
+            final Arena arena = Arena.ofConfined();
+            return tryAcquireSegment()
+                    ? new SlicingArena((ArenaImpl) arena, segment)
+                    : arena;
+        }
+
+        public final void close() {
+            pooledArena.close();
+        }
+
+        /**
+         * {@return {@code true } if the segment was acquired for exclusive use, {@code
+         * false} otherwise}
+         */
+        abstract boolean tryAcquireSegment();
+
+        /**
+         * Unconditionally releases the acquired segment if it was previously acquired,
+         * otherwise this is a no-op.
+         */
+        abstract void releaseSegment();
+
+        /**
+         * Thread safe implementation.
+         */
+        public static final class OfCarrier
+                extends LocalArenaPoolImpl {
+
+            // Unsafe allows earlier use in the init sequence and
+            // better start and warmup properties.
+            static final Unsafe UNSAFE = Unsafe.getUnsafe();
+            static final long SEG_AVAIL_OFFSET =
+                    UNSAFE.objectFieldOffset(LocalArenaPoolImpl.class, "segmentAvailability");
+
+            public OfCarrier(long byteSize,
+                             long byteAlignment) {
+                super(byteSize, byteAlignment);
+            }
+
+            @ForceInline
+            boolean tryAcquireSegment() {
+                return UNSAFE.compareAndSetInt(this, SEG_AVAIL_OFFSET, AVAILABLE, TAKEN);
+            }
+
+            @ForceInline
+            void releaseSegment() {
+                UNSAFE.putIntVolatile(this, SEG_AVAIL_OFFSET, AVAILABLE);
+            }
+        }
+
+        /**
+         * No need for thread-safe implementation here as a platform thread is exclusively
+         * mounted on a particular carrier thread.
+         */
+        public static final class OfPlatform
+                extends LocalArenaPoolImpl {
+
+            public OfPlatform(long byteSize,
+                              long byteAlignment) {
+                super(byteSize, byteAlignment);
+            }
+
+            @ForceInline
+            boolean tryAcquireSegment() {
+                if (segmentAvailability == TAKEN) {
+                    return false;
+                } else {
+                    segmentAvailability = TAKEN;
+                    return true;
+                }
+            }
+
+            @ForceInline
+            void releaseSegment() {
+                segmentAvailability = AVAILABLE;
+            }
+        }
+
+        /**
+         * A SlicingArena is similar to a {@linkplain SlicingAllocator} but if the backing
+         * segment cannot be used for allocation, a fall-back arena is used instead. This
+         * means allocation never fails due to the size and alignment of the backing
+         * segment.
+         * <p>
+         * Todo: Should we expose a variant of this class as a complement
+         *       to SlicingAllocator?
+         */
+        private final class SlicingArena implements Arena, NoInitSegmentAllocator {
+
+            @Stable
+            private final ArenaImpl delegate;
+            @Stable
+            private final MemorySegment segment;
+
+            private long sp = 0L;
+
+            @ForceInline
+            private SlicingArena(ArenaImpl arena,
+                                 MemorySegment segment) {
+                this.delegate = arena;
+                this.segment = segment;
+            }
+
+            @ForceInline
+            @Override
+            public MemorySegment.Scope scope() {
+                return delegate.scope();
+            }
+
+            @ForceInline
+            @Override
+            public NativeMemorySegmentImpl allocate(long byteSize, long byteAlignment) {
+                return NoInitSegmentAllocator.super.allocate(byteSize, byteAlignment);
+            }
+
+            @SuppressWarnings("restricted")
+            @ForceInline
+            public NativeMemorySegmentImpl allocateNoInit(long byteSize, long byteAlignment) {
+                final long min = segment.address();
+                final long start = Utils.alignUp(min + sp, byteAlignment) - min;
+                if (start + byteSize <= segment.byteSize()) {
+                    Utils.checkAllocationSizeAndAlign(byteSize, byteAlignment);
+                    final MemorySegment slice = segment.asSlice(start, byteSize, byteAlignment);
+                    sp = start + byteSize;
+                    return fastReinterpret(delegate, (NativeMemorySegmentImpl) slice, byteSize);
+                } else {
+                    return delegate.allocateNoInit(byteSize, byteAlignment);
+                }
+            }
+
+            @ForceInline
+            @Override
+            public void close() {
+                delegate.close();
+                // Intentionally do not releaseSegment() in a finally clause as
+                // the segment still is in play if close() initially fails (e.g. is closed
+                // from a non-owner thread). Later on the close() method might be
+                // successfully re-invoked (e.g. from its owner thread).
+                LocalArenaPoolImpl.this.releaseSegment();
+            }
+        }
+    }
+
+    // Equivalent to:
+    //     return (NativeMemorySegmentImpl) slice
+    //             .reinterpret(byteSize, delegate, null); */
+    @ForceInline
+    static NativeMemorySegmentImpl fastReinterpret(ArenaImpl arena,
+                                                   NativeMemorySegmentImpl segment,
+                                                   long byteSize) {
+        // We already know the segment:
+        //  * is native
+        //  * we have native access
+        //  * there is no cleanup action
+        //  * the segment is read/write
+        return SegmentFactories.makeNativeSegmentUnchecked(segment.address(), byteSize,
+                MemorySessionImpl.toMemorySession(arena), false, null);
+    }
+
+    public static CarrierLocalArenaPools create(long byteSize) {
+        if (byteSize < 0) {
+            throw new IllegalArgumentException();
+        }
+        return new CarrierLocalArenaPools(byteSize, 1L);
+    }
+
+    public static CarrierLocalArenaPools create(long byteSize,
+                                                long byteAlignment) {
+        Utils.checkAllocationSizeAndAlign(byteSize, byteAlignment);
+        return new CarrierLocalArenaPools(byteSize, byteAlignment);
+    }
+
+    public static CarrierLocalArenaPools create(MemoryLayout layout) {
+        Objects.requireNonNull(layout);
+        return new CarrierLocalArenaPools(layout.byteSize(), layout.byteAlignment());
+    }
+
+}

--- a/src/java.base/share/classes/jdk/internal/invoke/MhUtil.java
+++ b/src/java.base/share/classes/jdk/internal/invoke/MhUtil.java
@@ -75,4 +75,14 @@ public final class MhUtil {
         }
     }
 
+    public static MethodHandle findStatic(MethodHandles.Lookup lookup,
+                                           String name,
+                                           MethodType type) {
+        try {
+            return lookup.findStatic(lookup.lookupClass(), name, type);
+        } catch (ReflectiveOperationException e) {
+            throw new InternalError(e);
+        }
+    }
+
 }

--- a/test/jdk/java/foreign/TestCaptureStateUtil.java
+++ b/test/jdk/java/foreign/TestCaptureStateUtil.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test CaptureStateUtil
+ * @modules java.base/jdk.internal.foreign
+ * @run junit TestCaptureStateUtil
+ */
+
+import jdk.internal.foreign.CaptureStateUtil;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class TestCaptureStateUtil {
+
+    private static final String ERRNO_NAME = "errno";
+
+    private static final VarHandle ERRNO_HANDLE = Linker.Option.captureStateLayout()
+            .varHandle(MemoryLayout.PathElement.groupElement(ERRNO_NAME));
+
+    private static final MethodHandle INT_DUMMY_HANDLE;
+    private static final MethodHandle LONG_DUMMY_HANDLE;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            INT_DUMMY_HANDLE = lookup
+                    .findStatic(TestCaptureStateUtil.class, "dummy",
+                            MethodType.methodType(int.class, MemorySegment.class, int.class, int.class));
+            LONG_DUMMY_HANDLE = lookup
+                    .findStatic(TestCaptureStateUtil.class, "dummy",
+                            MethodType.methodType(long.class, MemorySegment.class, long.class, int.class));
+        } catch (ReflectiveOperationException e) {
+            throw new InternalError(e);
+        }
+    }
+
+    private static final MethodHandle ADAPTED_INT = CaptureStateUtil
+            .adaptSystemCall(INT_DUMMY_HANDLE, ERRNO_NAME);
+    private static final MethodHandle ADAPTED_LONG = CaptureStateUtil
+            .adaptSystemCall(LONG_DUMMY_HANDLE, ERRNO_NAME);
+
+    @Test
+    void successfulInt() throws Throwable {
+        int r = (int) ADAPTED_INT.invokeExact(1, 0);
+        assertEquals(1, r);
+    }
+
+    private static final int EACCES = 13; /* Permission denied */
+
+    @Test
+    void errorInt() throws Throwable {
+        int r = (int) ADAPTED_INT.invokeExact(-1, EACCES);
+        assertEquals(-EACCES, r);
+    }
+
+    @Test
+    void successfulLong() throws Throwable {
+        long r = (long) ADAPTED_LONG.invokeExact(1L, 0);
+        assertEquals(1, r);
+    }
+
+    @Test
+    void errorLong() throws Throwable {
+        long r = (long) ADAPTED_LONG.invokeExact(-1L, EACCES);
+        assertEquals(-EACCES, r);
+    }
+
+    @Test
+    void successfulIntPerHandle() throws Throwable {
+        MethodHandle handle = CaptureStateUtil
+                .adaptSystemCall(INT_DUMMY_HANDLE, ERRNO_NAME);
+        int r = (int) handle.invokeExact(1, 0);
+        assertEquals(1, r);
+    }
+
+    @Test
+    void invariants() throws Throwable {
+        MethodHandle noSegment = MethodHandles.lookup()
+                .findStatic(TestCaptureStateUtil.class, "wrongType",
+                        MethodType.methodType(long.class, long.class, int.class));
+
+        var noSegEx = assertThrows(IllegalArgumentException.class, () -> CaptureStateUtil.adaptSystemCall(noSegment, ERRNO_NAME));
+        assertTrue(noSegEx.getMessage().contains("does not have a MemorySegment as the first parameter"));
+
+        MethodHandle wrongReturnType = MethodHandles.lookup()
+                .findStatic(TestCaptureStateUtil.class, "wrongType",
+                        MethodType.methodType(short.class, MemorySegment.class, long.class, int.class));
+
+        var wrongRetEx = assertThrows(IllegalArgumentException.class, () -> CaptureStateUtil.adaptSystemCall(wrongReturnType, ERRNO_NAME));
+        assertTrue(wrongRetEx.getMessage().contains("does not return an int or a long"));
+
+        var wrongCaptureName = assertThrows(IllegalArgumentException.class, () -> CaptureStateUtil.adaptSystemCall(LONG_DUMMY_HANDLE, "foo"));
+        assertTrue(wrongCaptureName.getMessage().startsWith("Unknown state name: foo"), wrongCaptureName.getMessage());
+
+        assertThrows(NullPointerException.class, () -> CaptureStateUtil.adaptSystemCall(null, ERRNO_NAME));
+        assertThrows(NullPointerException.class, () -> CaptureStateUtil.adaptSystemCall(noSegment, null));
+    }
+
+    // Dummy method that is just returning the provided parameters
+    private static int dummy(MemorySegment segment, int result, int errno) {
+        ERRNO_HANDLE.set(segment, 0, errno);
+        return result;
+    }
+
+    // Dummy method that is just returning the provided parameters
+    private static long dummy(MemorySegment segment, long result, int errno) {
+        ERRNO_HANDLE.set(segment, 0, errno);
+        return result;
+    }
+
+    private static long wrongType(long result, int errno) {
+        return 0;
+    }
+
+    private static short wrongType(MemorySegment segment, long result, int errno) {
+        return 0;
+    }
+
+}

--- a/test/jdk/java/foreign/TestCarrierLocalArenaPools.java
+++ b/test/jdk/java/foreign/TestCarrierLocalArenaPools.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Test TestCarrierLocalArenaPools
+ * @library /test/lib
+ * @modules java.base/jdk.internal.foreign
+ * @run junit TestCarrierLocalArenaPools
+ */
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import jdk.internal.foreign.CarrierLocalArenaPools;
+import jdk.test.lib.thread.VThreadRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static org.junit.jupiter.api.Assertions.*;
+
+final class TestCarrierLocalArenaPools {
+
+    private static final long POOL_SIZE = 64;
+    private static final long SMALL_ALLOC_SIZE = 8;
+    private static final long VERY_LARGE_ALLOC_SIZE = 1L << 10;
+
+    @Test
+    void invariants1LongArg() {
+        assertThrows(IllegalArgumentException.class, () -> CarrierLocalArenaPools.create(-1));
+        CarrierLocalArenaPools pool = CarrierLocalArenaPools.create(0);
+        try (var arena = pool.take()) {
+            // This should come from the underlying arena and not from recyclable memory
+            assertDoesNotThrow(() -> arena.allocate(1));
+            try (var arena2 = pool.take()) {
+                assertDoesNotThrow(() -> arena.allocate(1));
+            }
+        }
+    }
+
+    @Test
+    void invariants2LongArgs() {
+        assertThrows(IllegalArgumentException.class, () -> CarrierLocalArenaPools.create(-1, 2));
+        assertThrows(IllegalArgumentException.class, () -> CarrierLocalArenaPools.create(1, -1));
+        assertThrows(IllegalArgumentException.class, () -> CarrierLocalArenaPools.create(1, 3));
+        CarrierLocalArenaPools pool = CarrierLocalArenaPools.create(0, 16);
+        try (var arena = pool.take()) {
+            // This should come from the underlying arena and not from recyclable memory
+            assertDoesNotThrow(() -> arena.allocate(1));
+            try (var arena2 = pool.take()) {
+                assertDoesNotThrow(() -> arena.allocate(1));
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void negativeAlloc(CarrierLocalArenaPools pool) {
+        Consumer<Arena> action = arena ->
+                assertThrows(IllegalArgumentException.class, () -> arena.allocate(-1));
+        doInTwoStackedArenas(pool, action, action);
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void negativeAllocVt(CarrierLocalArenaPools pool) {
+        VThreadRunner.run(() -> negativeAlloc(pool));
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void allocateConfinement(CarrierLocalArenaPools pool) {
+        Consumer<Arena> allocateAction = arena ->
+                assertThrows(WrongThreadException.class, () -> {
+                    CompletableFuture<Arena> future = CompletableFuture.supplyAsync(pool::take);
+                    var otherThreadArena = future.get();
+                    otherThreadArena.allocate(SMALL_ALLOC_SIZE);
+                    // Intentionally do not close the otherThreadArena here.
+                });
+        doInTwoStackedArenas(pool, allocateAction, allocateAction);
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void allocateConfinementVt(CarrierLocalArenaPools pool) {
+        VThreadRunner.run(() -> allocateConfinement(pool));
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void closeConfinement(CarrierLocalArenaPools pool) {
+        Consumer<Arena> closeAction = arena -> {
+            CompletableFuture<Arena> future = CompletableFuture.supplyAsync(pool::take);
+            Arena otherThreadArena = null;
+            try {
+                otherThreadArena = future.get();
+            } catch (InterruptedException | ExecutionException e) {
+                fail(e);
+            }
+            assertThrows(WrongThreadException.class, otherThreadArena::close);
+        };
+        doInTwoStackedArenas(pool, closeAction, closeAction);
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void closeConfinementVt(CarrierLocalArenaPools pool) {
+        VThreadRunner.run(() -> closeConfinement(pool));
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void reuse(CarrierLocalArenaPools pool) {
+        MemorySegment firstSegment;
+        MemorySegment secondSegment;
+        try (var arena = pool.take()) {
+            firstSegment = arena.allocate(SMALL_ALLOC_SIZE);
+        }
+        try (var arena = pool.take()) {
+            secondSegment = arena.allocate(SMALL_ALLOC_SIZE);
+        }
+        assertNotSame(firstSegment, secondSegment);
+        assertNotSame(firstSegment.scope(), secondSegment.scope());
+        assertEquals(firstSegment.address(), secondSegment.address());
+        assertThrows(IllegalStateException.class, () -> firstSegment.get(JAVA_BYTE, 0));
+        assertThrows(IllegalStateException.class, () -> secondSegment.get(JAVA_BYTE, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void reuseVt(CarrierLocalArenaPools pool) {
+        VThreadRunner.run(() -> reuse(pool));
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void largeAlloc(CarrierLocalArenaPools pool) {
+        try (var arena = pool.take()) {
+            var segment = arena.allocate(VERY_LARGE_ALLOC_SIZE);
+            assertEquals(VERY_LARGE_ALLOC_SIZE, segment.byteSize());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void largeAllocSizeVt(CarrierLocalArenaPools pool) {
+        VThreadRunner.run(() -> largeAlloc(pool));
+    }
+
+    @Test
+    void allocationSameAsPoolSize() {
+        var pool = CarrierLocalArenaPools.create(4);
+        long firstAddress;
+        try (var arena = pool.take()) {
+            var segment = arena.allocate(4);
+            firstAddress = segment.address();
+        }
+        try (var arena = pool.take()) {
+            var segment = arena.allocate(4 + 1);
+            assertNotEquals(firstAddress, segment.address());
+        }
+        for (int i = 0; i < 10; i++) {
+            try (var arena = pool.take()) {
+                var segment = arena.allocate(4);
+                assertEquals(firstAddress, segment.address());
+                var segmentTwo = arena.allocate(4);
+                assertNotEquals(firstAddress, segmentTwo.address());
+            }
+        }
+    }
+
+    @Test
+    void allocationCaptureStateLayout() {
+        var layout = Linker.Option.captureStateLayout();
+        var pool = CarrierLocalArenaPools.create(layout);
+        long firstAddress;
+        try (var arena = pool.take()) {
+            var segment = arena.allocate(layout);
+            firstAddress = segment.address();
+        }
+        for (int i = 0; i < 10; i++) {
+            try (var arena = pool.take()) {
+                var segment = arena.allocate(layout);
+                assertEquals(firstAddress, segment.address());
+                var segmentTwo = arena.allocate(layout);
+                assertNotEquals(firstAddress, segmentTwo.address());
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void outOfOrderUse(CarrierLocalArenaPools pool) {
+        Arena firstArena = pool.take();
+        Arena secondArena = pool.take();
+        firstArena.close();
+        Arena thirdArena = pool.take();
+        secondArena.close();
+        thirdArena.close();
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void zeroing(CarrierLocalArenaPools pool) {
+        try (var arena = pool.take()) {
+            var seg = arena.allocate(SMALL_ALLOC_SIZE);
+            seg.fill((byte) 1);
+        }
+        try (var arena = pool.take()) {
+            var seg = arena.allocate(SMALL_ALLOC_SIZE);
+            for (int i = 0; i < SMALL_ALLOC_SIZE; i++) {
+                assertEquals((byte) 0, seg.get(JAVA_BYTE, i));
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void zeroingVt(CarrierLocalArenaPools pool) {
+        VThreadRunner.run(() -> zeroing(pool));
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void useAfterFree(CarrierLocalArenaPools pool) {
+        MemorySegment segment = null;
+        try (var arena = pool.take()){
+            segment = arena.allocate(SMALL_ALLOC_SIZE);
+        }
+        final var closedSegment = segment;
+        var e = assertThrows(IllegalStateException.class, () -> closedSegment.get(ValueLayout.JAVA_INT, 0));
+        assertEquals("Already closed", e.getMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("pools")
+    void toStringTest(CarrierLocalArenaPools pool) {
+        assertTrue(pool.toString().contains("ArenaPool"));
+        try (var arena = pool.take()) {
+            assertTrue(arena.toString().contains("SlicingArena"));
+        }
+    }
+
+    // Factories and helper methods
+
+    static Stream<CarrierLocalArenaPools> pools() {
+        return Stream.of(
+                CarrierLocalArenaPools.create(POOL_SIZE),
+                CarrierLocalArenaPools.create(POOL_SIZE, 16),
+                CarrierLocalArenaPools.create(MemoryLayout.sequenceLayout(POOL_SIZE, JAVA_BYTE))
+        );
+    }
+
+    static void doInTwoStackedArenas(CarrierLocalArenaPools pool,
+                                     Consumer<Arena> firstAction,
+                                     Consumer<Arena> secondAction) {
+        try (var firstArena = pool.take()) {
+            firstAction.accept(firstArena);
+            try (var secondArena = pool.take()) {
+                secondAction.accept(secondArena);
+            }
+        }
+    }
+
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CaptureStateUtilBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CaptureStateUtilBench.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.lang.foreign;
+
+import jdk.internal.foreign.CaptureStateUtil;
+import jdk.internal.foreign.CarrierLocalArenaPools;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgs = {"--add-exports=java.base/jdk.internal.foreign=ALL-UNNAMED",
+        "--enable-native-access=ALL-UNNAMED"})
+public class CaptureStateUtilBench {
+
+    private static final CarrierLocalArenaPools POOLS = CarrierLocalArenaPools.create(16);
+
+    private static final String ERRNO_NAME = "errno";
+
+    private static final VarHandle ERRNO_HANDLE = Linker.Option.captureStateLayout()
+            .varHandle(MemoryLayout.PathElement.groupElement(ERRNO_NAME));
+
+    private static final long SIZE = Linker.Option.captureStateLayout().byteSize();
+
+    private static final MethodHandle DUMMY_EXPLICIT_ALLOC = dummyExplicitAlloc();
+    private static final MethodHandle DUMMY_TL_ALLOC = dummyTlAlloc();
+
+    @Benchmark
+    public int explicitAllocationSuccess() throws Throwable {
+        try (var arena = Arena.ofConfined()) {
+            return (int) DUMMY_EXPLICIT_ALLOC.invokeExact(arena.allocate(SIZE), 0, 0);
+        }
+    }
+
+    @Benchmark
+    public int explicitAllocationFail() throws Throwable {
+        try (var arena = Arena.ofConfined()) {
+            return (int) DUMMY_EXPLICIT_ALLOC.invokeExact(arena.allocate(SIZE), -1, 1);
+        }
+    }
+
+    @Benchmark
+    public int tlAllocationSuccess() throws Throwable {
+        try (var arena = POOLS.take()) {
+            return (int) DUMMY_EXPLICIT_ALLOC.invokeExact(arena.allocate(SIZE), 0, 0);
+        }
+    }
+
+    @Benchmark
+    public int tlAllocationFail() throws Throwable {
+        try (var arena = POOLS.take()) {
+            return (int) DUMMY_EXPLICIT_ALLOC.invokeExact(arena.allocate(SIZE), -1, 1);
+        }
+    }
+
+    @Benchmark
+    public int adaptedSysCallSuccess() throws Throwable {
+        return (int) DUMMY_TL_ALLOC.invokeExact(0, 0);
+    }
+
+    @Benchmark
+    public int adaptedSysCallFail() throws Throwable {
+        return (int) DUMMY_TL_ALLOC.invokeExact( -1, 1);
+    }
+
+    private static MethodHandle dummyExplicitAlloc() {
+        try {
+            return MethodHandles.lookup().findStatic(CaptureStateUtilBench.class,
+                    "dummy", MethodType.methodType(int.class, MemorySegment.class, int.class, int.class));
+        } catch (ReflectiveOperationException roe) {
+            throw new RuntimeException(roe);
+        }
+    }
+
+    private static MethodHandle dummyTlAlloc() {
+        final MethodHandle handle = dummyExplicitAlloc();
+        return CaptureStateUtil.adaptSystemCall(handle, ERRNO_NAME);
+    }
+
+    // Dummy method that is just returning the provided parameters
+    private static int dummy(MemorySegment segment, int result, int errno) {
+        if (errno != 0) {
+            // Assuming the capture state is only modified upon detecting an error.
+            ERRNO_HANDLE.set(segment, 0, errno);
+        }
+        return result;
+    }
+
+}


### PR DESCRIPTION
Going forward, converting older JDK code to use the relatively new FFM API requires system calls that can provide `errno` and the likes to explicitly allocate a `MemorySegment` to capture potential error states. This can lead to negative performance implications if not designed carefully and also introduces unnecessary code complexity.

Hence, this PR proposes to add a JDK internal method handle adapter that can be used to handle system calls with `errno`, `GetLastError`, and `WSAGetLastError`.

It relies on an efficient carrier-thread-local cache of memory regions to allide allocations.

Here are some benchmarks that ran on a platform thread:

```
Benchmark                                        Mode  Cnt   Score   Error  Units
CaptureStateUtilBench.adaptedSysCallFail         avgt   30  22.601 ? 0.411  ns/op
CaptureStateUtilBench.adaptedSysCallSuccess      avgt   30   3.592 ? 0.035  ns/op // <- Happy path
CaptureStateUtilBench.explicitAllocationFail     avgt   30  41.510 ? 0.784  ns/op
CaptureStateUtilBench.explicitAllocationSuccess  avgt   30  21.439 ? 0.079  ns/op // <- Allocating memory upon each invocation
CaptureStateUtilBench.tlAllocationFail           avgt   30  21.675 ? 0.491  ns/op 
CaptureStateUtilBench.tlAllocationSuccess        avgt   30   3.755 ? 0.078  ns/op // <- Using the pool explicitly from Java code
```

Adapted system call:

```
        return (int) ADAPTED_HANDLE.invoke(0, 0); // Uses a MH-internal pool
```

Explicit allocation:

```
        try (var arena = Arena.ofConfined()) {
            return (int) HANDLE.invoke(arena.allocate(4), 0, 0);
        }
```

Thread Local allocation:

```
        try (var arena = POOLS.take()) {
            return (int) HANDLE.invoke(arena.allocate(4), 0, 0); // Uses a manually specified pool
        }
```

The adapted system call exhibits a ~6x performance improvement for the happy path.

Tested and passed tiers 1-3.