### PR TITLE
8350636: Potential null-pointer dereference in MallocSiteTable::new_entry

### DIFF
--- a/src/hotspot/share/nmt/mallocSiteTable.cpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.cpp
@@ -179,7 +179,11 @@ MallocSite* MallocSiteTable::malloc_site(uint32_t marker) {
 MallocSiteHashtableEntry* MallocSiteTable::new_entry(const NativeCallStack& key, MemTag mem_tag) {
   void* p = AllocateHeap(sizeof(MallocSiteHashtableEntry), mtNMT,
     *hash_entry_allocation_stack(), AllocFailStrategy::RETURN_NULL);
-  return ::new (p) MallocSiteHashtableEntry(key, mem_tag);
+  if (p == nullptr) {
+    return nullptr;
+  } else {
+    return ::new (p) MallocSiteHashtableEntry(key, mem_tag);
+  }
 }
 
 bool MallocSiteTable::walk_malloc_site(MallocSiteWalker* walker) {


### PR DESCRIPTION
Hi,

This fixes a potential null pointer dereference in case of OOM. We return `nullptr` instead of `p` because I didn't feel like casting `p` from `void*` to `MallocSiteHashtableEntry*`.

I believe that this is a trivial PR, and I would appreciate it if a reviewer agrees!

Thanks,
Johan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350636](https://bugs.openjdk.org/browse/JDK-8350636): Potential null-pointer dereference in MallocSiteTable::new_entry (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23768/head:pull/23768` \
`$ git checkout pull/23768`

Update a local copy of the PR: \
`$ git checkout pull/23768` \
`$ git pull https://git.openjdk.org/jdk.git pull/23768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23768`

View PR using the GUI difftool: \
`$ git pr show -t 23768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23768.diff">https://git.openjdk.org/jdk/pull/23768.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23768#issuecomment-2681363029)
</details>
