### PR TITLE
8349032: C2: Parse Predicate refactoring in Loop Unswitching broke fix for JDK-8290850

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -94,10 +94,12 @@ void PhaseIdealLoop::register_control(Node* n, IdealLoopTree *loop, Node* pred, 
 //                                           uncommon_trap
 //
 //
-// We will create a region to guard the uct call if there is no one there. The continuation projection (if_cont) of the
-// new_iff is returned which is an IfTrue projection. This code is also used to clone predicates to cloned loops.
-// 'rewire_uncommon_proj_phi_inputs' should be set to the non-default value 'true' when called for a false-path loop
-// during Loop Unswitching.
+// We will create a region to guard the uct call if there is no one there.
+// The continuation projection (if_cont) of the new_iff is returned which
+// is an IfTrue projection. This code is also used to clone predicates to
+// cloned loops. 'rewire_uncommon_proj_phi_inputs' should be set to the
+// non-default value 'true' when called for a false-path loop during
+// Loop Unswitching.
 IfTrueNode* PhaseIdealLoop::create_new_if_for_predicate(const ParsePredicateSuccessProj* parse_predicate_success_proj,
                                                         Node* new_entry, const Deoptimization::DeoptReason reason,
                                                         const int opcode, const bool rewire_uncommon_proj_phi_inputs) {

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -94,10 +94,11 @@ void PhaseIdealLoop::register_control(Node* n, IdealLoopTree *loop, Node* pred, 
 //                                           uncommon_trap
 //
 //
-// We will create a region to guard the uct call if there is no one there.
-// The continuation projection (if_cont) of the new_iff is returned which
-// is an IfTrue projection. This code is also used to clone predicates to cloned loops.
-IfTrueNode* PhaseIdealLoop::create_new_if_for_predicate(ParsePredicateSuccessProj* parse_predicate_success_proj,
+// We will create a region to guard the uct call if there is no one there. The continuation projection (if_cont) of the
+// new_iff is returned which is an IfTrue projection. This code is also used to clone predicates to cloned loops.
+// 'rewire_uncommon_proj_phi_inputs' should be set to the non-default value 'true' when called for a false-path loop
+// during Loop Unswitching.
+IfTrueNode* PhaseIdealLoop::create_new_if_for_predicate(const ParsePredicateSuccessProj* parse_predicate_success_proj,
                                                         Node* new_entry, const Deoptimization::DeoptReason reason,
                                                         const int opcode, const bool rewire_uncommon_proj_phi_inputs) {
   assert(parse_predicate_success_proj->is_uncommon_trap_if_pattern(reason), "must be a uct if pattern!");

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1358,9 +1358,9 @@ public:
                                       bool* p_short_scale, int depth);
 
   // Create a new if above the uncommon_trap_if_pattern for the predicate to be promoted
-  IfTrueNode* create_new_if_for_predicate(
-    ParsePredicateSuccessProj* parse_predicate_proj, Node* new_entry, Deoptimization::DeoptReason reason, int opcode,
-    bool rewire_uncommon_proj_phi_inputs = false);
+  IfTrueNode* create_new_if_for_predicate(const ParsePredicateSuccessProj* parse_predicate_proj, Node* new_entry,
+                                          Deoptimization::DeoptReason reason, int opcode,
+                                          bool rewire_uncommon_proj_phi_inputs = false);
 
  private:
   // Helper functions for create_new_if_for_predicate()

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -81,20 +81,20 @@ ParsePredicateNode* ParsePredicate::init_parse_predicate(const Node* parse_predi
   return nullptr;
 }
 
-ParsePredicate ParsePredicate::clone_to_unswitched_loop(Node* new_control, const bool is_true_path_loop,
+ParsePredicate ParsePredicate::clone_to_unswitched_loop(Node* new_control, const bool is_false_path_loop,
                                                         PhaseIdealLoop* phase) const {
   ParsePredicateSuccessProj* success_proj = phase->create_new_if_for_predicate(_success_proj, new_control,
                                                                                _parse_predicate_node->deopt_reason(),
-                                                                               Op_ParsePredicate, is_true_path_loop);
-  NOT_PRODUCT(trace_cloned_parse_predicate(is_true_path_loop, success_proj));
+                                                                               Op_ParsePredicate, is_false_path_loop);
+  NOT_PRODUCT(trace_cloned_parse_predicate(is_false_path_loop, success_proj));
   return ParsePredicate(success_proj, _parse_predicate_node->deopt_reason());
 }
 
 #ifndef PRODUCT
-void ParsePredicate::trace_cloned_parse_predicate(const bool is_true_path_loop,
+void ParsePredicate::trace_cloned_parse_predicate(const bool is_false_path_loop,
                                                   const ParsePredicateSuccessProj* success_proj) {
   if (TraceLoopPredicate) {
-    tty->print("Parse Predicate cloned to %s path loop: ", is_true_path_loop ? "true" : "false");
+    tty->print("Parse Predicate cloned to %s path loop: ", is_false_path_loop ? "false" : "true");
     success_proj->in(0)->dump();
   }
 }
@@ -1066,8 +1066,8 @@ void CloneUnswitchedLoopPredicatesVisitor::visit(const ParsePredicate& parse_pre
     _has_hoisted_check_parse_predicates = true;
   }
 
-  _clone_predicate_to_true_path_loop.clone_parse_predicate(parse_predicate, true);
-  _clone_predicate_to_false_path_loop.clone_parse_predicate(parse_predicate, false);
+  _clone_predicate_to_true_path_loop.clone_parse_predicate(parse_predicate, false);
+  _clone_predicate_to_false_path_loop.clone_parse_predicate(parse_predicate, true);
   parse_predicate.kill(_phase->igvn());
 }
 

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -296,7 +296,7 @@ class ParsePredicate : public Predicate {
   }
 
   static ParsePredicateNode* init_parse_predicate(const Node* parse_predicate_proj, Deoptimization::DeoptReason deopt_reason);
-  NOT_PRODUCT(static void trace_cloned_parse_predicate(bool is_true_path_loop,
+  NOT_PRODUCT(static void trace_cloned_parse_predicate(bool is_false_path_loop,
                                                        const ParsePredicateSuccessProj* success_proj);)
 
  public:
@@ -327,7 +327,7 @@ class ParsePredicate : public Predicate {
     return _success_proj;
   }
 
-  ParsePredicate clone_to_unswitched_loop(Node* new_control, bool is_true_path_loop,
+  ParsePredicate clone_to_unswitched_loop(Node* new_control, bool is_false_path_loop,
                                           PhaseIdealLoop* phase) const;
 
   // Kills this Parse Predicate by marking it useless. Will be folded away in the next IGVN round.
@@ -1106,9 +1106,9 @@ public:
   ClonePredicateToTargetLoop(LoopNode* target_loop_head, const NodeInLoopBody& node_in_loop_body, PhaseIdealLoop* phase);
 
   // Clones the provided Parse Predicate to the head of the current predicate chain at the target loop.
-  void clone_parse_predicate(const ParsePredicate& parse_predicate, bool is_true_path_loop) {
+  void clone_parse_predicate(const ParsePredicate& parse_predicate, bool is_false_path_loop) {
     ParsePredicate cloned_parse_predicate = parse_predicate.clone_to_unswitched_loop(_old_target_loop_entry,
-                                                                                     is_true_path_loop, _phase);
+                                                                                     is_false_path_loop, _phase);
     _target_loop_predicate_chain.insert_predicate(cloned_parse_predicate);
   }
 

--- a/test/hotspot/jtreg/compiler/predicates/TestParsePredicateUCTWithPhi.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestParsePredicateUCTWithPhi.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8349032
+ * @summary Test that UCT for a Parse Predicate with a Phi does not incorrectly have a top input after Loop Unswitching.
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,*TestParsePredicateUCTWithPhi*::test
+ *                   compiler.predicates.TestParsePredicateUCTWithPhi
+ */
+
+package compiler.predicates;
+
+public class TestParsePredicateUCTWithPhi {
+    static int iFld;
+    static int[][] iArrFld = new int[100][100];
+    static int[] iArr = new int[100];
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10; i++) {
+            test();
+        }
+    }
+
+    static void test() {
+        int i1 = 3;
+        for (int i = 7; i < 28; i++) {
+            int i20 = 4;
+            try {
+                iArr[3] = i1 / i;
+            } catch (ArithmeticException a_e) {
+            }
+            try {
+                i1 = 6 / iArrFld[i][i];
+            } catch (ArithmeticException a_e) {
+            }
+            int i22 = 1;
+            while (++i22 < 7) {
+                try {
+                    i20 = i20 / iArrFld[i][i];
+                    i1 = 0;
+                    i1 = iArr[1] / i;
+                } catch (ArithmeticException a_e) {
+                }
+                iFld = i20;
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the refactoring for [JDK-8344035](https://bugs.openjdk.org/browse/JDK-8344035), the value passed for the `rewire_uncommon_proj_phi_inputs` parameter in `PhaseIdealLoop::create_new_if_for_predicate()` during Loop Unswitching was accidentally flipped. It should only be set to `true` when calling it for a false-path loop, which is the cloned loop. This is currently not the case and leads to a bad graph due to folding nodes wrongly:
https://github.com/openjdk/jdk/blob/735805d9259037ae594eb4f75e96860d43feea5d/src/hotspot/share/opto/predicates.cpp#L84-L88

I fixed this by just flipping the parameter from `is_true_path_loop` to `is_false_path_loop` to avoid a negation. I added an additional comment to `PhaseIdealLoop::create_new_if_for_predicate()` about `rewire_uncommon_proj_phi_inputs`.

More background about why we need `rewire_uncommon_proj_phi_inputs` in the first place can be found in the corresponding fix for [JDK-8290850](https://bugs.openjdk.org/browse/JDK-8290850): https://github.com/openjdk/jdk/pull/11452, and additionally in https://github.com/openjdk/jdk/pull/5185

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349032](https://bugs.openjdk.org/browse/JDK-8349032): C2: Parse Predicate refactoring in Loop Unswitching broke fix for JDK-8290850 (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) Review applies to [b225477e](https://git.openjdk.org/jdk/pull/23712/files/b225477e9a8f14d45ed7be4714a2b43acaf115e1)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23712/head:pull/23712` \
`$ git checkout pull/23712`

Update a local copy of the PR: \
`$ git checkout pull/23712` \
`$ git pull https://git.openjdk.org/jdk.git pull/23712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23712`

View PR using the GUI difftool: \
`$ git pr show -t 23712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23712.diff">https://git.openjdk.org/jdk/pull/23712.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23712#issuecomment-2671345592)
</details>
