### PR TITLE
8349476

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1311,6 +1311,8 @@ private:
   void print_heap_regions() const;
   void print_regions_on(outputStream* st) const;
 
+  void print_worker_threads_elapsed_time() const;
+
 public:
   void print_on(outputStream* st) const override;
   void print_extended_on(outputStream* st) const override;


### PR DESCRIPTION
Hi all,

  please review this change to print total cpu usage per worker thread group every gc (with `gc+cpu=debug`) to have a better overview about which threads are taking how much CPU.

I considered merging with the gc worker perfcounter update close by, but the opportunity to share code is very little, and the resulting code would be riddled with checking whether the perf counters should be updated or not.

I.e. the only shared code would be the closure with a one-liner calling `os::thread_cpu_time()`; most other code would be different, e.g. determining whether to update the perf counters or not, the actual log messages etc.

Tell me if you think I should try harder to do so.

Testing: gha

Thanks,
  Thomas