### PR TITLE
8311227: Add .editorconfig so IDEs would pick up the common settings automatically: indent, trim trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+trim_trailing_whitespace = true
+# Open curly brace is on the same line.
+indent_brace_style = K&R
+
+[Makefile]
+indent_style = tab
+
+[*.{cpp,hpp,c,h}]
+indent_style = space
+indent_size = 2
+
+[*.java]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Add an .editorconfig to define indentation, trim trailing whitespace and open curly brace position for C++ and Java.
This allows various editors to easily infer basics of the coding style.