### PR TITLE
8349664: HEX dump should always use ASCII or ISO_8859_1

### DIFF
--- a/src/java.base/share/classes/sun/security/util/HexDumpEncoder.java
+++ b/src/java.base/share/classes/sun/security/util/HexDumpEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public class HexDumpEncoder {
 
     protected void encodeBufferPrefix(OutputStream o) throws IOException {
         offset = 0;
-        pStream = new PrintStream(o);
+        pStream = new PrintStream(o, false, ISO_8859_1);
     }
 
     protected void encodeLinePrefix(OutputStream o, int len) {
@@ -303,6 +303,8 @@ public class HexDumpEncoder {
     /**
      * A 'streamless' version of encode that simply takes a buffer of
      * bytes and returns a string containing the encoded buffer.
+     * <P>
+     * Returned string is encoded with the ISO-8859-1, also known as ISO-LATIN-1.
      */
     public String encodeBuffer(byte[] aBuffer) {
         ByteArrayOutputStream   outStream = new ByteArrayOutputStream();
@@ -313,7 +315,7 @@ public class HexDumpEncoder {
             // This should never happen.
             throw new Error("CharacterEncoder.encodeBuffer internal error");
         }
-        return (outStream.toString());
+        return (outStream.toString(ISO_8859_1));
     }
 
     /**

--- a/test/jdk/sun/security/util/HexDumpEncoderTests.java
+++ b/test/jdk/sun/security/util/HexDumpEncoderTests.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
  * @bug 8349664
  * @summary HEX dump should always use ASCII or ISO_8859_1
  * @modules java.base/sun.security.util
+ * @library /test/lib
  */
 public class HexDumpEncoderTests {
 

--- a/test/jdk/sun/security/util/HexDumpEncoderTests.java
+++ b/test/jdk/sun/security/util/HexDumpEncoderTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.security.CertUtils;
+import sun.security.util.HexDumpEncoder;
+
+import java.io.FileInputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+
+/*
+ * @test
+ * @bug 8349664
+ * @summary HEX dump should always use ASCII or ISO_8859_1
+ * @modules java.base/sun.security.util
+ * @library /test/lib
+ */
+public class HexDumpEncoderTests {
+
+    private final static String CERT_PATH = Path.of(System.getProperty("test.src", "."))
+            .resolve("HostnameChecker")
+            .resolve("cert5.crt")
+            .toString();
+
+    private static String[] getTestCommand(final String encoding) {
+        return new String[]{
+                "--add-modules", "java.base",
+                "--add-exports", "java.base/sun.security.util=ALL-UNNAMED",
+                "-Dfile.encoding=" + encoding,
+                HexDumpEncoderTests.HexDumpEncoderTest.class.getName(),
+                CERT_PATH};
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        final var testCommandIso = getTestCommand("ISO-8859-1");
+
+        final var resultIso = ProcessTools.executeTestJava(testCommandIso);
+        resultIso.shouldHaveExitValue(0);
+
+        // This will take all available StandardCharsets and test them all comparing to the ISO_8859_1
+        // Dome im parallel, as this is significantly faster
+        Arrays.stream(StandardCharsets.class.getDeclaredFields())
+                .parallel()
+                .forEach(field -> {
+                    if (java.lang.reflect.Modifier.isStatic(field.getModifiers())) {
+                        try {
+                            final var charset = (Charset) field.get(StandardCharsets.ISO_8859_1); // getting the charset to test
+
+                            final var testCommand = getTestCommand(charset.name());
+
+                            final var result = ProcessTools.executeTestJava(testCommand);
+                            result.shouldHaveExitValue(0);
+
+                            // The outputs of the ISO encoding must be identical to the one tested
+                            Asserts.assertEquals(resultIso.getStdout(),
+                                    result.getStdout(),
+                                    "Encoding " + charset.name());
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                });
+    }
+
+    public static class HexDumpEncoderTest {
+
+        /**
+         * This will test the encode and encode buffer functions at once,
+         * as they are both representing the string in LATIN_1
+         * <p>
+         * The output is put as a system.out
+         */
+        public static void main(String[] args) throws Exception {
+
+            try (final FileInputStream fis = new FileInputStream(args[0])) {
+                var cert = CertUtils.getCertFromStream(fis);
+
+                final var certEncodedWithEncodeBuffer = hexDumpEncoderEncodeBuffer(cert);
+                final var certEncodedWithEncode = hexDumpEncoderEncode(cert);
+                System.out.printf("\nCert Encoded With Encode Buffer: %s\n", certEncodedWithEncodeBuffer);
+                System.out.printf("\nCert Encoded With Encode: %s\n", certEncodedWithEncode);
+            }
+        }
+
+        private static String hexDumpEncoderEncodeBuffer(final X509Certificate cert) {
+
+            final var encoder = new HexDumpEncoder();
+            return encoder.encodeBuffer(cert.getSignature());
+        }
+
+        private static String hexDumpEncoderEncode(final X509Certificate cert) {
+
+            final var encoder = new HexDumpEncoder();
+            return encoder.encode(cert.getSignature());
+        }
+
+    }
+}

--- a/test/jdk/sun/security/util/HexDumpEncoderTests.java
+++ b/test/jdk/sun/security/util/HexDumpEncoderTests.java
@@ -42,18 +42,14 @@ import java.util.Arrays;
  */
 public class HexDumpEncoderTests {
 
-    private final static String CERT_PATH = Path.of(System.getProperty("test.src", "."))
-            .resolve("HostnameChecker")
-            .resolve("cert5.crt")
-            .toString();
 
     private static String[] getTestCommand(final String encoding) {
         return new String[]{
                 "--add-modules", "java.base",
                 "--add-exports", "java.base/sun.security.util=ALL-UNNAMED",
                 "-Dfile.encoding=" + encoding,
-                HexDumpEncoderTests.HexDumpEncoderTest.class.getName(),
-                CERT_PATH};
+                HexDumpEncoderTests.HexDumpEncoderTest.class.getName()
+        };
     }
 
     public static void main(String[] args) throws Exception {
@@ -98,27 +94,10 @@ public class HexDumpEncoderTests {
          */
         public static void main(String[] args) throws Exception {
 
-            try (final FileInputStream fis = new FileInputStream(args[0])) {
-                var cert = CertUtils.getCertFromStream(fis);
-
-                final var certEncodedWithEncodeBuffer = hexDumpEncoderEncodeBuffer(cert);
-                final var certEncodedWithEncode = hexDumpEncoderEncode(cert);
-                System.out.printf("\nCert Encoded With Encode Buffer: %s\n", certEncodedWithEncodeBuffer);
-                System.out.printf("\nCert Encoded With Encode: %s\n", certEncodedWithEncode);
-            }
-        }
-
-        private static String hexDumpEncoderEncodeBuffer(final X509Certificate cert) {
-
             final var encoder = new HexDumpEncoder();
-            return encoder.encodeBuffer(cert.getSignature());
+
+            System.out.printf("\nCert Encoded With Encode Buffer: %s\n", encoder.encodeBuffer(new byte[100]));
+            System.out.printf("\nCert Encoded With Encode: %s\n", encoder.encode(new byte[100]));
         }
-
-        private static String hexDumpEncoderEncode(final X509Certificate cert) {
-
-            final var encoder = new HexDumpEncoder();
-            return encoder.encode(cert.getSignature());
-        }
-
     }
 }

--- a/test/jdk/sun/security/util/HexDumpEncoderTests.java
+++ b/test/jdk/sun/security/util/HexDumpEncoderTests.java
@@ -23,14 +23,10 @@
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.security.CertUtils;
 import sun.security.util.HexDumpEncoder;
 
-import java.io.FileInputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.security.cert.X509Certificate;
 import java.util.Arrays;
 
 /*
@@ -38,7 +34,6 @@ import java.util.Arrays;
  * @bug 8349664
  * @summary HEX dump should always use ASCII or ISO_8859_1
  * @modules java.base/sun.security.util
- * @library /test/lib
  */
 public class HexDumpEncoderTests {
 


### PR DESCRIPTION
Changed `HexDumpEncoder`, so `encodeBuffer` always uses ISO_8859_1. 
This also fixes the issue with conversion in `encode` method, as the input is always ISO_8859_1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349664](https://bugs.openjdk.org/browse/JDK-8349664): HEX dump should always use ASCII or ISO_8859_1 (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23661/head:pull/23661` \
`$ git checkout pull/23661`

Update a local copy of the PR: \
`$ git checkout pull/23661` \
`$ git pull https://git.openjdk.org/jdk.git pull/23661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23661`

View PR using the GUI difftool: \
`$ git pr show -t 23661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23661.diff">https://git.openjdk.org/jdk/pull/23661.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23661#issuecomment-2662880727)
</details>
