### PR TITLE
8349812: (fs) Files.newByteChannel with empty path name and CREATE_NEW throws unexpected exception

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixChannelFactory.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/classes/sun/nio/fs/UnixChannelFactory.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixChannelFactory.java
@@ -195,7 +195,7 @@ class UnixChannelFactory {
 
             // create flags
             if (flags.createNew) {
-                byte[] pathForSysCall = path.asByteArray();
+                byte[] pathForSysCall = path.getByteArrayForSysCalls();
 
                 // throw exception if file name is "." to avoid confusing error
                 if ((pathForSysCall[pathForSysCall.length-1] == '.') &&

--- a/test/jdk/java/nio/file/Files/SBC.java
+++ b/test/jdk/java/nio/file/Files/SBC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887
+ * @bug 4313887 8349812
  * @summary Unit test for java.nio.file.Files.newByteChannel
  * @library ..
  * @modules jdk.unsupported

--- a/test/jdk/java/nio/file/Files/SBC.java
+++ b/test/jdk/java/nio/file/Files/SBC.java
@@ -63,6 +63,7 @@ public class SBC {
             badCombinations(dir);
             unsupportedOptions(dir);
             nullTests(dir);
+            emptyPathTest();
 
         } finally {
             TestUtil.removeAll(dir);
@@ -422,6 +423,14 @@ public class SBC {
             Files.newByteChannel(file, opts, attrs);
             throw new RuntimeException("NullPointerException expected");
         } catch (NullPointerException x) { }
+    }
+
+    static void emptyPathTest() throws Exception {
+        try {
+            OpenOption[] opts = { WRITE, CREATE_NEW };
+            Files.newByteChannel(Path.of(""), opts);
+            throw new RuntimeException("FileAlreadyExistsException expected");
+        } catch (FileAlreadyExistsException x) { }
     }
 
     static void write(WritableByteChannel wbc, String msg) throws IOException {

--- a/test/jdk/java/nio/file/Files/SBC.java
+++ b/test/jdk/java/nio/file/Files/SBC.java
@@ -429,7 +429,10 @@ public class SBC {
         try {
             Files.newByteChannel(Path.of(""), WRITE, CREATE_NEW);
             throw new RuntimeException("FileAlreadyExistsException expected");
-        } catch (FileAlreadyExistsException x) { }
+        } catch (FileAlreadyExistsException x) {
+        } catch (AccessDeniedException x) {
+            /* Thrown on Windows only */
+        }
 
         try {
             Files.newByteChannel(Path.of(""), WRITE, CREATE, DELETE_ON_CLOSE);
@@ -442,7 +445,7 @@ public class SBC {
         } catch (FileSystemException x) { }
 
         try (var channel = Files.newByteChannel(Path.of(""), READ, LinkOption.NOFOLLOW_LINKS)) {
-        }
+        } catch(AccessDeniedException x) { /* Thrown on Windows only */ }
     }
 
     static void write(WritableByteChannel wbc, String msg) throws IOException {

--- a/test/jdk/java/nio/file/Files/SBC.java
+++ b/test/jdk/java/nio/file/Files/SBC.java
@@ -427,10 +427,22 @@ public class SBC {
 
     static void emptyPathTest() throws Exception {
         try {
-            OpenOption[] opts = { WRITE, CREATE_NEW };
-            Files.newByteChannel(Path.of(""), opts);
+            Files.newByteChannel(Path.of(""), WRITE, CREATE_NEW);
             throw new RuntimeException("FileAlreadyExistsException expected");
         } catch (FileAlreadyExistsException x) { }
+
+        try {
+            Files.newByteChannel(Path.of(""), WRITE, CREATE, DELETE_ON_CLOSE);
+            throw new RuntimeException("FileSystemException expected");
+        } catch (FileSystemException x) { }
+
+        try {
+            Files.newByteChannel(Path.of(""), WRITE, LinkOption.NOFOLLOW_LINKS);
+            throw new RuntimeException("FileSystemException expected");
+        } catch (FileSystemException x) { }
+
+        try (var channel = Files.newByteChannel(Path.of(""), READ, LinkOption.NOFOLLOW_LINKS)) {
+        }
     }
 
     static void write(WritableByteChannel wbc, String msg) throws IOException {


### PR DESCRIPTION
`UnixFileChannelFactory.open()` checks for the current directory by looking at the first byte of the name, which in case of an empty path is simply not there. This check throws an `ArrayIndexOutOfBoundsException` and prevents the correct exception from being thrown.

The suggested solution is to use another method that translates a path name into a byte array called `getByteArrayForSysCalls()` that is specifically designed to handle the case of empty path names.

Tested by running `java/nio` tests on Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349812](https://bugs.openjdk.org/browse/JDK-8349812): (fs) Files.newByteChannel with empty path name and CREATE_NEW throws unexpected exception (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23560/head:pull/23560` \
`$ git checkout pull/23560`

Update a local copy of the PR: \
`$ git checkout pull/23560` \
`$ git pull https://git.openjdk.org/jdk.git pull/23560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23560`

View PR using the GUI difftool: \
`$ git pr show -t 23560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23560.diff">https://git.openjdk.org/jdk/pull/23560.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23560#issuecomment-2650402692)
</details>
