### PR TITLE
8349873: StackOverflowError after JDK-8342550 if -Duser.timezone= is set to a deprecated zone id

### DIFF
--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -47,7 +47,6 @@ import jdk.internal.util.StaticProperty;
 import sun.util.calendar.ZoneInfo;
 import sun.util.calendar.ZoneInfoFile;
 import sun.util.locale.provider.TimeZoneNameUtility;
-import sun.util.logging.PlatformLogger;
 
 /**
  * {@code TimeZone} represents a time zone offset, and also figures out daylight
@@ -599,9 +598,9 @@ public abstract class TimeZone implements Serializable, Cloneable {
 
     private static TimeZone getTimeZone(String ID, boolean fallback) {
         if (ZoneId.SHORT_IDS.containsKey(ID)) {
-            PlatformLogger.getLogger(TimeZone.class.getName())
-                .warning("Use of the three-letter time zone ID \"%s\" is deprecated and it will be removed in a future release"
-                    .formatted(ID));
+            System.err.printf(
+                "WARNING: Use of the three-letter time zone ID \"%s\" is deprecated and it will be removed in a future release%n",
+                ID);
         }
         TimeZone tz = ZoneInfo.getTimeZone(ID);
         if (tz == null) {

--- a/test/jdk/java/util/TimeZone/ThreeLetterZoneID.java
+++ b/test/jdk/java/util/TimeZone/ThreeLetterZoneID.java
@@ -49,11 +49,11 @@ public class ThreeLetterZoneID {
 
     @Test
     public void testExplicitGetTimeZone() throws Exception {
-        ProcessTools.executeTestJava("ThreeLetterZoneID", "dummy").shouldMatch(WARNING);
+        ProcessTools.executeTestJava("ThreeLetterZoneID", "dummy").stderrShouldMatch(WARNING);
     }
 
     @Test
     public void testSysProp() throws Exception {
-        ProcessTools.executeTestJava("-Duser.timezone=PST", "ThreeLetterZoneID").shouldMatch(WARNING);
+        ProcessTools.executeTestJava("-Duser.timezone=PST", "ThreeLetterZoneID").stderrShouldMatch(WARNING);
     }
 }

--- a/test/jdk/java/util/TimeZone/ThreeLetterZoneID.java
+++ b/test/jdk/java/util/TimeZone/ThreeLetterZoneID.java
@@ -23,27 +23,37 @@
 
 /*
  * @test
- * @bug 8342550
+ * @bug 8342550 8349873
  * @summary Three-letter time zone IDs should output a deprecated warning
  *          message.
  * @library /test/lib
  * @build jdk.test.lib.process.ProcessTools
- * @run main ThreeLetterZoneID
+ * @run junit ThreeLetterZoneID
  */
 import java.util.TimeZone;
 import jdk.test.lib.process.ProcessTools;
 
+import org.junit.jupiter.api.Test;
+
 public class ThreeLetterZoneID {
-    public static void main(String... args) throws Exception {
+    private static final String WARNING =
+        "WARNING: Use of the three-letter time zone ID \"PST\" is deprecated and it will be removed in a future release";
+
+    public static void main(String... args) {
         if (args.length > 0) {
             TimeZone.getTimeZone("PST");
         } else {
-            checkWarningMessage();
+            TimeZone.getDefault();
         }
     }
 
-    public static void checkWarningMessage() throws Exception {
-        ProcessTools.executeTestJava("ThreeLetterZoneID", "dummy")
-            .shouldContain("Use of the three-letter time zone ID \"PST\" is deprecated and it will be removed in a future release");
+    @Test
+    public void testExplicitGetTimeZone() throws Exception {
+        ProcessTools.executeTestJava("ThreeLetterZoneID", "dummy").shouldMatch(WARNING);
+    }
+
+    @Test
+    public void testSysProp() throws Exception {
+        ProcessTools.executeTestJava("-Duser.timezone=PST", "ThreeLetterZoneID").shouldMatch(WARNING);
     }
 }


### PR DESCRIPTION
Fixing the regression caused by the JDK-8342550 fix. Since the logging facility depends on TimeZone class, it should not use the logging facility. Replacing the logging with simple System.err.printf() will fix the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349873](https://bugs.openjdk.org/browse/JDK-8349873): StackOverflowError after JDK-8342550 if -Duser.timezone= is set to a deprecated zone id (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) Review applies to [197d50fb](https://git.openjdk.org/jdk/pull/23597/files/197d50fbb03f262bb64365dd120db566e6844b7d)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23597/head:pull/23597` \
`$ git checkout pull/23597`

Update a local copy of the PR: \
`$ git checkout pull/23597` \
`$ git pull https://git.openjdk.org/jdk.git pull/23597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23597`

View PR using the GUI difftool: \
`$ git pr show -t 23597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23597.diff">https://git.openjdk.org/jdk/pull/23597.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23597#issuecomment-2654785421)
</details>
