### PR TITLE
8314840: 3 gc/epsilon tests ignore external vm options

### DIFF
--- a/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,13 +37,13 @@ import jdk.test.lib.process.ProcessTools;
 public class TestDieDefault {
 
   public static void passWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldNotContain("OutOfMemoryError");
     out.shouldHaveExitValue(0);
   }
 
   public static void failWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldContain("OutOfMemoryError");
     if (out.getExitValue() == 0) {
       throw new IllegalStateException("Should have failed with non-zero exit code");

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,13 +38,13 @@ import jdk.test.lib.process.ProcessTools;
 public class TestDieWithHeapDump {
 
   public static void passWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldNotContain("OutOfMemoryError");
     out.shouldHaveExitValue(0);
   }
 
   public static void failWith(String... args) throws Exception {
-    ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(args);
+    ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(args);
     Process p = pb.start();
     OutputAnalyzer out = new OutputAnalyzer(p);
     out.shouldContain("OutOfMemoryError");

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,14 +39,14 @@ public class TestDieWithOnError {
   static String ON_ERR_MSG = "Epsilon error handler message";
 
   public static void passWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldNotContain("OutOfMemoryError");
     out.stdoutShouldNotMatch("^" + ON_ERR_MSG);
     out.shouldHaveExitValue(0);
   }
 
   public static void failWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldContain("OutOfMemoryError");
     if (out.getExitValue() == 0) {
       throw new IllegalStateException("Should have failed with non-zero exit code");


### PR DESCRIPTION
These tests do not pass Java/JVM test command line options (flags) to the child process. More details in JBS.
Tiers 1 to 3 tested. Along with various flag combinations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314840](https://bugs.openjdk.org/browse/JDK-8314840): 3 gc/epsilon tests ignore external vm options (**Sub-task** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23751/head:pull/23751` \
`$ git checkout pull/23751`

Update a local copy of the PR: \
`$ git checkout pull/23751` \
`$ git pull https://git.openjdk.org/jdk.git pull/23751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23751`

View PR using the GUI difftool: \
`$ git pr show -t 23751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23751.diff">https://git.openjdk.org/jdk/pull/23751.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23751#issuecomment-2678826559)
</details>
