### PR TITLE
8350159: compiler/tiered/Level2RecompilationTest.java fails after JDK-8349915

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -633,9 +633,9 @@ CompileTask* CompilationPolicy::select_task(CompileQueue* compile_queue) {
       task = next_task;
       continue;
     }
-    if (task->compile_reason() == CompileTask::Reason_Whitebox) {
-      // Whitebox (CTW) tasks do not participate in rate selection and/or any level
-      // adjustments. Just return them in order.
+    if (task->is_blocking() && task->compile_reason() == CompileTask::Reason_Whitebox) {
+      // CTW tasks, submitted as blocking Whitebox requests, do not participate in rate
+      // selection and/or any level adjustments. Just return them in order.
       return task;
     }
     Method* method = task->method();

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -43,8 +43,6 @@
 
 # :hotspot_compiler
 
-compiler/tiered/Level2RecompilationTest.java 8350159 generic-all
-
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 


### PR DESCRIPTION
Recently added hunk in `CompilationPolicy::selected_task` was supposed to target CTW runs, that wanted to omit any level changes. But there are tests that _do test_ level changes, and they submit `Whitebox` requests. One of those tests is `compiler/tiered/Level2RecompilationTest.java`. So it looks like we need to disambiguate the "CTW" uses and "general Whitebox" uses.

Looks like checking for `-Xbatch` does the trick for CTW. It is not super-clean, but it works, and it matches other exceptions in around compilation policy, e.g. when checking for `-Xcomp`, etc.

Additional testing: 
 - [x] Linux AArch64 server fastdebug, `compiler/tiered/Level2RecompilationTest.java` now passes
 - [x] Linux AArch64 server fastdebug, CTW tests still work fine
 - [x] Linux AArch64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350159](https://bugs.openjdk.org/browse/JDK-8350159): compiler/tiered/Level2RecompilationTest.java fails after JDK-8349915 (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23668/head:pull/23668` \
`$ git checkout pull/23668`

Update a local copy of the PR: \
`$ git checkout pull/23668` \
`$ git pull https://git.openjdk.org/jdk.git pull/23668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23668`

View PR using the GUI difftool: \
`$ git pr show -t 23668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23668.diff">https://git.openjdk.org/jdk/pull/23668.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23668#issuecomment-2663696830)
</details>
