### PR TITLE
8328473: StringTable and SymbolTable statistics delay time to safepoint

### DIFF
--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -745,13 +745,29 @@ struct SizeFunc : StackObj {
 TableStatistics StringTable::get_table_statistics() {
   static TableStatistics ts;
   SizeFunc sz;
-  ts = _local_table->statistics_get(Thread::current(), sz, ts);
+
+  Thread* jt = Thread::current();
+  StringTableHash::StatisticsTask sts(_local_table);
+  if (!sts.prepare(jt)) {
+    return ts;  // return old table statistics
+  }
+  {
+    TraceTime timer("GetStatistics", TRACETIME_LOG(Debug, stringtable, perf));
+    while (sts.do_task(jt, sz)) {
+      sts.pause(jt);
+      if (jt->is_Java_thread()) {
+        ThreadBlockInVM tbivm(JavaThread::cast(jt));
+      }
+      sts.cont(jt);
+    }
+  }
+  ts = sts.done(jt);
   return ts;
 }
 
 void StringTable::print_table_statistics(outputStream* st) {
-  SizeFunc sz;
-  _local_table->statistics_to(Thread::current(), sz, st, "StringTable");
+  TableStatistics ts = get_table_statistics();
+  ts.print(st, "StringTable");
 #if INCLUDE_CDS_JAVA_HEAP
   if (!_shared_table.empty()) {
     _shared_table.print_table_statistics(st, "Shared String Table");

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -572,23 +572,35 @@ Symbol* SymbolTable::new_permanent_symbol(const char* name) {
   return sym;
 }
 
-struct SizeFunc : StackObj {
-  size_t operator()(Symbol* value) {
+TableStatistics SymbolTable::get_table_statistics() {
+  static TableStatistics ts;
+  auto sz = [&](Symbol* value) {
     assert(value != nullptr, "expected valid value");
     return (value)->size() * HeapWordSize;
   };
+
+  Thread* jt = Thread::current();
+  SymbolTableHash::StatisticsTask sts(_local_table);
+  if (!sts.prepare(jt)) {
+    return ts;  // return old table statistics
+  }
+  {
+    TraceTime timer("GetStatistics", TRACETIME_LOG(Debug, symboltable, perf));
+    while (sts.do_task(jt, sz)) {
+      sts.pause(jt);
+      if (jt->is_Java_thread()) {
+        ThreadBlockInVM tbivm(JavaThread::cast(jt));
+      }
+      sts.cont(jt);
+    }
+  }
+  ts = sts.done(jt);
+  return ts;
 };
 
-TableStatistics SymbolTable::get_table_statistics() {
-  static TableStatistics ts;
-  SizeFunc sz;
-  ts = _local_table->statistics_get(Thread::current(), sz, ts);
-  return ts;
-}
-
 void SymbolTable::print_table_statistics(outputStream* st) {
-  SizeFunc sz;
-  _local_table->statistics_to(Thread::current(), sz, st, "SymbolTable");
+  TableStatistics ts = get_table_statistics();
+  ts.print(st, "SymbolTable");
 
   if (!_shared_table.empty()) {
     _shared_table.print_table_statistics(st, "Shared Symbol Table");

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -56,7 +56,7 @@ class ConcurrentHashTable : public CHeapObj<MT> {
       _stats_rate->remove();
     }
   }
-  // Calculate statistics. Item sizes are calculated with VALUE_SIZE_FUNC, and accumloated in summary and literal_size.
+  // Calculate statistics. Item sizes are calculated with VALUE_SIZE_FUNC, and accumulated in summary and literal_size.
   template <typename VALUE_SIZE_FUNC>
   void internal_statistics_range(Thread* thread, size_t start, size_t stop,
                                  VALUE_SIZE_FUNC& sts_f, NumberSeq& summary, size_t& literal_size);

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,9 +56,12 @@ class ConcurrentHashTable : public CHeapObj<MT> {
       _stats_rate->remove();
     }
   }
-  // Calculate statistics. Item sizes are calculated with VALUE_SIZE_FUNC.
+  // Calculate statistics. Item sizes are calculated with VALUE_SIZE_FUNC, and accumloated in summary and literal_size.
   template <typename VALUE_SIZE_FUNC>
-  TableStatistics statistics_calculate(Thread* thread, VALUE_SIZE_FUNC& vs_f);
+  void internal_statistics_range(Thread* thread, size_t start, size_t stop,
+                                 VALUE_SIZE_FUNC& sts_f, NumberSeq& summary, size_t& literal_size);
+
+  TableStatistics internal_statistics_epilog(Thread* thread, NumberSeq summary, size_t literal_size);
 
   // This is the internal node structure.
   // Only constructed with placement new from memory allocated with MemTag of
@@ -531,12 +534,6 @@ class ConcurrentHashTable : public CHeapObj<MT> {
   template <typename VALUE_SIZE_FUNC>
   TableStatistics statistics_get(Thread* thread, VALUE_SIZE_FUNC& vs_f, TableStatistics old);
 
-  // Writes statistics to the outputStream. Item sizes are calculated with
-  // VALUE_SIZE_FUNC.
-  template <typename VALUE_SIZE_FUNC>
-  void statistics_to(Thread* thread, VALUE_SIZE_FUNC& vs_f, outputStream* st,
-                     const char* table_name);
-
   // Moves all nodes from this table to to_cht with new hash code.
   // Must be done at a safepoint.
   void rehash_nodes_to(Thread* thread, ConcurrentHashTable<CONFIG, MT>* to_cht);
@@ -559,6 +556,7 @@ class ConcurrentHashTable : public CHeapObj<MT> {
  public:
   class BulkDeleteTask;
   class GrowTask;
+  class StatisticsTask;
   class ScanTask;
 };
 


### PR DESCRIPTION
This change adds a safepoint poll to gathering statistics for the Symbol and String tables, using the ConcurrentHashTableTasks to chunk up the walk.  The stringTable and symbolTable is similar, like the GrowTask and DeleteTask code.  Maybe this can be cleaned up but I don't have a good idea about that yet that doesn't involve yet another level of templated functions and code. This is already pretty highly templatized.
Tested with tier1-4 and runThese internal test with JFR and failure injection to verify that we do try to safepoint while gathering statistics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328473](https://bugs.openjdk.org/browse/JDK-8328473): StringTable and SymbolTable statistics delay time to safepoint (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23750/head:pull/23750` \
`$ git checkout pull/23750`

Update a local copy of the PR: \
`$ git checkout pull/23750` \
`$ git pull https://git.openjdk.org/jdk.git pull/23750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23750`

View PR using the GUI difftool: \
`$ git pr show -t 23750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23750.diff">https://git.openjdk.org/jdk/pull/23750.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23750#issuecomment-2678605652)
</details>
