### PR TITLE
8280991: [XWayland] No displayChanged event after setDisplayMode call

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,6 +72,15 @@ public final class X11GraphicsDevice extends GraphicsDevice
     private boolean shutdownHookRegistered;
     private int scale;
 
+    // Wayland clients are by design not allowed to change the resolution in Wayland.
+    // XRandR in Xwayland is just an emulation, it doesn't actually change the resolution.
+    // This emulation is per window/x11 client, so different clients can have
+    // different emulated resolutions at the same time.
+    // So any request to get the current display mode will always return
+    // the original screen resolution, even if we are in emulated resolution.
+    // To handle this situation, we store the last set display mode in this variable.
+    private volatile DisplayMode xwlCurrentDisplayMode;
+
     public X11GraphicsDevice(int screennum) {
         this.screen = screennum;
         this.scale = initScaleFactor();
@@ -117,6 +126,20 @@ public final class X11GraphicsDevice extends GraphicsDevice
 
     private Rectangle getBoundsImpl() {
         Rectangle rect = pGetBounds(getScreen());
+
+        if (XToolkit.isOnWayland() && xwlCurrentDisplayMode != null) {
+            // XRandR resolution change in Xwayland is an emulation,
+            // and implemented in such a way that multiple display modes
+            // for a device are only available in a single screen scenario,
+            // if we have multiple screens they will each have a single display mode
+            // (no emulated resolution change is available).
+            // So we don't have to worry about x and y for a screen here.
+            rect.setSize(
+                    xwlCurrentDisplayMode.getWidth(),
+                    xwlCurrentDisplayMode.getHeight()
+            );
+        }
+
         if (getScaleFactor() != 1) {
             rect.x = scaleDown(rect.x);
             rect.y = scaleDown(rect.y);
@@ -400,10 +423,19 @@ public final class X11GraphicsDevice extends GraphicsDevice
     @Override
     public synchronized DisplayMode getDisplayMode() {
         if (isFullScreenSupported()) {
+            if (XToolkit.isOnWayland() && xwlCurrentDisplayMode != null) {
+                return xwlCurrentDisplayMode;
+            }
+
             DisplayMode mode = getCurrentDisplayMode(screen);
             if (mode == null) {
                 mode = getDefaultDisplayMode();
             }
+
+            if (XToolkit.isOnWayland()) {
+                xwlCurrentDisplayMode = mode;
+            }
+
             return mode;
         } else {
             if (origDisplayMode == null) {
@@ -473,6 +505,10 @@ public final class X11GraphicsDevice extends GraphicsDevice
         configDisplayMode(screen,
                           dm.getWidth(), dm.getHeight(),
                           dm.getRefreshRate());
+
+        if (XToolkit.isOnWayland()) {
+            xwlCurrentDisplayMode = dm;
+        }
 
         // update bounds of the fullscreen window
         w.setBounds(0, 0, dm.getWidth(), dm.getHeight());

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -499,7 +499,6 @@ java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 m
 
 # Wayland related
 
-java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java 8280991 linux-x64
 java/awt/FullScreen/SetFullScreenTest.java 8332155 linux-x64
 
 ############################################################################

--- a/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
+++ b/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,10 @@ public final class FullscreenWindowProps {
                 super.paint(g);
                 g.setColor(Color.GREEN);
                 g.fillRect(0, 0, getWidth(), getHeight());
+                g.setColor(Color.RED);
+                DisplayMode displayMode =
+                        getGraphicsConfiguration().getDevice().getDisplayMode();
+                g.drawString(displayMode.toString(), 100, 100);
             }
         };
         try {

--- a/test/jdk/java/awt/FullScreen/NoResizeEventOnDMChangeTest/NoResizeEventOnDMChangeTest.java
+++ b/test/jdk/java/awt/FullScreen/NoResizeEventOnDMChangeTest/NoResizeEventOnDMChangeTest.java
@@ -48,7 +48,6 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import jdk.test.lib.Platform;
@@ -57,7 +56,7 @@ import jtreg.SkippedException;
 public class NoResizeEventOnDMChangeTest {
 
     public static void main(String[] args) {
-        if (Platform.isOnWayland() && getGnomeShellMajorVersion() < 43) {
+        if (Platform.isOnWayland() && !isFixDelivered()) {
             throw new SkippedException("Test skipped because fix was not" +
                     "delivered in current GnomeShell version");
         }
@@ -247,23 +246,23 @@ public class NoResizeEventOnDMChangeTest {
         }
     }
 
-    private static int getGnomeShellMajorVersion() {
+    private static boolean isFixDelivered() {
         try {
             Process process =
                     new ProcessBuilder("/usr/bin/gnome-shell", "--version")
                             .start();
-            try (InputStreamReader isr = new InputStreamReader(process.getInputStream());
-                 BufferedReader reader = new BufferedReader(isr)) {
 
+            try (BufferedReader reader = process.inputReader()) {
                 if (process.waitFor(2, SECONDS) &&  process.exitValue() == 0) {
                     String line = reader.readLine();
                     if (line != null) {
+                        System.out.println("Gnome shell version: " + line);
                         String[] versionComponents = line
                                 .replaceAll("[^\\d.]", "")
                                 .split("\\.");
 
                         if (versionComponents.length >= 1) {
-                            return Integer.parseInt(versionComponents[0]);
+                            return Integer.parseInt(versionComponents[0]) > 42;
                         }
                     }
                 }
@@ -274,6 +273,6 @@ public class NoResizeEventOnDMChangeTest {
                  | NumberFormatException ignored) {
         }
 
-        return 1000;
+        return false;
     }
 }

--- a/test/jdk/java/awt/FullScreen/NoResizeEventOnDMChangeTest/NoResizeEventOnDMChangeTest.java
+++ b/test/jdk/java/awt/FullScreen/NoResizeEventOnDMChangeTest/NoResizeEventOnDMChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
  * @bug 6646411
  * @summary Tests that full screen window and its children receive resize
             event when display mode changes
+ * @library /test/lib
+ * @build   jdk.test.lib.Platform jtreg.SkippedException
  * @run main/othervm NoResizeEventOnDMChangeTest
  * @run main/othervm -Dsun.java2d.d3d=false NoResizeEventOnDMChangeTest
  */
@@ -44,9 +46,22 @@ import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
 
 public class NoResizeEventOnDMChangeTest {
+
     public static void main(String[] args) {
+        if (Platform.isOnWayland() && getGnomeShellMajorVersion() < 43) {
+            throw new SkippedException("Test skipped because fix was not" +
+                    "delivered in current GnomeShell version");
+        }
+
         final GraphicsDevice gd = GraphicsEnvironment.
             getLocalGraphicsEnvironment().getDefaultScreenDevice();
 
@@ -230,5 +245,35 @@ public class NoResizeEventOnDMChangeTest {
         public synchronized int getDmChanges() {
             return dmChanges;
         }
+    }
+
+    private static int getGnomeShellMajorVersion() {
+        try {
+            Process process =
+                    new ProcessBuilder("/usr/bin/gnome-shell", "--version")
+                            .start();
+            try (InputStreamReader isr = new InputStreamReader(process.getInputStream());
+                 BufferedReader reader = new BufferedReader(isr)) {
+
+                if (process.waitFor(2, SECONDS) &&  process.exitValue() == 0) {
+                    String line = reader.readLine();
+                    if (line != null) {
+                        String[] versionComponents = line
+                                .replaceAll("[^\\d.]", "")
+                                .split("\\.");
+
+                        if (versionComponents.length >= 1) {
+                            return Integer.parseInt(versionComponents[0]);
+                        }
+                    }
+                }
+            }
+        } catch (IOException
+                 | InterruptedException
+                 | IllegalThreadStateException
+                 | NumberFormatException ignored) {
+        }
+
+        return 1000;
     }
 }


### PR DESCRIPTION
Wayland clients are by design not allowed to change the resolution in Wayland.
XRandR in Xwayland is just an emulation, it doesn't actually change the desktop resolution. This emulation is per window/x11 client, so different clients can have different emulated resolutions at the same time.

Any request to get the current display mode from the system will always return the original screen resolution, even if we are in emulated resolution.
So with this fix, we store the last display mode set so that we can react correctly to the displayChanged event later.

---

There are two system side fixes related to this issue, which causes missing ConfigureNotify events to be emitted when an emulated resolution change occurs:

1. https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/731 - emits when the resolution changes to an emulated one 
2. https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/890 - emits when the resolution changes to a native one 

The second one is only available in GnomeShell 43+ (e.g. Ubuntu 22.10+), so one of the tests is excluded for versions below that.

---

Testing looks good (manual + automated).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280991](https://bugs.openjdk.org/browse/JDK-8280991): [XWayland] No displayChanged event after setDisplayMode call (**Bug** - P3)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23774/head:pull/23774` \
`$ git checkout pull/23774`

Update a local copy of the PR: \
`$ git checkout pull/23774` \
`$ git pull https://git.openjdk.org/jdk.git pull/23774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23774`

View PR using the GUI difftool: \
`$ git pr show -t 23774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23774.diff">https://git.openjdk.org/jdk/pull/23774.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23774#issuecomment-2681757417)
</details>
