### PR TITLE
8336042: Caller/callee param size mismatch in deoptimization causes crash

### DIFF
--- a/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
@@ -150,6 +150,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
     assert(locals < caller->fp() + frame::interpreter_frame_initial_sp_offset, "bad placement");
+    assert(locals >= interpreter_frame->sender_sp() + max_locals - 1, "bad placement");
   }
 #endif
 

--- a/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
@@ -149,7 +149,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals < caller->interpreter_frame_expression_stack(), "bad placement");
+    assert(locals <= caller->interpreter_frame_expression_stack(), "bad placement");
     assert(locals >= interpreter_frame->sender_sp() + max_locals - 1, "bad placement");
   }
 #endif

--- a/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
@@ -149,7 +149,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals < caller->fp() + frame::interpreter_frame_initial_sp_offset, "bad placement");
+    assert(locals < caller->interpreter_frame_expression_stack(), "bad placement");
     assert(locals >= interpreter_frame->sender_sp() + max_locals - 1, "bad placement");
   }
 #endif

--- a/src/hotspot/cpu/arm/abstractInterpreter_arm.cpp
+++ b/src/hotspot/cpu/arm/abstractInterpreter_arm.cpp
@@ -133,9 +133,9 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals <= caller->interpreter_frame_expression_stack(), "bad placement");
     // Test exact placement on top of caller args
     intptr_t* l2 = caller->interpreter_frame_last_sp() + caller_actual_parameters - 1;
+    assert(l2 <= caller->interpreter_frame_expression_stack(), "bad placement");
     assert(l2 >= locals, "bad placement");
   }
 #endif

--- a/src/hotspot/cpu/arm/abstractInterpreter_arm.cpp
+++ b/src/hotspot/cpu/arm/abstractInterpreter_arm.cpp
@@ -131,6 +131,15 @@ void AbstractInterpreter::layout_activation(Method* method,
 
   intptr_t* locals = interpreter_frame->sender_sp() + max_locals - 1;
 
+#ifdef ASSERT
+  if (caller->is_interpreted_frame()) {
+    assert(locals < caller->fp() + frame::interpreter_frame_initial_sp_offset, "bad placement");
+    // Test exact placement on top of caller args
+    intptr_t* l2 = caller->interpreter_frame_last_sp() + caller_actual_parameters - 1;
+    assert(l2 >= locals, "bad placement");
+  }
+#endif
+
   interpreter_frame->interpreter_frame_set_locals(locals);
   BasicObjectLock* montop = interpreter_frame->interpreter_frame_monitor_begin();
   BasicObjectLock* monbot = montop - moncount;

--- a/src/hotspot/cpu/arm/abstractInterpreter_arm.cpp
+++ b/src/hotspot/cpu/arm/abstractInterpreter_arm.cpp
@@ -133,7 +133,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals < caller->fp() + frame::interpreter_frame_initial_sp_offset, "bad placement");
+    assert(locals < caller->interpreter_frame_expression_stack(), "bad placement");
     // Test exact placement on top of caller args
     intptr_t* l2 = caller->interpreter_frame_last_sp() + caller_actual_parameters - 1;
     assert(l2 >= locals, "bad placement");

--- a/src/hotspot/cpu/arm/abstractInterpreter_arm.cpp
+++ b/src/hotspot/cpu/arm/abstractInterpreter_arm.cpp
@@ -133,7 +133,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals < caller->interpreter_frame_expression_stack(), "bad placement");
+    assert(locals <= caller->interpreter_frame_expression_stack(), "bad placement");
     // Test exact placement on top of caller args
     intptr_t* l2 = caller->interpreter_frame_last_sp() + caller_actual_parameters - 1;
     assert(l2 >= locals, "bad placement");

--- a/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
+++ b/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
@@ -133,7 +133,7 @@ void AbstractInterpreter::layout_activation(Method* method,
     assert(locals_base <= caller->interpreter_frame_expression_stack(), "bad placement");
     // Test caller-aligned placement vs callee-aligned
     intptr_t* l2 = caller->sp() + method->max_locals() - 1 + (frame::java_abi_size / Interpreter::stackElementSize);
-    assert(l2 >= locals_base, "bad placement");
+    assert(locals_base >= l2, "bad placement");
   }
 #endif
 

--- a/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
+++ b/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
@@ -131,7 +131,9 @@ void AbstractInterpreter::layout_activation(Method* method,
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
     assert(locals_base < caller->fp() - frame::ijava_state_size, "bad placement");
-    assert(locals_base >= interpreter_frame->sender_sp() + max_locals - 1, "bad placement");
+    // Test caller-aligned placement vs callee-aligned
+    intptr_t* l2 = caller->sp() + method->max_locals() - 1 + (frame::java_abi_size / Interpreter::stackElementSize);
+    assert(l2 >= locals_base, "bad placement");
   }
 #endif
 

--- a/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
+++ b/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
@@ -130,7 +130,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals_base < caller->interpreter_frame_expression_stack(), "bad placement");
+    assert(locals_base <= caller->interpreter_frame_expression_stack(), "bad placement");
     // Test caller-aligned placement vs callee-aligned
     intptr_t* l2 = caller->sp() + method->max_locals() - 1 + (frame::java_abi_size / Interpreter::stackElementSize);
     assert(l2 >= locals_base, "bad placement");

--- a/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
+++ b/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
@@ -128,6 +128,13 @@ void AbstractInterpreter::layout_activation(Method* method,
     caller->interpreter_frame_esp() + caller_actual_parameters :
     caller->sp() + method->max_locals() - 1 + (frame::java_abi_size / Interpreter::stackElementSize);
 
+#ifdef ASSERT
+  if (caller->is_interpreted_frame()) {
+    assert(locals_base < caller->fp() - frame::ijava_state_size, "bad placement");
+    assert(locals_base >= interpreter_frame->sender_sp() + max_locals - 1, "bad placement");
+  }
+#endif
+
   intptr_t* monitor_base = caller->sp() - frame::ijava_state_size / Interpreter::stackElementSize;
   intptr_t* monitor      = monitor_base - (moncount * frame::interpreter_frame_monitor_size());
   intptr_t* esp_base     = monitor - 1;

--- a/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
+++ b/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
@@ -131,8 +131,8 @@ void AbstractInterpreter::layout_activation(Method* method,
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
     assert(locals_base <= caller->interpreter_frame_expression_stack(), "bad placement");
-    // Test caller-aligned placement vs callee-aligned
-    intptr_t* l2 = caller->sp() + method->max_locals() - 1 + (frame::java_abi_size / Interpreter::stackElementSize);
+    const int caller_abi_bytesize = (is_bottom_frame ? frame::top_ijava_frame_abi_size : frame::parent_ijava_frame_abi_size);
+    intptr_t* l2 = caller->sp() + method->max_locals() - 1 + (caller_abi_bytesize / Interpreter::stackElementSize);
     assert(locals_base >= l2, "bad placement");
   }
 #endif

--- a/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
+++ b/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
@@ -130,7 +130,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals_base < caller->fp() - frame::ijava_state_size, "bad placement");
+    assert(locals_base < caller->interpreter_frame_expression_stack(), "bad placement");
     // Test caller-aligned placement vs callee-aligned
     intptr_t* l2 = caller->sp() + method->max_locals() - 1 + (frame::java_abi_size / Interpreter::stackElementSize);
     assert(l2 >= locals_base, "bad placement");

--- a/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
+++ b/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
@@ -141,7 +141,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals < caller->interpreter_frame_expression_stack(), "bad placement");
+    assert(locals <= caller->interpreter_frame_expression_stack(), "bad placement");
     assert(locals >= interpreter_frame->sender_sp() + max_locals - 1, "bad placement");
   }
 #endif

--- a/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
+++ b/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
@@ -141,7 +141,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals < caller->fp() + frame::interpreter_frame_initial_sp_offset, "bad placement");
+    assert(locals < caller->interpreter_frame_expression_stack(), "bad placement");
     assert(locals >= interpreter_frame->sender_sp() + max_locals - 1, "bad placement");
   }
 #endif

--- a/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
+++ b/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
@@ -142,6 +142,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
     assert(locals < caller->fp() + frame::interpreter_frame_initial_sp_offset, "bad placement");
+    assert(locals >= interpreter_frame->sender_sp() + max_locals - 1, "bad placement");
   }
 #endif
 

--- a/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
+++ b/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
@@ -183,7 +183,7 @@ void AbstractInterpreter::layout_activation(Method* method,
   if (caller->is_interpreted_frame()) {
     sender_sp = caller->interpreter_frame_top_frame_sp();
 #ifdef ASSERT
-    assert(locals_base <= (intptr_t*)((address)caller->fp() - frame::z_ijava_state_size), "bad placement");
+    assert(locals_base < caller->interpreter_frame_expression_stack(), "bad placement");
     // Test caller-aligned placement vs callee-aligned
     intptr_t* l2 = (caller->sp() + method->max_locals() - 1 +
       frame::z_parent_ijava_frame_abi_size / Interpreter::stackElementSize);

--- a/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
+++ b/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
@@ -182,6 +182,8 @@ void AbstractInterpreter::layout_activation(Method* method,
   intptr_t* sender_sp;
   if (caller->is_interpreted_frame()) {
     sender_sp = caller->interpreter_frame_top_frame_sp();
+    assert(locals_base <= (address)caller->fp() - frame::z_ijava_state_size, "bad placement");
+    assert(locals_base >= sender_sp + max_locals - 1, "bad placement");
   } else if (caller->is_compiled_frame()) {
     sender_sp = caller->fp() - caller->cb()->frame_size();
     // The bottom frame's sender_sp is its caller's unextended_sp.

--- a/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
+++ b/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
@@ -183,7 +183,7 @@ void AbstractInterpreter::layout_activation(Method* method,
   if (caller->is_interpreted_frame()) {
     sender_sp = caller->interpreter_frame_top_frame_sp();
 #ifdef ASSERT
-    assert(locals_base <= (address)caller->fp() - frame::z_ijava_state_size, "bad placement");
+    assert(locals_base <= (intptr_t*)((address)caller->fp() - frame::z_ijava_state_size), "bad placement");
     // Test caller-aligned placement vs callee-aligned
     intptr_t* l2 = (caller->sp() + method->max_locals() - 1 +
       frame::z_parent_ijava_frame_abi_size / Interpreter::stackElementSize);

--- a/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
+++ b/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
@@ -182,8 +182,13 @@ void AbstractInterpreter::layout_activation(Method* method,
   intptr_t* sender_sp;
   if (caller->is_interpreted_frame()) {
     sender_sp = caller->interpreter_frame_top_frame_sp();
+#ifdef ASSERT
     assert(locals_base <= (address)caller->fp() - frame::z_ijava_state_size, "bad placement");
-    assert(locals_base >= sender_sp + max_locals - 1, "bad placement");
+    // Test caller-aligned placement vs callee-aligned
+    intptr_t* l2 = (caller->sp() + method->max_locals() - 1 +
+      frame::z_parent_ijava_frame_abi_size / Interpreter::stackElementSize);
+    assert(l2 >= locals_base, "bad placement");
+#endif
   } else if (caller->is_compiled_frame()) {
     sender_sp = caller->fp() - caller->cb()->frame_size();
     // The bottom frame's sender_sp is its caller's unextended_sp.

--- a/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
+++ b/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
@@ -183,7 +183,7 @@ void AbstractInterpreter::layout_activation(Method* method,
   if (caller->is_interpreted_frame()) {
     sender_sp = caller->interpreter_frame_top_frame_sp();
 #ifdef ASSERT
-    assert(locals_base < caller->interpreter_frame_expression_stack(), "bad placement");
+    assert(locals_base <= caller->interpreter_frame_expression_stack(), "bad placement");
     // Test caller-aligned placement vs callee-aligned
     intptr_t* l2 = (caller->sp() + method->max_locals() - 1 +
       frame::z_parent_ijava_frame_abi_size / Interpreter::stackElementSize);

--- a/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
+++ b/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
@@ -187,7 +187,7 @@ void AbstractInterpreter::layout_activation(Method* method,
     // Test caller-aligned placement vs callee-aligned
     intptr_t* l2 = (caller->sp() + method->max_locals() - 1 +
       frame::z_parent_ijava_frame_abi_size / Interpreter::stackElementSize);
-    assert(l2 >= locals_base, "bad placement");
+    assert(locals_base >= l2, "bad placement");
 #endif
   } else if (caller->is_compiled_frame()) {
     sender_sp = caller->fp() - caller->cb()->frame_size();

--- a/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
+++ b/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
@@ -87,7 +87,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals < caller->interpreter_frame_expression_stack(), "bad placement");
+    assert(locals <= caller->interpreter_frame_expression_stack(), "bad placement");
     // Test exact placement on top of caller args
     intptr_t* l2 = caller->interpreter_frame_last_sp() + caller_actual_parameters - 1;
     assert(l2 >= locals, "bad placement");

--- a/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
+++ b/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
@@ -88,6 +88,9 @@ void AbstractInterpreter::layout_activation(Method* method,
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
     assert(locals < caller->fp() + frame::interpreter_frame_initial_sp_offset, "bad placement");
+    // Test exact placement on top of caller args
+    intptr_t* l2 = caller->interpreter_frame_last_sp() + caller_actual_parameters - 1;
+    assert(l2 >= locals, "bad placement");
   }
 #endif
 

--- a/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
+++ b/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
@@ -87,7 +87,7 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals < caller->fp() + frame::interpreter_frame_initial_sp_offset, "bad placement");
+    assert(locals < caller->interpreter_frame_expression_stack(), "bad placement");
     // Test exact placement on top of caller args
     intptr_t* l2 = caller->interpreter_frame_last_sp() + caller_actual_parameters - 1;
     assert(l2 >= locals, "bad placement");

--- a/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
+++ b/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
@@ -87,9 +87,9 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals <= caller->interpreter_frame_expression_stack(), "bad placement");
     // Test exact placement on top of caller args
     intptr_t* l2 = caller->interpreter_frame_last_sp() + caller_actual_parameters - 1;
+    assert(l2 <= caller->interpreter_frame_expression_stack(), "bad placement");
     assert(l2 >= locals, "bad placement");
   }
 #endif

--- a/src/hotspot/share/interpreter/bytecode.hpp
+++ b/src/hotspot/share/interpreter/bytecode.hpp
@@ -226,6 +226,8 @@ class Bytecode_invoke: public Bytecode_member_ref {
 
   bool has_appendix();
 
+  bool has_member_arg() const;
+
   int size_of_parameters() const;
 
  private:

--- a/src/hotspot/share/interpreter/bytecode.inline.hpp
+++ b/src/hotspot/share/interpreter/bytecode.inline.hpp
@@ -40,7 +40,7 @@ inline bool Bytecode_invoke::has_appendix() {
 
 inline bool Bytecode_invoke::has_member_arg() const {
   // NOTE: We could resolve the call and use the resolved adapter method here, but this function
-  // is used by deoptimization, where resolving could lead to problems, so we void that here
+  // is used by deoptimization, where resolving could lead to problems, so we avoid that here
   // by doing things symbolically.
   //
   // invokedynamic instructions don't have a class but obviously don't have a MemberName appendix.

--- a/src/hotspot/share/interpreter/bytecode.inline.hpp
+++ b/src/hotspot/share/interpreter/bytecode.inline.hpp
@@ -39,6 +39,11 @@ inline bool Bytecode_invoke::has_appendix() {
 }
 
 inline bool Bytecode_invoke::has_member_arg() const {
+  // NOTE: We could resolve the call and use the resolved adapter method here, but this function
+  // is used by deoptimization, where resolving could lead to problems, so we void that here
+  // by doing things symbolically.
+  //
+  // invokedynamic instructions don't have a class but obviously don't have a MemberName appendix.
   return !is_invokedynamic() && MethodHandles::has_member_arg(klass(), name());
 }
 

--- a/src/hotspot/share/interpreter/bytecode.inline.hpp
+++ b/src/hotspot/share/interpreter/bytecode.inline.hpp
@@ -28,6 +28,7 @@
 #include "interpreter/bytecode.hpp"
 
 #include "oops/cpCache.inline.hpp"
+#include "prims/methodHandles.hpp"
 
 inline bool Bytecode_invoke::has_appendix() {
   if (invoke_code() == Bytecodes::_invokedynamic) {
@@ -35,6 +36,10 @@ inline bool Bytecode_invoke::has_appendix() {
   } else {
     return resolved_method_entry()->has_appendix();
   }
+}
+
+inline bool Bytecode_invoke::has_member_arg() const {
+  return !is_invokedynamic() && MethodHandles::has_member_arg(klass(), name());
 }
 
 #endif // SHARE_INTERPRETER_BYTECODE_INLINE_HPP

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -641,11 +641,12 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   bool caller_was_method_handle = false;
   if (deopt_sender.is_interpreted_frame()) {
     methodHandle method(current, deopt_sender.interpreter_frame_method());
-    Bytecode_invoke cur = Bytecode_invoke_check(method, deopt_sender.interpreter_frame_bci());
-    if (cur.is_invokedynamic() || cur.is_invokehandle()) {
-      // Method handle invokes may involve fairly arbitrary chains of
-      // calls so it's impossible to know how much actual space the
-      // caller has for locals.
+    Bytecode_invoke cur(method, deopt_sender.interpreter_frame_bci());
+    if (!cur.is_invokedynamic() && MethodHandles::has_member_arg(cur.klass(), cur.name())) {
+      // This should cover all real-world cases.  One exception is a pathological chain of
+      // MH.linkToXXX() linker calls, which only trusted code could do anyway.  To handle that case, we
+      // would need to get the size from the resolved method entry.  Another exception would
+      // be an invokedynamic with an adapter that is really a MethodHandle linker.
       caller_was_method_handle = true;
     }
   }
@@ -748,9 +749,14 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   }
 #endif
 
+  int caller_actual_parameters = -1; // value not used except for interpreted frames, see below
+  if (deopt_sender.is_interpreted_frame()) {
+    caller_actual_parameters = callee_parameters + (caller_was_method_handle ? 1 : 0);
+  }
+
   UnrollBlock* info = new UnrollBlock(array->frame_size() * BytesPerWord,
                                       caller_adjustment * BytesPerWord,
-                                      caller_was_method_handle ? 0 : callee_parameters,
+                                      caller_actual_parameters,
                                       number_of_frames,
                                       frame_sizes,
                                       frame_pcs,

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -36,6 +36,7 @@
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/memAllocator.hpp"
 #include "interpreter/bytecode.hpp"
+#include "interpreter/bytecode.inline.hpp"
 #include "interpreter/bytecodeStream.hpp"
 #include "interpreter/interpreter.hpp"
 #include "interpreter/oopMapCache.hpp"
@@ -642,7 +643,7 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   if (deopt_sender.is_interpreted_frame()) {
     methodHandle method(current, deopt_sender.interpreter_frame_method());
     Bytecode_invoke cur(method, deopt_sender.interpreter_frame_bci());
-    if (!cur.is_invokedynamic() && MethodHandles::has_member_arg(cur.klass(), cur.name())) {
+    if (cur.has_member_arg()) {
       // This should cover all real-world cases.  One exception is a pathological chain of
       // MH.linkToXXX() linker calls, which only trusted code could do anyway.  To handle that case, we
       // would need to get the size from the resolved method entry.  Another exception would
@@ -945,7 +946,7 @@ JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_m
       if (Bytecodes::is_invoke(cur_code)) {
         Bytecode_invoke invoke(mh, iframe->interpreter_frame_bci());
         cur_invoke_parameter_size = invoke.size_of_parameters();
-        if (i != 0 && !invoke.is_invokedynamic() && MethodHandles::has_member_arg(invoke.klass(), invoke.name())) {
+        if (i != 0 && invoke.has_member_arg()) {
           callee_size_of_parameters++;
         }
       }

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -25,6 +25,7 @@
 #include "classfile/vmSymbols.hpp"
 #include "code/vmreg.inline.hpp"
 #include "interpreter/bytecode.hpp"
+#include "interpreter/bytecode.inline.hpp"
 #include "interpreter/interpreter.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
@@ -612,8 +613,7 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
       Bytecode_invoke inv(caller, elem->bci());
       // invokedynamic instructions don't have a class but obviously don't have a MemberName appendix.
       // NOTE:  Use machinery here that avoids resolving of any kind.
-      const bool has_member_arg =
-          !inv.is_invokedynamic() && MethodHandles::has_member_arg(inv.klass(), inv.name());
+      const bool has_member_arg = inv.has_member_arg();
       callee_parameters = callee->size_of_parameters() + (has_member_arg ? 1 : 0);
       callee_locals     = callee->max_locals();
     }

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -611,8 +611,6 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
       methodHandle caller(current, elem->method());
       methodHandle callee(current, element(index - 1)->method());
       Bytecode_invoke inv(caller, elem->bci());
-      // invokedynamic instructions don't have a class but obviously don't have a MemberName appendix.
-      // NOTE:  Use machinery here that avoids resolving of any kind.
       const bool has_member_arg = inv.has_member_arg();
       callee_parameters = callee->size_of_parameters() + (has_member_arg ? 1 : 0);
       callee_locals     = callee->max_locals();

--- a/test/hotspot/jtreg/compiler/jsr292/MHDeoptTest.java
+++ b/test/hotspot/jtreg/compiler/jsr292/MHDeoptTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package compiler.jsr292;
 
 import java.lang.invoke.MethodHandle;
@@ -8,10 +31,8 @@ import java.lang.reflect.Method;
 
 /*
  * @test
- * @bug 8166110
+ * @bug 8336042
  * @library /test/lib /
- * @modules java.base/jdk.internal.misc
- *          java.base/jdk.internal.vm.annotation
  *
  * @run main/bootclasspath/othervm -Xbatch -XX:-TieredCompilation compiler.jsr292.MHDeoptTest
  *

--- a/test/hotspot/jtreg/compiler/jsr292/MHDeoptTest.java
+++ b/test/hotspot/jtreg/compiler/jsr292/MHDeoptTest.java
@@ -1,0 +1,76 @@
+package compiler.jsr292;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+
+/*
+ * @test
+ * @bug 8166110
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.vm.annotation
+ *
+ * @run main/bootclasspath/othervm -Xbatch -XX:-TieredCompilation compiler.jsr292.MHDeoptTest
+ *
+ */
+public class MHDeoptTest {
+
+    static int xx = 0;
+
+    public static void main(String[] args) throws Throwable {
+        MethodHandle mh1 = MethodHandles.lookup().findStatic(MHDeoptTest.class, "body1", MethodType.methodType(int.class));
+        MethodHandle mh2 = MethodHandles.lookup().findStatic(MHDeoptTest.class, "body2", MethodType.methodType(int.class));
+        MethodHandle[] arr = new MethodHandle[] {mh2, mh1};
+
+        for (MethodHandle mh : arr) {
+            for (int i = 1; i < 50_000; i++) {
+                xx = i;
+                mainLink(mh);
+            }
+        }
+
+    }
+
+    static int mainLink(MethodHandle mh) throws Throwable {
+        return (int)mh.invokeExact();
+    }
+
+    static int cnt = 1000;
+
+    static int body1() {
+        int limit = 0x7fff;
+        // uncommon trap
+        if (xx == limit) {
+            // OSR
+            for (int i = 0; i < 50_000; i++) {
+            }
+            ++cnt;
+            ++xx;
+        }
+        if (xx == limit + 1) {
+            return cnt + 1;
+        }
+        return cnt;
+    }
+
+    static int body2() {
+        int limit = 0x7fff;
+        int dummy = 0;
+        // uncommon trap
+        if (xx == limit) {
+            // OSR
+            for (int i = 0; i < 50_000; i++) {
+            }
+            ++cnt;
+            ++xx;
+        }
+        if (xx == limit + 1) {
+            return cnt + 1;
+        }
+        return cnt;
+    }
+
+}


### PR DESCRIPTION
When calling a MethodHandle linker, such as linkToStatic, we drop the last argument, which causes a mismatch between what the caller pushed and what the callee received.  In deoptimization, we check for this in several places, but in one place we had outdated code.  See the bug for the gory details.

In this PR I add asserts and a test to reproduce the problem, plus the necessary fixes in deoptimizations.  There are other inefficiencies in deoptimization that I didn't address, hoping to simplify the fix for backports.

Some platforms align locals according to the caller during deoptimization, while some align locals according to the callee.  The asserts I added compute locals both ways and check that they are still within the frame.  I attempted this on all platforms, but am only able to test x64 and aarch64.  I need help testing those asserts for arm32, ppc, riscv, and s390.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8336042](https://bugs.openjdk.org/browse/JDK-8336042): Caller/callee param size mismatch in deoptimization causes crash (**Bug** - P3)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**) Review applies to [a7a0ed7a](https://git.openjdk.org/jdk/pull/23557/files/a7a0ed7a179afad52bb5f478b2f97ea567bbe5b1)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) Review applies to [ebf10dae](https://git.openjdk.org/jdk/pull/23557/files/ebf10daee793b28f41bf7269f64d4626ead09620)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Contributors
 * Richard Reingruber `<rrich@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23557/head:pull/23557` \
`$ git checkout pull/23557`

Update a local copy of the PR: \
`$ git checkout pull/23557` \
`$ git pull https://git.openjdk.org/jdk.git pull/23557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23557`

View PR using the GUI difftool: \
`$ git pr show -t 23557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23557.diff">https://git.openjdk.org/jdk/pull/23557.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23557#issuecomment-2652421176)
</details>
