### PR TITLE
8349888: AOTMode=create crashes with EpsilonGC

### DIFF
--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -846,6 +846,14 @@ void ClassListParser::parse_constant_pool_tag() {
     }
   }
 
+  if (SystemDictionaryShared::should_be_excluded(ik)) {
+    if (log_is_enabled(Warning, cds, resolve)) {
+      ResourceMark rm;
+      log_warning(cds, resolve)("Cannot aot-resolve constants for %s because it is excluded", ik->external_name());
+    }
+    return;
+  }
+
   if (preresolve_class) {
     AOTConstantPoolResolver::preresolve_class_cp_entries(THREAD, ik, &preresolve_list);
   }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/LambdaInExcludedClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/LambdaInExcludedClass.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test id=static Lambda expressions in excluded classes shouldn't be resolved during the assembly phase.
+ * @bug 8349888
+ * @requires vm.cds.supports.aot.class.linking
+ * @requires vm.gc.Epsilon
+ * @comment work around JDK-8345635
+ * @requires !vm.jvmci.enabled
+ * @library /test/jdk/lib/testlibrary /test/lib
+ * @build LambdaInExcludedClass
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller LambdaInExcludedClassApp
+ * @run driver LambdaInExcludedClass STATIC
+ */
+
+import jdk.test.lib.cds.CDSAppTester;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class LambdaInExcludedClass {
+    static final String mainClass = "LambdaInExcludedClassApp";
+
+    public static void main(String[] args) throws Exception {
+        Tester t = new Tester();
+        t.run(args);
+    }
+
+    static class Tester extends CDSAppTester {
+        public Tester() {
+            super(mainClass);
+        }
+
+        @Override
+        public String classpath(RunMode runMode) {
+            // Using "." as the classpath allows the LambdaInExcludedClassApp to be loaded in
+            // the assembly phase, but this class will be excluded from the AOT cache.
+            return ".";
+        }
+
+        @Override
+        public String[] vmArgs(RunMode runMode) {
+            return new String[] {
+                "-XX:+AOTClassLinking",
+                "-XX:+UnlockExperimentalVMOptions",
+                "-XX:+UseEpsilonGC",
+            };
+        }
+
+        @Override
+        public String[] appCommandLine(RunMode runMode) {
+            return new String[] {
+                mainClass,
+            };
+        }
+
+        @Override
+        public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {
+            if (runMode == RunMode.DUMP_STATIC) {
+                out.shouldContain("Skipping LambdaInExcludedClassApp: Unsupported location");
+                out.shouldContain("Cannot aot-resolve constants for LambdaInExcludedClassApp because it is excluded");
+            } else {
+                out.shouldContain("Hello LambdaInExcludedClassApp");
+            }
+        }
+    }
+}
+
+class LambdaInExcludedClassApp {
+    public static void main(String args[]) throws Exception {
+        // LambdaInExcludedClassApp is excluded, so aot-linking of lambda call sites
+        // should not happen for this class. Otherwise Epsilon GC may crash due
+        // to 8349888.
+        Runnable r = LambdaInExcludedClassApp::doit;
+        r.run();
+    }
+
+    static void doit() {
+        System.out.println("Hello LambdaInExcludedClassApp");
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/LambdaInExcludedClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/LambdaInExcludedClass.java
@@ -62,6 +62,7 @@ public class LambdaInExcludedClass {
         @Override
         public String[] vmArgs(RunMode runMode) {
             return new String[] {
+                "-Xmx128m",
                 "-XX:+AOTClassLinking",
                 "-XX:+UnlockExperimentalVMOptions",
                 "-XX:+UseEpsilonGC",


### PR DESCRIPTION
During AOT cache assembly, some classes may become excluded for various reasons. In the bug report, we have a class that was excluded because it wasn't loaded from a JAR file.

When AOT-resolving lambda call sites, we already exclude all sites that **refer** to excluded classes. However, we didn't exclude class sites that **live in** an excluded class. This PR fixes that.

This bug only affects EpsilonGC, which doesn't perform any collection. It doesn't affect other "real" collectors. Please see JBS issue for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349888](https://bugs.openjdk.org/browse/JDK-8349888): AOTMode=create crashes with EpsilonGC (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23741/head:pull/23741` \
`$ git checkout pull/23741`

Update a local copy of the PR: \
`$ git checkout pull/23741` \
`$ git pull https://git.openjdk.org/jdk.git pull/23741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23741`

View PR using the GUI difftool: \
`$ git pr show -t 23741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23741.diff">https://git.openjdk.org/jdk/pull/23741.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23741#issuecomment-2677416241)
</details>
