### PR TITLE
8350086: Inline hot Method accessors for faster task selection

### DIFF
--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -31,6 +31,7 @@
 #include "logging/logStream.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/method.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/jniHandles.hpp"
 #include "runtime/mutexLocker.hpp"

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1919,39 +1919,6 @@ void Method::clear_all_breakpoints() {
 
 #endif // INCLUDE_JVMTI
 
-int Method::invocation_count() const {
-  MethodCounters* mcs = method_counters();
-  MethodData* mdo = method_data();
-  if (((mcs != nullptr) ? mcs->invocation_counter()->carry() : false) ||
-      ((mdo != nullptr) ? mdo->invocation_counter()->carry() : false)) {
-    return InvocationCounter::count_limit;
-  } else {
-    return ((mcs != nullptr) ? mcs->invocation_counter()->count() : 0) +
-           ((mdo != nullptr) ? mdo->invocation_counter()->count() : 0);
-  }
-}
-
-int Method::backedge_count() const {
-  MethodCounters* mcs = method_counters();
-  MethodData* mdo = method_data();
-  if (((mcs != nullptr) ? mcs->backedge_counter()->carry() : false) ||
-      ((mdo != nullptr) ? mdo->backedge_counter()->carry() : false)) {
-    return InvocationCounter::count_limit;
-  } else {
-    return ((mcs != nullptr) ? mcs->backedge_counter()->count() : 0) +
-           ((mdo != nullptr) ? mdo->backedge_counter()->count() : 0);
-  }
-}
-
-int Method::highest_comp_level() const {
-  const MethodCounters* mcs = method_counters();
-  if (mcs != nullptr) {
-    return mcs->highest_comp_level();
-  } else {
-    return CompLevel_none;
-  }
-}
-
 int Method::highest_osr_comp_level() const {
   const MethodCounters* mcs = method_counters();
   if (mcs != nullptr) {

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -255,7 +255,7 @@ class Method : public Metadata {
   void set_deprecated_for_removal() { constMethod()->set_deprecated_for_removal(); }
   bool deprecated_for_removal() const { return constMethod()->deprecated_for_removal(); }
 
-  int highest_comp_level() const;
+  inline int highest_comp_level() const;
   void set_highest_comp_level(int level);
   int highest_osr_comp_level() const;
   void set_highest_osr_comp_level(int level);
@@ -334,8 +334,8 @@ class Method : public Metadata {
   inline float rate() const;
   inline void set_rate(float rate);
 
-  int invocation_count() const;
-  int backedge_count() const;
+  inline int invocation_count() const;
+  inline int backedge_count() const;
 
   bool was_executed_more_than(int n);
   bool was_never_executed()                     { return !was_executed_more_than(0);  }
@@ -344,7 +344,7 @@ class Method : public Metadata {
 
   static MethodCounters* build_method_counters(Thread* current, Method* m);
 
-  int interpreter_invocation_count()            { return invocation_count();          }
+  inline int interpreter_invocation_count() const;
 
 #ifndef PRODUCT
   int64_t  compiled_invocation_count() const    { return _compiled_invocation_count;}

--- a/src/hotspot/share/oops/method.inline.hpp
+++ b/src/hotspot/share/oops/method.inline.hpp
@@ -28,7 +28,9 @@
 #include "oops/method.hpp"
 
 #include "classfile/vmIntrinsics.hpp"
+#include "code/nmethod.inline.hpp"
 #include "oops/methodCounters.hpp"
+#include "oops/methodData.inline.hpp"
 #include "runtime/atomic.hpp"
 
 inline address Method::from_compiled_entry() const {
@@ -186,6 +188,43 @@ inline void Method::set_rate(float rate) {
   if (mcs != nullptr) {
     mcs->set_rate(rate);
   }
+}
+
+int Method::invocation_count() const {
+  MethodCounters* mcs = method_counters();
+  MethodData* mdo = method_data();
+  if (((mcs != nullptr) ? mcs->invocation_counter()->carry() : false) ||
+      ((mdo != nullptr) ? mdo->invocation_counter()->carry() : false)) {
+    return InvocationCounter::count_limit;
+  } else {
+    return ((mcs != nullptr) ? mcs->invocation_counter()->count() : 0) +
+           ((mdo != nullptr) ? mdo->invocation_counter()->count() : 0);
+  }
+}
+
+int Method::backedge_count() const {
+  MethodCounters* mcs = method_counters();
+  MethodData* mdo = method_data();
+  if (((mcs != nullptr) ? mcs->backedge_counter()->carry() : false) ||
+      ((mdo != nullptr) ? mdo->backedge_counter()->carry() : false)) {
+    return InvocationCounter::count_limit;
+  } else {
+    return ((mcs != nullptr) ? mcs->backedge_counter()->count() : 0) +
+           ((mdo != nullptr) ? mdo->backedge_counter()->count() : 0);
+  }
+}
+
+int Method::highest_comp_level() const {
+  const MethodCounters* mcs = method_counters();
+  if (mcs != nullptr) {
+    return mcs->highest_comp_level();
+  } else {
+    return CompLevel_none;
+  }
+}
+
+int Method::interpreter_invocation_count() const {
+  return invocation_count();
 }
 
 #endif // SHARE_OOPS_METHOD_INLINE_HPP

--- a/src/hotspot/share/oops/method.inline.hpp
+++ b/src/hotspot/share/oops/method.inline.hpp
@@ -190,7 +190,7 @@ inline void Method::set_rate(float rate) {
   }
 }
 
-int Method::invocation_count() const {
+inline int Method::invocation_count() const {
   MethodCounters* mcs = method_counters();
   MethodData* mdo = method_data();
   if (((mcs != nullptr) ? mcs->invocation_counter()->carry() : false) ||
@@ -202,7 +202,7 @@ int Method::invocation_count() const {
   }
 }
 
-int Method::backedge_count() const {
+inline int Method::backedge_count() const {
   MethodCounters* mcs = method_counters();
   MethodData* mdo = method_data();
   if (((mcs != nullptr) ? mcs->backedge_counter()->carry() : false) ||
@@ -214,7 +214,7 @@ int Method::backedge_count() const {
   }
 }
 
-int Method::highest_comp_level() const {
+inline int Method::highest_comp_level() const {
   const MethodCounters* mcs = method_counters();
   if (mcs != nullptr) {
     return mcs->highest_comp_level();
@@ -223,7 +223,7 @@ int Method::highest_comp_level() const {
   }
 }
 
-int Method::interpreter_invocation_count() const {
+inline int Method::interpreter_invocation_count() const {
   return invocation_count();
 }
 

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -33,6 +33,7 @@
 #include "memory/metaspaceClosure.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/method.inline.hpp"
 #include "oops/methodData.inline.hpp"
 #include "prims/jvmtiRedefineClasses.hpp"
 #include "runtime/atomic.hpp"

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -54,7 +54,7 @@
 #include "oops/instanceKlass.hpp"
 #include "oops/instanceOop.hpp"
 #include "oops/klassVtable.hpp"
-#include "oops/method.hpp"
+#include "oops/method.inline.hpp"
 #include "oops/objArrayOop.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"


### PR DESCRIPTION
These methods show up prominently on Leyden profiles, as compilation policy asks these properties for methods very often during compile task selection:
 - `Method::invocation_count`
 - `Method::backedge_count`
 - `Method::highest_comp_level`

We can move the definitions for these methods to method.inline.hpp to make them eligible for better inlining.

`interpreter_invocation_count()` method is a bit weird, looks like a leftover from [JDK-8251462](https://bugs.openjdk.org/browse/JDK-8251462). Removing it would prompt more cleanups and renamings in `ciMethod`, so I would leave it for future enhancement.

Additional testing: 
 - [x] Spot-checked Leyden profiles, methods are now fully inlined into hot `CompilerBroker` methods
 - [x] Ad-hoc Leyden benchmarks show minor improvements (< 1%) for time spent in compiler threads

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350086](https://bugs.openjdk.org/browse/JDK-8350086): Inline hot Method accessors for faster task selection (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23634/head:pull/23634` \
`$ git checkout pull/23634`

Update a local copy of the PR: \
`$ git checkout pull/23634` \
`$ git pull https://git.openjdk.org/jdk.git pull/23634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23634`

View PR using the GUI difftool: \
`$ git pr show -t 23634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23634.diff">https://git.openjdk.org/jdk/pull/23634.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23634#issuecomment-2659534061)
</details>
