### PR TITLE
8350617: Improve MethodHandles.tableSwitch and remove intrinsicData

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1780,11 +1780,6 @@ assertEquals("[three, thee, tee]", asListFix.invoke((Object)argv).toString());
     }
 
     /*non-public*/
-    Object intrinsicData() {
-        return null;
-    }
-
-    /*non-public*/
     MethodHandle withInternalMemberName(MemberName member, boolean isInvokeSpecial) {
         if (member != null) {
             return MethodHandleImpl.makeWrappedMember(this, member, isInvokeSpecial);

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -7643,27 +7643,25 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      */
     public static MethodHandle tableSwitch(MethodHandle fallback, MethodHandle... targets) {
         Objects.requireNonNull(fallback);
-        Objects.requireNonNull(targets);
-        targets = targets.clone();
-        MethodType type = tableSwitchChecks(fallback, targets);
-        return MethodHandleImpl.makeTableSwitch(type, fallback, targets);
+        var targetList = List.of(targets); // deep null checks
+        MethodType type = tableSwitchChecks(fallback, targetList);
+        return MethodHandleImpl.makeTableSwitch(type, fallback, targetList);
     }
 
-    private static MethodType tableSwitchChecks(MethodHandle defaultCase, MethodHandle[] caseActions) {
-        if (caseActions.length == 0)
-            throw new IllegalArgumentException("Not enough cases: " + Arrays.toString(caseActions));
+    private static MethodType tableSwitchChecks(MethodHandle defaultCase, List<MethodHandle> caseActions) {
+        if (caseActions.isEmpty())
+            throw new IllegalArgumentException("Not enough cases: " + caseActions);
 
         MethodType expectedType = defaultCase.type();
 
         if (!(expectedType.parameterCount() >= 1) || expectedType.parameterType(0) != int.class)
             throw new IllegalArgumentException(
-                "Case actions must have int as leading parameter: " + Arrays.toString(caseActions));
+                "Case actions must have int as leading parameter: " + caseActions);
 
         for (MethodHandle mh : caseActions) {
-            Objects.requireNonNull(mh);
             if (mh.type() != expectedType)
                 throw new IllegalArgumentException(
-                    "Case actions must have the same type: " + Arrays.toString(caseActions));
+                    "Case actions must have the same type: " + caseActions);
         }
 
         return expectedType;

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -7650,18 +7650,18 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
 
     private static MethodType tableSwitchChecks(MethodHandle defaultCase, List<MethodHandle> caseActions) {
         if (caseActions.isEmpty())
-            throw new IllegalArgumentException("Not enough cases: " + caseActions);
+            throw new IllegalArgumentException("At least one target required");
 
         MethodType expectedType = defaultCase.type();
 
-        if (!(expectedType.parameterCount() >= 1) || expectedType.parameterType(0) != int.class)
+        if (expectedType.parameterCount() < 1 || expectedType.parameterType(0) != int.class)
             throw new IllegalArgumentException(
-                "Case actions must have int as leading parameter: " + caseActions);
+                "Switch method handles must have int as leading parameter: " + expectedType);
 
         for (MethodHandle mh : caseActions) {
             if (mh.type() != expectedType)
                 throw new IllegalArgumentException(
-                    "Case actions must have the same type: " + caseActions);
+                    "Some targets do not have the expected type " + expectedType + ": " + caseActions);
         }
 
         return expectedType;

--- a/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
@@ -92,7 +92,8 @@ final class MethodTypeForm {
             LF_VH_GEN_INVOKER          = 23,  // VarHandle generic invoker
             LF_VH_GEN_LINKER           = 24,  // VarHandle generic linker
             LF_COLLECTOR               = 25,  // collector handle
-            LF_LIMIT                   = 26;
+            LF_SWITCH                  = 26,  // switches handles to invoke
+            LF_LIMIT                   = 27;
 
     /** Return the type corresponding uniquely (1-1) to this MT-form.
      *  It might have any primitive returns or arguments, but will have no references except Object.

--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -39,6 +39,7 @@ import java.util.function.UnaryOperator;
 import jdk.internal.access.JavaUtilCollectionAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.CDS;
+import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.Stable;
 
 /**
@@ -585,6 +586,7 @@ class ImmutableCollections {
 
         @Override
         @SuppressWarnings("unchecked")
+        @ForceInline
         public E get(int index) {
             if (index == 0) {
                 return e0;
@@ -685,6 +687,7 @@ class ImmutableCollections {
         }
 
         @Override
+        @ForceInline
         public E get(int index) {
             return elements[index];
         }


### PR DESCRIPTION
Remove the intrinsicData field. We can obtain this from the customized MH when we spin ultra-customized lambda forms. In the long run, we aim to remove this intrinsic if there is no regression for call site sharing.

The existing tableSwitch combinator's LF is unnecessarily complex. This patch also simplifies the tableSwitch combinator.

Note that I was forced to add `@ForceInline` on immutable lists due to regressions in `MethodHandlesTableSwitchRandom` with `sorted == true`, which eliminates the regression. Otherwise, all benchmark results are the same. Tested java/lang/invoke.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350617](https://bugs.openjdk.org/browse/JDK-8350617): Improve MethodHandles.tableSwitch and remove intrinsicData (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23763/head:pull/23763` \
`$ git checkout pull/23763`

Update a local copy of the PR: \
`$ git checkout pull/23763` \
`$ git pull https://git.openjdk.org/jdk.git pull/23763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23763`

View PR using the GUI difftool: \
`$ git pr show -t 23763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23763.diff">https://git.openjdk.org/jdk/pull/23763.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23763#issuecomment-2683379551)
</details>
