### PR TITLE
8350313: Include timings for leaving safepoint in safepoint logging

### DIFF
--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -867,7 +867,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
 
 jlong SafepointTracing::_last_safepoint_begin_time_ns = 0;
 jlong SafepointTracing::_last_safepoint_sync_time_ns = 0;
-jlong SafepointTracing::_last_vmop_evaluation_end_time_ns = 0;
+jlong SafepointTracing::_last_leave_safepoint_time_ns = 0;
 jlong SafepointTracing::_last_safepoint_end_time_ns = 0;
 jlong SafepointTracing::_last_app_time_ns = 0;
 int SafepointTracing::_nof_threads = 0;
@@ -970,7 +970,7 @@ void SafepointTracing::synchronized(int nof_threads, int nof_running, int traps)
 }
 
 void SafepointTracing::end_vmop_evaluation() {
-  _last_vmop_evaluation_end_time_ns = os::javaTimeNanos();
+  _last_leave_safepoint_time_ns = os::javaTimeNanos();
 }
 
 void SafepointTracing::end() {
@@ -995,10 +995,10 @@ void SafepointTracing::end() {
      "Total: " JLONG_FORMAT " ns",
       VM_Operation::name(_current_type),
       _last_app_time_ns,
-      _last_safepoint_sync_time_ns      - _last_safepoint_begin_time_ns,
-      _last_vmop_evaluation_end_time_ns - _last_safepoint_sync_time_ns,
-      _last_safepoint_end_time_ns       - _last_vmop_evaluation_end_time_ns,
-      _last_safepoint_end_time_ns       - _last_safepoint_begin_time_ns
+      _last_safepoint_sync_time_ns  - _last_safepoint_begin_time_ns,
+      _last_leave_safepoint_time_ns - _last_safepoint_sync_time_ns,
+      _last_safepoint_end_time_ns   - _last_leave_safepoint_time_ns,
+      _last_safepoint_end_time_ns   - _last_safepoint_begin_time_ns
      );
 
   RuntimeService::record_safepoint_end(_last_safepoint_end_time_ns - _last_safepoint_sync_time_ns);

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -471,6 +471,8 @@ void SafepointSynchronize::disarm_safepoint() {
 // operation has been carried out
 void SafepointSynchronize::end() {
   assert(Threads_lock->owned_by_self(), "must hold Threads_lock");
+  SafepointTracing::end_vmop_evaluation();
+
   EventSafepointEnd event;
   assert(Thread::current()->is_VM_thread(), "Only VM thread can execute a safepoint");
 
@@ -865,6 +867,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
 
 jlong SafepointTracing::_last_safepoint_begin_time_ns = 0;
 jlong SafepointTracing::_last_safepoint_sync_time_ns = 0;
+jlong SafepointTracing::_last_vmop_evaluation_end_time_ns = 0;
 jlong SafepointTracing::_last_safepoint_end_time_ns = 0;
 jlong SafepointTracing::_last_app_time_ns = 0;
 int SafepointTracing::_nof_threads = 0;
@@ -966,6 +969,10 @@ void SafepointTracing::synchronized(int nof_threads, int nof_running, int traps)
   RuntimeService::record_safepoint_synchronized(_last_safepoint_sync_time_ns - _last_safepoint_begin_time_ns);
 }
 
+void SafepointTracing::end_vmop_evaluation() {
+  _last_vmop_evaluation_end_time_ns = os::javaTimeNanos();
+}
+
 void SafepointTracing::end() {
   _last_safepoint_end_time_ns = os::javaTimeNanos();
 
@@ -984,12 +991,14 @@ void SafepointTracing::end() {
      "Time since last: " JLONG_FORMAT " ns, "
      "Reaching safepoint: " JLONG_FORMAT " ns, "
      "At safepoint: " JLONG_FORMAT " ns, "
+     "Leaving safepoint: " JLONG_FORMAT " ns, "
      "Total: " JLONG_FORMAT " ns",
       VM_Operation::name(_current_type),
       _last_app_time_ns,
-      _last_safepoint_sync_time_ns    - _last_safepoint_begin_time_ns,
-      _last_safepoint_end_time_ns     - _last_safepoint_sync_time_ns,
-      _last_safepoint_end_time_ns     - _last_safepoint_begin_time_ns
+      _last_safepoint_sync_time_ns      - _last_safepoint_begin_time_ns,
+      _last_vmop_evaluation_end_time_ns - _last_safepoint_sync_time_ns,
+      _last_safepoint_end_time_ns       - _last_vmop_evaluation_end_time_ns,
+      _last_safepoint_end_time_ns       - _last_safepoint_begin_time_ns
      );
 
   RuntimeService::record_safepoint_end(_last_safepoint_end_time_ns - _last_safepoint_sync_time_ns);

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -471,7 +471,7 @@ void SafepointSynchronize::disarm_safepoint() {
 // operation has been carried out
 void SafepointSynchronize::end() {
   assert(Threads_lock->owned_by_self(), "must hold Threads_lock");
-  SafepointTracing::end_vmop_evaluation();
+  SafepointTracing::leave();
 
   EventSafepointEnd event;
   assert(Thread::current()->is_VM_thread(), "Only VM thread can execute a safepoint");
@@ -867,7 +867,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
 
 jlong SafepointTracing::_last_safepoint_begin_time_ns = 0;
 jlong SafepointTracing::_last_safepoint_sync_time_ns = 0;
-jlong SafepointTracing::_last_leave_safepoint_time_ns = 0;
+jlong SafepointTracing::_last_safepoint_leave_time_ns = 0;
 jlong SafepointTracing::_last_safepoint_end_time_ns = 0;
 jlong SafepointTracing::_last_app_time_ns = 0;
 int SafepointTracing::_nof_threads = 0;
@@ -969,8 +969,8 @@ void SafepointTracing::synchronized(int nof_threads, int nof_running, int traps)
   RuntimeService::record_safepoint_synchronized(_last_safepoint_sync_time_ns - _last_safepoint_begin_time_ns);
 }
 
-void SafepointTracing::end_vmop_evaluation() {
-  _last_leave_safepoint_time_ns = os::javaTimeNanos();
+void SafepointTracing::leave() {
+  _last_safepoint_leave_time_ns = os::javaTimeNanos();
 }
 
 void SafepointTracing::end() {
@@ -996,8 +996,8 @@ void SafepointTracing::end() {
       VM_Operation::name(_current_type),
       _last_app_time_ns,
       _last_safepoint_sync_time_ns  - _last_safepoint_begin_time_ns,
-      _last_leave_safepoint_time_ns - _last_safepoint_sync_time_ns,
-      _last_safepoint_end_time_ns   - _last_leave_safepoint_time_ns,
+      _last_safepoint_leave_time_ns - _last_safepoint_sync_time_ns,
+      _last_safepoint_end_time_ns   - _last_safepoint_leave_time_ns,
       _last_safepoint_end_time_ns   - _last_safepoint_begin_time_ns
      );
 

--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -230,7 +230,7 @@ private:
   // Absolute
   static jlong _last_safepoint_begin_time_ns;
   static jlong _last_safepoint_sync_time_ns;
-  static jlong _last_leave_safepoint_time_ns;
+  static jlong _last_safepoint_leave_time_ns;
   static jlong _last_safepoint_end_time_ns;
 
   // Relative
@@ -252,7 +252,7 @@ public:
 
   static void begin(VM_Operation::VMOp_Type type);
   static void synchronized(int nof_threads, int nof_running, int traps);
-  static void end_vmop_evaluation();
+  static void leave();
   static void end();
 
   static void statistics_exit_log();

--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -230,7 +230,7 @@ private:
   // Absolute
   static jlong _last_safepoint_begin_time_ns;
   static jlong _last_safepoint_sync_time_ns;
-  static jlong _last_vmop_evaluation_end_time_ns;
+  static jlong _last_leave_safepoint_time_ns;
   static jlong _last_safepoint_end_time_ns;
 
   // Relative

--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -230,6 +230,7 @@ private:
   // Absolute
   static jlong _last_safepoint_begin_time_ns;
   static jlong _last_safepoint_sync_time_ns;
+  static jlong _last_vmop_evaluation_end_time_ns;
   static jlong _last_safepoint_end_time_ns;
 
   // Relative
@@ -251,6 +252,7 @@ public:
 
   static void begin(VM_Operation::VMOp_Type type);
   static void synchronized(int nof_threads, int nof_running, int traps);
+  static void end_vmop_evaluation();
   static void end();
 
   static void statistics_exit_log();


### PR DESCRIPTION
Hi there,
Please help with reviewing the PR. The change is to improve the observability of timings of safepoints. We have a production use case where leaving the safepoint introduced a significant latency, mostly due to VMThread getting de-scheduled, more details can be find in JBS bug [JDK-8350324](https://bugs.openjdk.org/browse/JDK-8350324). 

Current safepoint log is like:
```
[3.427s][info][gc       ] GC(6) Pause Final Mark (unload classes) 0.201ms
[3.428s][info][safepoint] Safepoint "ShenandoahFinalMarkStartEvac", Time since last: 2463125 ns, Reaching safepoint: 14958 ns, At safepoint: 410834 ns, Total: 425792 ns

```

The "At safepoint" time include the time to evaluate the VM operation and the time to leave safepoint(cleanup, disarm WaitBarrier..etc.), from safepoint log we don't really know how much time it takes to leave safepoint. 

As proposed in [JDK-8350313](https://bugs.openjdk.org/browse/JDK-8350313), we think a "Leaving safepoint" counter just like "Reaching safepoint" could be nice to have. It comes with the symmetry advantage with "Reaching safepoint" counter. "Leaving safepoint" measures the time spent in safepoint machinery from the "finishing side". And, it more clearly captures the transitional state where some threads might be still at safepoint, and some have already unparked, like "Reaching safepoint".

With the new "Leaving safepoint" counter, the log will be like:
```
[17.764s][info][gc       ] GC(84) Pause Final Mark (unload classes) 0.179ms
[17.764s][info][safepoint] Safepoint "ShenandoahFinalMarkStartEvac", Time since last: 3340792 ns, Reaching safepoint: 31250 ns, At safepoint: 187958 ns, Leaving safepoint: 177833 ns, Total: 397041 ns
```

### Tests
- [x] Verified the new safepoint log
- [x] Tier 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8350313](https://bugs.openjdk.org/browse/JDK-8350313): Include timings for leaving safepoint in safepoint logging (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23756/head:pull/23756` \
`$ git checkout pull/23756`

Update a local copy of the PR: \
`$ git checkout pull/23756` \
`$ git pull https://git.openjdk.org/jdk.git pull/23756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23756`

View PR using the GUI difftool: \
`$ git pr show -t 23756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23756.diff">https://git.openjdk.org/jdk/pull/23756.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23756#issuecomment-2679965978)
</details>
