### PR TITLE
8350266: [PPC64] Interpreter: intrinsify Thread.currentThread()

### DIFF
--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -1996,8 +1996,20 @@ address TemplateInterpreterGenerator::generate_CRC32C_updateBytes_entry(Abstract
   return start;
 }
 
+address TemplateInterpreterGenerator::generate_currentThread() {
+  address entry_point = __ pc();
+
+  __ ld(R3_RET, JavaThread::vthread_offset(), R16_thread);
+  __ resolve_oop_handle(R3_RET, R11_scratch1, R12_scratch2, MacroAssembler::PRESERVATION_FRAME_LR);
+
+  // restore caller sp for c2i case (from compiled) and for resized sender frame (from interpreted).
+  __ resize_frame_absolute(R21_sender_SP, R11_scratch1, R0);
+  __ blr();
+
+  return entry_point;
+}
+
 // Not supported
-address TemplateInterpreterGenerator::generate_currentThread() { return nullptr; }
 address TemplateInterpreterGenerator::generate_Float_intBitsToFloat_entry() { return nullptr; }
 address TemplateInterpreterGenerator::generate_Float_floatToRawIntBits_entry() { return nullptr; }
 address TemplateInterpreterGenerator::generate_Double_longBitsToDouble_entry() { return nullptr; }


### PR DESCRIPTION
Implementation of intrinsic Thread.currentThread() for PPC64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350266](https://bugs.openjdk.org/browse/JDK-8350266): [PPC64] Interpreter: intrinsify Thread.currentThread() (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23677/head:pull/23677` \
`$ git checkout pull/23677`

Update a local copy of the PR: \
`$ git checkout pull/23677` \
`$ git pull https://git.openjdk.org/jdk.git pull/23677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23677`

View PR using the GUI difftool: \
`$ git pr show -t 23677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23677.diff">https://git.openjdk.org/jdk/pull/23677.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23677#issuecomment-2702164116)
</details>
