### PR TITLE
8350524: Some hotspot/jtreg/serviceability/dcmd/vm tier1 tests fail on static JDK

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
@@ -48,6 +48,9 @@ public class DynLibsTest {
     public void run(CommandExecutor executor) {
         OutputAnalyzer output = executor.execute("VM.dynlibs");
         if (WhiteBox.getWhiteBox().isStatic()) {
+            // On static JDK, JDK/VM native libraries are statically
+            // linked with the launcher. There is no separate mapping
+            // for libjvm, libjava, etc.
             output.shouldContain("java");
             output.shouldNotContain(Platform.buildSharedLibraryName("jvm"));
             output.shouldNotContain(Platform.buildSharedLibraryName("java"));

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
@@ -28,6 +28,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Platform;
 import jdk.test.lib.dcmd.CommandExecutor;
 import jdk.test.lib.dcmd.JMXExecutor;
+import jdk.test.whitebox.WhiteBox;
 
 /*
  * @test
@@ -37,16 +38,25 @@ import jdk.test.lib.dcmd.JMXExecutor;
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run testng DynLibsTest
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run testng/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI DynLibsTest
  */
 
 public class DynLibsTest {
 
     public void run(CommandExecutor executor) {
         OutputAnalyzer output = executor.execute("VM.dynlibs");
-        output.shouldContain(Platform.buildSharedLibraryName("jvm"));
-        output.shouldContain(Platform.buildSharedLibraryName("java"));
-        output.shouldContain(Platform.buildSharedLibraryName("management"));
+        if (WhiteBox.getWhiteBox().isStatic()) {
+            output.shouldContain("java");
+            output.shouldNotContain(Platform.buildSharedLibraryName("jvm"));
+            output.shouldNotContain(Platform.buildSharedLibraryName("java"));
+            output.shouldNotContain(Platform.buildSharedLibraryName("management"));
+        } else {
+            output.shouldContain(Platform.buildSharedLibraryName("jvm"));
+            output.shouldContain(Platform.buildSharedLibraryName("java"));
+            output.shouldContain(Platform.buildSharedLibraryName("management"));
+        }
     }
 
     @Test

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemDumpMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemDumpMapTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, 2024, Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Red Hat, Inc. and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemDumpMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemDumpMapTest.java
@@ -40,7 +40,9 @@ import java.util.regex.Pattern;
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run testng/othervm -XX:+UsePerfData SystemDumpMapTest
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run testng/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UsePerfData SystemDumpMapTest
  */
 public class SystemDumpMapTest extends SystemMapTestBase {
 

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 import jdk.test.lib.dcmd.CommandExecutor;
 import jdk.test.lib.dcmd.JMXExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.whitebox.WhiteBox;
 
 /*
  * @test id=normal
@@ -36,7 +37,9 @@ import jdk.test.lib.process.OutputAnalyzer;
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run testng/othervm -XX:+UsePerfData SystemMapTest
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run testng/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UsePerfData SystemMapTest
  */
 
 /*
@@ -49,7 +52,9 @@ import jdk.test.lib.process.OutputAnalyzer;
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run testng/othervm -XX:+UsePerfData -XX:+UseZGC SystemMapTest
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run testng/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UsePerfData -XX:+UseZGC SystemMapTest
  */
 public class SystemMapTest extends SystemMapTestBase {
     public void run(CommandExecutor executor) {

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, 2024, Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Red Hat, Inc. and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTest.java
@@ -26,7 +26,6 @@ import org.testng.annotations.Test;
 import jdk.test.lib.dcmd.CommandExecutor;
 import jdk.test.lib.dcmd.JMXExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.whitebox.WhiteBox;
 
 /*
  * @test id=normal

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
@@ -90,7 +90,7 @@ public class SystemMapTestBase {
             regexBase_shared_and_committed + "hsperfdata_.*"
         };
 
-        static final String shouldMatchUnconditionally_linux_libjvm[] = {
+        static final String shouldMatch_linux_libjvm[] = {
             // libjvm
             regexBase_committed + "/lib/.*/libjvm.so"
         };
@@ -109,10 +109,12 @@ public class SystemMapTestBase {
 
         public String[] shouldMatchUnconditionally() {
             if (WhiteBox.getWhiteBox().isStatic()) {
+                // On static JDK, libjvm is statically linked with the 'java'
+                // launcher. There is no separate mapping for libjvm.
                 return shouldMatchUnconditionally_linux;
             } else {
                 return StringArrayUtils.concat(shouldMatchUnconditionally_linux,
-                                               shouldMatchUnconditionally_linux_libjvm);
+                                               shouldMatch_linux_libjvm);
             }
         }
 
@@ -137,7 +139,7 @@ public class SystemMapTestBase {
             winimage + ".*[\\/\\\\]bin[\\/\\\\]java[.]exe",
         };
 
-        static final String shouldMatchUnconditionally_windows_libjvm[] = {
+        static final String shouldMatch_windows_libjvm[] = {
             // libjvm
             winimage + ".*[\\/\\\\]bin[\\/\\\\].*[\\/\\\\]jvm.dll"
         };
@@ -156,10 +158,12 @@ public class SystemMapTestBase {
 
         public String[] shouldMatchUnconditionally() {
             if (WhiteBox.getWhiteBox().isStatic()) {
+                // On static JDK, libjvm is statically linked with the 'java'
+                // launcher. There is no separate mapping for libjvm.
                 return shouldMatchUnconditionally_windows;
             } else {
                 return StringArrayUtils.concat(shouldMatchUnconditionally_windows,
-                                               shouldMatchUnconditionally_windows_libjvm);
+                                               shouldMatch_windows_libjvm);
             }
         }
 
@@ -187,7 +191,7 @@ public class SystemMapTestBase {
             macOSbase + macprivate + space + someNumber + space + ".*/.*/hsperfdata_.*"
         };
 
-        static final String shouldMatchUnconditionally_macOS_libjvm[] = {
+        static final String shouldMatch_macOS_libjvm[] = {
             // libjvm
             macOSbase + macow + space + someNumber + space + "/.*/lib/server/libjvm.dylib",
         };
@@ -205,10 +209,12 @@ public class SystemMapTestBase {
 
         public String[] shouldMatchUnconditionally() {
             if (WhiteBox.getWhiteBox().isStatic()) {
+                // On static JDK, libjvm is statically linked with the 'java'
+                // launcher. There is no separate mapping for libjvm.
                 return shouldMatchUnconditionally_macOS;
             } else {
                 return StringArrayUtils.concat(shouldMatchUnconditionally_macOS,
-                                               shouldMatchUnconditionally_macOS_libjvm);
+                                               shouldMatch_macOS_libjvm);
             }
         }
 

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2024, Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Red Hat, Inc. and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
@@ -23,6 +23,8 @@
  */
 
 import jdk.test.lib.Platform;
+import jdk.test.lib.StringArrayUtils;
+import jdk.test.whitebox.WhiteBox;
 
 public class SystemMapTestBase {
 
@@ -82,12 +84,15 @@ public class SystemMapTestBase {
         static final String shouldMatchUnconditionally_linux[] = {
             // java launcher
             regexBase_committed + "/bin/java",
-            // libjvm
-            regexBase_committed + "/lib/.*/libjvm.so",
             // heap segment, should be part of all user space apps on all architectures OpenJDK supports.
             regexBase_committed + "\\[heap\\]",
             // we should see the hs-perf data file, and it should appear as shared as well as committed
             regexBase_shared_and_committed + "hsperfdata_.*"
+        };
+
+        static final String shouldMatchUnconditionally_linux_libjvm[] = {
+            // libjvm
+            regexBase_committed + "/lib/.*/libjvm.so"
         };
 
         static final String shouldMatchIfNMTIsEnabled_linux[] = {
@@ -103,7 +108,12 @@ public class SystemMapTestBase {
         };
 
         public String[] shouldMatchUnconditionally() {
-            return shouldMatchUnconditionally_linux;
+            if (WhiteBox.getWhiteBox().isStatic()) {
+                return shouldMatchUnconditionally_linux;
+            } else {
+                return StringArrayUtils.concat(shouldMatchUnconditionally_linux,
+                                               shouldMatchUnconditionally_linux_libjvm);
+            }
         }
 
         public String[] shouldMatchIfNMTIsEnabled() {
@@ -125,6 +135,9 @@ public class SystemMapTestBase {
         static final String shouldMatchUnconditionally_windows[] = {
             // java launcher
             winimage + ".*[\\/\\\\]bin[\\/\\\\]java[.]exe",
+        };
+
+        static final String shouldMatchUnconditionally_windows_libjvm[] = {
             // libjvm
             winimage + ".*[\\/\\\\]bin[\\/\\\\].*[\\/\\\\]jvm.dll"
         };
@@ -142,7 +155,12 @@ public class SystemMapTestBase {
         };
 
         public String[] shouldMatchUnconditionally() {
-            return shouldMatchUnconditionally_windows;
+            if (WhiteBox.getWhiteBox().isStatic()) {
+                return shouldMatchUnconditionally_windows;
+            } else {
+                return StringArrayUtils.concat(shouldMatchUnconditionally_windows,
+                                               shouldMatchUnconditionally_windows_libjvm);
+            }
         }
 
         public String[] shouldMatchIfNMTIsEnabled() {
@@ -165,10 +183,13 @@ public class SystemMapTestBase {
         static final String shouldMatchUnconditionally_macOS[] = {
             // java launcher
             macOSbase + macow + space + someNumber + space + "/.*/bin/java",
-            // libjvm
-            macOSbase + macow + space + someNumber + space + "/.*/lib/server/libjvm.dylib",
             // we should see the hs-perf data file, and it should appear as shared as well as committed
             macOSbase + macprivate + space + someNumber + space + ".*/.*/hsperfdata_.*"
+        };
+
+        static final String shouldMatchUnconditionally_macOS_libjvm[] = {
+            // libjvm
+            macOSbase + macow + space + someNumber + space + "/.*/lib/server/libjvm.dylib",
         };
 
         static final String shouldMatchIfNMTIsEnabled_macOS[] = {
@@ -183,7 +204,12 @@ public class SystemMapTestBase {
         };
 
         public String[] shouldMatchUnconditionally() {
-            return shouldMatchUnconditionally_macOS;
+            if (WhiteBox.getWhiteBox().isStatic()) {
+                return shouldMatchUnconditionally_macOS;
+            } else {
+                return StringArrayUtils.concat(shouldMatchUnconditionally_macOS,
+                                               shouldMatchUnconditionally_macOS_libjvm);
+            }
         }
 
         public String[] shouldMatchIfNMTIsEnabled() {


### PR DESCRIPTION
Please review the fix in following tests to not check for shared libraries when running on static JDK:

test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
test/hotspot/jtreg/serviceability/dcmd/vm/SystemDumpMapTest.java
test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350524](https://bugs.openjdk.org/browse/JDK-8350524): Some hotspot/jtreg/serviceability/dcmd/vm tier1 tests fail on static JDK (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23734/head:pull/23734` \
`$ git checkout pull/23734`

Update a local copy of the PR: \
`$ git checkout pull/23734` \
`$ git pull https://git.openjdk.org/jdk.git pull/23734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23734`

View PR using the GUI difftool: \
`$ git pr show -t 23734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23734.diff">https://git.openjdk.org/jdk/pull/23734.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23734#issuecomment-2675985869)
</details>
