### PR TITLE
8349771: Replace usages of -mx and -ms in some monitor tests

### DIFF
--- a/test/hotspot/jtreg/runtime/Monitor/StressWrapper_TestRecursiveLocking_36M.java
+++ b/test/hotspot/jtreg/runtime/Monitor/StressWrapper_TestRecursiveLocking_36M.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/Monitor/StressWrapper_TestRecursiveLocking_36M.java
+++ b/test/hotspot/jtreg/runtime/Monitor/StressWrapper_TestRecursiveLocking_36M.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,21 +34,21 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=0
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 1
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=1
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 1
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=2
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 1
  */
 
@@ -64,21 +64,21 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=0
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 2
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=1
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 2
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=2
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 2
  */
 
@@ -95,21 +95,21 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=0
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 1
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=1
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 1
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=2
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 1
  */
 
@@ -126,21 +126,21 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=0
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 2
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=1
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 2
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=2
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 2
  */
 
@@ -157,21 +157,21 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:-EliminateNestedLocks
  *     -XX:LockingMode=0
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 1
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:-EliminateNestedLocks
  *     -XX:LockingMode=1
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 1
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:-EliminateNestedLocks
  *     -XX:LockingMode=2
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 1
  */
 
@@ -188,20 +188,20 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:LockingMode=0
  *     -XX:-EliminateNestedLocks
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 2
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:LockingMode=1
  *     -XX:-EliminateNestedLocks
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 2
  *
  * @run main/othervm/timeout=240 -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:LockingMode=2
  *     -XX:-EliminateNestedLocks
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 120 2
  */

--- a/test/hotspot/jtreg/runtime/Monitor/TestRecursiveLocking.java
+++ b/test/hotspot/jtreg/runtime/Monitor/TestRecursiveLocking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/Monitor/TestRecursiveLocking.java
+++ b/test/hotspot/jtreg/runtime/Monitor/TestRecursiveLocking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,21 +34,21 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=0
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 1
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=1
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 1
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=2
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 1
  */
 
@@ -64,21 +64,21 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=0
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 2
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=1
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 2
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -Xint
  *     -XX:LockingMode=2
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 2
  */
 
@@ -95,21 +95,21 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=0
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 1
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=1
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 1
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=2
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 1
  */
 
@@ -126,21 +126,21 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=0
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 2
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=1
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 2
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:TieredStopAtLevel=1
  *     -XX:LockingMode=2
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 2
  */
 
@@ -157,21 +157,21 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:-EliminateNestedLocks
  *     -XX:LockingMode=0
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 1
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:-EliminateNestedLocks
  *     -XX:LockingMode=1
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 1
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:-EliminateNestedLocks
  *     -XX:LockingMode=2
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 1
  */
 
@@ -188,21 +188,21 @@
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:LockingMode=0
  *     -XX:-EliminateNestedLocks
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 2
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:LockingMode=1
  *     -XX:-EliminateNestedLocks
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 2
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:LockingMode=2
  *     -XX:-EliminateNestedLocks
- *     -ms256m -mx256m
+ *     -Xms256m -Xmx256m
  *     TestRecursiveLocking 5 2
  */
 


### PR DESCRIPTION
Hi all,
This PR updates two runtime/Monitor tests to replace the usage of the outdated `-mx` and `-ms` java launcher options with `-Xmx` and `-Xms`.

As noted in [JDK-8349771](https://bugs.openjdk.org/browse/JDK-8349771), these outdated options will soon be deprecated for removal from the java launcher code.

Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349771](https://bugs.openjdk.org/browse/JDK-8349771): Replace usages of -mx and -ms in some monitor tests (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23553/head:pull/23553` \
`$ git checkout pull/23553`

Update a local copy of the PR: \
`$ git checkout pull/23553` \
`$ git pull https://git.openjdk.org/jdk.git pull/23553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23553`

View PR using the GUI difftool: \
`$ git pr show -t 23553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23553.diff">https://git.openjdk.org/jdk/pull/23553.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23553#issuecomment-2649745694)
</details>
