### PR TITLE
8350260: Improve HTML instruction formatting in PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -633,6 +633,8 @@ public final class PassFailJFrame {
                               ? configureHTML(instructions, rows, columns)
                               : configurePlainText(instructions, rows, columns);
         text.setEditable(false);
+        text.setBorder(createTextBorder());
+        text.setCaretPosition(0);
 
         JPanel textPanel = new JPanel(new BorderLayout());
         textPanel.setBorder(createEmptyBorder(GAP, 0, GAP, 0));
@@ -687,7 +689,6 @@ public final class PassFailJFrame {
         JTextArea text = new JTextArea(instructions, rows, columns);
         text.setLineWrap(true);
         text.setWrapStyleWord(true);
-        text.setBorder(createTextBorder());
         return text;
     }
 
@@ -701,10 +702,10 @@ public final class PassFailJFrame {
 
         HTMLEditorKit kit = (HTMLEditorKit) text.getEditorKit();
         StyleSheet styles = kit.getStyleSheet();
-        // Reduce the default margins
-        styles.addRule("ol, ul { margin-left-ltr: 20; margin-left-rtl: 20 }");
-        // Make the size of code blocks the same as other text
-        styles.addRule("code { font-size: inherit }");
+        // Reduce the list default margins
+        styles.addRule("ol, ul { margin-left-ltr: 30; margin-left-rtl: 30 }");
+        // Make the size of code (and other elements) the same as other text
+        styles.addRule("code, kbd, samp, pre { font-size: inherit }");
 
         return text;
     }


### PR DESCRIPTION
**Problem:**

When instructions are long, the formatting in `PassFailJFrame` looks off:

1. When the instructions are displayed on the screen for the first time, the HTML is scrolled to the bottom, which isn't convenient;
2. Numbers above 10 in the list are clipped on the left;
3. No border around the HTML text.

These problems were found while converting the instructions for `test/jdk/javax/accessibility/TestJCheckBoxToggleAccessibility.java` in https://github.com/openjdk/jdk/pull/23436.

<details>
<summary>Screenshots of the instructions</summary>
The instructions are scrolled to the bottom when the test starts:  
![01-instructions-bottom](https://github.com/user-attachments/assets/66c8d319-83d7-4219-91a5-96c964b9a0fe)

The number 10 in the list is clipped on the left:  
![02-clipped-numbering](https://github.com/user-attachments/assets/8db421ff-7b91-4db8-988c-03828097890e)

The headings _“Testing with…”_ are flushed to the left, there's no additional space between the scroll pane border and the text.
</details>

**Fix:**

1. Adjust the list margins to accommodate for longer text;
2. Install the text border to either text instruction component;
3. Scroll the text to the top.

<details>
<summary>Screenshot of the instructions <i>with the fix</i></summary>
The stated issues are resolved:  
![03-top-no-clipping](https://github.com/user-attachments/assets/d14cfae2-733d-468d-93b9-c93d2d00cb3c)
</details>