### PR TITLE
JDK-8349780 : AIX os::get_summary_cpu_info  support Power 11

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -166,7 +166,7 @@ extern "C" int getargs(procsinfo*, int, char*, int);
 #endif
 #ifndef PV_11
   #define PV_11           0x600000        /* Power PC 11 */
-endif
+#endif
 #ifndef PV_11_Compat
   #define PV_11_Compat    0x608000        /* Power PC 11 */
 #endif
@@ -1278,7 +1278,9 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
     break;
   default:
     strncpy(buf, "unknown", buflen);
-  }
+ }
+  printf("%s",buf);
+  exit(1);
 }
 
 void os::pd_print_cpu_info(outputStream* st, char* buf, size_t buflen) {

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1279,8 +1279,6 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
   default:
     strncpy(buf, "unknown", buflen);
  }
-  printf("%s",buf);
-  exit(1);
 }
 
 void os::pd_print_cpu_info(outputStream* st, char* buf, size_t buflen) {

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -164,6 +164,12 @@ extern "C" int getargs(procsinfo*, int, char*, int);
 #ifndef PV_10_Compat
   #define PV_10_Compat  0x508000  /* Power PC 10 */
 #endif
+#ifndef PV_11
+  #define PV_11           0x600000        /* Power PC 11 */
+endif
+#ifndef PV_11_Compat
+  #define PV_11_Compat    0x608000        /* Power PC 11 */
+#endif
 
 static address resolve_function_descriptor_to_code_pointer(address p);
 
@@ -1219,6 +1225,9 @@ void os::print_memory_info(outputStream* st) {
 void os::get_summary_cpu_info(char* buf, size_t buflen) {
   // read _system_configuration.version
   switch (_system_configuration.version) {
+  case PV_11:
+    strncpy(buf, "Power PC 11", buflen);
+    break;
   case PV_10:
     strncpy(buf, "Power PC 10", buflen);
     break;

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1273,6 +1273,9 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
   case PV_10_Compat:
     strncpy(buf, "PV_10_Compat", buflen);
     break;
+  case PV_11_Compat:
+    strncpy(buf, "PV_11_Compat", buflen);
+    break;
   default:
     strncpy(buf, "unknown", buflen);
   }

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1278,7 +1278,7 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
     break;
   default:
     strncpy(buf, "unknown", buflen);
- }
+  }
 }
 
 void os::pd_print_cpu_info(outputStream* st, char* buf, size_t buflen) {


### PR DESCRIPTION
AIX os::get_summary_cpu_info function still misses support for Power 11, this should be changed.

JBS-Issue: [JDK-8349780](https://bugs.openjdk.org/browse/JDK-8349780l)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349780](https://bugs.openjdk.org/browse/JDK-8349780): AIX os::get_summary_cpu_info  support Power 11 (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23556/head:pull/23556` \
`$ git checkout pull/23556`

Update a local copy of the PR: \
`$ git checkout pull/23556` \
`$ git pull https://git.openjdk.org/jdk.git pull/23556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23556`

View PR using the GUI difftool: \
`$ git pr show -t 23556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23556.diff">https://git.openjdk.org/jdk/pull/23556.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23556#issuecomment-2660976748)
</details>
