### PR TITLE
8350667: Remove startThread_lock() and _startThread_lock on AIX

### DIFF
--- a/src/hotspot/os/aix/osThread_aix.cpp
+++ b/src/hotspot/os/aix/osThread_aix.cpp
@@ -37,11 +37,9 @@ OSThread::OSThread()
     _siginfo(nullptr),
     _ucontext(nullptr),
     _expanding_stack(0),
-    _alt_sig_stack(nullptr),
-    _startThread_lock(new Monitor(Mutex::event, "startThread_lock")) {
+    _alt_sig_stack(nullptr) {
   sigemptyset(&_caller_sigmask);
 }
 
 OSThread::~OSThread() {
-  delete _startThread_lock;
 }

--- a/src/hotspot/os/aix/osThread_aix.hpp
+++ b/src/hotspot/os/aix/osThread_aix.hpp
@@ -114,15 +114,6 @@ class OSThread : public OSThreadBase {
   void set_alt_sig_stack(address val)     { _alt_sig_stack = val; }
   address alt_sig_stack(void)             { return _alt_sig_stack; }
 
- private:
-  Monitor* _startThread_lock;     // sync parent and child in thread creation
-
- public:
-
-  Monitor* startThread_lock() const {
-    return _startThread_lock;
-  }
-
   // Printing
   uintx thread_id_for_printing() const override {
     return (uintx)_thread_id;

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -796,6 +796,8 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   // OSThread::thread_id is the pthread id.
   osthread->set_thread_id(tid);
 
+  // child thread synchronization is not done here on AIX, a thread is started in suspended state
+
   return true;
 }
 


### PR DESCRIPTION
The startThread_lock() and _startThread_lock coding is not used on AIX so it can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350667](https://bugs.openjdk.org/browse/JDK-8350667): Remove startThread_lock() and _startThread_lock on AIX (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23779/head:pull/23779` \
`$ git checkout pull/23779`

Update a local copy of the PR: \
`$ git checkout pull/23779` \
`$ git pull https://git.openjdk.org/jdk.git pull/23779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23779`

View PR using the GUI difftool: \
`$ git pr show -t 23779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23779.diff">https://git.openjdk.org/jdk/pull/23779.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23779#issuecomment-2682504252)
</details>
