### PR TITLE
8350210: CTW: Use stackless exceptions

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -305,6 +305,8 @@ public class CtwRunner {
                 // Expand the optimization scope by disallowing most traps.
                 "-XX:PerMethodTrapLimit=0",
                 "-XX:PerMethodSpecTrapLimit=0",
+                // Do not pay extra stack trace generation cost for normally thrown exceptions
+                "-XX:-StackTraceInThrowable",
                 "-XX:+IgnoreUnrecognizedVMOptions",
                 // Do not pay extra zapping cost for explicit GC invocations
                 "-XX:-ZapUnusedHeapArea",


### PR DESCRIPTION
Looking at reducing CTW costs in our infra, there are a few simple improvements we can take.

CTW runners compiling 3rd party JARs normally catch lots of stray exceptions when trying to load non-existing classes, e.g. for resolving the static final fields, or preloading the constant pool. Generating stack traces for these take considerable time, and stack traces for those exceptions are not essential to debug CTW runs. So, we can summarily disable them.

This has no effect on `applications/ctw/modules`. Compiling a large 3rd party JAR like `solr-core-7.4.0.jar`, for example, improves from ~15.3s to ~12.5s.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350210](https://bugs.openjdk.org/browse/JDK-8350210): CTW: Use stackless exceptions (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23671/head:pull/23671` \
`$ git checkout pull/23671`

Update a local copy of the PR: \
`$ git checkout pull/23671` \
`$ git pull https://git.openjdk.org/jdk.git pull/23671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23671`

View PR using the GUI difftool: \
`$ git pr show -t 23671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23671.diff">https://git.openjdk.org/jdk/pull/23671.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23671#issuecomment-2665019659)
</details>
