### PR TITLE
8294155: Exception thrown before awaitAndCheck hangs PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1787,8 +1787,20 @@ public final class PassFailJFrame {
 
         public PassFailJFrame build() throws InterruptedException,
                 InvocationTargetException {
-            validate();
-            return new PassFailJFrame(this);
+            try {
+                validate();
+                return new PassFailJFrame(this);
+            } catch (final Throwable t) {
+                // Dispose of all the windows, including those that may not
+                // be registered with PassFailJFrame to allow AWT to shut down
+                try {
+                    invokeOnEDT(() -> Arrays.stream(Window.getWindows())
+                                            .forEach(Window::dispose));
+                } catch (Throwable edt) {
+                    t.addSuppressed(edt);
+                }
+                throw t;
+            }
         }
 
         /**


### PR DESCRIPTION
If a manual test throws an exception during construction of `PassFailJFrame`, the test execution hangs. When the builder pattern is used, no UI appears on the screens, but the Java process does not terminate automatically because there are windows which prevent AWT from shutting down.

**Fix:**

Catch exceptions in `PassFailJFrame.Builder.build()` and dispose of all the windows if an exception occurs.

This ensures all the created windows are disposed of, which lets AWT shut down cleanly.

_Note:_ the above problem doesn't occur when the test is run with `jtreg` because jtreg shuts down the JVM as soon as the main thread exits.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294155](https://bugs.openjdk.org/browse/JDK-8294155): Exception thrown before awaitAndCheck hangs PassFailJFrame (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23564/head:pull/23564` \
`$ git checkout pull/23564`

Update a local copy of the PR: \
`$ git checkout pull/23564` \
`$ git pull https://git.openjdk.org/jdk.git pull/23564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23564`

View PR using the GUI difftool: \
`$ git pr show -t 23564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23564.diff">https://git.openjdk.org/jdk/pull/23564.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23564#issuecomment-2651324580)
</details>
