### PR TITLE
8350476: Fix typo introduced in JDK-8350147

### DIFF
--- a/src/java.base/share/classes/javax/crypto/KEM.java
+++ b/src/java.base/share/classes/javax/crypto/KEM.java
@@ -65,7 +65,7 @@ import java.util.Objects;
  * new shared secret and key encapsulation message.
  * <p>
  *
- * Example operation using a ficticious {@code KEM} algorithm {@code ABC}:
+ * Example operation using a fictitious {@code KEM} algorithm {@code ABC}:
  * {@snippet lang = java:
  *     // Receiver side
  *     KeyPairGenerator g = KeyPairGenerator.getInstance("ABC");


### PR DESCRIPTION
Typo: s/ficticious/fictitious/ 

No unit test.  Check that javadoc still builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350476](https://bugs.openjdk.org/browse/JDK-8350476): Fix typo introduced in JDK-8350147 (**Bug** - P4)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23733/head:pull/23733` \
`$ git checkout pull/23733`

Update a local copy of the PR: \
`$ git checkout pull/23733` \
`$ git pull https://git.openjdk.org/jdk.git pull/23733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23733`

View PR using the GUI difftool: \
`$ git pr show -t 23733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23733.diff">https://git.openjdk.org/jdk/pull/23733.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23733#issuecomment-2675953290)
</details>
