### PR TITLE
8350325: [PPC64] ConvF2HFIdealizationTests timeouts on Power8

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/ConvF2HFIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ConvF2HFIdealizationTests.java
@@ -31,6 +31,7 @@ import jdk.test.lib.Asserts;
  * @test
  * @bug 8338061
  * @summary Test that Ideal transformations of ConvF2HF are being performed as expected.
+ * @requires (os.arch != "ppc64" & os.arch != "ppc64le") | vm.cpu.features ~= ".*darn.*"
  * @modules jdk.incubator.vector
  * @library /test/lib /
  * @run driver compiler.c2.irTests.ConvF2HFIdealizationTests

--- a/test/jdk/jdk/incubator/vector/ScalarFloat16OperationsTest.java
+++ b/test/jdk/jdk/incubator/vector/ScalarFloat16OperationsTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8342103
  * @summary C2 compiler support for Float16 type and associated operations
- * @requires (os.arch != "ppc64" & os.arch != "ppc64le") | vm.cpu.features ~= ".*darn.*"
  * @modules jdk.incubator.vector
  * @library /test/lib
  * @compile ScalarFloat16OperationsTest.java

--- a/test/jdk/jdk/incubator/vector/ScalarFloat16OperationsTest.java
+++ b/test/jdk/jdk/incubator/vector/ScalarFloat16OperationsTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8342103
  * @summary C2 compiler support for Float16 type and associated operations
- * @requires !(os.arch == "ppc64" | os.arch == "ppc64le") | vm.cpu.features ~= ".*darn.*"
+ * @requires (os.arch != "ppc64" & os.arch != "ppc64le") | vm.cpu.features ~= ".*darn.*"
  * @modules jdk.incubator.vector
  * @library /test/lib
  * @compile ScalarFloat16OperationsTest.java

--- a/test/jdk/jdk/incubator/vector/ScalarFloat16OperationsTest.java
+++ b/test/jdk/jdk/incubator/vector/ScalarFloat16OperationsTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8342103
  * @summary C2 compiler support for Float16 type and associated operations
+ * @requires !(os.arch == "ppc64" | os.arch == "ppc64le") | vm.cpu.features ~= ".*darn.*"
  * @modules jdk.incubator.vector
  * @library /test/lib
  * @compile ScalarFloat16OperationsTest.java


### PR DESCRIPTION
Skip ConvF2HFIdealizationTests for Power8

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350325](https://bugs.openjdk.org/browse/JDK-8350325): [PPC64] ConvF2HFIdealizationTests timeouts on Power8 (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23692/head:pull/23692` \
`$ git checkout pull/23692`

Update a local copy of the PR: \
`$ git checkout pull/23692` \
`$ git pull https://git.openjdk.org/jdk.git pull/23692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23692`

View PR using the GUI difftool: \
`$ git pr show -t 23692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23692.diff">https://git.openjdk.org/jdk/pull/23692.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23692#issuecomment-2702164383)
</details>
