### PR TITLE
8261669: Add lint warning for widening primitive conversions that lose information

### DIFF
--- a/make/CompileDemos.gmk
+++ b/make/CompileDemos.gmk
@@ -173,14 +173,14 @@ $(BUILD_DEMO_CodePointIM_JAR): $(CODEPOINT_METAINF_SERVICE_FILE)
 
 $(eval $(call SetupBuildDemo, FileChooserDemo, \
     DEMO_SUBDIR := jfc, \
-    DISABLED_WARNINGS := rawtypes deprecation unchecked this-escape, \
+    DISABLED_WARNINGS := rawtypes deprecation unchecked this-escape lossy-conversions, \
 ))
 
 $(eval $(call SetupBuildDemo, SwingSet2, \
     DEMO_SUBDIR := jfc, \
     EXTRA_COPY_TO_JAR := .java, \
     EXTRA_MANIFEST_ATTR := SplashScreen-Image: resources/images/splash.png, \
-    DISABLED_WARNINGS := rawtypes deprecation unchecked static serial cast this-escape, \
+    DISABLED_WARNINGS := rawtypes deprecation unchecked static serial cast this-escape lossy-conversions, \
 ))
 
 $(eval $(call SetupBuildDemo, Font2DTest, \
@@ -222,7 +222,7 @@ $(eval $(call SetupBuildDemo, TableExample, \
 ))
 
 $(eval $(call SetupBuildDemo, TransparentRuler, \
-    DISABLED_WARNINGS := this-escape, \
+    DISABLED_WARNINGS := this-escape lossy-conversions, \
     DEMO_SUBDIR := jfc, \
     MAIN_CLASS := transparentruler.Ruler, \
 ))

--- a/make/CompileToolsJdk.gmk
+++ b/make/CompileToolsJdk.gmk
@@ -47,7 +47,7 @@ $(eval $(call SetupJavaCompilation, BUILD_TOOLS_JDK, \
         build/tools/jigsaw \
         build/tools/depend, \
     BIN := $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes, \
-    DISABLED_WARNINGS := dangling-doc-comments options, \
+    DISABLED_WARNINGS := dangling-doc-comments options lossy-conversions, \
     JAVAC_FLAGS := \
         --add-exports java.desktop/sun.awt=ALL-UNNAMED \
         --add-exports java.base/sun.text=ALL-UNNAMED \

--- a/make/modules/java.base/Java.gmk
+++ b/make/modules/java.base/Java.gmk
@@ -28,8 +28,8 @@
 # The base module should be built with all warnings enabled. When a
 # new warning is added to javac, it can be temporarily added to the
 # disabled warnings list.
-#
-# DISABLED_WARNINGS_java +=
+
+DISABLED_WARNINGS_java += lossy-conversions
 
 DOCLINT += -Xdoclint:all/protected \
     '-Xdoclint/package:java.*,javax.*'

--- a/make/modules/jdk.hotspot.agent/Java.gmk
+++ b/make/modules/jdk.hotspot.agent/Java.gmk
@@ -26,7 +26,7 @@
 ################################################################################
 
 DISABLED_WARNINGS_java += rawtypes serial cast static overrides \
-    dangling-doc-comments fallthrough this-escape
+    dangling-doc-comments fallthrough this-escape lossy-conversions
 COPY += .gif .png .properties
 
 ################################################################################

--- a/make/modules/jdk.internal.vm.ci/Java.gmk
+++ b/make/modules/jdk.internal.vm.ci/Java.gmk
@@ -25,7 +25,7 @@
 
 ################################################################################
 
-DISABLED_WARNINGS_java += dangling-doc-comments this-escape
+DISABLED_WARNINGS_java += dangling-doc-comments this-escape lossy-conversions
 
 # -parameters provides method's parameters information in class file,
 # JVMCI compilers make use of that information for various sanity checks.

--- a/make/modules/jdk.jfr/Java.gmk
+++ b/make/modules/jdk.jfr/Java.gmk
@@ -25,7 +25,7 @@
 
 ################################################################################
 
-DISABLED_WARNINGS_java += dangling-doc-comments exports
+DISABLED_WARNINGS_java += dangling-doc-comments exports lossy-conversions
 COPY := .xsd .xml .dtd .ini
 JAVAC_FLAGS := -XDstringConcat=inline
 

--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -84,7 +84,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
     CLASSPATH := $(JMH_COMPILE_JARS), \
     CREATE_API_DIGEST := true, \
     DISABLED_WARNINGS := restricted this-escape processing rawtypes removal cast \
-        serial preview dangling-doc-comments, \
+        serial preview dangling-doc-comments lossy-conversions, \
     SRC := $(MICROBENCHMARK_SRC), \
     BIN := $(MICROBENCHMARK_CLASSES), \
     JAVAC_FLAGS := \

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeTag.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeTag.java
@@ -54,14 +54,14 @@ public enum TypeTag {
 
     /** The tag of the basic type `long'.
      */
-    LONG(LONG_CLASS, LONG_SUPERCLASSES, true),
+    LONG(LONG_CLASS, LONG_SUPERCLASSES, LONG_LOSSY_SUPERCLASSES, true),
 
     /** The tag of the basic type `float'.
      */
     FLOAT(FLOAT_CLASS, FLOAT_SUPERCLASSES, true),
     /** The tag of the basic type `int'.
      */
-    INT(INT_CLASS, INT_SUPERCLASSES, true),
+    INT(INT_CLASS, INT_SUPERCLASSES, INT_LOSSY_SUPERCLASSES, true),
     /** The tag of the basic type `double'.
      */
     DOUBLE(DOUBLE_CLASS, DOUBLE_CLASS, true),
@@ -133,6 +133,7 @@ public enum TypeTag {
 
     final int superClasses;
     final int numericClass;
+    final int lossySuperClasses;
     final boolean isPrimitive;
 
     private TypeTag() {
@@ -140,8 +141,13 @@ public enum TypeTag {
     }
 
     private TypeTag(int numericClass, int superClasses, boolean isPrimitive) {
-        this.superClasses = superClasses;
+        this(numericClass, superClasses, 0, isPrimitive);
+    }
+
+    private TypeTag(int numericClass, int superClasses, int lossySuperClasses, boolean isPrimitive) {
         this.numericClass = numericClass;
+        this.superClasses = superClasses;
+        this.lossySuperClasses = lossySuperClasses;
         this.isPrimitive = isPrimitive;
     }
 
@@ -164,8 +170,10 @@ public enum TypeTag {
                 LONG_CLASS | FLOAT_CLASS | DOUBLE_CLASS;
 
         static final int INT_SUPERCLASSES = INT_CLASS | LONG_CLASS | FLOAT_CLASS | DOUBLE_CLASS;
+        static final int INT_LOSSY_SUPERCLASSES = FLOAT_CLASS;
 
         static final int LONG_SUPERCLASSES = LONG_CLASS | FLOAT_CLASS | DOUBLE_CLASS;
+        static final int LONG_LOSSY_SUPERCLASSES = FLOAT_CLASS | DOUBLE_CLASS;
 
         static final int FLOAT_SUPERCLASSES = FLOAT_CLASS | DOUBLE_CLASS;
     }
@@ -184,6 +192,10 @@ public enum TypeTag {
 
     public boolean isInSuperClassesOf(TypeTag tag) {
         return (this.numericClass & tag.superClasses) != 0;
+    }
+
+    public boolean isInLossySuperclassesOf(TypeTag tag) {
+        return (this.numericClass & tag.lossySuperClasses) != 0;
     }
 
     /** Returns the number of type tags.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ConstFold.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ConstFold.java
@@ -316,24 +316,51 @@ strictfp class ConstFold {
          if (etype.tsym.type == ttype.tsym.type)
              return etype;
          if (etype.isNumeric()) {
-             Object n = etype.constValue();
+             Number folded = fold((Number)etype.constValue(), ttype);
              switch (ttype.getTag()) {
              case BYTE:
-                 return syms.byteType.constType(0 + (byte)intValue(n));
+                 return syms.byteType.constType(folded);
              case CHAR:
-                 return syms.charType.constType(0 + (char)intValue(n));
+                 return syms.charType.constType(folded);
              case SHORT:
-                 return syms.shortType.constType(0 + (short)intValue(n));
+                 return syms.shortType.constType(folded);
              case INT:
-                 return syms.intType.constType(intValue(n));
+                 return syms.intType.constType(folded);
              case LONG:
-                 return syms.longType.constType(longValue(n));
+                 return syms.longType.constType(folded);
              case FLOAT:
-                 return syms.floatType.constType(floatValue(n));
+                 return syms.floatType.constType(folded);
              case DOUBLE:
-                 return syms.doubleType.constType(doubleValue(n));
+                 return syms.doubleType.constType(folded);
              }
          }
          return ttype;
      }
+
+    /** Fold the given numeric constant to fit into the target numeric type.
+     *  For types smaller than 32 bits, {@link Integer}s are returned.
+     *  @param value      constant value
+     *  @param ttype      The target type of the coercion
+     *  @return folded value, or null if operation is invalid
+     */
+    Number fold(Number value, Type ttype) {
+        switch (ttype.getTag()) {
+        case BYTE:
+            return (int)value.byteValue();
+        case CHAR:
+            return (int)(char)value.intValue();
+        case SHORT:
+            return (int)value.shortValue();
+        case INT:
+            return value.intValue();
+        case LONG:
+            return value.longValue();
+        case FLOAT:
+            return value.floatValue();
+        case DOUBLE:
+            return value.doubleValue();
+        default:
+            return null;
+        }
+    }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -2796,6 +2796,16 @@ compiler.misc.possible.loss.of.precision=\
 compiler.warn.possible.loss.of.precision=\
     implicit cast from {0} to {1} in compound assignment is possibly lossy
 
+# 0: type, 1: type
+# lint: lossy-conversions
+compiler.warn.possible.loss.of.precision.assignment=\
+    implicit cast from {0} to {1} in assignment is possibly lossy
+
+# 0: type, 1: type
+# lint: lossy-conversions
+compiler.warn.possible.loss.of.precision.parameter=\
+    implicit cast from {0} to {1} in parameter is possibly lossy
+
 compiler.misc.unchecked.assign=\
     unchecked conversion
 

--- a/test/langtools/tools/javac/diags/examples/LossyConversion.java
+++ b/test/langtools/tools/javac/diags/examples/LossyConversion.java
@@ -22,10 +22,16 @@
  */
 
 // key: compiler.warn.possible.loss.of.precision
+// key: compiler.warn.possible.loss.of.precision.assignment
+// key: compiler.warn.possible.loss.of.precision.parameter
 // options: -Xlint:lossy-conversions
 
 class LossyConversion {
     void m(int a) {
-        a += 1.0;
+        a += 1.0;               // compound
+        float b = 0x10000001;   // assignment
+        m2(0x10000001);         // parameter
+    }
+    void m2(float f) {
     }
 }

--- a/test/langtools/tools/javac/lint/LossyConversions.java
+++ b/test/langtools/tools/javac/lint/LossyConversions.java
@@ -113,15 +113,15 @@ public class LossyConversions {
 
         e += a; e -= a; e *= a; e /= a; //no warnings
         e += b; e -= b; e *= b; e /= b; //no warnings
-        e += c; e -= c; e *= c; e /= c; //no warnings
-        e += d; e -= d; e *= d; e /= d; //no warnings
+        e += c; e -= c; e *= c; e /= c;
+        e += d; e -= d; e *= d; e /= d;
         e += e; e -= e; e *= e; e /= e; //no warnings
         e += f; e -= f; e *= f; e /= f;
 
         f += a; f -= a; f *= a; f /= a; //no warnings
         f += b; f -= b; f *= b; f /= b; //no warnings
         f += c; f -= c; f *= c; f /= c; //no warnings
-        f += d; f -= d; f *= d; f /= d; //no warnings
+        f += d; f -= d; f *= d; f /= d;
         f += e; f -= e; f *= e; f /= e; //no warnings
         f += f; f -= f; f *= f; f /= f; //no warnings
     }
@@ -188,5 +188,44 @@ public class LossyConversions {
         d += f; d -= f; d *= f; d /= f;
 
         e += f; e -= f; e *= f; e /= f;
+    }
+
+    public static final int INT2FLOAT_SAFE   = 0x10000000;
+    public static final int INT2FLOAT_UNSAFE = 0x10000001;
+
+    public static final long LONG2FLOAT_SAFE   = 0x10000000L;
+    public static final long LONG2FLOAT_UNSAFE = 0x10000001L;
+
+    public static final long LONG2DOUBLE_SAFE   = 0x1000000000000000L;
+    public static final long LONG2DOUBLE_UNSAFE = 0x1000000000000001L;
+
+    public void lossyAssignments() {
+
+        float f;
+        double d;
+
+        f = INT2FLOAT_SAFE;             // no warning
+        f = INT2FLOAT_UNSAFE;
+
+        f = LONG2FLOAT_SAFE;            // no warning
+        f = LONG2FLOAT_UNSAFE;
+
+        d = LONG2DOUBLE_SAFE;           // no warning
+        d = LONG2DOUBLE_UNSAFE;
+
+        floatMethod(INT2FLOAT_SAFE);    // no warning
+        floatMethod(INT2FLOAT_UNSAFE);
+
+        floatMethod(LONG2FLOAT_SAFE);   // no warning
+        floatMethod(LONG2FLOAT_UNSAFE);
+
+        doubleMethod(LONG2DOUBLE_SAFE); // no warning
+        doubleMethod(LONG2DOUBLE_UNSAFE);
+    }
+
+    public void floatMethod(float x) {
+    }
+
+    public void doubleMethod(double x) {
     }
 }

--- a/test/langtools/tools/javac/lint/LossyConversions.out
+++ b/test/langtools/tools/javac/lint/LossyConversions.out
@@ -170,10 +170,28 @@ LossyConversions.java:112:14: compiler.warn.possible.loss.of.precision: double, 
 LossyConversions.java:112:22: compiler.warn.possible.loss.of.precision: double, long
 LossyConversions.java:112:30: compiler.warn.possible.loss.of.precision: double, long
 LossyConversions.java:112:38: compiler.warn.possible.loss.of.precision: double, long
+LossyConversions.java:116:14: compiler.warn.possible.loss.of.precision: int, float
+LossyConversions.java:116:22: compiler.warn.possible.loss.of.precision: int, float
+LossyConversions.java:116:30: compiler.warn.possible.loss.of.precision: int, float
+LossyConversions.java:116:38: compiler.warn.possible.loss.of.precision: int, float
+LossyConversions.java:117:14: compiler.warn.possible.loss.of.precision: long, float
+LossyConversions.java:117:22: compiler.warn.possible.loss.of.precision: long, float
+LossyConversions.java:117:30: compiler.warn.possible.loss.of.precision: long, float
+LossyConversions.java:117:38: compiler.warn.possible.loss.of.precision: long, float
 LossyConversions.java:119:14: compiler.warn.possible.loss.of.precision: double, float
 LossyConversions.java:119:22: compiler.warn.possible.loss.of.precision: double, float
 LossyConversions.java:119:30: compiler.warn.possible.loss.of.precision: double, float
 LossyConversions.java:119:38: compiler.warn.possible.loss.of.precision: double, float
+LossyConversions.java:124:14: compiler.warn.possible.loss.of.precision: long, double
+LossyConversions.java:124:22: compiler.warn.possible.loss.of.precision: long, double
+LossyConversions.java:124:30: compiler.warn.possible.loss.of.precision: long, double
+LossyConversions.java:124:38: compiler.warn.possible.loss.of.precision: long, double
+LossyConversions.java:208:13: compiler.warn.possible.loss.of.precision.assignment: int, float
+LossyConversions.java:211:13: compiler.warn.possible.loss.of.precision.assignment: long, float
+LossyConversions.java:214:13: compiler.warn.possible.loss.of.precision.assignment: long, double
+LossyConversions.java:217:21: compiler.warn.possible.loss.of.precision.parameter: int, float
+LossyConversions.java:220:21: compiler.warn.possible.loss.of.precision.parameter: long, float
+LossyConversions.java:223:22: compiler.warn.possible.loss.of.precision.parameter: long, double
 - compiler.err.warnings.and.werror
 1 error
-176 warnings
+194 warnings


### PR DESCRIPTION
This PR is a prototype to stimulate discussion of [JDK-8261669](https://bugs.openjdk.org/browse/JDK-8261669), which seeks to add more warnings when an implicit cast of a primitive value might lose information. This can possibly happen when converting an `int` to `float`, or when converting a `long` to `float` or `double`. Java does not require an explicit cast for such assignments, even though they may result in information loss.

I'm interested in feedback both on whether this is a good idea and also the approach taken - thanks!

Currently, we generate this warning, but only for assignment operators, e.g.:
```java
int x = 0;
x += 1.0f;   // warning here
```

This PR would add warnings for two additional cases, (a) regular assignments and (b) method parameters, e.g.:
```java
void method(float f) { }
...
float a = 0x10000001;   // warning here
method(0x10000001);     // warning here
```

It would _not_ generate a warning in cases (a) and (b) when the value is a constant value and we can determine that no information would be lost, e.g.:
```java
float f1 = 0x10000000;     // no warning here
```
The definition of "no information would be lost" is that a round trip results in the same value, e.g., `(int)(float)x == x`. In the examples above, `0x10000000` survives the round trip but `0x10000001` does not.

As usual, warnings can be suppressed via `@SuppressWarnings` or by adding an explicit cast:

```java
float a = (float)0x10000001;   // no warning here
```