### PR TITLE
8349859: Support static JDK in libfontmanager/freetypeScaler.c

### DIFF
--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -407,6 +407,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     LDFLAGS_aix := -Wl$(COMMA)-berok, \
     JDK_LIBS := libawt java.base:libjava $(LIBFONTMANAGER_JDK_LIBS), \
     JDK_LIBS_macosx := libawt_lwawt, \
+    JDK_LIBS_unix := java.base:libjvm, \
     LIBS := $(LIBFONTMANAGER_LIBS), \
     LIBS_unix := $(LIBM), \
     LIBS_macosx := \


### PR DESCRIPTION
Please review the change that looks up `FT_Property_Set` from the current executable first when running on static JDK. If `FT_Property_Set` can be found, don't `dlopen` `libfreetype.so`. If a bundled `libfreetype` is statically linked with the launcher executable (on static JDK), `FT_Property_Set` is provided in the current executable. 

According to the existing comment in `setInterpreterVersion`, `libfreetype` is always bundled on Windows & Mac. This change only applies to Linux.

I tested the change by stepping through the code using `test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349859](https://bugs.openjdk.org/browse/JDK-8349859): Support static JDK in libfontmanager/freetypeScaler.c (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23574/head:pull/23574` \
`$ git checkout pull/23574`

Update a local copy of the PR: \
`$ git checkout pull/23574` \
`$ git pull https://git.openjdk.org/jdk.git pull/23574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23574`

View PR using the GUI difftool: \
`$ git pr show -t 23574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23574.diff">https://git.openjdk.org/jdk/pull/23574.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23574#issuecomment-2652334676)
</details>
