### PR TITLE
8350666: cmp-baseline builds fail after JDK-8280682

### DIFF
--- a/src/hotspot/share/cds/aotClassLocation.cpp
+++ b/src/hotspot/share/cds/aotClassLocation.cpp
@@ -270,7 +270,7 @@ AOTClassLocation* AOTClassLocation::allocate(JavaThread* current, const char* pa
   cs->_manifest_length = manifest_length;
   cs->_check_time = check_time;
   cs->_from_cpattr = from_cpattr;
-  cs->_timestamp = timestamp;
+  cs->_timestamp = check_time ? timestamp : 0;
   cs->_filesize = filesize;
   cs->_file_type = type;
   cs->_group = group;


### PR DESCRIPTION
A fix for initializing the `_timestamp` field in `AOTClassLocation` properly so that the cmp-baseline builds are successful.

Sanity tested with builds-tier5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350666](https://bugs.openjdk.org/browse/JDK-8350666): cmp-baseline builds fail after JDK-8280682 (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23787/head:pull/23787` \
`$ git checkout pull/23787`

Update a local copy of the PR: \
`$ git checkout pull/23787` \
`$ git pull https://git.openjdk.org/jdk.git pull/23787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23787`

View PR using the GUI difftool: \
`$ git pr show -t 23787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23787.diff">https://git.openjdk.org/jdk/pull/23787.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23787#issuecomment-2683507415)
</details>
