### PR TITLE
8350267: Set mtune and mcpu settings in JDK native lib compilation on Linux ppc64(le)

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -715,11 +715,13 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
       if test "x$FLAGS_CPU" = xppc64; then
         # -mminimal-toc fixes `relocation truncated to fit' error for gcc 4.1.
         # Use ppc64 instructions, but schedule for power5
-        $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -mminimal-toc -mcpu=powerpc64 -mtune=power5"
+        $1_CFLAGS_CPU="-mcpu=powerpc64 -mtune=power5"
+        $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -mminimal-toc"
       elif test "x$FLAGS_CPU" = xppc64le; then
         # Little endian machine uses ELFv2 ABI.
         # Use Power8, this is the first CPU to support PPC64 LE with ELFv2 ABI.
-        $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -DABI_ELFv2 -mcpu=power8 -mtune=power10"
+        $1_CFLAGS_CPU="-mcpu=power8 -mtune=power10"
+        $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -DABI_ELFv2"
       fi
     elif test "x$FLAGS_CPU" = xs390x; then
       $1_CFLAGS_CPU="-mbackchain -march=z10"


### PR DESCRIPTION
Currently we only set mcpu/mtune for hotspot; this might be a little problematic because other options might be used in the jdk native libs compilation .
Those other (compared to hotspot) options are defined by the gcc - version used in the build process.
'gcc -c -Q --help=target'  shows these options, they can vary depending on gcc version and build environment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350267](https://bugs.openjdk.org/browse/JDK-8350267): Set mtune and mcpu settings in JDK native lib compilation on Linux ppc64(le) (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Andreas Steiner](https://openjdk.org/census#asteiner) (@ansteiner - Author)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23698/head:pull/23698` \
`$ git checkout pull/23698`

Update a local copy of the PR: \
`$ git checkout pull/23698` \
`$ git pull https://git.openjdk.org/jdk.git pull/23698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23698`

View PR using the GUI difftool: \
`$ git pr show -t 23698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23698.diff">https://git.openjdk.org/jdk/pull/23698.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23698#issuecomment-2668963735)
</details>
