### PR TITLE
8349991: GraphUtils.java can use String.replace() instead of String.replaceAll()

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/GraphUtils.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/GraphUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -251,9 +251,9 @@ public class GraphUtils {
         }
 
         protected String formatProperties(Properties p) {
-            return p.toString().replaceAll(",", " ")
-                .replaceAll("\\{", "[")
-                .replaceAll("\\}", "]");
+            return p.toString().replace(',', ' ')
+                .replace('{', '[')
+                .replace('}', ']');
         }
 
         protected static String wrap(String s) {


### PR DESCRIPTION
This is a tiny performance improvement that replaces a few invocations of `String.replaceAll()` with equivalent invocations of `String.replace(char, char)` and avoids the unnecessary use of regular expressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349991](https://bugs.openjdk.org/browse/JDK-8349991): GraphUtils.java can use String.replace() instead of String.replaceAll() (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23658/head:pull/23658` \
`$ git checkout pull/23658`

Update a local copy of the PR: \
`$ git checkout pull/23658` \
`$ git pull https://git.openjdk.org/jdk.git pull/23658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23658`

View PR using the GUI difftool: \
`$ git pr show -t 23658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23658.diff">https://git.openjdk.org/jdk/pull/23658.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23658#issuecomment-2661831671)
</details>
