### PR TITLE
8350723: RISC-V: debug.cpp help() is missing riscv line for pns

### DIFF
--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -625,6 +625,7 @@ void help() {
   tty->print_cr("                   pns($sp, $fp, $pc)  on Linux/AArch64 or");
   tty->print_cr("                   pns($sp, 0, $pc)    on Linux/ppc64 or");
   tty->print_cr("                   pns($sp, $s8, $pc)  on Linux/mips or");
+  tty->print_cr("                   pns($sp, $fp, $pc)  on Linux/RISC-V");
   tty->print_cr("                 - in gdb do 'set overload-resolution off' before calling pns()");
   tty->print_cr("                 - in dbx do 'frame 1' before calling pns()");
   tty->print_cr("class metadata.");


### PR DESCRIPTION
Hi all,

This PR add RISC-V entry line for pns() call in src/hotspot/share/utilities/debug.cpp file. This will be useful when call help() function in gdb. No risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350723](https://bugs.openjdk.org/browse/JDK-8350723): RISC-V: debug.cpp help() is missing riscv line for pns (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23793/head:pull/23793` \
`$ git checkout pull/23793`

Update a local copy of the PR: \
`$ git checkout pull/23793` \
`$ git pull https://git.openjdk.org/jdk.git pull/23793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23793`

View PR using the GUI difftool: \
`$ git pr show -t 23793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23793.diff">https://git.openjdk.org/jdk/pull/23793.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23793#issuecomment-2684158132)
</details>
