### PR TITLE
8329951: `var` emits deprecation warnings that do not point to the file or position

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Analyzer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Analyzer.java
@@ -366,7 +366,7 @@ public class Analyzer {
         }
 
         boolean isImplicitlyTyped(JCVariableDecl decl) {
-            return decl.vartype.pos == Position.NOPOS;
+            return decl.declaredUsingVar();
         }
 
         /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5693,9 +5693,9 @@ public class Attr extends JCTree.Visitor {
 
     private void setSyntheticVariableType(JCVariableDecl tree, Type type) {
         if (type.isErroneous()) {
-            tree.vartype = make.at(Position.NOPOS).Erroneous();
+            tree.vartype = make.at(tree.pos()).Erroneous();
         } else {
-            tree.vartype = make.at(Position.NOPOS).Type(type);
+            tree.vartype = make.at(tree.pos()).Type(type);
         }
     }
 

--- a/test/langtools/tools/javac/tree/VarWarnPosition.java
+++ b/test/langtools/tools/javac/tree/VarWarnPosition.java
@@ -1,0 +1,26 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8329951
+ * @summary Check that "var" variable synthetic types have a source position
+ * @compile/process/ref=VarWarnPosition.out -Xlint:deprecation -XDrawDiagnostics VarWarnPosition.java
+ */
+
+import java.util.*;
+import java.util.function.*;
+
+public class VarWarnPosition {
+
+    VarWarnPosition() {
+
+        // Test 1
+        @SuppressWarnings("deprecation")
+        List<Depr> deprecatedList = null;
+        for (var deprValue : deprecatedList) { }
+
+        // Test 2
+        Consumer<Depr> c = d -> { };
+    }
+}
+
+@Deprecated
+class Depr {}

--- a/test/langtools/tools/javac/tree/VarWarnPosition.out
+++ b/test/langtools/tools/javac/tree/VarWarnPosition.out
@@ -1,0 +1,4 @@
+VarWarnPosition.java:18:14: compiler.warn.has.been.deprecated: Depr, compiler.misc.unnamed.package
+VarWarnPosition.java:21:18: compiler.warn.has.been.deprecated: Depr, compiler.misc.unnamed.package
+VarWarnPosition.java:21:28: compiler.warn.has.been.deprecated: Depr, compiler.misc.unnamed.package
+3 warnings


### PR DESCRIPTION
This PR fixes a bug that causes certain warnings to be emitted without source file location information.

For this example:
```java
import java.util.*;
import java.util.function.*;
public class Example {

    @SuppressWarnings("deprecation")
    List<Observable> m1() { return null; }

    void m2() {
        for (var o : m1()) { }
    }
}
```
the compiler outputs this:
```
$ javac -Xlint:deprecation Example.java 
warning: [deprecation] Observable in java.util has been deprecated
1 warning
```
but it should instead output this:
```
Example.java:9: warning: [deprecation] Observable in java.util has been deprecated
        for (var o : m1()) { }
             ^
1 warning
```
The bug happens because the "synthetic" type that is installed dynamically for implicitly typed variables is not given a source code position. This makes sense because that type doesn't appear in the source code; however, certain error messages expect to be able to point to the type part of a variable declaration. To fix this we just copy the position of the variable declaration itself.

This change necessitated another change: The fix for [JDK-8200199](https://bugs.openjdk.org/browse/JDK-8200199) was relying on the position being null in order to identify implicitly typed variables. But since then`JCVariableDecl.declaredUsingVar()` was added, so we can just use it for that now.