### PR TITLE
8350137: After JDK-8348975, Linux builds contain man pages for windows only tools

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -673,7 +673,7 @@ ifeq ($(ENABLE_PANDOC), true)
 
   $(foreach m, $(ALL_MODULES), \
     $(eval MAN_$m := $(call ApplySpecFilter, $(filter %.md, $(call FindFiles, \
-          $(call FindModuleManDirs, $m))))) \
+          $(call FindModuleManDirsForDocs, $m))))) \
     $(if $(MAN_$m), \
       $(eval $(call SetupProcessMarkdown, MAN_TO_HTML_$m, \
         FILES := $(MAN_$m), \

--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -87,7 +87,9 @@ SRC_SUBDIRS += share/classes
 
 SPEC_SUBDIRS += share/specs
 
-MAN_SUBDIRS += share/man windows/man
+MAN_SUBDIRS += share/man $(TARGET_OS)/man
+
+MAN_DOCS_SUBDIRS += share/man windows/man
 
 # Find all module-info.java files for the current build target platform and
 # configuration.
@@ -152,6 +154,10 @@ FindModuleSpecsDirs = \
 FindModuleManDirs = \
     $(strip $(wildcard \
         $(foreach sub, $(MAN_SUBDIRS), $(addsuffix /$(strip $1)/$(sub), $(TOP_SRC_DIRS)))))
+
+FindModuleManDirsForDocs = \
+    $(strip $(wildcard \
+        $(foreach sub, $(MAN_DOCS_SUBDIRS), $(addsuffix /$(strip $1)/$(sub), $(TOP_SRC_DIRS)))))
 
 # Construct the complete module source path
 GetModuleSrcPath = \

--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -89,6 +89,7 @@ SPEC_SUBDIRS += share/specs
 
 MAN_SUBDIRS += share/man $(TARGET_OS)/man
 
+# The docs should include the sum of all man pages for all platforms
 MAN_DOCS_SUBDIRS += share/man windows/man
 
 # Find all module-info.java files for the current build target platform and


### PR DESCRIPTION
This patch fixes a regression where the windows tools man pages appeared on the Linux and the MacOS builds

The man pages found using `FindModuleManDirs` were used in both `Docs.gmk` used to generate the documentation for the JDK as well as in `LauncherCommon.gmk` here https://github.com/openjdk/jdk/blob/efbad00c4d7931177ccc5e9bce3b30dfbac94010/make/common/modules/LauncherCommon.gmk#L195

I've separated the logic between generated the docs and the man pages. I've checked on a MacOs machine and the man pages no longer appear.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350137](https://bugs.openjdk.org/browse/JDK-8350137): After JDK-8348975, Linux builds contain man pages for windows only tools (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23697/head:pull/23697` \
`$ git checkout pull/23697`

Update a local copy of the PR: \
`$ git checkout pull/23697` \
`$ git pull https://git.openjdk.org/jdk.git pull/23697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23697`

View PR using the GUI difftool: \
`$ git pr show -t 23697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23697.diff">https://git.openjdk.org/jdk/pull/23697.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23697#issuecomment-2668949654)
</details>
