### PR TITLE
8249825: Tests sun/security/ssl/SSLSocketImpl/SetClientMode.java and NonAutoClose.java marked with @ignore

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SetClientMode.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SetClientMode.java
@@ -72,7 +72,7 @@ public class SetClientMode {
         String protocol = args[0];
 
         if ("TLSv1".equals(protocol) || "TLSv1.1".equals(protocol)) {
-          SecurityUtils.removeFromDisabledTlsAlgs(protocol);
+            SecurityUtils.removeFromDisabledTlsAlgs(protocol);
         }
         String keyFilename =
             System.getProperty("test.src", "./") + "/" + pathToStores +
@@ -95,7 +95,7 @@ public class SetClientMode {
             (SSLServerSocketFactory) SSLServerSocketFactory.getDefault();
 
         try (SSLServerSocket serverSocket =
-            (SSLServerSocket) ssf.createServerSocket(serverPort)) {
+                (SSLServerSocket) ssf.createServerSocket(serverPort)) {
             serverSocket.setEnabledProtocols(new String[]{ protocol });
             serverPort = serverSocket.getLocalPort();
 
@@ -140,7 +140,7 @@ public class SetClientMode {
     static class Client extends Thread {
         private final SSLSocket socket;
 
-        public Client(SSLSocket s ) {
+        public Client(SSLSocket s) {
             socket = s;
         }
 
@@ -148,12 +148,7 @@ public class SetClientMode {
             try {
                 socket.startHandshake();
                 HANDSHAKE_COMPLETE.countDown();
-
-                // If we were to invoke setUseClientMode()
-                // here, the expected exception will happen.
-                //clientsideSocket.getSession();
-                //clientsideSocket.setUseClientMode( false );
-            } catch (Exception e ) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }


### PR DESCRIPTION
The following tests are marked with @ignore (not running):

- sun/security/ssl/SSLSocketImpl/SetClientMode.java: it checks that setting the clientMode after the handshake has begun is not permitted, but this was failing intermittently due to a race condition, it was possible that SetClientMode was called before the client socket was updated with handshake `isNegotiated = true`. The fix is to introduce a latch to sync between client and main threads. Included additional refactoring to ensure test stability.

- sun/security/ssl/SSLSocketImpl/NonAutoClose.java: This test should only run in TLS <= 1.2, as TLSv1.3 changes the behaviour of close_notify. Included additional refactoring to ensure test stability.

Executed both tests 10K times, no test flakiness found

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249825](https://bugs.openjdk.org/browse/JDK-8249825): Tests sun/security/ssl/SSLSocketImpl/SetClientMode.java and NonAutoClose.java marked with @<!---->ignore (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23709/head:pull/23709` \
`$ git checkout pull/23709`

Update a local copy of the PR: \
`$ git checkout pull/23709` \
`$ git pull https://git.openjdk.org/jdk.git pull/23709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23709`

View PR using the GUI difftool: \
`$ git pr show -t 23709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23709.diff">https://git.openjdk.org/jdk/pull/23709.diff</a>

</details>
