### PR TITLE
8349727: [PPC] C1: Improve Class.isInstance intrinsic

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -2839,25 +2839,27 @@ void LIR_Assembler::negate(LIR_Opr left, LIR_Opr dest, LIR_Opr tmp) {
 
 void LIR_Assembler::rt_call(LIR_Opr result, address dest,
                             const LIR_OprList* args, LIR_Opr tmp, CodeEmitInfo* info) {
-  // Stubs: Called via rt_call, but dest is a stub address (no function descriptor).
+  // Stubs: Called via rt_call, but dest is a stub address (no FunctionDescriptor).
   if (dest == Runtime1::entry_for(C1StubId::register_finalizer_id) ||
-      dest == Runtime1::entry_for(C1StubId::new_multi_array_id   )) {
+      dest == Runtime1::entry_for(C1StubId::new_multi_array_id   ) ||
+      dest == Runtime1::entry_for(C1StubId::is_instance_of_id    )) {
     //__ load_const_optimized(R0, dest);
     __ add_const_optimized(R0, R29_TOC, MacroAssembler::offset_to_global_toc(dest));
     __ mtctr(R0);
     __ bctrl();
-    assert(info != nullptr, "sanity");
-    add_call_info_here(info);
-    __ post_call_nop();
+    if (info != nullptr) {
+      add_call_info_here(info);
+      __ post_call_nop();
+    }
     return;
   }
 
   __ call_c(dest, relocInfo::runtime_call_type);
+  assert(__ last_calls_return_pc() == __ pc(), "pcn not at return pc");
   if (info != nullptr) {
     add_call_info_here(info);
+    __ post_call_nop();
   }
-  assert(__ last_calls_return_pc() == __ pc(), "pcn not at return pc");
-  __ post_call_nop();
 }
 
 

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -2843,6 +2843,7 @@ void LIR_Assembler::rt_call(LIR_Opr result, address dest,
   if (dest == Runtime1::entry_for(C1StubId::register_finalizer_id) ||
       dest == Runtime1::entry_for(C1StubId::new_multi_array_id   ) ||
       dest == Runtime1::entry_for(C1StubId::is_instance_of_id    )) {
+    assert(CodeCache::contains(dest), "simplified call is only for special C1 stubs");
     //__ load_const_optimized(R0, dest);
     __ add_const_optimized(R0, R29_TOC, MacroAssembler::offset_to_global_toc(dest));
     __ mtctr(R0);

--- a/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
@@ -1128,9 +1128,10 @@ void LIRGenerator::do_InstanceOf(InstanceOf* x) {
                 x->profiled_method(), x->profiled_bci());
 }
 
+
 // Intrinsic for Class::isInstance
 address LIRGenerator::isInstance_entry() {
-  return CAST_FROM_FN_PTR(address, Runtime1::is_instance_of);
+  return Runtime1::entry_for(C1StubId::is_instance_of_id);
 }
 
 

--- a/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
@@ -611,12 +611,7 @@ OopMapSet* Runtime1::generate_code_for(C1StubId id, StubAssembler* sasm) {
 
     case C1StubId::is_instance_of_id:
       {
-        // Called like a C function.
-#if !defined(ABI_ELFv2)
-        // ABIv1 requires a FunctionDescriptor with updated entry after relocating.
-        __ relocate(relocInfo::internal_word_type, /* plain address */ 2); // entry at offset 0
-        __ emit_fd();
-#endif
+        // Called like a C function, but without FunctionDescriptor (see LIR_Assembler::rt_call).
 
         // Arguments and return value.
         Register mirror = R3_ARG1;

--- a/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
@@ -609,6 +609,78 @@ OopMapSet* Runtime1::generate_code_for(C1StubId id, StubAssembler* sasm) {
       }
       break;
 
+    case C1StubId::is_instance_of_id:
+      {
+        // Called like a C function.
+#if !defined(ABI_ELFv2)
+        // ABIv1 requires a FunctionDescriptor with updated entry after relocating.
+        __ relocate(relocInfo::internal_word_type, /* plain address */ 2); // entry at offset 0
+        __ emit_fd();
+#endif
+
+        // Arguments and return value.
+        Register mirror = R3_ARG1;
+        Register obj    = R4_ARG2;
+        Register result = R3_RET;
+
+        // Other argument registers can be used as temp registers.
+        Register klass  = R5;
+        Register offset = R6;
+        Register sub_klass = R7;
+
+        Label is_secondary, success;
+
+        // Get the Klass*.
+        __ ld(klass, java_lang_Class::klass_offset(), mirror);
+
+        // Return false if obj or klass is null.
+        mirror = noreg; // killed by next instruction
+        __ li(result, 0); // assume result is false
+        __ cmpdi(CR0, obj, 0);
+        __ cmpdi(CR1, klass, 0);
+        __ cror(CR0, Assembler::equal, CR1, Assembler::equal);
+        __ bclr(Assembler::bcondCRbiIs1, Assembler::bi0(CR0, Assembler::equal), Assembler::bhintbhBCLRisReturn);
+
+        __ lwz(offset, in_bytes(Klass::super_check_offset_offset()), klass);
+        __ load_klass(sub_klass, obj);
+        __ cmpwi(CR0, offset, in_bytes(Klass::secondary_super_cache_offset()));
+        __ beq(CR0, is_secondary); // Klass is a secondary superclass
+
+        // Klass is a concrete class
+        __ ldx(R0, sub_klass, offset);
+        __ cmpd(CR0, klass, R0);
+        if (VM_Version::has_brw()) {
+          // Power10 can set the result by one instruction. No need for a branch.
+          __ setbc(result, CR0, Assembler::equal);
+        } else {
+          __ beq(CR0, success);
+        }
+        __ blr();
+
+        __ bind(is_secondary);
+
+        // This is necessary because I am never in my own secondary_super list.
+        __ cmpd(CR0, sub_klass, klass);
+        __ beq(CR0, success);
+
+        __ lookup_secondary_supers_table_var(sub_klass, klass,
+                                             /*temps*/R9, R10, R11, R12,
+                                             /*result*/R8);
+        __ cmpdi(CR0, R8, 0); // 0 means is subclass
+        if (VM_Version::has_brw()) {
+          // Power10 can set the result by one instruction. No need for a branch.
+          __ setbc(result, CR0, Assembler::equal);
+        } else {
+          __ beq(CR0, success);
+        }
+        __ blr();
+
+        __ bind(success);
+        __ li(result, 1);
+        __ blr();
+      }
+      break;
+
     case C1StubId::monitorenter_nofpu_id:
     case C1StubId::monitorenter_id:
       {

--- a/src/hotspot/cpu/ppc/relocInfo_ppc.cpp
+++ b/src/hotspot/cpu/ppc/relocInfo_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,25 +33,14 @@
 
 void Relocation::pd_set_data_value(address x, bool verify_only) {
   if (!verify_only) {
-    switch (format()) {
-      case 2: { // plain address
-        *((address*)addr()) = x;
-        break;
-      }
-      case 1: { // native move compressed
-        assert(type() == relocInfo::oop_type, "how to encode else?");
-        narrowOop no = CompressedOops::encode(cast_to_oop(x));
-        nativeMovConstReg_at(addr())->set_narrow_oop(no, code());
-        break;
-      }
-      case 0: { // normal native move
-        nativeMovConstReg_at(addr())->set_data_plain(((intptr_t)x), code());
-        break;
-      }
-      default: ShouldNotReachHere();
+    if (format() != 1) {
+      nativeMovConstReg_at(addr())->set_data_plain(((intptr_t)x), code());
+    } else {
+      assert(type() == relocInfo::oop_type, "how to encode else?");
+      narrowOop no = CompressedOops::encode(cast_to_oop(x));
+      nativeMovConstReg_at(addr())->set_narrow_oop(no, code());
     }
   } else {
-    // Only used by DataRelocation.
     guarantee((address) (nativeMovConstReg_at(addr())->data()) == x, "data must match");
   }
 }
@@ -107,16 +96,7 @@ address* Relocation::pd_address_in_code() {
 }
 
 address Relocation::pd_get_address_from_code() {
-  switch (format()) { // plain address
-    case 2: {
-      return *((address*)addr());
-    }
-    case 0: { // normal native move
-      return (address)(nativeMovConstReg_at(addr())->data());
-    }
-    default: ShouldNotReachHere();
-  }
-  return nullptr;
+  return (address)(nativeMovConstReg_at(addr())->data());
 }
 
 void poll_Relocation::fix_relocation_after_move(const CodeBuffer* src, CodeBuffer* dest) {


### PR DESCRIPTION
PPC64 implementation of [JDK-8337251](https://bugs.openjdk.org/browse/JDK-8337251).
The new runtime stub is called like a C function. The initial version therefore used a `FunctionDescriptor` with relocation on PPC64 with ABIv1. I've changed that with the 3rd Commit. `rt_call` jumps directly to the entry point, now. 

Performance measured on Power10: `make run-test TEST="micro:SecondarySupersLookup" MICRO="VM_OPTIONS=-XX:TieredStopAtLevel=1"`

Before this patch (C code)
```
Benchmark                             Mode  Cnt   Score   Error  Units
SecondarySupersLookup.testNegative00  avgt   15  18.570 ± 0.009  ns/op
...
SecondarySupersLookup.testNegative30  avgt   15  18.566 ± 0.002  ns/op
SecondarySupersLookup.testNegative32  avgt   15  19.177 ± 1.347  ns/op
SecondarySupersLookup.testNegative40  avgt   15  18.569 ± 0.006  ns/op
SecondarySupersLookup.testNegative50  avgt   15  19.207 ± 1.334  ns/op
SecondarySupersLookup.testNegative55  avgt   15  19.708 ± 1.338  ns/op
SecondarySupersLookup.testNegative56  avgt   15  19.132 ± 0.137  ns/op
SecondarySupersLookup.testNegative57  avgt   15  19.133 ± 0.134  ns/op
SecondarySupersLookup.testNegative58  avgt   15  19.772 ± 1.316  ns/op
SecondarySupersLookup.testNegative59  avgt   15  19.109 ± 0.014  ns/op
SecondarySupersLookup.testNegative60  avgt   15  22.381 ± 0.016  ns/op
SecondarySupersLookup.testNegative61  avgt   15  22.331 ± 0.011  ns/op
SecondarySupersLookup.testNegative62  avgt   15  22.352 ± 0.029  ns/op
SecondarySupersLookup.testNegative63  avgt   15  30.371 ± 0.031  ns/op
SecondarySupersLookup.testNegative64  avgt   15  29.927 ± 0.221  ns/op
SecondarySupersLookup.testPositive01  avgt   15  18.571 ± 0.006  ns/op
...
SecondarySupersLookup.testPositive09  avgt   15  18.599 ± 0.140  ns/op
SecondarySupersLookup.testPositive10  avgt   15  19.210 ± 1.332  ns/op
SecondarySupersLookup.testPositive16  avgt   15  18.603 ± 0.142  ns/op
SecondarySupersLookup.testPositive20  avgt   15  19.210 ± 1.333  ns/op
SecondarySupersLookup.testPositive30  avgt   15  18.600 ± 0.140  ns/op
SecondarySupersLookup.testPositive32  avgt   15  18.637 ± 0.189  ns/op
SecondarySupersLookup.testPositive40  avgt   15  19.137 ± 0.190  ns/op
SecondarySupersLookup.testPositive50  avgt   15  18.567 ± 0.002  ns/op
SecondarySupersLookup.testPositive60  avgt   15  19.069 ± 0.004  ns/op
SecondarySupersLookup.testPositive63  avgt   15  26.024 ± 0.017  ns/op
SecondarySupersLookup.testPositive64  avgt   15  29.932 ± 1.002  ns/op
```

After this patch (assembler code):
```
Benchmark                             Mode  Cnt   Score   Error  Units
SecondarySupersLookup.testNegative00  avgt   15  18.889 ± 0.016  ns/op
...
SecondarySupersLookup.testNegative30  avgt   15  18.830 ± 0.222  ns/op
SecondarySupersLookup.testNegative32  avgt   15  18.885 ± 0.006  ns/op
SecondarySupersLookup.testNegative40  avgt   15  18.884 ± 0.003  ns/op
SecondarySupersLookup.testNegative50  avgt   15  18.885 ± 0.004  ns/op
SecondarySupersLookup.testNegative55  avgt   15  18.775 ± 0.287  ns/op
SecondarySupersLookup.testNegative56  avgt   15  18.877 ± 0.008  ns/op
SecondarySupersLookup.testNegative57  avgt   15  18.821 ± 0.211  ns/op
SecondarySupersLookup.testNegative58  avgt   15  18.874 ± 0.006  ns/op
SecondarySupersLookup.testNegative59  avgt   15  18.991 ± 0.344  ns/op
SecondarySupersLookup.testNegative60  avgt   15  18.876 ± 0.195  ns/op
SecondarySupersLookup.testNegative61  avgt   15  18.827 ± 0.265  ns/op
SecondarySupersLookup.testNegative62  avgt   15  19.009 ± 0.182  ns/op
SecondarySupersLookup.testNegative63  avgt   15  61.667 ± 0.341  ns/op
SecondarySupersLookup.testNegative64  avgt   15  62.559 ± 0.119  ns/op
SecondarySupersLookup.testPositive01  avgt   15  18.766 ± 0.295  ns/op
...
SecondarySupersLookup.testPositive09  avgt   15  18.872 ± 0.007  ns/op
SecondarySupersLookup.testPositive10  avgt   15  18.869 ± 0.005  ns/op
SecondarySupersLookup.testPositive16  avgt   15  18.869 ± 0.004  ns/op
SecondarySupersLookup.testPositive20  avgt   15  18.869 ± 0.006  ns/op
SecondarySupersLookup.testPositive30  avgt   15  18.921 ± 0.260  ns/op
SecondarySupersLookup.testPositive32  avgt   15  18.766 ± 0.296  ns/op
SecondarySupersLookup.testPositive40  avgt   15  18.763 ± 0.189  ns/op
SecondarySupersLookup.testPositive50  avgt   15  18.869 ± 0.008  ns/op
SecondarySupersLookup.testPositive60  avgt   15  18.718 ± 0.258  ns/op
SecondarySupersLookup.testPositive63  avgt   15  34.618 ± 0.037  ns/op
SecondarySupersLookup.testPositive64  avgt   15  52.376 ± 0.463  ns/op
```

The patch avoids the slowdown until 62. The 63 and 64 cases were slow due to https://github.com/openjdk/jdk/blob/b6443f6ff96707f67552df41c01d18c193560223/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp#L2556 which is assumed to be not so relevant in real world applications?

4th Commit unrolls the `repne_scan` loop to avoid the performance regression:
```
SecondarySupersLookup.testPositive63  avgt   15  24.314 ± 0.102  ns/op
SecondarySupersLookup.testPositive64  avgt   15  28.907 ± 0.045  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349727](https://bugs.openjdk.org/browse/JDK-8349727): [PPC] C1: Improve Class.isInstance intrinsic (**Enhancement** - P4)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Varada M](https://openjdk.org/census#varadam) (@varada1110 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23602/head:pull/23602` \
`$ git checkout pull/23602`

Update a local copy of the PR: \
`$ git checkout pull/23602` \
`$ git pull https://git.openjdk.org/jdk.git pull/23602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23602`

View PR using the GUI difftool: \
`$ git pr show -t 23602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23602.diff">https://git.openjdk.org/jdk/pull/23602.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23602#issuecomment-2654844556)
</details>
