### PR TITLE
8350147: Replace example in KEM class with the one from JEP 452

### DIFF
--- a/src/java.base/share/classes/javax/crypto/KEM.java
+++ b/src/java.base/share/classes/javax/crypto/KEM.java
@@ -73,11 +73,11 @@ import java.util.Objects;
  *     publishKey(kp.getPublic());
  *
  *     // Sender side
- *     KEM senderKEM = KEM.getInstance("ABC-KEM");
+ *     KEM senderKEM = KEM.getInstance("ABC");
  *     PublicKey receiverPublicKey = retrieveKey();
- *     ABCKEMParameterSpec spec = new ABCKEMParameterSpec(...);
+ *     ABCKEMParameterSpec senderSpec = new ABCKEMParameterSpec(...);
  *     KEM.Encapsulator e = senderKEM.newEncapsulator(
- *             receiverPublicKey, spec, null);
+ *             receiverPublicKey, senderSpec, null);
  *     KEM.Encapsulated enc = e.encapsulate();
  *     SecretKey senderSecret = enc.key();
  *
@@ -88,9 +88,9 @@ import java.util.Objects;
  *     byte[] ciphertext = receiveBytes();
  *     byte[] params = receiveBytes();
  *
- *     KEM receiverKEM = KEM.getInstance("ABC-KEM");
+ *     KEM receiverKEM = KEM.getInstance("ABC");
  *     AlgorithmParameters algParams =
- *             AlgorithmParameters.getInstance("ABC-KEM");
+ *             AlgorithmParameters.getInstance("ABC");
  *     algParams.init(params);
  *     ABCKEMParameterSpec receiverSpec =
  *             algParams.getParameterSpec(ABCKEMParameterSpec.class);

--- a/src/java.base/share/classes/javax/crypto/KEM.java
+++ b/src/java.base/share/classes/javax/crypto/KEM.java
@@ -75,7 +75,7 @@ import java.util.Objects;
  *     // Sender side
  *     KEM senderKEM = KEM.getInstance("ABC");
  *     PublicKey receiverPublicKey = retrieveKey();
- *     ABCKEMParameterSpec senderSpec = new ABCKEMParameterSpec(...);
+ *     ABCKEMParameterSpec senderSpec = new ABCKEMParameterSpec(args);
  *     KEM.Encapsulator e = senderKEM.newEncapsulator(
  *             receiverPublicKey, senderSpec, null);
  *     KEM.Encapsulated enc = e.encapsulate();

--- a/src/java.base/share/classes/javax/crypto/KEM.java
+++ b/src/java.base/share/classes/javax/crypto/KEM.java
@@ -65,24 +65,40 @@ import java.util.Objects;
  * new shared secret and key encapsulation message.
  * <p>
  *
- * Example:
+ * Example operation using a ficticious {@code KEM} algorithm {@code ABC}:
  * {@snippet lang = java:
- *    // Receiver side
- *    var kpg = KeyPairGenerator.getInstance("X25519");
- *    var kp = kpg.generateKeyPair();
+ *     // Receiver side
+ *     KeyPairGenerator g = KeyPairGenerator.getInstance("ABC");
+ *     KeyPair kp = g.generateKeyPair();
+ *     publishKey(kp.getPublic());
  *
- *    // Sender side
- *    var kem1 = KEM.getInstance("DHKEM");
- *    var sender = kem1.newEncapsulator(kp.getPublic());
- *    var encapsulated = sender.encapsulate();
- *    var k1 = encapsulated.key();
+ *     // Sender side
+ *     KEM senderKEM = KEM.getInstance("ABC-KEM");
+ *     PublicKey receiverPublicKey = retrieveKey();
+ *     ABCKEMParameterSpec spec = new ABCKEMParameterSpec(...);
+ *     KEM.Encapsulator e = senderKEM.newEncapsulator(
+ *             receiverPublicKey, spec, null);
+ *     KEM.Encapsulated enc = e.encapsulate();
+ *     SecretKey senderSecret = enc.key();
  *
- *    // Receiver side
- *    var kem2 = KEM.getInstance("DHKEM");
- *    var receiver = kem2.newDecapsulator(kp.getPrivate());
- *    var k2 = receiver.decapsulate(encapsulated.encapsulation());
+ *     sendBytes(enc.encapsulation());
+ *     sendBytes(enc.params());
  *
- *    assert Arrays.equals(k1.getEncoded(), k2.getEncoded());
+ *     // Receiver side
+ *     byte[] ciphertext = receiveBytes();
+ *     byte[] params = receiveBytes();
+ *
+ *     KEM receiverKEM = KEM.getInstance("ABC-KEM");
+ *     AlgorithmParameters algParams =
+ *             AlgorithmParameters.getInstance("ABC-KEM");
+ *     algParams.init(params);
+ *     ABCKEMParameterSpec receiverSpec =
+ *             algParams.getParameterSpec(ABCKEMParameterSpec.class);
+ *     KEM.Decapsulator d =
+ *             receiverKEM.newDecapsulator(kp.getPrivate(), receiverSpec);
+ *     SecretKey receiverSecret = d.decapsulate(ciphertext);
+ *
+ *     // senderSecret and receiverSecret should now be equal.
  * }
  *
  * @since 21


### PR DESCRIPTION
The example code in the JEP was much clearer than that in the current `KEM` class.  It's easier to keep the various nested classes straight, rather than using `var`s which require scrolling to see what the return types are. 

Added/tweaked example for clarity.

Generated/checked javadocs, but no regression/JCK tests is necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350147](https://bugs.openjdk.org/browse/JDK-8350147): Replace example in KEM class with the one from JEP 452 (**Enhancement** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23652/head:pull/23652` \
`$ git checkout pull/23652`

Update a local copy of the PR: \
`$ git checkout pull/23652` \
`$ git pull https://git.openjdk.org/jdk.git pull/23652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23652`

View PR using the GUI difftool: \
`$ git pr show -t 23652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23652.diff">https://git.openjdk.org/jdk/pull/23652.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23652#issuecomment-2660735830)
</details>
