### PR TITLE
8350214: Test gtest/AsyncLogGtest.java fails after JDK-8349755

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -720,7 +720,7 @@ void LogConfiguration::notify_update_listeners() {
 bool LogConfiguration::_async_mode = false;
 
 
-#ifdef assert
+#ifdef ASSERT
 void LogConfiguration::remove_wildcard_deathtests(LogLevelType* level, const LogSelectionList& selections, LogTagSet* ts) {
   // Some UL tags (deathtest, deathtest2) are used for testing which results in the VM crashing.
   // We want to avoid any wildcard selections from crashing the VM.
@@ -752,4 +752,4 @@ void LogConfiguration::remove_wildcard_deathtests(LogLevelType* level, const Log
     }
   }
 }
-#endif
+#endif // ASSERT

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -132,7 +132,9 @@ class LogConfiguration : public AllStatic {
   static bool is_async_mode() { return _async_mode; }
   static void set_async_mode(bool value) {
     _async_mode = value;
-  }
+  };;
+
+  DEBUG_ONLY(static void remove_wildcard_deathtests(LogLevelType* level, const LogSelectionList& selections, LogTagSet* ts));
 };
 
 #endif // SHARE_LOGGING_LOGCONFIGURATION_HPP

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -132,7 +132,7 @@ class LogConfiguration : public AllStatic {
   static bool is_async_mode() { return _async_mode; }
   static void set_async_mode(bool value) {
     _async_mode = value;
-  };;
+  }
 
   DEBUG_ONLY(static void remove_wildcard_deathtests(LogLevelType* level, const LogSelectionList& selections, LogTagSet* ts));
 };

--- a/src/hotspot/share/logging/logSelectionList.hpp
+++ b/src/hotspot/share/logging/logSelectionList.hpp
@@ -56,6 +56,9 @@ class LogSelectionList : public StackObj {
   bool parse(const char* str, outputStream* errstream = nullptr);
   LogLevelType level_for(const LogTagSet& ts) const;
 
+  const LogSelection* selections() const { return _selections; }
+  size_t number_of_selections()  const { return _nselections; }
+
   // Verify that each selection actually selects something.
   // Returns false if some invalid selection was found. If given an outputstream,
   // this function will list all the invalid selections on the stream.

--- a/test/hotspot/jtreg/runtime/logging/AsyncDeathTest.java
+++ b/test/hotspot/jtreg/runtime/logging/AsyncDeathTest.java
@@ -50,5 +50,12 @@ public class AsyncDeathTest {
         OutputAnalyzer output2 = new OutputAnalyzer(pb2.start());
         output2.shouldHaveExitValue(0);
         output2.shouldContain("Induce a recursive log for testing");
+
+        // For -Xlog:all=debug we expect neither deathtest nor deathtest2 to be logged as they should only be able to be selected explicitly.
+        ProcessBuilder pb3 =
+            ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:async", "-Xlog:all=debug", "--version");
+        OutputAnalyzer output3 = new OutputAnalyzer(pb3.start());
+        output3.shouldHaveExitValue(0);
+        output3.shouldNotContain("Induce a recursive log for testing");
     }
 }


### PR DESCRIPTION
Hi,

[8349755](https://bugs.openjdk.org/browse/JDK-8349755) introduced a bug in debug builds when running with `-Xlog:async -Xlog:all=debug`. Specifically, this will cause UL to select for `deathtest` and `deathtest2`, which should only be selected when explicitly asked for.

In order to fix this, I've added a small debug-only snippet which ensures that any wildcard selector does not select `deathtest` or `deathtest2`. I've also added a testcase in order to catch this regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350214](https://bugs.openjdk.org/browse/JDK-8350214): Test gtest/AsyncLogGtest.java fails after JDK-8349755 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23675/head:pull/23675` \
`$ git checkout pull/23675`

Update a local copy of the PR: \
`$ git checkout pull/23675` \
`$ git pull https://git.openjdk.org/jdk.git pull/23675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23675`

View PR using the GUI difftool: \
`$ git pr show -t 23675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23675.diff">https://git.openjdk.org/jdk/pull/23675.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23675#issuecomment-2665693791)
</details>
