### PR TITLE
8350571: Remove mention of Tonga test suite from JMX tests

### DIFF
--- a/test/jdk/javax/management/MBeanServer/ExceptionFactory.java
+++ b/test/jdk/javax/management/MBeanServer/ExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,12 +67,8 @@ import javax.management.remote.JMXProviderException;
 import javax.management.remote.JMXServerErrorException;
 
 /**
- *  |----- Original Description Coming From Tonga Original Source Code -------|
- *  |                                                                         |
- *  | That class creates an ArrayList and fill it with an instance of each of |
- *  | the Exception class of the JMX API.                                     |
- *  | It's dedicated to use by ExceptionTest.                                 |
- *  |-------------------------------------------------------------------------|
+ * This class creates an ArrayList and fills it with an instance of each
+ * Exception class in the JMX API.  Used by ExceptionTest.
  */
 public class ExceptionFactory {
 

--- a/test/jdk/javax/management/MBeanServer/ExceptionTest.java
+++ b/test/jdk/javax/management/MBeanServer/ExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,7 +188,6 @@ public class ExceptionTest {
         return true;
     }
 
-    // Utility inner class coming from JMX Tonga test suite.
     // Also used by ExceptionFactory.
     static class Utils {
 
@@ -222,9 +221,6 @@ public class ExceptionTest {
         }
 
         /**
-         * Reproduces the original parsing and collection of test parameters
-         * from the DTonga JMX test suite.
-         *
          * Collects passed args and returns them in a map(argname, value) structure,
          * which will be then propagated as necessary to various called methods.
          */

--- a/test/jdk/javax/management/mxbean/Utils.java
+++ b/test/jdk/javax/management/mxbean/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ import java.util.Properties;
 import java.lang.reflect.Method;
 import javax.management.remote.JMXConnectorServerMBean;
 
-// utility class for MXBean* tests coming from JMX Tonga test suite
 class Utils {
 
     // DEBUG is printed depending on the DEBUG and DEBUG_LEVEL JAVA property
@@ -60,9 +59,6 @@ class Utils {
     }
 
     /**
-     * Reproduces the original parsing and collection of test parameters
-     * from the DTonga JMX test suite.
-     *
      * Collects passed args and returns them in a map(argname, value) structure,
      * which will be then propagated as necessary to various called methods.
      */

--- a/test/jdk/javax/management/query/SupportedQueryTypesTest.java
+++ b/test/jdk/javax/management/query/SupportedQueryTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,7 +287,6 @@ public class SupportedQueryTypesTest {
         }
     }
 
-    // Utility inner class coming from JMX Tonga test suite.
     private static class Utils {
 
         // DEBUG is printed depending on the DEBUG and DEBUG_LEVEL JAVA property
@@ -320,9 +319,6 @@ public class SupportedQueryTypesTest {
         }
 
         /**
-         * Reproduces the original parsing and collection of test parameters
-         * from the DTonga JMX test suite.
-         *
          * Collects passed args and returns them in a map(argname, value) structure,
          * which will be then propagated as necessary to various called methods.
          */

--- a/test/jdk/javax/management/security/Utils.java
+++ b/test/jdk/javax/management/security/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ import java.util.StringTokenizer;
 import java.lang.reflect.Method;
 import javax.management.remote.JMXConnectorServerMBean;
 
-// utility class for MXBean* tests coming from JMX Tonga test suite
 class Utils {
 
     private static final String SERVER_SIDE_NAME = "-server";
@@ -64,9 +63,6 @@ class Utils {
     }
 
     /**
-     * Reproduces the original parsing and collection of test parameters
-     * from the DTonga JMX test suite.
-     *
      * Collects passed args and returns them in a map(argname, value) structure,
      * which will be then propagated as necessary to various called methods.
      */


### PR DESCRIPTION
Trivial removal of confusing "Tonga" references in comments within a few JMX tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350571](https://bugs.openjdk.org/browse/JDK-8350571): Remove mention of Tonga test suite from JMX tests (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23747/head:pull/23747` \
`$ git checkout pull/23747`

Update a local copy of the PR: \
`$ git checkout pull/23747` \
`$ git pull https://git.openjdk.org/jdk.git pull/23747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23747`

View PR using the GUI difftool: \
`$ git pr show -t 23747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23747.diff">https://git.openjdk.org/jdk/pull/23747.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23747#issuecomment-2678176521)
</details>
