### PR TITLE
8349925: [REDO] Support static JDK in libfontmanager/freetypeScaler.c

### DIFF
--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -407,6 +407,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     LDFLAGS_aix := -Wl$(COMMA)-berok, \
     JDK_LIBS := libawt java.base:libjava $(LIBFONTMANAGER_JDK_LIBS), \
     JDK_LIBS_macosx := libawt_lwawt, \
+    JDK_LIBS_unix := java.base:libjvm, \
     LIBS := $(LIBFONTMANAGER_LIBS), \
     LIBS_unix := $(LIBM), \
     LIBS_macosx := \

--- a/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
+++ b/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 #if !defined(_WIN32) && !defined(__APPLE_)
 #include <dlfcn.h>
+#include "jvm.h"
 #endif
 #include <math.h>
 #include "ft2build.h"
@@ -298,6 +299,21 @@ static void setInterpreterVersion(FT_Library library) {
 #if defined(_WIN32) || defined(__APPLE__)
     FT_Property_Set(library, module, property, (void*)(&version));
 #else
+
+    FT_Prop_Set_Func func = NULL;
+    if (JVM_IsStaticallyLinked()) {
+      // The bundled libfreetype may be statically linked with
+      // the launcher.
+      func = (FT_Prop_Set_Func)dlsym(RTLD_DEFAULT, "FT_Property_Set");
+      if (func != NULL) {
+        func(library, module, property, (void*)(&version));
+        return;
+      }
+
+      // libfreetype is not statically linked with the executable,
+      // fall through to find the system provided library dynamically.
+    }
+
     void *lib = dlopen("libfreetype.so", RTLD_LOCAL|RTLD_LAZY);
     if (lib == NULL) {
         lib = dlopen("libfreetype.so.6", RTLD_LOCAL|RTLD_LAZY);
@@ -305,7 +321,7 @@ static void setInterpreterVersion(FT_Library library) {
             return;
         }
     }
-    FT_Prop_Set_Func func = (FT_Prop_Set_Func)dlsym(lib, "FT_Property_Set");
+    func = (FT_Prop_Set_Func)dlsym(lib, "FT_Property_Set");
     if (func != NULL) {
         func(library, module, property, (void*)(&version));
     }


### PR DESCRIPTION
Please help review this change. The current version calls `FT_Property_Set` using the function address returned from `dlsym` for the static case as well. This is to avoid build issue on build system using older `libfreetype` that does not define `FT_Property_Set`. Thanks for everyone provided info on https://github.com/openjdk/jdk/pull/23574!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349925](https://bugs.openjdk.org/browse/JDK-8349925): [REDO] Support static JDK in libfontmanager/freetypeScaler.c (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23600/head:pull/23600` \
`$ git checkout pull/23600`

Update a local copy of the PR: \
`$ git checkout pull/23600` \
`$ git pull https://git.openjdk.org/jdk.git pull/23600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23600`

View PR using the GUI difftool: \
`$ git pr show -t 23600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23600.diff">https://git.openjdk.org/jdk/pull/23600.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23600#issuecomment-2654765098)
</details>
