### PR TITLE
8270265: LineBreakMeasurer calculates incorrect line breaks with zero-width characters

### DIFF
--- a/src/java.desktop/share/classes/sun/font/ExtendedTextSourceLabel.java
+++ b/src/java.desktop/share/classes/sun/font/ExtendedTextSourceLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/sun/font/ExtendedTextSourceLabel.java
+++ b/src/java.desktop/share/classes/sun/font/ExtendedTextSourceLabel.java
@@ -493,10 +493,9 @@ class ExtendedTextSourceLabel extends ExtendedTextLabel implements Decoration.La
     --start;
     while (width >= -epsilon && ++start < length) {
       int cidx = l2v(start) * numvals + advx;
-      if (cidx >= charinfo.length) {
-          break; // layout bailed for some reason
-      }
-      float adv = charinfo[cidx];
+      float adv = cidx < charinfo.length ?
+                  charinfo[cidx] : // layout provided info for this glyph
+                  0; // glyph info omitted, assume no advance
       if (adv != 0) {
           width -= adv + advTracking;
       }

--- a/src/java.desktop/share/native/libfontmanager/HBShaper.c
+++ b/src/java.desktop/share/native/libfontmanager/HBShaper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/native/libfontmanager/HBShaper.c
+++ b/src/java.desktop/share/native/libfontmanager/HBShaper.c
@@ -272,6 +272,7 @@ JNIEXPORT jboolean JNICALL Java_sun_font_SunLayoutEngine_shape
 
      buffer = hb_buffer_create();
      hb_buffer_set_script(buffer, getHBScriptCode(script));
+     hb_buffer_set_invisible_glyph(buffer, INVISIBLE_GLYPH_ID);
      hb_buffer_set_language(buffer,
                             hb_ot_tag_to_language(HB_OT_TAG_DEFAULT_LANGUAGE));
      if ((flags & TYPO_RTL) != 0) {

--- a/src/java.desktop/share/native/libfontmanager/HBShaper_Panama.c
+++ b/src/java.desktop/share/native/libfontmanager/HBShaper_Panama.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/native/libfontmanager/HBShaper_Panama.c
+++ b/src/java.desktop/share/native/libfontmanager/HBShaper_Panama.c
@@ -107,6 +107,7 @@ JDKEXPORT void jdk_hb_shape(
 
      buffer = hb_buffer_create();
      hb_buffer_set_script(buffer, getHBScriptCode(script));
+     hb_buffer_set_invisible_glyph(buffer, INVISIBLE_GLYPH_ID);
      hb_buffer_set_language(buffer,
                             hb_ot_tag_to_language(HB_OT_TAG_DEFAULT_LANGUAGE));
      if ((flags & TYPO_RTL) != 0) {

--- a/src/java.desktop/share/native/libfontmanager/hb-jdk-p.h
+++ b/src/java.desktop/share/native/libfontmanager/hb-jdk-p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/native/libfontmanager/hb-jdk-p.h
+++ b/src/java.desktop/share/native/libfontmanager/hb-jdk-p.h
@@ -48,6 +48,8 @@
 extern "C" {
 #endif
 
+// Matches sun.font.CharToGlyphMapper.INVISIBLE_GLYPH_ID
+#define INVISIBLE_GLYPH_ID 0xffff
 
 hb_font_t* jdk_font_create_hbp(
                hb_face_t* face,

--- a/src/java.desktop/share/native/libfontmanager/hb-jdk.h
+++ b/src/java.desktop/share/native/libfontmanager/hb-jdk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/native/libfontmanager/hb-jdk.h
+++ b/src/java.desktop/share/native/libfontmanager/hb-jdk.h
@@ -50,6 +50,9 @@ typedef struct JDKFontInfo_Struct {
 #define HBFloatToFixedScale ((float)(1 << 16))
 #define HBFloatToFixed(f) ((unsigned int)((f) * HBFloatToFixedScale))
 
+// Matches sun.font.CharToGlyphMapper.INVISIBLE_GLYPH_ID
+#define INVISIBLE_GLYPH_ID 0xffff
+
 /*
  * Note:
  *

--- a/test/jdk/java/awt/font/TextLayout/FormatCharAdvanceTest.java
+++ b/test/jdk/java/awt/font/TextLayout/FormatCharAdvanceTest.java
@@ -276,7 +276,7 @@ public class FormatCharAdvanceTest {
         ab2 = findTextBoundingBox(image).width;
         assertEqual(ab1, ab2, "drawString (using AttributedCharacterIterator)", c, font);
 
-        int max = metrics.stringWidth("AB");
+        int max = metrics.stringWidth("AB") + 2; // add a little wiggle room to the max width
         LineBreakMeasurer measurer1 = new LineBreakMeasurer(as1.getIterator(), frc);
         LineBreakMeasurer measurer2 = new LineBreakMeasurer(as2.getIterator(), frc);
         assertEqual(2, measurer1.nextOffset(max), "nextOffset 1", c, font);

--- a/test/jdk/java/awt/font/TextLayout/FormatCharAdvanceTest.java
+++ b/test/jdk/java/awt/font/TextLayout/FormatCharAdvanceTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8208377 6562489
+ * @bug 8208377 6562489 8270265
  * @summary Confirm that format-category glyphs are not rendered or measured.
  */
 
@@ -275,6 +275,12 @@ public class FormatCharAdvanceTest {
         g2d.drawString(as2.getIterator(), w / 2, h / 2);
         ab2 = findTextBoundingBox(image).width;
         assertEqual(ab1, ab2, "drawString (using AttributedCharacterIterator)", c, font);
+
+        int max = metrics.stringWidth("AB");
+        LineBreakMeasurer measurer1 = new LineBreakMeasurer(as1.getIterator(), frc);
+        LineBreakMeasurer measurer2 = new LineBreakMeasurer(as2.getIterator(), frc);
+        assertEqual(2, measurer1.nextOffset(max), "nextOffset 1", c, font);
+        assertEqual(7, measurer2.nextOffset(max), "nextOffset 2", c, font);
     }
 
     private static void assertEqual(int i1, int i2, String scenario, char c, Font font) {


### PR DESCRIPTION
When a string contains zero-width characters, `LineBreakMeasurer` calculates line breaks incorrectly.

The root cause appears to be that `LineBreakMeasurer` eventually calls into `StandardGlyphVector.getGlyphInfo()`, which derives the glyph advances from the glyph IDs. However, HarfBuzz's default treatment of zero-width characters is to provide the glyph ID of the space character (`U+0020`) combined with an artificial zero advance (not the font's space glyph advance). Unaware of HarfBuzz's sleight of hand, `StandardGlyphVector.getGlyphInfo()` retrieves the actual advances of the space glyph (since that was the glyph ID returned) and provides these back up the call chain to `LineBreakMeasurer` et al.

I think the correct fix is to use `hb_buffer_set_invisible_glyph` to register `0xFFFF` as the invisible glyph ID with HarfBuzz (matching `CharToGlyphMapper.INVISIBLE_GLYPH_ID`).

I haven't seen any unwanted side effects, but there is a risk, since this is changing the global HarfBuzz configuration.

For more information on HarfBuzz's behavior in this area, see: https://harfbuzz.github.io/setting-buffer-properties.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270265](https://bugs.openjdk.org/browse/JDK-8270265): LineBreakMeasurer calculates incorrect line breaks with zero-width characters (**Bug** - P4)


### Reviewers
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23603/head:pull/23603` \
`$ git checkout pull/23603`

Update a local copy of the PR: \
`$ git checkout pull/23603` \
`$ git pull https://git.openjdk.org/jdk.git pull/23603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23603`

View PR using the GUI difftool: \
`$ git pr show -t 23603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23603.diff">https://git.openjdk.org/jdk/pull/23603.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23603#issuecomment-2655113784)
</details>
