### PR TITLE
8349888: AOTMode=create crashes with EpsilonGC

### DIFF
--- a/src/hotspot/share/cds/aotClassLinker.cpp
+++ b/src/hotspot/share/cds/aotClassLinker.cpp
@@ -207,6 +207,8 @@ Array<InstanceKlass*>* AOTClassLinker::write_classes(oop class_loader, bool is_j
   ResourceMark rm;
   GrowableArray<InstanceKlass*> list;
 
+  ArchiveBuilder* builder = ArchiveBuilder::current();
+
   for (int i = 0; i < _sorted_candidates->length(); i++) {
     InstanceKlass* ik = _sorted_candidates->at(i);
     if (ik->class_loader() != class_loader) {
@@ -223,8 +225,8 @@ Array<InstanceKlass*>* AOTClassLinker::write_classes(oop class_loader, bool is_j
       } else {
         list.append(ik);
       }
-    } else {
-      list.append(ArchiveBuilder::current()->get_buffered_addr(ik));
+    } else if (builder->has_been_buffered(ik)) {
+      list.append(builder->get_buffered_addr(ik));
     }
   }
 
@@ -269,6 +271,7 @@ int AOTClassLinker::count_public_classes(oop loader) {
 
 // Used in logging: "boot1", "boot2", "plat", "app" and "unreg", or "array"
 const char* AOTClassLinker::class_category_name(Klass* k) {
+  assert(k != nullptr, "sanity");
   if (ArchiveBuilder::is_active() && ArchiveBuilder::current()->is_in_buffer_space(k)) {
     k = ArchiveBuilder::current()->get_source_addr(k);
   }


### PR DESCRIPTION
Reliably reproduces in current mainline, see the bug for reproducer. I think we are crashing after feeding `nullptr` to `class_category_name`. That `nullptr` is from `ArchiveBuilder::current()->get_buffered_addr` of `HelloStream`, which is skipped, as per warning message right before the crash. 

So it looks like the fix is to check if we are dealing with class that is available in the buffer before reaching for its buffered address. @iklam, see if this is a right fix?

Additional testing:
 - [x] Linux x86_64 server fastdebug, reproducer now passes
 - [x] Linux x86_64 server fastdebug, `runtime/cds` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349888](https://bugs.openjdk.org/browse/JDK-8349888): AOTMode=create crashes with EpsilonGC (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23581/head:pull/23581` \
`$ git checkout pull/23581`

Update a local copy of the PR: \
`$ git checkout pull/23581` \
`$ git pull https://git.openjdk.org/jdk.git pull/23581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23581`

View PR using the GUI difftool: \
`$ git pr show -t 23581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23581.diff">https://git.openjdk.org/jdk/pull/23581.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23581#issuecomment-2653285446)
</details>
