### PR TITLE
8349781: make test TEST=gtest fails on WSL

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -111,8 +111,8 @@ ifneq ($(wildcard $(JTREG_FAILURE_HANDLER)), )
       #
 endif
 
-GTEST_LAUNCHER_DIRS := $(patsubst %/gtestLauncher, %, \
-    $(wildcard $(TEST_IMAGE_DIR)/hotspot/gtest/*/gtestLauncher))
+GTEST_LAUNCHER_DIRS := $(patsubst %/gtestLauncher$(EXECUTABLE_SUFFIX), %, \
+    $(wildcard $(TEST_IMAGE_DIR)/hotspot/gtest/*/gtestLauncher$(EXECUTABLE_SUFFIX)))
 GTEST_VARIANTS := $(strip $(patsubst $(TEST_IMAGE_DIR)/hotspot/gtest/%, %, \
     $(GTEST_LAUNCHER_DIRS)))
 


### PR DESCRIPTION
`make test TEST=gtest` fails to run gtest on WSL. This is because we're looking for a nonexistent file `gtestLauncher`; on Windows the file is named `gtestLauncher.exe`.

This PR adds `$EXECUTABLE_SUFFIX` to the executable path, similar to what [GtestImage.gmk already does](https://github.com/openjdk/jdk/blob/64bd8d2592d26e02a7f2f96caa47cba5e158aaa2/make/hotspot/test/GtestImage.gmk#L37).

I verified that with the proposed change, `make test TEST=gtest` works correctly both on WSL and on Cygwin. Other platforms are unaffected, because EXECUTABLE_SUFFIX is [empty on all non-Windows platforms](https://github.com/openjdk/jdk/blob/64bd8d2592d26e02a7f2f96caa47cba5e158aaa2/make/autoconf/toolchain.m4#L188).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8349781: make test TEST=gtest fails on WSL`

### Issue
 * [JDK-8349781](https://bugs.openjdk.org/browse/JDK-8349781): make test TEST=gtest fails on WSL (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23555/head:pull/23555` \
`$ git checkout pull/23555`

Update a local copy of the PR: \
`$ git checkout pull/23555` \
`$ git pull https://git.openjdk.org/jdk.git pull/23555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23555`

View PR using the GUI difftool: \
`$ git pr show -t 23555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23555.diff">https://git.openjdk.org/jdk/pull/23555.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23555#issuecomment-2650206017)
</details>
