### PR TITLE
8350616: Skip ValidateHazardPtrsClosure in non-debug builds

### DIFF
--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -366,7 +366,7 @@ class ScanHazardPtrPrintMatchingThreadsClosure : public ThreadClosure {
   }
 };
 
-#ifdef DEBUG
+#ifdef ASSERT
 // Closure to validate hazard ptrs.
 //
 class ValidateHazardPtrsClosure : public ThreadClosure {
@@ -952,7 +952,7 @@ void ThreadsSMRSupport::free_list(ThreadsList* threads) {
     log_debug(thread, smr)("tid=%zu: ThreadsSMRSupport::free_list: threads=" INTPTR_FORMAT " is not freed.", os::current_thread_id(), p2i(threads));
   }
 
-#ifdef DEBUG
+#ifdef ASSERT
   ValidateHazardPtrsClosure validate_cl;
   threads_do(&validate_cl);
 #endif

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -366,6 +366,7 @@ class ScanHazardPtrPrintMatchingThreadsClosure : public ThreadClosure {
   }
 };
 
+#ifdef DEBUG
 // Closure to validate hazard ptrs.
 //
 class ValidateHazardPtrsClosure : public ThreadClosure {
@@ -386,6 +387,7 @@ class ValidateHazardPtrsClosure : public ThreadClosure {
            p2i(thread));
   }
 };
+#endif
 
 // Closure to determine if the specified JavaThread is found by
 // threads_do().
@@ -950,8 +952,10 @@ void ThreadsSMRSupport::free_list(ThreadsList* threads) {
     log_debug(thread, smr)("tid=%zu: ThreadsSMRSupport::free_list: threads=" INTPTR_FORMAT " is not freed.", os::current_thread_id(), p2i(threads));
   }
 
+#ifdef DEBUG
   ValidateHazardPtrsClosure validate_cl;
   threads_do(&validate_cl);
+#endif
 
   delete scan_table;
 }


### PR DESCRIPTION
Simple cleanup to skip debug code in a non-debug build. This removes some overhead when working with very large numbers of threads. Basic perf testing starting a new thread when 20000 already exist:

Before: 532377 ns
After:  361178 ns

which is 32% improvement.

Testing:
  - tiers 1-3 sanity

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350616](https://bugs.openjdk.org/browse/JDK-8350616): Skip ValidateHazardPtrsClosure in non-debug builds (**Sub-task** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23762/head:pull/23762` \
`$ git checkout pull/23762`

Update a local copy of the PR: \
`$ git checkout pull/23762` \
`$ git pull https://git.openjdk.org/jdk.git pull/23762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23762`

View PR using the GUI difftool: \
`$ git pr show -t 23762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23762.diff">https://git.openjdk.org/jdk/pull/23762.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23762#issuecomment-2680254796)
</details>
