### PR TITLE
8349836: G1: Improve group prediction log message

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -107,7 +107,7 @@ double G1CSetCandidateGroup::predict_group_total_time_ms() const {
                          predicted_copy_time_ms +
                          non_young_other_time_ms;
 
-  log_trace(gc, ergo, cset) ("Group %u: %u regions prediction total_time %.2fms card_rs_length %zu merge_scan_time %.2fms code_root_scan_time_ms %.2fms evac_time_ms %.2fms other_time %.2fms bytes_to_copy %zu",
+  log_trace(gc, ergo, cset) ("Prediction for group %u (%u regions): total_time %.2fms card_rs_length %zu merge_scan_time %.2fms code_root_scan_time_ms %.2fms evac_time_ms %.2fms other_time %.2fms bytes_to_copy %zu",
                              group_id(),
                              length(),
                              total_time_ms,

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -102,8 +102,15 @@ double G1CSetCandidateGroup::predict_group_total_time_ms() const {
   double merge_scan_time_ms = p->predict_merge_scan_time(card_rs_length);
   double non_young_other_time_ms = p->predict_non_young_other_time_ms(length());
 
-  log_trace(gc, ergo, cset) ("Prediction for group with %u regions, card_rs_length %zu, merge_scan_time %.2fms, code_root_scan_time_ms %.2fms, evac_time_ms %.2fms, other_time %.2fms, bytes_to_cop %zu",
+  double total_time_ms = merge_scan_time_ms +
+                         predict_code_root_scan_time_ms +
+                         predicted_copy_time_ms +
+                         non_young_other_time_ms;
+
+  log_trace(gc, ergo, cset) ("Group %u: %u regions prediction total_time %.2fms card_rs_length %zu merge_scan_time %.2fms code_root_scan_time_ms %.2fms evac_time_ms %.2fms other_time %.2fms bytes_to_copy %zu",
+                             group_id(),
                              length(),
+                             total_time_ms,
                              card_rs_length,
                              merge_scan_time_ms,
                              predict_code_root_scan_time_ms,
@@ -111,10 +118,7 @@ double G1CSetCandidateGroup::predict_group_total_time_ms() const {
                              non_young_other_time_ms,
                              predict_bytes_to_copy);
 
-  return merge_scan_time_ms +
-         predict_code_root_scan_time_ms +
-         predicted_copy_time_ms +
-         non_young_other_time_ms;
+  return total_time_ms;
 }
 
 int G1CSetCandidateGroup::compare_gc_efficiency(G1CSetCandidateGroup** gr1, G1CSetCandidateGroup** gr2) {


### PR DESCRIPTION
Hi all,

  please review this minor change to the group prediction log message
printed with gc+ergo+cset=trace:

  * add group id to be able to refer to something concrete when discussing results
  * add total time
  * fix typo in `bytes_to_cop`

Testing: gha, local verification

`Group 10: 5 regions prediction total_time 20.0ms card_rs_length 123456 merge_scan_time 10.2ms code_root_scan_time_ms 5.5ms evac_time_ms 3.7ms other_time 0.3ms bytes_to_copy 1234567`

instead of

`Prediction for group with 76 regions, card_rs_length 320, merge_scan_time 0.02ms, code_root_scan_time_ms 0.00ms, evac_time_ms 9.92ms, other_time 45.60ms, bytes_to_cop 61408560`

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349836](https://bugs.openjdk.org/browse/JDK-8349836): G1: Improve group prediction log message (**Enhancement** - P5)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) Review applies to [3c9cd94f](https://git.openjdk.org/jdk/pull/23562/files/3c9cd94f6fed4c3713d5a6626a792ccd2dce03ed)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23562/head:pull/23562` \
`$ git checkout pull/23562`

Update a local copy of the PR: \
`$ git checkout pull/23562` \
`$ git pull https://git.openjdk.org/jdk.git pull/23562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23562`

View PR using the GUI difftool: \
`$ git pr show -t 23562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23562.diff">https://git.openjdk.org/jdk/pull/23562.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23562#issuecomment-2651315770)
</details>
