### PR TITLE
8347833: CrashOnOutOfMemory should stop GC threads before HeapDumpOnOutOfMemoryError

### DIFF
--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -267,15 +267,7 @@ void report_java_out_of_memory(const char* message) {
   // commands multiple times we just do it once when the first threads reports
   // the error.
   if (Atomic::cmpxchg(&out_of_memory_reported, 0, 1) == 0) {
-    // create heap dump before OnOutOfMemoryError commands are executed
-    if (HeapDumpOnOutOfMemoryError) {
-      tty->print_cr("java.lang.OutOfMemoryError: %s", message);
-      HeapDumper::dump_heap_from_oome();
-    }
-
-    if (OnOutOfMemoryError && OnOutOfMemoryError[0]) {
-      VMError::report_java_out_of_memory(message);
-    }
+    VMError::report_java_out_of_memory(message, HeapDumpOnOutOfMemoryError);
 
     if (CrashOnOutOfMemoryError) {
       tty->print_cr("Aborting due to java.lang.OutOfMemoryError: %s", message);

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -267,7 +267,7 @@ void report_java_out_of_memory(const char* message) {
   // commands multiple times we just do it once when the first threads reports
   // the error.
   if (Atomic::cmpxchg(&out_of_memory_reported, 0, 1) == 0) {
-    VMError::report_java_out_of_memory(message, HeapDumpOnOutOfMemoryError);
+    VMError::report_java_out_of_memory(message, HeapDumpOnOutOfMemoryError, CrashOnOutOfMemoryError);
 
     if (CrashOnOutOfMemoryError) {
       tty->print_cr("Aborting due to java.lang.OutOfMemoryError: %s", message);

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -190,7 +190,7 @@ public:
                              va_list detail_args);
 
   // reporting OutOfMemoryError
-  static void report_java_out_of_memory(const char* message, bool dumpHeap);
+  static void report_java_out_of_memory(const char* message, bool dumpHeap, bool abort);
 
   // Called by the WatcherThread to check if error reporting has timed-out.
   //  Returns true if error reporting has not completed within the ErrorLogTimeout limit.

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -190,7 +190,7 @@ public:
                              va_list detail_args);
 
   // reporting OutOfMemoryError
-  static void report_java_out_of_memory(const char* message);
+  static void report_java_out_of_memory(const char* message, bool dumpHeap);
 
   // Called by the WatcherThread to check if error reporting has timed-out.
   //  Returns true if error reporting has not completed within the ErrorLogTimeout limit.

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryAndCrashOnOutOfMemory.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryAndCrashOnOutOfMemory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestHeapDumpOnOutOfMemoryAndCrashOnOutOfMemory
+ * @summary Test verifies call to -XX:HeapDumpOnOutOfMemoryError and
+ *          CrashOnOutOfMemoryError handled in a single safepoint operation
+ * @library /test/lib
+ * @requires vm.flagless
+ * @run driver TestHeapDumpOnOutOfMemoryAndCrashOnOutOfMemory
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestHeapDumpOnOutOfMemoryAndCrashOnOutOfMemory {
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1) {
+            try {
+                Object[] oa = new Object[Integer.MAX_VALUE];
+                for(int i = 0; i < oa.length; i++) {
+                    oa[i] = new Object[Integer.MAX_VALUE];
+                }
+                throw new Error("OOME not triggered");
+            } catch (OutOfMemoryError err) {
+                return;
+            }
+        }
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+HeapDumpOnOutOfMemoryError",
+                  "-XX:+CrashOnOutOfMemoryError",
+                  "-Xlog:gc",
+                  TestHeapDumpOnOutOfMemoryError.class.getName());
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        int exitValue = output.getExitValue();
+        if(0 != exitValue) {
+          //expecting a non zero value, as it could be due to HeapDumpOnOutOfMemory or CrashOnOutOfMemory
+          output.stdoutShouldNotBeEmpty();
+          output.shouldNotContain("[info][gc] GC");
+          System.out.println("PASSED");
+        } else {
+          throw new Error("Expected to get non zero exit value");
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryAndCrashOnOutOfMemory.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryAndCrashOnOutOfMemory.java
@@ -40,7 +40,7 @@ public class TestHeapDumpOnOutOfMemoryAndCrashOnOutOfMemory {
         if (args.length == 1) {
             try {
                 Object[] oa = new Object[Integer.MAX_VALUE];
-                for(int i = 0; i < oa.length; i++) {
+                for (int i = 0; i < oa.length; i++) {
                     oa[i] = new Object[Integer.MAX_VALUE];
                 }
                 throw new Error("OOME not triggered");
@@ -49,12 +49,13 @@ public class TestHeapDumpOnOutOfMemoryAndCrashOnOutOfMemory {
             }
         }
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+HeapDumpOnOutOfMemoryError",
+                  "-Xmx128m",
                   "-XX:+CrashOnOutOfMemoryError",
-                  "-Xlog:gc",
+                  "-Xlog:safepoint=trace:file=safepoint.log",
                   TestHeapDumpOnOutOfMemoryError.class.getName());
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         int exitValue = output.getExitValue();
-        if(0 != exitValue) {
+        if (exitValue != 0) {
           //expecting a non zero value, as it could be due to HeapDumpOnOutOfMemory or CrashOnOutOfMemory
           output.stdoutShouldNotBeEmpty();
           output.shouldNotContain("[info][gc] GC");


### PR DESCRIPTION
When CrashOnOutOfMemory  and HeapDumpOnOutOfMemoryError invoked together, we should make sure, it is performed in a single safepoint, this will avoid allowing other threads to run and throw OOM errors after the initial one is already under error logging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347833](https://bugs.openjdk.org/browse/JDK-8347833): CrashOnOutOfMemory should stop GC threads before HeapDumpOnOutOfMemoryError (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23519/head:pull/23519` \
`$ git checkout pull/23519`

Update a local copy of the PR: \
`$ git checkout pull/23519` \
`$ git pull https://git.openjdk.org/jdk.git pull/23519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23519`

View PR using the GUI difftool: \
`$ git pr show -t 23519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23519.diff">https://git.openjdk.org/jdk/pull/23519.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23519#issuecomment-2643666309)
</details>
