### PR TITLE
8349475: Test tools/javac/api/TestJavacTaskWithWarning.java writes files in src dir

### DIFF
--- a/test/langtools/tools/javac/api/TestJavacTaskWithWarning.java
+++ b/test/langtools/tools/javac/api/TestJavacTaskWithWarning.java
@@ -50,7 +50,7 @@ public class TestJavacTaskWithWarning {
     public static void warningTest() throws Exception {
 
         // Create a source file that will generate a warning
-        String srcdir = System.getProperty("test.classes");
+        String srcdir = System.getProperty(".");
         File file = new File(srcdir, "GeneratesWarning.java");
         try (PrintStream out = new PrintStream(new FileOutputStream(file))) {
             out.print(

--- a/test/langtools/tools/javac/api/TestJavacTaskWithWarning.java
+++ b/test/langtools/tools/javac/api/TestJavacTaskWithWarning.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug     8348212
+ * @bug     8348212 8349475
  * @summary Ensure the warn() phase executes when the compiler is invoked via the API
  * @modules jdk.compiler/com.sun.tools.javac.api
  */
@@ -50,7 +50,7 @@ public class TestJavacTaskWithWarning {
     public static void warningTest() throws Exception {
 
         // Create a source file that will generate a warning
-        String srcdir = System.getProperty("test.src");
+        String srcdir = System.getProperty("test.classes");
         File file = new File(srcdir, "GeneratesWarning.java");
         try (PrintStream out = new PrintStream(new FileOutputStream(file))) {
             out.print(

--- a/test/langtools/tools/javac/api/TestJavacTaskWithWarning.java
+++ b/test/langtools/tools/javac/api/TestJavacTaskWithWarning.java
@@ -50,7 +50,7 @@ public class TestJavacTaskWithWarning {
     public static void warningTest() throws Exception {
 
         // Create a source file that will generate a warning
-        String srcdir = System.getProperty(".");
+        String srcdir = ".";
         File file = new File(srcdir, "GeneratesWarning.java");
         try (PrintStream out = new PrintStream(new FileOutputStream(file))) {
             out.print(


### PR DESCRIPTION
Correct generating files into the work directory, not the directory of test sources.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349475](https://bugs.openjdk.org/browse/JDK-8349475): Test tools/javac/api/TestJavacTaskWithWarning.java writes files in src dir (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [09c0bdd4](https://git.openjdk.org/jdk/pull/23527/files/09c0bdd44ece3e8d4798f4a5f58fbf9fa2097b41)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) Review applies to [09c0bdd4](https://git.openjdk.org/jdk/pull/23527/files/09c0bdd44ece3e8d4798f4a5f58fbf9fa2097b41)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23527/head:pull/23527` \
`$ git checkout pull/23527`

Update a local copy of the PR: \
`$ git checkout pull/23527` \
`$ git pull https://git.openjdk.org/jdk.git pull/23527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23527`

View PR using the GUI difftool: \
`$ git pr show -t 23527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23527.diff">https://git.openjdk.org/jdk/pull/23527.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23527#issuecomment-2644253627)
</details>
