### PR TITLE
8350224: Test javax/swing/JComboBox/TestComboBoxComponentRendering.java fails in ubuntu 23.x and later

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -695,10 +695,6 @@ sanity/client/SwingSet/src/ToolTipDemoTest.java 8293001 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
 sanity/client/SwingSet/src/EditorPaneDemoTest.java 8212240 linux-x64
 
-# jdk_swing Ubuntu 23.04 specific
-
-javax/swing/JComboBox/TestComboBoxComponentRendering.java 8309734 linux-all
-
 # This test fails on macOS 14
 javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
 

--- a/test/jdk/javax/swing/JComboBox/TestComboBoxComponentRendering.java
+++ b/test/jdk/javax/swing/JComboBox/TestComboBoxComponentRendering.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JComboBox/TestComboBoxComponentRendering.java
+++ b/test/jdk/javax/swing/JComboBox/TestComboBoxComponentRendering.java
@@ -33,6 +33,7 @@
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.image.BufferedImage;
+import java.awt.Font;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
@@ -137,6 +138,7 @@ class ComboBoxCustomRenderer extends JLabel
         implements ListCellRenderer {
 
     public ComboBoxCustomRenderer() {
+        setFont(new Font("SansSerif", Font.BOLD, 32));
         setOpaque(true);
         setHorizontalAlignment(CENTER);
         setVerticalAlignment(CENTER);


### PR DESCRIPTION
Test is failing in ubuntu 23.x and beyond with expected red pixel not being picked up
Increase in fontsize increase the possibility of font red pixel being picked up. 
Test is now passing in ubuntu 24.04 and in CI..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350224](https://bugs.openjdk.org/browse/JDK-8350224): Test javax/swing/JComboBox/TestComboBoxComponentRendering.java fails in ubuntu 23.x and later (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23670/head:pull/23670` \
`$ git checkout pull/23670`

Update a local copy of the PR: \
`$ git checkout pull/23670` \
`$ git pull https://git.openjdk.org/jdk.git pull/23670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23670`

View PR using the GUI difftool: \
`$ git pr show -t 23670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23670.diff">https://git.openjdk.org/jdk/pull/23670.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23670#issuecomment-2664850513)
</details>
