### PR TITLE
8351344: Avoid explicit Objects.requireNonNull in String.join

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3645,8 +3645,6 @@ public final class String
      */
     public static String join(CharSequence delimiter,
             Iterable<? extends CharSequence> elements) {
-        Objects.requireNonNull(delimiter);
-        Objects.requireNonNull(elements);
         var delim = delimiter.toString();
         var elems = new String[8];
         int size = 0;

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -3648,6 +3648,7 @@ public final class String
         var delim = delimiter.toString();
         var elems = new String[8];
         int size = 0;
+        // implicit null check
         for (CharSequence cs: elements) {
             if (size >= elems.length) {
                 elems = Arrays.copyOf(elems, elems.length << 1);


### PR DESCRIPTION
We have helpful NPE messages now - they are more user-friendly.
And shorter methods are more likely to be inlined.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8351344](https://bugs.openjdk.org/browse/JDK-8351344): Avoid explicit Objects.requireNonNull in String.join (**Enhancement** - P5)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23710/head:pull/23710` \
`$ git checkout pull/23710`

Update a local copy of the PR: \
`$ git checkout pull/23710` \
`$ git pull https://git.openjdk.org/jdk.git pull/23710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23710`

View PR using the GUI difftool: \
`$ git pr show -t 23710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23710.diff">https://git.openjdk.org/jdk/pull/23710.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23710#issuecomment-2703640768)
</details>
