### PR TITLE
8350049: [JMH] Float16OperationsBenchmark fails java.lang.NoClassDefFoundError

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/Float16OperationsBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/Float16OperationsBenchmark.java
@@ -31,7 +31,7 @@ import static java.lang.Float.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector", "-Xbatch",  "-XX:-TieredCompilation"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector", "-Xbatch",  "-XX:-TieredCompilation"})
 public class Float16OperationsBenchmark {
     @Param({"256", "512", "1024", "2048"})
     int vectorDim;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/Float16OperationsBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/Float16OperationsBenchmark.java
@@ -31,7 +31,7 @@ import static java.lang.Float.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector", "-Xbatch",  "-XX:-TieredCompilation"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector", "-Xbatch", "-XX:-TieredCompilation"})
 public class Float16OperationsBenchmark {
     @Param({"256", "512", "1024", "2048"})
     int vectorDim;


### PR DESCRIPTION
Hi all,

The newly added JMH tests 'org.openjdk.bench.jdk.incubator.vector.VectorMultiplyOptBenchmark' fails "java.lang.NoClassDefFoundError: jdk/incubator/vector/Float16" by below test command:

```shell
make test MICRO="FORK=1;WARMUP_ITER=2" TEST="micro:org.openjdk.bench.jdk.incubator.vector.VectorMultiplyOptBenchmark.test_bm_pattern1"
```

The `@Fork(jvmArgsPrepend = ..)` in microbenchmarks should replaced as `@Fork(jvmArgs = ..)` since [JDK-8343345](https://bugs.openjdk.org/browse/JDK-8343345). Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350049](https://bugs.openjdk.org/browse/JDK-8350049): [JMH] Float16OperationsBenchmark fails java.lang.NoClassDefFoundError (**Bug** - P4)


### Reviewers
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23624/head:pull/23624` \
`$ git checkout pull/23624`

Update a local copy of the PR: \
`$ git checkout pull/23624` \
`$ git pull https://git.openjdk.org/jdk.git pull/23624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23624`

View PR using the GUI difftool: \
`$ git pr show -t 23624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23624.diff">https://git.openjdk.org/jdk/pull/23624.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23624#issuecomment-2658122920)
</details>
