### PR TITLE
8320220: Compilation of cyclic hierarchy causes infinite recursion

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2374,7 +2374,12 @@ public class Check {
                 return;
             if (seenClasses.contains(c)) {
                 errorFound = true;
-                noteCyclic(pos, (ClassSymbol)c);
+                log.error(pos, Errors.CyclicInheritance(c));
+                seenClasses.stream()
+                  .filter(s -> !s.type.isErroneous())
+                  .filter(ClassSymbol.class::isInstance)
+                  .map(ClassSymbol.class::cast)
+                  .forEach(Check.this::handleCyclic);
             } else if (!c.type.isErroneous()) {
                 try {
                     seenClasses.add(c);
@@ -2451,7 +2456,8 @@ public class Check {
         if ((c.flags_field & ACYCLIC) != 0) return true;
 
         if ((c.flags_field & LOCKED) != 0) {
-            noteCyclic(pos, (ClassSymbol)c);
+            log.error(pos, Errors.CyclicInheritance(c));
+            handleCyclic((ClassSymbol)c);
         } else if (!c.type.isErroneous()) {
             try {
                 c.flags_field |= LOCKED;
@@ -2478,9 +2484,10 @@ public class Check {
         return complete;
     }
 
-    /** Note that we found an inheritance cycle. */
-    private void noteCyclic(DiagnosticPosition pos, ClassSymbol c) {
-        log.error(pos, Errors.CyclicInheritance(c));
+    /** Handle finding an inheritance cycle on a class by setting
+     *  the class' and its supertypes' types to the error type.
+     **/
+    private void handleCyclic(ClassSymbol c) {
         for (List<Type> l=types.interfaces(c.type); l.nonEmpty(); l=l.tail)
             l.head = types.createErrorType((ClassSymbol)l.head.tsym, Type.noType);
         Type st = types.supertype(c.type);

--- a/test/langtools/tools/javac/ClassCycle/ClassCycle4.java
+++ b/test/langtools/tools/javac/ClassCycle/ClassCycle4.java
@@ -1,0 +1,10 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8320220
+ * @summary Fix infinite recursion in cyclic inheritance situation
+ * @compile/fail/ref=ClassCycle4.out -XDrawDiagnostics ClassCycle4.java
+ */
+
+interface ClassCycle4 extends I1, I2 {}
+interface I1 extends ClassCycle4 {}
+interface I2 extends ClassCycle4 {}

--- a/test/langtools/tools/javac/ClassCycle/ClassCycle4.out
+++ b/test/langtools/tools/javac/ClassCycle/ClassCycle4.out
@@ -1,0 +1,2 @@
+ClassCycle4.java:8:1: compiler.err.cyclic.inheritance: ClassCycle4
+1 error


### PR DESCRIPTION
This input currently causes an infinite loop:
```java
interface A extends B, C {}
interface B extends A {}
interface C extends A {}
```
However, less complicated cycles are handled properly.

When a cycle is found, we currently:
(a) Emit a warning; and
(b) Set the symbol's type to the error type.

These two steps are done in `Check.noteCyclic()`.

Step (b) is what normally prevents the infinite loop from happening later in the compilation. But we only do this for the first class in the loop, presumably because it would be too verbose to do (a) for every class in the loop. But that means we're also only doing (b) for the first class in the loop.

In more complicated scenarios like the bug example, that means some classes in the cycle can escape without (b) being applied. But this is incorrect (or, at least, weirdly indeterminate) because a loop is a loop no matter which class you start with.

So the solution is to continue to do (a) only to the first class in the cycle but do (b) for every class in the cycle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320220](https://bugs.openjdk.org/browse/JDK-8320220): Compilation of cyclic hierarchy causes infinite recursion (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23704/head:pull/23704` \
`$ git checkout pull/23704`

Update a local copy of the PR: \
`$ git checkout pull/23704` \
`$ git pull https://git.openjdk.org/jdk.git pull/23704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23704`

View PR using the GUI difftool: \
`$ git pr show -t 23704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23704.diff">https://git.openjdk.org/jdk/pull/23704.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23704#issuecomment-2672967464)
</details>
