### PR TITLE
8349851: RISC-V: Call VM leaf can use movptr2

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -793,7 +793,9 @@ void MacroAssembler::call_VM_leaf_base(address entry_point,
                                        Label *retaddr) {
   int32_t offset = 0;
   push_reg(RegSet::of(t1, xmethod), sp);   // push << t1 & xmethod >> to sp
-  mv(t1, entry_point, offset);
+
+  movptr(t1, entry_point, offset, t2);
+
   jalr(t1, offset);
   if (retaddr != nullptr) {
     bind(*retaddr);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -793,9 +793,7 @@ void MacroAssembler::call_VM_leaf_base(address entry_point,
                                        Label *retaddr) {
   int32_t offset = 0;
   push_reg(RegSet::of(t1, xmethod), sp);   // push << t1 & xmethod >> to sp
-
-  movptr(t1, entry_point, offset, t2);
-
+  movptr(t1, entry_point, offset, t0);
   jalr(t1, offset);
   if (retaddr != nullptr) {
     bind(*retaddr);


### PR DESCRIPTION
Hi, please consider.

There should be a small speed up to vm leafs.
We can scratch t2 here as we just pushed it. (maybe I should have used t0)

Passes t1

/Robbin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349851](https://bugs.openjdk.org/browse/JDK-8349851): RISC-V: Call VM leaf can use movptr2 (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23565/head:pull/23565` \
`$ git checkout pull/23565`

Update a local copy of the PR: \
`$ git checkout pull/23565` \
`$ git pull https://git.openjdk.org/jdk.git pull/23565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23565`

View PR using the GUI difftool: \
`$ git pr show -t 23565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23565.diff">https://git.openjdk.org/jdk/pull/23565.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23565#issuecomment-2651545727)
</details>
