### PR TITLE
8349858: Print compilation task before blocking compiler thread for shutdown

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2074,7 +2074,21 @@ void CompileBroker::maybe_block() {
     if (PrintCompilation && (Verbose || WizardMode))
       tty->print_cr("compiler thread " INTPTR_FORMAT " poll detects block request", p2i(Thread::current()));
 #endif
+    // If we are executing a task during the request to block, report the task
+    // before disappearing.
+    CompilerThread* thread = CompilerThread::current();
+    if (thread != nullptr) {
+      CompileTask* task = thread->task();
+      if (task != nullptr) {
+        if (PrintCompilation) {
+          task->print(tty, "blocked");
+        }
+        task->print_ul("blocked");
+      }
+    }
+    // Go to VM state and block for final VM shutdown safepoint.
     ThreadInVMfromNative tivfn(JavaThread::current());
+    assert(false, "Should never unblock from TIVNM entry");
   }
 }
 


### PR DESCRIPTION
JIT compilers in current Hotspot are compiling the code while being in native state. So if there is a running compilation, it does not block shutdown naturally. The shutdown code has cooperative mechanism to coordinate shutdown of compiler threads. Shutdown code sets the `CompilerBroker::should_block`, and compilers are regularly checking it with `CompilerBroker::maybe_block`. When shutdown is pending, the running compiler threads would eventually hit that `maybe_block`, block at transition to VM state, and that would allow shutdown to proceed.

One of the problems with this mechanism is observability: if compiler thread was running a long-running compilation, nothing would be written in the compilation logs about it. The compilation would just -- poof! -- disappear without a trace. This is arguably against the user expectation: we print _something_ whether the compilation succeeded or failed.

This kind of shutdown-during-heavy-compilation regularly happens in short runs in Leyden benchmarks. It made me scratch my head for quite a while before I understood where the compilation task went. I would like to add some sort of diagnostics for these cases.

Example `-XX:+PrintCompilation` output in Leyden after the patch (includes richer compile-task timings):

```
...
    430    W3.4    Q2.7    C0.3   4397               com.sun.tools.javac.comp.Check::checkProfile (40 bytes)
    447    W0.0    Q0.0   C10.3   4398               java.util.StringJoiner::toString (53 bytes)
    456    W0.0   Q10.4    C9.7   4399               java.lang.System$1::join (11 bytes)
Generated source code for 51 classes and compiled them in 403 ms (1 iterations)
    476   W36.6   Q11.6   C72.1   4393               com.sun.tools.javac.jvm.PoolWriter$WriteablePoolHelper::writeConstant (843 bytes)   blocked
    481    W0.0    Q0.0  C157.6   4390               com.sun.tools.javac.comp.TransTypes::visitIdent (129 bytes)   blocked
<end of log>
```

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349858](https://bugs.openjdk.org/browse/JDK-8349858): Print compilation task before blocking compiler thread for shutdown (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23586/head:pull/23586` \
`$ git checkout pull/23586`

Update a local copy of the PR: \
`$ git checkout pull/23586` \
`$ git pull https://git.openjdk.org/jdk.git pull/23586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23586`

View PR using the GUI difftool: \
`$ git pr show -t 23586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23586.diff">https://git.openjdk.org/jdk/pull/23586.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23586#issuecomment-2653650594)
</details>
