### PR TITLE
8349933: Mixing of includes and snippets stack causes the wrong -post snippet to be included

### DIFF
--- a/make/common/MakeIncludeEnd.gmk
+++ b/make/common/MakeIncludeEnd.gmk
@@ -34,12 +34,12 @@ ifneq ($(NO_CUSTOM_EXTENSIONS), true)
 endif
 
 # Pop our helper name off the stack
-HELPER_STACK := $(wordlist 2, $(words $(HELPER_STACK)), $(HELPER_STACK))
+INCLUDE_STACK := $(wordlist 2, $(words $(INCLUDE_STACK)), $(INCLUDE_STACK))
 
 # Print an indented message, also counting the top-level makefile as a level
 ifeq ($(LOG_FLOW), true)
-  $(info :$(foreach s, top $(HELPER_STACK),    )Leave $(THIS_INCLUDE))
+  $(info :$(foreach s, top $(INCLUDE_STACK) $(SNIPPET_STACK),    )Leave $(THIS_INCLUDE))
 endif
 
 # Restore the previous helper name
-THIS_INCLUDE := $(firstword $(HELPER_STACK))
+THIS_INCLUDE := $(firstword $(INCLUDE_STACK))

--- a/make/common/MakeIncludeStart.gmk
+++ b/make/common/MakeIncludeStart.gmk
@@ -39,11 +39,11 @@ else
 endif
 
 ifeq ($(LOG_FLOW), true)
-  $(info :$(foreach s, top $(HELPER_STACK),    )Enter $(THIS_INCLUDE) [$(THIS_INCLUDE_MSG)])
+  $(info :$(foreach s, top $(INCLUDE_STACK) $(SNIPPET_STACK),    )Enter $(THIS_INCLUDE) [$(THIS_INCLUDE_MSG)])
 endif
 
-ifneq ($(filter $(THIS_INCLUDE), $(HELPER_STACK)), )
-  $(error Internal makefile error: Include loop detected: $(THIS_INCLUDE) $(HELPER_STACK))
+ifneq ($(filter $(THIS_INCLUDE), $(INCLUDE_STACK)), )
+  $(error Internal makefile error: Include loop detected: $(THIS_INCLUDE) $(INCLUDE_STACK))
 endif
 
 ifeq ($(words $(MAKEFILE_LIST)), 2)
@@ -66,7 +66,7 @@ ifneq ($(IS_PREINIT_ENV), true)
 endif
 
 # Push our helper name onto the stack
-HELPER_STACK := $(THIS_INCLUDE) $(HELPER_STACK)
+INCLUDE_STACK := $(THIS_INCLUDE) $(INCLUDE_STACK)
 
 # Setup an automatic include guard
 ifneq ($(INCLUDE_GUARD_$(THIS_INCLUDE)), true)

--- a/make/common/MakeSnippetEnd.gmk
+++ b/make/common/MakeSnippetEnd.gmk
@@ -34,12 +34,12 @@ ifneq ($(NO_CUSTOM_EXTENSIONS), true)
 endif
 
 # Pop our helper name off the stack
-HELPER_STACK := $(wordlist 2, $(words $(HELPER_STACK)), $(HELPER_STACK))
+SNIPPET_STACK := $(wordlist 2, $(words $(SNIPPET_STACK)), $(SNIPPET_STACK))
 
 # Print an indented message, also counting the top-level makefile as a level
 ifeq ($(LOG_FLOW), true)
-  $(info :$(foreach s, top $(HELPER_STACK),    )Leave $(THIS_SNIPPET))
+  $(info :$(foreach s, top $(INCLUDE_STACK) $(SNIPPET_STACK),    )Leave $(THIS_SNIPPET))
 endif
 
 # Restore the previous helper name
-THIS_SNIPPET := $(firstword $(HELPER_STACK))
+THIS_SNIPPET := $(firstword $(SNIPPET_STACK))

--- a/make/common/MakeSnippetStart.gmk
+++ b/make/common/MakeSnippetStart.gmk
@@ -33,11 +33,11 @@ endif
 
 # Print an indented message, also counting the top-level makefile as a level
 ifeq ($(LOG_FLOW), true)
-  $(info :$(foreach s, top $(HELPER_STACK),    )Enter $(THIS_SNIPPET) [snippet])
+  $(info :$(foreach s, top $(INCLUDE_STACK) $(SNIPPET_STACK),    )Enter $(THIS_SNIPPET) [snippet])
 endif
 
 # Push our helper name onto the stack
-HELPER_STACK := $(THIS_SNIPPET) $(HELPER_STACK)
+SNIPPET_STACK := $(THIS_SNIPPET) $(SNIPPET_STACK)
 
 # Hook to include the corresponding custom file, if present.
 ifneq ($(NO_CUSTOM_EXTENSIONS), true)


### PR DESCRIPTION
The new framework for tracing makefile inclusion has a bug. In the Make[Include|Snippet]End.gmk files, the variables THIS_INCLUDE and THIS_SNIPPET respectively are restored from the HELPER_STACK variable. The problem is that we can't know if the next item on the stack is a previous "include" or "snippet". In a complex tree of includes/snippets, this can cause the wrong custom -post file to get included.

My proposed fix is to split HELPER_STACK into two variables, INCLUDE_STACK and SNIPPET_STACK, so we keep track of which files were includes and which ones were snippets. When printing indentations we just concatenate these variables to get the total stack size.

This patch fixes the observed issue for me locally. I'm running extensive testing on it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349933](https://bugs.openjdk.org/browse/JDK-8349933): Mixing of includes and snippets stack causes the wrong -post snippet to be included (**Bug** - P3)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23601/head:pull/23601` \
`$ git checkout pull/23601`

Update a local copy of the PR: \
`$ git checkout pull/23601` \
`$ git pull https://git.openjdk.org/jdk.git pull/23601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23601`

View PR using the GUI difftool: \
`$ git pr show -t 23601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23601.diff">https://git.openjdk.org/jdk/pull/23601.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23601#issuecomment-2654798431)
</details>
