### PR TITLE
8350444: Check for verifer error in StackMapReader::check_offset()

### DIFF
--- a/src/hotspot/share/classfile/stackMapTable.cpp
+++ b/src/hotspot/share/classfile/stackMapTable.cpp
@@ -46,7 +46,7 @@ StackMapTable::StackMapTable(StackMapReader* reader, TRAPS) {
   }
 }
 
-void StackMapReader::check_offset(StackMapFrame* frame) {
+void StackMapReader::check_offset(StackMapFrame* frame, TRAPS) {
   int offset = frame->offset();
   if (offset >= _code_length || _code_data[offset] == 0) {
     _verifier->verify_error(ErrorContext::bad_stackmap(0, frame),
@@ -230,7 +230,7 @@ StackMapFrame* StackMapReader::next(TRAPS) {
   check_size(CHECK_NULL);
   StackMapFrame* frame = next_helper(CHECK_VERIFY_(_verifier, nullptr));
   if (frame != nullptr) {
-    check_offset(frame);
+    check_offset(frame, CHECK_VERIFY_(frame->verifier(), nullptr));
     _prev_frame = frame;
   }
   return frame;

--- a/src/hotspot/share/classfile/stackMapTable.cpp
+++ b/src/hotspot/share/classfile/stackMapTable.cpp
@@ -46,7 +46,7 @@ StackMapTable::StackMapTable(StackMapReader* reader, TRAPS) {
   }
 }
 
-void StackMapReader::check_offset(StackMapFrame* frame, TRAPS) {
+void StackMapReader::check_offset(StackMapFrame* frame) {
   int offset = frame->offset();
   if (offset >= _code_length || _code_data[offset] == 0) {
     _verifier->verify_error(ErrorContext::bad_stackmap(0, frame),
@@ -230,7 +230,10 @@ StackMapFrame* StackMapReader::next(TRAPS) {
   check_size(CHECK_NULL);
   StackMapFrame* frame = next_helper(CHECK_VERIFY_(_verifier, nullptr));
   if (frame != nullptr) {
-    check_offset(frame, CHECK_VERIFY_(frame->verifier(), nullptr));
+    check_offset(frame);
+    if (frame->verifier()->has_error()) {
+      return nullptr;
+    }
     _prev_frame = frame;
   }
   return frame;

--- a/src/hotspot/share/classfile/stackMapTable.hpp
+++ b/src/hotspot/share/classfile/stackMapTable.hpp
@@ -131,7 +131,7 @@ class StackMapReader : StackObj {
   bool _first;
 
   StackMapFrame* next_helper(TRAPS);
-  void check_offset(StackMapFrame* frame);
+  void check_offset(StackMapFrame* frame, TRAPS);
   void check_size(TRAPS);
   int32_t chop(VerificationType* locals, int32_t length, int32_t chops);
   VerificationType parse_verification_type(u1* flags, TRAPS);

--- a/src/hotspot/share/classfile/stackMapTable.hpp
+++ b/src/hotspot/share/classfile/stackMapTable.hpp
@@ -131,7 +131,7 @@ class StackMapReader : StackObj {
   bool _first;
 
   StackMapFrame* next_helper(TRAPS);
-  void check_offset(StackMapFrame* frame, TRAPS);
+  void check_offset(StackMapFrame* frame);
   void check_size(TRAPS);
   int32_t chop(VerificationType* locals, int32_t length, int32_t chops);
   VerificationType parse_verification_type(u1* flags, TRAPS);


### PR DESCRIPTION
This small patch adds error propagation in the newly added `check_offset()` method. Verified with tier 1-5 tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350444](https://bugs.openjdk.org/browse/JDK-8350444): Check for verifer error in StackMapReader::check_offset() (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23717/head:pull/23717` \
`$ git checkout pull/23717`

Update a local copy of the PR: \
`$ git checkout pull/23717` \
`$ git pull https://git.openjdk.org/jdk.git pull/23717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23717`

View PR using the GUI difftool: \
`$ git pr show -t 23717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23717.diff">https://git.openjdk.org/jdk/pull/23717.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23717#issuecomment-2672557685)
</details>
