### PR TITLE
8350722: Remove duplicate SerialGC logic for detecting pointers in young gen

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -704,10 +704,7 @@ void SerialHeap::do_full_collection(bool clear_all_soft_refs) {
 }
 
 bool SerialHeap::is_in_young(const void* p) const {
-  bool result = p < _old_gen->reserved().start();
-  assert(result == _young_gen->is_in_reserved(p),
-         "incorrect test - result=%d, p=" PTR_FORMAT, result, p2i(p));
-  return result;
+  return _young_gen->is_in_reserved(p);
 }
 
 bool SerialHeap::requires_barriers(stackChunkOop obj) const {

--- a/src/hotspot/share/gc/serial/serialHeap.inline.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.inline.hpp
@@ -32,14 +32,12 @@
 
 class ScavengeHelper {
   DefNewGeneration* _young_gen;
-  HeapWord*         _young_gen_end;
 public:
   ScavengeHelper(DefNewGeneration* young_gen) :
-    _young_gen(young_gen),
-    _young_gen_end(young_gen->reserved().end()) {}
+    _young_gen(young_gen) {}
 
   bool is_in_young_gen(void* p) const {
-    return p < _young_gen_end;
+    return _young_gen->is_in_reserved(p);
   }
 
   template <typename T, typename Func>


### PR DESCRIPTION
Checking whether a pointer is in the young generation is currently done by comparing the pointer to the end of the young generation reserved space. The duplication of these checks in various places complicates any changes the layout of the young generation since all these locations need to be updated. This PR replaces the duplicated logic with the DefNewGeneration::is_in_reserved method.