### PR TITLE
8350214

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -30,8 +30,8 @@
 #include "memory/resourceArea.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/os.inline.hpp"
+#include "runtime/globals.hpp"
 
-DEBUG_ONLY(bool AsyncLogWriter::ignore_recursive_logging = false;)
 
 class AsyncLogWriter::AsyncLogLocker : public StackObj {
   static Thread* _holder;
@@ -116,10 +116,11 @@ bool AsyncLogWriter::is_enqueue_allowed() {
     // Do not log while holding the Async log lock.
     // Try to catch possible occurrences in debug builds.
 #ifdef ASSERT
-    if (!AsyncLogWriter::ignore_recursive_logging) {
+    if (!TestingAsyncLoggingDeathTestNoCrash) {
       ShouldNotReachHere();
     }
 #endif // ASSERT
+
     return false;
   }
 
@@ -142,8 +143,14 @@ bool AsyncLogWriter::enqueue(LogFileStreamOutput& output, const LogDecorations& 
   }
 
   AsyncLogLocker locker;
-  DEBUG_ONLY(log_debug(deathtest)("Induce a recursive log for testing (for crashing)");)
-  DEBUG_ONLY(log_debug(deathtest2)("Induce a recursive log for testing");)
+
+#ifdef ASSERT
+  if (TestingAsyncLoggingDeathTest || TestingAsyncLoggingDeathTestNoCrash) {
+    log_debug(deathtest)("Induce a recursive log for testing (for crashing)");
+    log_debug(deathtest2)("Induce a recursive log for testing");
+  }
+#endif // ASSERT
+
   AsyncLogWriter::instance()->enqueue_locked(&output, decorations, msg);
   return true;
 }

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -198,7 +198,6 @@ class AsyncLogWriter : public NonJavaThread {
   static bool is_enqueue_allowed();
 
 public:
-  DEBUG_ONLY(static bool ignore_recursive_logging;)
   static bool enqueue(LogFileStreamOutput& output, const LogDecorations& decorations, const char* msg);
   static bool enqueue(LogFileStreamOutput& output, LogMessageBuffer::Iterator msg_iterator);
 

--- a/src/hotspot/share/logging/logTagSet.cpp
+++ b/src/hotspot/share/logging/logTagSet.cpp
@@ -78,13 +78,7 @@ void LogTagSet::log(LogLevelType level, const char* msg) {
   // the implied memory order of Atomic::add().
   LogOutputList::Iterator it = _output_list.iterator(level);
   LogDecorations decorations(level, *this, _decorators);
-#ifdef ASSERT
-  // If we log for tag deathtest2 then we're testing that recursive logging works.
-  // In this case, do not crash when detecting recursive logging.
-  if (this->contains(LogTagType::_deathtest2)) {
-    AsyncLogWriter::ignore_recursive_logging = true;
-  }
-#endif
+
   for (; it != _output_list.end(); it++) {
     (*it)->write(decorations, msg);
   }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -481,6 +481,10 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   develop(bool, ZapTLAB, trueInDebug,                                       \
           "Zap allocated TLABs")                                            \
+  develop(bool, TestingAsyncLoggingDeathTest, falseInDebug,                 \
+          "Recursive logging death test")                                   \
+  develop(bool, TestingAsyncLoggingDeathTestNoCrash, falseInDebug,          \
+          "Recursive logging death test (no crash)")                        \
                                                                             \
   product(bool, ExecutingUnitTests, false,                                  \
           "Whether the JVM is running unit tests or not")                   \

--- a/test/hotspot/jtreg/runtime/logging/AsyncDeathTest.java
+++ b/test/hotspot/jtreg/runtime/logging/AsyncDeathTest.java
@@ -40,15 +40,22 @@ public class AsyncDeathTest {
     public static void main(String[] args) throws Exception {
         // For deathtest we expect the VM to reach ShouldNotReachHere() and die
         ProcessBuilder pb =
-            ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:async", "-Xlog:os,deathtest=debug", "-XX:-CreateCoredumpOnCrash", "--version");
+            ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:async", "-Xlog:os,deathtest=debug", "-XX:-CreateCoredumpOnCrash", "-XX:+TestingAsyncLoggingDeathTest", "--version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
         output.shouldNotContain("Induce a recursive log for testing");
         // For deathtest2 we expect the VM to ignore that recursive logging has been detected and is handled by printing synchronously.
         ProcessBuilder pb2 =
-            ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:async", "-Xlog:os,deathtest2=debug", "--version");
+            ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:async", "-Xlog:os,deathtest2=debug", "-XX:+TestingAsyncLoggingDeathTestNoCrash" , "--version");
         OutputAnalyzer output2 = new OutputAnalyzer(pb2.start());
         output2.shouldHaveExitValue(0);
         output2.shouldContain("Induce a recursive log for testing");
+
+        // For -Xlog:all=debug we expect neither deathtest nor deathtest2 to be logged as they should only be able to be selected explicitly.
+        ProcessBuilder pb3 =
+            ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:async", "-Xlog:all=debug", "--version");
+        OutputAnalyzer output3 = new OutputAnalyzer(pb3.start());
+        output3.shouldHaveExitValue(0);
+        output3.shouldNotContain("Induce a recursive log for testing");
     }
 }


### PR DESCRIPTION
Hi,

[8349755](https://bugs.openjdk.org/browse/JDK-8349755) introduced a bug in debug builds when running with -Xlog:async -Xlog:all=debug. Specifically, this will cause UL to select for deathtest and deathtest2, which should only be selected when explicitly asked for.

In order to fix this, I've added some develop-only globals. We now only log if either of the testing globals are set, and we only crash on recursive logging if `TestingAsyncLoggingDeathTestNoCrash` is set to `false`.