### PR TITLE
8350545: Several sun/management/jdp tests fails java.net.SocketException

### DIFF
--- a/test/jdk/sun/management/jdp/DynamicLauncher.java
+++ b/test/jdk/sun/management/jdp/DynamicLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 
+import jtreg.SkippedException;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.Utils;
@@ -60,6 +61,9 @@ public abstract class DynamicLauncher {
                 }
             }
         } while (tryAgain);
+        if (output.contains("java.net.SocketException: No such device")) {
+            throw new SkippedException("Network setup issue, skip this test");
+        }
         output.shouldHaveExitValue(0);
         // java.lang.Exception is thrown by JdpTestCase if something goes wrong
         // for instance - see JdpTestCase::shutdown()

--- a/test/jdk/sun/management/jdp/JdpDefaultsTest.java
+++ b/test/jdk/sun/management/jdp/JdpDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@
  *
  * @library /test/lib
  *
- * @build ClientConnection JdpTestUtil JdpTestCase JdpOnTestCase DynamicLauncher
+ * @build ClientConnection JdpTestUtil JdpTestCase JdpOnTestCase DynamicLauncher jtreg.SkippedException
  * @run main/othervm JdpDefaultsTest
  */
 

--- a/test/jdk/sun/management/jdp/JdpJmxRemoteDynamicPortTest.java
+++ b/test/jdk/sun/management/jdp/JdpJmxRemoteDynamicPortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  *
  * @library /test/lib
  *
- * @build ClientConnection JdpTestUtil JdpTestCase JdpJmxRemoteDynamicPortTestCase DynamicLauncher
+ * @build ClientConnection JdpTestUtil JdpTestCase JdpJmxRemoteDynamicPortTestCase DynamicLauncher jtreg.SkippedException
  * @run main/othervm JdpJmxRemoteDynamicPortTest
  */
 

--- a/test/jdk/sun/management/jdp/JdpOffTest.java
+++ b/test/jdk/sun/management/jdp/JdpOffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  *
  * @library /test/lib
  *
- * @build ClientConnection JdpTestUtil JdpTestCase JdpOffTestCase DynamicLauncher
+ * @build ClientConnection JdpTestUtil JdpTestCase JdpOffTestCase DynamicLauncher jtreg.SkippedException
  * @run main/othervm JdpOffTest
  */
 

--- a/test/jdk/sun/management/jdp/JdpSpecificAddressTest.java
+++ b/test/jdk/sun/management/jdp/JdpSpecificAddressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@
  *
  * @library /test/lib
  *
- * @build ClientConnection JdpTestUtil JdpTestCase JdpOnTestCase DynamicLauncher
+ * @build ClientConnection JdpTestUtil JdpTestCase JdpOnTestCase DynamicLauncher jtreg.SkippedException
  * @run main/othervm JdpSpecificAddressTest
  */
 


### PR DESCRIPTION
Hi all,

Four sun/management/jdp tests fails "java.net.SocketException: No such device" on some machines. The machine cannot connect to the Internet directly and needs to be connected to the Internet through a jump machine. The sun/management/jdp tests report "java.net.SocketException: No such device" failure do not caused by JVM bug but environmentalk issue, so this PR match the output and throw `jtreg.SkippedException` instead of report test fails.

Change has been verified locally, test-fix only and make tests more robustness, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350545](https://bugs.openjdk.org/browse/JDK-8350545): Several sun/management/jdp tests fails java.net.SocketException (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23738/head:pull/23738` \
`$ git checkout pull/23738`

Update a local copy of the PR: \
`$ git checkout pull/23738` \
`$ git pull https://git.openjdk.org/jdk.git pull/23738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23738`

View PR using the GUI difftool: \
`$ git pr show -t 23738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23738.diff">https://git.openjdk.org/jdk/pull/23738.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23738#issuecomment-2676830595)
</details>
