### PR TITLE
8349702: jdk.internal.net.http.Http2Connection::putStream needs to provide cause while cancelling stream

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1602,7 +1602,12 @@ class Http2Connection  {
             stateLock.unlock();
         }
         if (debug.on()) debug.log("connection closed: closing stream %d", stream);
-        stream.cancel();
+        Throwable reason = cause.get();
+        if (reason == null) {
+            stream.cancel();
+        } else {
+            stream.cancelImpl(reason);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes stream cancellation in `Http2Connection::putStream`. See comments in the ticket for details on the issue. `tier1,2` results are attached to the ticket too.