### PR TITLE
8350646: Calendar.Builder.build() Throws ArrayIndexOutOfBoundsException

### DIFF
--- a/src/java.base/share/classes/java/util/JapaneseImperialCalendar.java
+++ b/src/java.base/share/classes/java/util/JapaneseImperialCalendar.java
@@ -1858,8 +1858,9 @@ class JapaneseImperialCalendar extends Calendar {
             era = internalGet(ERA);
             // Don't check under, historically we have allowed values under
             // BEFORE_MEIJI to be ignored during normalization
-            // We check against eras.length over Reiwa ERA due to possibility
-            // of additional eras via "jdk.calendar.japanese.supplemental.era"
+            // We check against eras.length (not the highest constant ERA value)
+            // due to future added eras, or additional eras via
+            // "jdk.calendar.japanese.supplemental.era"
             if (era >= eras.length) {
                 throw new IllegalArgumentException("Invalid era");
             }

--- a/src/java.base/share/classes/java/util/JapaneseImperialCalendar.java
+++ b/src/java.base/share/classes/java/util/JapaneseImperialCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1856,6 +1856,13 @@ class JapaneseImperialCalendar extends Calendar {
 
         if (isSet(ERA)) {
             era = internalGet(ERA);
+            // Don't check under, historically we have allowed values under
+            // BEFORE_MEIJI to be ignored during normalization
+            // We check against eras.length over Reiwa ERA due to possibility
+            // of additional eras via "jdk.calendar.japanese.supplemental.era"
+            if (era >= eras.length) {
+                throw new IllegalArgumentException("Invalid era");
+            }
             year = isSet(YEAR) ? internalGet(YEAR) : 1;
         } else {
             if (isSet(YEAR)) {

--- a/test/jdk/java/util/Calendar/Builder/BuilderTest.java
+++ b/test/jdk/java/util/Calendar/Builder/BuilderTest.java
@@ -246,7 +246,7 @@ public class BuilderTest {
         checkException(calb, IllegalArgumentException.class);
         calb = builder().setCalendarType("japanese").setWeekDate(2013, 1, MONDAY);
         checkException(calb, IllegalArgumentException.class);
-        // JDK-8350646 : Ensure IAE (instead of AIOOBE) for ERA over REIWA
+        // JDK-8350646 : Ensure IAE (instead of AIOOBE) for ERA over largest supported
         calb = builder().setCalendarType("japanese").setFields(ERA, 6);
         checkException(calb, IllegalArgumentException.class);
         // Note that we don't check ERAs under BEFORE_MEIJI, i.e. -1, -2, ... as

--- a/test/jdk/java/util/Calendar/Builder/BuilderTest.java
+++ b/test/jdk/java/util/Calendar/Builder/BuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,9 @@
 
 /*
  * @test
- * @bug 4745761
+ * @bug 4745761 8350646
  * @summary Unit test for Calendar.Builder.
+ * @run main BuilderTest
  */
 
 import java.time.LocalDateTime;
@@ -245,6 +246,11 @@ public class BuilderTest {
         checkException(calb, IllegalArgumentException.class);
         calb = builder().setCalendarType("japanese").setWeekDate(2013, 1, MONDAY);
         checkException(calb, IllegalArgumentException.class);
+        // JDK-8350646 : Ensure IAE (instead of AIOOBE) for ERA over REIWA
+        calb = builder().setCalendarType("japanese").setFields(ERA, 6);
+        checkException(calb, IllegalArgumentException.class);
+        // Note that we don't check ERAs under BEFORE_MEIJI, i.e. -1, -2, ... as
+        // historically JapaneseImperialCalendar ignores such values when normalizing
     }
 
     private static Calendar.Builder builder() {

--- a/test/jdk/java/util/Calendar/SupplementalJapaneseEraTest.java
+++ b/test/jdk/java/util/Calendar/SupplementalJapaneseEraTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,22 @@ public class SupplementalJapaneseEraTest {
     }
 
     private static void testProperty() {
+        // JDK-8350646: Ensure that IAE is thrown for out of range era, when
+        // additional era is defined
+        try {
+            new Calendar.Builder()
+                    .setCalendarType("japanese")
+                    .setFields(ERA, 7)
+                    .build();
+            System.err.println("Out of range era should have thrown IAE");
+            errors++;
+        } catch (Exception e) {
+            if (!(e instanceof IllegalArgumentException)) {
+                System.err.printf("Out of range era threw \"%s\" instead of IAE\n", e);
+                errors++;
+            }
+        }
+
         Calendar jcal = new Calendar.Builder()
             .setCalendarType("japanese")
             .setFields(ERA, 6, YEAR, 1, DAY_OF_YEAR, 1)

--- a/test/jdk/java/util/Calendar/SupplementalJapaneseEraTest.java
+++ b/test/jdk/java/util/Calendar/SupplementalJapaneseEraTest.java
@@ -72,7 +72,7 @@ public class SupplementalJapaneseEraTest {
         try {
             new Calendar.Builder()
                     .setCalendarType("japanese")
-                    .setFields(ERA, 7)
+                    .setFields(ERA, JapaneseEra.values().length + 2)
                     .build();
             System.err.println("Out of range era should have thrown IAE");
             errors++;

--- a/test/jdk/java/util/Calendar/SupplementalJapaneseEraTestRun.java
+++ b/test/jdk/java/util/Calendar/SupplementalJapaneseEraTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8048123 8054214 8173423
+ * @bug 8048123 8054214 8173423 8350646
  * @summary Test for jdk.calendar.japanese.supplemental.era support
  * @library /test/lib
  * @build SupplementalJapaneseEraTest


### PR DESCRIPTION
Please review this PR which prevents an `AIOOBE` from leaking out when `java.util.Calendar.Builder` is used to build a Japanese calendar with an era value too large.

Note that we don't check under `BEFORE_MEIJI`/0 as historically Japanese calendar ignores negative values during normalization. See `JapaneseImperialCalendar` L2018: `date.setEra(era > 0 ? eras[era] : null);`. 

We also check against `eras.length` over `REIWA`/5 due to the possibility of additional eras via the property override or future eras in general.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8350806](https://bugs.openjdk.org/browse/JDK-8350806) to be approved

### Issues
 * [JDK-8350646](https://bugs.openjdk.org/browse/JDK-8350646): Calendar.Builder.build() Throws ArrayIndexOutOfBoundsException (**Bug** - P4)
 * [JDK-8350806](https://bugs.openjdk.org/browse/JDK-8350806): Calendar.Builder.build() Throws ArrayIndexOutOfBoundsException (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23789/head:pull/23789` \
`$ git checkout pull/23789`

Update a local copy of the PR: \
`$ git checkout pull/23789` \
`$ git pull https://git.openjdk.org/jdk.git pull/23789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23789`

View PR using the GUI difftool: \
`$ git pr show -t 23789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23789.diff">https://git.openjdk.org/jdk/pull/23789.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23789#issuecomment-2683560296)
</details>
