### PR TITLE
8350051: [JMH] Several tests fails NPE

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -120,6 +120,11 @@ $(JMH_UNPACKED_JARS_DONE): $(JMH_RUNTIME_JARS)
             $$($(UNZIP) -oq $(jar) -d $(JMH_UNPACKED_DIR)))
 	$(RM) -r $(JMH_UNPACKED_DIR)/META-INF
 	$(RM) $(JMH_UNPACKED_DIR)/*.xml
+	$(MKDIR) -p $(MICROBENCHMARK_CLASSES)/org/openjdk/bench/javax/xml
+	$(CP) $(TOPDIR)/test/jaxp/javax/xml/jaxp/unittest/validation/tck/reZ003vExc23082309.xml \
+            $(TOPDIR)/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/message_12.xml \
+            $(TOPDIR)/test/jaxp/javax/xml/jaxp/unittest/transform/msgAttach.xml \
+            $(MICROBENCHMARK_CLASSES)/org/openjdk/bench/javax/xml
 	$(TOUCH) $@
 
 # Create benchmarks JAR file with benchmarks for both the old and new JDK

--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -120,16 +120,22 @@ $(JMH_UNPACKED_JARS_DONE): $(JMH_RUNTIME_JARS)
             $$($(UNZIP) -oq $(jar) -d $(JMH_UNPACKED_DIR)))
 	$(RM) -r $(JMH_UNPACKED_DIR)/META-INF
 	$(RM) $(JMH_UNPACKED_DIR)/*.xml
-	$(MKDIR) -p $(MICROBENCHMARK_CLASSES)/org/openjdk/bench/javax/xml
-	$(CP) $(TOPDIR)/test/jaxp/javax/xml/jaxp/unittest/validation/tck/reZ003vExc23082309.xml \
-            $(TOPDIR)/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/message_12.xml \
-            $(TOPDIR)/test/jaxp/javax/xml/jaxp/unittest/transform/msgAttach.xml \
-            $(MICROBENCHMARK_CLASSES)/org/openjdk/bench/javax/xml
 	$(TOUCH) $@
+
+# Copy dependency files for inclusion in the benchmark JARs
+$(eval $(call SetupCopyFiles, COPY_JAXP_TEST_XML, \
+    SRC := $(TOPDIR)/test/jaxp/javax/xml/jaxp/unittest, \
+    DEST := $(MICROBENCHMARK_CLASSES)/org/openjdk/bench/javax/xml, \
+    FILES := \
+        stream/XMLStreamWriterTest/message_12.xml \
+        validation/tck/reZ003vExc23082309.xml \
+        transform/msgAttach.xml, \
+    FLATTEN := true, \
+))
 
 # Create benchmarks JAR file with benchmarks for both the old and new JDK
 $(eval $(call SetupJarArchive, BUILD_JDK_JAR, \
-    DEPENDENCIES := $(BUILD_JDK_MICROBENCHMARK) $(JMH_UNPACKED_JARS_DONE), \
+    DEPENDENCIES := $(BUILD_JDK_MICROBENCHMARK) $(JMH_UNPACKED_JARS_DONE) $(COPY_JAXP_TEST_XML), \
     SRCS := $(MICROBENCHMARK_CLASSES) $(JMH_UNPACKED_DIR), \
     BIN := $(MICROBENCHMARK_JAR_BIN), \
     SUFFIXES := .*, \

--- a/test/micro/org/openjdk/bench/javax/xml/AbstractXMLMicro.java
+++ b/test/micro/org/openjdk/bench/javax/xml/AbstractXMLMicro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,15 +38,13 @@ import java.util.concurrent.ConcurrentHashMap;
 @State(Scope.Benchmark)
 public abstract class AbstractXMLMicro {
 
-  public static final String BUILDIMPL = "build-impl.xml";
-  public static final String LOGCOMP = "log_comp.xml";
   public static final String MESSAGE12 = "message_12.xml";
   public static final String MSGATTACH = "msgAttach.xml";
   public static final String REZ = "reZ003vExc23082309.xml";
 
   protected static final ConcurrentHashMap<String, byte[]> byteCache = new ConcurrentHashMap<>();
 
-  @Param({BUILDIMPL,LOGCOMP,MESSAGE12,MSGATTACH,REZ})
+  @Param({MESSAGE12,MSGATTACH,REZ})
   protected String doc;
 
   /**


### PR DESCRIPTION
Hi all,

Several JMH tests fails 'Cannot invoke "java.io.InputStream.available()" because "is" is null', because the file 'build/linux-x86_64-server-release/images/test/micro/benchmarks.jar' missing the required xml input file defined by test/micro/org/openjdk/bench/javax/xml/AbstractXMLMicro.java. This PR copy the required xml file to benchmarks.jar, and remove two unexist xml input file.

After this PR, below JMH tests will run passes.

```
org.openjdk.bench.javax.xml.DOM.testBuild
org.openjdk.bench.javax.xml.DOM.testModify
org.openjdk.bench.javax.xml.DOM.testWalk
org.openjdk.bench.javax.xml.SAXUsingJDK.testParse
org.openjdk.bench.javax.xml.STAX.testParse
```

Test command:

```shell
rm -rf build/jmh-result/ ; mkdir -p build/jmh-result/ ; time for test in `cat list.txt` ; do time make test TEST="micro:$test" MICRO="FORK=1;WARMUP_ITER=2" CONF=release &> build/jmh-result/$test.log ; done
```

Change has been verified locally, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350051](https://bugs.openjdk.org/browse/JDK-8350051): [JMH] Several tests fails NPE (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23625/head:pull/23625` \
`$ git checkout pull/23625`

Update a local copy of the PR: \
`$ git checkout pull/23625` \
`$ git pull https://git.openjdk.org/jdk.git pull/23625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23625`

View PR using the GUI difftool: \
`$ git pr show -t 23625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23625.diff">https://git.openjdk.org/jdk/pull/23625.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23625#issuecomment-2658479164)
</details>
