### PR TITLE
8350614: [JMH] jdk.incubator.vector.VectorCommutativeOperSharingBenchmark fails

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorCommutativeOperSharingBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorCommutativeOperSharingBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class VectorCommutativeOperSharingBenchmark {
     @Param({"1024","2048"})
     int size;


### PR DESCRIPTION
Hi all,

The newly added JMH test jdk.incubator.vector.VectorCommutativeOperSharingBenchmark run fails "java.lang.NoClassDefFoundError: jdk/incubator/vector/Vector".

The `@Fork(jvmArgsPrepend = ..)` in microbenchmarks should replaced as `@Fork(jvmArgs = ..)` after [JDK-8343345](https://bugs.openjdk.org/browse/JDK-8343345). Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350614](https://bugs.openjdk.org/browse/JDK-8350614): [JMH] jdk.incubator.vector.VectorCommutativeOperSharingBenchmark fails (**Bug** - P4)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23761/head:pull/23761` \
`$ git checkout pull/23761`

Update a local copy of the PR: \
`$ git checkout pull/23761` \
`$ git pull https://git.openjdk.org/jdk.git pull/23761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23761`

View PR using the GUI difftool: \
`$ git pr show -t 23761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23761.diff">https://git.openjdk.org/jdk/pull/23761.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23761#issuecomment-2680234047)
</details>
