### PR TITLE
JDK-8346465 : Add a check in setData() to restrict the update of Built-In ICC_Profiles

### DIFF
--- a/test/jdk/java/awt/color/ICC_Profile/BuiltInProfileCheck.java
+++ b/test/jdk/java/awt/color/ICC_Profile/BuiltInProfileCheck.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8346465
+ * @summary Tests if setData() throws IAE for BuiltIn profiles
+ */
+
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_Profile;
+
+public class BuiltInProfileCheck {
+    private static final int HEADER_TAG = ICC_Profile.icSigHead;
+    private static final int PROFILE_CLASS_START_INDEX =
+                                       ICC_Profile.icHdrDeviceClass;
+    private static final String EXCEPTION_MSG = "BuiltIn profile cannot be modified";
+
+    public static void main(String[] args) {
+        System.out.println("CASE 1: Testing BuiltIn Profile");
+        updateProfile(true);
+        System.out.println("Passed \n");
+
+        System.out.println("CASE 2: Testing Custom Profile");
+        updateProfile(false);
+        System.out.println("Passed \n");
+    }
+
+    private static void updateProfile(boolean isBuiltIn) {
+        ICC_Profile builtInProfile = ICC_Profile.getInstance(ColorSpace.CS_sRGB);
+        //create a copy of the BuiltIn profile
+        ICC_Profile customProfile = ICC_Profile.getInstance(builtInProfile.getData());
+
+        ICC_Profile iccProfile = isBuiltIn ? builtInProfile : customProfile;
+
+        byte[] headerData = iccProfile.getData(HEADER_TAG);
+        int index = PROFILE_CLASS_START_INDEX;
+        //set profile class to valid icSigInputClass = 0x73636E72
+        headerData[index] = 0x73;
+        headerData[index + 1] = 0x63;
+        headerData[index + 2] = 0x6E;
+        headerData[index + 3] = 0x72;
+
+        if (isBuiltIn) {
+            try {
+                //try updating a BuiltIn Profile, the following stmt should throw IAE
+                iccProfile.setData(HEADER_TAG, headerData);
+                throw new RuntimeException("Test Failed ! IAE NOT thrown.");
+            } catch (IllegalArgumentException iae) {
+                if (!iae.getMessage().equals(EXCEPTION_MSG)) {
+                    throw new RuntimeException("Test Failed ! IAE with exception msg \""
+                                               + EXCEPTION_MSG + "\" NOT thrown.");
+                }
+            }
+        } else {
+            //modifying custom profile should NOT throw IAE
+            iccProfile.setData(HEADER_TAG, headerData);
+        }
+    }
+}

--- a/test/jdk/java/awt/color/ICC_Profile/SetHeaderInfo.java
+++ b/test/jdk/java/awt/color/ICC_Profile/SetHeaderInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,9 @@ public final class SetHeaderInfo {
                          ColorSpace.CS_CIEXYZ, ColorSpace.CS_PYCC,
                          ColorSpace.CS_GRAY};
         for (int cspace : cspaces) {
-            ICC_Profile icc = ICC_Profile.getInstance(cspace);
+            ICC_Profile builtInProfile = ICC_Profile.getInstance(cspace);
+            ICC_Profile icc = ICC_Profile.getInstance(builtInProfile.getData());
+
             testSame(icc);
             testCustom(icc);
             // some corner cases

--- a/test/jdk/java/awt/color/ICC_ProfileSetNullDataTest.java
+++ b/test/jdk/java/awt/color/ICC_ProfileSetNullDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,22 +30,23 @@ import java.awt.color.ICC_Profile;
  * @summary Test checks behavior of the ICC_Profile.setData(int, byte[])
  */
 public final class ICC_ProfileSetNullDataTest {
+    private static final int[] colorSpace = new int [] {
+            ColorSpace.CS_sRGB, ColorSpace.CS_LINEAR_RGB,
+            ColorSpace.CS_PYCC, ColorSpace.CS_GRAY,
+            ColorSpace.CS_CIEXYZ
+    };
 
     public static void main(String[] args) {
-        test(ICC_Profile.getInstance(ColorSpace.CS_sRGB));
-        test(ICC_Profile.getInstance(ColorSpace.CS_LINEAR_RGB));
-        test(ICC_Profile.getInstance(ColorSpace.CS_CIEXYZ));
-        test(ICC_Profile.getInstance(ColorSpace.CS_PYCC));
-        test(ICC_Profile.getInstance(ColorSpace.CS_GRAY));
-    }
-
-    private static void test(ICC_Profile profile) {
         byte[] tagData = null;
-        try {
-            profile.setData(ICC_Profile.icSigCmykData, tagData);
-        } catch (IllegalArgumentException e) {
-            return;
+        for (int cs : colorSpace) {
+            ICC_Profile builtInProfile = ICC_Profile.getInstance(cs);
+            ICC_Profile profile = ICC_Profile.getInstance(builtInProfile.getData());
+            try {
+                profile.setData(ICC_Profile.icSigCmykData, tagData);
+            } catch (IllegalArgumentException e) {
+                return;
+            }
+            throw new RuntimeException("IllegalArgumentException expected");
         }
-        throw new RuntimeException("IllegalArgumentException expected");
     }
 }

--- a/test/jdk/sun/java2d/cmm/ProfileOp/SetDataTest.java
+++ b/test/jdk/sun/java2d/cmm/ProfileOp/SetDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  * @run     main SetDataTest
  */
 
-
 import java.util.ArrayList;
 import java.util.List;
 import java.awt.color.ICC_Profile;
@@ -47,7 +46,8 @@ public class SetDataTest {
         static byte[] invalidTRCData;
 
         static {
-            profile = ICC_Profile.getInstance(CS_GRAY);
+            ICC_Profile builtInProfile = ICC_Profile.getInstance(CS_GRAY);
+            profile = ICC_Profile.getInstance(builtInProfile.getData());
             validTRCdata = profile.getData(icSigGrayTRCTag);
             invalidTRCData = new byte[]{0x42, 0x42, 0x42, 0x42, 1, 3, 4, 6,};
         }


### PR DESCRIPTION
Built-in Profiles are singleton objects and if the user happens to modify this shared profile object via setData() then the modified version of the profile is returned each time the same built-in profile is requested via getInstance().

It is good to protect Built-in profiles from such direct modification by adding BuiltIn profile check in `setData()` such that **only copies** of Built-In profiles are allowed to be updated.

With the proposed fix, if Built-In profile is updated using `.setData()` it throws _**IAE - "BuiltIn profile cannot be modified"**_

Fix consists of:
* `private boolean isBuiltIn = false` in ICC_Profile which is set to true when BuiltIn profiles are created and false for non-builtIn profile.
* Converted BuiltInProfile from private interface to private static class (with all the profile instances as static final)
* `isBuiltIn` flag is set to true when BuiltInProfile are loaded.
* JavaDoc update for setData() (CSR required)

There are no restrictions on creating copies of BuiltIn profile and then modifying it, but what is being restricted with this fix is - the direct modification of the shared BuiltIn profile instance.

Applications which need a modified version of the ICC Profile should instead do the following:

```
byte[] profileData = ICC_Profile.getData() // get the byte array represtation of BuiltIn- profile
ICCProfile newProfile = ICC_Profile.getInstance(profileData) // create a new profile
newProfile.setData() // to modify and customize the profile
```

Following existing tests are modified to update a copy of Built-In profile.

- java/awt/color/ICC_Profile/SetHeaderInfo.java
- java/awt/color/ICC_ProfileSetNullDataTest.java
- sun/java2d/cmm/ProfileOp/SetDataTest.java

NOTE : For existing tests only necessary updates are done.