### PR TITLE
8350386: Test TestCodeCacheFull.java fails with option -XX:-UseCodeCacheFlushing

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
@@ -36,6 +36,7 @@ import jdk.test.whitebox.code.BlobType;
 /**
  * @test TestCodeCacheFull
  * @requires vm.hasJFR
+ * @requires vm.opt.UseCodeCacheFlushing == null | vm.opt.UseCodeCacheFlushing == true
  *
  * @library /test/lib
  * @modules jdk.jfr
@@ -45,7 +46,6 @@ import jdk.test.whitebox.code.BlobType;
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *     -XX:+UseCodeCacheFlushing
  *     -XX:+SegmentedCodeCache -XX:-UseLargePages jdk.jfr.event.compiler.TestCodeCacheFull
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI

--- a/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ import jdk.test.whitebox.code.BlobType;
  *
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:+UseCodeCacheFlushing
  *     -XX:+SegmentedCodeCache -XX:-UseLargePages jdk.jfr.event.compiler.TestCodeCacheFull
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI


### PR DESCRIPTION
Hi all,

Test jdk/jfr/event/compiler/TestCodeCacheFull.java fails with option `-XX:-UseCodeCacheFlushing`, because this test is incompatible with `-XX:-UseCodeCacheFlushing` when `-XX:+SegmentedCodeCache` is enable, the detail analyze has been recorded by [JDK-8350386](https://bugs.openjdk.org/browse/JDK-8350386). This PR add `* @requires vm.opt.UseCodeCacheFlushing == null | vm.opt.UseCodeCacheFlushing == true` to make sure `UseCodeCacheFlushing` is not set or set as true.

Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350386](https://bugs.openjdk.org/browse/JDK-8350386): Test TestCodeCacheFull.java fails with option -XX:-UseCodeCacheFlushing (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23721/head:pull/23721` \
`$ git checkout pull/23721`

Update a local copy of the PR: \
`$ git checkout pull/23721` \
`$ git pull https://git.openjdk.org/jdk.git pull/23721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23721`

View PR using the GUI difftool: \
`$ git pr show -t 23721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23721.diff">https://git.openjdk.org/jdk/pull/23721.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23721#issuecomment-2673308092)
</details>
