### PR TITLE
8349926: [BACKOUT] Support static JDK in libfontmanager/freetypeScaler.c

### DIFF
--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -407,7 +407,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     LDFLAGS_aix := -Wl$(COMMA)-berok, \
     JDK_LIBS := libawt java.base:libjava $(LIBFONTMANAGER_JDK_LIBS), \
     JDK_LIBS_macosx := libawt_lwawt, \
-    JDK_LIBS_unix := java.base:libjvm, \
     LIBS := $(LIBFONTMANAGER_LIBS), \
     LIBS_unix := $(LIBM), \
     LIBS_macosx := \

--- a/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
+++ b/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
@@ -32,7 +32,6 @@
 #include <stdlib.h>
 #if !defined(_WIN32) && !defined(__APPLE_)
 #include <dlfcn.h>
-#include "jvm.h"
 #endif
 #include <math.h>
 #include "ft2build.h"
@@ -299,19 +298,6 @@ static void setInterpreterVersion(FT_Library library) {
 #if defined(_WIN32) || defined(__APPLE__)
     FT_Property_Set(library, module, property, (void*)(&version));
 #else
-
-    if (JVM_IsStaticallyLinked()) {
-      // The bundled libfreetype may be statically linked with
-      // the launcher.
-      if (dlsym(RTLD_DEFAULT, "FT_Property_Set") != NULL) {
-        FT_Property_Set(library, module, property, (void*)(&version));
-        return;
-      }
-
-      // libfreetype is not statically linked with the executable,
-      // fall through to find the system provided library dynamically.
-    }
-
     void *lib = dlopen("libfreetype.so", RTLD_LOCAL|RTLD_LAZY);
     if (lib == NULL) {
         lib = dlopen("libfreetype.so.6", RTLD_LOCAL|RTLD_LAZY);


### PR DESCRIPTION
Backout change [JDK-8349859](https://git.openjdk.org/jdk/commit/332d87cc7e19d55ddb98a43a6eb3a77f3518ecfd) because it causes build failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349926](https://bugs.openjdk.org/browse/JDK-8349926): [BACKOUT] Support static JDK in libfontmanager/freetypeScaler.c (**Sub-task** - P2)


### Reviewers
 * [Jiangli Zhou](https://openjdk.org/census#jiangli) (@jianglizhou - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23591/head:pull/23591` \
`$ git checkout pull/23591`

Update a local copy of the PR: \
`$ git checkout pull/23591` \
`$ git pull https://git.openjdk.org/jdk.git pull/23591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23591`

View PR using the GUI difftool: \
`$ git pr show -t 23591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23591.diff">https://git.openjdk.org/jdk/pull/23591.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23591#issuecomment-2654456037)
</details>
