### PR TITLE
8349934: Wrong file regex for copyright header format check in .jcheck/conf

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -36,6 +36,6 @@ pattern=^([124-8][0-9]{6}): (\S.*)$
 dirs=test/jdk|test/langtools|test/lib-test|test/hotspot/jtreg|test/jaxp
 
 [checks "copyright"]
-files=^(?!LICENSE|license\.txt|.*\.bin|.*\.gif|.*\.jpg|.*\.png|.*\.icon|.*\.tiff|.*\.dat|.*\.patch|.*\.wav|.*\.class|.*-header|.*\.jar|).*
+files=^(?!LICENSE|license\.txt|.*\.bin|.*\.gif|.*\.jpg|.*\.png|.*\.icon|.*\.tiff|.*\.dat|.*\.patch|.*\.wav|.*\.class|.*-header|.*\.jar).*
 oracle_locator=.*Copyright \(c\)(.*)Oracle and/or its affiliates\. All rights reserved\.
 oracle_validator=.*Copyright \(c\) (\d{4})(?:, (\d{4}))?, Oracle and/or its affiliates\. All rights reserved\.


### PR DESCRIPTION
The copyright header format check was introduced in [JDK-8346046](https://bugs.openjdk.org/browse/JDK-8346046). However, a user recently reported that the check doesn't catch incorrect copyright headers in this pr(https://github.com/openjdk/jdk/pull/23550).

After investigation, I found that the issue was caused by the file regex in .jcheck/conf. There is a redundant "|" character after ".*\.jar".

`files=^(?!LICENSE|license\.txt|.*\.bin|.*\.gif|.*\.jpg|.*\.png|.*\.icon|.*\.tiff|.*\.dat|.*\.patch|.*\.wav|.*\.class|.*-header|.*\.jar|).*`

This redundant "|" prevents the regex from matching any string.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349934](https://bugs.openjdk.org/browse/JDK-8349934): Wrong file regex for copyright header format check in .jcheck/conf (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23598/head:pull/23598` \
`$ git checkout pull/23598`

Update a local copy of the PR: \
`$ git checkout pull/23598` \
`$ git pull https://git.openjdk.org/jdk.git pull/23598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23598`

View PR using the GUI difftool: \
`$ git pr show -t 23598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23598.diff">https://git.openjdk.org/jdk/pull/23598.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23598#issuecomment-2654712655)
</details>
