### PR TITLE
8327378: XMLStreamReader throws EOFException instead of XMLStreamException

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLDTDScannerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLDTDScannerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -63,7 +63,7 @@ import jdk.xml.internal.XMLSecurityManager;
  * @author Glenn Marcy, IBM
  * @author Eric Ye, IBM
  *
- * @LastModified: July 2023
+ * @LastModified: Feb 2025
  */
 public class XMLDTDScannerImpl
 extends XMLScanner
@@ -670,7 +670,10 @@ implements XMLDTDScanner, XMLComponent, XMLEntityHandler {
         //fIncludeSectDepth != 0 or fExtEntityDepth != 0 throw Exception
         if (augs != null && Boolean.TRUE.equals(augs.getItem(Constants.LAST_ENTITY))
             && ( fMarkUpDepth != 0 || fExtEntityDepth !=0 || fIncludeSectDepth != 0)){
-            throw new EOFException();
+            fErrorReporter.reportError(XMLMessageFormatter.XML_DOMAIN,
+                    "PrematureEOF",
+                    new Object[]{ name },
+                    XMLErrorReporter.SEVERITY_FATAL_ERROR);
         }
 
     } // endEntity(String)

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLDocumentScannerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLDocumentScannerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 
 /*
@@ -71,7 +71,7 @@ import jdk.xml.internal.XMLSecurityManager.Limit;
  * Refer to the table in unit-test javax.xml.stream.XMLStreamReaderTest.SupportDTD for changes
  * related to property SupportDTD.
  * @author Joe Wang, Sun Microsystems
- * @LastModified: Nov 2023
+ * @LastModified: Feb 2025
  */
 public class XMLDocumentScannerImpl
         extends XMLDocumentFragmentScannerImpl{
@@ -1225,7 +1225,6 @@ public class XMLDocumentScannerImpl
             }
             // premature end of file
             catch (EOFException e) {
-                e.printStackTrace();
                 reportFatalError("PrematureEOF", null);
                 return false;
                 //throw e;

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/ExceptionTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamReaderTest/ExceptionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package stream.XMLStreamReaderTest;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.StringReader;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/*
+ * @test
+ * @bug 8327378
+ * @summary Verifies exception handling
+ * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
+ * @run junit stream.XMLStreamReaderTest.ExceptionTest
+ */
+public class ExceptionTest {
+
+    /**
+     * Verifies that the XMLStreamReader throws XMLStreamException instead of EOFException.
+     * The specification for the XMLStreamReader's next method:
+     * Throws: XMLStreamException - if there is an error processing the underlying XML source
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void testExpectedException() throws Exception {
+        XMLInputFactory xmlInputFactory = XMLInputFactory.newDefaultFactory();
+        XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(
+                new StringReader("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><!DOCTYPE foo [ <!ELEMENT foo ANY ><!ENTITY"));
+
+        assertThrows(XMLStreamException.class, () -> {
+            while (xmlStreamReader.hasNext()) {
+                int event = xmlStreamReader.next();
+            }
+        });
+    }
+}


### PR DESCRIPTION
Fix an error handling where the XMLStreamReader impl throws EOFException instead of XMLStreamException as defined.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327378](https://bugs.openjdk.org/browse/JDK-8327378): XMLStreamReader throws EOFException instead of XMLStreamException (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23524/head:pull/23524` \
`$ git checkout pull/23524`

Update a local copy of the PR: \
`$ git checkout pull/23524` \
`$ git pull https://git.openjdk.org/jdk.git pull/23524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23524`

View PR using the GUI difftool: \
`$ git pr show -t 23524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23524.diff">https://git.openjdk.org/jdk/pull/23524.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23524#issuecomment-2644028003)
</details>
