### PR TITLE
8349753: Incorrect use of CodeBlob::is_buffer_blob() in few places

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -656,7 +656,7 @@ void CodeBlob::print_value_on(outputStream* st) const {
 }
 
 void CodeBlob::dump_for_addr(address addr, outputStream* st, bool verbose) const {
-  if (is_buffer_blob()) {
+  if (is_buffer_blob() || is_adapter_blob() || is_vtable_blob() || is_method_handles_adapter_blob()) {
     // the interpreter is generated into a buffer blob
     InterpreterCodelet* i = Interpreter::codelet_containing(addr);
     if (i != nullptr) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1516,9 +1516,14 @@ void CodeCache::print_trace(const char* event, CodeBlob* cb, uint size) {
 void CodeCache::print_internals() {
   int nmethodCount = 0;
   int runtimeStubCount = 0;
+  int upcallStubCount = 0;
   int adapterCount = 0;
+  int mhAdapterCount = 0;
+  int vtableBlobCount = 0;
   int deoptimizationStubCount = 0;
   int uncommonTrapStubCount = 0;
+  int exceptionStubCount = 0;
+  int safepointStubCount = 0;
   int bufferBlobCount = 0;
   int total = 0;
   int nmethodNotEntrant = 0;
@@ -1555,12 +1560,22 @@ void CodeCache::print_internals() {
         }
       } else if (cb->is_runtime_stub()) {
         runtimeStubCount++;
+      } else if (cb->is_upcall_stub()) {
+        upcallStubCount++;
       } else if (cb->is_deoptimization_stub()) {
         deoptimizationStubCount++;
       } else if (cb->is_uncommon_trap_stub()) {
         uncommonTrapStubCount++;
+      } else if (cb->is_exception_stub()) {
+        exceptionStubCount++;
+      } else if (cb->is_safepoint_stub()) {
+        safepointStubCount++;
       } else if (cb->is_adapter_blob()) {
         adapterCount++;
+      } else if (cb->is_method_handles_adapter_blob()) {
+        mhAdapterCount++;
+      } else if (cb->is_vtable_blob()) {
+        vtableBlobCount++;
       } else if (cb->is_buffer_blob()) {
         bufferBlobCount++;
       }
@@ -1587,10 +1602,15 @@ void CodeCache::print_internals() {
   tty->print_cr("\tjava: %d",nmethodJava);
   tty->print_cr("\tnative: %d",nmethodNative);
   tty->print_cr("runtime_stubs: %d",runtimeStubCount);
+  tty->print_cr("upcall_stubs: %d",upcallStubCount);
   tty->print_cr("adapters: %d",adapterCount);
+  tty->print_cr("MH adapters: %d",mhAdapterCount);
+  tty->print_cr("VTables: %d",vtableBlobCount);
   tty->print_cr("buffer blobs: %d",bufferBlobCount);
   tty->print_cr("deoptimization_stubs: %d",deoptimizationStubCount);
   tty->print_cr("uncommon_traps: %d",uncommonTrapStubCount);
+  tty->print_cr("exception_stubs: %d",exceptionStubCount);
+  tty->print_cr("safepoint_stubs: %d",safepointStubCount);
   tty->print_cr("\nnmethod size distribution");
   tty->print_cr("-------------------------------------------------");
 
@@ -1616,9 +1636,14 @@ void CodeCache::print() {
 
   CodeBlob_sizes live[CompLevel_full_optimization + 1];
   CodeBlob_sizes runtimeStub;
+  CodeBlob_sizes upcallStub;
   CodeBlob_sizes uncommonTrapStub;
   CodeBlob_sizes deoptimizationStub;
+  CodeBlob_sizes exceptionStub;
+  CodeBlob_sizes safepointStub;
   CodeBlob_sizes adapter;
+  CodeBlob_sizes mhAdapter;
+  CodeBlob_sizes vtableBlob;
   CodeBlob_sizes bufferBlob;
   CodeBlob_sizes other;
 
@@ -1630,12 +1655,22 @@ void CodeCache::print() {
         live[level].add(cb);
       } else if (cb->is_runtime_stub()) {
         runtimeStub.add(cb);
+      } else if (cb->is_upcall_stub()) {
+        upcallStub.add(cb);
       } else if (cb->is_deoptimization_stub()) {
         deoptimizationStub.add(cb);
       } else if (cb->is_uncommon_trap_stub()) {
         uncommonTrapStub.add(cb);
+      } else if (cb->is_exception_stub()) {
+        exceptionStub.add(cb);
+      } else if (cb->is_safepoint_stub()) {
+        safepointStub.add(cb);
       } else if (cb->is_adapter_blob()) {
         adapter.add(cb);
+      } else if (cb->is_method_handles_adapter_blob()) {
+        mhAdapter.add(cb);
+      } else if (cb->is_vtable_blob()) {
+        vtableBlob.add(cb);
       } else if (cb->is_buffer_blob()) {
         bufferBlob.add(cb);
       } else {
@@ -1666,9 +1701,14 @@ void CodeCache::print() {
     const CodeBlob_sizes* sizes;
   } non_nmethod_blobs[] = {
     { "runtime",        &runtimeStub },
+    { "upcall",         &upcallStub },
     { "uncommon trap",  &uncommonTrapStub },
     { "deoptimization", &deoptimizationStub },
+    { "exception",      &exceptionStub },
+    { "safepoint",      &safepointStub },
     { "adapter",        &adapter },
+    { "mh_adapter",     &mhAdapter },
+    { "vtable",         &vtableBlob },
     { "buffer blob",    &bufferBlob },
     { "other",          &other },
   };

--- a/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
+++ b/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
@@ -124,7 +124,7 @@ void CodeBlobCollector::do_blob(CodeBlob* cb) {
     return;
   }
   // exclude VtableStubs, which are processed separately
-  if (cb->is_buffer_blob() && strcmp(cb->name(), "vtable chunks") == 0) {
+  if (cb->is_vtable_blob()) {
     return;
   }
 

--- a/test/hotspot/jtreg/compiler/codecache/CheckCodeCacheInfo.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckCodeCacheInfo.java
@@ -56,9 +56,14 @@ public class CheckCodeCacheInfo {
                        + pair
                        + "Non-nmethod blobs:\\n"
                        + " #\\d+ runtime = " + entry
+                       + " #\\d+ upcall = " + entry
                        + " #\\d+ uncommon trap = " + entry
                        + " #\\d+ deoptimization = " + entry
+                       + " #\\d+ exception = " + entry
+                       + " #\\d+ safepoint = " + entry
                        + " #\\d+ adapter = " + entry
+                       + " #\\d+ mh_adapter = " + entry
+                       + " #\\d+ vtable = " + entry
                        + " #\\d+ buffer blob = " + entry
                        + " #\\d+ other = " + entry;
     }


### PR DESCRIPTION
`CodeBlob::is_buffer_blob()` method is incorrectly used in few places because BufferBlob is not "leaf" class. You need to add checks for its subclasses too.

I also updated statistic output for CodeCache (`-XX:+PrintCodeCache -XX:+Verbose`) and corresponding test to reflect current state of code blobs.

Tested tier1-4, stress, xcomp

New output:
```
Non-nmethod blobs:
 #67 runtime = 43K (hdr 4K 10%, loc 1K 3%, code 36K 84%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #0 upcall = 0K
 #1 uncommon trap = 0K (hdr 0K 13%, loc 0K 2%, code 0K 84%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #1 deoptimization = 2K (hdr 0K 3%, loc 0K 1%, code 2K 94%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #1 exception = 0K (hdr 0K 30%, loc 0K 3%, code 0K 63%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #3 safepoint = 4K (hdr 0K 4%, loc 0K 1%, code 4K 93%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #639 adapter = 955K (hdr 44K 4%, loc 24K 2%, code 880K 92%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #1 mh_adapter = 10K (hdr 0K 0%, loc 0K 0%, code 9K 99%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #1 vtable = 32K (hdr 0K 0%, loc 0K 0%, code 32K 99%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #12 buffer blob = 917K (hdr 0K 0%, loc 0K 0%, code 916K 99%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #0 other = 0K
```

Output before:
```
Non-nmethod blobs:
 #66 runtime = 42K (hdr 4K 10%, loc 1K 3%, code 36K 84%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #1 uncommon trap = 0K (hdr 0K 13%, loc 0K 2%, code 0K 84%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #1 deoptimization = 2K (hdr 0K 3%, loc 0K 1%, code 2K 94%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #639 adapter = 955K (hdr 44K 4%, loc 24K 2%, code 880K 92%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #12 buffer blob = 917K (hdr 0K 0%, loc 0K 0%, code 916K 99%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
 #6 other = 47K (hdr 0K 0%, loc 0K 0%, code 46K 98%, stub 0K 0%, [oops 0K 0%, metadata 0K 0%, data 0K 0%, pcs 0K 0%])
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349753](https://bugs.openjdk.org/browse/JDK-8349753): Incorrect use of CodeBlob::is_buffer_blob() in few places (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23607/head:pull/23607` \
`$ git checkout pull/23607`

Update a local copy of the PR: \
`$ git checkout pull/23607` \
`$ git pull https://git.openjdk.org/jdk.git pull/23607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23607`

View PR using the GUI difftool: \
`$ git pr show -t 23607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23607.diff">https://git.openjdk.org/jdk/pull/23607.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23607#issuecomment-2655224006)
</details>
