### PR TITLE
8350019: HttpClient: DelegatingExecutor should resort to the fallback executor only on RejectedExecutionException

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,13 +172,13 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         public void ensureExecutedAsync(Runnable command) {
             try {
                 delegate.execute(command);
-            } catch (Throwable t) {
+            } catch (RejectedExecutionException t) {
                 errorHandler.accept(command, t);
                 ASYNC_POOL.execute(command);
             }
         }
 
-        private void shutdown() {
+        void shutdown() {
             if (delegate instanceof ExecutorService service) {
                 service.shutdown();
             }

--- a/test/jdk/java/net/httpclient/whitebox/DelegatingExecutorTestDriver.java
+++ b/test/jdk/java/net/httpclient/whitebox/DelegatingExecutorTestDriver.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8350019
+ * @summary Verifies `HttpClientImpl.DelegatingExecutor` behavior
+ * @modules java.net.http/jdk.internal.net.http
+ * @run junit java.net.http/jdk.internal.net.http.DelegatingExecutorTest
+ */

--- a/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/DelegatingExecutorTest.java
+++ b/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/DelegatingExecutorTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.net.http;
+
+import jdk.internal.net.http.HttpClientImpl.DelegatingExecutor;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class DelegatingExecutorTest {
+
+    @Test
+    public void testInlineExecution() {
+        Thread callSiteThread = Thread.currentThread();
+        Thread[] runSiteThreadRef = {null};
+        new DelegatingExecutor(() -> false, null, null)
+                .execute(() -> runSiteThreadRef[0] = Thread.currentThread());
+        assertSame(callSiteThread, runSiteThreadRef[0]);
+    }
+
+    @Test
+    public void testDelegateDeferral() {
+        ImmediateExecutor delegate = new ImmediateExecutor();
+        Runnable task = () -> {};
+        new DelegatingExecutor(() -> true, delegate, null).execute(task);
+        delegate.assertReception(task);
+    }
+
+    @Test
+    public void testRejectedExecutionException() throws InterruptedException {
+
+        // Create a deterministically throwing task
+        RuntimeException error = new RejectedExecutionException();
+        FirstThrowingAndThenCompletingRunnable task = new FirstThrowingAndThenCompletingRunnable(error);
+
+        // Create a recording delegate
+        ImmediateExecutor delegate = new ImmediateExecutor();
+
+        // Create a recording error handler
+        List<Runnable> reportedTasks = new ArrayList<>();
+        List<Throwable> reportedErrors = new ArrayList<>();
+        BiConsumer<Runnable, Throwable> errorHandler = (task_, error_) -> {
+            synchronized (this) {
+                reportedTasks.add(task_);
+                reportedErrors.add(error_);
+            }
+        };
+
+        // Verify the initial failing execution
+        new DelegatingExecutor(() -> true, delegate, errorHandler).execute(task);
+        delegate.assertReception(task);
+
+        // Verify fallback to the async. pool
+        assertEquals(1, reportedTasks.size());
+        assertSame(task, reportedTasks.getFirst());
+        assertEquals(1, reportedErrors.size());
+        assertSame(error, reportedErrors.getFirst());
+        boolean completed = task.completionLatch.await(5, TimeUnit.SECONDS);
+        assertTrue(completed);
+
+    }
+
+    @Test
+    public void testNotRejectedExecutionException() {
+
+        // Create a deterministically throwing task
+        RuntimeException error = new RuntimeException();
+        FirstThrowingAndThenCompletingRunnable task = new FirstThrowingAndThenCompletingRunnable(error);
+
+        // Create a recording delegate
+        ImmediateExecutor delegate = new ImmediateExecutor();
+
+        // Verify the immediate exception propagation
+        Throwable thrownError = assertThrows(
+                Throwable.class,
+                () -> new DelegatingExecutor(() -> true, delegate, null).execute(task));
+        delegate.assertReception(task);
+        assertSame(error, thrownError);
+
+    }
+
+    private static final class ImmediateExecutor implements Executor {
+
+        private final List<Runnable> receivedTasks = new ArrayList<>();
+
+        @Override
+        public synchronized void execute(Runnable task) {
+            receivedTasks.add(task);
+            task.run();
+        }
+
+        private synchronized void assertReception(Runnable... tasks) {
+            assertSame(tasks.length, receivedTasks.size());
+            for (int taskIndex = 0; taskIndex < tasks.length; taskIndex++) {
+                assertSame(tasks[taskIndex], receivedTasks.get(taskIndex));
+            }
+        }
+
+    }
+
+    private static final class FirstThrowingAndThenCompletingRunnable implements Runnable {
+
+        private final AtomicInteger invocationCounter = new AtomicInteger(0);
+
+        private final CountDownLatch completionLatch = new CountDownLatch(1);
+
+        private final RuntimeException exception;
+
+        private FirstThrowingAndThenCompletingRunnable(RuntimeException exception) {
+            this.exception = exception;
+        }
+
+        @Override
+        public void run() {
+            switch (invocationCounter.getAndIncrement()) {
+                case 0: throw exception;
+                case 1: { completionLatch.countDown(); break; }
+                default: fail();
+            }
+        }
+
+    }
+
+    @Test
+    public void testDelegateShutdown() {
+        AtomicInteger invocationCounter = new AtomicInteger();
+        try (ExecutorService delegate = new ThreadPoolExecutor(1, 1, 1, TimeUnit.DAYS, new LinkedBlockingQueue<>()) {
+            @Override
+            public void shutdown() {
+                invocationCounter.incrementAndGet();
+                super.shutdown();
+            }
+        }) {
+            new DelegatingExecutor(() -> true, delegate, null).shutdown();
+            assertEquals(1, invocationCounter.get());
+        }
+    }
+
+}


### PR DESCRIPTION
Updates `HttpClientImpl.DelegatingExecutor` to resort to the fallback executor only on `RejectedExecutionException`. `DelegatingExecutorTest` is added to verify the behavior of `DelegatingExecutor`. `tier1,2` reports are attached to the ticket.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350019](https://bugs.openjdk.org/browse/JDK-8350019): HttpClient: DelegatingExecutor should resort to the fallback executor only on RejectedExecutionException (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23713/head:pull/23713` \
`$ git checkout pull/23713`

Update a local copy of the PR: \
`$ git checkout pull/23713` \
`$ git pull https://git.openjdk.org/jdk.git pull/23713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23713`

View PR using the GUI difftool: \
`$ git pr show -t 23713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23713.diff">https://git.openjdk.org/jdk/pull/23713.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23713#issuecomment-2671686323)
</details>
