### PR TITLE
8350197: [UBSAN] Node::dump_idx reported float-cast-overflow

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -6831,7 +6831,7 @@ void PhaseIdealLoop::get_idoms(Node* n, const uint count, Unique_Node_List& idom
 void PhaseIdealLoop::dump_idoms_in_reverse(const Node* n, const Node_List& idom_list) const {
   Node* next;
   uint padding = 3;
-  uint node_index_padding_width = C->unique() == 0 ? 0 : static_cast<int>(log10(static_cast<double>(C->unique()))) + 1;
+  uint node_index_padding_width = (C->unique() == 0 ? 0 : static_cast<int>(log10(static_cast<double>(C->unique())))) + 1;
   for (int i = idom_list.size() - 1; i >= 0; i--) {
     if (i == 9 || i == 99) {
       padding++;

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -6831,7 +6831,7 @@ void PhaseIdealLoop::get_idoms(Node* n, const uint count, Unique_Node_List& idom
 void PhaseIdealLoop::dump_idoms_in_reverse(const Node* n, const Node_List& idom_list) const {
   Node* next;
   uint padding = 3;
-  uint node_index_padding_width = static_cast<int>(log10(static_cast<double>(C->unique()))) + 1;
+  uint node_index_padding_width = C->unique() == 0 ? 0 : static_cast<int>(log10(static_cast<double>(C->unique()))) + 1;
   for (int i = idom_list.size() - 1; i >= 0; i--) {
     if (i == 9 || i == 99) {
       padding++;

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2024, Alibaba Group Holding Limited. All rights reserved.
+ * Copyright (c) 2024, 2025, Alibaba Group Holding Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2425,9 +2425,9 @@ void Node::dump_idx(bool align, outputStream* st, DumpConfig* dc) const {
   bool is_new = C->node_arena()->contains(this);
   if (align) { // print prefix empty spaces$
     // +1 for leading digit, +1 for "o"
-    uint max_width = static_cast<uint>(log10(static_cast<double>(C->unique()))) + 2;
+    uint max_width = C->unique() == 0 ? 0 : static_cast<uint>(log10(static_cast<double>(C->unique()))) + 2;
     // +1 for leading digit, maybe +1 for "o"
-    uint width = static_cast<uint>(log10(static_cast<double>(_idx))) + 1 + (is_new ? 0 : 1);
+    uint width = (_idx == 0 ? 0 : static_cast<uint>(log10(static_cast<double>(_idx)))) + 1 + (is_new ? 0 : 1);
     while (max_width > width) {
       st->print(" ");
       width++;

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2425,7 +2425,7 @@ void Node::dump_idx(bool align, outputStream* st, DumpConfig* dc) const {
   bool is_new = C->node_arena()->contains(this);
   if (align) { // print prefix empty spaces$
     // +1 for leading digit, +1 for "o"
-    uint max_width = C->unique() == 0 ? 0 : static_cast<uint>(log10(static_cast<double>(C->unique()))) + 2;
+    uint max_width = (C->unique() == 0 ? 0 : static_cast<uint>(log10(static_cast<double>(C->unique())))) + 2;
     // +1 for leading digit, maybe +1 for "o"
     uint width = (_idx == 0 ? 0 : static_cast<uint>(log10(static_cast<double>(_idx)))) + 1 + (is_new ? 0 : 1);
     while (max_width > width) {


### PR DESCRIPTION
Hi all,

The function of 'Node::dump_idx(bool, outputStream*, Node::DumpConfig*)' in file src/hotspot/share/opto/node.cpp:2430 reported "runtime error: -inf is outside the range of representable values of type 'unsigned int'" by clang17's UndefinedBehaviorSanitizer.

This PR add an extra check for the argument before pass call to `log10`. Risk is low.

Additional testing:

- [x] Jtreg tests(include tier1/2/3 etc.) on linux-x64 with release build
- [x] Jtreg tests(include tier1/2/3 etc.) on linux-aarch64 with release build
- [x] Jtreg tests(include tier1/2/3 etc.) on linux-x64 with fastdebug build
- [x] Jtreg tests(include tier1/2/3 etc.) on linux-aarch64 with fastdebug build

Below code snippet demonstrate the undefined behaviour of float-cast-overflow:

```c
#include <stdio.h>
#include <math.h>
int input = 0;
int main()
{
  printf("result = %lf\n", log10((double)input));
  printf("result = %u\n", (unsigned int)log10((double)input));
  printf("result = %u\n", input==0 ? 0 : (unsigned int)log10((double)input));
  return 0;
}
```

```shell
> clang -fsanitize=undefined log10.c -lm && ./a.out 
result = -inf
log10.c:9:27: runtime error: -inf is outside the range of representable values of type 'unsigned int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior log10.c:9:27 in 
result = 0
result = 0
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350197](https://bugs.openjdk.org/browse/JDK-8350197): [UBSAN] Node::dump_idx reported float-cast-overflow (**Bug** - P5)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23662/head:pull/23662` \
`$ git checkout pull/23662`

Update a local copy of the PR: \
`$ git checkout pull/23662` \
`$ git pull https://git.openjdk.org/jdk.git pull/23662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23662`

View PR using the GUI difftool: \
`$ git pr show -t 23662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23662.diff">https://git.openjdk.org/jdk/pull/23662.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23662#issuecomment-2663080499)
</details>
