### PR TITLE
8350499: Minimal build fails with slowdebug builds

### DIFF
--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -31,9 +31,6 @@
 #include "classfile/stackMapTableFormat.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
-#if INCLUDE_CDS
-#include "classfile/systemDictionaryShared.hpp"
-#endif
 #include "classfile/verifier.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
@@ -62,6 +59,9 @@
 #include "services/threadService.hpp"
 #include "utilities/align.hpp"
 #include "utilities/bytes.hpp"
+#if INCLUDE_CDS
+#include "classfile/systemDictionaryShared.hpp"
+#endif
 
 #define NOFAILOVER_MAJOR_VERSION                       51
 #define NONZERO_PADDING_BYTES_IN_SWITCH_MAJOR_VERSION  51

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -31,7 +31,9 @@
 #include "classfile/stackMapTableFormat.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
+#if INCLUDE_CDS
 #include "classfile/systemDictionaryShared.hpp"
+#endif
 #include "classfile/verifier.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
@@ -234,11 +236,13 @@ bool Verifier::verify(InstanceKlass* klass, bool should_verify_class, TRAPS) {
          exception_name == vmSymbols::java_lang_ClassFormatError())) {
       log_info(verification)("Fail over class verification to old verifier for: %s", klass->external_name());
       log_info(class, init)("Fail over class verification to old verifier for: %s", klass->external_name());
+#if INCLUDE_CDS
       // Exclude any classes that fail over during dynamic dumping
       if (CDSConfig::is_dumping_dynamic_archive()) {
         SystemDictionaryShared::warn_excluded(klass, "Failed over class verification while dynamic dumping");
         SystemDictionaryShared::set_excluded(klass);
       }
+#endif
       message_buffer = NEW_RESOURCE_ARRAY(char, message_buffer_len);
       exception_message = message_buffer;
       exception_name = inference_verify(


### PR DESCRIPTION
minimal build fails with slowdebug builds after [8311208](https://github.com/openjdk/jdk/commit/498a58244d79) (permissions required):

```
Building target 'images' in configuration 'linux-x86_64-minimal-slowdebug'
/usr/bin/ld: /home/aoqi/work/theaoqi/jdk/build/linux-x86_64-minimal-slowdebug/hotspot/variant-minimal/libjvm/objs/verifier.o: in function `Verifier::verify(InstanceKlass*, bool, JavaThread*)':
/home/aoqi/work/theaoqi/jdk/src/hotspot/share/classfile/verifier.cpp:239: undefined reference to `SystemDictionaryShared::warn_excluded(InstanceKlass*, char const*)'
/usr/bin/ld: /home/aoqi/work/theaoqi/jdk/src/hotspot/share/classfile/verifier.cpp:240: undefined reference to `SystemDictionaryShared::set_excluded(InstanceKlass*)'
collect2: error: ld returned 1 exit status
gmake[3]: *** [lib/CompileJvm.gmk:174: /home/aoqi/work/theaoqi/jdk/build/linux-x86_64-minimal-slowdebug/support/modules_libs/java.base/minimal/libjvm.so] Error 1
gmake[2]: *** [make/Main.gmk:236: hotspot-minimal-libs] Error 2

ERROR: Build failed for target 'images' in configuration 'linux-x86_64-minimal-slowdebug' (exit code 2) 
```

It may be because the systemDictionaryShared.cpp file is [excluded](https://github.com/openjdk/jdk/blob/bd8ad309b59bceb3073a8d6411cca74e73508885/make/hotspot/lib/JvmFeatures.gmk#L130) when using slowdebug and minimal builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350499](https://bugs.openjdk.org/browse/JDK-8350499): Minimal build fails with slowdebug builds (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23729/head:pull/23729` \
`$ git checkout pull/23729`

Update a local copy of the PR: \
`$ git checkout pull/23729` \
`$ git pull https://git.openjdk.org/jdk.git pull/23729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23729`

View PR using the GUI difftool: \
`$ git pr show -t 23729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23729.diff">https://git.openjdk.org/jdk/pull/23729.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23729#issuecomment-2675172128)
</details>
