### PR TITLE
8350683: Non-C2 / minimal JVM crashes in the build on ppc64 platforms

### DIFF
--- a/src/hotspot/cpu/ppc/compiledIC_ppc.cpp
+++ b/src/hotspot/cpu/ppc/compiledIC_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,6 @@
 #include "memory/resourceArea.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"
-#ifdef COMPILER2
-#include "opto/matcher.hpp"
-#endif
 
 // ----------------------------------------------------------------------------
 
@@ -78,7 +75,6 @@
 const int IC_pos_in_java_to_interp_stub = 8;
 #define __ masm->
 address CompiledDirectCall::emit_to_interp_stub(MacroAssembler *masm, address mark/* = nullptr*/) {
-#ifdef COMPILER2
   if (mark == nullptr) {
     // Get the mark within main instrs section which is set to the address of the call.
     mark = __ inst_mark();
@@ -108,7 +104,7 @@ address CompiledDirectCall::emit_to_interp_stub(MacroAssembler *masm, address ma
   // - call
   __ calculate_address_from_global_toc(reg_scratch, __ method_toc());
   AddressLiteral ic = __ allocate_metadata_address((Metadata *)nullptr);
-  bool success = __ load_const_from_method_toc(as_Register(Matcher::inline_cache_reg_encode()),
+  bool success = __ load_const_from_method_toc(R19_inline_cache_reg,
                                                ic, reg_scratch, /*fixed_size*/ true);
   if (!success) {
     return nullptr; // CodeCache is full
@@ -134,13 +130,9 @@ address CompiledDirectCall::emit_to_interp_stub(MacroAssembler *masm, address ma
   assert(!is_NativeCallTrampolineStub_at(__ addr_at(stub_start_offset)),
          "must not confuse java_to_interp with trampoline stubs");
 
- // End the stub.
+  // End the stub.
   __ end_a_stub();
   return stub;
-#else
-  ShouldNotReachHere();
-  return nullptr;
-#endif
 }
 #undef __
 


### PR DESCRIPTION
When building a JVM without C2 (e.g. minimal) on ppc64 platforms , it crashes in the build because of unwanted dependencies to C2.
AIX crash is (linux ppc64le crash is similar) :

```
# Internal Error (compiledIC_ppc.cpp:141), pid=17695018, tid=258
# Error: ShouldNotReachHere()
#
 
iar: 0x0900000008800c60 libjvm.so::AixNativeCallstack::print_callstack_for_context(outputStream*, ucontext_t const*, bool, char*, unsigned long)+0x4bc (C++ uses_alloca saves_cr saves_lr stores_bc gpr_saved:18 fixedparms:5 parmsonstk:1)
lr: 0x09000000087ea9b8 libjvm.so::fdStream::write(char const*, unsigned long)+0x44 (C++ uses_alloca saves_lr stores_bc gpr_saved:4 fixedparms:3 parmsonstk:1)
sp: 0x000000011023aab0 (base - 0x2DD8)
rtoc: 0x08001000a0088ff0
|---stackaddr----| |----lrsave------|: <function name>
0x000000011023aea0 - 0x0900000008800730 libjvm.so::os::Aix::platform_print_native_stack(outputStream*, void const*, char*, int, unsigned char*&)+0x24 (C++ uses_alloca saves_lr stores_bc gpr_saved:1 fixedparms:5 parmsonstk:1)
0x000000011023af20 - 0x0900000008800644 libjvm.so::NativeStackPrinter::print_stack(outputStream*, char*, int, unsigned char*&, bool, int)+0x60 (C++ uses_alloca saves_cr saves_lr stores_bc gpr_saved:6 fixedparms:7 parmsonstk:1)
0x000000011023afc0 - 0x09000000087f6ff8 libjvm.so::VMError::report(outputStream*, bool)+0x11f0 (C++ fp_present uses_alloca saves_cr saves_lr stores_bc gpr_saved:13 fixedparms:2 parmsonstk:1)
0x000000011023b830 - 0x09000000087e9fdc libjvm.so::VMError::report_and_die(int, char const*, char const*, char*, Thread*, unsigned char*, void const*, void const*, char const*, int, unsigned long)+0x6a0 (C++ uses_alloca saves_lr stores_bc gpr_saved:18 fixedparms:8 parmsonstk:1)
0x000000011023ba10 - 0x09000000087e96a0 libjvm.so::report_vm_error(char const*, int, char const*, char const*, ...)+0xa0 (C++ uses_alloca saves_lr stores_bc gpr_saved:5 fixedparms:4 parmsonstk:1)
0x000000011023bad0 - 0x09000000087e95cc libjvm.so::report_vm_error(char const*, int, char const*)+0x24 (C++ uses_alloca saves_lr stores_bc gpr_saved:1 fixedparms:3 parmsonstk:1)
0x000000011023bb50 - 0x09000000087e956c libjvm.so::report_should_not_reach_here(char const*, int)+0x20 (C++ uses_alloca saves_lr stores_bc gpr_saved:1 fixedparms:2 parmsonstk:1)
0x000000011023bbd0 - 0x0900000008906e5c libjvm.so::CompiledDirectCall::emit_to_interp_stub(MacroAssembler*, unsigned char*)+0x28 (C++ uses_alloca saves_lr stores_bc gpr_saved:1 fixedparms:2 parmsonstk:1)
0x000000011023bc50 - 0x0900000008902848 libjvm.so::SharedRuntime::generate_native_wrapper(MacroAssembler*, methodHandle const&, int, BasicType*, VMRegPair*, BasicType)+0x380 (C++ uses_alloca saves_cr saves_lr stores_bc gpr_saved:18 fixedparms:6 parmsonstk:1)
0x000000011023c000 - 0x0900000008901f7c libjvm.so::AdapterHandlerLibrary::create_native_wrapper(methodHandle const&)+0x464 (C++ fp_present uses_alloca saves_cr saves_lr stores_bc gpr_saved:18 fixedparms:1 parmsonstk:1)
0x000000011023c5d0 - 0x09000000088f0d78 libjvm.so::Method::link_method(methodHandle const&, JavaThread*)+0x17c (C++ uses_alloca saves_lr stores_bc gpr_saved:5 fixedparms:3 parmsonstk:1)
0x000000011023c670 - 0x09000000088f0ab8 libjvm.so::InstanceKlass::link_methods(JavaThread*)+0xcc (C++ uses_alloca saves_lr stores_bc gpr_saved:10 fixedparms:2 parmsonstk:1)
0x000000011023c760 - 0x09000000088d5e48 libjvm.so::InstanceKlass::link_class_impl(JavaThread*)+0x38c (C++ uses_alloca saves_cr saves_lr stores_bc gpr_saved:10 fixedparms:2 parmsonstk:1)
0x000000011023c8f0 - 0x09000000088d4de8 libjvm.so::InstanceKlass::initialize_impl(JavaThread*)+0x94 (C++ uses_alloca saves_cr saves_lr stores_bc gpr_saved:14 fixedparms:2 parmsonstk:1)
0x000000011023cae0 - 0x09000000088d4cf4 libjvm.so::InstanceKlass::initialize(JavaThread*)+0x60 (C++ uses_alloca saves_lr stores_bc gpr_saved:3 fixedparms:2 parmsonstk:1)
0x000000011023cb70 - 0x0900000008c40ea0 libjvm.so::initialize_class(Symbol*, JavaThread*)+0x64 (C++ uses_alloca saves_lr stores_bc gpr_saved:2 fixedparms:2 parmsonstk:1)
0x000000011023cc00 - 0x0900000008c35384 libjvm.so::Threads::create_vm(JavaVMInitArgs*, bool*)+0x6ec (C++ uses_alloca saves_lr stores_bc gpr_saved:8 fixedparms:2 parmsonstk:1)
0x000000011023d540 - 0x0900000008c5a91c libjvm.so::JNI_CreateJavaVM+0xa4 (C++ uses_alloca saves_lr stores_bc gpr_saved:8 fixedparms:3 parmsonstk:1)
0x000000011023d640 - 0x00000001000100f4 javac::JavaMain+0x148 (C++ saves_lr stores_bc gpr_saved:11 fixedparms:1 parmsonstk:1)
0x000000011023d730 - 0x000000010000ff74 javac::ThreadJavaMain+0x10 (C++ saves_lr stores_bc fixedparms:1 parmsonstk:1)
0x000000011023d7a0 - 0x090000000056204c libpthreads.a::_pthread_body+0xec (C saves_lr stores_bc gpr_saved:1 fixedparms:1 )
0x000000011023d820 - 0x0000000000000000
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350683](https://bugs.openjdk.org/browse/JDK-8350683): Non-C2 / minimal JVM crashes in the build on ppc64 platforms (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Contributors
 * Martin Doerr `<mdoerr@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23794/head:pull/23794` \
`$ git checkout pull/23794`

Update a local copy of the PR: \
`$ git checkout pull/23794` \
`$ git pull https://git.openjdk.org/jdk.git pull/23794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23794`

View PR using the GUI difftool: \
`$ git pr show -t 23794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23794.diff">https://git.openjdk.org/jdk/pull/23794.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23794#issuecomment-2684408712)
</details>
