### PR TITLE
8349927: Waiting for compiler termination delays shutdown for 10+ ms

### DIFF
--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -519,7 +519,7 @@ int VM_Exit::wait_for_threads_in_native_to_block() {
   jlong start_time = os::javaTimeNanos();
 
   // Deadline for user threads in native code.
-  // User-settable flag counts "attempts" in 10ms units.
+  // User-settable flag counts "attempts" in 10ms units, to a maximum of 10s.
   jlong user_threads_deadline = start_time + (UserThreadWaitAttemptsAtExit * millis_to_nanos(10));
 
   // Deadline for compiler threads: at least 10 seconds.

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -500,7 +500,6 @@ int VM_Exit::wait_for_threads_in_native_to_block() {
   assert(SafepointSynchronize::is_at_safepoint(), "must be at safepoint already");
 
   Thread * thr_cur = Thread::current();
-  Monitor timer(Mutex::nosafepoint, "VM_ExitTimer_lock");
 
   // Compiler threads need longer wait because they can access VM data directly
   // while in native. If they are active and some structures being used are
@@ -509,12 +508,23 @@ int VM_Exit::wait_for_threads_in_native_to_block() {
   // data, and they will be stopped during state transition. In theory, we
   // don't have to wait for user threads to be quiescent, but it's always
   // better to terminate VM when current thread is the only active thread, so
-  // wait for user threads too. Numbers are in 10 milliseconds.
-  int wait_time_per_attempt = 10;               // in milliseconds
-  int max_wait_attempts_user_thread = UserThreadWaitAttemptsAtExit;
-  int max_wait_attempts_compiler_thread = 1000; // at least 10 seconds
+  // wait for user threads too.
 
-  int attempts = 0;
+  // Time per attempt. It is practical to start waiting with 10us delays
+  // (around scheduling delay / timer slack), and exponentially ramp up
+  // to 10ms if compiler threads are not responding.
+  jlong max_wait_time = millis_to_nanos(10);
+  jlong wait_time = 10000;
+
+  jlong start_time = os::javaTimeNanos();
+
+  // Deadline for user threads in native code.
+  // User-settable flag counts "attempts" in 10ms units.
+  jlong user_threads_deadline = start_time + (UserThreadWaitAttemptsAtExit * millis_to_nanos(10));
+
+  // Deadline for compiler threads: at least 10 seconds.
+  jlong compiler_threads_deadline = start_time + millis_to_nanos(10000);
+
   JavaThreadIteratorWithHandle jtiwh;
   while (true) {
     int num_active = 0;
@@ -543,19 +553,20 @@ int VM_Exit::wait_for_threads_in_native_to_block() {
       }
     }
 
+    jlong time = os::javaTimeNanos();
+
     if (num_active == 0) {
-       return 0;
-    } else if (attempts >= max_wait_attempts_compiler_thread) {
-       return num_active;
-    } else if (num_active_compiler_thread == 0 &&
-               attempts >= max_wait_attempts_user_thread) {
-       return num_active;
+      return 0;
+    }
+    if (time >= compiler_threads_deadline) {
+      return num_active;
+    }
+    if ((num_active_compiler_thread == 0) && (time >= user_threads_deadline)) {
+      return num_active;
     }
 
-    attempts++;
-
-    MonitorLocker ml(&timer, Mutex::_no_safepoint_check_flag);
-    ml.wait(wait_time_per_attempt);
+    os::naked_short_nanosleep(wait_time);
+    wait_time = MIN2(max_wait_time, wait_time * 2);
   }
 }
 


### PR DESCRIPTION
See bug for extended description. This PR reworks the shutdown waiting mechanism in three ways: 
 1. Use exponential backoff with very small wait time at the start, to catch compiler threads earlier.
 2. Avoid timed-wait on Monitor, when a sleep would suffice.
 3. Track the time accurately, so we are not at the mercy of sleep/wait accuracy.

I originally found this issue when studying Leyden performance, but it affects mainline in the same way. For example, JavacBenchApp from Leyden shows we consistently save ~10ms of round-trip time:

```
Benchmark 1: build/linux-x86_64-server-release/images/jdk/bin/java -Xmx512m -Xms512m -XX:+UseParallelGC \
 -cp JavacBenchApp.jar JavacBenchApp 1 1

# Before
  Time (mean ± σ):     495.4 ms ±   2.4 ms    [User: 1321.2 ms, System: 110.4 ms]
  Range (min … max):   489.8 ms … 502.6 ms    100 runs

# After
  Time (mean ± σ):     485.4 ms ±   2.7 ms    [User: 1318.9 ms, System: 110.3 ms]
  Range (min … max):   479.8 ms … 494.3 ms    100 runs
```

Additional testing:
 - [x] Linux x86_64 server fastdebug, `tier1`
 - [x] Linux AArch64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349927](https://bugs.openjdk.org/browse/JDK-8349927): Waiting for compiler termination delays shutdown for 10+ ms (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [31696b1c](https://git.openjdk.org/jdk/pull/23593/files/31696b1cba028ad96fed7822dd9eb46445a9158e)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role) Review applies to [31696b1c](https://git.openjdk.org/jdk/pull/23593/files/31696b1cba028ad96fed7822dd9eb46445a9158e)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23593/head:pull/23593` \
`$ git checkout pull/23593`

Update a local copy of the PR: \
`$ git checkout pull/23593` \
`$ git pull https://git.openjdk.org/jdk.git pull/23593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23593`

View PR using the GUI difftool: \
`$ git pr show -t 23593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23593.diff">https://git.openjdk.org/jdk/pull/23593.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23593#issuecomment-2654634156)
</details>
