### PR TITLE
8350621: Code cache stops scheduling GC

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -860,7 +860,7 @@ uint64_t CodeCache::_cold_gc_count = INT_MAX;
 double CodeCache::_last_unloading_time = 0.0;
 size_t CodeCache::_last_unloading_used = 0;
 volatile bool CodeCache::_on_gc_allocation_ongoing = false;
-bool CodeCache::_unloading_gc_requested = false;
+volatile bool CodeCache::_unloading_gc_requested = false;
 double CodeCache::_unloading_gc_requested_time = 0;
 TruncatedSeq CodeCache::_unloading_gc_intervals(10 /* samples */);
 TruncatedSeq CodeCache::_unloading_allocation_rates(10 /* samples */);

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -827,7 +827,7 @@ bool CodeCache::try_to_gc(GCCause::Cause cause) {
   // will reset our flag correctly which may prevent future GC requests.
   // In order to avoid that, automatically reset it after a fixed delay of 250ms.
   if (elapsed_since_last_gc_request > 0.25 && _unloading_gc_requested) {
-    log_debug(codecache)("Previous GC request has not been reset after %fs, ", elapsed_since_last_gc_request);
+    log_debug(codecache)("Previous GC request has not been reset after %fs, force auto-reset", elapsed_since_last_gc_request);
     Atomic::cmpxchg(&_unloading_gc_requested, true, false);
   }
 

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -28,6 +28,7 @@
 #include "code/codeBlob.hpp"
 #include "code/nmethod.hpp"
 #include "gc/shared/gcBehaviours.hpp"
+#include "gc/shared/gcCause.hpp"
 #include "memory/allocation.hpp"
 #include "memory/heap.hpp"
 #include "oops/instanceKlass.hpp"
@@ -108,7 +109,8 @@ class CodeCache : AllStatic {
   static double            _last_unloading_time;
   static TruncatedSeq      _unloading_gc_intervals;
   static TruncatedSeq      _unloading_allocation_rates;
-  static volatile bool     _unloading_threshold_gc_requested;
+  static volatile bool     _unloading_gc_requested;
+  static double            _unloading_gc_requested_time;
 
   static ExceptionCache* volatile _exception_cache_purge_list;
 
@@ -128,6 +130,8 @@ class CodeCache : AllStatic {
   static CodeBlob* first_blob(CodeHeap* heap);                // Returns the first CodeBlob on the given CodeHeap
   static CodeBlob* first_blob(CodeBlobType code_blob_type);            // Returns the first CodeBlob of the given type
   static CodeBlob* next_blob(CodeHeap* heap, CodeBlob* cb);   // Returns the next CodeBlob on the given CodeHeap
+
+  static bool try_to_gc(GCCause::Cause cause);
 
  private:
   static size_t bytes_allocated_in_freelists();

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -109,7 +109,8 @@ class CodeCache : AllStatic {
   static double            _last_unloading_time;
   static TruncatedSeq      _unloading_gc_intervals;
   static TruncatedSeq      _unloading_allocation_rates;
-  static volatile bool     _unloading_gc_requested;
+  static volatile bool     _on_gc_allocation_ongoing;
+  static bool              _unloading_gc_requested;
   static double            _unloading_gc_requested_time;
 
   static ExceptionCache* volatile _exception_cache_purge_list;

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -131,7 +131,8 @@ class CodeCache : AllStatic {
   static CodeBlob* first_blob(CodeBlobType code_blob_type);            // Returns the first CodeBlob of the given type
   static CodeBlob* next_blob(CodeHeap* heap, CodeBlob* cb);   // Returns the next CodeBlob on the given CodeHeap
 
-  static bool try_to_gc(GCCause::Cause cause);
+  template <typename Function>
+  static void try_to_gc(GCCause::Cause cause, Function log_on_gc);
 
  private:
   static size_t bytes_allocated_in_freelists();

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -110,7 +110,7 @@ class CodeCache : AllStatic {
   static TruncatedSeq      _unloading_gc_intervals;
   static TruncatedSeq      _unloading_allocation_rates;
   static volatile bool     _on_gc_allocation_ongoing;
-  static bool              _unloading_gc_requested;
+  static volatile bool     _unloading_gc_requested;
   static double            _unloading_gc_requested_time;
 
   static ExceptionCache* volatile _exception_cache_purge_list;


### PR DESCRIPTION
The purpose of this PR is to fix a bug where we can end up in a situation where the GC is not scheduled anymore by `CodeCache`.

This situation is possible because the `_unloading_threshold_gc_requested` flag is set to `true` when triggering the GC and we expect the GC to call `CodeCache::on_gc_marking_cycle_finish` which in turn will call `CodeCache::update_cold_gc_count`, which will reset the flag `_unloading_threshold_gc_requested` allowing further GC scheduling.

Unfortunately this can't work properly under certain circumstances.
For example, if using G1GC, calling `G1CollectedHeap::collect` does no give the guarantee that the GC will actually run as it can be already running (see [here](https://github.com/openjdk/jdk/blob/7d11418c820b46926a25907766d16083a4b349de/src/hotspot/share/gc/g1/g1CollectedHeap.cpp#L1763)).

I have observed this behavior on JVM in version 21 that were migrated recently from java 17.
Those JVMs have some pressure on code cache and quite a large heap in comparison to allocation rate, which means that objects are mostly GC'd by young collections and full GC take a long time to happen.

I have been able to reproduce this issue with ParallelGC and G1GC, and I imagine that other GC can be impacted as well.

In order to reproduce this issue, I found a very simple and convenient way:

```java
public class CodeCacheMain {
    public static void main(String[] args) throws InterruptedException {
        while (true) {
            Thread.sleep(100);
        }
    }
}
```

Run this simple app with the following JVM flags:

```
-Xlog:gc*=info,codecache=info -Xmx512m -XX:ReservedCodeCacheSize=2496k -XX:StartAggressiveSweepingAt=15
```

- 512m for the heap just to clarify the intent that we don't want to be bothered by a full GC
- low `ReservedCodeCacheSize` to put pressure on code cache quickly
- `StartAggressiveSweepingAt` can be set to 20 or 15 for faster bug reproduction

Itself, the program will hardly get pressure on code cache, but the good news is that it is sufficient to attach a jconsole on it which will:
- allows us to monitor code cache
- indirectly generate activity on the code cache, just what we need to reproduce the bug

Some logs related to code cache will show up at some point with GC activity:

```
[648.733s][info][codecache      ] Triggering aggressive GC due to having only 14.970% free memory
```

And then it will stop and we'll end up with the following message:

```
[672.714s][info][codecache      ] Code cache is full - disabling compilation
```

Leaving the JVM in an unstable situation.

I considered a few different options before making this change:
1) Always call `Universe::heap()->collect(...)` without making any check (the GC impl should handle the situation)
2) Fix all GCs implementation to ensure `_unloading_threshold_gc_requested` gets back to `false` at some point (probably what is supposed to happen today)
3) Change `CollectedHeap::collect` to return a `bool` instead of `void` to indicate if GC was run or scheduled

But I discarded them:
1) Dumb option that I used to check that the bug would be corrected, but will probably put a bit of pressure on resources when allocation need to be performed at code cache level (as it will be called at each allocation attempt). In addition, the log indicating that we trigger GC is spammed, not easy to decide how to handle the log correctly.
2) This option is possible and was my favorite up to some point. GC's implementation can have quite a lot of branches and it can be difficult to ensure we don't forget a case when to reset the flag. This could eventually be a solution to be explored in addition to the solution I propose in the PR. We could introduce a static method in `CodeCache` that would let a GC implementation to just reset the flag in a case the GC will not actually run for example (to be discussed)
3) I explored this solution, but it adds quite a lot of changes and is risky in the long term (in my opinion). G1GC already has a [G1CollectedHeap::try_collect](https://github.com/openjdk/jdk/blob/7d11418c820b46926a25907766d16083a4b349de/src/hotspot/share/gc/g1/g1CollectedHeap.cpp#L1870) method that returns a `bool`, but this bool is `true` even when the GC is not run.

As a result, I decided to simply add a way for `CodeCache` to recover from this situation. The idea is to let the GC code as-is but keep in memory the time of the last GC request and reset the flag to `false` if it was not reset in a certain amount of time (250ms in my PR). This should only be helpful in corner cases where the GC impl has not reset the flag by itself.

Among the advantages of this solution: it gives a security to recover from a situation that may be created by changes in GC implementation, because someone forgot to take care about code cache.

I took a lot of time investigating this issue and exploring solutions, and am willing to take any input on it as it is my first PR on the project.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350621](https://bugs.openjdk.org/browse/JDK-8350621): Code cache stops scheduling GC (**Bug** - P2)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 26, a new backport will be created when this pr is integrated.)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23656/head:pull/23656` \
`$ git checkout pull/23656`

Update a local copy of the PR: \
`$ git checkout pull/23656` \
`$ git pull https://git.openjdk.org/jdk.git pull/23656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23656`

View PR using the GUI difftool: \
`$ git pr show -t 23656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23656.diff">https://git.openjdk.org/jdk/pull/23656.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23656#issuecomment-2836351898)
</details>
