### PR TITLE
8350344: Cross-build failure: _vptr name conflict

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -73,29 +73,29 @@ static_assert(!std::is_polymorphic<UncommonTrapBlob>::value,   "no virtual metho
 
 // Add proxy vtables.
 // We need only few for now - they are used only from prints.
-const nmethod::Vptr                  nmethod::_vptr;
-const BufferBlob::Vptr               BufferBlob::_vptr;
-const RuntimeStub::Vptr              RuntimeStub::_vptr;
-const SingletonBlob::Vptr            SingletonBlob::_vptr;
-const DeoptimizationBlob::Vptr       DeoptimizationBlob::_vptr;
-const UpcallStub::Vptr               UpcallStub::_vptr;
+const nmethod::Vptr                  nmethod::_vpntr;
+const BufferBlob::Vptr               BufferBlob::_vpntr;
+const RuntimeStub::Vptr              RuntimeStub::_vpntr;
+const SingletonBlob::Vptr            SingletonBlob::_vpntr;
+const DeoptimizationBlob::Vptr       DeoptimizationBlob::_vpntr;
+const UpcallStub::Vptr               UpcallStub::_vpntr;
 
 const CodeBlob::Vptr* CodeBlob::vptr() const {
   constexpr const CodeBlob::Vptr* array[(size_t)CodeBlobKind::Number_Of_Kinds] = {
       nullptr/* None */,
-      &nmethod::_vptr,
-      &BufferBlob::_vptr,
-      &AdapterBlob::_vptr,
-      &VtableBlob::_vptr,
-      &MethodHandlesAdapterBlob::_vptr,
-      &RuntimeStub::_vptr,
-      &DeoptimizationBlob::_vptr,
-      &SafepointBlob::_vptr,
+      &nmethod::_vpntr,
+      &BufferBlob::_vpntr,
+      &AdapterBlob::_vpntr,
+      &VtableBlob::_vpntr,
+      &MethodHandlesAdapterBlob::_vpntr,
+      &RuntimeStub::_vpntr,
+      &DeoptimizationBlob::_vpntr,
+      &SafepointBlob::_vpntr,
 #ifdef COMPILER2
-      &ExceptionBlob::_vptr,
-      &UncommonTrapBlob::_vptr,
+      &ExceptionBlob::_vpntr,
+      &UncommonTrapBlob::_vpntr,
 #endif
-      &UpcallStub::_vptr
+      &UpcallStub::_vpntr
   };
 
   return array[(size_t)_kind];

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -346,7 +346,7 @@ class BufferBlob: public RuntimeBlob {
     }
   };
 
-  static const Vptr _vptr;
+  static const Vptr _vpntr;
 };
 
 
@@ -434,7 +434,7 @@ class RuntimeStub: public RuntimeBlob {
     }
   };
 
-  static const Vptr _vptr;
+  static const Vptr _vpntr;
 };
 
 
@@ -474,7 +474,7 @@ class SingletonBlob: public RuntimeBlob {
     }
   };
 
-  static const Vptr _vptr;
+  static const Vptr _vpntr;
 };
 
 
@@ -557,7 +557,7 @@ class DeoptimizationBlob: public SingletonBlob {
     }
   };
 
-  static const Vptr _vptr;
+  static const Vptr _vpntr;
 };
 
 
@@ -685,7 +685,7 @@ class UpcallStub: public RuntimeBlob {
     }
   };
 
-  static const Vptr _vptr;
+  static const Vptr _vpntr;
 };
 
 #endif // SHARE_CODE_CODEBLOB_HPP

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -996,7 +996,7 @@ public:
     }
   };
 
-  static const Vptr _vptr;
+  static const Vptr _vpntr;
 };
 
 #endif // SHARE_CODE_NMETHOD_HPP


### PR DESCRIPTION
With this change, I aim to address a build issue caused by the recent #23533 update, which introduced the CodeBlob _vptr field. This naming has led to build failures in HotSpot, reproduced on the Linaro GCC cross-toolchain for AArch64 and ARM32.
```
src/hotspot/share/code/codeBlob.hpp:349:21: error: member '_vptr' conflicts with virtual function table field name
   static const Vptr _vptr;
                     ^~~~~
src/hotspot/share/code/codeBlob.hpp:437:21: error: member '_vptr' conflicts with virtual function table field name
   static const Vptr _vptr;
                     ^~~~~
src/hotspot/share/code/codeBlob.hpp:477:21: error: member '_vptr' conflicts with virtual function table field name
   static const Vptr _vptr;
                     ^~~~~
src/hotspot/share/code/codeBlob.hpp:560:21: error: member '_vptr' conflicts with virtual function table field name
   static const Vptr _vptr; 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350344](https://bugs.openjdk.org/browse/JDK-8350344): Cross-build failure: _vptr name conflict (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23703/head:pull/23703` \
`$ git checkout pull/23703`

Update a local copy of the PR: \
`$ git checkout pull/23703` \
`$ git pull https://git.openjdk.org/jdk.git pull/23703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23703`

View PR using the GUI difftool: \
`$ git pr show -t 23703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23703.diff">https://git.openjdk.org/jdk/pull/23703.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23703#issuecomment-2669135163)
</details>
