### PR TITLE
8347426: Invalid value used for enum Cell in iTypeFlow::StateVector::meet_exception

### DIFF
--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -500,15 +500,17 @@ bool ciTypeFlow::StateVector::meet_exception(ciInstanceKlass* exc,
   bool different = false;
 
   // Meet locals from incoming array.
-  Cell limit = local(_outer->max_locals()-1);
-  for (Cell c = start_cell(); c <= limit; c = next_cell(c)) {
-    ciType* t1 = type_at(c);
-    ciType* t2 = incoming->type_at(c);
-    if (!t1->equals(t2)) {
-      ciType* new_type = type_meet(t1, t2);
-      if (!t1->equals(new_type)) {
-        set_type_at(c, new_type);
-        different = true;
+  if (_outer->max_locals() > 0) {
+    Cell limit = local(_outer->max_locals() - 1);
+    for (Cell c = start_cell(); c <= limit; c = next_cell(c)) {
+      ciType* t1 = type_at(c);
+      ciType* t2 = incoming->type_at(c);
+      if (!t1->equals(t2)) {
+        ciType* new_type = type_meet(t1, t2);
+        if (!t1->equals(new_type)) {
+          set_type_at(c, new_type);
+          different = true;
+        }
       }
     }
   }

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -500,17 +500,15 @@ bool ciTypeFlow::StateVector::meet_exception(ciInstanceKlass* exc,
   bool different = false;
 
   // Meet locals from incoming array.
-  if (_outer->max_locals() > 0) {
-    Cell limit = local(_outer->max_locals() - 1);
-    for (Cell c = start_cell(); c <= limit; c = next_cell(c)) {
-      ciType* t1 = type_at(c);
-      ciType* t2 = incoming->type_at(c);
-      if (!t1->equals(t2)) {
-        ciType* new_type = type_meet(t1, t2);
-        if (!t1->equals(new_type)) {
-          set_type_at(c, new_type);
-          different = true;
-        }
+  Cell limit = local_limit_cell();
+  for (Cell c = start_cell(); c < limit; c = next_cell(c)) {
+    ciType* t1 = type_at(c);
+    ciType* t2 = incoming->type_at(c);
+    if (!t1->equals(t2)) {
+      ciType* new_type = type_meet(t1, t2);
+      if (!t1->equals(new_type)) {
+        set_type_at(c, new_type);
+        different = true;
       }
     }
   }

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -213,6 +213,8 @@ public:
       return (Cell)(outer()->max_locals() + stack_size());
     }
 
+    Cell local_limit_cell() const { return (Cell) outer()->max_locals(); }
+
     // Cell creation
     Cell      local(int lnum) const {
       assert(lnum < outer()->max_locals(), "index check");

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -216,6 +216,7 @@ public:
     // Cell creation
     Cell      local(int lnum) const {
       assert(lnum < outer()->max_locals(), "index check");
+      assert(Cell_0 <= lnum && lnum <= Cell_max, "out of Cell's range");
       return (Cell)(lnum);
     }
 


### PR DESCRIPTION
As guess on the JBS ticket, we have a UB when `_outer->max_locals() == 0`, because then we try to do `(Cell)(-1)` which is out of range since Cell's range is [0, `INT_MAX`].

The obvious fix that is
```cpp
Cell limit = local(_outer->max_locals());
for (Cell c = start_cell(); c < limit; c = next_cell(c)) {
```
since `local` asserts its argument to be in [0, `outer->max_locals()`). Of course
```cpp
Cell limit = (Cell)(_outer->max_locals());
```
would work, but it seems to break (the very light) abstraction.

I've also added an assert to transform the UB into a clear failure.

This fix makes the UB warning go away on Mac with arm64.

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347426](https://bugs.openjdk.org/browse/JDK-8347426): Invalid value used for enum Cell in iTypeFlow::StateVector::meet_exception (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23772/head:pull/23772` \
`$ git checkout pull/23772`

Update a local copy of the PR: \
`$ git checkout pull/23772` \
`$ git pull https://git.openjdk.org/jdk.git pull/23772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23772`

View PR using the GUI difftool: \
`$ git pr show -t 23772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23772.diff">https://git.openjdk.org/jdk/pull/23772.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23772#issuecomment-2681456895)
</details>
