### PR TITLE
8350546: Several java/net/InetAddress tests fails UnknownHostException

### DIFF
--- a/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
+++ b/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
@@ -25,8 +25,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 
-import jtreg.SkippedException;
-
 /**
  * @test
  * @bug 8135305
@@ -40,7 +38,7 @@ public class IsReachableViaLoopbackTest {
     public static void main(String[] args) {
         try {
             InetAddress addr = InetAddress.getLoopbackAddress();
-            InetAddress remoteAddr = InetAddress.getByName("23.197.138.208");  //real address of bugs.openjdk.org
+            InetAddress remoteAddr = InetAddress.getByName("23.197.138.208");  // use literal address to avoid DNS checks
             if (!addr.isReachable(10000))
                 throw new RuntimeException("Localhost should always be reachable");
             NetworkInterface inf = NetworkInterface.getByInetAddress(addr);

--- a/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
+++ b/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
@@ -21,9 +21,9 @@
  * questions.
  */
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
 
 import jtreg.SkippedException;
 

--- a/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
+++ b/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
@@ -39,8 +39,8 @@ import jtreg.SkippedException;
 public class IsReachableViaLoopbackTest {
     public static void main(String[] args) {
         try {
-            InetAddress addr = InetAddress.getByName("localhost");
-            InetAddress remoteAddr = InetAddress.getByName("bugs.openjdk.org");
+            InetAddress addr = InetAddress.getLoopbackAddress();
+            InetAddress remoteAddr = InetAddress.getByAddress("bugs.openjdk.org".getBytes());
             if (!addr.isReachable(10000))
                 throw new RuntimeException("Localhost should always be reachable");
             NetworkInterface inf = NetworkInterface.getByInetAddress(addr);

--- a/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
+++ b/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
@@ -32,7 +32,6 @@ import jtreg.SkippedException;
  * @bug 8135305
  * @key intermittent
  * @library /test/lib
- * @build jtreg.SkippedException
  * @summary ensure we can't ping external hosts via loopback if
  * @run main IsReachableViaLoopbackTest
  */

--- a/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
+++ b/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
@@ -61,7 +61,7 @@ public class IsReachableViaLoopbackTest {
             }
         } catch (java.net.UnknownHostException e) {
             e.printStackTrace();
-            throw new SkippedException("Network setup issue, skip this test");
+            throw new SkippedException("Network setup issue");
         } catch (IOException e) {
             throw new RuntimeException("Unexpected exception:" + e);
         }

--- a/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
+++ b/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
@@ -40,7 +40,7 @@ public class IsReachableViaLoopbackTest {
     public static void main(String[] args) {
         try {
             InetAddress addr = InetAddress.getLoopbackAddress();
-            InetAddress remoteAddr = InetAddress.getByAddress("bugs.openjdk.org".getBytes());
+            InetAddress remoteAddr = InetAddress.getByName("23.197.138.208");  //real address of bugs.openjdk.org
             if (!addr.isReachable(10000))
                 throw new RuntimeException("Localhost should always be reachable");
             NetworkInterface inf = NetworkInterface.getByInetAddress(addr);
@@ -58,9 +58,6 @@ public class IsReachableViaLoopbackTest {
             } else {
                 System.out.println("inf == null");
             }
-        } catch (java.net.UnknownHostException e) {
-            e.printStackTrace();
-            throw new SkippedException("Network setup issue");
         } catch (IOException e) {
             throw new RuntimeException("Unexpected exception:" + e);
         }

--- a/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
+++ b/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,16 @@ import java.io.*;
 import java.net.*;
 import java.util.*;
 
+import jtreg.SkippedException;
+
 /**
  * @test
  * @bug 8135305
  * @key intermittent
+ * @library /test/lib
+ * @build jtreg.SkippedException
  * @summary ensure we can't ping external hosts via loopback if
+ * @run main IsReachableViaLoopbackTest
  */
 
 public class IsReachableViaLoopbackTest {
@@ -54,7 +59,9 @@ public class IsReachableViaLoopbackTest {
             } else {
                 System.out.println("inf == null");
             }
-
+        } catch (java.net.UnknownHostException e) {
+            e.printStackTrace();
+            throw new SkippedException("Network setup issue, skip this test");
         } catch (IOException e) {
             throw new RuntimeException("Unexpected exception:" + e);
         }

--- a/test/jdk/java/net/InetAddress/getOriginalHostName.java
+++ b/test/jdk/java/net/InetAddress/getOriginalHostName.java
@@ -27,7 +27,6 @@
  * @summary test functionality of getOriginalHostName(InetAddress)
  * @modules java.base/jdk.internal.access
  * @library /test/lib
- * @build jtreg.SkippedException
  * @run main getOriginalHostName
  */
 

--- a/test/jdk/java/net/InetAddress/getOriginalHostName.java
+++ b/test/jdk/java/net/InetAddress/getOriginalHostName.java
@@ -43,8 +43,8 @@ public class getOriginalHostName {
         InetAddress ia = null;
         ia = getInetAddress(HOST);
         if (ia != null) testInetAddress(ia, HOST);
-        ia = getInetAddress("255.255.255.0");
-        if (ia != null) testInetAddress(ia, null);
+        ia = InetAddress.getByName("255.255.255.0");
+        testInetAddress(ia, null);
         ia = InetAddress.getByAddress(new byte[]{1,1,1,1});
         testInetAddress(ia, null);
         ia = InetAddress.getLocalHost();

--- a/test/jdk/java/net/InetAddress/getOriginalHostName.java
+++ b/test/jdk/java/net/InetAddress/getOriginalHostName.java
@@ -26,8 +26,6 @@
  * @bug 8133196
  * @summary test functionality of getOriginalHostName(InetAddress)
  * @modules java.base/jdk.internal.access
- * @library /test/lib
- * @run main getOriginalHostName
  */
 
 import java.net.InetAddress;
@@ -40,24 +38,19 @@ public class getOriginalHostName {
     private static final JavaNetInetAddressAccess jna =
         SharedSecrets.getJavaNetInetAddressAccess();
 
-    public static void main(String[] args) {
-        try {
-            final String HOST = "dummyserver.java.net";
-            InetAddress ia = null;
-            ia = getInetAddress(HOST);
-            if (ia != null) testInetAddress(ia, HOST);
-            ia = getInetAddress("255.255.255.0");
-            if (ia != null) testInetAddress(ia, null);
-            ia = InetAddress.getByAddress(new byte[]{1,1,1,1});
-            testInetAddress(ia, null);
-            ia = InetAddress.getLocalHost();
-            testInetAddress(ia, ia.getHostName());
-            ia = InetAddress.getLoopbackAddress();
-            testInetAddress(ia, ia.getHostName());
-        } catch (Exception e) {
-            throw new RuntimeException("Unexpected exception:" + e);
-        }
-        System.out.println("getOriginalHostName EXIT");
+    public static void main(String[] args) throws Exception {
+        final String HOST = "dummyserver.java.net";
+        InetAddress ia = null;
+        ia = getInetAddress(HOST);
+        if (ia != null) testInetAddress(ia, HOST);
+        ia = getInetAddress("255.255.255.0");
+        if (ia != null) testInetAddress(ia, null);
+        ia = InetAddress.getByAddress(new byte[]{1,1,1,1});
+        testInetAddress(ia, null);
+        ia = InetAddress.getLocalHost();
+        testInetAddress(ia, ia.getHostName());
+        ia = InetAddress.getLoopbackAddress();
+        testInetAddress(ia, ia.getHostName());
     }
 
     private static InetAddress getInetAddress(String host) {

--- a/test/jdk/java/net/InetAddress/getOriginalHostName.java
+++ b/test/jdk/java/net/InetAddress/getOriginalHostName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,9 @@
  * @bug 8133196
  * @summary test functionality of getOriginalHostName(InetAddress)
  * @modules java.base/jdk.internal.access
+ * @library /test/lib
+ * @build jtreg.SkippedException
+ * @run main getOriginalHostName
  */
 
 import java.net.InetAddress;
@@ -38,19 +41,27 @@ public class getOriginalHostName {
     private static final JavaNetInetAddressAccess jna =
         SharedSecrets.getJavaNetInetAddressAccess();
 
-    public static void main(String[] args) throws Exception {
-        final String HOST = "dummyserver.java.net";
-        InetAddress ia = null;
-        ia = InetAddress.getByName(HOST);
-        testInetAddress(ia, HOST);
-        ia = InetAddress.getByName("255.255.255.0");
-        testInetAddress(ia, null);
-        ia = InetAddress.getByAddress(new byte[]{1,1,1,1});
-        testInetAddress(ia, null);
-        ia = InetAddress.getLocalHost();
-        testInetAddress(ia, ia.getHostName());
-        ia = InetAddress.getLoopbackAddress();
-        testInetAddress(ia, ia.getHostName());
+    public static void main(String[] args) {
+        try {
+            final String HOST = "dummyserver.java.net";
+            InetAddress ia = null;
+            ia = InetAddress.getByName(HOST);
+            testInetAddress(ia, HOST);
+            ia = InetAddress.getByName("255.255.255.0");
+            testInetAddress(ia, null);
+            ia = InetAddress.getByAddress(new byte[]{1,1,1,1});
+            testInetAddress(ia, null);
+            ia = InetAddress.getLocalHost();
+            testInetAddress(ia, ia.getHostName());
+            ia = InetAddress.getLoopbackAddress();
+            testInetAddress(ia, ia.getHostName());
+        } catch (java.net.UnknownHostException e) {
+            e.printStackTrace();
+            throw new jtreg.SkippedException("Network setup issue, skip this test");
+        } catch (Exception e) {
+            throw new RuntimeException("Unexpected exception:" + e);
+        }
+        System.out.println("getOriginalHostName EXIT");
     }
 
 

--- a/test/jdk/java/net/InetAddress/getOriginalHostName.java
+++ b/test/jdk/java/net/InetAddress/getOriginalHostName.java
@@ -43,6 +43,8 @@ public class getOriginalHostName {
         InetAddress ia = null;
         ia = getInetAddress(HOST);
         if (ia != null) testInetAddress(ia, HOST);
+        ia = InetAddress.getByAddress(HOST, new byte[] { 1, 2, 3, 4});
+        testInetAddress(ia, HOST);
         ia = InetAddress.getByName("255.255.255.0");
         testInetAddress(ia, null);
         ia = InetAddress.getByAddress(new byte[]{1,1,1,1});

--- a/test/jdk/java/net/InetAddress/getOriginalHostName.java
+++ b/test/jdk/java/net/InetAddress/getOriginalHostName.java
@@ -57,7 +57,7 @@ public class getOriginalHostName {
             testInetAddress(ia, ia.getHostName());
         } catch (java.net.UnknownHostException e) {
             e.printStackTrace();
-            throw new jtreg.SkippedException("Network setup issue, skip this test");
+            throw new jtreg.SkippedException("Network setup issue");
         } catch (Exception e) {
             throw new RuntimeException("Unexpected exception:" + e);
         }

--- a/test/jdk/java/net/InetAddress/getOriginalHostName.java
+++ b/test/jdk/java/net/InetAddress/getOriginalHostName.java
@@ -44,25 +44,30 @@ public class getOriginalHostName {
         try {
             final String HOST = "dummyserver.java.net";
             InetAddress ia = null;
-            ia = InetAddress.getByName(HOST);
-            testInetAddress(ia, HOST);
-            ia = InetAddress.getByName("255.255.255.0");
-            testInetAddress(ia, null);
+            ia = getInetAddress(HOST);
+            if (ia != null) testInetAddress(ia, HOST);
+            ia = getInetAddress("255.255.255.0");
+            if (ia != null) testInetAddress(ia, null);
             ia = InetAddress.getByAddress(new byte[]{1,1,1,1});
             testInetAddress(ia, null);
             ia = InetAddress.getLocalHost();
             testInetAddress(ia, ia.getHostName());
             ia = InetAddress.getLoopbackAddress();
             testInetAddress(ia, ia.getHostName());
-        } catch (java.net.UnknownHostException e) {
-            e.printStackTrace();
-            throw new jtreg.SkippedException("Network setup issue");
         } catch (Exception e) {
             throw new RuntimeException("Unexpected exception:" + e);
         }
         System.out.println("getOriginalHostName EXIT");
     }
 
+    private static InetAddress getInetAddress(String host) {
+        try {
+            return InetAddress.getByName(host);
+        } catch (java.net.UnknownHostException uhe) {
+            System.out.println("Skipping " + host + " due to " + uhe);
+            return null;
+        }
+    }
 
     private static void testInetAddress(InetAddress ia, String expected)
         throws Exception {


### PR DESCRIPTION
Hi all,

Two java/net/InetAddress tests fails "java.net.UnknownHostException" on some special machines. The machine cannot connect to the Internet directly and needs to be connected to the Internet through a jump machine. The java/net/InetAddress tests report "java.net.UnknownHostException: bugs.openjdk.org: Temporary failure in name resolution" failure do not caused by JVM bug but environmentalk issue, so this PR match the java.net.UnknownHostException and throw jtreg.SkippedException instead of report test fails.

And run the tests with JVM options `-Dhttp.proxyHost=192.168.50.1 -Dhttp.proxyPort=10991 -Dhttps.proxyHost=192.168.50.1 -Dhttps.proxyPort=10991 -DsocksProxyHost=192.168.50.1 -DsocksProxyPort=10991` can not work around. So I create this PR to fix the test bug.

Command wget shows that the machine should connect to internet through a jumper machine(192.168.50.1:10991):
```
> wget www.bing.com
--2025-02-24 17:56:25--  http://www.bing.com/
Connecting to 192.168.50.1:10991... connected.
Proxy request sent, awaiting response... 301 Moved Permanently
Location: http://cn.bing.com/ [following]
--2025-02-24 17:56:25--  http://cn.bing.com/
Reusing existing connection to 192.168.50.1:10991.
Proxy request sent, awaiting response... 200 OK
Length: 13006 (13K) [text/html]
Saving to: ‘index.html’
```

Change has been verified locally, test-fix only and make tests more robustness, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350546](https://bugs.openjdk.org/browse/JDK-8350546): Several java/net/InetAddress tests fails UnknownHostException (**Bug** - P4)


### Reviewers
 * [Mikhail Yankelevich](https://openjdk.org/census#myankelevich) (@myankelev - Author) Review applies to [3016bed9](https://git.openjdk.org/jdk/pull/23767/files/3016bed90c49471cd3b7a6e466e53a515e8ac776)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23767/head:pull/23767` \
`$ git checkout pull/23767`

Update a local copy of the PR: \
`$ git checkout pull/23767` \
`$ git pull https://git.openjdk.org/jdk.git pull/23767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23767`

View PR using the GUI difftool: \
`$ git pr show -t 23767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23767.diff">https://git.openjdk.org/jdk/pull/23767.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23767#issuecomment-2681204073)
</details>
