### PR TITLE
8350548: java.lang.classfile package javadoc has errors

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/package-info.java
@@ -368,13 +368,13 @@
  * <p>
  * or lift the code transform into the class transform directly:
  * {@snippet lang=java :
- * ClassTransform ct = ClassTransform.transformingMethodBodiess(fooToBar);
+ * ClassTransform ct = ClassTransform.transformingMethodBodies(fooToBar);
  * }
  * <p>
  * and then transform the classfile:
  * {@snippet lang=java :
  * var cc = ClassFile.of();
- * byte[] newBytes = cc.transform(cc.parse(bytes), ct);
+ * byte[] newBytes = cc.transformClass(cc.parse(bytes), ct);
  * }
  * <p>
  * This is much more concise (and less error-prone) than the equivalent
@@ -393,7 +393,7 @@
  *
  * {@snippet lang=java :
  * var cc = ClassFile.of();
- * byte[] newBytes = cc.transform(cc.parse(bytes),
+ * byte[] newBytes = cc.transformClass(cc.parse(bytes),
  *                                ClassTransform.transformingMethods(
  *                                    MethodTransform.transformingCode(
  *                                        fooToBar.andThen(instrumentCalls))));


### PR DESCRIPTION
j.l.classfile package-summary contains many code snippets.
Some of the shorter snippets are embedded in the javadoc and therefore are not validated by the tests.
One embedded code snippet contains a typo, and two snippets do not reflect the actual API method name.

This patch fixes the code snippets.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350548](https://bugs.openjdk.org/browse/JDK-8350548): java.lang.classfile package javadoc has errors (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23743/head:pull/23743` \
`$ git checkout pull/23743`

Update a local copy of the PR: \
`$ git checkout pull/23743` \
`$ git pull https://git.openjdk.org/jdk.git pull/23743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23743`

View PR using the GUI difftool: \
`$ git pr show -t 23743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23743.diff">https://git.openjdk.org/jdk/pull/23743.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23743#issuecomment-2677693356)
</details>
