### PR TITLE
8349180: Remove redundant initialization in ciField constructor

### DIFF
--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -102,8 +102,6 @@ ciField::ciField(ciInstanceKlass* klass, int index, Bytecodes::Code bc) :
     _type = ciType::make(field_type);
   }
 
-  _name = (ciSymbol*)ciEnv::current(THREAD)->get_symbol(name);
-
   // Get the field's declared holder.
   //
   // Note: we actually create a ciInstanceKlass for this klass,


### PR DESCRIPTION
In `ciField`'s ctor, `_name` is initialized twice. I think we can indeed apply the suggested fix and remove the second assignment. `_name` is set correctly the first time (and without the useless cast), and not modified in between.

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349180](https://bugs.openjdk.org/browse/JDK-8349180): Remove redundant initialization in ciField constructor (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23637/head:pull/23637` \
`$ git checkout pull/23637`

Update a local copy of the PR: \
`$ git checkout pull/23637` \
`$ git pull https://git.openjdk.org/jdk.git pull/23637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23637`

View PR using the GUI difftool: \
`$ git pr show -t 23637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23637.diff">https://git.openjdk.org/jdk/pull/23637.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23637#issuecomment-2663604591)
</details>
