### PR TITLE
8336762: [JVMCI] Append the jvmci_name to the nmethod name for "hosted" JVMCI compilations

### DIFF
--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -220,7 +220,7 @@ void CompileTask::print_tty() {
 void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, int comp_level,
                              bool is_osr_method, int osr_bci, bool is_blocking,
                              const char* msg, bool short_form, bool cr,
-                             jlong time_queued, jlong time_started) {
+                             jlong time_queued, jlong time_started, const char* method_name_suffix) {
   if (!short_form) {
     // Print current time
     st->print(UINT64_FORMAT " ", (uint64_t) tty->time_stamp().milliseconds());
@@ -267,6 +267,9 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
     st->print("(method)");
   } else {
     method->print_short_name(st);
+    if (method_name_suffix != nullptr) {
+      st->print("$%s", method_name_suffix);
+    }
     if (is_osr_method) {
       st->print(" @ %d", osr_bci);
     }
@@ -286,9 +289,10 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
 
 // ------------------------------------------------------------------
 // CompileTask::print_compilation
-void CompileTask::print(outputStream* st, const char* msg, bool short_form, bool cr) {
+void CompileTask::print(outputStream* st, const char* msg, bool short_form, bool cr, const char* method_name_suffix) {
   bool is_osr_method = osr_bci() != InvocationEntryBci;
-  print_impl(st, is_unloaded() ? nullptr : method(), compile_id(), comp_level(), is_osr_method, osr_bci(), is_blocking(), msg, short_form, cr, _time_queued, _time_started);
+  print_impl(st, is_unloaded() ? nullptr : method(), compile_id(), comp_level(), is_osr_method, osr_bci(), is_blocking(),
+      msg, short_form, cr, _time_queued, _time_started, method_name_suffix);
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -224,15 +224,15 @@ private:
   static void  print_impl(outputStream* st, Method* method, int compile_id, int comp_level,
                                       bool is_osr_method = false, int osr_bci = -1, bool is_blocking = false,
                                       const char* msg = nullptr, bool short_form = false, bool cr = true,
-                                      jlong time_queued = 0, jlong time_started = 0);
+                                      jlong time_queued = 0, jlong time_started = 0, const char* method_name_suffix = nullptr);
 
 public:
-  void         print(outputStream* st = tty, const char* msg = nullptr, bool short_form = false, bool cr = true);
+  void         print(outputStream* st = tty, const char* msg = nullptr, bool short_form = false, bool cr = true, const char* method_name_suffix = nullptr);
   void         print_ul(const char* msg = nullptr);
-  static void  print(outputStream* st, const nmethod* nm, const char* msg = nullptr, bool short_form = false, bool cr = true) {
+  static void  print(outputStream* st, const nmethod* nm, const char* msg = nullptr, bool short_form = false, bool cr = true, const char* method_name_suffix = nullptr) {
     print_impl(st, nm->method(), nm->compile_id(), nm->comp_level(),
                            nm->is_osr_method(), nm->is_osr_method() ? nm->osr_entry_bci() : -1, /*is_blocking*/ false,
-                           msg, short_form, cr);
+                           msg, short_form, cr, 0, 0, method_name_suffix);
   }
   static void  print_ul(const nmethod* nm, const char* msg = nullptr);
 

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -818,7 +818,7 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
         // Since this compilation didn't pass through the broker it wasn't logged yet.
         if (PrintCompilation) {
           ttyLocker ttyl;
-          CompileTask::print(tty, nm, "(hosted JVMCI compilation)");
+          CompileTask::print(tty, nm, "(hosted JVMCI compilation)", false, true, nm->jvmci_name());
         }
       }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336762](https://bugs.openjdk.org/browse/JDK-8336762): [JVMCI] Append the jvmci_name to the nmethod name for "hosted" JVMCI compilations (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23520/head:pull/23520` \
`$ git checkout pull/23520`

Update a local copy of the PR: \
`$ git checkout pull/23520` \
`$ git pull https://git.openjdk.org/jdk.git pull/23520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23520`

View PR using the GUI difftool: \
`$ git pr show -t 23520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23520.diff">https://git.openjdk.org/jdk/pull/23520.diff</a>

</details>
