### PR TITLE
8349624: Validation for slot missing in CodeBuilder local variable instructions

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -484,7 +484,7 @@ public final class DirectCodeBuilder
         bytecodesBufWriter.writeU1(opcode.bytecode());
     }
 
-    // Instruction version, refer to opcode
+    // Instruction version, refer to opcode, trusted
     public void writeLocalVar(Opcode opcode, int slot) {
         if (opcode.isWide()) {
             bytecodesBufWriter.writeU2U2(opcode.bytecode(), slot);
@@ -493,12 +493,12 @@ public final class DirectCodeBuilder
         }
     }
 
-    // Shortcut version, refer to and validate slot
-    private void writeLocalVar(int bytecode, int slot) {
-        // TODO validation like (slot & 0xFFFF) == slot
-        if (slot < 256) {
+    // local var access, not a trusted write method, needs slot validation
+    private void localAccess(int bytecode, int slot) {
+        if ((slot & ~0xFF) == 0) {
             bytecodesBufWriter.writeU1U1(bytecode, slot);
         } else {
+            BytecodeHelpers.validateSlot(slot);
             bytecodesBufWriter.writeU1U1U2(WIDE, bytecode, slot);
         }
     }
@@ -989,7 +989,7 @@ public final class DirectCodeBuilder
         if (slot >= 0 && slot <= 3) {
             bytecodesBufWriter.writeU1(ALOAD_0 + slot);
         } else {
-            writeLocalVar(ALOAD, slot);
+            localAccess(ALOAD, slot);
         }
         return this;
     }
@@ -1017,7 +1017,7 @@ public final class DirectCodeBuilder
         if (slot >= 0 && slot <= 3) {
             bytecodesBufWriter.writeU1(ASTORE_0 + slot);
         } else {
-            writeLocalVar(ASTORE, slot);
+            localAccess(ASTORE, slot);
         }
         return this;
     }
@@ -1100,7 +1100,7 @@ public final class DirectCodeBuilder
         if (slot >= 0 && slot <= 3) {
             bytecodesBufWriter.writeU1(DLOAD_0 + slot);
         } else {
-            writeLocalVar(DLOAD, slot);
+            localAccess(DLOAD, slot);
         }
         return this;
     }
@@ -1134,7 +1134,7 @@ public final class DirectCodeBuilder
         if (slot >= 0 && slot <= 3) {
             bytecodesBufWriter.writeU1(DSTORE_0 + slot);
         } else {
-            writeLocalVar(DSTORE, slot);
+            localAccess(DSTORE, slot);
         }
         return this;
     }
@@ -1246,7 +1246,7 @@ public final class DirectCodeBuilder
         if (slot >= 0 && slot <= 3) {
             bytecodesBufWriter.writeU1(FLOAD_0 + slot);
         } else {
-            writeLocalVar(FLOAD, slot);
+            localAccess(FLOAD, slot);
         }
         return this;
     }
@@ -1280,7 +1280,7 @@ public final class DirectCodeBuilder
         if (slot >= 0 && slot <= 3) {
             bytecodesBufWriter.writeU1(FSTORE_0 + slot);
         } else {
-            writeLocalVar(FSTORE, slot);
+            localAccess(FSTORE, slot);
         }
         return this;
     }
@@ -1506,7 +1506,7 @@ public final class DirectCodeBuilder
         if (slot >= 0 && slot <= 3) {
             bytecodesBufWriter.writeU1(ILOAD_0 + slot);
         } else {
-            writeLocalVar(ILOAD, slot);
+            localAccess(ILOAD, slot);
         }
         return this;
     }
@@ -1606,7 +1606,7 @@ public final class DirectCodeBuilder
         if (slot >= 0 && slot <= 3) {
             bytecodesBufWriter.writeU1(ISTORE_0 + slot);
         } else {
-            writeLocalVar(ISTORE, slot);
+            localAccess(ISTORE, slot);
         }
         return this;
     }
@@ -1701,7 +1701,7 @@ public final class DirectCodeBuilder
         if (slot >= 0 && slot <= 3) {
             bytecodesBufWriter.writeU1(LLOAD_0 + slot);
         } else {
-            writeLocalVar(LLOAD, slot);
+            localAccess(LLOAD, slot);
         }
         return this;
     }
@@ -1753,7 +1753,7 @@ public final class DirectCodeBuilder
         if (slot >= 0 && slot <= 3) {
             bytecodesBufWriter.writeU1(LSTORE_0 + slot);
         } else {
-            writeLocalVar(LSTORE, slot);
+            localAccess(LSTORE, slot);
         }
         return this;
     }


### PR DESCRIPTION
In CodeBuilder, validation for a slot was missing due to concurrent patches, and the original patch did not add effective tests for CodeBuilder because of the complex exceptional behaviors. Now the bug is fixed with renames to prevent future risky usages, and the tests have been enhanced to ensure at least the failure-case behavior (while the non-failure case is harder to check due to exceptional behaviors)

Testing: JDK tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349624](https://bugs.openjdk.org/browse/JDK-8349624): Validation for slot missing in CodeBuilder local variable instructions (**Bug** - P3)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23522/head:pull/23522` \
`$ git checkout pull/23522`

Update a local copy of the PR: \
`$ git checkout pull/23522` \
`$ git pull https://git.openjdk.org/jdk.git pull/23522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23522`

View PR using the GUI difftool: \
`$ git pr show -t 23522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23522.diff">https://git.openjdk.org/jdk/pull/23522.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23522#issuecomment-2643926210)
</details>
