### PR TITLE
8349921: Crash in codeBuffer.cpp:1004: guarantee(sect->end() <= tend) failed: sanity

### DIFF
--- a/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
@@ -44,7 +44,7 @@
                                        do_arch_blob,                    \
                                        do_arch_entry,                   \
                                        do_arch_entry_init)              \
-  do_arch_blob(compiler, 35000 ZGC_ONLY(+5000))                        \
+  do_arch_blob(compiler, 35000 ZGC_ONLY(+5000))                         \
   do_stub(compiler, vector_iota_indices)                                \
   do_arch_entry(aarch64, compiler, vector_iota_indices,                 \
                 vector_iota_indices, vector_iota_indices)               \

--- a/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
@@ -44,7 +44,7 @@
                                        do_arch_blob,                    \
                                        do_arch_entry,                   \
                                        do_arch_entry_init)              \
-  do_arch_blob(compiler, 30000 ZGC_ONLY(+10000))                        \
+  do_arch_blob(compiler, 35000 ZGC_ONLY(+5000))                        \
   do_stub(compiler, vector_iota_indices)                                \
   do_arch_entry(aarch64, compiler, vector_iota_indices,                 \
                 vector_iota_indices, vector_iota_indices)               \
@@ -109,7 +109,7 @@
                                     do_arch_blob,                       \
                                     do_arch_entry,                      \
                                     do_arch_entry_init)                 \
-  do_arch_blob(final, 20000 ZGC_ONLY(+100000))                          \
+  do_arch_blob(final, 20000 ZGC_ONLY(+60000))                          \
   do_stub(final, copy_byte_f)                                           \
   do_arch_entry(aarch64, final, copy_byte_f, copy_byte_f,               \
                 copy_byte_f)                                            \

--- a/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubDeclarations_aarch64.hpp
@@ -109,7 +109,7 @@
                                     do_arch_blob,                       \
                                     do_arch_entry,                      \
                                     do_arch_entry_init)                 \
-  do_arch_blob(final, 20000 ZGC_ONLY(+60000))                          \
+  do_arch_blob(final, 20000 ZGC_ONLY(+60000))                           \
   do_stub(final, copy_byte_f)                                           \
   do_arch_entry(aarch64, final, copy_byte_f, copy_byte_f,               \
                 copy_byte_f)                                            \


### PR DESCRIPTION
The compiler blob base size needs increasing in case the JDK is built without ZGC. The increment when ZGC is used can be comparably decreased. The final blob size increment when ZGC is included is over generous and can also be decreased.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349921](https://bugs.openjdk.org/browse/JDK-8349921): Crash in codeBuffer.cpp:1004: guarantee(sect-&gt;end() &lt;= tend) failed: sanity (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23776/head:pull/23776` \
`$ git checkout pull/23776`

Update a local copy of the PR: \
`$ git checkout pull/23776` \
`$ git pull https://git.openjdk.org/jdk.git pull/23776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23776`

View PR using the GUI difftool: \
`$ git pr show -t 23776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23776.diff">https://git.openjdk.org/jdk/pull/23776.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23776#issuecomment-2682266319)
</details>
