### PR TITLE
8350716: [s390] intrinsify Thread.currentThread()

### DIFF
--- a/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
@@ -2006,8 +2006,19 @@ address TemplateInterpreterGenerator::generate_CRC32C_updateBytes_entry(Abstract
   return __ addr_at(entry_off);
 }
 
+address TemplateInterpreterGenerator::generate_currentThread() {
+  address entry_point = __ pc();
+  __ z_lg(Z_RET, Address(Z_thread, JavaThread::threadObj_offset()));
+  __ resolve_oop_handle(Z_RET);
+
+  // Restore caller sp for c2i case.
+  __ resize_frame_absolute(Z_R10, Z_R0, true); // Cut the stack back to where the caller started.
+  __ z_br(Z_R14);
+
+  return entry_point;
+}
+
 // Not supported
-address TemplateInterpreterGenerator::generate_currentThread() { return nullptr; }
 address TemplateInterpreterGenerator::generate_Float_intBitsToFloat_entry() { return nullptr; }
 address TemplateInterpreterGenerator::generate_Float_floatToRawIntBits_entry() { return nullptr; }
 address TemplateInterpreterGenerator::generate_Double_longBitsToDouble_entry() { return nullptr; }

--- a/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
@@ -2007,7 +2007,8 @@ address TemplateInterpreterGenerator::generate_CRC32C_updateBytes_entry(Abstract
 }
 
 address TemplateInterpreterGenerator::generate_currentThread() {
-  address entry_point = __ pc();
+  uint64_t entry_off = __ offset();
+
   __ z_lg(Z_RET, Address(Z_thread, JavaThread::threadObj_offset()));
   __ resolve_oop_handle(Z_RET);
 
@@ -2015,7 +2016,7 @@ address TemplateInterpreterGenerator::generate_currentThread() {
   __ resize_frame_absolute(Z_R10, Z_R0, true); // Cut the stack back to where the caller started.
   __ z_br(Z_R14);
 
-  return entry_point;
+  return __ addr_at(entry_off);
 }
 
 // Not supported


### PR DESCRIPTION
s390x port for [JDK-8278793](https://bugs.openjdk.org/browse/JDK-8278793)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350716](https://bugs.openjdk.org/browse/JDK-8350716): [s390] intrinsify Thread.currentThread() (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) Review applies to [60837a28](https://git.openjdk.org/jdk/pull/23791/files/60837a2800419d6159452d009223630a434a9323)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23791/head:pull/23791` \
`$ git checkout pull/23791`

Update a local copy of the PR: \
`$ git checkout pull/23791` \
`$ git pull https://git.openjdk.org/jdk.git pull/23791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23791`

View PR using the GUI difftool: \
`$ git pr show -t 23791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23791.diff">https://git.openjdk.org/jdk/pull/23791.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23791#issuecomment-2683864379)
</details>
