### PR TITLE
8349943: [JMH] Use jvmArgs consistently

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallByRefHighArity.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallByRefHighArity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class CallByRefHighArity {
 
     static {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverRandom.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import jdk.internal.misc.Unsafe;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
 public class LoopOverRandom extends JavaLayouts {
     static final int SEED = 0;
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/SegmentOfBuffer.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/SegmentOfBuffer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -57,13 +57,13 @@ public class SegmentOfBuffer {
     }
 
     @Benchmark
-    @Fork(value = 3, jvmArgsAppend = "-XX:CompileCommand=inline,jdk.internal.foreign.AbstractMemorySegmentImpl::ofBuffer,false")
+    @Fork(value = 3, jvmArgs = "-XX:CompileCommand=inline,jdk.internal.foreign.AbstractMemorySegmentImpl::ofBuffer,false")
     public long ofBufferInlineFalse() {
         return MemorySegment.ofBuffer(buffer).address();
     }
 
     @Benchmark
-    @Fork(value = 3, jvmArgsAppend = "-XX:CompileCommand=inline,jdk.internal.foreign.AbstractMemorySegmentImpl::ofBuffer,true")
+    @Fork(value = 3, jvmArgs = "-XX:CompileCommand=inline,jdk.internal.foreign.AbstractMemorySegmentImpl::ofBuffer,true")
     public long ofBufferInlineTrue() {
         return MemorySegment.ofBuffer(buffer).address();
     }

--- a/test/micro/org/openjdk/bench/java/security/MLDSA.java
+++ b/test/micro/org/openjdk/bench/java/security/MLDSA.java
@@ -56,7 +56,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 3, jvmArgsAppend = {"--add-opens", "java.base/sun.security.provider=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-opens", "java.base/sun.security.provider=ALL-UNNAMED"})
 
 public class MLDSA {
         @Param({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"} )

--- a/test/micro/org/openjdk/bench/java/security/MLKEMBench.java
+++ b/test/micro/org/openjdk/bench/java/security/MLKEMBench.java
@@ -55,7 +55,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 3, jvmArgsAppend = {"--add-opens", "java.base/com.sun.crypto.provider=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-opens", "java.base/com.sun.crypto.provider=ALL-UNNAMED"})
 
 public class MLKEMBench {
         @Param({"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"} )

--- a/test/micro/org/openjdk/bench/javax/crypto/full/AESBench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/AESBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidParameterSpecException;
 
-@Fork(jvmArgsAppend = {"-Xms20g", "-Xmx20g", "-XX:+UseZGC"})
+@Fork(jvmArgs = {"-Xms20g", "-Xmx20g", "-XX:+UseZGC"})
 public class AESBench extends CryptoBase {
 
     public static final int SET_SIZE = 8;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorMultiplyOptBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorMultiplyOptBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.util.stream.*;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class VectorMultiplyOptBenchmark {
     @Param({"1024", "2048", "4096"})
     private int  SIZE;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorXXH3HashingBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorXXH3HashingBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.util.stream.*;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class VectorXXH3HashingBenchmark {
     @Param({"1024", "2048", "4096", "8192"})
     private int  SIZE;

--- a/test/micro/org/openjdk/bench/vm/compiler/MergeStores.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeStores.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -743,8 +743,10 @@ public class MergeStores {
         UNSAFE.putLongUnaligned(null, native_adr + offset + 0, vL);
     }
 
-    @Fork(value = 1, jvmArgsPrepend = {
-        "-XX:+UnlockDiagnosticVMOptions", "-XX:-MergeStores"
+    @Fork(value = 1, jvmArgs = {
+        "-XX:+UnlockDiagnosticVMOptions", "-XX:-MergeStores",
+        "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+        "--add-exports", "java.base/jdk.internal.util=ALL-UNNAMED"
     })
     public static class MergeStoresDisabled extends MergeStores {}
 }


### PR DESCRIPTION
As is suggested in JDK-8342958, `jvmArgs` should be used consistently in microbenchmarks to 'align with the intuition that when you use jvmArgsAppend/-Prepend intent is to add to a set of existing flags, while if you supply jvmArgs intent is "run with these and nothing else"'.

All the previous flags were aligned in
https://github.com/openjdk/jdk/pull/21683, while some recent tests use inconsistent `jvmArgs` again. We update them to keep the consistency.

Change-Id: Ia52af6d2132c561f58bf07bc2f78eed41134d2d8