### PR TITLE
8350584: Check the usage of LOG_PLEASE

### DIFF
--- a/test/hotspot/gtest/metaspace/test_clms.cpp
+++ b/test/hotspot/gtest/metaspace/test_clms.cpp
@@ -38,7 +38,7 @@
 
 #ifdef _LP64
 
-#define LOG_PLEASE
+// #define LOG_PLEASE
 #include "metaspaceGtestCommon.hpp"
 #include "metaspaceGtestContexts.hpp"
 #include "metaspaceGtestRangeHelpers.hpp"

--- a/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
@@ -40,7 +40,7 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#define LOG_PLEASE
+// #define LOG_PLEASE
 #include "metaspaceGtestCommon.hpp"
 #include "metaspaceGtestContexts.hpp"
 #include "metaspaceGtestRangeHelpers.hpp"

--- a/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
+++ b/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
@@ -30,7 +30,7 @@
 #include "utilities/macros.hpp"
 #include "utilities/resourceHash.hpp"
 
-#define LOG_PLEASE
+// #define LOG_PLEASE
 #include "testutils.hpp"
 #include "unittest.hpp"
 


### PR DESCRIPTION
Hi all,

Seen discussion in https://github.com/openjdk/jdk/pull/23290#issuecomment-2678001782. The LOG_PLEASE macro seems currently being defined are debugging leftovers that shouldn't have been committed. It's definition is typically
commented or uncommented to provide some additional logging for some tests of interest.

This PR comment out the `#define LOG_PLEASE` same to other gtests. Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350584](https://bugs.openjdk.org/browse/JDK-8350584): Check the usage of LOG_PLEASE (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23764/head:pull/23764` \
`$ git checkout pull/23764`

Update a local copy of the PR: \
`$ git checkout pull/23764` \
`$ git pull https://git.openjdk.org/jdk.git pull/23764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23764`

View PR using the GUI difftool: \
`$ git pr show -t 23764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23764.diff">https://git.openjdk.org/jdk/pull/23764.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23764#issuecomment-2680344704)
</details>
