### PR TITLE
8350665: SIZE_FORMAT_HEX macro undefined in gtest

### DIFF
--- a/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
+++ b/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
@@ -58,9 +58,9 @@ namespace {
 
 static void diagnostic_print(ReservedMemoryRegion* rmr) {
   CommittedRegionIterator iter = rmr->iterate_committed_regions();
-  LOG("In reserved region " PTR_FORMAT ", size " SIZE_FORMAT_HEX ":", p2i(rmr->base()), rmr->size());
+  LOG("In reserved region " PTR_FORMAT ", size 0x%zx:", p2i(rmr->base()), rmr->size());
   for (const CommittedMemoryRegion* region = iter.next(); region != nullptr; region = iter.next()) {
-    LOG("   committed region: " PTR_FORMAT ", size " SIZE_FORMAT_HEX, p2i(region->base()), region->size());
+    LOG("   committed region: " PTR_FORMAT ", size 0x%zx", p2i(region->base()), region->size());
   }
 }
 


### PR DESCRIPTION
Hi all,

SIZE_FORMAT_HEX macro undefined in test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp.
The SIZE_FORMAT_HEX macro should be replace as "0x%zx" instead.

Trivial fix, change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350665](https://bugs.openjdk.org/browse/JDK-8350665): SIZE_FORMAT_HEX macro undefined in gtest (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23778/head:pull/23778` \
`$ git checkout pull/23778`

Update a local copy of the PR: \
`$ git checkout pull/23778` \
`$ git pull https://git.openjdk.org/jdk.git pull/23778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23778`

View PR using the GUI difftool: \
`$ git pr show -t 23778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23778.diff">https://git.openjdk.org/jdk/pull/23778.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23778#issuecomment-2682431559)
</details>
