### PR TITLE
8350483: AArch64: turn on signum intrinsics by default on Ampere CPUs

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -161,6 +161,9 @@ void VM_Version::initialize() {
         (_model == CPU_MODEL_AMPERE_1A || _model == CPU_MODEL_AMPERE_1B)) {
       FLAG_SET_DEFAULT(CodeEntryAlignment, 32);
     }
+    if (FLAG_IS_DEFAULT(UseSignumIntrinsic)) {
+      FLAG_SET_DEFAULT(UseSignumIntrinsic, true);
+    }
   }
 
   // ThunderX


### PR DESCRIPTION
Set -XX:+UseSignumIntrinsic by default for Ampere CPUs. It is to fix performance problem found on JMH cases `vm.compiler.Signum|java.lang.*MathBench.sig[nN]um*` where fmov is used to transmit data between GPRs and FPRs with significant time cost.

Verified on Ampere-1A and found the scores (thrpt, ops/s) of `java.lang.*MathBench.sig[nN]um*` improved 40~50%, while `vm.compiler.Signum._1_signumFloatTest` and `vm.compiler.Signum._3_signumDoubleTest` results gained exponential increases. Also passed GHA sanity checks, and Jtreg tier1 on Ampere-1A as function-wise smoke tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350483](https://bugs.openjdk.org/browse/JDK-8350483): AArch64: turn on signum intrinsics by default on Ampere CPUs (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23735/head:pull/23735` \
`$ git checkout pull/23735`

Update a local copy of the PR: \
`$ git checkout pull/23735` \
`$ git pull https://git.openjdk.org/jdk.git pull/23735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23735`

View PR using the GUI difftool: \
`$ git pr show -t 23735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23735.diff">https://git.openjdk.org/jdk/pull/23735.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23735#issuecomment-2676264053)
</details>
