### PR TITLE
8349523: Unused runtime calls to drem/frem should be removed

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -436,7 +436,7 @@ void Compile::disconnect_useless_nodes(Unique_Node_List& useful, Unique_Node_Lis
         n->raw_del_out(j);
         --j;
         --max;
-        if (child->Opcode() == Op_Proj && static_cast<ProjNode*>(child)->_con == TypeFunc::Parms && n->is_pure_function()) {
+        if (child->is_data_proj_of_pure_function(n)) {
           worklist.push(n);
         }
       }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -436,6 +436,9 @@ void Compile::disconnect_useless_nodes(Unique_Node_List& useful, Unique_Node_Lis
         n->raw_del_out(j);
         --j;
         --max;
+        if (child->Opcode() == Op_Proj && static_cast<ProjNode*>(child)->_con == TypeFunc::Parms && n->is_pure_function()) {
+          worklist.push(n);
+        }
       }
     }
     if (n->outcnt() == 1 && n->has_special_unique_user()) {

--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -1641,6 +1641,7 @@ Node* ModFloatingNode::replace_with_con(PhaseGVN* phase, const Type* con) {
 }
 
 // Will remove the node if the result is not used, rewiring input to output directly.
+// Returns a dummy constant node if removal happens, and nullptr if nothing is changed.
 Node* ModFloatingNode::remove(PhaseGVN* phase) {
   PhaseIterGVN* igvn = phase->is_IterGVN();
   bool result_is_ignored = proj_out_or_null(TypeFunc::Parms) == nullptr;

--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -1515,10 +1515,11 @@ Node* ModFNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   if (!can_reshape) {
     return nullptr;
   }
+  PhaseIterGVN* igvn = phase->is_IterGVN();
 
-  Node* dummy_node = remove(phase);
-  if (dummy_node != nullptr) {
-    return dummy_node;
+  bool result_is_ignored = proj_out_or_null(TypeFunc::Parms) == nullptr;
+  if (result_is_ignored) {
+    return replace_with_con(igvn, TypeF::make(0.));
   }
 
   // Either input is TOP ==> the result is TOP
@@ -1540,10 +1541,10 @@ Node* ModFNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
   // If either is a NaN, return an input NaN
   if (g_isnan(f1)) {
-    return replace_with_con(phase, t1);
+    return replace_with_con(igvn, t1);
   }
   if (g_isnan(f2)) {
-    return replace_with_con(phase, t2);
+    return replace_with_con(igvn, t2);
   }
 
   // If an operand is infinity or the divisor is +/- zero, punt.
@@ -1558,17 +1559,18 @@ Node* ModFNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     xr ^= min_jint;
   }
 
-  return replace_with_con(phase, TypeF::make(jfloat_cast(xr)));
+  return replace_with_con(igvn, TypeF::make(jfloat_cast(xr)));
 }
 
 Node* ModDNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   if (!can_reshape) {
     return nullptr;
   }
+  PhaseIterGVN* igvn = phase->is_IterGVN();
 
-  Node* dummy_node = remove(phase);
-  if (dummy_node != nullptr) {
-    return dummy_node;
+  bool result_is_ignored = proj_out_or_null(TypeFunc::Parms) == nullptr;
+  if (result_is_ignored) {
+    return replace_with_con(igvn, TypeD::make(0.));
   }
 
   // Either input is TOP ==> the result is TOP
@@ -1590,10 +1592,10 @@ Node* ModDNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
   // If either is a NaN, return an input NaN
   if (g_isnan(f1)) {
-    return replace_with_con(phase, t1);
+    return replace_with_con(igvn, t1);
   }
   if (g_isnan(f2)) {
-    return replace_with_con(phase, t2);
+    return replace_with_con(igvn, t2);
   }
 
   // If an operand is infinity or the divisor is +/- zero, punt.
@@ -1608,58 +1610,35 @@ Node* ModDNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     xr ^= min_jlong;
   }
 
-  return replace_with_con(phase, TypeD::make(jdouble_cast(xr)));
+  return replace_with_con(igvn, TypeD::make(jdouble_cast(xr)));
 }
 
-Node* ModFloatingNode::replace_with_con(PhaseGVN* phase, const Type* con) {
+Node* ModFloatingNode::replace_with_con(PhaseIterGVN* phase, const Type* con) {
   Compile* C = phase->C;
   Node* con_node = phase->makecon(con);
   CallProjections projs;
   extract_projections(&projs, false, false);
-  C->gvn_replace_by(projs.fallthrough_proj, in(TypeFunc::Control));
+  phase->replace_node(projs.fallthrough_proj, in(TypeFunc::Control));
   if (projs.fallthrough_catchproj != nullptr) {
-    C->gvn_replace_by(projs.fallthrough_catchproj, in(TypeFunc::Control));
+    phase->replace_node(projs.fallthrough_catchproj, in(TypeFunc::Control));
   }
   if (projs.fallthrough_memproj != nullptr) {
-    C->gvn_replace_by(projs.fallthrough_memproj, in(TypeFunc::Memory));
+    phase->replace_node(projs.fallthrough_memproj, in(TypeFunc::Memory));
   }
   if (projs.catchall_memproj != nullptr) {
-    C->gvn_replace_by(projs.catchall_memproj, C->top());
+    phase->replace_node(projs.catchall_memproj, C->top());
   }
   if (projs.fallthrough_ioproj != nullptr) {
-    C->gvn_replace_by(projs.fallthrough_ioproj, in(TypeFunc::I_O));
+    phase->replace_node(projs.fallthrough_ioproj, in(TypeFunc::I_O));
   }
   assert(projs.catchall_ioproj == nullptr, "no exceptions from floating mod");
   assert(projs.catchall_catchproj == nullptr, "no exceptions from floating mod");
   if (projs.resproj != nullptr) {
-    C->gvn_replace_by(projs.resproj, con_node);
+    phase->replace_node(projs.resproj, con_node);
   }
-  C->gvn_replace_by(this, C->top());
+  phase->replace_node(this, C->top());
   C->remove_macro_node(this);
   disconnect_inputs(C);
-  return nullptr;
-}
-
-// Will remove the node if the result is not used, rewiring input to output directly.
-// Returns a dummy constant node if removal happens, and nullptr if nothing is changed.
-Node* ModFloatingNode::remove(PhaseGVN* phase) {
-  PhaseIterGVN* igvn = phase->is_IterGVN();
-  bool result_is_ignored = proj_out_or_null(TypeFunc::Parms) == nullptr;
-  if (igvn != nullptr && result_is_ignored) {
-    int projections[] = {
-        TypeFunc::Control,
-        TypeFunc::I_O,
-        TypeFunc::Memory,
-        TypeFunc::FramePtr,
-        TypeFunc::ReturnAdr,
-    };
-    for (int projection : projections) {
-      if (proj_out_or_null(projection) != nullptr) {
-        igvn->replace_node(proj_out(projection), in(projection));
-      }
-    }
-    return new ConINode(TypeInt::ZERO);
-  }
   return nullptr;
 }
 

--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -1517,8 +1517,8 @@ Node* ModFNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   }
   PhaseIterGVN* igvn = phase->is_IterGVN();
 
-  bool result_is_ignored = proj_out_or_null(TypeFunc::Parms) == nullptr;
-  if (result_is_ignored) {
+  bool result_is_unused = proj_out_or_null(TypeFunc::Parms) == nullptr;
+  if (result_is_unused) {
     return replace_with_con(igvn, TypeF::make(0.));
   }
 
@@ -1568,8 +1568,8 @@ Node* ModDNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   }
   PhaseIterGVN* igvn = phase->is_IterGVN();
 
-  bool result_is_ignored = proj_out_or_null(TypeFunc::Parms) == nullptr;
-  if (result_is_ignored) {
+  bool result_is_unused = proj_out_or_null(TypeFunc::Parms) == nullptr;
+  if (result_is_unused) {
     return replace_with_con(igvn, TypeD::make(0.));
   }
 

--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -1653,7 +1653,7 @@ Node* ModFloatingNode::remove(PhaseGVN* phase) {
         TypeFunc::FramePtr,
         TypeFunc::ReturnAdr,
     };
-    for(int projection: projections) {
+    for (int projection : projections) {
       if (proj_out_or_null(projection) != nullptr) {
         igvn->replace_node(proj_out(projection), in(projection));
       }

--- a/src/hotspot/share/opto/divnode.hpp
+++ b/src/hotspot/share/opto/divnode.hpp
@@ -158,8 +158,7 @@ public:
 // Base class for float and double modulus
 class ModFloatingNode : public CallLeafNode {
 protected:
-  Node* replace_with_con(PhaseGVN* phase, const Type* con);
-  Node* remove(PhaseGVN* phase);
+  Node* replace_with_con(PhaseIterGVN* phase, const Type* con);
 
 public:
   ModFloatingNode(Compile* C, const TypeFunc* tf, const char *name);

--- a/src/hotspot/share/opto/divnode.hpp
+++ b/src/hotspot/share/opto/divnode.hpp
@@ -159,6 +159,7 @@ public:
 class ModFloatingNode : public CallLeafNode {
 protected:
   Node* replace_with_con(PhaseGVN* phase, const Type* con);
+  Node* remove(PhaseGVN* phase);
 
 public:
   ModFloatingNode(Compile* C, const TypeFunc* tf, const char *name);

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2945,11 +2945,11 @@ bool Node::is_pure_function() const {
 
 // `maybe_pure_function` is assumed to be the input of `this`. This is a bit redundant,
 // but we already have and need maybe_pure_function in all the call sites, so
-// it makes obvious that the `maybe_pure_function` is the same node as in the caller,
+// it makes it obvious that the `maybe_pure_function` is the same node as in the caller,
 // while it takes more thinking to realize that a locally computed in(0) must be equal to
 // the local in the caller.
 bool Node::is_data_proj_of_pure_function(const Node* maybe_pure_function) const {
-  return Opcode() == Op_Proj && static_cast<const ProjNode*>(this)->_con == TypeFunc::Parms && maybe_pure_function->is_pure_function();
+  return Opcode() == Op_Proj && as_Proj()->_con == TypeFunc::Parms && maybe_pure_function->is_pure_function();
 }
 
 //=============================================================================

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1452,6 +1452,8 @@ static void kill_dead_code( Node *dead, PhaseIterGVN *igvn ) {
             // The restriction (outcnt() <= 2) is the same as in set_req_X()
             // and remove_globally_dead_node().
             igvn->add_users_to_worklist( n );
+          } else if (dead->Opcode() == Op_Proj && static_cast<ProjNode*>(dead)->_con == TypeFunc::Parms && n->is_pure_function()) {
+            igvn->_worklist.push(n);
           } else {
             BarrierSet::barrier_set()->barrier_set_c2()->enqueue_useful_gc_barrier(igvn, n);
           }
@@ -2930,6 +2932,16 @@ bool Node::is_dead_loop_safe() const {
 
 bool Node::is_div_or_mod(BasicType bt) const { return Opcode() == Op_Div(bt) || Opcode() == Op_Mod(bt) ||
                                                       Opcode() == Op_UDiv(bt) || Opcode() == Op_UMod(bt); }
+
+bool Node::is_pure_function() const {
+  switch (Opcode()) {
+  case Op_ModD:
+  case Op_ModF:
+    return true;
+  default:
+    return false;
+  }
+}
 
 //=============================================================================
 //------------------------------yank-------------------------------------------

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1452,7 +1452,7 @@ static void kill_dead_code( Node *dead, PhaseIterGVN *igvn ) {
             // The restriction (outcnt() <= 2) is the same as in set_req_X()
             // and remove_globally_dead_node().
             igvn->add_users_to_worklist( n );
-          } else if (dead->Opcode() == Op_Proj && static_cast<ProjNode*>(dead)->_con == TypeFunc::Parms && n->is_pure_function()) {
+          } else if (dead->is_data_proj_of_pure_function(n)) {
             igvn->_worklist.push(n);
           } else {
             BarrierSet::barrier_set()->barrier_set_c2()->enqueue_useful_gc_barrier(igvn, n);
@@ -2941,6 +2941,15 @@ bool Node::is_pure_function() const {
   default:
     return false;
   }
+}
+
+// `maybe_pure_function` is assumed to be the input of `this`. This is a bit redundant,
+// but we already have and need maybe_pure_function in all the call sites, so
+// it makes obvious that the `maybe_pure_function` is the same node as in the caller,
+// while it takes more thinking to realize that a locally computed in(0) must be equal to
+// the local in the caller.
+bool Node::is_data_proj_of_pure_function(const Node* maybe_pure_function) const {
+  return Opcode() == Op_Proj && static_cast<const ProjNode*>(this)->_con == TypeFunc::Parms && maybe_pure_function->is_pure_function();
 }
 
 //=============================================================================

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1281,6 +1281,8 @@ public:
 
   bool is_div_or_mod(BasicType bt) const;
 
+  bool is_pure_function() const;
+
 //----------------- Printing, etc
 #ifndef PRODUCT
  public:

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1283,6 +1283,8 @@ public:
 
   bool is_pure_function() const;
 
+  bool is_data_proj_of_pure_function(const Node* maybe_pure_function) const;
+
 //----------------- Printing, etc
 #ifndef PRODUCT
  public:

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1342,7 +1342,7 @@ void PhaseIterGVN::remove_globally_dead_node( Node *dead ) {
                 }
                 assert(!(i < imax), "sanity");
               }
-            } else if (dead->Opcode() == Op_Proj && static_cast<ProjNode*>(dead)->_con == TypeFunc::Parms && in->is_pure_function()) {
+            } else if (dead->is_data_proj_of_pure_function(in)) {
               _worklist.push(in);
             } else {
               BarrierSet::barrier_set()->barrier_set_c2()->enqueue_useful_gc_barrier(this, in);

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1342,6 +1342,8 @@ void PhaseIterGVN::remove_globally_dead_node( Node *dead ) {
                 }
                 assert(!(i < imax), "sanity");
               }
+            } else if (dead->Opcode() == Op_Proj && static_cast<ProjNode*>(dead)->_con == TypeFunc::Parms && in->is_pure_function()) {
+              _worklist.push(in);
             } else {
               BarrierSet::barrier_set()->barrier_set_c2()->enqueue_useful_gc_barrier(this, in);
             }

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
@@ -41,7 +41,7 @@ public class ModDNodeTests {
         TestFramework.run();
     }
 
-    @Run(test = {"constant", "notConstant", "veryNotConstant"})
+    @Run(test = {"constant", "notConstant", "veryNotConstant", "unusedResult", "repeatedlyUnused"})
     public void runMethod() {
         Asserts.assertEQ(constant(), q % 72.0d % 30.0d);
         Asserts.assertEQ(alsoConstant(), q % 31.432d);
@@ -49,6 +49,8 @@ public class ModDNodeTests {
         Asserts.assertTrue(Double.isNaN(nanRightConstant()));
         Asserts.assertEQ(notConstant(37.5d), 37.5d % 32.0d);
         Asserts.assertEQ(veryNotConstant(531.25d, 14.5d), 531.25d % 32.0d % 14.5d);
+        unusedResult(1.1d, 2.2d);
+        repeatedlyUnused(1.1d, 2.2d);
     }
 
     @Test
@@ -113,5 +115,20 @@ public class ModDNodeTests {
     @IR(counts = {IRNode.CON_D, "1"})
     public double veryNotConstant(double x, double y) {
         return x % 32.0d % y;
+    }
+
+    @Test
+    @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
+    public void unusedResult(double x, double y) {
+        double unused = x % y;
+    }
+
+    @Test
+    @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
+    public void repeatedlyUnused(double x, double y) {
+        double unused = 1.;
+        for (int i = 0; i < 100_000; i++) {
+            unused = x % y;
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
@@ -122,12 +122,16 @@ public class ModDNodeTests {
 
     @Test
     @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(failOn = IRNode.MOD_D, phase = CompilePhase.ITER_GVN1)
+    @IR(counts = {IRNode.MOD_D, "1"}, phase = CompilePhase.AFTER_PARSING)
     public void unusedResult(double x, double y) {
         double unused = x % y;
     }
 
     @Test
     @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(failOn = IRNode.MOD_D, phase = CompilePhase.ITER_GVN1)
+    @IR(counts = {IRNode.MOD_D, "1"}, phase = CompilePhase.AFTER_PARSING)
     public void repeatedlyUnused(double x, double y) {
         double unused = 1.d;
         for (int i = 0; i < 100_000; i++) {
@@ -137,6 +141,8 @@ public class ModDNodeTests {
 
     @Test
     @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(counts = {IRNode.MOD_D, "1"}, phase = CompilePhase.ITER_GVN2)
+    @IR(failOn = IRNode.MOD_D, phase = CompilePhase.BEFORE_MACRO_EXPANSION)
     public double unusedResultAfterLoopOpt1(double x, double y) {
         double unused = x % y;
 
@@ -155,6 +161,8 @@ public class ModDNodeTests {
 
     @Test
     @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(counts = {IRNode.MOD_D, "2"}, phase = CompilePhase.AFTER_CLOOPS)
+    @IR(failOn = IRNode.MOD_D, phase = CompilePhase.PHASEIDEALLOOP1)
     public double unusedResultAfterLoopOpt2(double x, double y) {
         double unused = x % y;
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
@@ -42,7 +42,12 @@ public class ModDNodeTests {
     }
 
     @Run(test = {"constant", "notConstant", "veryNotConstant",
-            "unusedResult", "repeatedlyUnused", "unusedResultAfterLoopOpt1", "unusedResultAfterLoopOpt2"})
+            "unusedResult",
+            "repeatedlyUnused",
+            "unusedResultAfterLoopOpt1",
+            "unusedResultAfterLoopOpt2",
+            "unusedResultAfterLoopOpt3",
+    })
     public void runMethod() {
         Asserts.assertEQ(constant(), q % 72.0d % 30.0d);
         Asserts.assertEQ(alsoConstant(), q % 31.432d);
@@ -54,6 +59,7 @@ public class ModDNodeTests {
         repeatedlyUnused(1.1d, 2.2d);
         Asserts.assertEQ(unusedResultAfterLoopOpt1(1.1d, 2.2d), 0.d);
         Asserts.assertEQ(unusedResultAfterLoopOpt2(1.1d, 2.2d), 0.d);
+        Asserts.assertEQ(unusedResultAfterLoopOpt3(1.1d, 2.2d), 0.d);
     }
 
     @Test
@@ -139,6 +145,10 @@ public class ModDNodeTests {
         }
     }
 
+    // The difference between unusedResultAfterLoopOpt1 and unusedResultAfterLoopOpt2
+    // is that they exercise a slightly different reason why the node is being removed,
+    // and thus a different execution path. In unusedResultAfterLoopOpt1 the modulo is
+    // used in the traps of the parse predicate. In unusedResultAfterLoopOpt2, it is not.
     @Test
     @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
     @IR(counts = {IRNode.MOD_D, "1"}, phase = CompilePhase.ITER_GVN2)
@@ -161,9 +171,29 @@ public class ModDNodeTests {
 
     @Test
     @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
-    @IR(counts = {IRNode.MOD_D, "2"}, phase = CompilePhase.AFTER_CLOOPS)
+    @IR(counts = {IRNode.MOD_D, "1"}, phase = CompilePhase.AFTER_CLOOPS)
     @IR(failOn = IRNode.MOD_D, phase = CompilePhase.PHASEIDEALLOOP1)
     public double unusedResultAfterLoopOpt2(double x, double y) {
+        int a = 77;
+        int b = 0;
+        do {
+            a--;
+            b++;
+        } while (a > 0);
+
+        double unused = x % y;
+
+        if (b == 78) { // dead
+            return unused;
+        }
+        return 0.d;
+    }
+
+    @Test
+    @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(counts = {IRNode.MOD_D, "2"}, phase = CompilePhase.AFTER_CLOOPS)
+    @IR(failOn = IRNode.MOD_D, phase = CompilePhase.PHASEIDEALLOOP1)
+    public double unusedResultAfterLoopOpt3(double x, double y) {
         double unused = x % y;
 
         int a = 77;

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
@@ -127,7 +127,7 @@ public class ModDNodeTests {
     @Test
     @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
     public void repeatedlyUnused(double x, double y) {
-        double unused = 1.;
+        double unused = 1.d;
         for (int i = 0; i < 100_000; i++) {
             unused = x % y;
         }

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
@@ -127,7 +127,6 @@ public class ModDNodeTests {
     }
 
     @Test
-    @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
     @IR(failOn = IRNode.MOD_D, phase = CompilePhase.ITER_GVN1)
     @IR(counts = {IRNode.MOD_D, "1"}, phase = CompilePhase.AFTER_PARSING)
     public void unusedResult(double x, double y) {
@@ -135,7 +134,6 @@ public class ModDNodeTests {
     }
 
     @Test
-    @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
     @IR(failOn = IRNode.MOD_D, phase = CompilePhase.ITER_GVN1)
     @IR(counts = {IRNode.MOD_D, "1"}, phase = CompilePhase.AFTER_PARSING)
     public void repeatedlyUnused(double x, double y) {
@@ -148,9 +146,8 @@ public class ModDNodeTests {
     // The difference between unusedResultAfterLoopOpt1 and unusedResultAfterLoopOpt2
     // is that they exercise a slightly different reason why the node is being removed,
     // and thus a different execution path. In unusedResultAfterLoopOpt1 the modulo is
-    // used in the traps of the parse predicate. In unusedResultAfterLoopOpt2, it is not.
+    // used in the traps of the parse predicates. In unusedResultAfterLoopOpt2, it is not.
     @Test
-    @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
     @IR(counts = {IRNode.MOD_D, "1"}, phase = CompilePhase.ITER_GVN2)
     @IR(failOn = IRNode.MOD_D, phase = CompilePhase.BEFORE_MACRO_EXPANSION)
     public double unusedResultAfterLoopOpt1(double x, double y) {
@@ -170,7 +167,6 @@ public class ModDNodeTests {
     }
 
     @Test
-    @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
     @IR(counts = {IRNode.MOD_D, "1"}, phase = CompilePhase.AFTER_CLOOPS)
     @IR(failOn = IRNode.MOD_D, phase = CompilePhase.PHASEIDEALLOOP1)
     public double unusedResultAfterLoopOpt2(double x, double y) {
@@ -190,7 +186,6 @@ public class ModDNodeTests {
     }
 
     @Test
-    @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
     @IR(counts = {IRNode.MOD_D, "2"}, phase = CompilePhase.AFTER_CLOOPS)
     @IR(failOn = IRNode.MOD_D, phase = CompilePhase.PHASEIDEALLOOP1)
     public double unusedResultAfterLoopOpt3(double x, double y) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
@@ -41,10 +41,9 @@ public class ModDNodeTests {
         TestFramework.run();
     }
 
-    @Run(test = {"constant", "notConstant", "veryNotConstant", "unusedResult",
-                 "repeatedlyUnused"})
-    public void
-    runMethod() {
+    @Run(test = {"constant", "notConstant", "veryNotConstant",
+            "unusedResult", "repeatedlyUnused"})
+    public void runMethod() {
         Asserts.assertEQ(constant(), q % 72.0d % 30.0d);
         Asserts.assertEQ(alsoConstant(), q % 31.432d);
         Asserts.assertTrue(Double.isNaN(nanLeftConstant()));

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
@@ -41,8 +41,10 @@ public class ModDNodeTests {
         TestFramework.run();
     }
 
-    @Run(test = {"constant", "notConstant", "veryNotConstant", "unusedResult", "repeatedlyUnused"})
-    public void runMethod() {
+    @Run(test = {"constant", "notConstant", "veryNotConstant", "unusedResult",
+                 "repeatedlyUnused"})
+    public void
+    runMethod() {
         Asserts.assertEQ(constant(), q % 72.0d % 30.0d);
         Asserts.assertEQ(alsoConstant(), q % 31.432d);
         Asserts.assertTrue(Double.isNaN(nanLeftConstant()));

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
@@ -41,8 +41,10 @@ public class ModFNodeTests {
         TestFramework.run();
     }
 
-    @Run(test = {"constant", "notConstant", "veryNotConstant", "unusedResult", "repeatedlyUnused"})
-    public void runMethod() {
+    @Run(test = {"constant", "notConstant", "veryNotConstant", "unusedResult",
+                 "repeatedlyUnused"})
+    public void
+    runMethod() {
         Asserts.assertEQ(constant(), q % 72.0f % 30.0f);
         Asserts.assertEQ(alsoConstant(), q % 31.432f);
         Asserts.assertTrue(Float.isNaN(nanLeftConstant()));

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
@@ -42,7 +42,7 @@ public class ModFNodeTests {
     }
 
     @Run(test = {"constant", "notConstant", "veryNotConstant", "unusedResult",
-                 "repeatedlyUnused"})
+            "repeatedlyUnused"})
     public void runMethod() {
         Asserts.assertEQ(constant(), q % 72.0f % 30.0f);
         Asserts.assertEQ(alsoConstant(), q % 31.432f);

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
@@ -122,12 +122,16 @@ public class ModFNodeTests {
 
     @Test
     @IR(failOn = {"frem"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(failOn = IRNode.MOD_F, phase = CompilePhase.ITER_GVN1)
+    @IR(counts = {IRNode.MOD_F, "1"}, phase = CompilePhase.AFTER_PARSING)
     public void unusedResult(float x, float y) {
         float unused = x % y;
     }
 
     @Test
     @IR(failOn = {"frem"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(failOn = IRNode.MOD_F, phase = CompilePhase.ITER_GVN1)
+    @IR(counts = {IRNode.MOD_F, "1"}, phase = CompilePhase.AFTER_PARSING)
     public void repeatedlyUnused(float x, float y) {
         float unused = 1.f;
         for (int i = 0; i < 100_000; i++) {
@@ -137,6 +141,8 @@ public class ModFNodeTests {
 
     @Test
     @IR(failOn = {"frem"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(counts = {IRNode.MOD_F, "1"}, phase = CompilePhase.ITER_GVN2)
+    @IR(failOn = IRNode.MOD_F, phase = CompilePhase.BEFORE_MACRO_EXPANSION)
     public float unusedResultAfterLoopOpt1(float x, float y) {
         float unused = x % y;
 
@@ -155,6 +161,8 @@ public class ModFNodeTests {
 
     @Test
     @IR(failOn = {"frem"}, phase = CompilePhase.BEFORE_MATCHING)
+    @IR(counts = {IRNode.MOD_F, "2"}, phase = CompilePhase.AFTER_CLOOPS)
+    @IR(failOn = IRNode.MOD_F, phase = CompilePhase.PHASEIDEALLOOP1)
     public float unusedResultAfterLoopOpt2(float x, float y) {
         float unused = x % y;
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
@@ -41,7 +41,7 @@ public class ModFNodeTests {
         TestFramework.run();
     }
 
-    @Run(test = {"constant", "notConstant", "veryNotConstant", "unusedResult"})
+    @Run(test = {"constant", "notConstant", "veryNotConstant", "unusedResult", "repeatedlyUnused"})
     public void runMethod() {
         Asserts.assertEQ(constant(), q % 72.0f % 30.0f);
         Asserts.assertEQ(alsoConstant(), q % 31.432f);
@@ -50,7 +50,7 @@ public class ModFNodeTests {
         Asserts.assertEQ(notConstant(37.5f), 37.5f % 32.0f);
         Asserts.assertEQ(veryNotConstant(531.25f, 14.5f), 531.25f % 32.0f % 14.5f);
         unusedResult(1.1f, 2.2f);
-        repeatedlyUnused(1.1d, 2.2d);
+        repeatedlyUnused(1.1f, 2.2f);
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
@@ -41,7 +41,7 @@ public class ModFNodeTests {
         TestFramework.run();
     }
 
-    @Run(test = {"constant", "notConstant", "veryNotConstant"})
+    @Run(test = {"constant", "notConstant", "veryNotConstant", "unusedResult"})
     public void runMethod() {
         Asserts.assertEQ(constant(), q % 72.0f % 30.0f);
         Asserts.assertEQ(alsoConstant(), q % 31.432f);
@@ -49,6 +49,8 @@ public class ModFNodeTests {
         Asserts.assertTrue(Float.isNaN(nanRightConstant()));
         Asserts.assertEQ(notConstant(37.5f), 37.5f % 32.0f);
         Asserts.assertEQ(veryNotConstant(531.25f, 14.5f), 531.25f % 32.0f % 14.5f);
+        unusedResult(1.1f, 2.2f);
+        repeatedlyUnused(1.1d, 2.2d);
     }
 
     @Test
@@ -113,5 +115,20 @@ public class ModFNodeTests {
     @IR(counts = {IRNode.CON_F, "1"})
     public float veryNotConstant(float x, float y) {
         return x % 32.0f % y;
+    }
+
+    @Test
+    @IR(failOn = {"frem"}, phase = CompilePhase.BEFORE_MATCHING)
+    public void unusedResult(float x, float y) {
+        float unused = x % y;
+    }
+
+    @Test
+    @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
+    public void repeatedlyUnused(double x, double y) {
+        double unused = 1.;
+        for (int i = 0; i < 100_000; i++) {
+            unused = x % y;
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
@@ -125,9 +125,9 @@ public class ModFNodeTests {
     }
 
     @Test
-    @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
-    public void repeatedlyUnused(double x, double y) {
-        double unused = 1.;
+    @IR(failOn = {"frem"}, phase = CompilePhase.BEFORE_MATCHING)
+    public void repeatedlyUnused(float x, float y) {
+        float unused = 1.f;
         for (int i = 0; i < 100_000; i++) {
             unused = x % y;
         }

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
@@ -127,7 +127,6 @@ public class ModFNodeTests {
     }
 
     @Test
-    @IR(failOn = {"frem"}, phase = CompilePhase.BEFORE_MATCHING)
     @IR(failOn = IRNode.MOD_F, phase = CompilePhase.ITER_GVN1)
     @IR(counts = {IRNode.MOD_F, "1"}, phase = CompilePhase.AFTER_PARSING)
     public void unusedResult(float x, float y) {
@@ -135,7 +134,6 @@ public class ModFNodeTests {
     }
 
     @Test
-    @IR(failOn = {"frem"}, phase = CompilePhase.BEFORE_MATCHING)
     @IR(failOn = IRNode.MOD_F, phase = CompilePhase.ITER_GVN1)
     @IR(counts = {IRNode.MOD_F, "1"}, phase = CompilePhase.AFTER_PARSING)
     public void repeatedlyUnused(float x, float y) {
@@ -148,9 +146,8 @@ public class ModFNodeTests {
     // The difference between unusedResultAfterLoopOpt1 and unusedResultAfterLoopOpt2
     // is that they exercise a slightly different reason why the node is being removed,
     // and thus a different execution path. In unusedResultAfterLoopOpt1 the modulo is
-    // used in the traps of the parse predicate. In unusedResultAfterLoopOpt2, it is not.
+    // used in the traps of the parse predicates. In unusedResultAfterLoopOpt2, it is not.
     @Test
-    @IR(failOn = {"frem"}, phase = CompilePhase.BEFORE_MATCHING)
     @IR(counts = {IRNode.MOD_F, "1"}, phase = CompilePhase.ITER_GVN2)
     @IR(failOn = IRNode.MOD_F, phase = CompilePhase.BEFORE_MACRO_EXPANSION)
     public float unusedResultAfterLoopOpt1(float x, float y) {
@@ -170,7 +167,6 @@ public class ModFNodeTests {
     }
 
     @Test
-    @IR(failOn = {"drem"}, phase = CompilePhase.BEFORE_MATCHING)
     @IR(counts = {IRNode.MOD_F, "1"}, phase = CompilePhase.AFTER_CLOOPS)
     @IR(failOn = IRNode.MOD_F, phase = CompilePhase.PHASEIDEALLOOP1)
     public float unusedResultAfterLoopOpt2(float x, float y) {
@@ -190,7 +186,6 @@ public class ModFNodeTests {
     }
 
     @Test
-    @IR(failOn = {"frem"}, phase = CompilePhase.BEFORE_MATCHING)
     @IR(counts = {IRNode.MOD_F, "2"}, phase = CompilePhase.AFTER_CLOOPS)
     @IR(failOn = IRNode.MOD_F, phase = CompilePhase.PHASEIDEALLOOP1)
     public float unusedResultAfterLoopOpt3(float x, float y) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
@@ -43,8 +43,7 @@ public class ModFNodeTests {
 
     @Run(test = {"constant", "notConstant", "veryNotConstant", "unusedResult",
                  "repeatedlyUnused"})
-    public void
-    runMethod() {
+    public void runMethod() {
         Asserts.assertEQ(constant(), q % 72.0f % 30.0f);
         Asserts.assertEQ(alsoConstant(), q % 31.432f);
         Asserts.assertTrue(Float.isNaN(nanLeftConstant()));

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2531,6 +2531,16 @@ public class IRNode {
         machOnlyNameRegex(X86_CMOVEL_IMM01UCF, "cmovL_imm_01UCF");
     }
 
+    public static final String MOD_F = PREFIX + "MOD_F" + POSTFIX;
+    static {
+        macroNodes(MOD_F, "ModF");
+    }
+
+    public static final String MOD_D = PREFIX + "MOD_D" + POSTFIX;
+    static {
+        macroNodes(MOD_D, "ModD");
+    }
+
     /*
      * Utility methods to set up IR_NODE_MAPPINGS.
      */
@@ -2574,6 +2584,16 @@ public class IRNode {
         intervalToRegexMap.put(new PhaseInterval(CompilePhase.PRINT_OPTO_ASSEMBLY), optoRegex);
         MultiPhaseRangeEntry entry = new MultiPhaseRangeEntry(CompilePhase.PRINT_OPTO_ASSEMBLY, intervalToRegexMap);
         IR_NODE_MAPPINGS.put(irNode, entry);
+    }
+
+    /**
+     * Apply {@code regex} on all ideal graph phases up to and including {@link CompilePhase#BEFORE_MACRO_EXPANSION}.
+     */
+    private static void macroNodes(String irNodePlaceholder, String irNodeRegex) {
+        String regex = START + irNodeRegex + MID + END;
+        IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.BEFORE_MACRO_EXPANSION, regex,
+                CompilePhase.BEFORE_STRINGOPTS,
+                CompilePhase.BEFORE_MACRO_EXPANSION));
     }
 
     private static void callOfNodes(String irNodePlaceholder, String callRegex) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2592,8 +2592,8 @@ public class IRNode {
     private static void macroNodes(String irNodePlaceholder, String irNodeRegex) {
         String regex = START + irNodeRegex + MID + END;
         IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.BEFORE_MACRO_EXPANSION, regex,
-                CompilePhase.BEFORE_STRINGOPTS,
-                CompilePhase.BEFORE_MACRO_EXPANSION));
+                                                                          CompilePhase.BEFORE_STRINGOPTS,
+                                                                          CompilePhase.BEFORE_MACRO_EXPANSION));
     }
 
     private static void callOfNodes(String irNodePlaceholder, String callRegex) {


### PR DESCRIPTION
Remove frem and drem macros nodes when the result is not used. These nodes have other outputs (like memory), which is not meaningful, but preventing them to be dropped so easily. This patch removes the useless frem/drem nodes, and by rewiring the inputs to the outputs.

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349523](https://bugs.openjdk.org/browse/JDK-8349523): Unused runtime calls to drem/frem should be removed (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [2582890a](https://git.openjdk.org/jdk/pull/23694/files/2582890ac1b0019c362b285dc366ca23045e7bbd)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) Review applies to [bfd185d8](https://git.openjdk.org/jdk/pull/23694/files/bfd185d88a1feb295c03e269a569c05ae81d67cd)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23694/head:pull/23694` \
`$ git checkout pull/23694`

Update a local copy of the PR: \
`$ git checkout pull/23694` \
`$ git pull https://git.openjdk.org/jdk.git pull/23694/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23694`

View PR using the GUI difftool: \
`$ git pr show -t 23694`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23694.diff">https://git.openjdk.org/jdk/pull/23694.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23694#issuecomment-2668569543)
</details>
