### PR TITLE
8349915: CTW: Lots of level 3 compiles are done at level 2 after JDK-8348570

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -673,7 +673,10 @@ CompileTask* CompilationPolicy::select_task(CompileQueue* compile_queue) {
   methodHandle max_method_h(Thread::current(), max_method);
 
   if (max_task != nullptr && max_task->comp_level() == CompLevel_full_profile && TieredStopAtLevel > CompLevel_full_profile &&
-      max_method != nullptr && is_method_profiled(max_method_h) && !Arguments::is_compiler_only()) {
+      max_method != nullptr && is_method_profiled(max_method_h) &&
+      !Arguments::is_compiler_only() &&
+      (max_task->compile_reason() != CompileTask::Reason_Whitebox))  // CTW should not drop the compilation level
+  {
     max_task->set_comp_level(CompLevel_limited_profile);
 
     if (CompileBroker::compilation_is_complete(max_method_h, max_task->osr_bci(), CompLevel_limited_profile)) {

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -199,6 +199,8 @@ class CompileTask : public CHeapObj<mtCompiler> {
   int          comp_level()                      { return _comp_level;}
   void         set_comp_level(int comp_level)    { _comp_level = comp_level;}
 
+  CompileReason compile_reason()                 { return _compile_reason; }
+
   AbstractCompiler* compiler() const;
   CompileTask*      select_for_compilation();
 


### PR DESCRIPTION
Noticed this in manual CTW runs after [JDK-8348570](https://bugs.openjdk.org/browse/JDK-8348570) that lots and lots of methods are compiled at level 2 instead of requested level 3:

```
...
[97] javax.enterprise.deploy.shared.ActionType::getValue() WARNING compilation level = 2, but not 3
[97] javax.enterprise.deploy.shared.ActionType::getOffset() WARNING compilation level = 2, but not 3
[97] javax.enterprise.deploy.shared.ActionType::getEnumValueTable() WARNING compilation level = 2, but not 3
[97] javax.enterprise.deploy.shared.ActionType::getStringTable() WARNING compilation level = 2, but not 3
[97] javax.enterprise.deploy.shared.ActionType::getActionType(int) WARNING compilation level = 2, but not 3
[97] javax.enterprise.deploy.shared.ActionType::toString() WARNING compilation level = 2, but not 3
[99] javax.enterprise.deploy.shared.DConfigBeanVersionType
[98] javax.enterprise.deploy.shared.CommandType::toString() WARNING compilation level = 2, but not 3
[98] javax.enterprise.deploy.shared.CommandType::getOffset() WARNING compilation level = 2, but not 3
...
```

I narrowed it down to level downgrade in compilation policy here:
 https://github.com/openjdk/jdk/blob/ed17c55ea34b3b6009dab11d64f21e0b7af3d701/src/hotspot/share/compiler/compilationPolicy.cpp#L677

[JDK-8348570](https://bugs.openjdk.org/browse/JDK-8348570) enters here, because we mark all methods as having profiles to extend the CTW scope. So now `is_method_profiled(max_method_h)` is `true` and downgrade happens. There is already check for `!Arguments::is_compiler_only()` there, so I think we better exclude CTW from this downgrade as well.

I looked at possibly making this kind of downgrade fatal in CTW runner, but the error propagation there is not simple. I filed [JDK-8349917](https://bugs.openjdk.org/browse/JDK-8349917) if anyone want to take a stab on it.

I looked at other `set_comp_level()` uses in Hotspot, and this is the only place where it is called. So I presume we have caught all places where this downgrade can happen.

Additional testing:
 - [x] Linux x86_64 server fastdebug, eyeballing some manual CTW run results
 - [x] Linux x86_64 server fastdebug, `applications/ctw/modules` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349915](https://bugs.openjdk.org/browse/JDK-8349915): CTW: Lots of level 3 compiles are done at level 2 after JDK-8348570 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23589/head:pull/23589` \
`$ git checkout pull/23589`

Update a local copy of the PR: \
`$ git checkout pull/23589` \
`$ git pull https://git.openjdk.org/jdk.git pull/23589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23589`

View PR using the GUI difftool: \
`$ git pr show -t 23589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23589.diff">https://git.openjdk.org/jdk/pull/23589.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23589#issuecomment-2653947552)
</details>
