### PR TITLE
8350518: org.openjdk.bench.java.util.TreeMapUpdate.compute fails with  "java.lang.IllegalArgumentException: key out of range"

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/TreeMapUpdate.java
+++ b/test/micro/org/openjdk/bench/java/util/TreeMapUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/TreeMapUpdate.java
+++ b/test/micro/org/openjdk/bench/java/util/TreeMapUpdate.java
@@ -56,7 +56,7 @@ import java.util.stream.IntStream;
 @Fork(3)
 @State(Scope.Thread)
 public class TreeMapUpdate {
-    @Param({"TreeMap", "descendingMap", "tailMap"})
+    @Param({"TreeMap", "descendingMap", "subMap"})
     public String mode;
 
     @Param({"10", "1000", "100000"})
@@ -86,8 +86,8 @@ public class TreeMapUpdate {
             case "descendingMap":
                 transformer = map -> map.descendingMap();
                 break;
-            case "tailMap":
-                transformer = map -> map.tailMap(0, true);
+            case "subMap":
+                transformer = comparator ? map -> map.headMap(0, true) : map -> map.tailMap(0, true);
                 break;
             default:
                 throw new IllegalStateException(mode);


### PR DESCRIPTION
It appears that the benchmark was erroneous. The combination of "tailMap" mode and comparator = true didn't work correctly, as the comparator is descending. This PR changes the benchmark to use headMap instead of tailMap in comparator mode. The "tailMap" mode is renamed to "subMap". Now, all parameter combinations work correctly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350518](https://bugs.openjdk.org/browse/JDK-8350518): org.openjdk.bench.java.util.TreeMapUpdate.compute fails with  "java.lang.IllegalArgumentException: key out of range" (**Bug** - P4)


### Reviewers
 * [Sergey Kuksenko](https://openjdk.org/census#skuksenko) (@kuksenko - Committer) Review applies to [1cf4704a](https://git.openjdk.org/jdk/pull/23744/files/1cf4704a0a43deddd9d8cac57e0180dadfa5fd8f)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23744/head:pull/23744` \
`$ git checkout pull/23744`

Update a local copy of the PR: \
`$ git checkout pull/23744` \
`$ git pull https://git.openjdk.org/jdk.git pull/23744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23744`

View PR using the GUI difftool: \
`$ git pr show -t 23744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23744.diff">https://git.openjdk.org/jdk/pull/23744.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23744#issuecomment-2677760254)
</details>
