### PR TITLE
JDK-8350585: InlineSecondarySupersTest must be guarded on ppc64 by COMPILER2

### DIFF
--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -4889,12 +4889,14 @@ void generate_lookup_secondary_supers_table_stub() {
     // arraycopy stubs used by compilers
     generate_arraycopy_stubs();
 
+#ifdef COMPILER2
     if (UseSecondarySupersTable) {
       StubRoutines::_lookup_secondary_supers_table_slow_path_stub = generate_lookup_secondary_supers_table_slow_path_stub();
       if (!InlineSecondarySupersTest) {
         generate_lookup_secondary_supers_table_stub();
       }
     }
+#endif // COMPILER2
 
     StubRoutines::_upcall_stub_exception_handler = generate_upcall_stub_exception_handler();
     StubRoutines::_upcall_stub_load_target = generate_upcall_stub_load_target();


### PR DESCRIPTION
In the minimal build we run into this error (e.g. on AIX) :
```
src/hotspot/cpu/ppc/stubGenerator_ppc.cpp:4894:12: error: use of undeclared identifier 'InlineSecondarySupersTest'
      if (!InlineSecondarySupersTest) {
```

The reason is the missing `COMPILER2` define check in the ppc64 coding.