### PR TITLE
8349907: jdk.tools.jlink.internal.plugins.ZipPlugin does not close the Deflater in exceptional cases

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ZipPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ZipPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,27 +82,25 @@ public final class ZipPlugin extends AbstractPlugin {
     }
 
     static byte[] compress(byte[] bytesIn, int compressionLevel) {
-        Deflater deflater = new Deflater(compressionLevel);
-        deflater.setInput(bytesIn);
-        ByteArrayOutputStream stream = new ByteArrayOutputStream(bytesIn.length);
-        byte[] buffer = new byte[1024];
+        try (Deflater deflater = new Deflater(compressionLevel)) {
+            deflater.setInput(bytesIn);
+            ByteArrayOutputStream stream = new ByteArrayOutputStream(bytesIn.length);
+            byte[] buffer = new byte[1024];
 
-        deflater.finish();
-        while (!deflater.finished()) {
-            int count = deflater.deflate(buffer);
-            stream.write(buffer, 0, count);
+            deflater.finish();
+            while (!deflater.finished()) {
+                int count = deflater.deflate(buffer);
+                stream.write(buffer, 0, count);
+            }
+
+            try {
+                stream.close();
+            } catch (IOException ex) {
+                return bytesIn; // return the original uncompressed input
+            }
+
+            return stream.toByteArray(); // the compressed output
         }
-
-        try {
-            stream.close();
-        } catch (IOException ex) {
-            return bytesIn;
-        }
-
-        byte[] bytesOut = stream.toByteArray();
-        deflater.end();
-
-        return bytesOut;
     }
 
     @Override

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ZipPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ZipPlugin.java
@@ -82,9 +82,11 @@ public final class ZipPlugin extends AbstractPlugin {
     }
 
     static byte[] compress(byte[] bytesIn, int compressionLevel) {
-        try (Deflater deflater = new Deflater(compressionLevel)) {
+        try (Deflater deflater = new Deflater(compressionLevel);
+             ByteArrayOutputStream stream = new ByteArrayOutputStream(bytesIn.length)) {
+
             deflater.setInput(bytesIn);
-            ByteArrayOutputStream stream = new ByteArrayOutputStream(bytesIn.length);
+
             byte[] buffer = new byte[1024];
 
             deflater.finish();
@@ -92,14 +94,9 @@ public final class ZipPlugin extends AbstractPlugin {
                 int count = deflater.deflate(buffer);
                 stream.write(buffer, 0, count);
             }
-
-            try {
-                stream.close();
-            } catch (IOException ex) {
-                return bytesIn; // return the original uncompressed input
-            }
-
             return stream.toByteArray(); // the compressed output
+        } catch (IOException e) {
+            return bytesIn; // return the original uncompressed input
         }
     }
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ZipPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ZipPlugin.java
@@ -96,7 +96,12 @@ public final class ZipPlugin extends AbstractPlugin {
             }
             return stream.toByteArray(); // the compressed output
         } catch (IOException e) {
-            return bytesIn; // return the original uncompressed input
+            // the IOException is only declared by ByteArrayOutputStream.close()
+            // but the impl of ByteArrayOutputStream.close() is a no-op, so for
+            // all practical purposes there should never be an IOException thrown
+            assert false : "unexpected " + e;
+            // don't propagate the exception, instead return the original uncompressed input
+            return bytesIn;
         }
     }
 


### PR DESCRIPTION
Can I please get a review of this change in `jdk.tools.jlink.internal.plugins.ZipPlugin` which proposes to close the `Deflater` instance cleanly? This addresses https://bugs.openjdk.org/browse/JDK-8349907.

As noted in that issue, the `Deflater` instance wasn't being closed in the exception code path of this method. The commit in this PR merely changes the code to use a try-with-resources block on the `Deflater` instance.

No new tests have been introduced given the nature of the change. I've added a `noreg-hard` to the issue. Existing tier1, tier2 and tier3 tests continue to pass with this change without any related failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349907](https://bugs.openjdk.org/browse/JDK-8349907): jdk.tools.jlink.internal.plugins.ZipPlugin does not close the Deflater in exceptional cases (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) Review applies to [3437f9ba](https://git.openjdk.org/jdk/pull/23588/files/3437f9ba0fd0e7d7a879dd9b94c205e994e5264a)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23588/head:pull/23588` \
`$ git checkout pull/23588`

Update a local copy of the PR: \
`$ git checkout pull/23588` \
`$ git pull https://git.openjdk.org/jdk.git pull/23588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23588`

View PR using the GUI difftool: \
`$ git pr show -t 23588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23588.diff">https://git.openjdk.org/jdk/pull/23588.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23588#issuecomment-2653834725)
</details>
