### PR TITLE
8350609: Cleanup unknown unwind opcode (0xB) for windows

### DIFF
--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_atan2_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_atan2_windows_x86.S
@@ -2695,7 +2695,7 @@ _TEXT   ENDS
 
         ALIGN 004H
 _unwind___jsvml_atan28_ha_z0_B1_B10:
-        DD      1873409
+        DD      1611265
         DD      6018198
         DD      4614286
         DD      3569795
@@ -2707,8 +2707,6 @@ _unwind___jsvml_atan28_ha_z0_B1_B10:
         DD      5167169
         DD      5433398
         DD      4913195
-        DD      11356960
-        DD      11426583
         DD      11469067
 
 .xdata  ENDS
@@ -2725,7 +2723,7 @@ _unwind___jsvml_atan28_ha_z0_B1_B10:
 
         ALIGN 004H
 _unwind___jsvml_atan28_ha_z0_B12_B16:
-        DD      1604897
+        DD      1342753
         DD      3757181
         DD      3568754
         DD      3630184
@@ -2736,8 +2734,6 @@ _unwind___jsvml_atan28_ha_z0_B12_B16:
         DD      927797
         DD      1185834
         DD      1443871
-        DD      3439380
-        DD      3500811
         DD      imagerel _B7_1
         DD      imagerel _B7_12
         DD      imagerel _unwind___jsvml_atan28_ha_z0_B1_B10

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_cos_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_cos_windows_x86.S
@@ -925,7 +925,7 @@ _unwind___jsvml_cos8_ha_z0_B1_B10:
 
         ALIGN 004H
 _unwind___jsvml_cos8_ha_z0_B12_B16:
-        DD      3470081
+        DD      2945793
         DD      8606963
         DD      8418537
         DD      8479967
@@ -945,10 +945,6 @@ _unwind___jsvml_cos8_ha_z0_B12_B16:
         DD      3311688
         DD      3569725
         DD      3827762
-        DD      8157991
-        DD      8219422
-        DD      8280853
-        DD      8342284
         DD      5183488
         DD      10343424
         DD      10944768

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_cosh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_cosh_windows_x86.S
@@ -622,7 +622,7 @@ _unwind___jsvml_cosh8_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_cosh8_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -643,10 +643,6 @@ _unwind___jsvml_cosh8_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      10867712
         DD      10944768
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_expm1_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_expm1_windows_x86.S
@@ -1690,7 +1690,7 @@ _unwind___jsvml_expm18_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_expm18_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -1711,10 +1711,6 @@ _unwind___jsvml_expm18_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      10867712
         DD      10944768
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_hypot_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_hypot_windows_x86.S
@@ -1611,7 +1611,7 @@ _unwind___jsvml_hypot8_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_hypot8_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -1632,10 +1632,6 @@ _unwind___jsvml_hypot8_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      11392000
         DD      11469056
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_log1p_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_log1p_windows_x86.S
@@ -1861,7 +1861,7 @@ _unwind___jsvml_log1p8_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_log1p8_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -1882,10 +1882,6 @@ _unwind___jsvml_log1p8_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      10867712
         DD      10944768
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_pow_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_pow_windows_x86.S
@@ -610,7 +610,7 @@ _unwind___jsvml_pow8_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_pow8_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -631,10 +631,6 @@ _unwind___jsvml_pow8_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      11392000
         DD      11469056
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_sin_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_sin_windows_x86.S
@@ -3872,7 +3872,7 @@ _unwind___jsvml_sin8_ha_z0_B1_B10:
 
         ALIGN 004H
 _unwind___jsvml_sin8_ha_z0_B12_B16:
-        DD      2943009
+        DD      2418721
         DD      8082664
         DD      7894238
         DD      7955668
@@ -3891,10 +3891,6 @@ _unwind___jsvml_sin8_ha_z0_B12_B16:
         DD      3053640
         DD      3307581
         DD      3565618
-        DD      7633703
-        DD      7695134
-        DD      7756565
-        DD      7817996
         DD      imagerel _B9_1
         DD      imagerel _B9_12
         DD      imagerel _unwind___jsvml_sin8_ha_z0_B1_B10

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_sinh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_sinh_windows_x86.S
@@ -1942,7 +1942,7 @@ _unwind___jsvml_sinh8_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_sinh8_ha_z0_B11_B15:
-        DD      2808865
+        DD      2284577
         DD      7558364
         DD      7369937
         DD      7431367
@@ -1960,10 +1960,6 @@ _unwind___jsvml_sinh8_ha_z0_B11_B15:
         DD      2799687
         DD      3057724
         DD      3307569
-        DD      7109414
-        DD      7170845
-        DD      7232276
-        DD      7293707
         DD      imagerel _B9_1
         DD      imagerel _B9_11
         DD      imagerel _unwind___jsvml_sinh8_ha_z0_B1_B9

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_tan_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_tan_windows_x86.S
@@ -2366,7 +2366,7 @@ _unwind___jsvml_tan8_ha_z0_B1_B10:
 
         ALIGN 004H
 _unwind___jsvml_tan8_ha_z0_B12_B16:
-        DD      2808865
+        DD      2284577
         DD      7558364
         DD      7369937
         DD      7431367
@@ -2384,10 +2384,6 @@ _unwind___jsvml_tan8_ha_z0_B12_B16:
         DD      2791495
         DD      3049532
         DD      3307569
-        DD      7109414
-        DD      7170845
-        DD      7232276
-        DD      7293707
         DD      imagerel _B5_1
         DD      imagerel _B5_12
         DD      imagerel _unwind___jsvml_tan8_ha_z0_B1_B10

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_tanh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_d_tanh_windows_x86.S
@@ -2133,7 +2133,7 @@ _unwind___jsvml_tanh8_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_tanh8_ha_z0_B11_B15:
-        DD      2674977
+        DD      2150689
         DD      7034065
         DD      6845638
         DD      6907068
@@ -2150,10 +2150,6 @@ _unwind___jsvml_tanh8_ha_z0_B11_B15:
         DD      2525255
         DD      2783292
         DD      3041329
-        DD      6585126
-        DD      6646557
-        DD      6707988
-        DD      6769419
         DD      imagerel _B9_1
         DD      imagerel _B9_11
         DD      imagerel _unwind___jsvml_tanh8_ha_z0_B1_B9

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_atan2_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_atan2_windows_x86.S
@@ -976,11 +976,10 @@ _TEXT   ENDS
 
         ALIGN 004H
 _unwind___jsvml_atan2f16_ha_z0_B1_B10:
-        DD      670721
+        DD      539649
         DD      11326524
         DD      5392436
         DD      5134377
-        DD      11430679
         DD      11469067
 
 .xdata  ENDS
@@ -997,7 +996,7 @@ _unwind___jsvml_atan2f16_ha_z0_B1_B10:
 
         ALIGN 004H
 _unwind___jsvml_atan2f16_ha_z0_B12_B16:
-        DD      2809377
+        DD      2416161
         DD      8017118
         DD      7828691
         DD      7890121
@@ -1016,9 +1015,6 @@ _unwind___jsvml_atan2f16_ha_z0_B12_B16:
         DD      3049534
         DD      3307571
         DD      3565608
-        DD      7633693
-        DD      7691028
-        DD      7752459
         DD      imagerel _B3_1
         DD      imagerel _B3_12
         DD      imagerel _unwind___jsvml_atan2f16_ha_z0_B1_B10

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_cos_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_cos_windows_x86.S
@@ -1172,7 +1172,7 @@ _unwind___jsvml_cosf16_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_cosf16_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -1193,10 +1193,6 @@ _unwind___jsvml_cosf16_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      10867712
         DD      10944768
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_cosh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_cosh_windows_x86.S
@@ -255,7 +255,7 @@ _unwind___jsvml_coshf16_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_coshf16_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -276,10 +276,6 @@ _unwind___jsvml_coshf16_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      10867712
         DD      10944768
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_expm1_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_expm1_windows_x86.S
@@ -939,7 +939,7 @@ _unwind___jsvml_expm1f16_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_expm1f16_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -960,10 +960,6 @@ _unwind___jsvml_expm1f16_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      10867712
         DD      10944768
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_hypot_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_hypot_windows_x86.S
@@ -1043,7 +1043,7 @@ _unwind___jsvml_hypotf16_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_hypotf16_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -1064,10 +1064,6 @@ _unwind___jsvml_hypotf16_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      11392000
         DD      11469056
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_log1p_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_log1p_windows_x86.S
@@ -1117,7 +1117,7 @@ _unwind___jsvml_log1pf16_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_log1pf16_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -1138,10 +1138,6 @@ _unwind___jsvml_log1pf16_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      10867712
         DD      10944768
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_pow_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_pow_windows_x86.S
@@ -291,7 +291,7 @@ _unwind___jsvml_powf16_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_powf16_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -312,10 +312,6 @@ _unwind___jsvml_powf16_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      11392000
         DD      11469056
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_sin_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_sin_windows_x86.S
@@ -264,7 +264,7 @@ _unwind___jsvml_sinf16_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_sinf16_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -285,10 +285,6 @@ _unwind___jsvml_sinf16_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      10867712
         DD      10944768
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_sinh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_sinh_windows_x86.S
@@ -465,7 +465,7 @@ _unwind___jsvml_sinhf16_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_sinhf16_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -486,10 +486,6 @@ _unwind___jsvml_sinhf16_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      10867712
         DD      10944768
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_tan_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_tan_windows_x86.S
@@ -661,7 +661,7 @@ _unwind___jsvml_tanf16_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_tanf16_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -682,10 +682,6 @@ _unwind___jsvml_tanf16_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      10867712
         DD      10944768
 

--- a/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_tanh_windows_x86.S
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/jsvml_s_tanh_windows_x86.S
@@ -660,7 +660,7 @@ _unwind___jsvml_tanhf16_ha_z0_B1_B9:
 
         ALIGN 004H
 _unwind___jsvml_tanhf16_ha_z0_B11_B15:
-        DD      3472641
+        DD      2948353
         DD      9131261
         DD      8942834
         DD      9004264
@@ -681,10 +681,6 @@ _unwind___jsvml_tanhf16_ha_z0_B11_B15:
         DD      3573831
         DD      3831868
         DD      4089905
-        DD      8682278
-        DD      8743709
-        DD      8805140
-        DD      8866571
         DD      10867712
         DD      10944768
 


### PR DESCRIPTION
This PR is to clean-up unknown unwind opcodes (0xB) in Windows intrinsic functions introduced in commit https://github.com/openjdk/jdk17u-dev/commit/9f05c411e6d6bdf612cf0cf8b9fe4ca9ecde50d1#diff-a024df6bcd94607260545e647922261703a652dee1afadb1fa758f6e74a568d1

![image](https://github.com/user-attachments/assets/5b295365-ba8e-4fd6-8b8b-f7243f80a496)

According to the Windows unwind Opcodes outlined at https://learn.microsoft.com/en-us/cpp/build/exception-handling-x64?view=msvc-170#unwind-operation-code, the opcode 0xB (1011) is not a valid Opcode, as the valid opcodes range from 0 to 10.

Test performed:
1.  tier1 tests
2.  Vector tests under /test/jdk/incubator/vector

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350609](https://bugs.openjdk.org/browse/JDK-8350609): Cleanup unknown unwind opcode (0xB) for windows (**Enhancement** - P3)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @vivdesh (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23707/head:pull/23707` \
`$ git checkout pull/23707`

Update a local copy of the PR: \
`$ git checkout pull/23707` \
`$ git pull https://git.openjdk.org/jdk.git pull/23707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23707`

View PR using the GUI difftool: \
`$ git pr show -t 23707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23707.diff">https://git.openjdk.org/jdk/pull/23707.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23707#issuecomment-2680083245)
</details>
