### PR TITLE
Convert to using GrowableArray instead of LinkedList

### DIFF
--- a/src/hotspot/share/nmt/allocationSite.hpp
+++ b/src/hotspot/share/nmt/allocationSite.hpp
@@ -31,9 +31,10 @@
 // Allocation site represents a code path that makes a memory
 // allocation
 class AllocationSite {
- private:
+protected:
   const NativeCallStack  _call_stack;
   const MemTag           _mem_tag;
+
  public:
   AllocationSite(const NativeCallStack& stack, MemTag mem_tag) : _call_stack(stack), _mem_tag(mem_tag) { }
 

--- a/src/hotspot/share/nmt/mallocSiteTable.hpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.hpp
@@ -39,10 +39,19 @@ class MallocSite : public AllocationSite {
   MemoryCounter _c;
 public:
   MallocSite() : AllocationSite(NativeCallStack(), mtNone) {}
+
   MallocSite(const MallocSite& other)
   : AllocationSite(*other.call_stack(), other.mem_tag()), _c(other._c) {}
+
   MallocSite(const NativeCallStack& stack, MemTag mem_tag) :
     AllocationSite(stack, mem_tag) {}
+
+  MallocSite& operator=(const MallocSite& other) {
+    this->_c = other._c;
+    const_cast<NativeCallStack&>(this->_call_stack) = other._call_stack;
+    const_cast<MemTag&>(this->_mem_tag) = other._mem_tag;
+    return *this;
+  }
 
   void allocate(size_t size)      { _c.allocate(size);   }
   void deallocate(size_t size)    { _c.deallocate(size); }

--- a/src/hotspot/share/nmt/mallocSiteTable.hpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.hpp
@@ -37,7 +37,8 @@
 // os::malloc() to allocate memory
 class MallocSite : public AllocationSite {
   MemoryCounter _c;
- public:
+public:
+  MallocSite() : AllocationSite(NativeCallStack(), mtNone) {}
   MallocSite(const NativeCallStack& stack, MemTag mem_tag) :
     AllocationSite(stack, mem_tag) {}
 

--- a/src/hotspot/share/nmt/mallocSiteTable.hpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.hpp
@@ -39,6 +39,8 @@ class MallocSite : public AllocationSite {
   MemoryCounter _c;
 public:
   MallocSite() : AllocationSite(NativeCallStack(), mtNone) {}
+  MallocSite(const MallocSite& other)
+  : AllocationSite(*other.call_stack(), other.mem_tag()), _c(other._c) {}
   MallocSite(const NativeCallStack& stack, MemTag mem_tag) :
     AllocationSite(stack, mem_tag) {}
 

--- a/src/hotspot/share/nmt/memBaseline.cpp
+++ b/src/hotspot/share/nmt/memBaseline.cpp
@@ -80,12 +80,12 @@ int compare_virtual_memory_site(const VirtualMemoryAllocationSite& s1,
  */
 class MallocAllocationSiteWalker : public MallocSiteWalker {
  private:
-  GrowableArray<MallocSite>& _malloc_sites;
+  GrowableArrayCHeap<MallocSite, mtNMT>& _malloc_sites;
 
   // Entries in MallocSiteTable with size = 0 and count = 0,
   // when the malloc site is not longer there.
  public:
-  MallocAllocationSiteWalker(GrowableArray<MallocSite>& malloc_sites)
+  MallocAllocationSiteWalker(GrowableArrayCHeap<MallocSite, mtNMT>& malloc_sites)
   : _malloc_sites(malloc_sites) {}
 
   bool do_malloc_site(const MallocSite* site) {
@@ -216,7 +216,7 @@ bool MemBaseline::aggregate_virtual_memory_allocation_sites() {
   return true;
 }
 
-GrowableArray<MallocSite>& MemBaseline::malloc_sites(SortingOrder order) {
+GrowableArrayCHeap<MallocSite, mtNMT>& MemBaseline::malloc_sites(SortingOrder order) {
   assert(!_malloc_sites.is_empty(), "Not detail baseline");
   switch(order) {
     case by_size:

--- a/src/hotspot/share/nmt/memBaseline.cpp
+++ b/src/hotspot/share/nmt/memBaseline.cpp
@@ -102,7 +102,6 @@ class MallocAllocationSiteWalker : public MallocSiteWalker {
 // Walk all virtual memory regions for baselining
 class VirtualMemoryAllocationWalker : public VirtualMemoryWalker {
 private:
-  GrowableArray<ReservedMemoryRegion> _virtual_memory_regions_a;
   typedef LinkedListImpl<ReservedMemoryRegion, AnyObj::C_HEAP, mtNMT,
                          AllocFailStrategy::RETURN_NULL> EntryList;
   EntryList _virtual_memory_regions;

--- a/src/hotspot/share/nmt/memBaseline.hpp
+++ b/src/hotspot/share/nmt/memBaseline.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_NMT_MEMBASELINE_HPP
 #define SHARE_NMT_MEMBASELINE_HPP
 
+#include "memory/arena.hpp"
 #include "memory/metaspaceStats.hpp"
 #include "nmt/mallocSiteTable.hpp"
 #include "nmt/mallocTracker.hpp"
@@ -70,12 +71,14 @@ class MemBaseline : public CHeapObj<mtNMT> {
   // Malloc allocation sites
   GrowableArrayCHeap<MallocSite, mtNMT>                  _malloc_sites;
 
+
   // All virtual memory allocations
-  LinkedListImpl<ReservedMemoryRegion>        _virtual_memory_allocations;
+  Arena _arena;
+  LinkedListImpl<ReservedMemoryRegion, AnyObj::ARENA>        _virtual_memory_allocations;
 
   // Virtual memory allocations by allocation sites, always in by_address
   // order
-  LinkedListImpl<VirtualMemoryAllocationSite> _virtual_memory_sites;
+  LinkedListImpl<VirtualMemoryAllocationSite, AnyObj::ARENA> _virtual_memory_sites;
 
   SortingOrder         _malloc_sites_order;
   SortingOrder         _virtual_memory_sites_order;
@@ -86,6 +89,9 @@ class MemBaseline : public CHeapObj<mtNMT> {
   // create a memory baseline
   MemBaseline():
     _instance_class_count(0), _array_class_count(0), _thread_count(0),
+    _arena(mtNMT),
+    _virtual_memory_allocations(&_arena),
+    _virtual_memory_sites(&_arena),
     _baseline_type(Not_baselined) {
   }
 

--- a/src/hotspot/share/nmt/memBaseline.hpp
+++ b/src/hotspot/share/nmt/memBaseline.hpp
@@ -40,7 +40,7 @@ typedef LinkedListIterator<ReservedMemoryRegion>         VirtualMemoryAllocation
 /*
  * Baseline a memory snapshot
  */
-class MemBaseline {
+class MemBaseline : public CHeapObj<mtNMT> {
  public:
 
   enum BaselineType {

--- a/src/hotspot/share/nmt/memBaseline.hpp
+++ b/src/hotspot/share/nmt/memBaseline.hpp
@@ -105,7 +105,7 @@ class MemBaseline : public CHeapObj<mtNMT> {
     return _metaspace_stats;
   }
 
-  GrowableArray<MallocSite>& malloc_sites(SortingOrder order);
+  GrowableArrayCHeap<MallocSite, mtNMT>& malloc_sites(SortingOrder order);
   VirtualMemorySiteIterator virtual_memory_sites(SortingOrder order);
 
   // Virtual memory allocation iterator always returns in virtual memory

--- a/src/hotspot/share/nmt/memBaseline.hpp
+++ b/src/hotspot/share/nmt/memBaseline.hpp
@@ -31,9 +31,9 @@
 #include "nmt/nmtCommon.hpp"
 #include "nmt/virtualMemoryTracker.hpp"
 #include "runtime/mutex.hpp"
+#include "utilities/growableArray.hpp"
 #include "utilities/linkedlist.hpp"
 
-typedef LinkedListIterator<MallocSite>                   MallocSiteIterator;
 typedef LinkedListIterator<VirtualMemoryAllocationSite>  VirtualMemorySiteIterator;
 typedef LinkedListIterator<ReservedMemoryRegion>         VirtualMemoryAllocationIterator;
 
@@ -68,7 +68,7 @@ class MemBaseline {
 
   // Allocation sites information
   // Malloc allocation sites
-  LinkedListImpl<MallocSite>                  _malloc_sites;
+  GrowableArray<MallocSite>                  _malloc_sites;
 
   // All virtual memory allocations
   LinkedListImpl<ReservedMemoryRegion>        _virtual_memory_allocations;
@@ -105,7 +105,7 @@ class MemBaseline {
     return _metaspace_stats;
   }
 
-  MallocSiteIterator malloc_sites(SortingOrder order);
+  GrowableArray<MallocSite>& malloc_sites(SortingOrder order);
   VirtualMemorySiteIterator virtual_memory_sites(SortingOrder order);
 
   // Virtual memory allocation iterator always returns in virtual memory
@@ -183,7 +183,7 @@ class MemBaseline {
     _array_class_count = 0;
     _thread_count = 0;
 
-    _malloc_sites.clear();
+    _malloc_sites.shrink_to_fit();
     _virtual_memory_sites.clear();
     _virtual_memory_allocations.clear();
   }

--- a/src/hotspot/share/nmt/memBaseline.hpp
+++ b/src/hotspot/share/nmt/memBaseline.hpp
@@ -68,7 +68,7 @@ class MemBaseline : public CHeapObj<mtNMT> {
 
   // Allocation sites information
   // Malloc allocation sites
-  GrowableArray<MallocSite>                  _malloc_sites;
+  GrowableArrayCHeap<MallocSite, mtNMT>                  _malloc_sites;
 
   // All virtual memory allocations
   LinkedListImpl<ReservedMemoryRegion>        _virtual_memory_allocations;

--- a/src/hotspot/share/nmt/memReporter.cpp
+++ b/src/hotspot/share/nmt/memReporter.cpp
@@ -323,7 +323,7 @@ void MemDetailReporter::report_detail() {
 }
 
 int MemDetailReporter::report_malloc_sites() {
-  GrowableArray<MallocSite>& malloc_sites = _baseline.malloc_sites(MemBaseline::by_size);
+  GrowableArrayCHeap<MallocSite, mtNMT>& malloc_sites = _baseline.malloc_sites(MemBaseline::by_size);
   if (malloc_sites.is_empty()) return 0;
 
   outputStream* out = output();
@@ -796,8 +796,8 @@ void MemDetailDiffReporter::report_diff() {
 }
 
 void MemDetailDiffReporter::diff_malloc_sites() const {
-  GrowableArray<MallocSite>& early = _early_baseline.malloc_sites(MemBaseline::by_site_and_type);
-  GrowableArray<MallocSite>& current = _current_baseline.malloc_sites(MemBaseline::by_site_and_type);
+  GrowableArrayCHeap<MallocSite, mtNMT>& early = _early_baseline.malloc_sites(MemBaseline::by_site_and_type);
+  GrowableArrayCHeap<MallocSite, mtNMT>& current = _current_baseline.malloc_sites(MemBaseline::by_site_and_type);
 
   int early_i = 0;
   int current_i = 0;

--- a/src/hotspot/share/nmt/memTracker.cpp
+++ b/src/hotspot/share/nmt/memTracker.cpp
@@ -49,7 +49,7 @@
 
 NMT_TrackingLevel MemTracker::_tracking_level = NMT_unknown;
 
-MemBaseline MemTracker::_baseline;
+MemBaseline* MemTracker::_baseline = nullptr;
 
 bool MemTracker::NmtVirtualMemoryLocker::_safe_to_use;
 
@@ -75,6 +75,7 @@ void MemTracker::initialize() {
       log_warning(nmt)("NMT initialization failed. NMT disabled.");
       return;
     }
+    _baseline = new MemBaseline();
   } else {
     if (MallocLimit != nullptr) {
       warning("MallocLimit will be ignored since NMT is disabled.");

--- a/src/hotspot/share/nmt/memTracker.hpp
+++ b/src/hotspot/share/nmt/memTracker.hpp
@@ -261,7 +261,7 @@ class MemTracker : AllStatic {
 
   // Stored baseline
   static inline MemBaseline& get_baseline() {
-    return _baseline;
+    return *_baseline;
   }
 
   static void tuning_statistics(outputStream* out);
@@ -314,7 +314,7 @@ class MemTracker : AllStatic {
   // Tracking level
   static NMT_TrackingLevel   _tracking_level;
   // Stored baseline
-  static MemBaseline      _baseline;
+  static MemBaseline* _baseline;
 };
 
 #endif // SHARE_NMT_MEMTRACKER_HPP


### PR DESCRIPTION
Piece-meal replace the usage of `LinkedList` in MemReporter. Blocker: GrowableArray exits on OOM, we need a safe interface for checking for OOM so we can give up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23592/head:pull/23592` \
`$ git checkout pull/23592`

Update a local copy of the PR: \
`$ git checkout pull/23592` \
`$ git pull https://git.openjdk.org/jdk.git pull/23592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23592`

View PR using the GUI difftool: \
`$ git pr show -t 23592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23592.diff">https://git.openjdk.org/jdk/pull/23592.diff</a>

</details>
