### PR TITLE
8350383: Test: add more test case for string compare (UL case)

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsics.java
@@ -155,6 +155,7 @@ public class TestStringIntrinsics {
                 char cL = latin1.charAt(indexL);
                 char cU = utf16.charAt(indexU);
                 invokeAndCheck(m, cL - cU, latin1, latin1.replace(cL, cU));
+                invokeAndCheck(m, cU - cL, latin1.replace(cL, cU), latin1);
                 invokeAndCheck(m, cU - cL, utf16, utf16.replace(cU, cL));
 
                 // Different lengths


### PR DESCRIPTION
Hi,
Can you help to review this simple test case improvement?

Compared to LL/UU/LU string compare, UL case seems not enough to cover all the code path in intrinsics. This patch is to add these test case for UL string compare.

NOTE: 
* L means string in Latin, 
* U means string in utf, 
* LL string compare means L.compareTo(L),
* LU string compare means L.compareTo(U),
* and so on.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350383](https://bugs.openjdk.org/browse/JDK-8350383): Test: add more test case for string compare (UL case) (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23705/head:pull/23705` \
`$ git checkout pull/23705`

Update a local copy of the PR: \
`$ git checkout pull/23705` \
`$ git pull https://git.openjdk.org/jdk.git pull/23705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23705`

View PR using the GUI difftool: \
`$ git pr show -t 23705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23705.diff">https://git.openjdk.org/jdk/pull/23705.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23705#issuecomment-2669653935)
</details>
