### PR TITLE
8349689: Several virtual thread tests missing /native keyword

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/JfrEvents.java
+++ b/test/jdk/java/lang/Thread/virtual/JfrEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @requires vm.continuations
  * @modules jdk.jfr java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm --enable-native-access=ALL-UNNAMED JfrEvents
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED JfrEvents
  */
 
 import java.io.IOException;

--- a/test/jdk/java/lang/Thread/virtual/MonitorEnterExit.java
+++ b/test/jdk/java/lang/Thread/virtual/MonitorEnterExit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm --enable-native-access=ALL-UNNAMED MonitorEnterExit
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED MonitorEnterExit
  */
 
 /*
@@ -35,7 +35,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
+ * @run junit/othervm/native -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
  */
 
 /*
@@ -43,7 +43,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
+ * @run junit/othervm/native -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
  */
 
 /*
@@ -51,7 +51,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xint -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
+ * @run junit/othervm/native -Xint -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
  */
 
 /*
@@ -59,7 +59,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xint -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
+ * @run junit/othervm/native -Xint -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
  */
 
 /*
@@ -67,7 +67,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
+ * @run junit/othervm/native -Xcomp -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
  */
 
 /*
@@ -75,7 +75,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
+ * @run junit/othervm/native -Xcomp -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
  */
 
 /*
@@ -83,7 +83,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
+ * @run junit/othervm/native -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
  */
 
 /*
@@ -91,7 +91,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
+ * @run junit/othervm/native -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
  */
 
 /*
@@ -99,7 +99,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:-TieredCompilation -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
+ * @run junit/othervm/native -Xcomp -XX:-TieredCompilation -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
  */
 
 /*
@@ -107,7 +107,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:-TieredCompilation -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
+ * @run junit/othervm/native -Xcomp -XX:-TieredCompilation -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
  */
 
 import java.time.Duration;

--- a/test/jdk/java/lang/Thread/virtual/MonitorWaitNotify.java
+++ b/test/jdk/java/lang/Thread/virtual/MonitorWaitNotify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm --enable-native-access=ALL-UNNAMED MonitorWaitNotify
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED MonitorWaitNotify
  */
 
 /*
@@ -35,7 +35,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
+ * @run junit/othervm/native -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
  */
 
 /*
@@ -43,7 +43,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
+ * @run junit/othervm/native -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
  */
 
 /*
@@ -51,7 +51,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xint -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
+ * @run junit/othervm/native -Xint -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
  */
 
 /*
@@ -59,7 +59,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xint -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
+ * @run junit/othervm/native -Xint -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
  */
 
 /*
@@ -67,7 +67,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
+ * @run junit/othervm/native -Xcomp -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
  */
 
 /*
@@ -75,7 +75,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
+ * @run junit/othervm/native -Xcomp -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
  */
 
 /*
@@ -83,7 +83,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
+ * @run junit/othervm/native -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
  */
 
 /*
@@ -91,7 +91,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
+ * @run junit/othervm/native -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
  */
 
 /*
@@ -99,7 +99,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:-TieredCompilation -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
+ * @run junit/othervm/native -Xcomp -XX:-TieredCompilation -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
  */
 
 /*
@@ -107,7 +107,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -Xcomp -XX:-TieredCompilation -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
+ * @run junit/othervm/native -Xcomp -XX:-TieredCompilation -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
  */
 
 import java.util.ArrayList;

--- a/test/jdk/java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  * @modules java.base/java.lang:+open
  * @library /test/lib
  * @requires vm.opt.LockingMode != 1
- * @run main/othervm --enable-native-access=ALL-UNNAMED RetryMonitorEnterWhenPinned
+ * @run main/othervm/native --enable-native-access=ALL-UNNAMED RetryMonitorEnterWhenPinned
  */
 
 import java.time.Duration;

--- a/test/jdk/java/lang/Thread/virtual/Starvation.java
+++ b/test/jdk/java/lang/Thread/virtual/Starvation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @requires vm.continuations
  * @library /test/lib
  * @bug 8345294
- * @run main/othervm --enable-native-access=ALL-UNNAMED Starvation 100000
+ * @run main/othervm/timeout=200/native --enable-native-access=ALL-UNNAMED Starvation 100000
  */
 
 import java.time.Duration;

--- a/test/jdk/java/lang/Thread/virtual/SynchronizedNative.java
+++ b/test/jdk/java/lang/Thread/virtual/SynchronizedNative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 /*
@@ -36,7 +36,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm -Xint --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/native -Xint --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 /*
@@ -44,7 +44,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm -Xcomp -XX:TieredStopAtLevel=1 --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/native -Xcomp -XX:TieredStopAtLevel=1 --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 /*
@@ -52,7 +52,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm -Xcomp -XX:-TieredCompilation --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/native -Xcomp -XX:-TieredCompilation --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 import java.util.concurrent.CountDownLatch;

--- a/test/jdk/java/lang/Thread/virtual/ThreadAPI.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm --enable-native-access=ALL-UNNAMED ThreadAPI
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED ThreadAPI
  */
 
 /*
@@ -37,7 +37,7 @@
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
- * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations
+ * @run junit/othervm/native -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations
  *     --enable-native-access=ALL-UNNAMED ThreadAPI
  */
 

--- a/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
@@ -36,7 +36,8 @@
  * @summary Test that Thread.yield loop polls for safepoints
  * @requires vm.continuations & vm.compMode != "Xcomp"
  * @library /test/lib
- * @run junit/othervm/native --enable-native-access=ALL-UNNAMED -Xcomp -XX:-TieredCompilation -XX:CompileCommand=inline,*::yield* -XX:CompileCommand=inline,*::*Yield ThreadPollOnYield
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED -Xcomp -XX:-TieredCompilation
+ *                           -XX:CompileCommand=inline,*::yield* -XX:CompileCommand=inline,*::*Yield ThreadPollOnYield
  */
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
@@ -47,10 +47,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ThreadPollOnYield {
-    public static volatile boolean flag = false;
     static void foo(AtomicBoolean done) {
         while (!done.get()) {
-            flag = true;
             Thread.yield();
         }
     }
@@ -65,9 +63,6 @@ class ThreadPollOnYield {
         done.set(true);
         vthread.join();
 
-        if (flag != true) {
-            throw new RuntimeException("flag = " + flag);
-        }
         System.out.println("First vthread done");
 
         AtomicBoolean done2 = new AtomicBoolean();

--- a/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Test that Thread.yield loop polls for safepoints
  * @requires vm.continuations
  * @library /test/lib
- * @run junit/othervm ThreadPollOnYield
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED ThreadPollOnYield
  */
 
 /*
@@ -36,7 +36,7 @@
  * @summary Test that Thread.yield loop polls for safepoints
  * @requires vm.continuations & vm.compMode != "Xcomp"
  * @library /test/lib
- * @run junit/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=inline,*::yield* -XX:CompileCommand=inline,*::*Yield ThreadPollOnYield
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED -Xcomp -XX:-TieredCompilation -XX:CompileCommand=inline,*::yield* -XX:CompileCommand=inline,*::*Yield ThreadPollOnYield
  */
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -46,8 +46,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ThreadPollOnYield {
+    public static volatile boolean flag = false;
     static void foo(AtomicBoolean done) {
         while (!done.get()) {
+            flag = true;
             Thread.yield();
         }
     }
@@ -62,6 +64,9 @@ class ThreadPollOnYield {
         done.set(true);
         vthread.join();
 
+        if (flag != true) {
+            throw new RuntimeException("flag = " + flag);
+        }
         System.out.println("First vthread done");
 
         AtomicBoolean done2 = new AtomicBoolean();

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @requires vm.debug != true
  * @modules jdk.management
  * @library /test/lib
- * @run main/othervm/timeout=300 --enable-native-access=ALL-UNNAMED GetStackTraceALotWhenPinned 100000
+ * @run main/othervm/native/timeout=300 --enable-native-access=ALL-UNNAMED GetStackTraceALotWhenPinned 100000
  */
 
 /*
@@ -36,7 +36,7 @@
  * @requires vm.debug == true
  * @modules jdk.management
  * @library /test/lib
- * @run main/othervm/timeout=300 --enable-native-access=ALL-UNNAMED GetStackTraceALotWhenPinned 50000
+ * @run main/othervm/native/timeout=300 --enable-native-access=ALL-UNNAMED GetStackTraceALotWhenPinned 50000
  */
 
 import java.time.Instant;

--- a/test/jdk/java/lang/Thread/virtual/stress/PinALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/PinALot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,14 +26,14 @@
  * @summary Stress test timed park when pinned
  * @requires vm.debug != true
  * @library /test/lib
- * @run main/othervm --enable-native-access=ALL-UNNAMED PinALot 500000
+ * @run main/othervm/native --enable-native-access=ALL-UNNAMED PinALot 500000
  */
 
 /*
  * @test
  * @requires vm.debug == true
  * @library /test/lib
- * @run main/othervm/timeout=300 --enable-native-access=ALL-UNNAMED PinALot 200000
+ * @run main/othervm/native/timeout=300 --enable-native-access=ALL-UNNAMED PinALot 200000
  */
 
 import java.time.Duration;

--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
@@ -27,7 +27,7 @@
  * @summary Test java.lang.management.ThreadMXBean with virtual threads
  * @modules java.base/java.lang:+open java.management
  * @library /test/lib
- * @run junit/othervm VirtualThreads
+ * @run junit/othervm/native VirtualThreads
  */
 
 /**

--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
@@ -27,7 +27,7 @@
  * @summary Test java.lang.management.ThreadMXBean with virtual threads
  * @modules java.base/java.lang:+open java.management
  * @library /test/lib
- * @run junit/othervm/native VirtualThreads
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED VirtualThreads
  */
 
 /**

--- a/test/jdk/java/nio/channels/vthread/SelectorOps.java
+++ b/test/jdk/java/nio/channels/vthread/SelectorOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,22 +25,22 @@
  * @test id=default
  * @summary Test virtual threads doing selection operations
  * @library /test/lib
- * @run junit/othervm --enable-native-access=ALL-UNNAMED SelectorOps
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED SelectorOps
  */
 
 /*
  * @test id=poller-modes
  * @requires (os.family == "linux") | (os.family == "mac")
  * @library /test/lib
- * @run junit/othervm -Djdk.pollerMode=1 --enable-native-access=ALL-UNNAMED SelectorOps
- * @run junit/othervm -Djdk.pollerMode=2 --enable-native-access=ALL-UNNAMED SelectorOps
+ * @run junit/othervm/native -Djdk.pollerMode=1 --enable-native-access=ALL-UNNAMED SelectorOps
+ * @run junit/othervm/native -Djdk.pollerMode=2 --enable-native-access=ALL-UNNAMED SelectorOps
  */
 
 /*
  * @test id=no-vmcontinuations
  * @requires vm.continuations
  * @library /test/lib
- * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations
+ * @run junit/othervm/native -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations
  *     --enable-native-access=ALL-UNNAMED SelectorOps
  */
 


### PR DESCRIPTION
H all,

This PR add `/native` keyword in the test header for virtual thread tests. The `/native` keyword will make run the related tests by jtreg standalone more friendly.

I runed all the tests without -nativepath argument and find the fail tests. This will find all the virtual thread tests which missing '/native' flag.

1. java/lang/management/ThreadMXBean/VirtualThreads.java#default

VirtualThreads.java:223 call "invoker()" in test/lib/jdk/test/lib/thread/VThreadPinner.java file, which will call the native function "call".
java/lang/management/ThreadMXBean/VirtualThreads.java#no-vmcontinuations run this test with VM option "-XX:-VMContinuations" and `assumeTrue(VThreadScheduler.supportsCustomScheduler(), "No support for custom schedulers");` will make junit skip the 'testGetThreadInfoCarrierThread' unit test, so 'VirtualThreads.java#no-vmcontinuations' do not need '/native' keywork.

2. java/lang/Thread/virtual/stress/PinALot.java

PinALot.java:58 call "invoker()" in test/lib/jdk/test/lib/thread/VThreadPinner.java file, which will call the native function "call".

3. java/lang/Thread/virtual/SynchronizedNative.java

Call System.loadLibrary("SynchronizedNative") at line 85.

4. Tests java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java, java/lang/Thread/virtual/ThreadAPI.java, java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java, java/lang/Thread/virtual/MonitorWaitNotify.java, java/lang/Thread/virtual/MonitorPinnedEvents.java, java/lang/Thread/virtual/MonitorEnterExit.java and other tests are similar to java/lang/Thread/virtual/stress/PinALot.java


- Why we need the '/native' keywork?

I usually run the tests through jtreg directively, rather than run the tests through make test. If I run the test which load the native shared library files and the test missing '/native' keyword but I forgot to pass the '-nativepath' argument to jtreg, or pass the incorrect '-nativepath' argument to jtreg, sometimes it will report timeouted after a long time, such as java/lang/Thread/virtual/JfrEvents.java. If we add the missing '/native' keywork, jtreg will report 'Error. Use -nativepath to specify the location of native code' right away. So add the missing '/native' keyword will make run the tests more friendly.

Change has been verified locally, test-fix, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349689](https://bugs.openjdk.org/browse/JDK-8349689): Several virtual thread tests missing /native keyword (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23550/head:pull/23550` \
`$ git checkout pull/23550`

Update a local copy of the PR: \
`$ git checkout pull/23550` \
`$ git pull https://git.openjdk.org/jdk.git pull/23550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23550`

View PR using the GUI difftool: \
`$ git pr show -t 23550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23550.diff">https://git.openjdk.org/jdk/pull/23550.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23550#issuecomment-2649693518)
</details>
