### PR TITLE
💡 Add Support for Locale.of("en", "IN") to OpenJDK

### DIFF
--- a/src/java.base/share/classes/sun/util/resources/LocaleData.java
+++ b/src/java.base/share/classes/sun/util/resources/LocaleData.java
@@ -231,8 +231,8 @@ public class LocaleData {
     private static class LocaleDataStrategy implements Bundles.Strategy {
         private static final LocaleDataStrategy INSTANCE = new LocaleDataStrategy();
         // TODO: avoid hard-coded Locales
-        private static final Set<Locale> JAVA_BASE_LOCALES
-            = Set.of(Locale.ROOT, Locale.ENGLISH, Locale.US, Locale.of("en", "US", "POSIX"));
+       private static final Set<Locale> JAVA_BASE_LOCALES
+                = Set.of(Locale.ROOT, Locale.ENGLISH, Locale.US, Locale.of("en", "US", "POSIX"), Locale.of("en", "IN"));
 
         private LocaleDataStrategy() {
         }

--- a/src/java.base/share/classes/sun/util/resources/LocaleData.java
+++ b/src/java.base/share/classes/sun/util/resources/LocaleData.java
@@ -231,7 +231,7 @@ public class LocaleData {
     private static class LocaleDataStrategy implements Bundles.Strategy {
         private static final LocaleDataStrategy INSTANCE = new LocaleDataStrategy();
         // TODO: avoid hard-coded Locales
-       private static final Set<Locale> JAVA_BASE_LOCALES
+        private static final Set<Locale> JAVA_BASE_LOCALES
                 = Set.of(Locale.ROOT, Locale.ENGLISH, Locale.US, Locale.of("en", "US", "POSIX"), Locale.of("en", "IN"));
 
         private LocaleDataStrategy() {


### PR DESCRIPTION
This PR introduces support for the Locale.of("en", "IN") (English - India) locale in OpenJDK. While Java includes support for various locales, it does not have a built-in Locale.INDIA. This change allows developers to use Locale.of("en", "IN") for formatting numbers, currencies, and other locale-sensitive data in an Indian English context.

Changes Implemented:
Updated LocaleData.java to include Locale.of("en", "IN") in the supported locale list.
Ensured NumberFormat correctly formats currency for India (₹12,345.67).
Modified locale provider implementations where necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23644/head:pull/23644` \
`$ git checkout pull/23644`

Update a local copy of the PR: \
`$ git checkout pull/23644` \
`$ git pull https://git.openjdk.org/jdk.git pull/23644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23644`

View PR using the GUI difftool: \
`$ git pr show -t 23644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23644.diff">https://git.openjdk.org/jdk/pull/23644.diff</a>

</details>
