### PR TITLE
8349909: jdk.internal.jimage.decompressor.ZipDecompressor does not close the Inflater in exceptional cases

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/ZipDecompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/ZipDecompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,15 +50,17 @@ final class ZipDecompressor implements ResourceDecompressor {
         }
         byte[] bytesOut = new byte[(int) originalSize];
 
-        Inflater inflater = new Inflater();
-        inflater.setInput(bytesIn, offset, bytesIn.length - offset);
-
         int count = 0;
-        while (!inflater.finished() && count < originalSize) {
-            count += inflater.inflate(bytesOut, count, bytesOut.length - count);
-        }
+        Inflater inflater = new Inflater();
+        try {
+            inflater.setInput(bytesIn, offset, bytesIn.length - offset);
 
-        inflater.end();
+            while (!inflater.finished() && count < originalSize) {
+                count += inflater.inflate(bytesOut, count, bytesOut.length - count);
+            }
+        } finally {
+            inflater.end();
+        }
 
         if (count != originalSize) {
             throw new IOException("Resource content size mismatch");


### PR DESCRIPTION
Can I please get a review of this change which proposes to properly close the `Inflater` instance used in `jdk.internal.jimage.decompressor.ZipDecompressor.decompress()` method? This addresses https://bugs.openjdk.org/browse/JDK-8349909.

As noted in that issue, in the exceptional case in the `decompress()` method, the `Inflater` instance isn't currently being closed. The commit in this PR uses a try/finally block to `end()` the `Inflater` instance.

Unlike some other places within the JDK, the code in `jdk.internal.jimage.decompressor.ZipDecompressor` is expected to maintain Java 8 (API) compatibility, so this part of the code cannot use the newly introduced `Inflater.close()` method and thus cannot use the try-with-resources statement too.

No new tests have been added given the nature of this change. A noreg label has been added to the JBS issue. Existing tests in tier1, tier2 and tier3 continue to pass with this change.