### PR TITLE
8349787: java/lang/Thread/virtual/ThreadPollOnYield.java#default passes unexpectedly without libVThreadPinner.so

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
@@ -48,10 +48,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ThreadPollOnYield {
-    public static CountDownLatch latch = new CountDownLatch(1);
+    private static CountDownLatch started = new CountDownLatch(1);
     static void foo(AtomicBoolean done) {
+        started.countDown();
         while (!done.get()) {
-            latch.countDown();
             Thread.yield();
         }
     }
@@ -62,7 +62,7 @@ class ThreadPollOnYield {
         var vthread = Thread.ofVirtual().start(() -> {
             VThreadPinner.runPinned(() -> foo(done));
         });
-        latch.await();
+        started.await();
         done.set(true);
         vthread.join();
 

--- a/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
@@ -41,14 +41,17 @@
  */
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CountDownLatch;
 
 import jdk.test.lib.thread.VThreadPinner;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ThreadPollOnYield {
+    public static CountDownLatch latch = new CountDownLatch(1);
     static void foo(AtomicBoolean done) {
         while (!done.get()) {
+            latch.countDown();
             Thread.yield();
         }
     }
@@ -59,7 +62,7 @@ class ThreadPollOnYield {
         var vthread = Thread.ofVirtual().start(() -> {
             VThreadPinner.runPinned(() -> foo(done));
         });
-        Thread.sleep(5000);
+        latch.await();
         done.set(true);
         vthread.join();
 

--- a/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ThreadPollOnYield {
-    private static CountDownLatch started = new CountDownLatch(1);
+    private static final CountDownLatch started = new CountDownLatch(1);
     static void foo(AtomicBoolean done) {
         started.countDown();
         while (!done.get()) {


### PR DESCRIPTION
Hi all,

Test test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java run passed unexpected without native library or with the incorrect native library path. The test command with incorrect native library path shows below. We will seen this tests run passed unexpected before this PR, because the first virtual thread do not run normally without the dependent shared library libVThreadPinner.so, and there is no assert when the first virtual thread run abnormal.

```shell
mkdir -p empty-directory ; jtreg -v:fail,error -w tmp -nr -jdk:build/linux-x86_64-server-release/images/jdk -nativepath:empty-directory test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java#default
```

This PR add a latch variable will make sure the first virtual thread run once at least. After this PR run the same test command which with incorrect native library path, and we will seen this pass run timed out as expected.

Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349787](https://bugs.openjdk.org/browse/JDK-8349787): java/lang/Thread/virtual/ThreadPollOnYield.java#default passes unexpectedly without libVThreadPinner.so (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23576/head:pull/23576` \
`$ git checkout pull/23576`

Update a local copy of the PR: \
`$ git checkout pull/23576` \
`$ git pull https://git.openjdk.org/jdk.git pull/23576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23576`

View PR using the GUI difftool: \
`$ git pr show -t 23576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23576.diff">https://git.openjdk.org/jdk/pull/23576.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23576#issuecomment-2652576152)
</details>
