### PR TITLE
8349848: Support lint control of sunapi diagnostics

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -173,6 +173,7 @@ public class Lint {
             if (!options.isSet(Option.PREVIEW)) {
                 values.add(LintCategory.PREVIEW);
             }
+            values.add(LintCategory.PROPRIETARY);
             values.add(LintCategory.SYNCHRONIZATION);
             values.add(LintCategory.INCUBATING);
         }
@@ -314,6 +315,11 @@ public class Lint {
          * Warn about issues regarding annotation processing.
          */
         PROCESSING("processing"),
+
+        /**
+         * Warn about use of internal proprietary API's.
+         */
+        PROPRIETARY("proprietary"),
 
         /**
          * Warn about unchecked operations on raw types.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1772,6 +1772,24 @@ compiler.note.preview.filename.additional=\
 compiler.note.preview.plural.additional=\
     Some input files additionally use preview features of Java SE {0}.
 
+# 0: file name
+compiler.note.proprietary.filename=\
+    {0} uses an internal proprietary API that may be removed in a future release
+
+compiler.note.proprietary.plural=\
+    Some input files use an internal proprietary API that may be removed in a future release
+
+# The following string may appear after one of the above proprietary messages.
+compiler.note.proprietary.recompile=\
+    Recompile with -Xlint:proprietary for details.
+
+# 0: file name
+compiler.note.proprietary.filename.additional=\
+    {0} has additional uses of an internal proprietary API that may be removed in a future release
+
+compiler.note.proprietary.plural.additional=\
+    Some input files additionally use an internal proprietary API that may be removed in a future release
+
 # Notes related to annotation processing
 
 # Print a client-generated note; assumed to be localized, no translation required
@@ -1960,6 +1978,7 @@ compiler.warn.has.been.deprecated.for.removal.module=\
     module {0} has been deprecated and marked for removal
 
 # 0: symbol
+# lint: proprietary
 compiler.warn.sun.proprietary=\
     {0} is internal proprietary API and may be removed in a future release
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -246,6 +246,9 @@ javac.opt.Xlint.desc.path=\
 
 javac.opt.Xlint.desc.processing=\
     Warn about issues regarding annotation processing.
+
+javac.opt.Xlint.desc.proprietary=\
+    Warn about use of internal proprietary APIs.
 
 javac.opt.Xlint.desc.rawtypes=\
     Warn about use of raw types.

--- a/test/langtools/tools/javac/diags/examples/Proprietary.java
+++ b/test/langtools/tools/javac/diags/examples/Proprietary.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.warn.sun.proprietary
+
+class Proprietary {
+    sun.misc.Unsafe x;
+}

--- a/test/langtools/tools/javac/diags/examples/ProprietaryFilename.java
+++ b/test/langtools/tools/javac/diags/examples/ProprietaryFilename.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.note.proprietary.filename
+// key: compiler.note.proprietary.recompile
+// options: -Xlint:-proprietary
+
+class ProprietaryFilename {
+    sun.misc.Unsafe x;
+}

--- a/test/langtools/tools/javac/diags/examples/ProprietaryFilenameAdditional.java
+++ b/test/langtools/tools/javac/diags/examples/ProprietaryFilenameAdditional.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.warn.sun.proprietary
+// key: compiler.note.proprietary.filename.additional
+// options: -Xmaxwarns 1
+
+class ProprietaryFilename {
+    sun.misc.Unsafe x;
+}
+
+class ProprietaryFilenameAdditional {
+    sun.misc.Unsafe x;
+}

--- a/test/langtools/tools/javac/diags/examples/ProprietaryPlural/Proprietary1.java
+++ b/test/langtools/tools/javac/diags/examples/ProprietaryPlural/Proprietary1.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.note.proprietary.plural
+// key: compiler.note.proprietary.recompile
+// options: -Xlint:-proprietary
+
+class Proprietary1 {
+    sun.misc.Unsafe x;
+}

--- a/test/langtools/tools/javac/diags/examples/ProprietaryPlural/Proprietary2.java
+++ b/test/langtools/tools/javac/diags/examples/ProprietaryPlural/Proprietary2.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+class Proprietary2 {
+    sun.misc.Unsafe x;
+}

--- a/test/langtools/tools/javac/diags/examples/ProprietaryPluralAdditional/Proprietary1.java
+++ b/test/langtools/tools/javac/diags/examples/ProprietaryPluralAdditional/Proprietary1.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.note.proprietary.plural.additional
+// key: compiler.warn.sun.proprietary
+// options: -Xmaxwarns 1
+
+class Proprietary1 {
+    sun.misc.Unsafe x;
+}

--- a/test/langtools/tools/javac/diags/examples/ProprietaryPluralAdditional/Proprietary2.java
+++ b/test/langtools/tools/javac/diags/examples/ProprietaryPluralAdditional/Proprietary2.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+class Proprietary2 {
+    sun.misc.Unsafe x;
+}

--- a/test/langtools/tools/javac/diags/examples/ProprietaryPluralAdditional/Proprietary3.java
+++ b/test/langtools/tools/javac/diags/examples/ProprietaryPluralAdditional/Proprietary3.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+class Proprietary3 {
+    sun.misc.Unsafe x;
+}

--- a/test/langtools/tools/javac/lint/Proprietary.1.out
+++ b/test/langtools/tools/javac/lint/Proprietary.1.out
@@ -1,0 +1,4 @@
+Proprietary.java:11:13: compiler.warn.sun.proprietary: sun.misc.Unsafe
+- compiler.err.warnings.and.werror
+1 error
+1 warning

--- a/test/langtools/tools/javac/lint/Proprietary.2.out
+++ b/test/langtools/tools/javac/lint/Proprietary.2.out
@@ -1,0 +1,2 @@
+- compiler.note.proprietary.filename: Proprietary.java
+- compiler.note.proprietary.recompile

--- a/test/langtools/tools/javac/lint/Proprietary.java
+++ b/test/langtools/tools/javac/lint/Proprietary.java
@@ -1,0 +1,14 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8349848
+ * @summary Test for -Xlint:proprietary
+ *
+ * @compile/fail/ref=Proprietary.1.out  -XDrawDiagnostics -Werror                     Proprietary.java
+ * @compile/ref=Proprietary.2.out       -XDrawDiagnostics -Werror -Xlint:-proprietary Proprietary.java
+ */
+
+class Proprietary {
+    sun.misc.Unsafe x;      // should get a warning here
+    @SuppressWarnings("proprietary")
+    sun.misc.Unsafe y;      // should not get a warning here
+}


### PR DESCRIPTION
This PR creates a new lint category `proprietary` that controls the mandatory warning "Foo is internal proprietary API and may be removed in a future release".

This allows developers to suppress this warning using `-Xlint:-proprietary` and/or `@SuppressWarnings`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Change requires CSR request [JDK-8350135](https://bugs.openjdk.org/browse/JDK-8350135) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8349848](https://bugs.openjdk.org/browse/JDK-8349848): Support lint control of sunapi diagnostics (**Enhancement** - P4)
 * [JDK-8350135](https://bugs.openjdk.org/browse/JDK-8350135): Support lint control of sunapi diagnostics (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23650/head:pull/23650` \
`$ git checkout pull/23650`

Update a local copy of the PR: \
`$ git checkout pull/23650` \
`$ git pull https://git.openjdk.org/jdk.git pull/23650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23650`

View PR using the GUI difftool: \
`$ git pr show -t 23650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23650.diff">https://git.openjdk.org/jdk/pull/23650.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23650#issuecomment-2660281903)
</details>
