### PR TITLE
8350201: Out of bounds access on Linux aarch64 in os::print_register_info

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -447,7 +447,7 @@ void os::print_context(outputStream *st, const void *context) {
 }
 
 void os::print_register_info(outputStream *st, const void *context, int& continuation) {
-  const int register_count = 32 /* r0-r32 */ + 3 /* pc, lr, sp */;
+  const int register_count = 32 /* r0-r31 */ + 3 /* pc, lr, sp */;
   int n = continuation;
   assert(n >= 0 && n <= register_count, "Invalid continuation value");
   if (context == nullptr || n == register_count) {

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -354,7 +354,7 @@ void os::print_context(outputStream *st, const void *context) {
 }
 
 void os::print_register_info(outputStream *st, const void *context, int& continuation) {
-  const int register_count = 32 /* r0-r31 */;
+  const int register_count = 31 /* r0-r30 */;
   int n = continuation;
   assert(n >= 0 && n <= register_count, "Invalid continuation value");
   if (context == nullptr || n == register_count) {

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -467,7 +467,7 @@ void os::print_context(outputStream *st, const void *context) {
 }
 
 void os::print_register_info(outputStream *st, const void *context, int& continuation) {
-  const int register_count = 32 /* r0-r32 */ + 3 /* pc, lr, ctr */;
+  const int register_count = 32 /* r0-r31 */ + 3 /* pc, lr, ctr */;
   int n = continuation;
   assert(n >= 0 && n <= register_count, "Invalid continuation value");
   if (context == nullptr || n == register_count) {


### PR DESCRIPTION
When running jtreg test VendorInfoPluginsTest we noticed the following issue (ubsanized binaries were used)

```
jdk/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp:369:46: runtime error: index 31 out of bounds for type 'long long unsigned int [31]'
    #0 0xffff84380470 in os::print_register_info(outputStream*, void const*, int&) (/jtreg_jdk_tier2_work/JTwork/scratch/10/images/vendorinfo.image/lib/server/libjvm.so+0x4d80470)
    #1 0xffff84bf566c in VMError::report(outputStream*, bool) (/jtreg_jdk_tier2_work/JTwork/scratch/10/images/vendorinfo.image/lib/server/libjvm.so+0x55f566c)
    #2 0xffff84bf812c in VMError::report_and_die(int, char const*, char const*, std::__va_list, Thread*, unsigned char*, void const*, void const*, char const*, int, unsigned long) (/jtreg_jdk_tier2_work/JTwork/scratch/10/images/vendorinfo.image/lib/server/libjvm.so+0x55f812c)
    #3 0xffff84bf90b4 in VMError::report_and_die(Thread*, unsigned int, unsigned char*, void const*, void const*, char const*, ...) (/jtreg_jdk_tier2_work/JTwork/scratch/10/images/vendorinfo.image/lib/server/libjvm.so+0x55f90b4)
    #4 0xffff84bf9138 in VMError::report_and_die(Thread*, unsigned int, unsigned char*, void const*, void const*) (/jtreg_jdk_tier2_work/JTwork/scratch/10/images/vendorinfo.image/lib/server/libjvm.so+0x55f9138)
    #5 0xffff8489ede8 in JVM_handle_linux_signal (/jtreg_jdk_tier2_work/JTwork/scratch/10/images/vendorinfo.image/lib/server/libjvm.so+0x529ede8)
```

Looks like we have registers 0 - 30 according to sys/ucontext.h on Linux aarch64

```
typedef struct
  {
    unsigned long long int __ctx(fault_address);
    unsigned long long int __ctx(regs)[31];
    unsigned long long int __ctx(sp);
    unsigned long long int __ctx(pc);
    unsigned long long int __ctx(pstate);
    /* This field contains extension records for additional processor
       state such as the FP/SIMD state.  It has to match the definition
       of the corresponding field in the sigcontext struct, see the
       arch/arm64/include/uapi/asm/sigcontext.h linux header for details.  */
    unsigned char __reserved[4096] __attribute__ ((__aligned__ (16)));
  } mcontext_t;


```
and according to the arm developer documentation

https://developer.arm.com/documentation/100069/0606/Overview-of-AArch64-state/Registers-in-AArch64-state#:~:text=In%20AArch64%20state%2C%20the%20following,are%20accessible%20as%20W0%2DW30.

"Thirty-one 64-bit general-purpose registers X0-X30, the bottom halves of which are accessible as W0-W30."

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350201](https://bugs.openjdk.org/browse/JDK-8350201): Out of bounds access on Linux aarch64 in os::print_register_info (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23667/head:pull/23667` \
`$ git checkout pull/23667`

Update a local copy of the PR: \
`$ git checkout pull/23667` \
`$ git pull https://git.openjdk.org/jdk.git pull/23667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23667`

View PR using the GUI difftool: \
`$ git pr show -t 23667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23667.diff">https://git.openjdk.org/jdk/pull/23667.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23667#issuecomment-2663426599)
</details>
