### PR TITLE
8350682: [JMH] vector.IndexInRangeBenchmark failed with IndexOutOfBoundsException for size=1024

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
@@ -48,7 +48,7 @@ public class IndexInRangeBenchmark {
 
     @Setup(Level.Trial)
     public void Setup() {
-        mask = new boolean[512];
+        mask = new boolean[size + 64];
     }
 
     @Benchmark


### PR DESCRIPTION
Array initialization by parameter was added. Extra constant was used to align cycle step with used arrays.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350682](https://bugs.openjdk.org/browse/JDK-8350682): [JMH] vector.IndexInRangeBenchmark failed with IndexOutOfBoundsException for size=1024 (**Enhancement** - P4)


### Reviewers
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer)
 * [Derek White](https://openjdk.org/census#drwhite) (@dwhite-intel - Committer)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23783/head:pull/23783` \
`$ git checkout pull/23783`

Update a local copy of the PR: \
`$ git checkout pull/23783` \
`$ git pull https://git.openjdk.org/jdk.git pull/23783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23783`

View PR using the GUI difftool: \
`$ git pr show -t 23783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23783.diff">https://git.openjdk.org/jdk/pull/23783.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23783#issuecomment-2683019647)
</details>
