### PR TITLE
8350649: Shenandoah: Accidental Java mirror resurrection after JDK-8346567

### DIFF
--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -329,7 +329,7 @@ jint Klass::array_layout_helper(BasicType etype) {
 }
 
 int Klass::modifier_flags() const {
-  int mods = java_lang_Class::modifiers(java_mirror());
+  int mods = java_lang_Class::modifiers(java_mirror_no_keepalive());
   assert(mods == compute_modifier_flags(), "should be same");
   return mods;
 }


### PR DESCRIPTION
See bug for description of the bug. 

Java mirror handle resolution includes LRB barrier for Shenandoah that resurrects the object unless the access is marked as `AS_NO_KEEPALIVE`. I see no reason not to read the Java mirror with AS_NO_KEEPALIVE for the purposes of getting the modifiers. Before [JDK-8346567](https://bugs.openjdk.org/browse/JDK-8346567), we pulled class modifiers from the native `Klass*`, and so we bypassed this trouble.

Additional testing:
 - [ ] Linux x86_64 server fastdebug, original reproducer now passes
 - [ ] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [ ] Linux x86_64 server fastdebug, `jdk_jfr`
 - [ ] Linux x86_64 server fastdebug, `jdk_jfr` with `-XX:+UseShenandoahGC`