### PR TITLE
8350668: has_extra_module_paths in filemap.cpp may be uninitialized

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -303,7 +303,7 @@ bool FileMapInfo::validate_class_location() {
   assert(CDSConfig::is_using_archive(), "runtime only");
 
   AOTClassLocationConfig* config = header()->class_location_config();
-  bool has_extra_module_paths;
+  bool has_extra_module_paths = false;
   if (!config->validate(header()->has_aot_linked_classes(), &has_extra_module_paths)) {
     if (PrintSharedArchiveAndExit) {
       MetaspaceShared::set_archive_loading_failed();


### PR DESCRIPTION
Please review this trivial patch. The `has_extra_module_paths` local variable should be initialized to `false`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350668](https://bugs.openjdk.org/browse/JDK-8350668): has_extra_module_paths in filemap.cpp may be uninitialized (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23780/head:pull/23780` \
`$ git checkout pull/23780`

Update a local copy of the PR: \
`$ git checkout pull/23780` \
`$ git pull https://git.openjdk.org/jdk.git pull/23780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23780`

View PR using the GUI difftool: \
`$ git pr show -t 23780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23780.diff">https://git.openjdk.org/jdk/pull/23780.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23780#issuecomment-2682515292)
</details>
