### PR TITLE
8349637: Integer.numberOfLeadingZeros outputs incorrectly in certain cases

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -6234,6 +6234,13 @@ void C2_MacroAssembler::vector_count_leading_zeros_int_avx(XMMRegister dst, XMMR
   vpcmpeqd(xtmp1, xtmp1, xtmp1, vec_enc);
   vpsrld(xtmp1, xtmp1, 24, vec_enc);
 
+  // As 2^24 is the largest possible integer that can be exactly represented by a float value, special handling has to be
+  // done to avoid losing precision by potentially rounding up. To avoid that, we construct a mask to remove low set bits
+  // when the number has the upper 8 bits set. This is a valid transformation as it only removes low bits, and keeps the high bits intact.
+  vpxor(xtmp2, xtmp2, xtmp2, vec_enc);
+  vpsrld(xtmp2, src, 24, vec_enc);
+  vpandn(src, xtmp2, src, vec_enc);
+
   // Extract biased exponent.
   vcvtdq2ps(dst, src, vec_enc);
   vpsrld(dst, dst, 23, vec_enc);


### PR DESCRIPTION
Hi all,
This is a fix for a miscompile in the AVX2 implementation of `CountLeadingZerosV` for int types. Currently, the implementation turns ints into floats, in order to calculating the leading zeros based on the exponent part of the float. Unfortunately, floats can only accurately represent integers up to 2^24. After that, multiple integer values can map onto the same floating point value. The issue manifests when an int is converted to a floating point representation that is higher than it, crossing a bit boundary. As an example, `(float)0x01FFFFFF == (float)0x02000000`, but `lzcnt(0x01FFFFFF) == 7` and `lzcnt(0x02000000) == 6`. The values are incorrectly rounded up.

This patch fixes the issue by masking the input in the cases where it is larger than 2^24, to set the low bits to 0. Removing these bits prevents the accidental rounding behavior. I've added these cases to`TestNumberOfContinuousZeros`, and removed the set random seed so that it can produce random inputs to test with.

Reviews would be appreciated!