### PR TITLE
8350211: CTW: Attempt to preload all classes in constant pool

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
@@ -122,17 +122,16 @@ public class Compiler {
 
     private static void preloadClasses(String className, long id,
             ConstantPool constantPool) {
-        try {
-            for (int i = 0, n = constantPool.getSize(); i < n; ++i) {
-                try {
+        for (int i = 0, n = constantPool.getSize(); i < n; ++i) {
+            try {
+                if (constantPool.getTagAt(i) == ConstantPool.Tag.CLASS) {
                     constantPool.getClassAt(i);
-                } catch (IllegalArgumentException ignore) {
                 }
+            } catch (Throwable t) {
+                CompileTheWorld.OUT.println(String.format("[%d]\t%s\tWARNING preloading failed : %s",
+                         id, className, t));
+                t.printStackTrace(CompileTheWorld.ERR);
             }
-        } catch (Throwable t) {
-            CompileTheWorld.OUT.println(String.format("[%d]\t%s\tWARNING preloading failed : %s",
-                    id, className, t));
-            t.printStackTrace(CompileTheWorld.ERR);
         }
     }
 


### PR DESCRIPTION
CTW runners do preloading for constant pools ahead of time. I believe this is done to expose more loaded classes to the compilations, so to extend the compilation scope.

Unfortunately, current code catches the first exception when loading the constant pool and stops preloading. This routinely happens when CTW runner processes a 3rd party JAR, where dependencies might normally be in other JARs.

I believe we should attempt to resolve all constant pool entries when preloading is requested. This would likely expand the scope of CTW testing.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `applications/ctw/modules` still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350211](https://bugs.openjdk.org/browse/JDK-8350211): CTW: Attempt to preload all classes in constant pool (**Enhancement** - P4)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23673/head:pull/23673` \
`$ git checkout pull/23673`

Update a local copy of the PR: \
`$ git checkout pull/23673` \
`$ git pull https://git.openjdk.org/jdk.git pull/23673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23673`

View PR using the GUI difftool: \
`$ git pr show -t 23673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23673.diff">https://git.openjdk.org/jdk/pull/23673.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23673#issuecomment-2665337910)
</details>
