### PR TITLE
8350094: Linux gcc 13.2.0 build fails when ubsan is enabled

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -516,10 +516,11 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
       OPTIONAL: true)
 
   # GCC reports lots of likely false positives for stringop-truncation and format-overflow.
+  # GCC 13 also for array-bounds and stringop-overflow
   # Silence them for now.
   UBSAN_CHECKS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize=shift-base -fno-sanitize=alignment \
       $ADDITIONAL_UBSAN_CHECKS"
-  UBSAN_CFLAGS="$UBSAN_CHECKS -Wno-stringop-truncation -Wno-format-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
+  UBSAN_CFLAGS="$UBSAN_CHECKS -Wno-stringop-truncation -Wno-format-overflow -Wno-array-bounds -Wno-stringop-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
   UBSAN_LDFLAGS="$UBSAN_CHECKS"
   UTIL_ARG_ENABLE(NAME: ubsan, DEFAULT: false, RESULT: UBSAN_ENABLED,
       DESC: [enable UndefinedBehaviorSanitizer],


### PR DESCRIPTION
When using a gcc 13.2.0 devkit, the Linux builds (x86_64 and ppc64le) fail with warnings as errors in case that ubsan is enabled.
The 2 warnings as errors are about memset usages ; we see those issues with gcc 13.2 but did not see it with previously used gcc 11.
They only occur with ubsan enabled (seems the warnings change a bit in this case).

src/java.desktop/share/native/liblcms/cmsmd5.c:303:5: error: 'memset' offset [0, 7] is out of the bounds [0, 0] [-Werror=array-bounds=]

src/java.desktop/share/native/liblcms/cmsmd5.c:303:5: error: 'memset' writing 8 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c:144:10: error: 'memset' specified bound between 9223372036854775808 and 18446744073709551615 exceeds maximum object

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8350094](https://bugs.openjdk.org/browse/JDK-8350094): Linux gcc 13.2.0 build fails when ubsan is enabled (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23639/head:pull/23639` \
`$ git checkout pull/23639`

Update a local copy of the PR: \
`$ git checkout pull/23639` \
`$ git pull https://git.openjdk.org/jdk.git pull/23639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23639`

View PR using the GUI difftool: \
`$ git pr show -t 23639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23639.diff">https://git.openjdk.org/jdk/pull/23639.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23639#issuecomment-2659582036)
</details>
