### PR TITLE
8347040: C2: assert(!loop->_body.contains(in)) failed

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3183,10 +3183,10 @@ void OuterStripMinedLoopNode::transform_to_counted_loop(PhaseIterGVN* igvn, Phas
         if (iloop->get_loop(iloop->get_ctrl(in)) != outer_loop_ilt) {
           continue;
         }
-        assert(!loop->_body.contains(in), "");
-        loop->_body.push(in);
         wq.push(in);
       }
+      assert(!loop->_body.contains(n), "Shouldn't append node to body twice");
+      loop->_body.push(n);
     }
     iloop->set_loop(safepoint, loop);
     loop->_body.push(safepoint);

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestAssertWhenOuterStripMinedLoopRemoved.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestAssertWhenOuterStripMinedLoopRemoved.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8347040
+ * @summary C2: assert(!loop->_body.contains(in)) failed
+ * @run main/othervm -XX:-BackgroundCompilation TestAssertWhenOuterStripMinedLoopRemoved
+ */
+
+
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+public class TestAssertWhenOuterStripMinedLoopRemoved {
+    static final int COUNT = 100000;
+    static final MemorySegment segment = Arena.global().allocate(JAVA_LONG, COUNT);
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            test();
+        }
+    }
+
+    static void test() {
+        var i = 0;
+        var j = 0;
+        while (i < 100000) {
+            segment.setAtIndex(JAVA_LONG, i++, 0);
+            segment.setAtIndex(JAVA_LONG, j++, 0);
+        }
+    }
+}


### PR DESCRIPTION
`OuterStripMinedLoopNode::transform_to_counted_loop()` merges the
outer strip mined loop and the inner loop into a single loop.  To
achieve that, it needs to append the nodes of the outer strip mined
loop to the body of the inner loop. To make sure each of these nodes
is appended only once, a `Unique_Node_List` is used: nodes found by
following the safepoint's inputs are first enqueued into the list and
then, each unique node should be added to the loop body. That's not
what the current code does, though, because it enqueues the nodes it
finds to the list and add them to the loop body right away.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347040](https://bugs.openjdk.org/browse/JDK-8347040): C2: assert(!loop-&gt;_body.contains(in)) failed (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23676/head:pull/23676` \
`$ git checkout pull/23676`

Update a local copy of the PR: \
`$ git checkout pull/23676` \
`$ git pull https://git.openjdk.org/jdk.git pull/23676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23676`

View PR using the GUI difftool: \
`$ git pr show -t 23676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23676.diff">https://git.openjdk.org/jdk/pull/23676.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23676#issuecomment-2665662573)
</details>
