### PR TITLE
8349783: g1RemSetSummary.cpp:344:68: runtime error: member call on null pointer of type 'struct G1HeapRegion'

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -341,7 +341,6 @@ public:
 
     if (max_cardset_mem_sz_group() != nullptr) {
       G1CSetCandidateGroup* cset_group = max_cardset_mem_sz_group();
-      G1HeapRegionRemSet* rem_set = max_rs_mem_sz_region()->rem_set();
       out->print_cr("    Collectionset Candidate Group with largest cardset = %u:(%u regions), "
                     "size = %zu occupied = %zu",
                     cset_group->group_id(), cset_group->length(),
@@ -389,7 +388,6 @@ void G1RemSetSummary::print_on(outputStream* out, bool show_thread_times) {
     }
     out->cr();
   }
-
   HRRSStatsIter blk;
   G1CollectedHeap::heap()->heap_region_iterate(&blk);
   blk.do_cset_groups();


### PR DESCRIPTION
Hi,

Please review this cleanup to remove dead code.

Testing: local testing with --enable-ubsan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349783](https://bugs.openjdk.org/browse/JDK-8349783): g1RemSetSummary.cpp:344:68: runtime error: member call on null pointer of type 'struct G1HeapRegion' (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23587/head:pull/23587` \
`$ git checkout pull/23587`

Update a local copy of the PR: \
`$ git checkout pull/23587` \
`$ git pull https://git.openjdk.org/jdk.git pull/23587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23587`

View PR using the GUI difftool: \
`$ git pr show -t 23587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23587.diff">https://git.openjdk.org/jdk/pull/23587.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23587#issuecomment-2653778045)
</details>
