### PR TITLE
8349977: JVMCIRuntime::_shared_library_javavm_id should be jlong

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -2724,7 +2724,7 @@ C2V_VMENTRY_PREFIX(jboolean, attachCurrentThread, (JNIEnv* env, jobject c2vm, jb
     if (res == JNI_OK) {
       guarantee(peerJNIEnv != nullptr, "must be");
       runtime->init_JavaVM_info(javaVM_info, JVMCI_CHECK_0);
-      JVMCI_event_1("attached to JavaVM[%d] for JVMCI runtime %d", runtime->get_shared_library_javavm_id(), runtime->id());
+      JVMCI_event_1("attached to JavaVM[" JLONG_FORMAT "] for JVMCI runtime %d", runtime->get_shared_library_javavm_id(), runtime->id());
       return true;
     }
     JVMCI_THROW_MSG_0(InternalError, err_msg("Error %d while attaching %s", res, attach_args.name));
@@ -2757,7 +2757,7 @@ C2V_VMENTRY_PREFIX(jboolean, detachCurrentThread, (JNIEnv* env, jobject c2vm, jb
     if (res != JNI_OK) {
       JVMCI_THROW_MSG_0(InternalError, err_msg("Error %d while attaching %s", res, thread->name()));
     }
-    JVMCI_event_1("detached from JavaVM[%d] for JVMCI runtime %d",
+    JVMCI_event_1("detached from JavaVM[" JLONG_FORMAT "] for JVMCI runtime %d",
         runtime->get_shared_library_javavm_id(), runtime->id());
     if (release) {
       return runtime->detach_thread(thread, "user thread detach");

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1569,7 +1569,7 @@ bool JVMCIRuntime::destroy_shared_library_javavm() {
   guarantee(_num_attached_threads == cannot_be_attached,
       "cannot destroy JavaVM for JVMCI runtime %d with %d attached threads", _id, _num_attached_threads);
   JavaVM* javaVM;
-  int javaVM_id = _shared_library_javavm_id;
+  jlong javaVM_id = _shared_library_javavm_id;
   {
     // Exactly one thread can destroy the JavaVM
     // and release the handle to it.
@@ -1588,9 +1588,9 @@ bool JVMCIRuntime::destroy_shared_library_javavm() {
       result = javaVM->DestroyJavaVM();
     }
     if (result == JNI_OK) {
-      JVMCI_event_1("destroyed JavaVM[%d]@" PTR_FORMAT " for JVMCI runtime %d", javaVM_id, p2i(javaVM), _id);
+      JVMCI_event_1("destroyed JavaVM[" JLONG_FORMAT "]@" PTR_FORMAT " for JVMCI runtime %d", javaVM_id, p2i(javaVM), _id);
     } else {
-      warning("Non-zero result (%d) when calling JNI_DestroyJavaVM on JavaVM[%d]@" PTR_FORMAT, result, javaVM_id, p2i(javaVM));
+      warning("Non-zero result (%d) when calling JNI_DestroyJavaVM on JavaVM[" JLONG_FORMAT "]@" PTR_FORMAT, result, javaVM_id, p2i(javaVM));
     }
     return true;
   }

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -183,7 +183,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   JavaVM* _shared_library_javavm;
 
   // Id for _shared_library_javavm.
-  int _shared_library_javavm_id;
+  jlong _shared_library_javavm_id;
 
   // Position and link in global list of JVMCI shared library runtimes.
   // The HotSpot heap based runtime will have an id of -1 and the
@@ -280,7 +280,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   bool has_shared_library_javavm() { return _shared_library_javavm != nullptr; }
 
   // Gets an ID for the JVMCI shared library JavaVM associated with this runtime.
-  int get_shared_library_javavm_id() { return _shared_library_javavm_id; }
+  jlong get_shared_library_javavm_id() { return _shared_library_javavm_id; }
 
   // Copies info about the JVMCI shared library JavaVM associated with this
   // runtime into `info` as follows:


### PR DESCRIPTION
The `JVMCIRuntime::_shared_library_javavm_id` field is initialized from a jlong in [libgraal](https://github.com/oracle/graal/blob/d544bbe3fe416d39e9e5b8fc645a67a36a5d7c07/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jni/functions/JNIInvocationInterface.java#L396-L397) and so it's C++ type in HotSpot should match.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349977](https://bugs.openjdk.org/browse/JDK-8349977): JVMCIRuntime::_shared_library_javavm_id should be jlong (**Bug** - P4)


### Reviewers
 * [Yudi Zheng](https://openjdk.org/census#yzheng) (@mur47x111 - Committer)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23610/head:pull/23610` \
`$ git checkout pull/23610`

Update a local copy of the PR: \
`$ git checkout pull/23610` \
`$ git pull https://git.openjdk.org/jdk.git pull/23610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23610`

View PR using the GUI difftool: \
`$ git pr show -t 23610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23610.diff">https://git.openjdk.org/jdk/pull/23610.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23610#issuecomment-2656094234)
</details>
