### PR TITLE
8348432: Use block size as the default Hmac key length for JDK providers

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/KeyGeneratorCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/KeyGeneratorCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,52 +136,52 @@ final class KeyGeneratorCore {
 
         public static final class SHA224 extends HmacKG {
             public SHA224() {
-                super("HmacSHA224", 224);
+                super("HmacSHA224", 512);
             }
         }
         public static final class SHA256 extends HmacKG {
             public SHA256() {
-                super("HmacSHA256", 256);
+                super("HmacSHA256", 512);
             }
         }
         public static final class SHA384 extends HmacKG {
             public SHA384() {
-                super("HmacSHA384", 384);
+                super("HmacSHA384", 1024);
             }
         }
         public static final class SHA512 extends HmacKG {
             public SHA512() {
-                super("HmacSHA512", 512);
+                super("HmacSHA512", 1024);
             }
         }
         public static final class SHA512_224 extends HmacKG {
             public SHA512_224() {
-                super("HmacSHA512/224", 224);
+                super("HmacSHA512/224", 1024);
             }
         }
         public static final class SHA512_256 extends HmacKG {
             public SHA512_256() {
-                super("HmacSHA512/256", 256);
+                super("HmacSHA512/256", 1024);
             }
         }
         public static final class SHA3_224 extends HmacKG {
             public SHA3_224() {
-                super("HmacSHA3-224", 224);
+                super("HmacSHA3-224", 1152);
             }
         }
         public static final class SHA3_256 extends HmacKG {
             public SHA3_256() {
-                super("HmacSHA3-256", 256);
+                super("HmacSHA3-256", 1088);
             }
         }
         public static final class SHA3_384 extends HmacKG {
             public SHA3_384() {
-                super("HmacSHA3-384", 384);
+                super("HmacSHA3-384", 832);
             }
         }
         public static final class SHA3_512 extends HmacKG {
             public SHA3_512() {
-                super("HmacSHA3-512", 512);
+                super("HmacSHA3-512", 576);
             }
         }
     }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -290,15 +290,16 @@ final class P11KeyGenerator extends KeyGeneratorSpi {
                 if (algorithm.startsWith("Hmac")) {
                     String digest = algorithm.substring(4);
                     keySize = adjustKeySize(switch (digest) {
-                        case "MD5" -> 512;
-                        case "SHA1" -> 160;
-                        case "SHA224", "SHA512/224", "SHA3-224" -> 224;
-                        case "SHA256", "SHA512/256", "SHA3-256" -> 256;
-                        case "SHA384", "SHA3-384" -> 384;
-                        case "SHA512", "SHA3-512" -> 512;
+                        case "MD5", "SHA1", "SHA224", "SHA256" -> 512;
+                        case "SHA384", "SHA512", "SHA512/224", "SHA512/256"
+                                -> 1024;
+                        case "SHA3-224" -> 1152;
+                        case "SHA3-256" -> 1088;
+                        case "SHA3-384" -> 832;
+                        case "SHA3-512" -> 576;
                         default -> {
-                            throw new ProviderException("Unsupported algorithm " +
-                                    algorithm);
+                            throw new ProviderException("Unsupported algorithm "
+                                    + algorithm);
                         }
                     }, range);
                 } else {


### PR DESCRIPTION
Could someone help review this straight forward change?

Changing to use block size instead of the hash output length as the default Hmac key sizes. The relevant regression tests have been adjusted accordingly as well.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8349757](https://bugs.openjdk.org/browse/JDK-8349757) to be approved

### Issues
 * [JDK-8348432](https://bugs.openjdk.org/browse/JDK-8348432): Use block size as the default Hmac key length for JDK providers (**Enhancement** - P4)
 * [JDK-8349757](https://bugs.openjdk.org/browse/JDK-8349757): Use block size as the default Hmac key length for JDK providers (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23526/head:pull/23526` \
`$ git checkout pull/23526`

Update a local copy of the PR: \
`$ git checkout pull/23526` \
`$ git pull https://git.openjdk.org/jdk.git pull/23526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23526`

View PR using the GUI difftool: \
`$ git pr show -t 23526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23526.diff">https://git.openjdk.org/jdk/pull/23526.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23526#issuecomment-2644238873)
</details>
