### PR TITLE
8350263: JvmciNotifyBootstrapFinishedEventTest intermittently times out

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/TestUncaughtErrorInCompileMethod.config
+++ b/test/hotspot/jtreg/compiler/jvmci/TestUncaughtErrorInCompileMethod.config
@@ -1,1 +1,1 @@
-compiler.jvmci.TestUncaughtErrorInCompileMethod
+compiler.jvmci.TestUncaughtErrorInCompileMethod$Locator

--- a/test/hotspot/jtreg/compiler/jvmci/events/JvmciNotifyBootstrapFinishedEventTest.config
+++ b/test/hotspot/jtreg/compiler/jvmci/events/JvmciNotifyBootstrapFinishedEventTest.config
@@ -1,2 +1,2 @@
-compiler.jvmci.events.JvmciNotifyBootstrapFinishedEventTest
+compiler.jvmci.events.JvmciNotifyBootstrapFinishedEventTest$Locator
 compiler.jvmci.common.JVMCIHelpers

--- a/test/hotspot/jtreg/compiler/jvmci/events/JvmciNotifyBootstrapFinishedEventTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/events/JvmciNotifyBootstrapFinishedEventTest.java
@@ -62,29 +62,34 @@ import jdk.test.lib.Asserts;
 import jdk.vm.ci.services.JVMCIServiceLocator;
 import jdk.vm.ci.hotspot.HotSpotVMEventListener;
 
-public class JvmciNotifyBootstrapFinishedEventTest extends JVMCIServiceLocator implements HotSpotVMEventListener {
+public class JvmciNotifyBootstrapFinishedEventTest {
     private static final boolean BOOTSTRAP = Boolean
             .getBoolean("compiler.jvmci.events.JvmciNotifyBootstrapFinishedEventTest.bootstrap");
-    private static volatile int gotBoostrapNotification = 0;
+    private static volatile int gotBootstrapNotification = 0;
 
     public static void main(String args[]) {
         if (BOOTSTRAP) {
-            Asserts.assertEQ(gotBoostrapNotification, 1, "Did not receive expected number of bootstrap events");
+            Asserts.assertEQ(gotBootstrapNotification, 1, "Did not receive expected number of bootstrap events");
         } else {
-            Asserts.assertEQ(gotBoostrapNotification, 0, "Got unexpected bootstrap event");
+            Asserts.assertEQ(gotBootstrapNotification, 0, "Got unexpected bootstrap event");
         }
     }
 
-    @Override
-    public <S> S getProvider(Class<S> service) {
-        if (service == HotSpotVMEventListener.class) {
-            return service.cast(this);
+    public static class Locator extends JVMCIServiceLocator implements HotSpotVMEventListener {
+        public Locator() {
+            Thread.dumpStack();
         }
-        return null;
-    }
+        @Override
+        public <S> S getProvider(Class<S> service) {
+            if (service == HotSpotVMEventListener.class) {
+                return service.cast(this);
+            }
+            return null;
+        }
 
-    @Override
-    public void notifyBootstrapFinished() {
-        gotBoostrapNotification++;
+        @Override
+        public void notifyBootstrapFinished() {
+            gotBootstrapNotification++;
+        }
     }
 }


### PR DESCRIPTION
[JDK-8346781](https://bugs.openjdk.org/browse/JDK-8346781) changed `JVMCIServiceLocator` such that set of providers is computed eagerly in `JVMCIServiceLocator.<clinit>`. There are some JVMCI test classes that directly subclassed `JVMCIServiceLocator` which meant deadlock could occur between the main thread running the test and a JVMCI compiler thread. This PR fixes this by ensuring that `JVMCIServiceLocator` providers are separate classes from the main test class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350263](https://bugs.openjdk.org/browse/JDK-8350263): JvmciNotifyBootstrapFinishedEventTest intermittently times out (**Bug** - P4)


### Reviewers
 * [Yudi Zheng](https://openjdk.org/census#yzheng) (@mur47x111 - Committer)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23679/head:pull/23679` \
`$ git checkout pull/23679`

Update a local copy of the PR: \
`$ git checkout pull/23679` \
`$ git pull https://git.openjdk.org/jdk.git pull/23679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23679`

View PR using the GUI difftool: \
`$ git pr show -t 23679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23679.diff">https://git.openjdk.org/jdk/pull/23679.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23679#issuecomment-2665844015)
</details>
