### PR TITLE
8349874: Missing comma in copyright from JDK-8349689

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/Starvation.java
+++ b/test/jdk/java/lang/Thread/virtual/Starvation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Trivial fix for missing comma.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349874](https://bugs.openjdk.org/browse/JDK-8349874): Missing comma in copyright from JDK-8349689 (**Bug** - P4)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23577/head:pull/23577` \
`$ git checkout pull/23577`

Update a local copy of the PR: \
`$ git checkout pull/23577` \
`$ git pull https://git.openjdk.org/jdk.git pull/23577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23577`

View PR using the GUI difftool: \
`$ git pr show -t 23577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23577.diff">https://git.openjdk.org/jdk/pull/23577.diff</a>

</details>
