### PR TITLE
8349908: RISC-V: C2 SelectFromTwoVector

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
 // Copyright (c) 2020, 2023, Arm Limited. All rights reserved.
 // Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -99,6 +99,8 @@ source %{
           return false;
         }
         break;
+      case Op_SelectFromTwoVector:
+        return true;
       default:
         break;
     }
@@ -108,6 +110,13 @@ source %{
   bool Matcher::match_rule_supported_vector_masked(int opcode, int vlen, BasicType bt) {
     if (!UseRVV) {
       return false;
+    }
+    switch (opcode) {
+      case Op_SelectFromTwoVector:
+        // Currently, there is no selectFrom(av, bv, mask) in vector API.
+        return false;
+      default:
+        break;
     }
     return match_rule_supported_vector(opcode, vlen, bt);
   }
@@ -4421,6 +4430,34 @@ instruct vmask_reinterpret_diff_esize(vRegMask dst, vRegMask_V0 src, vReg tmp) %
     BasicType to_bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(to_bt, Matcher::vector_length(this));
     __ vmseq_vi(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), -1);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// ------------------------------ Vector selectFrom -----------------------------
+
+instruct select_from_two_vectors(vReg dst, vReg src1, vReg src2, vReg index, vRegMask_V0 v0, vReg tmp) %{
+  match(Set dst (SelectFromTwoVector (Binary index src1) src2));
+  effect(TEMP_DEF dst, TEMP v0, TEMP tmp);
+  format %{ "select_from_two_vectors $dst, $src1, $src2, $index" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vrgather_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src1$$reg),
+                   as_VectorRegister($index$$reg));
+    bool use_imm = __ is_simm5(Matcher::vector_length(this) - 1);
+    if (use_imm) {
+      __ vmsgtu_vi(v0, as_VectorRegister($index$$reg), Matcher::vector_length(this) - 1);
+      __ vadd_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($index$$reg),
+                 -Matcher::vector_length(this), Assembler::v0_t);
+    } else {
+      __ mv(t0, Matcher::vector_length(this) - 1);
+      __ vmsgtu_vx(v0, as_VectorRegister($index$$reg), t0);
+      __ mv(t0, -Matcher::vector_length(this));
+      __ vadd_vx(as_VectorRegister($tmp$$reg), as_VectorRegister($index$$reg), t0, Assembler::v0_t);
+    }
+    __ vrgather_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src2$$reg),
+                  as_VectorRegister($tmp$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -4455,7 +4455,7 @@ instruct select_from_two_vectors(vReg dst, vReg src1, vReg src2, vReg index, vRe
       __ vadd_vx(as_VectorRegister($tmp$$reg), as_VectorRegister($index$$reg), t0, Assembler::v0_t);
     }
     __ vrgather_vv(as_VectorRegister($dst$$reg), as_VectorRegister($src2$$reg),
-                  as_VectorRegister($tmp$$reg), Assembler::v0_t);
+                   as_VectorRegister($tmp$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -113,7 +113,7 @@ source %{
     }
     switch (opcode) {
       case Op_SelectFromTwoVector:
-        // Currently, there is no selectFrom(av, bv, mask) in vector API.
+        // There is no masked version of selectFrom two vector, i.e. selectFrom(av, bv, mask) in vector API.
         return false;
       default:
         break;

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -99,8 +99,6 @@ source %{
           return false;
         }
         break;
-      case Op_SelectFromTwoVector:
-        return true;
       default:
         break;
     }


### PR DESCRIPTION
Hi,
Can you help to review the patch?
This optimization is mainly for the vector API.

Thanks

## Test

### jtreg
test/jdk/jdk/incubator/vector/

### Performance
run on bananapi

master vs patch
<google-sheets-html-origin style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">
Benchmark | (size) | Mode | Cnt | Score -master | Error - master | Score - patch | Error - patch | Units | Improvement (master / patch)
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
SelectFromBenchmark.selectFromByteVector | 1024 | avgt | 10 | 26422.495 | 674.565 | 721.604 | 1.036 | ns/op | 36.616
SelectFromBenchmark.selectFromByteVector | 2048 | avgt | 10 | 53964.411 | 1751.618 | 1385.24 | 0.956 | ns/op | 38.957
SelectFromBenchmark.selectFromDoubleVector | 1024 | avgt | 10 | 218430.616 | 1369.409 | 7739.774 | 14.408 | ns/op | 28.222
SelectFromBenchmark.selectFromDoubleVector | 2048 | avgt | 10 | 387889.456 | 7889.791 | 16197.77 | 66.775 | ns/op | 23.947
SelectFromBenchmark.selectFromFloatVector | 1024 | avgt | 10 | 103483.717 | 492.525 | 3580.358 | 29.127 | ns/op | 28.903
SelectFromBenchmark.selectFromFloatVector | 2048 | avgt | 10 | 226125.02 | 3118.836 | 7797.025 | 4.346 | ns/op | 29.001
SelectFromBenchmark.selectFromIntVector | 1024 | avgt | 10 | 97007.999 | 2607.711 | 2898.38 | 0.833 | ns/op | 33.47
SelectFromBenchmark.selectFromIntVector | 2048 | avgt | 10 | 222303.308 | 3096.615 | 6398.214 | 30.345 | ns/op | 34.745
SelectFromBenchmark.selectFromLongVector | 1024 | avgt | 10 | 245033.436 | 1652.527 | 6307.773 | 24.597 | ns/op | 38.846
SelectFromBenchmark.selectFromLongVector | 2048 | avgt | 10 | 438503.547 | 5972.265 | 17215.996 | 167.442 | ns/op | 25.471
SelectFromBenchmark.selectFromShortVector | 1024 | avgt | 10 | 53632.502 | 2159.433 | 1418.215 | 2.953 | ns/op | 37.817
SelectFromBenchmark.selectFromShortVector | 2048 | avgt | 10 | 111764.327 | 1220.509 | 3061.386 | 14.716 | ns/op | 36.508

</google-sheets-html-origin>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349908](https://bugs.openjdk.org/browse/JDK-8349908): RISC-V: C2 SelectFromTwoVector (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23614/head:pull/23614` \
`$ git checkout pull/23614`

Update a local copy of the PR: \
`$ git checkout pull/23614` \
`$ git pull https://git.openjdk.org/jdk.git pull/23614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23614`

View PR using the GUI difftool: \
`$ git pr show -t 23614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23614.diff">https://git.openjdk.org/jdk/pull/23614.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23614#issuecomment-2656757872)
</details>
