### PR TITLE
8349752: Tier1 build failure caused by JDK-8349178

### DIFF
--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -863,11 +863,11 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_HOTSPOT_JTREG_EXECUTABLES_JDK_LIBS_exeinvoke := java.base:libjvm
   BUILD_HOTSPOT_JTREG_EXECUTABLES_JDK_LIBS_exestack-gap := java.base:libjvm
   BUILD_HOTSPOT_JTREG_EXECUTABLES_JDK_LIBS_exestack-tls := java.base:libjvm
-  BUILD_HOTSPOT_JTREG_LIBRARIES_JDK_LIBS_libatExit := -ldl
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exeinvoke := -lpthread
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exestack-gap := -lpthread
   BUILD_TEST_exeinvoke_exeinvoke.c_OPTIMIZATION := NONE
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exeFPRegs := -ldl
+  BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libatExit += -ldl
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetCallTraceTest := -ldl
   BUILD_HOTSPOT_JTREG_LIBRARIES_LDFLAGS_libfast-math := -ffast-math
 else

--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -863,6 +863,7 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_HOTSPOT_JTREG_EXECUTABLES_JDK_LIBS_exeinvoke := java.base:libjvm
   BUILD_HOTSPOT_JTREG_EXECUTABLES_JDK_LIBS_exestack-gap := java.base:libjvm
   BUILD_HOTSPOT_JTREG_EXECUTABLES_JDK_LIBS_exestack-tls := java.base:libjvm
+  BUILD_HOTSPOT_JTREG_LIBRARIES_JDK_LIBS_libatExit := -ldl
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exeinvoke := -lpthread
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exestack-gap := -lpthread
   BUILD_TEST_exeinvoke_exeinvoke.c_OPTIMIZATION := NONE


### PR DESCRIPTION
Add `BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libatExit += -ldl` for linux target.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349752](https://bugs.openjdk.org/browse/JDK-8349752): Tier1 build failure caused by JDK-8349178 (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23544/head:pull/23544` \
`$ git checkout pull/23544`

Update a local copy of the PR: \
`$ git checkout pull/23544` \
`$ git pull https://git.openjdk.org/jdk.git pull/23544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23544`

View PR using the GUI difftool: \
`$ git pr show -t 23544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23544.diff">https://git.openjdk.org/jdk/pull/23544.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23544#issuecomment-2649143437)
</details>
