### PR TITLE
JDK-8349638: Build libjdwp with SIZE optimization

### DIFF
--- a/make/modules/jdk.jdwp.agent/Lib.gmk
+++ b/make/modules/jdk.jdwp.agent/Lib.gmk
@@ -52,7 +52,7 @@ TARGETS += $(BUILD_LIBDT_SOCKET)
 # JDWP_LOGGING causes log messages to be compiled into the library.
 $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
     NAME := jdwp, \
-    OPTIMIZATION := LOW, \
+    OPTIMIZATION := SIZE, \
     CFLAGS := -DJDWP_LOGGING, \
     DISABLED_WARNINGS_gcc_eventFilter.c := unused-variable, \
     DISABLED_WARNINGS_gcc_SDE.c := unused-function, \


### PR DESCRIPTION
The libjdwp is currently built with LOW optimization level, it could be built with SIZE optimization to lower the lib size by ~ 10 % on UNIX.
On Windows LOW and SIZE currently translate to the same O1 optimization flag so no difference there.

On Linux x86_64 for example the lib shrinks from
300K to 268K and the debuginfo file shrinks from 1.9M to 1.7M .

On Linux ppc64le for example the lib shrinks from
428K to 368K and the debuginfo file shrinks from 2.0M to 1.7M .