### PR TITLE
8350280: The JDK-8346050 testlibrary changes break the build

### DIFF
--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -70,6 +70,7 @@ $(eval $(call SetupJavaCompilation, BUILD_TEST_LIB_JAR, \
         --add-exports java.base/jdk.internal.module=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.platform=ALL-UNNAMED \
         --add-exports java.base/sun.security.pkcs=ALL-UNNAMED \
+        --add-exports java.base/sun.security.provider.certpath=ALL-UNNAMED \
         --add-exports java.base/sun.security.tools.keytool=ALL-UNNAMED \
         --add-exports java.base/sun.security.x509=ALL-UNNAMED \
         --enable-preview, \


### PR DESCRIPTION
Please review following trivial PR that fix library build by adding --add-exports. 
Testing: tier1