### PR TITLE
8350480: RISC-V: Relax assertion about registers in C2_MacroAssembler::minmax_fp

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2135,7 +2135,8 @@ void C2_MacroAssembler::enc_cmove(int cmpFlag, Register op1, Register op2, Regis
 // Set dst to NaN if any NaN input.
 void C2_MacroAssembler::minmax_fp(FloatRegister dst, FloatRegister src1, FloatRegister src2,
                                   bool is_double, bool is_min) {
-  assert_different_registers(dst, src1, src2);
+  assert_different_registers(dst, src1);
+  assert_different_registers(dst, src2);
 
   Label Done, Compare;
 


### PR DESCRIPTION
Hi, please review this trivial change.
The current assertion about the registers is more than needed.
It requires that `dst`, `src1` and `src2` must be different from each other.
But the code only required that `dst` must be different from `src1` and `src2`.
Patch simply relaxes the assersion removing the unneeded constraint.
fastdebug builds OK with change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350480](https://bugs.openjdk.org/browse/JDK-8350480): RISC-V: Relax assertion about registers in C2_MacroAssembler::minmax_fp (**Bug** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23723/head:pull/23723` \
`$ git checkout pull/23723`

Update a local copy of the PR: \
`$ git checkout pull/23723` \
`$ git pull https://git.openjdk.org/jdk.git pull/23723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23723`

View PR using the GUI difftool: \
`$ git pr show -t 23723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23723.diff">https://git.openjdk.org/jdk/pull/23723.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23723#issuecomment-2673612370)
</details>
