### PR TITLE
JDK-8350497: os::create_thread unify init thread attributes part across UNIX platforms

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -174,7 +174,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     EXCLUDE_FILES := $(JVM_EXCLUDE_FILES), \
     EXCLUDE_PATTERNS := $(JVM_EXCLUDE_PATTERNS), \
     DEFAULT_CFLAGS := false, \
-    CFLAGS := $(JVM_CFLAGS), \
+    CFLAGS := $(JVM_CFLAGS) $(JVM_CFLAGS_FEATURES_LTO), \
     abstract_vm_version.cpp_CXXFLAGS := $(CFLAGS_VM_VERSION), \
     arguments.cpp_CXXFLAGS := $(CFLAGS_VM_VERSION), \
     DISABLED_WARNINGS_gcc := $(DISABLED_WARNINGS_gcc), \
@@ -221,7 +221,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     ASFLAGS := $(JVM_ASFLAGS), \
     LD_SET_ORIGIN := false, \
     DEFAULT_LDFLAGS := false, \
-    LDFLAGS := $(JVM_LDFLAGS), \
+    LDFLAGS := $(JVM_LDFLAGS) $(JVM_LDFLAGS_FEATURES_LTO), \
     LIBS := $(JVM_LIBS), \
     OPTIMIZATION := $(JVM_OPTIMIZATION), \
     OBJECT_DIR := $(JVM_OUTPUTDIR)/objs, \

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -170,23 +170,23 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
   # later on if desired
   JVM_OPTIMIZATION := HIGHEST_JVM
   ifeq ($(call isCompiler, gcc), true)
-    JVM_CFLAGS_FEATURES += -flto=auto -fuse-linker-plugin -fno-strict-aliasing \
+    JVM_CFLAGS_FEATURES_LTO += -flto=auto -fuse-linker-plugin -fno-strict-aliasing \
         -fno-fat-lto-objects
-    JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto=auto \
+    JVM_LDFLAGS_FEATURES_LTO += $(CXX_O_FLAG_HIGHEST_JVM) -flto=auto \
         -fuse-linker-plugin -fno-strict-aliasing
   else ifeq ($(call isCompiler, clang), true)
-    JVM_CFLAGS_FEATURES += -flto -fno-strict-aliasing
+    JVM_CFLAGS_FEATURES_LTO += -flto -fno-strict-aliasing
     ifeq ($(call isBuildOs, aix), true)
-      JVM_CFLAGS_FEATURES += -ffat-lto-objects
+      JVM_CFLAGS_FEATURES_LTO += -ffat-lto-objects
     endif
-    JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto -fno-strict-aliasing
+    JVM_LDFLAGS_FEATURES_LTO += $(CXX_O_FLAG_HIGHEST_JVM) -flto -fno-strict-aliasing
   else ifeq ($(call isCompiler, microsoft), true)
-    JVM_CFLAGS_FEATURES += -GL
-    JVM_LDFLAGS_FEATURES += -LTCG:INCREMENTAL
+    JVM_CFLAGS_FEATURES_LTO += -GL
+    JVM_LDFLAGS_FEATURES_LTO += -LTCG:INCREMENTAL
   endif
 else
   ifeq ($(call isCompiler, gcc), true)
-    JVM_LDFLAGS_FEATURES += -O1
+    JVM_LDFLAGS_FEATURES_LTO += -O1
   endif
 endif
 

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -706,8 +706,12 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   // Init thread attributes.
   pthread_attr_t attr;
   int rslt = pthread_attr_init(&attr);
-  guarantee(rslt == 0, "pthread_attr_init has to return 0");
-  guarantee(pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) == 0, "???");
+  if (rslt != 0) {
+    thread->set_osthread(nullptr);
+    delete osthread;
+    return false;
+  }
+  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
   // Make sure we run in 1:1 kernel-user-thread mode.
   guarantee(pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM) == 0, "???");

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -638,7 +638,12 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
 
   // init thread attributes
   pthread_attr_t attr;
-  pthread_attr_init(&attr);
+  int rslt = pthread_attr_init(&attr);
+  if (rslt != 0) {
+    thread->set_osthread(nullptr);
+    delete osthread;
+    return false;
+  }
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
   // calculate stack size if it's not specified by caller


### PR DESCRIPTION
In os::create_thread the 'init thread attributes' part of the method should be unified across UNIX platforms, e.g. regarding return code checking.