### PR TITLE
8349959: Test CR6740048.java passes unexpectedly missing CR6740048.xsd

### DIFF
--- a/test/jaxp/javax/xml/jaxp/unittest/validation/CR6740048.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/validation/CR6740048.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,8 @@ public class CR6740048 {
                 docBuilderFactory.setValidating(true);
                 docBuilderFactory.setAttribute(SCHEMA_LANGUAGE_URL, XML_SCHEMA_URL);
                 docBuilderFactory.setAttribute(SCHEMA_SOURCE_URL, xsd);
+            } else {
+                Assert.fail("getResourceAsStream CR6740048.xsd return null");
             }
 
             final DocumentBuilder documentBuilder = docBuilderFactory.newDocumentBuilder();

--- a/test/jaxp/javax/xml/jaxp/unittest/validation/CR6740048.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/validation/CR6740048.java
@@ -59,13 +59,9 @@ public class CR6740048 {
             DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
             docBuilderFactory.setNamespaceAware(true);
 
-            if (xsd != null) {
-                docBuilderFactory.setValidating(true);
-                docBuilderFactory.setAttribute(SCHEMA_LANGUAGE_URL, XML_SCHEMA_URL);
-                docBuilderFactory.setAttribute(SCHEMA_SOURCE_URL, xsd);
-            } else {
-                Assert.fail("getResourceAsStream CR6740048.xsd return null");
-            }
+            docBuilderFactory.setValidating(true);
+            docBuilderFactory.setAttribute(SCHEMA_LANGUAGE_URL, XML_SCHEMA_URL);
+            docBuilderFactory.setAttribute(SCHEMA_SOURCE_URL, xsd);
 
             final DocumentBuilder documentBuilder = docBuilderFactory.newDocumentBuilder();
             documentBuilder.setErrorHandler(new ErrorHandler() {


### PR DESCRIPTION
Hi all,

Test test/jaxp/javax/xml/jaxp/unittest/validation/CR6740048.java run passes unexpectedly when missing the depentdent file test/jaxp/javax/xml/jaxp/unittest/validation/CR6740048.xsd. This PR add a NULL check after call `getResourceAsStream("CR6740048.xsd")`.

This PR do not change the original test logic but make test more robustness. Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349959](https://bugs.openjdk.org/browse/JDK-8349959): Test CR6740048.java passes unexpectedly missing CR6740048.xsd (**Bug** - P4)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23627/head:pull/23627` \
`$ git checkout pull/23627`

Update a local copy of the PR: \
`$ git checkout pull/23627` \
`$ git pull https://git.openjdk.org/jdk.git pull/23627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23627`

View PR using the GUI difftool: \
`$ git pr show -t 23627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23627.diff">https://git.openjdk.org/jdk/pull/23627.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23627#issuecomment-2658512660)
</details>
