### PR TITLE
8350701 test foreign.AllocFromSliceTest failed with Exception for size >1024

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/AllocFromSliceTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/AllocFromSliceTest.java
@@ -55,10 +55,10 @@ public class AllocFromSliceTest extends CLayouts {
 
     @Setup
     public void setup() {
-        arr = new byte[1024];
+        arr = new byte[size * 2];
         Random random = new Random(0);
         random.nextBytes(arr);
-        start = random.nextInt(1024 - size);
+        start = random.nextInt(size);
     }
 
     @Benchmark


### PR DESCRIPTION
The 'size' parameters was used instead of hardcoded constant to improve support for different sizes.