### PR TITLE
6562489: Font-Renderer should ignore invisible characters \u2062 and \u2063

### DIFF
--- a/test/jdk/java/awt/font/TextLayout/FormatCharAdvanceTest.java
+++ b/test/jdk/java/awt/font/TextLayout/FormatCharAdvanceTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8208377
+ * @bug 8208377 6562489
  * @summary Confirm that format-category glyphs are not rendered or measured.
  */
 
@@ -174,6 +174,9 @@ public class FormatCharAdvanceTest {
         testChar('\u202D', image, g2d, font); // left-to-right override (LRO)
         testChar('\u202E', image, g2d, font); // right-to-left override (RLO)
         testChar('\u2060', image, g2d, font); // word joiner (WJ)
+        testChar('\u2061', image, g2d, font); // function application
+        testChar('\u2062', image, g2d, font); // invisible times
+        testChar('\u2063', image, g2d, font); // invisible separator
         testChar('\u2066', image, g2d, font); // left-to-right isolate (LRI)
         testChar('\u2067', image, g2d, font); // right-to-left isolate (RLI)
         testChar('\u2068', image, g2d, font); // first strong isolate (FSI)


### PR DESCRIPTION
Expands regression test to cover bug JDK-6562489.

No additional fix is required after the JDK-8208377 fix (see #22670).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6562489](https://bugs.openjdk.org/browse/JDK-6562489): Font-Renderer should ignore invisible characters \u2062 and \u2063 (**Bug** - P4)


### Reviewers
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23547/head:pull/23547` \
`$ git checkout pull/23547`

Update a local copy of the PR: \
`$ git checkout pull/23547` \
`$ git pull https://git.openjdk.org/jdk.git pull/23547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23547`

View PR using the GUI difftool: \
`$ git pr show -t 23547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23547.diff">https://git.openjdk.org/jdk/pull/23547.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23547#issuecomment-2649634311)
</details>
