### PR TITLE
Configurable G1 heap expansion aggressiveness

### DIFF
--- a/src/hotspot/share/gc/g1/g1Analytics.hpp
+++ b/src/hotspot/share/gc/g1/g1Analytics.hpp
@@ -28,6 +28,7 @@
 #include "gc/g1/g1AnalyticsSequences.hpp"
 #include "memory/allocation.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/numberSeq.hpp"
 
 class TruncatedSeq;
 class G1Predictions;
@@ -112,6 +113,10 @@ public:
 
   uint number_of_recorded_pause_times() const {
     return NumPrevPausesForHeuristics;
+  }
+
+  uint number_of_available_pause_times() const {
+    return _recent_gc_times_ms->num();
   }
 
   void append_prev_collection_pause_end_ms(double ms) {

--- a/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
@@ -30,6 +30,7 @@
 #include "runtime/globals.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "gc/g1/g1_globals.hpp"
 
 G1HeapSizingPolicy* G1HeapSizingPolicy::create(const G1CollectedHeap* g1h, const G1Analytics* analytics) {
   return new G1HeapSizingPolicy(g1h, analytics);
@@ -88,7 +89,10 @@ size_t G1HeapSizingPolicy::young_collection_expansion_amount() {
   double long_term_pause_time_ratio = _analytics->long_term_pause_time_ratio();
   double short_term_pause_time_ratio = _analytics->short_term_pause_time_ratio();
   const double pause_time_threshold = 1.0 / (1.0 + GCTimeRatio);
-  double threshold = scale_with_heap(pause_time_threshold);
+  double threshold = pause_time_threshold;
+  if (G1ScaleWithHeapPauseTimeThreshold) {
+    threshold = scale_with_heap(pause_time_threshold);
+  }
 
   size_t expand_bytes = 0;
 

--- a/src/hotspot/share/gc/g1/g1HeapSizingPolicy.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapSizingPolicy.hpp
@@ -31,11 +31,6 @@ class G1Analytics;
 class G1CollectedHeap;
 
 class G1HeapSizingPolicy: public CHeapObj<mtGC> {
-  // MinOverThresholdForGrowth must be less than the number of recorded
-  // pause times in G1Analytics, representing the minimum number of pause
-  // time ratios that exceed GCTimeRatio before a heap expansion will be triggered.
-  const static uint MinOverThresholdForGrowth = 4;
-
   const G1CollectedHeap* _g1h;
   const G1Analytics* _analytics;
 

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -308,6 +308,15 @@
           "disables this check.")                                           \
           range(0.0, (double)max_uintx)                                     \
                                                                             \
+  product(bool, G1ScaleWithHeapPauseTimeThreshold, true, EXPERIMENTAL,      \
+        "If true, pause time threshold is linearly lowered for heap "       \
+        "smaller than 1/2 of max heap size: the smaller the heap the "      \
+        "smaller pause time threshold. For heap larger than 1/2 of max "    \
+        "heap size the pause time threshold is equal to "                   \
+        "1.0 / (1.0 + GCTimeRatio). If false, pause time threshold is "     \
+        "always equal to 1.0 / (1.0 + GCTimeRatio) regardless of the "      \
+        "current heap size.")                                               \
+                                                                            \
   product(uint, G1RemSetFreeMemoryRescheduleDelayMillis, 10, EXPERIMENTAL,  \
           "Time after which the card set free memory task reschedules "     \
           "itself if there is work remaining.")                             \

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -317,6 +317,17 @@
         "always equal to 1.0 / (1.0 + GCTimeRatio) regardless of the "      \
         "current heap size.")                                               \
                                                                             \
+  product(uintx, G1MinPausesOverThresholdForGrowth, 4, EXPERIMENTAL,        \
+          "Number of recent pause time ratios which exceed the pause time " \
+          "threshold that trigger heap expansion. The pause time ratio is " \
+          "the pause time of last GC pause divided by the time since end "  \
+          "of previous GC pause. Pause time threshold is determined by "    \
+          "GCTimeRatio and G1ScaleWithHeapPauseTimeThreshold. Must be an "  \
+          "integer between 1 and 10. 1 means most aggressive heap "         \
+          "expansion, 10 means least aggressive heap expansion. The "       \
+          "default is 4.")                                                  \
+          range(1, 10)                                                      \
+                                                                            \
   product(uint, G1RemSetFreeMemoryRescheduleDelayMillis, 10, EXPERIMENTAL,  \
           "Time after which the card set free memory task reschedules "     \
           "itself if there is work remaining.")                             \


### PR DESCRIPTION
**Context and Motivation**

In multi-tenant environments e.g. Kubernetes clusters in cloud environments there is a strong incentive to use as little memory as possible. Lower memory usage means more processes can be packed on a single VM which directly translates to lower cloud cost.
Configuring G1 heap size in this setup is currently challenging. On the one hand we would like to set the max heap size to a high value so that application doesn’t fail with heap OOME when faced with unexpectedly high load or organic growth. On the other hand we need to set max heap size to as small a value as possible because G1 is very eager to expand heap even when tuned to collect garbage aggressively.
Ideally, we would like to:
- Set the initial heap size to a small value.
- Set the max heap size to a value larger than expected usage so that application can handle unexpected load and organic growth.
- Configure G1 GC to not expand heap aggressively. This is currently not possible.

We propose two new JVM G1 flags that would give us more control over G1 heap expansion aggressiveness and realize significant cost savings in multi-tenant environments.
At the same time we don’t want to change existing G1 behavior - with default values of the new flags current G1 behavior would be maintained.

**Analysis**

Currently even with very aggressive G1 configuration such as:
```
-XX:-G1UseAdaptiveIHOP -XX:InitiatingHeapOccupancyPercent=20 -XX:GCTimeRatio=4 -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=60
```
the heap is fairly eagerly expanded.

We found two culprits responsible for this in `G1HeapSizingPolicy::young_collection_expansion_amount()` function.

First, the `scale_with_heap()` function makes `pause_time_threshold` small in cases where current heap size is smaller than 1/2 of max heap size. While it is likely a desired behavior in many situations, it also causes memory usage spikes in situations where max heap size is much larger than current heap size.

Second, the `MinOverThresholdForGrowth` constant equal to 4 is an arbitrary value which hardcodes the heap expansion aggressiveness. We observed that `short_term_pause_time_ratio` can exceed `pause_time_threshold` and trigger heap expansion too eagerly in many situations, especially when allocation rate is spiky.

**Proposal**

We would like to introduce two new experimental flags:
- `G1ScaleWithHeapPauseTimeThreshold`: a binary flag that would allow disabling scale_with_heap()
- `G1MinPausesOverThresholdForGrowth`: a value between 1 and 10, a configurable replacement for the `MinOverThresholdForGrowth` constant.
We don’t want to change the default behavior of G1. Default values for these flags (`G1ScaleWithHeapPauseTimeThreshold=true`,`G1MinPausesOverThresholdForGrowth=4`) would maintain the existing behavior.

**Alternatives**

There is currently no good alternative. Potentially we could configure G1 aggressively to trigger GC very frequently e.g.:
```
-XX:-G1UseAdaptiveIHOP -XX:InitiatingHeapOccupancyPercent=20 -XX:GCTimeRatio=4 -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=60
```
Even with this configuration we see occasional large memory spikes where heap is quickly expanded. Even though the expanded heap contracts eventually, this poses a significant problem because in practice we don’t know if such a spike could have been avoided so it is not obvious how much memory the application really needs. Of course such configuration would also consume more CPU.

**Experimental results**
We tested this change on patched jdk17.
With new flags we can use far less aggressive `-XX:GCTimeRatio=9` and still depend on adaptive IHOP. Together with `-XX:-G1ScaleWithHeapPauseTimeThreshold` and `-XX:G1MinPausesOverThresholdForGrowth=10` (this effectively disables heap expansion based on short time pause ratio and only depends on long time pause ratio).

Compared to more aggressive G1 configuration mentioned above we see lower CPU usage, and 30%-60% lower max memory usage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23534/head:pull/23534` \
`$ git checkout pull/23534`

Update a local copy of the PR: \
`$ git checkout pull/23534` \
`$ git pull https://git.openjdk.org/jdk.git pull/23534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23534`

View PR using the GUI difftool: \
`$ git pr show -t 23534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23534.diff">https://git.openjdk.org/jdk/pull/23534.diff</a>

</details>
