### PR TITLE
8350303: ARM32: StubCodeGenerator::verify_stub(StubGenStubId) failed after JDK-8343767

### DIFF
--- a/src/hotspot/share/runtime/stubDeclarations.hpp
+++ b/src/hotspot/share/runtime/stubDeclarations.hpp
@@ -552,6 +552,8 @@
            catch_exception_entry)                                       \
   do_stub(initial, fence)                                               \
   do_entry(initial, fence, fence_entry, fence_entry)                    \
+  do_stub(initial, atomic_add)                                         \
+  do_entry(initial, atomic_add, atomic_add_entry, atomic_add_entry)  \
   do_stub(initial, atomic_xchg)                                         \
   do_entry(initial, atomic_xchg, atomic_xchg_entry, atomic_xchg_entry)  \
   do_stub(initial, atomic_cmpxchg)                                      \
@@ -638,8 +640,6 @@
                                   do_arch_blob,                         \
                                   do_arch_entry, do_arch_entry_init)    \
   do_blob(compiler)                                                     \
-  do_stub(compiler, atomic_add)                                         \
-  do_entry(compiler, atomic_add, atomic_add_entry, atomic_add_entry)    \
   do_stub(compiler, array_sort)                                         \
   do_entry(compiler, array_sort, array_sort, select_arraysort_function) \
   do_stub(compiler, array_partition)                                    \


### PR DESCRIPTION
We encountered the following runtime error on ARM32:

```
assert(StubRoutines::stub_to_blob(stub_id) == blob_id()) failed: wrong blob initial for generation of stub atomic_add
```

I suppose it might be a mistake in JDK-8343767. `atomic_add` stub belongs to **initial** stubs, but it is set as **compiler** stub in JDK-8343767.

Note that only ARM32 is affected as only ARM32 defines this stub.

Tests: cross-build for `arm32, ppc64, riscv64, s390x` passed. Tier1~3 passed on Linux/AArch64 and Linux/x86_64