### PR TITLE
8350334: Add final keywords to FFM methods

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -89,12 +89,12 @@ public abstract sealed class AbstractMemorySegmentImpl
     abstract ByteBuffer makeByteBuffer();
 
     @Override
-    public AbstractMemorySegmentImpl asReadOnly() {
+    public final AbstractMemorySegmentImpl asReadOnly() {
         return dup(0, length, true, scope);
     }
 
     @Override
-    public boolean isReadOnly() {
+    public final boolean isReadOnly() {
         return readOnly;
     }
 
@@ -105,13 +105,13 @@ public abstract sealed class AbstractMemorySegmentImpl
     }
 
     @Override
-    public AbstractMemorySegmentImpl asSlice(long offset) {
+    public final AbstractMemorySegmentImpl asSlice(long offset) {
         checkBounds(offset, 0);
         return asSliceNoCheck(offset, length - offset);
     }
 
     @Override
-    public MemorySegment asSlice(long offset, long newSize, long byteAlignment) {
+    public final MemorySegment asSlice(long offset, long newSize, long byteAlignment) {
         checkBounds(offset, newSize);
         Utils.checkAlign(byteAlignment);
 
@@ -122,7 +122,7 @@ public abstract sealed class AbstractMemorySegmentImpl
     }
 
     @Override
-    public MemorySegment asSlice(long offset, MemoryLayout layout) {
+    public final MemorySegment asSlice(long offset, MemoryLayout layout) {
         Objects.requireNonNull(layout);
         return asSlice(offset, layout.byteSize(), layout.byteAlignment());
     }
@@ -172,7 +172,7 @@ public abstract sealed class AbstractMemorySegmentImpl
     }
 
     @Override
-    public Spliterator<MemorySegment> spliterator(MemoryLayout elementLayout) {
+    public final Spliterator<MemorySegment> spliterator(MemoryLayout elementLayout) {
         Objects.requireNonNull(elementLayout);
         if (elementLayout.byteSize() == 0) {
             throw new IllegalArgumentException("Element layout size cannot be zero");
@@ -189,7 +189,7 @@ public abstract sealed class AbstractMemorySegmentImpl
     }
 
     @Override
-    public Stream<MemorySegment> elements(MemoryLayout elementLayout) {
+    public final Stream<MemorySegment> elements(MemoryLayout elementLayout) {
         return StreamSupport.stream(spliterator(elementLayout), false);
     }
 
@@ -200,7 +200,7 @@ public abstract sealed class AbstractMemorySegmentImpl
     }
 
     @Override
-    public MemorySegment allocate(long byteSize, long byteAlignment) {
+    public final MemorySegment allocate(long byteSize, long byteAlignment) {
         Utils.checkAllocationSizeAndAlign(byteSize, byteAlignment);
         return asSlice(0, byteSize, byteAlignment);
     }
@@ -255,13 +255,13 @@ public abstract sealed class AbstractMemorySegmentImpl
     }
 
     @Override
-    public MemorySegment copyFrom(MemorySegment src) {
+    public final MemorySegment copyFrom(MemorySegment src) {
         MemorySegment.copy(src, 0, this, 0, src.byteSize());
         return this;
     }
 
     @Override
-    public long mismatch(MemorySegment other) {
+    public final long mismatch(MemorySegment other) {
         Objects.requireNonNull(other);
         return SegmentBulkOperations.mismatch(this, 0, byteSize(),
                 (AbstractMemorySegmentImpl) other, 0, other.byteSize());
@@ -398,19 +398,19 @@ public abstract sealed class AbstractMemorySegmentImpl
     }
 
     @Override
-    public RuntimeException apply(String s, List<Number> numbers) {
+    public final RuntimeException apply(String s, List<Number> numbers) {
         long offset = numbers.get(0).longValue();
         long length = byteSize() - numbers.get(1).longValue() + 1;
         return outOfBoundException(offset, length);
     }
 
     @Override
-    public MemorySessionImpl scope() {
+    public final MemorySessionImpl scope() {
         return scope;
     }
 
     @Override
-    public boolean isAccessibleBy(Thread thread) {
+    public final boolean isAccessibleBy(Thread thread) {
         return sessionImpl().isAccessibleBy(thread);
     }
 
@@ -424,7 +424,7 @@ public abstract sealed class AbstractMemorySegmentImpl
                         this, offset, length));
     }
 
-    static class SegmentSplitter implements Spliterator<MemorySegment> {
+    static final class SegmentSplitter implements Spliterator<MemorySegment> {
         AbstractMemorySegmentImpl segment;
         long elemCount;
         final long elementSize;
@@ -501,7 +501,7 @@ public abstract sealed class AbstractMemorySegmentImpl
     // Object methods
 
     @Override
-    public String toString() {
+    public final String toString() {
         final String kind;
         if (this instanceof HeapMemorySegmentImpl) {
             kind = "heap";
@@ -519,14 +519,14 @@ public abstract sealed class AbstractMemorySegmentImpl
     }
 
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         return o instanceof AbstractMemorySegmentImpl that &&
                 unsafeGetBase() == that.unsafeGetBase() &&
                 unsafeGetOffset() == that.unsafeGetOffset();
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         return Objects.hash(
                 unsafeGetOffset(),
                 unsafeGetBase());
@@ -680,235 +680,235 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @ForceInline
     @Override
-    public byte get(ValueLayout.OfByte layout, long offset) {
+    public final byte get(ValueLayout.OfByte layout, long offset) {
         return (byte) layout.varHandle().get((MemorySegment)this, offset);
     }
 
     @ForceInline
     @Override
-    public void set(ValueLayout.OfByte layout, long offset, byte value) {
+    public final void set(ValueLayout.OfByte layout, long offset, byte value) {
         layout.varHandle().set((MemorySegment)this, offset, value);
     }
 
     @ForceInline
     @Override
-    public boolean get(ValueLayout.OfBoolean layout, long offset) {
+    public final boolean get(ValueLayout.OfBoolean layout, long offset) {
         return (boolean) layout.varHandle().get((MemorySegment)this, offset);
     }
 
     @ForceInline
     @Override
-    public void set(ValueLayout.OfBoolean layout, long offset, boolean value) {
+    public final void set(ValueLayout.OfBoolean layout, long offset, boolean value) {
         layout.varHandle().set((MemorySegment)this, offset, value);
     }
 
     @ForceInline
     @Override
-    public char get(ValueLayout.OfChar layout, long offset) {
+    public final char get(ValueLayout.OfChar layout, long offset) {
         return (char) layout.varHandle().get((MemorySegment)this, offset);
     }
 
     @ForceInline
     @Override
-    public void set(ValueLayout.OfChar layout, long offset, char value) {
+    public final void set(ValueLayout.OfChar layout, long offset, char value) {
         layout.varHandle().set((MemorySegment)this, offset, value);
     }
 
     @ForceInline
     @Override
-    public short get(ValueLayout.OfShort layout, long offset) {
+    public final short get(ValueLayout.OfShort layout, long offset) {
         return (short) layout.varHandle().get((MemorySegment)this, offset);
     }
 
     @ForceInline
     @Override
-    public void set(ValueLayout.OfShort layout, long offset, short value) {
+    public final void set(ValueLayout.OfShort layout, long offset, short value) {
         layout.varHandle().set((MemorySegment)this, offset, value);
     }
 
     @ForceInline
     @Override
-    public int get(ValueLayout.OfInt layout, long offset) {
+    public final int get(ValueLayout.OfInt layout, long offset) {
         return (int) layout.varHandle().get((MemorySegment)this, offset);
     }
 
     @ForceInline
     @Override
-    public void set(ValueLayout.OfInt layout, long offset, int value) {
+    public final void set(ValueLayout.OfInt layout, long offset, int value) {
         layout.varHandle().set((MemorySegment)this, offset, value);
     }
 
     @ForceInline
     @Override
-    public float get(ValueLayout.OfFloat layout, long offset) {
+    public final float get(ValueLayout.OfFloat layout, long offset) {
         return (float) layout.varHandle().get((MemorySegment)this, offset);
     }
 
     @ForceInline
     @Override
-    public void set(ValueLayout.OfFloat layout, long offset, float value) {
+    public final void set(ValueLayout.OfFloat layout, long offset, float value) {
         layout.varHandle().set((MemorySegment)this, offset, value);
     }
 
     @ForceInline
     @Override
-    public long get(ValueLayout.OfLong layout, long offset) {
+    public final long get(ValueLayout.OfLong layout, long offset) {
         return (long) layout.varHandle().get((MemorySegment)this, offset);
     }
 
     @ForceInline
     @Override
-    public void set(ValueLayout.OfLong layout, long offset, long value) {
+    public final void set(ValueLayout.OfLong layout, long offset, long value) {
         layout.varHandle().set((MemorySegment)this, offset, value);
     }
 
     @ForceInline
     @Override
-    public double get(ValueLayout.OfDouble layout, long offset) {
+    public final double get(ValueLayout.OfDouble layout, long offset) {
         return (double) layout.varHandle().get((MemorySegment)this, offset);
     }
 
     @ForceInline
     @Override
-    public void set(ValueLayout.OfDouble layout, long offset, double value) {
+    public final void set(ValueLayout.OfDouble layout, long offset, double value) {
         layout.varHandle().set((MemorySegment)this, offset, value);
     }
 
     @ForceInline
     @Override
-    public MemorySegment get(AddressLayout layout, long offset) {
+    public final MemorySegment get(AddressLayout layout, long offset) {
         return (MemorySegment) layout.varHandle().get((MemorySegment)this, offset);
     }
 
     @ForceInline
     @Override
-    public void set(AddressLayout layout, long offset, MemorySegment value) {
+    public final void set(AddressLayout layout, long offset, MemorySegment value) {
         Objects.requireNonNull(value);
         layout.varHandle().set((MemorySegment)this, offset, value);
     }
 
     @ForceInline
     @Override
-    public byte getAtIndex(ValueLayout.OfByte layout, long index) {
+    public final byte getAtIndex(ValueLayout.OfByte layout, long index) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         return (byte) layout.varHandle().get((MemorySegment)this, index * layout.byteSize());
     }
 
     @ForceInline
     @Override
-    public boolean getAtIndex(ValueLayout.OfBoolean layout, long index) {
+    public final boolean getAtIndex(ValueLayout.OfBoolean layout, long index) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         return (boolean) layout.varHandle().get((MemorySegment)this, index * layout.byteSize());
     }
 
     @ForceInline
     @Override
-    public char getAtIndex(ValueLayout.OfChar layout, long index) {
+    public final char getAtIndex(ValueLayout.OfChar layout, long index) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         return (char) layout.varHandle().get((MemorySegment)this, index * layout.byteSize());
     }
 
     @ForceInline
     @Override
-    public void setAtIndex(ValueLayout.OfChar layout, long index, char value) {
+    public final void setAtIndex(ValueLayout.OfChar layout, long index, char value) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         layout.varHandle().set((MemorySegment)this, index * layout.byteSize(), value);
     }
 
     @ForceInline
     @Override
-    public short getAtIndex(ValueLayout.OfShort layout, long index) {
+    public final short getAtIndex(ValueLayout.OfShort layout, long index) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         return (short) layout.varHandle().get((MemorySegment)this, index * layout.byteSize());
     }
 
     @ForceInline
     @Override
-    public void setAtIndex(ValueLayout.OfByte layout, long index, byte value) {
+    public final void setAtIndex(ValueLayout.OfByte layout, long index, byte value) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         layout.varHandle().set((MemorySegment)this, index * layout.byteSize(), value);
     }
 
     @ForceInline
     @Override
-    public void setAtIndex(ValueLayout.OfBoolean layout, long index, boolean value) {
+    public final void setAtIndex(ValueLayout.OfBoolean layout, long index, boolean value) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         layout.varHandle().set((MemorySegment)this, index * layout.byteSize(), value);
     }
 
     @ForceInline
     @Override
-    public void setAtIndex(ValueLayout.OfShort layout, long index, short value) {
+    public final void setAtIndex(ValueLayout.OfShort layout, long index, short value) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         layout.varHandle().set((MemorySegment)this, index * layout.byteSize(), value);
     }
 
     @ForceInline
     @Override
-    public int getAtIndex(ValueLayout.OfInt layout, long index) {
+    public final int getAtIndex(ValueLayout.OfInt layout, long index) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         return (int) layout.varHandle().get((MemorySegment)this, index * layout.byteSize());
     }
 
     @ForceInline
     @Override
-    public void setAtIndex(ValueLayout.OfInt layout, long index, int value) {
+    public final void setAtIndex(ValueLayout.OfInt layout, long index, int value) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         layout.varHandle().set((MemorySegment)this, index * layout.byteSize(), value);
     }
 
     @ForceInline
     @Override
-    public float getAtIndex(ValueLayout.OfFloat layout, long index) {
+    public final float getAtIndex(ValueLayout.OfFloat layout, long index) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         return (float) layout.varHandle().get((MemorySegment)this, index * layout.byteSize());
     }
 
     @ForceInline
     @Override
-    public void setAtIndex(ValueLayout.OfFloat layout, long index, float value) {
+    public final void setAtIndex(ValueLayout.OfFloat layout, long index, float value) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         layout.varHandle().set((MemorySegment)this, index * layout.byteSize(), value);
     }
 
     @ForceInline
     @Override
-    public long getAtIndex(ValueLayout.OfLong layout, long index) {
+    public final long getAtIndex(ValueLayout.OfLong layout, long index) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         return (long) layout.varHandle().get((MemorySegment)this, index * layout.byteSize());
     }
 
     @ForceInline
     @Override
-    public void setAtIndex(ValueLayout.OfLong layout, long index, long value) {
+    public final void setAtIndex(ValueLayout.OfLong layout, long index, long value) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         layout.varHandle().set((MemorySegment)this, index * layout.byteSize(), value);
     }
 
     @ForceInline
     @Override
-    public double getAtIndex(ValueLayout.OfDouble layout, long index) {
+    public final double getAtIndex(ValueLayout.OfDouble layout, long index) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         return (double) layout.varHandle().get((MemorySegment)this, index * layout.byteSize());
     }
 
     @ForceInline
     @Override
-    public void setAtIndex(ValueLayout.OfDouble layout, long index, double value) {
+    public final void setAtIndex(ValueLayout.OfDouble layout, long index, double value) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         layout.varHandle().set((MemorySegment)this, index * layout.byteSize(), value);
     }
 
     @ForceInline
     @Override
-    public MemorySegment getAtIndex(AddressLayout layout, long index) {
+    public final MemorySegment getAtIndex(AddressLayout layout, long index) {
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         return (MemorySegment) layout.varHandle().get((MemorySegment)this, index * layout.byteSize());
     }
 
     @ForceInline
     @Override
-    public void setAtIndex(AddressLayout layout, long index, MemorySegment value) {
+    public final void setAtIndex(AddressLayout layout, long index, MemorySegment value) {
         Objects.requireNonNull(value);
         Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
         layout.varHandle().set((MemorySegment)this, index * layout.byteSize(), value);
@@ -916,27 +916,27 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @ForceInline
     @Override
-    public String getString(long offset) {
+    public final String getString(long offset) {
         return getString(offset, sun.nio.cs.UTF_8.INSTANCE);
     }
 
     @ForceInline
     @Override
-    public String getString(long offset, Charset charset) {
+    public final String getString(long offset, Charset charset) {
         Objects.requireNonNull(charset);
         return StringSupport.read(this, offset, charset);
     }
 
     @ForceInline
     @Override
-    public void setString(long offset, String str) {
+    public final void setString(long offset, String str) {
         Objects.requireNonNull(str);
         setString(offset, str, sun.nio.cs.UTF_8.INSTANCE);
     }
 
     @ForceInline
     @Override
-    public void setString(long offset, String str, Charset charset) {
+    public final void setString(long offset, String str, Charset charset) {
         Objects.requireNonNull(charset);
         Objects.requireNonNull(str);
         StringSupport.write(this, offset, charset, str);

--- a/src/java.base/share/classes/jdk/internal/foreign/GlobalSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/GlobalSession.java
@@ -43,23 +43,23 @@ non-sealed class GlobalSession extends MemorySessionImpl {
 
     @Override
     @ForceInline
-    public void release0() {
+    public final void release0() {
         // do nothing
     }
 
     @Override
     @ForceInline
-    public void acquire0() {
+    public final void acquire0() {
         // do nothing
     }
 
     @Override
-    void addInternal(ResourceList.ResourceCleanup resource) {
+    final void addInternal(ResourceList.ResourceCleanup resource) {
         // do nothing
     }
 
     @Override
-    public void justClose() {
+    public final void justClose() {
         throw nonCloseable();
     }
 
@@ -70,7 +70,7 @@ non-sealed class GlobalSession extends MemorySessionImpl {
      * {@link Object#equals(Object)}, as that would be problematic when comparing buffers, whose equality and
      * hash codes are content-dependent.
      */
-    static class HeapSession extends GlobalSession {
+    static final class HeapSession extends GlobalSession {
 
         final Object ref;
 

--- a/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -73,7 +73,7 @@ abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
     }
 
     @Override
-    public long unsafeGetOffset() {
+    public final long unsafeGetOffset() {
         return offset;
     }
 
@@ -88,7 +88,7 @@ abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
     abstract HeapMemorySegmentImpl dup(long offset, long size, boolean readOnly, MemorySessionImpl scope);
 
     @Override
-    ByteBuffer makeByteBuffer() {
+    final ByteBuffer makeByteBuffer() {
         if (!(base instanceof byte[] baseByte)) {
             throw new UnsupportedOperationException("Not an address to an heap-allocated byte array");
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -23,6 +23,7 @@
  *  questions.
  *
  */
+
 package jdk.internal.foreign;
 
 import jdk.internal.vm.annotation.ForceInline;
@@ -54,7 +55,7 @@ import static java.util.stream.Collectors.joining;
  * by the path (see {@link #offset}), or obtain var handle to access the selected layout element
  * given an address pointing to a segment associated with the root layout (see {@link #dereferenceHandle()}).
  */
-public class LayoutPath {
+public final class LayoutPath {
 
     private static final long[] EMPTY_STRIDES = new long[0];
     private static final long[] EMPTY_BOUNDS = new long[0];

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -100,7 +100,7 @@ public abstract sealed class MemorySessionImpl
                 (owner == null || owner == thread);
     }
 
-    public void addCloseAction(Runnable runnable) {
+    public final void addCloseAction(Runnable runnable) {
         Objects.requireNonNull(runnable);
         addInternal(ResourceList.ResourceCleanup.ofRunnable(runnable));
     }
@@ -115,7 +115,7 @@ public abstract sealed class MemorySessionImpl
      * new segment to the client). For this reason, it's not worth adding extra complexity to the segment
      * initialization logic here - and using an optimistic logic works well in practice.
      */
-    public void addOrCleanupIfFail(ResourceList.ResourceCleanup resource) {
+    public final void addOrCleanupIfFail(ResourceList.ResourceCleanup resource) {
         try {
             addInternal(resource);
         } catch (Throwable ex) {
@@ -160,7 +160,7 @@ public abstract sealed class MemorySessionImpl
 
     public abstract void acquire0();
 
-    public void whileAlive(Runnable action) {
+    public final void whileAlive(Runnable action) {
         Objects.requireNonNull(action);
         acquire0();
         try {
@@ -183,7 +183,7 @@ public abstract sealed class MemorySessionImpl
      * Returns true, if this session is still open. This method may be called in any thread.
      * @return {@code true} if this session is not closed yet.
      */
-    public boolean isAlive() {
+    public final boolean isAlive() {
         return state >= OPEN;
     }
 
@@ -196,7 +196,7 @@ public abstract sealed class MemorySessionImpl
      * please use {@link #checkValidState()}.
      */
     @ForceInline
-    public void checkValidStateRaw() {
+    public final void checkValidStateRaw() {
         if (owner != null && owner != Thread.currentThread()) {
             throw WRONG_THREAD;
         }
@@ -210,7 +210,7 @@ public abstract sealed class MemorySessionImpl
      * @throws IllegalStateException if this session is already closed or if this is
      * a confined session and this method is called outside the owner thread.
      */
-    public void checkValidState() {
+    public final void checkValidState() {
         try {
             checkValidStateRaw();
         } catch (ScopedMemoryAccess.ScopedAccessError error) {
@@ -223,7 +223,7 @@ public abstract sealed class MemorySessionImpl
     }
 
     @Override
-    protected Object clone() throws CloneNotSupportedException {
+    protected final Object clone() throws CloneNotSupportedException {
         throw new CloneNotSupportedException();
     }
 
@@ -236,7 +236,7 @@ public abstract sealed class MemorySessionImpl
      * @throws IllegalStateException if this session is already closed or if this is
      * a confined session and this method is called outside the owner thread.
      */
-    public void close() {
+    public final void close() {
         justClose();
         resourceList.cleanup();
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -51,12 +51,12 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     }
 
     @Override
-    public long address() {
+    public final long address() {
         return min;
     }
 
     @Override
-    public Optional<Object> heapBase() {
+    public final Optional<Object> heapBase() {
         return Optional.empty();
     }
 
@@ -78,22 +78,22 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     }
 
     @Override
-    public boolean isNative() {
+    public final boolean isNative() {
         return true;
     }
 
     @Override
-    public long unsafeGetOffset() {
+    public final long unsafeGetOffset() {
         return min;
     }
 
     @Override
-    public Object unsafeGetBase() {
+    public final Object unsafeGetBase() {
         return null;
     }
 
     @Override
-    public long maxAlignMask() {
+    public final long maxAlignMask() {
         return 0;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,10 @@ import java.util.Objects;
  * are initialized in the right order (that is, that {@code MemorySegment} is always initialized first).
  * See {@link SegmentFactories#ensureInitialized()}.
  */
-public class SegmentFactories {
+public final class SegmentFactories {
+
+    // Suppresses default constructor, ensuring non-instantiability.
+    private SegmentFactories() {}
 
     // The maximum alignment supported by malloc - typically 16 bytes on
     // 64-bit platforms and 8 bytes on 32-bit platforms.

--- a/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
@@ -104,7 +104,7 @@ sealed class SharedSession extends MemorySessionImpl permits ImplicitSession {
     /**
      * A shared resource list; this implementation has to handle add vs. add races, as well as add vs. cleanup races.
      */
-    static class SharedResourceList extends ResourceList {
+    static final class SharedResourceList extends ResourceList {
 
         static final VarHandle FST = MhUtil.findVarHandle(
                 MethodHandles.lookup(), ResourceList.class, "fst", ResourceCleanup.class);

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
  *  questions.
  *
  */
+
 package jdk.internal.foreign.layout;
 
 import java.lang.foreign.MemoryLayout;
@@ -79,7 +80,7 @@ abstract sealed class AbstractGroupLayout<L extends AbstractGroupLayout<L> & Mem
     }
 
     @Override
-    public L withByteAlignment(long byteAlignment) {
+    public final L withByteAlignment(long byteAlignment) {
         if (byteAlignment < minByteAlignment) {
             throw new IllegalArgumentException("Invalid alignment constraint");
         }


### PR DESCRIPTION
This PR proposes to add the `final` keyword to some classes and methods in order to assist compiler devirtualization (e.g. in Graal native image).

Passes `make test TEST=jdk_foreign`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350334](https://bugs.openjdk.org/browse/JDK-8350334): Add final keywords to FFM methods (**Enhancement** - P5)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23696/head:pull/23696` \
`$ git checkout pull/23696`

Update a local copy of the PR: \
`$ git checkout pull/23696` \
`$ git pull https://git.openjdk.org/jdk.git pull/23696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23696`

View PR using the GUI difftool: \
`$ git pr show -t 23696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23696.diff">https://git.openjdk.org/jdk/pull/23696.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23696#issuecomment-2668819672)
</details>
