### PR TITLE
prototype for strict static fields

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -191,6 +191,7 @@ class ClassFileParser {
   bool _has_localvariable_table;
   bool _has_final_method;
   bool _has_contended_fields;
+  bool _has_strict_static_fields;
 
   // precomputed flags
   bool _has_finalizer;

--- a/src/hotspot/share/include/jvm_constants.h
+++ b/src/hotspot/share/include/jvm_constants.h
@@ -45,6 +45,7 @@
                                         JVM_ACC_VOLATILE | \
                                         JVM_ACC_TRANSIENT | \
                                         JVM_ACC_ENUM | \
+                                        JVM_ACC_STRICT | \
                                         JVM_ACC_SYNTHETIC)
 
 #define JVM_RECOGNIZED_METHOD_MODIFIERS (JVM_ACC_PUBLIC | \

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -702,6 +702,38 @@ void InterpreterRuntime::resolve_get_put(Bytecodes::Code bytecode, int field_ind
     if ((is_put && !has_initialized_final_update) || !info.access_flags().is_final()) {
       put_code = ((is_static) ? Bytecodes::_putstatic : Bytecodes::_putfield);
     }
+    assert(!info.is_strict_static_unset(), "after initialization, no unset flags");
+  } else if (is_static && info.is_strict_static_unset()) {
+    // During <clinit>, closely track the state of strict statics.
+    // 1. if we are reading an uninitialized strict static, throw
+    // 2. if we are writing one, clear the "unset" flag
+    //
+    // Note: If we were handling an attempted write of a null to a
+    // null-restricted strict static, we would NOT clear the "unset"
+    // flag.  This does not happen today, but will with NR fields.
+    assert(klass->is_being_initialized(), "else should have thrown");
+    assert(klass->is_reentrant_initialization(THREAD),
+           "<clinit> must be running in current thread");
+    bool do_notify = true;
+
+    #if 0 //sample code to support null-restricted strict statics
+    if (state == atos && is_put && info.is_null_restricted() &&
+        *(oop*)THREAD->last_frame().interpreter_frame_tos_at(0) == nullptr) {
+      do_notify = false;
+      // Stacked value to store is nullptr, which will cause the
+      // interpreter to throw as soon as it realizes that this field
+      // is null restricted.  We must not clear the "unset" flag in
+      // this case, since the field will remain unset after the throw.
+      // If more general restrictions are put on field stores, so that
+      // they can fail even less predictably, then the interpreter
+      // will have to be modified to take responsibility for clearing
+      // the "unset" flag, perhaps by making a second downcall.
+    }
+    #endif //end sample code
+    
+    if (do_notify) {
+      klass->notify_strict_static_access(info.index(), is_put, CHECK);
+    }
   }
 
   ResolvedFieldEntry* entry = pool->resolved_field_entry_at(field_index);

--- a/src/hotspot/share/oops/fieldInfo.cpp
+++ b/src/hotspot/share/oops/fieldInfo.cpp
@@ -37,8 +37,10 @@ void FieldInfo::print(outputStream* os, ConstantPool* cp) {
                 field_flags().as_uint(),
                 initializer_index(),
                 generic_signature_index(),
-                _field_flags.is_injected() ? lookup_symbol(generic_signature_index())->as_utf8() : cp->symbol_at(generic_signature_index())->as_utf8(),
-                contended_group());
+                (generic_signature_index() == 0 ? "(none)"
+                 : _field_flags.is_injected() ? lookup_symbol(generic_signature_index())->as_utf8()
+                 : cp->symbol_at(generic_signature_index())->as_utf8()),
+                (!is_contended() ? -1 : contended_group()));
 }
 
 void FieldInfo::print_from_growable_array(outputStream* os, GrowableArray<FieldInfo>* array, ConstantPool* cp) {

--- a/src/hotspot/share/oops/fieldInfo.hpp
+++ b/src/hotspot/share/oops/fieldInfo.hpp
@@ -285,6 +285,7 @@ class FieldStatus {
   enum FieldStatusBitPosition {
     _fs_access_watched,       // field access is watched by JVMTI
     _fs_modification_watched, // field modification is watched by JVMTI
+    _fs_strict_static_unset,  // JVM_ACC_STRICT static field has not yet been set
     _initialized_final_update // (static) final field updated outside (class) initializer
   };
 
@@ -305,11 +306,13 @@ class FieldStatus {
 
   bool is_access_watched()        { return test_flag(_fs_access_watched); }
   bool is_modification_watched()  { return test_flag(_fs_modification_watched); }
+  bool is_strict_static_unset()   { return test_flag(_fs_strict_static_unset); }
   bool is_initialized_final_update() { return test_flag(_initialized_final_update); }
 
   void update_access_watched(bool z);
   void update_modification_watched(bool z);
   void update_initialized_final_update(bool z);
+  void update_strict_static_unset(bool z);
 };
 
 #endif // SHARE_OOPS_FIELDINFO_HPP

--- a/src/hotspot/share/oops/fieldInfo.inline.hpp
+++ b/src/hotspot/share/oops/fieldInfo.inline.hpp
@@ -167,6 +167,7 @@ inline void FieldStatus::update_flag(FieldStatusBitPosition pos, bool z) {
 
 inline void FieldStatus::update_access_watched(bool z) { update_flag(_fs_access_watched, z); }
 inline void FieldStatus::update_modification_watched(bool z) { update_flag(_fs_modification_watched, z); }
+inline void FieldStatus::update_strict_static_unset(bool z) { update_flag(_fs_strict_static_unset, z); }
 inline void FieldStatus::update_initialized_final_update(bool z) { update_flag(_initialized_final_update, z); }
 
 #endif // SHARE_OOPS_FIELDINFO_INLINE_HPP

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1317,6 +1317,36 @@ void InstanceKlass::initialize_impl(TRAPS) {
       }
       call_class_initializer(THREAD);
     }
+
+    if (has_strict_static_fields() && !HAS_PENDING_EXCEPTION) {
+      // Step 8 also verifies that strict static fields have been initialized.
+      // Status bits were set in ClassFileParser::post_process_parsed_stream.
+      // After <clinit>, bits must all be clear, or else we must throw an error.
+      // This is an extremely fast check, so we won't bother with a timer.
+      assert(fields_status() != nullptr, "");
+      Symbol* bad_strict_static = nullptr;
+      for (int index = 0, limit = fields_status()->length(); index < limit; index++) {
+        // Very fast loop over single byte array looking for a set bit.
+        if (fields_status()->adr_at(index)->is_strict_static_unset()) {
+          // This strict static field has not been set by the class initializer.
+          // Note that in the common no-error case, we read no field metadata.
+          // We only unpack it when we need to report an error.
+          FieldInfo fi = field(index);
+          bad_strict_static = fi.name(constants());
+          if (debug_logging_enabled) {
+            ResourceMark rm(jt);
+            const char* msg = format_strict_static_message(bad_strict_static);
+            log_debug(class, init)("%s", msg);
+          } else {
+            // If we are not logging, do not bother to look for a second offense.
+            break;
+          }
+        }
+      }
+      if (bad_strict_static != nullptr) {
+        throw_strict_static_exception(bad_strict_static, "after initialization of", THREAD);
+      }
+    }
   }
 
   // Step 9
@@ -1368,6 +1398,57 @@ void InstanceKlass::set_initialization_state_and_notify(ClassState state, TRAPS)
     set_init_state(state);
   }
 }
+
+void InstanceKlass::notify_strict_static_access(int field_index, bool is_writing, TRAPS) {
+  guarantee(field_index >= 0 && field_index < fields_status()->length(), "valid field index");
+  DEBUG_ONLY(FieldInfo fi = field(field_index));
+  assert(fi.access_flags().is_strict(), "");
+  assert(fi.access_flags().is_static(), "");
+  FieldStatus& fs = *fields_status()->adr_at(field_index);
+  if (fs.is_strict_static_unset()) {
+    //fi.print(tty, constants());
+    if (!is_reentrant_initialization(THREAD)) {
+      // The unset state is (or should be) transient, and observable only in one
+      // thread during the execution of <clinit>.  Something is wrong here, and
+      // we should just throw.
+      if (is_in_error_state()) {
+        oop init_error = get_initialization_error(THREAD);
+        if (init_error != nullptr) {
+          THROW_OOP(init_error);
+        }
+      }
+      THROW_MSG(vmSymbols::java_lang_InternalError(), "unscoped access to strict static");
+    } else if (is_writing) {
+      // clear the "unset" bit, since the field is actually going to be written
+      fs.update_strict_static_unset(false);
+    } else {
+      // throw an IllegalStateException, since we are reading before writing
+      // see also InstanceKlass::initialize_impl, Step 8 (at end)
+      Symbol* bad_strict_static = field(field_index).name(constants());
+      constexpr const char* error_format = "Strict static \"%s\" not initialized by %s";
+      throw_strict_static_exception(bad_strict_static, "before first read in", CHECK);
+    }
+  }
+}
+
+void InstanceKlass::throw_strict_static_exception(Symbol* field_name, const char* when, TRAPS) {
+  ResourceMark rm(THREAD);
+  const char* msg = format_strict_static_message(field_name, when);
+  // FIXME: Maybe replace IllegalStateException with something more precise.
+  // Perhaps a new-fangled UninitializedFieldException?
+  THROW_MSG(vmSymbols::java_lang_IllegalStateException(), msg);
+}
+
+const char* InstanceKlass::format_strict_static_message(Symbol* field_name, const char* when) {
+  stringStream ss;
+  // we can use similar format strings for both -Xlog:class+init and for the ISE throw
+  ss.print("Strict static \"%s\" is unset %s %s",
+           field_name->as_C_string(),
+           when == nullptr ? "in" : when,
+           external_name());
+  return ss.as_string();
+}
+
 
 // Update hierarchy. This is done before the new klass has been added to the SystemDictionary. The Compile_lock
 // is grabbed, to ensure that the compiler is not using the class hierarchy.

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -767,6 +767,13 @@ public:
   inline u2 next_method_idnum();
   void set_initial_method_idnum(u2 value)             { _idnum_allocated_count = value; }
 
+  // runtime support for strict statics
+  bool has_strict_static_fields() const    { return _misc_flags.has_strict_static_fields(); }
+  void set_has_strict_static_fields(bool b){ _misc_flags.set_has_strict_static_fields(b); }
+  void notify_strict_static_access(int field_index, bool is_writing, TRAPS);
+  const char* format_strict_static_message(Symbol* field_name, const char* doing_what = nullptr);
+  void throw_strict_static_exception(Symbol* field_name, const char* when, TRAPS);
+
   // generics support
   Symbol* generic_signature() const;
   u2 generic_signature_index() const;

--- a/src/hotspot/share/oops/instanceKlassFlags.hpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.hpp
@@ -54,6 +54,7 @@ class InstanceKlassFlags {
     flag(has_localvariable_table            , 1 << 11) /* has localvariable information */ \
     flag(has_miranda_methods                , 1 << 12) /* True if this class has miranda methods in it's vtable */ \
     flag(has_final_method                   , 1 << 13) /* True if klass has final method */ \
+    flag(has_strict_static_fields           , 1 << 14) /* True if strict static fields declared */ \
     /* end of list */
 
 #define IK_FLAGS_ENUM_NAME(name, value)    _misc_##name = value,

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -1990,7 +1990,9 @@ JNI_ENTRY(jfieldID, jni_GetStaticFieldID(JNIEnv *env, jclass clazz,
 
   fieldDescriptor fd;
   if (!k->is_instance_klass() ||
-      !InstanceKlass::cast(k)->find_field(fieldname, signame, true, &fd)) {
+      !InstanceKlass::cast(k)->find_field(fieldname, signame, true, &fd) ||
+      // strict fields need special tracking during <clinit>; do not hand them out so early
+      (fd.access_flags().is_strict() && !InstanceKlass::cast(k)->is_initialized())) {
     THROW_MSG_NULL(vmSymbols::java_lang_NoSuchFieldError(), (char*) name);
   }
 

--- a/src/hotspot/share/runtime/fieldDescriptor.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.hpp
@@ -67,6 +67,7 @@ class fieldDescriptor {
   // Initial field value
   inline bool has_initial_value()        const;
   inline int initial_value_index()       const;
+  inline bool is_strict_static_unset()   const;
   constantTag initial_value_tag() const;  // The tag will return true on one of is_int(), is_long(), is_single(), is_double()
   jint int_initial_value()        const;
   jlong long_initial_value()      const;
@@ -82,6 +83,7 @@ class fieldDescriptor {
   bool is_protected()             const    { return access_flags().is_protected(); }
 
   bool is_static()                const    { return access_flags().is_static(); }
+  bool is_strict()                const    { return access_flags().is_strict(); }
   bool is_final()                 const    { return access_flags().is_final(); }
   bool is_stable()                const    { return field_flags().is_stable(); }
   bool is_volatile()              const    { return access_flags().is_volatile(); }

--- a/src/hotspot/share/runtime/fieldDescriptor.inline.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.inline.hpp
@@ -49,6 +49,10 @@ inline ConstantPool* fieldDescriptor::constants() const {
 inline int fieldDescriptor::offset()                    const    { return field().offset(); }
 inline bool fieldDescriptor::has_initial_value()        const    { return field().field_flags().is_initialized(); }
 inline int fieldDescriptor::initial_value_index()       const    { return field().initializer_index(); }
+inline bool fieldDescriptor::is_strict_static_unset() const {
+  return (is_strict() && is_static() &&
+          field_holder()->field_status(index()).is_strict_static_unset());
+}
 
 inline void fieldDescriptor::set_is_field_access_watched(const bool value) {
   field_holder()->fields_status()->adr_at(index())->update_access_watched(value);

--- a/src/hotspot/share/utilities/accessFlags.hpp
+++ b/src/hotspot/share/utilities/accessFlags.hpp
@@ -57,6 +57,7 @@ class AccessFlags {
   bool is_native      () const         { return (_flags & JVM_ACC_NATIVE      ) != 0; }
   bool is_interface   () const         { return (_flags & JVM_ACC_INTERFACE   ) != 0; }
   bool is_abstract    () const         { return (_flags & JVM_ACC_ABSTRACT    ) != 0; }
+  bool is_strict      () const         { return (_flags & JVM_ACC_STRICT      ) != 0; }
 
   // Attribute flags
   bool is_synthetic   () const         { return (_flags & JVM_ACC_SYNTHETIC   ) != 0; }

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -389,6 +389,10 @@ final class MemberName implements Member, Cloneable {
     public boolean isFinal() {
         return Modifier.isFinal(flags);
     }
+    /** Utility method to query the modifier flags of this member. */
+    public boolean isStrict() {
+        return Modifier.isStrict(flags);
+    }
     /** Utility method to query whether this member or its defining class is final. */
     public boolean canBeStaticallyBound() {
         return Modifier.isFinal(flags | clazz.getModifiers());

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1167,6 +1167,21 @@ public final class Unsafe {
     }
 
     /**
+     * The reading or writing of strict static fields may require
+     * special processing.  Notify the VM that such an event is about
+     * to happen.  The VM may respond by throwing an exception, in the
+     * case of a read of an uninitialized field.  If the VM allows the
+     * method to return normally, no further calls are needed, with
+     * the same arguments.
+     */
+    public void notifyStrictStaticAccess(Class<?> c, long staticFieldOffset, boolean writing) {
+        if (c == null) {
+            throw new NullPointerException();
+        }
+        notifyStrictStaticAccess0(c, staticFieldOffset, writing);
+    }
+
+    /**
      * Reports the offset of the first element in the storage allocation of a
      * given array class.  If {@link #arrayIndexScale} returns a non-zero value
      * for the same class, you may use that scale factor, together with this
@@ -3840,6 +3855,7 @@ public final class Unsafe {
     private native Object staticFieldBase0(Field f);
     private native boolean shouldBeInitialized0(Class<?> c);
     private native void ensureClassInitialized0(Class<?> c);
+    private native void notifyStrictStaticAccess0(Class<?> c, long staticFieldOffset, boolean writing);
     private native int arrayBaseOffset0(Class<?> arrayClass);
     private native int arrayIndexScale0(Class<?> arrayClass);
     private native int getLoadAverage0(double[] loadavg, int nelems);

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleBooleanFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleBooleanFieldAccessorImpl.java
@@ -62,7 +62,7 @@ class MethodHandleBooleanFieldAccessorImpl extends MethodHandleFieldAccessorImpl
             } else {
                 return (boolean) getter.invokeExact(obj);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             throw newGetIllegalArgumentException(obj);
@@ -131,7 +131,7 @@ class MethodHandleBooleanFieldAccessorImpl extends MethodHandleFieldAccessorImpl
             } else {
                 setter.invokeExact(obj, z);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             // receiver is of invalid type

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleByteFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleByteFieldAccessorImpl.java
@@ -66,7 +66,7 @@ class MethodHandleByteFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
             } else {
                 return (byte) getter.invokeExact(obj);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             throw newGetIllegalArgumentException(obj);
@@ -137,7 +137,7 @@ class MethodHandleByteFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
             } else {
                 setter.invokeExact(obj, b);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             // receiver is of invalid type

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleCharacterFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleCharacterFieldAccessorImpl.java
@@ -70,7 +70,7 @@ class MethodHandleCharacterFieldAccessorImpl extends MethodHandleFieldAccessorIm
             } else {
                 return (char) getter.invokeExact(obj);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             throw newGetIllegalArgumentException(obj);
@@ -143,7 +143,7 @@ class MethodHandleCharacterFieldAccessorImpl extends MethodHandleFieldAccessorIm
             } else {
                 setter.invokeExact(obj, c);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             // receiver is of invalid type

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleDoubleFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleDoubleFieldAccessorImpl.java
@@ -90,7 +90,7 @@ class MethodHandleDoubleFieldAccessorImpl extends MethodHandleFieldAccessorImpl 
             } else {
                 return (double) getter.invokeExact(obj);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             throw newGetIllegalArgumentException(obj);
@@ -192,7 +192,7 @@ class MethodHandleDoubleFieldAccessorImpl extends MethodHandleFieldAccessorImpl 
             } else {
                 setter.invokeExact(obj, d);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             // receiver is of invalid type

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleFloatFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleFloatFieldAccessorImpl.java
@@ -86,7 +86,7 @@ class MethodHandleFloatFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
             } else {
                 return (float) getter.invokeExact(obj);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             throw newGetIllegalArgumentException(obj);
@@ -183,7 +183,7 @@ class MethodHandleFloatFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
             } else {
                 setter.invokeExact(obj, f);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             // receiver is of invalid type

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleIntegerFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleIntegerFieldAccessorImpl.java
@@ -78,7 +78,7 @@ class MethodHandleIntegerFieldAccessorImpl extends MethodHandleFieldAccessorImpl
             } else {
                 return (int) getter.invokeExact(obj);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             throw newGetIllegalArgumentException(obj);
@@ -165,7 +165,7 @@ class MethodHandleIntegerFieldAccessorImpl extends MethodHandleFieldAccessorImpl
             } else {
                 setter.invokeExact(obj, i);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             // receiver is of invalid type

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleLongFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleLongFieldAccessorImpl.java
@@ -82,7 +82,7 @@ class MethodHandleLongFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
             } else {
                 return (long) getter.invokeExact(obj);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             throw newGetIllegalArgumentException(obj);
@@ -174,7 +174,7 @@ class MethodHandleLongFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
             } else {
                 setter.invokeExact(obj, l);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             // receiver is of invalid type

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleObjectFieldAccessorImpl.java
@@ -55,7 +55,7 @@ class MethodHandleObjectFieldAccessorImpl extends MethodHandleFieldAccessorImpl 
     public Object get(Object obj) throws IllegalArgumentException {
         try {
             return isStatic() ? getter.invokeExact() : getter.invokeExact(obj);
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             throw newGetIllegalArgumentException(obj);
@@ -108,7 +108,7 @@ class MethodHandleObjectFieldAccessorImpl extends MethodHandleFieldAccessorImpl 
             } else {
                 setter.invokeExact(obj, value);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             // already ensure the receiver type.  So this CCE is due to the value.

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleShortFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleShortFieldAccessorImpl.java
@@ -74,7 +74,7 @@ class MethodHandleShortFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
             } else {
                 return (short) getter.invokeExact(obj);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             throw newGetIllegalArgumentException(obj);
@@ -153,7 +153,7 @@ class MethodHandleShortFieldAccessorImpl extends MethodHandleFieldAccessorImpl {
             } else {
                 setter.invokeExact(obj, s);
             }
-        } catch (IllegalArgumentException|NullPointerException e) {
+        } catch (IllegalArgumentException|IllegalStateException|NullPointerException e) {
             throw e;
         } catch (ClassCastException e) {
             // receiver is of invalid type

--- a/test/hotspot/jtreg/runtime/strictStatic/StrictStaticTests.java
+++ b/test/hotspot/jtreg/runtime/strictStatic/StrictStaticTests.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8888888
+ * @summary test tracking of strict static fields
+ * @run main strictStatic.StrictStaticTests
+ */
+
+package strictStatic;
+
+import java.lang.classfile.*;
+import java.lang.constant.*;
+import java.lang.reflect.*;
+import java.lang.invoke.*;
+
+import static java.lang.invoke.MethodHandles.*;
+import static java.lang.invoke.MethodType.*;
+import static java.lang.constant.ConstantDescs.*;
+
+public class StrictStaticTests {
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+    private static final String THIS_PACKAGE = LOOKUP.lookupClass().getPackageName();
+
+    static Class<?> buildClass(String className,
+                               Class<?> staticType,
+                               int writeCount,   // how many putstatics? (0=>error)
+                               byte readFlag,    // read before (-1) or after (1)?
+                               int extraCount    // how many extra strict statics?
+                               ) {
+        ClassDesc cn = ClassDesc.of(THIS_PACKAGE+"."+className);
+        ClassDesc CD_Integer = Integer.class.describeConstable().orElseThrow();
+        String    VO_NAME = "valueOf";
+        MethodTypeDesc VO_TYPE = MethodTypeDesc.of(CD_Integer, CD_int);
+        String    SS_NAME = "SS";
+        ClassDesc SS_TYPE = staticType.describeConstable().orElseThrow();
+        String    XS_NAME = "EXTRAS";
+        ClassDesc XS_TYPE = CD_boolean;
+        String    PS_NAME = "PLAIN";
+        ClassDesc PS_TYPE = CD_byte;
+
+        boolean prim = staticType.isPrimitive();
+        boolean pop2 = staticType == double.class;
+        final ConstantDesc SS_INIT, SS_INIT_2;
+        if (!prim) {
+            SS_INIT = "foo";
+            SS_INIT_2 = null;
+        } else if (!pop2) {
+            SS_INIT = 1;
+            SS_INIT_2 = 0;
+        } else {
+            SS_INIT = 3.14;
+            SS_INIT_2 = 0.0;
+        }
+        byte[] classBytes = ClassFile.of().build(cn, clb -> {
+                clb.withField(SS_NAME, SS_TYPE, ClassFile.ACC_STATIC|ClassFile.ACC_STRICT);
+                for (int i = 0; i < extraCount; i++) {
+                    clb.withField(XS_NAME+i, XS_TYPE, ClassFile.ACC_STATIC|ClassFile.ACC_STRICT);
+                    clb.withField(PS_NAME+i, PS_TYPE, ClassFile.ACC_STATIC);
+                }
+                clb.withMethodBody(CLASS_INIT_NAME, MTD_void, ClassFile.ACC_STATIC, cob -> {
+                        // always store into the extra strict static(s)
+                        for (int i = 0; i < extraCount/2; i++) {
+                            cob.loadConstant(i&1);
+                            cob.putstatic(cn, XS_NAME+i, XS_TYPE);
+                        }
+                        if (readFlag < 0) {
+                            // perform an early read, which must fail
+                            cob.getstatic(cn, SS_NAME, SS_TYPE);
+                            if (pop2) cob.pop2(); else cob.pop();
+                        }
+                        // perform any writes on the test field
+                        ConstantDesc initializer = SS_INIT;
+                        for (int i = 0; i < writeCount; i++) {
+                            if (i > 0) initializer = SS_INIT_2;
+                            cob.loadConstant(initializer);
+                            cob.putstatic(cn, SS_NAME, SS_TYPE);
+                            // if we write zero times we must fail
+                        }
+                        if (readFlag < 0) {
+                            // perform a late read, which must work
+                            cob.getstatic(cn, SS_NAME, SS_TYPE);
+                            if (prim) {
+                                if (pop2) cob.pop2(); else cob.pop();
+                            } else {
+                                cob.loadConstant(initializer);
+                                var L_skip = cob.newLabel();
+                                cob.if_acmpeq(L_skip);
+                                cob.loadConstant(null);
+                                cob.athrow();  // NPE!
+                                cob.labelBinding(L_skip);
+                            }
+                        }
+                        // finish storing into the extra strict static(s)
+                        for (int i = extraCount/2; i < extraCount; i++) {
+                            cob.loadConstant(i&1);
+                            cob.putstatic(cn, XS_NAME+i, XS_TYPE);
+                        }
+                        cob.return_();
+                    });
+            });
+        var vererrs = ClassFile.of().verify(classBytes);
+        if (vererrs != null && !vererrs.isEmpty()) {
+            System.out.println(vererrs);
+            var cm = ClassFile.of().parse(classBytes);
+            System.out.println("" + cm + cm.fields() + cm.methods() + cm.methods().get(0).code().orElseThrow().elementList());
+        }
+        ++COUNT;
+        try {
+            return LOOKUP.defineHiddenClass(classBytes, false).lookupClass();
+        } catch (IllegalAccessException ex) {
+            throw new AssertionError(ex);
+        }
+    }
+
+    static int COUNT = 0;
+
+    private static final Class<?> STATIC_TYPES[] = {
+        Object.class,
+        String.class,
+        int.class,
+        boolean.class,
+        double.class
+    };
+
+    static boolean isSSFailure(Throwable ex) {
+        return ex instanceof ExceptionInInitializerError &&
+            ex.getCause() instanceof IllegalStateException;
+    }
+    static void testPositives() {
+        for (var staticType : STATIC_TYPES) {
+            for (int writeCount = 1; writeCount <= 3; writeCount++) {
+                for (byte readFlag = 0; readFlag <= 1; readFlag++) {
+                    for (int extraCount = 0; extraCount <= 3; extraCount++) {
+                        var cn = String.format("Positive%sW%d%sE%d",
+                                               staticType.getSimpleName(),
+                                               writeCount,
+                                               readFlag > 0 ? "Rafter" : readFlag < 0 ? "Rbefore" : "",
+                                               extraCount);
+                        var cls = buildClass(cn, staticType, writeCount, readFlag, extraCount);
+                        try {
+                            LOOKUP.ensureInitialized(cls);
+                        } catch (Throwable ex) {
+                            reportThrow(false, ex, cn);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    static void testFailedWrites() {
+        for (var staticType : STATIC_TYPES) {
+            for (int writeCount = 0; writeCount <= 0; writeCount++) {
+                for (byte readFlag = 0; readFlag <= 0; readFlag++) {
+                    for (int extraCount = 0; extraCount <= 3; extraCount++) {
+                        var cn = String.format("NoWrite%sW%d%sE%d",
+                                               staticType.getSimpleName(),
+                                               writeCount,
+                                               readFlag > 0 ? "Rafter" : readFlag < 0 ? "Rbefore" : "",
+                                               extraCount);
+                        var cls = buildClass(cn, staticType, writeCount, readFlag, extraCount);
+                        try {
+                            LOOKUP.ensureInitialized(cls);
+                            throw new AssertionError(cn);
+                        } catch (Throwable ex) {
+                            reportThrow(isSSFailure(ex), ex, cn);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    static void testFailedReads() {
+        for (var staticType : STATIC_TYPES) {
+            for (int writeCount = 0; writeCount <= 1; writeCount++) {
+                for (byte readFlag = -1; readFlag <= -1; readFlag++) {
+                    for (int extraCount = 0; extraCount <= 3; extraCount++) {
+                        var cn = String.format("BadRead%sW%d%sE%d",
+                                               staticType.getSimpleName(),
+                                               writeCount,
+                                               readFlag > 0 ? "Rafter" : readFlag < 0 ? "Rbefore" : "",
+                                               extraCount);
+                        var cls = buildClass(cn, staticType, writeCount, readFlag, extraCount);
+                        try {
+                            LOOKUP.ensureInitialized(cls);
+                            throw new AssertionError(cn);
+                        } catch (Throwable ex) {
+                            reportThrow(isSSFailure(ex), ex, cn);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static boolean VERBOSE = false;
+
+    private static void reportThrow(boolean ok, Throwable ex, String cn) {
+        if (!ok)  throw new AssertionError(ex);
+        if (VERBOSE) {
+            if (ex instanceof ExceptionInInitializerError && ex.getCause() != null)
+                ex = ex.getCause();
+            System.out.printf("%s: %s: %s\n", ok ? "ok" : "FAIL", cn, ex);
+        }
+    }
+
+    public static void main(String... av) {
+        testPositives();
+        testFailedWrites();
+        testFailedReads();
+        System.out.println("tested "+COUNT+" classes");
+    }
+}


### PR DESCRIPTION
Prototype strict static feature.

If a static field is marked ACC_STRICT, the VM insists on two things:

A. Before <clinit> finishes, the field has been written at least once.

B. Before the first write to the field, there have been no reads.

Strict statics can be final or non-final.  They can be read and written directly by bytecode, or indirectly by means of reflection, method handles, or JNI.  Regardless of the means of reading and writing, the two new conditions A and B are enforced.

No other new constraints are enforced.  The same strict static field can be written many times within the <clinit>, even if it is final.  (Yes, finals can be written multiple times in the VM, even though the language tries to prevent that.)

A strict static final is "locked down" when <clinit> exits.  No further modification is allowed, and compilers are free to constant-fold the last-written value.
