### PR TITLE
java.net.URI.scanIPv4Address throws unnecessary URISyntaxException

### DIFF
--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -3466,7 +3466,6 @@ public final class URI
                 if (q < m) break;
                 return q;
             }
-            fail("Malformed IPv4 address", q);
             return -1;
         }
 
@@ -3495,12 +3494,16 @@ public final class URI
                 return -1;
             }
 
+            if (p == -1) {
+                return p;
+            }
+
             if (p > start && p < n) {
                 // IPv4 address is followed by something - check that
                 // it's a ":" as this is the only valid character to
                 // follow an address.
                 if (input.charAt(p) != ':') {
-                    p = -1;
+                    return -1;
                 }
             }
 


### PR DESCRIPTION
`java.net.URI.scanIPv4Address` is a private method, it is only called by `java.net.URI.takeIPv4Address` and `java.net.URI.parseIPv4Address`, the URISyntaxException("Malformed IPv4 address") is not necessary, returning -1 should be good. In one of our systems, we noticed the exception consumes ~0.3% CPU.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23537/head:pull/23537` \
`$ git checkout pull/23537`

Update a local copy of the PR: \
`$ git checkout pull/23537` \
`$ git pull https://git.openjdk.org/jdk.git pull/23537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23537`

View PR using the GUI difftool: \
`$ git pr show -t 23537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23537.diff">https://git.openjdk.org/jdk/pull/23537.diff</a>

</details>
