### PR TITLE
8349906: G1: Improve initial survivor rate for newly used young regions

### DIFF
--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
@@ -75,7 +75,7 @@ void G1SurvRateGroup::stop_adding_regions() {
     double new_pred = _stats_arrays_length > 1
                     ? _accum_surv_rate_pred[_stats_arrays_length - 1] - _accum_surv_rate_pred[_stats_arrays_length - 2]
                     : InitialSurvivorRate;
-    
+
     for (size_t i = _stats_arrays_length; i < _num_added_regions; ++i) {
       // Initialize predictors and accumulated survivor rate predictions.
       _surv_rate_predictors[i] = new TruncatedSeq(10);

--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
@@ -68,13 +68,21 @@ void G1SurvRateGroup::stop_adding_regions() {
     _accum_surv_rate_pred = REALLOC_C_HEAP_ARRAY(double, _accum_surv_rate_pred, _num_added_regions, mtGC);
     _surv_rate_predictors = REALLOC_C_HEAP_ARRAY(TruncatedSeq*, _surv_rate_predictors, _num_added_regions, mtGC);
 
+    // Assume that the prediction for the newly added regions is the same as the
+    // ones at the (current) end of the array. Particularly predictions at the end
+    // of this array fairly seldom get updated, so having a better initial value
+    // that is at least somewhat related to the actual application is preferable.
+    double new_pred = _stats_arrays_length > 1
+                    ? _accum_surv_rate_pred[_stats_arrays_length - 1] - _accum_surv_rate_pred[_stats_arrays_length - 2]
+                    : InitialSurvivorRate;
+    
     for (size_t i = _stats_arrays_length; i < _num_added_regions; ++i) {
       // Initialize predictors and accumulated survivor rate predictions.
       _surv_rate_predictors[i] = new TruncatedSeq(10);
-      _surv_rate_predictors[i]->add(InitialSurvivorRate);
-      _accum_surv_rate_pred[i] = ((i == 0) ? 0.0 : _accum_surv_rate_pred[i-1]) + InitialSurvivorRate;
+      _surv_rate_predictors[i]->add(new_pred);
+      _accum_surv_rate_pred[i] = ((i == 0) ? 0.0 : _accum_surv_rate_pred[i-1]) + new_pred;
     }
-    _last_pred = InitialSurvivorRate;
+    _last_pred = new_pred;
 
     _stats_arrays_length = _num_added_regions;
   }
@@ -110,7 +118,7 @@ double G1SurvRateGroup::accum_surv_rate_pred(uint age) const {
 void G1SurvRateGroup::fill_in_last_surv_rates() {
   if (_num_added_regions > 0) { // conservative
     double surv_rate = _surv_rate_predictors[_num_added_regions-1]->last();
-    for (size_t i = _num_added_regions; i < _stats_arrays_length; ++i) {
+    for (uint i = _num_added_regions; i < _stats_arrays_length; ++i) {
       _surv_rate_predictors[i]->add(surv_rate);
     }
   }

--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
@@ -28,8 +28,6 @@
 #include "logging/log.hpp"
 #include "memory/allocation.hpp"
 
-#include "logging/logStream.hpp"
-
 G1SurvRateGroup::G1SurvRateGroup() :
   _stats_arrays_length(0),
   _num_added_regions(0),


### PR DESCRIPTION
Hi all,

  please review this change that tries to improve the survivor rate initial values for newly expanded regions.

Currently G1 uses `InitialSurvivorRate` as survivor rate for such regions, but it is typically a pretty bad choice because

* it's rather conservative, estimating that 40% of region contents will survive
* such a conservative value is kind of bad particularly in cases for regions that are expanded late in the mutator phase because they are not frequently updated (and with our running weights changes get propagated over a very long time), i.e. this 40% sticks for a long time (*)
* it is a random value, i.e. not particularly specific to the application.

The suggestion is to use the survivor rate for the last region we know the survivor rate already.

(*) to clarify this a little: G1 keeps track of `[0...m]` survivor rate predictors. For a given garbage collection, `[0...n]` of those are updated (`n` is the number of eden/survivor regions depending on the rate group). However those for `]n...m]` are not, particularly those in that range that are seldom allocated, the predictors are not updated very frequently. Now the young gen sizing uses these predictions "at the end" of the predictor anyway, and since they are infrequently updated and their values are very conservative, G1 won't expand young gen as much as it could/should.

Testing: gha, tier1-7 (with other changes)

Hth,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349906](https://bugs.openjdk.org/browse/JDK-8349906): G1: Improve initial survivor rate for newly used young regions (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) Review applies to [5c4ded01](https://git.openjdk.org/jdk/pull/23584/files/5c4ded01c1611a0c9f612bc2f9a565c547a6585a)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23584/head:pull/23584` \
`$ git checkout pull/23584`

Update a local copy of the PR: \
`$ git checkout pull/23584` \
`$ git pull https://git.openjdk.org/jdk.git pull/23584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23584`

View PR using the GUI difftool: \
`$ git pr show -t 23584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23584.diff">https://git.openjdk.org/jdk/pull/23584.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23584#issuecomment-2653491687)
</details>
