### PR TITLE
8349764: RISC-V: C1: Improve Class.isInstance intrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
@@ -1104,7 +1104,7 @@ void LIRGenerator::do_InstanceOf(InstanceOf* x) {
 
 // Intrinsic for Class::isInstance
 address LIRGenerator::isInstance_entry() {
-  return CAST_FROM_FN_PTR(address, Runtime1::is_instance_of);
+  return Runtime1::entry_for(C1StubId::is_instance_of_id);
 }
 
 void LIRGenerator::do_If(If* x) {

--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -950,7 +950,8 @@ OopMapSet* Runtime1::generate_code_for(C1StubId id, StubAssembler* sasm) {
         __ add(x17, x15, x13);
         __ ld(x17, Address(x17));
         __ beq(klass, x17, success);
-        __ j(fail);
+        __ mv(result, 0);
+        __ ret();
 
         __ bind(is_secondary);
         __ load_klass(obj, obj);

--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -949,15 +949,11 @@ OopMapSet* Runtime1::generate_code_for(C1StubId id, StubAssembler* sasm) {
         __ load_klass(x15, obj);
         __ add(x17, x15, x13);
         __ ld(x17, Address(x17));
-        Label L_OK;
-        __ mv(result, 1);
-        __ beq(klass, x17, L_OK);
+        __ beq(klass, x17, success);
         __ mv(result, 0);
-        __ bind(L_OK);
         __ ret();
 
         __ bind(is_secondary);
-
         __ load_klass(obj, obj);
 
         // This is necessary because I am never in my own secondary_super list.

--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -927,14 +927,14 @@ OopMapSet* Runtime1::generate_code_for(C1StubId id, StubAssembler* sasm) {
 
     case C1StubId::is_instance_of_id:
       {
-        // Mirror: c_rarg0
-        // Object: c_rarg1
+        // Mirror: x10
+        // Object: x11
         // Temps: x13, x14, x15, x16, x17
         // Result: x10
 
-        // Get the Klass* into c_rarg6
-        Register klass = c_rarg6, obj = c_rarg1, result = x10;
-        __ ld(klass, Address(c_rarg0, java_lang_Class::klass_offset()));
+        // Get the Klass* into x16
+        Register klass = x16, obj = x11, result = x10;
+        __ ld(klass, Address(x10, java_lang_Class::klass_offset()));
 
         Label fail, is_secondary, success;
 
@@ -950,8 +950,7 @@ OopMapSet* Runtime1::generate_code_for(C1StubId id, StubAssembler* sasm) {
         __ add(x17, x15, x13);
         __ ld(x17, Address(x17));
         __ beq(klass, x17, success);
-        __ mv(result, 0);
-        __ ret();
+        __ j(fail);
 
         __ bind(is_secondary);
         __ load_klass(obj, obj);
@@ -960,6 +959,7 @@ OopMapSet* Runtime1::generate_code_for(C1StubId id, StubAssembler* sasm) {
         __ beq(obj, klass, success);
 
         __ lookup_secondary_supers_table_var(obj, klass, result, x13, x14, x15, x17, &success);
+
         __ bind(fail);
         __ mv(result, 0);
         __ ret();


### PR DESCRIPTION
Follow this patch https://github.com/openjdk/jdk/pull/22491, RISC-V implementation for Class.isInstance intrinsic.


### JMH numbers (tested on milkv megrez with hotspot client build):

#### before this patch:
```
Benchmark                             Mode  Cnt    Score   Error  Units
SecondarySupersLookup.testNegative00  avgt   15   48.589 ± 0.981  ns/op
SecondarySupersLookup.testNegative01  avgt   15   48.577 ± 0.297  ns/op
SecondarySupersLookup.testNegative02  avgt   15   48.760 ± 0.740  ns/op
SecondarySupersLookup.testNegative03  avgt   15   48.442 ± 0.029  ns/op
SecondarySupersLookup.testNegative04  avgt   15   48.453 ± 0.095  ns/op
SecondarySupersLookup.testNegative05  avgt   15   48.435 ± 0.025  ns/op
SecondarySupersLookup.testNegative06  avgt   15   48.540 ± 0.476  ns/op
SecondarySupersLookup.testNegative07  avgt   15   48.452 ± 0.032  ns/op
SecondarySupersLookup.testNegative08  avgt   15   48.466 ± 0.034  ns/op
SecondarySupersLookup.testNegative09  avgt   15   48.478 ± 0.132  ns/op
SecondarySupersLookup.testNegative10  avgt   15   48.435 ± 0.032  ns/op
SecondarySupersLookup.testNegative16  avgt   15   48.440 ± 0.027  ns/op
SecondarySupersLookup.testNegative20  avgt   15   47.977 ± 0.989  ns/op
SecondarySupersLookup.testNegative30  avgt   15   48.655 ± 0.487  ns/op
SecondarySupersLookup.testNegative32  avgt   15   48.566 ± 0.251  ns/op
SecondarySupersLookup.testNegative40  avgt   15   48.513 ± 0.196  ns/op
SecondarySupersLookup.testNegative50  avgt   15   48.454 ± 0.075  ns/op
SecondarySupersLookup.testNegative55  avgt   15   71.670 ± 1.632  ns/op
SecondarySupersLookup.testNegative56  avgt   15   70.923 ± 1.679  ns/op
SecondarySupersLookup.testNegative57  avgt   15   70.140 ± 0.048  ns/op
SecondarySupersLookup.testNegative58  avgt   15   70.473 ± 0.726  ns/op
SecondarySupersLookup.testNegative59  avgt   15   70.127 ± 0.022  ns/op
SecondarySupersLookup.testNegative60  avgt   15   82.525 ± 1.178  ns/op
SecondarySupersLookup.testNegative61  avgt   15   81.647 ± 0.758  ns/op
SecondarySupersLookup.testNegative62  avgt   15   82.347 ± 1.943  ns/op
SecondarySupersLookup.testNegative63  avgt   15  129.188 ± 1.550  ns/op
SecondarySupersLookup.testNegative64  avgt   15  130.274 ± 1.668  ns/op
SecondarySupersLookup.testPositive01  avgt   15   63.390 ± 0.222  ns/op
SecondarySupersLookup.testPositive02  avgt   15   63.435 ± 0.027  ns/op
SecondarySupersLookup.testPositive03  avgt   15   63.469 ± 0.080  ns/op
SecondarySupersLookup.testPositive04  avgt   15   63.896 ± 1.008  ns/op
SecondarySupersLookup.testPositive05  avgt   15   63.457 ± 0.035  ns/op
SecondarySupersLookup.testPositive06  avgt   15   63.235 ± 0.261  ns/op
SecondarySupersLookup.testPositive07  avgt   15   63.455 ± 0.022  ns/op
SecondarySupersLookup.testPositive08  avgt   15   63.672 ± 0.480  ns/op
SecondarySupersLookup.testPositive09  avgt   15   63.458 ± 0.028  ns/op
SecondarySupersLookup.testPositive10  avgt   15   63.365 ± 0.220  ns/op
SecondarySupersLookup.testPositive16  avgt   15   63.279 ± 0.278  ns/op
SecondarySupersLookup.testPositive20  avgt   15   63.239 ± 0.309  ns/op
SecondarySupersLookup.testPositive30  avgt   15   63.357 ± 0.238  ns/op
SecondarySupersLookup.testPositive32  avgt   15   63.902 ± 0.981  ns/op
SecondarySupersLookup.testPositive40  avgt   15   61.624 ± 1.551  ns/op
SecondarySupersLookup.testPositive50  avgt   15   63.347 ± 0.217  ns/op
SecondarySupersLookup.testPositive60  avgt   15   61.963 ± 0.848  ns/op
SecondarySupersLookup.testPositive63  avgt   15  114.361 ± 1.086  ns/op
SecondarySupersLookup.testPositive64  avgt   15  129.291 ± 0.228  ns/op
Finished running test 'micro:vm.lang.SecondarySupersLookup'
```

#### apply this patch:
```
Benchmark                             Mode  Cnt    Score   Error  Units
SecondarySupersLookup.testNegative00  avgt   15   29.739 ± 1.085  ns/op
SecondarySupersLookup.testNegative01  avgt   15   29.377 ± 0.704  ns/op
SecondarySupersLookup.testNegative02  avgt   15   30.091 ± 0.994  ns/op
SecondarySupersLookup.testNegative03  avgt   15   30.293 ± 0.743  ns/op
SecondarySupersLookup.testNegative04  avgt   15   30.305 ± 0.750  ns/op
SecondarySupersLookup.testNegative05  avgt   15   31.173 ± 1.826  ns/op
SecondarySupersLookup.testNegative06  avgt   15   30.355 ± 1.294  ns/op
SecondarySupersLookup.testNegative07  avgt   15   29.967 ± 1.481  ns/op
SecondarySupersLookup.testNegative08  avgt   15   30.003 ± 0.914  ns/op
SecondarySupersLookup.testNegative09  avgt   15   29.869 ± 0.947  ns/op
SecondarySupersLookup.testNegative10  avgt   15   29.764 ± 0.807  ns/op
SecondarySupersLookup.testNegative16  avgt   15   29.849 ± 0.922  ns/op
SecondarySupersLookup.testNegative20  avgt   15   29.331 ± 0.775  ns/op
SecondarySupersLookup.testNegative30  avgt   15   29.624 ± 0.894  ns/op
SecondarySupersLookup.testNegative32  avgt   15   29.981 ± 0.897  ns/op
SecondarySupersLookup.testNegative40  avgt   15   30.317 ± 1.399  ns/op
SecondarySupersLookup.testNegative50  avgt   15   30.643 ± 0.046  ns/op
SecondarySupersLookup.testNegative55  avgt   15   39.532 ± 1.233  ns/op
SecondarySupersLookup.testNegative56  avgt   15   39.051 ± 0.195  ns/op
SecondarySupersLookup.testNegative57  avgt   15   40.058 ± 1.319  ns/op
SecondarySupersLookup.testNegative58  avgt   15   39.070 ± 0.112  ns/op
SecondarySupersLookup.testNegative59  avgt   15   39.045 ± 0.101  ns/op
SecondarySupersLookup.testNegative60  avgt   15   47.358 ± 0.047  ns/op
SecondarySupersLookup.testNegative61  avgt   15   48.375 ± 1.612  ns/op
SecondarySupersLookup.testNegative62  avgt   15   47.392 ± 0.107  ns/op
SecondarySupersLookup.testNegative63  avgt   15  102.903 ± 0.471  ns/op
SecondarySupersLookup.testNegative64  avgt   15  103.617 ± 0.071  ns/op
SecondarySupersLookup.testPositive01  avgt   15   39.182 ± 0.305  ns/op
SecondarySupersLookup.testPositive02  avgt   15   39.161 ± 0.313  ns/op
SecondarySupersLookup.testPositive03  avgt   15   39.292 ± 0.304  ns/op
SecondarySupersLookup.testPositive04  avgt   15   38.955 ± 0.394  ns/op
SecondarySupersLookup.testPositive05  avgt   15   39.074 ± 0.242  ns/op
SecondarySupersLookup.testPositive06  avgt   15   39.411 ± 0.979  ns/op
SecondarySupersLookup.testPositive07  avgt   15   38.907 ± 0.945  ns/op
SecondarySupersLookup.testPositive08  avgt   15   38.956 ± 0.013  ns/op
SecondarySupersLookup.testPositive09  avgt   15   38.843 ± 0.242  ns/op
SecondarySupersLookup.testPositive10  avgt   15   38.763 ± 0.276  ns/op
SecondarySupersLookup.testPositive16  avgt   15   39.396 ± 0.476  ns/op
SecondarySupersLookup.testPositive20  avgt   15   39.187 ± 0.291  ns/op
SecondarySupersLookup.testPositive30  avgt   15   39.056 ± 0.242  ns/op
SecondarySupersLookup.testPositive32  avgt   15   39.180 ± 0.305  ns/op
SecondarySupersLookup.testPositive40  avgt   15   38.521 ± 0.255  ns/op
SecondarySupersLookup.testPositive50  avgt   15   38.957 ± 0.007  ns/op
SecondarySupersLookup.testPositive60  avgt   15   38.415 ± 0.020  ns/op
SecondarySupersLookup.testPositive63  avgt   15   88.788 ± 1.223  ns/op
SecondarySupersLookup.testPositive64  avgt   15  104.534 ± 1.687  ns/op
```

### Testing
- [x] Run tier1-3 tests on SOPHON SG2042 (release)
- [x] Run tier1-3 tests on MILK-V MEGREZ (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349764](https://bugs.openjdk.org/browse/JDK-8349764): RISC-V: C1: Improve Class.isInstance intrinsic (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23551/head:pull/23551` \
`$ git checkout pull/23551`

Update a local copy of the PR: \
`$ git checkout pull/23551` \
`$ git pull https://git.openjdk.org/jdk.git pull/23551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23551`

View PR using the GUI difftool: \
`$ git pr show -t 23551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23551.diff">https://git.openjdk.org/jdk/pull/23551.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23551#issuecomment-2650022727)
</details>
