### PR TITLE
8347459: C2: missing transformation for chain of shifts/multiplications by constants

### DIFF
--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -579,7 +579,7 @@ protected:
   virtual bool depends_only_on_test() const { return false; }
 
   Node *Ideal_masked_input       (PhaseGVN *phase, uint mask);
-  Node *Ideal_sign_extended_input(PhaseGVN *phase, int  num_bits);
+  Node* Ideal_sign_extended_input(PhaseGVN* phase, int num_rejected_bits);
 
 public:
   // We must ensure that stores of object references will be visible

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -993,11 +993,7 @@ static Node* collapseDoubleShiftLeft(PhaseGVN* phase, Node* outer_shift, int con
   }
 
   if (con0 + con1 >= nbits) {
-    if (bt == T_INT) {
-      return phase->intcon(0);
-    } else {
-      return phase->longcon(0);
-    }
+    return ConNode::make(TypeInteger::zero(bt));
   }
 
   // con0 + con1 < nbits ==> actual shift happens now

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -974,7 +974,7 @@ static int maskShiftAmount(PhaseGVN* phase, Node* shiftNode, int nBits) {
 // if con0 + con1 >= nbits => 0
 // if con0 + con1 < nbits => X << (con1 + con0)
 static Node* collapseDoubleShiftLeft(PhaseGVN* phase, Node* outer_shift, int con0, int nbits, BasicType bt) {
-  Node *inner_shift = outer_shift->in(1);
+  Node* inner_shift = outer_shift->in(1);
   int inner_shift_op = inner_shift->Opcode();
   if (inner_shift_op != Op_LShift(bt)) {
     return nullptr;

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1019,7 +1019,7 @@ Node* LShiftINode::Identity(PhaseGVN* phase) {
 // If the right input is a constant, and the left input is an add of a
 // constant, flatten the tree: (X+con1)<<con0 ==> X<<con0 + con1<<con0
 //
-// (X << con1) << con2 ==> X << (con1 + con2) (see collapseDoubleShiftLeft for corner cases)
+// (X << con1) << con2 ==> X << (con1 + con2) (see collapseDoubleShiftLeft for details)
 Node *LShiftINode::Ideal(PhaseGVN *phase, bool can_reshape) {
   int con = maskShiftAmount(phase, this, BitsPerJavaInteger);
   if (con == 0) {
@@ -1202,7 +1202,7 @@ Node* LShiftLNode::Identity(PhaseGVN* phase) {
 // If the right input is a constant, and the left input is an add of a
 // constant, flatten the tree: (X+con1)<<con0 ==> X<<con0 + con1<<con0
 //
-// (X << con1) << con2 ==> X << (con1 + con2) (see collapseDoubleShiftLeft for corner cases)
+// (X << con1) << con2 ==> X << (con1 + con2) (see collapseDoubleShiftLeft for details)
 Node *LShiftLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   int con = maskShiftAmount(phase, this, BitsPerJavaLong);
   if (con == 0) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
@@ -37,16 +37,26 @@ public class LShiftINodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test = { "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8",
-                  "testDoubleShift1",
-                  "testDoubleShift2",
-                  "testDoubleShift3",
-                  "testDoubleShift4",
-                  "testDoubleShift5",
-                  "testDoubleShift6",
-                  "testDoubleShift7",
-    })
-    public void runMethod() {
+    @Run(test =
+             {
+                 "test1",
+                 "test2",
+                 "test3",
+                 "test4",
+                 "test5",
+                 "test6",
+                 "test7",
+                 "test8",
+                 "testDoubleShift1",
+                 "testDoubleShift2",
+                 "testDoubleShift3",
+                 "testDoubleShift4",
+                 "testDoubleShift5",
+                 "testDoubleShift6",
+                 "testDoubleShift7",
+             })
+    public void
+    runMethod() {
         int a = RunInfo.getRandom().nextInt();
         int b = RunInfo.getRandom().nextInt();
         int c = RunInfo.getRandom().nextInt();
@@ -154,51 +164,51 @@ public class LShiftINodeIdealizationTests {
     }
 
     @Test
-    @IR(counts = { IRNode.LSHIFT, "1"})
+    @IR(counts = {IRNode.LSHIFT, "1"})
     // Checks (x << 2) << 3 => x << 5
     public int testDoubleShift1(int x) {
         return (x << 2) << 3;
     }
 
     @Test
-    @IR(counts = { IRNode.LSHIFT, "1"})
+    @IR(counts = {IRNode.LSHIFT, "1"})
     // Checks ((x << 2) << 3) << 1 => x << 6
     public int testDoubleShift2(int x) {
         return ((x << 2) << 3) << 1;
     }
 
     @Test
-    @IR(failOn = { IRNode.LSHIFT })
+    @IR(failOn = {IRNode.LSHIFT})
     // Checks (x << 31) << 1 => 0
     public int testDoubleShift3(int x) {
         return (x << 31) << 1;
     }
 
     @Test
-    @IR(failOn = { IRNode.LSHIFT })
+    @IR(failOn = {IRNode.LSHIFT})
     // Checks (x << 1) << 31 => 0
     public int testDoubleShift4(int x) {
         return (x << 1) << 31;
     }
 
     @Test
-    @IR(failOn = { IRNode.LSHIFT })
+    @IR(failOn = {IRNode.LSHIFT})
     // Checks ((x << 30) << 1) << 1 => 0
     public int testDoubleShift5(int x) {
         return ((x << 30) << 1) << 1;
     }
 
     @Test
-    @IR(failOn = { IRNode.MUL })
-    @IR(counts = { IRNode.LSHIFT, "1"})
+    @IR(failOn = {IRNode.MUL})
+    @IR(counts = {IRNode.LSHIFT, "1"})
     // Checks (x * 4) << 3 => x << 5
     public int testDoubleShift6(int x) {
         return (x * 4) << 3;
     }
 
     @Test
-    @IR(failOn = { IRNode.MUL })
-    @IR(counts = { IRNode.LSHIFT, "1"})
+    @IR(failOn = {IRNode.MUL})
+    @IR(counts = {IRNode.LSHIFT, "1"})
     // Checks (x << 3) * 4 => x << 5
     public int testDoubleShift7(int x) {
         return (x << 3) * 4;

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
@@ -38,7 +38,15 @@ public class LShiftINodeIdealizationTests {
     }
 
     @Run(test = {"test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8",
-            "testDoubleShift1", "testDoubleShift2", "testDoubleShift3", "testDoubleShift4", "testDoubleShift5", "testDoubleShift6", "testDoubleShift7",})
+            "testDoubleShift1",
+            "testDoubleShift2",
+            "testDoubleShift3",
+            "testDoubleShift4",
+            "testDoubleShift5",
+            "testDoubleShift6",
+            "testDoubleShift7",
+            "testDoubleShiftSliceAndStore",
+    })
     public void runMethod() {
         int a = RunInfo.getRandom().nextInt();
         int b = RunInfo.getRandom().nextInt();
@@ -144,6 +152,10 @@ public class LShiftINodeIdealizationTests {
         Asserts.assertEQ(((a << 30) << 1) << 1, testDoubleShift5(a));
         Asserts.assertEQ((a * 4) << 3, testDoubleShift6(a));
         Asserts.assertEQ((a << 3) * 4, testDoubleShift7(a));
+
+        short[] arr = new short[1];
+        arr[0] = (short)1;
+        Asserts.assertEQ((short)(1 << 3), testDoubleShiftSliceAndStore(arr)[0]);
     }
 
     @Test
@@ -195,5 +207,15 @@ public class LShiftINodeIdealizationTests {
     // Checks (x << 3) * 4 => x << 5
     public int testDoubleShift7(int x) {
         return (x << 3) * 4;
+    }
+
+    @Test
+    @IR(failOn = {IRNode.MUL, IRNode.RSHIFT})
+    @IR(counts = {IRNode.LSHIFT, "1"})
+    // Checks (short) (a[0] << 3) => (((a[0] << 3) << 16) >> 16) => ((a[0] << 19) >> 16) => (a[0] << 3)
+    public short[] testDoubleShiftSliceAndStore(short[] a) {
+        short[] res = new short[1];
+        res[0] = (short) (a[0] << 3);
+        return res;
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
@@ -37,7 +37,9 @@ public class LShiftINodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test = { "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8" })
+    @Run(test = { "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8",
+                  "testDoubleShift1", "testDoubleShift2", "testDoubleShift3", "testDoubleShift4", "testDoubleShift5"
+    })
     public void runMethod() {
         int a = RunInfo.getRandom().nextInt();
         int b = RunInfo.getRandom().nextInt();
@@ -66,6 +68,8 @@ public class LShiftINodeIdealizationTests {
         Asserts.assertEQ((a >>> 8) << 4, test6(a));
         Asserts.assertEQ(((a >> 4) & 0xFF) << 8, test7(a));
         Asserts.assertEQ(((a >>> 4) & 0xFF) << 8, test8(a));
+
+        assertDoubleShiftResult(a);
     }
 
     @Test
@@ -130,5 +134,49 @@ public class LShiftINodeIdealizationTests {
     // Checks ((x >>> 4) & 0xFF) << 8 => (x << 4) & 0xFF00
     public int test8(int x) {
         return ((x >>> 4) & 0xFF) << 8;
+    }
+
+    @DontCompile
+    public void assertDoubleShiftResult(int a) {
+        Asserts.assertEQ((a << 2) << 3, testDoubleShift1(a));
+        Asserts.assertEQ(((a << 2) << 3) << 1, testDoubleShift2(a));
+        Asserts.assertEQ((a << 31) << 1, testDoubleShift3(a));
+        Asserts.assertEQ((a << 1) << 31, testDoubleShift4(a));
+        Asserts.assertEQ(((a << 30) << 1) << 1, testDoubleShift5(a));
+    }
+
+    @Test
+    @IR(counts = { IRNode.LSHIFT, "1"})
+    // Checks (x << 2) << 3 => x << 5
+    public int testDoubleShift1(int x) {
+        return (x << 2) << 3;
+    }
+
+    @Test
+    @IR(counts = { IRNode.LSHIFT, "1"})
+    // Checks ((x << 2) << 3) << 1 => x << 6
+    public int testDoubleShift2(int x) {
+        return ((x << 2) << 3) << 1;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.LSHIFT })
+    // Checks (x << 31) << 1 => 0
+    public int testDoubleShift3(int x) {
+        return (x << 31) << 1;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.LSHIFT })
+    // Checks (x << 31) << 1 => 0
+    public int testDoubleShift4(int x) {
+        return (x << 31) << 1;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.LSHIFT })
+    // Checks ((x << 30) << 1) << 1 => 0
+    public int testDoubleShift5(int x) {
+        return ((x << 30) << 1) << 1;
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
@@ -37,26 +37,9 @@ public class LShiftINodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test =
-             {
-                 "test1",
-                 "test2",
-                 "test3",
-                 "test4",
-                 "test5",
-                 "test6",
-                 "test7",
-                 "test8",
-                 "testDoubleShift1",
-                 "testDoubleShift2",
-                 "testDoubleShift3",
-                 "testDoubleShift4",
-                 "testDoubleShift5",
-                 "testDoubleShift6",
-                 "testDoubleShift7",
-             })
-    public void
-    runMethod() {
+    @Run(test = {"test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8",
+            "testDoubleShift1", "testDoubleShift2", "testDoubleShift3", "testDoubleShift4", "testDoubleShift5", "testDoubleShift6", "testDoubleShift7",})
+    public void runMethod() {
         int a = RunInfo.getRandom().nextInt();
         int b = RunInfo.getRandom().nextInt();
         int c = RunInfo.getRandom().nextInt();

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftINodeIdealizationTests.java
@@ -38,7 +38,13 @@ public class LShiftINodeIdealizationTests {
     }
 
     @Run(test = { "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8",
-                  "testDoubleShift1", "testDoubleShift2", "testDoubleShift3", "testDoubleShift4", "testDoubleShift5"
+                  "testDoubleShift1",
+                  "testDoubleShift2",
+                  "testDoubleShift3",
+                  "testDoubleShift4",
+                  "testDoubleShift5",
+                  "testDoubleShift6",
+                  "testDoubleShift7",
     })
     public void runMethod() {
         int a = RunInfo.getRandom().nextInt();
@@ -143,6 +149,8 @@ public class LShiftINodeIdealizationTests {
         Asserts.assertEQ((a << 31) << 1, testDoubleShift3(a));
         Asserts.assertEQ((a << 1) << 31, testDoubleShift4(a));
         Asserts.assertEQ(((a << 30) << 1) << 1, testDoubleShift5(a));
+        Asserts.assertEQ((a * 4) << 3, testDoubleShift6(a));
+        Asserts.assertEQ((a << 3) * 4, testDoubleShift7(a));
     }
 
     @Test
@@ -168,9 +176,9 @@ public class LShiftINodeIdealizationTests {
 
     @Test
     @IR(failOn = { IRNode.LSHIFT })
-    // Checks (x << 31) << 1 => 0
+    // Checks (x << 1) << 31 => 0
     public int testDoubleShift4(int x) {
-        return (x << 31) << 1;
+        return (x << 1) << 31;
     }
 
     @Test
@@ -178,5 +186,21 @@ public class LShiftINodeIdealizationTests {
     // Checks ((x << 30) << 1) << 1 => 0
     public int testDoubleShift5(int x) {
         return ((x << 30) << 1) << 1;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.MUL })
+    @IR(counts = { IRNode.LSHIFT, "1"})
+    // Checks (x * 4) << 3 => x << 5
+    public int testDoubleShift6(int x) {
+        return (x * 4) << 3;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.MUL })
+    @IR(counts = { IRNode.LSHIFT, "1"})
+    // Checks (x << 3) * 4 => x << 5
+    public int testDoubleShift7(int x) {
+        return (x << 3) * 4;
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
@@ -37,7 +37,8 @@ public class LShiftLNodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test = { "test3", "test4", "test5", "test6", "test7", "test8" })
+    @Run(test = { "test3", "test4", "test5", "test6", "test7", "test8",
+                  "testDoubleShift1", "testDoubleShift2", "testDoubleShift3", "testDoubleShift4", "testDoubleShift5"})
     public void runMethod() {
         long a = RunInfo.getRandom().nextLong();
         long b = RunInfo.getRandom().nextLong();
@@ -64,6 +65,8 @@ public class LShiftLNodeIdealizationTests {
         Asserts.assertEQ((a >>> 8L) << 4L, test6(a));
         Asserts.assertEQ(((a >> 4L) & 0xFFL) << 8L, test7(a));
         Asserts.assertEQ(((a >>> 4L) & 0xFFL) << 8L, test8(a));
+
+        assertDoubleShiftResult(a);
     }
 
     @Test
@@ -112,5 +115,49 @@ public class LShiftLNodeIdealizationTests {
     // Checks ((x >>> 4) & 0xFF) << 8 => (x << 4) & 0xFF00
     public long test8(long x) {
         return ((x >>> 4L) & 0xFFL) << 8L;
+    }
+
+    @DontCompile
+    public void assertDoubleShiftResult(long a) {
+        Asserts.assertEQ((a << 2L) << 3L, testDoubleShift1(a));
+        Asserts.assertEQ(((a << 2L) << 3L) << 1L, testDoubleShift2(a));
+        Asserts.assertEQ((a << 31L) << 1L, testDoubleShift3(a));
+        Asserts.assertEQ((a << 1L) << 31L, testDoubleShift4(a));
+        Asserts.assertEQ(((a << 30L) << 1L) << 1L, testDoubleShift5(a));
+    }
+
+    @Test
+    @IR(counts = { IRNode.LSHIFT, "1"})
+    // Checks (x << 2) << 3 => x << 5
+    public long testDoubleShift1(long x) {
+        return (x << 2L) << 3L;
+    }
+
+    @Test
+    @IR(counts = { IRNode.LSHIFT, "1"})
+    // Checks ((x << 2) << 3) << 1 => x << 6
+    public long testDoubleShift2(long x) {
+        return ((x << 2L) << 3L) << 1L;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.LSHIFT })
+    // Checks (x << 31) << 1 => 0
+    public long testDoubleShift3(long x) {
+        return (x << 31L) << 1L;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.LSHIFT })
+    // Checks (x << 31) << 1 => 0
+    public long testDoubleShift4(long x) {
+        return (x << 31L) << 1L;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.LSHIFT })
+    // Checks ((x << 30) << 1) << 1 => 0
+    public long testDoubleShift5(long x) {
+        return ((x << 30L) << 1L) << 1L;
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
@@ -38,7 +38,14 @@ public class LShiftLNodeIdealizationTests {
     }
 
     @Run(test = { "test3", "test4", "test5", "test6", "test7", "test8",
-                  "testDoubleShift1", "testDoubleShift2", "testDoubleShift3", "testDoubleShift4", "testDoubleShift5"})
+                  "testDoubleShift1",
+                  "testDoubleShift2",
+                  "testDoubleShift3",
+                  "testDoubleShift4",
+                  "testDoubleShift5",
+                  "testDoubleShift6",
+                  "testDoubleShift7",
+    })
     public void runMethod() {
         long a = RunInfo.getRandom().nextLong();
         long b = RunInfo.getRandom().nextLong();
@@ -121,9 +128,11 @@ public class LShiftLNodeIdealizationTests {
     public void assertDoubleShiftResult(long a) {
         Asserts.assertEQ((a << 2L) << 3L, testDoubleShift1(a));
         Asserts.assertEQ(((a << 2L) << 3L) << 1L, testDoubleShift2(a));
-        Asserts.assertEQ((a << 31L) << 1L, testDoubleShift3(a));
-        Asserts.assertEQ((a << 1L) << 31L, testDoubleShift4(a));
-        Asserts.assertEQ(((a << 30L) << 1L) << 1L, testDoubleShift5(a));
+        Asserts.assertEQ((a << 63L) << 1L, testDoubleShift3(a));
+        Asserts.assertEQ((a << 1L) << 63L, testDoubleShift4(a));
+        Asserts.assertEQ(((a << 62L) << 1L) << 1L, testDoubleShift5(a));
+        Asserts.assertEQ((a * 4L) << 3L, testDoubleShift6(a));
+        Asserts.assertEQ((a << 3L) * 4L, testDoubleShift7(a));
     }
 
     @Test
@@ -142,22 +151,38 @@ public class LShiftLNodeIdealizationTests {
 
     @Test
     @IR(failOn = { IRNode.LSHIFT })
-    // Checks (x << 31) << 1 => 0
+    // Checks (x << 63) << 1 => 0
     public long testDoubleShift3(long x) {
-        return (x << 31L) << 1L;
+        return (x << 63L) << 1L;
     }
 
     @Test
     @IR(failOn = { IRNode.LSHIFT })
-    // Checks (x << 31) << 1 => 0
+    // Checks (x << 1) << 63 => 0
     public long testDoubleShift4(long x) {
-        return (x << 31L) << 1L;
+        return (x << 1L) << 63L;
     }
 
     @Test
     @IR(failOn = { IRNode.LSHIFT })
-    // Checks ((x << 30) << 1) << 1 => 0
+    // Checks ((x << 62) << 1) << 1 => 0
     public long testDoubleShift5(long x) {
-        return ((x << 30L) << 1L) << 1L;
+        return ((x << 62L) << 1L) << 1L;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.MUL })
+    @IR(counts = { IRNode.LSHIFT, "1"})
+    // Checks (x * 4) << 3 => x << 5
+    public long testDoubleShift6(long x) {
+        return (x * 4L) << 3L;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.MUL })
+    @IR(counts = { IRNode.LSHIFT, "1"})
+    // Checks (x << 3) * 4 => x << 5
+    public long testDoubleShift7(long x) {
+        return (x << 3L) * 4L;
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
@@ -37,16 +37,24 @@ public class LShiftLNodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test = { "test3", "test4", "test5", "test6", "test7", "test8",
-                  "testDoubleShift1",
-                  "testDoubleShift2",
-                  "testDoubleShift3",
-                  "testDoubleShift4",
-                  "testDoubleShift5",
-                  "testDoubleShift6",
-                  "testDoubleShift7",
-    })
-    public void runMethod() {
+    @Run(test =
+             {
+                 "test3",
+                 "test4",
+                 "test5",
+                 "test6",
+                 "test7",
+                 "test8",
+                 "testDoubleShift1",
+                 "testDoubleShift2",
+                 "testDoubleShift3",
+                 "testDoubleShift4",
+                 "testDoubleShift5",
+                 "testDoubleShift6",
+                 "testDoubleShift7",
+             })
+    public void
+    runMethod() {
         long a = RunInfo.getRandom().nextLong();
         long b = RunInfo.getRandom().nextLong();
         long c = RunInfo.getRandom().nextLong();
@@ -136,51 +144,51 @@ public class LShiftLNodeIdealizationTests {
     }
 
     @Test
-    @IR(counts = { IRNode.LSHIFT, "1"})
+    @IR(counts = {IRNode.LSHIFT, "1"})
     // Checks (x << 2) << 3 => x << 5
     public long testDoubleShift1(long x) {
         return (x << 2L) << 3L;
     }
 
     @Test
-    @IR(counts = { IRNode.LSHIFT, "1"})
+    @IR(counts = {IRNode.LSHIFT, "1"})
     // Checks ((x << 2) << 3) << 1 => x << 6
     public long testDoubleShift2(long x) {
         return ((x << 2L) << 3L) << 1L;
     }
 
     @Test
-    @IR(failOn = { IRNode.LSHIFT })
+    @IR(failOn = {IRNode.LSHIFT})
     // Checks (x << 63) << 1 => 0
     public long testDoubleShift3(long x) {
         return (x << 63L) << 1L;
     }
 
     @Test
-    @IR(failOn = { IRNode.LSHIFT })
+    @IR(failOn = {IRNode.LSHIFT})
     // Checks (x << 1) << 63 => 0
     public long testDoubleShift4(long x) {
         return (x << 1L) << 63L;
     }
 
     @Test
-    @IR(failOn = { IRNode.LSHIFT })
+    @IR(failOn = {IRNode.LSHIFT})
     // Checks ((x << 62) << 1) << 1 => 0
     public long testDoubleShift5(long x) {
         return ((x << 62L) << 1L) << 1L;
     }
 
     @Test
-    @IR(failOn = { IRNode.MUL })
-    @IR(counts = { IRNode.LSHIFT, "1"})
+    @IR(failOn = {IRNode.MUL})
+    @IR(counts = {IRNode.LSHIFT, "1"})
     // Checks (x * 4) << 3 => x << 5
     public long testDoubleShift6(long x) {
         return (x * 4L) << 3L;
     }
 
     @Test
-    @IR(failOn = { IRNode.MUL })
-    @IR(counts = { IRNode.LSHIFT, "1"})
+    @IR(failOn = {IRNode.MUL})
+    @IR(counts = {IRNode.LSHIFT, "1"})
     // Checks (x << 3) * 4 => x << 5
     public long testDoubleShift7(long x) {
         return (x << 3L) * 4L;

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
@@ -37,24 +37,9 @@ public class LShiftLNodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test =
-             {
-                 "test3",
-                 "test4",
-                 "test5",
-                 "test6",
-                 "test7",
-                 "test8",
-                 "testDoubleShift1",
-                 "testDoubleShift2",
-                 "testDoubleShift3",
-                 "testDoubleShift4",
-                 "testDoubleShift5",
-                 "testDoubleShift6",
-                 "testDoubleShift7",
-             })
-    public void
-    runMethod() {
+    @Run(test = {"test3", "test4", "test5", "test6", "test7", "test8",
+            "testDoubleShift1", "testDoubleShift2", "testDoubleShift3", "testDoubleShift4", "testDoubleShift5", "testDoubleShift6", "testDoubleShift7",})
+    public void runMethod() {
         long a = RunInfo.getRandom().nextLong();
         long b = RunInfo.getRandom().nextLong();
         long c = RunInfo.getRandom().nextLong();

--- a/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/LShiftLNodeIdealizationTests.java
@@ -38,7 +38,14 @@ public class LShiftLNodeIdealizationTests {
     }
 
     @Run(test = {"test3", "test4", "test5", "test6", "test7", "test8",
-            "testDoubleShift1", "testDoubleShift2", "testDoubleShift3", "testDoubleShift4", "testDoubleShift5", "testDoubleShift6", "testDoubleShift7",})
+            "testDoubleShift1",
+            "testDoubleShift2",
+            "testDoubleShift3",
+            "testDoubleShift4",
+            "testDoubleShift5",
+            "testDoubleShift6",
+            "testDoubleShift7",
+    })
     public void runMethod() {
         long a = RunInfo.getRandom().nextLong();
         long b = RunInfo.getRandom().nextLong();


### PR DESCRIPTION
This collapses double shift lefts by constants in a single constant: (x << con1) << con2 => x << (con1 + con2). Care must be taken in the case con1 + con2 is bigger than the number of bits in the integer type. In this case, we must simplify to 0.

Moreover, the simplification logic of the sign extension trick had to be improved. For instance, we use `(x << 16) >> 16` to convert a 32 bits into a 16 bits integer, with sign extension. When storing this into a 16-bit field, this can be simplified into simple `x`. But in the case where `x` is itself a left-shift expression, say `y << 3`, this PR makes the IR looks like `(y << 19) >> 16` instead of the old `((y << 3) << 16) >> 16`. The former logic didn't handle the case where the left and the right shift have different magnitude. In this PR, I generalize this simplification to cases where the left shift has a larger magnitude than the right shift. This improvement was needed not to miss vectorization opportunities: without the simplification, we have a left shift and a right shift instead of a single left shift, which confuses the type inference.

This also works for multiplications by powers of 2 since they are already translated into shifts.

Thanks,
Marc