### PR TITLE
8350006: IGV: show memory slices as type information

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -547,12 +547,8 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
       Compile::AliasType* at = C->alias_type(adr_type);
       if (at != nullptr) {
         print_prop("alias_index", at->index());
-        ciField* field = at->field();
-        if (field != nullptr) {
-          stringStream field_stream;
-          field->print_name_on(&field_stream);
-          print_prop("alias_field", field_stream.freeze());
-        }
+        // The value of at->field(), if present, is already dumped in the
+        // "source"/"destination" properties.
         const Type* element = at->element();
         if (element != nullptr) {
           stringStream element_stream;

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -542,6 +542,35 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
     assert(s2.size() < sizeof(buffer), "size in range");
     print_prop("dump_spec", buffer);
 
+    const TypePtr* adr_type = node->adr_type();
+    if (adr_type != nullptr && C->have_alias_type(adr_type)) {
+      Compile::AliasType* at = C->alias_type(adr_type);
+      if (at != nullptr) {
+        print_prop("alias_index", at->index());
+        ciField* field = at->field();
+        if (field != nullptr) {
+          stringStream field_stream;
+          field->print_name_on(&field_stream);
+          print_prop("alias_field", field_stream.freeze());
+        }
+        const Type* element = at->element();
+        if (element != nullptr) {
+          stringStream element_stream;
+          element->dump_on(&element_stream);
+          print_prop("alias_element", element_stream.freeze());
+        }
+        if (at->is_rewritable()) {
+          print_prop("alias_is_rewritable", "true");
+        }
+        if (at->is_volatile()) {
+          print_prop("alias_is_volatile", "true");
+        }
+        if (at->general_index() != at->index()) {
+          print_prop("alias_general_index", at->general_index());
+        }
+      }
+    }
+
     if (node->is_block_proj()) {
       print_prop("is_block_proj", "true");
     }

--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,7 +98,7 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   outputStream *_output;
   ciMethod *_current_method;
   int _depth;
-  char buffer[512];
+  char buffer[2048];
   bool _should_send_method;
   PhaseChaitin* _chaitin;
   bool _traverse_outs;

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/showTypes.filter
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/showTypes.filter
@@ -44,8 +44,16 @@ function simplifyType(type) {
 }
 
 // Merge a possibly existing extra label, bottom type, and phase type into a
-// new, single extra label.
-function mergeAndAppendTypeInfo(extra_label, bottom_type, phase_type) {
+// new, single extra label. For memory nodes, add an extra label with the memory
+// slice, extracted from the dump_spec field.
+function mergeAndAppendTypeInfo(extra_label, bottom_type, phase_type, category, dump_spec) {
+  new_extra_label = extra_label == null ? "" : (extra_label + " ");
+  if (category == "memory") {
+    m = /idx=([^\s]+);/.exec(dump_spec);
+    if (m != null) {
+      return new_extra_label + "mem: " + m[1];
+    }
+  }
   if (phase_type == null && bottom_type == null) {
     return extra_label;
   }
@@ -62,11 +70,10 @@ function mergeAndAppendTypeInfo(extra_label, bottom_type, phase_type) {
     type += "B: ";
     type += simplifyType(bottom_type);
   }
-  new_extra_label = extra_label == null ? "" : (extra_label + " ");
   return new_extra_label + type;
 }
 
 editProperty(not(or([matches("bottom_type", "bottom"),
                      matches("bottom_type", "abIO")])),
-             ["extra_label", "bottom_type", "phase_type"], "extra_label",
-             function(propertyValues) {return mergeAndAppendTypeInfo(propertyValues[0], propertyValues[1], propertyValues[2]);});
+             ["extra_label", "bottom_type", "phase_type", "category", "dump_spec"], "extra_label",
+             function(propertyValues) {return mergeAndAppendTypeInfo(propertyValues[0], propertyValues[1], propertyValues[2], propertyValues[3], propertyValues[4]);});


### PR DESCRIPTION
This changeset extends the "Show types" filter in IGV to show the memory slice corresponding to each memory node. This information can be useful e.g. in the ongoing investigation of [JDK-8333393](https://bugs.openjdk.org/browse/JDK-8333393). Here is an example of a memory subgraph with the extended "Show types" filter enabled:

![example](https://github.com/user-attachments/assets/1810a257-c6d6-4b6e-9638-5bbef1c48717)

#### Testing

- tier1 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; release and debug mode).

- Tested IGV manually on a few selected graphs. Tested automatically that displaying thousands of graphs with the "Show types" filter enabled does not trigger any assertion failure (by enabling assertions, instrumenting IGV to display parsed graphs eagerly, and running `java -Xbatch -XX:-TieredCompilation -XX:PrintIdealGraphLevel=3`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350006](https://bugs.openjdk.org/browse/JDK-8350006): IGV: show memory slices as type information (**Enhancement** - P4)


### Reviewers
 * [Daniel Lundén](https://openjdk.org/census#dlunden) (@dlunde - Committer)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23621/head:pull/23621` \
`$ git checkout pull/23621`

Update a local copy of the PR: \
`$ git checkout pull/23621` \
`$ git pull https://git.openjdk.org/jdk.git pull/23621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23621`

View PR using the GUI difftool: \
`$ git pr show -t 23621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23621.diff">https://git.openjdk.org/jdk/pull/23621.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23621#issuecomment-2658570109)
</details>
