### PR TITLE
8350758: G1: Use actual last prediction in accumulated survivor rate prediction too

### DIFF
--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
@@ -68,14 +68,6 @@ void G1SurvRateGroup::stop_adding_regions() {
     _accum_surv_rate_pred = REALLOC_C_HEAP_ARRAY(double, _accum_surv_rate_pred, _num_added_regions, mtGC);
     _surv_rate_predictors = REALLOC_C_HEAP_ARRAY(TruncatedSeq*, _surv_rate_predictors, _num_added_regions, mtGC);
 
-    // Assume that the prediction for the newly added regions is the same as the
-    // ones at the (current) end of the array. Particularly predictions at the end
-    // of this array fairly seldom get updated, so having a better initial value
-    // that is at least somewhat related to the actual application is preferable.
-    double new_pred = _stats_arrays_length > 1
-                    ? _accum_surv_rate_pred[_stats_arrays_length - 1] - _accum_surv_rate_pred[_stats_arrays_length - 2]
-                    : InitialSurvivorRate;
-
     for (uint i = _stats_arrays_length; i < _num_added_regions; ++i) {
       // Initialize predictors and accumulated survivor rate predictions.
       _surv_rate_predictors[i] = new TruncatedSeq(10);
@@ -83,11 +75,16 @@ void G1SurvRateGroup::stop_adding_regions() {
         _surv_rate_predictors[i]->add(InitialSurvivorRate);
         _accum_surv_rate_pred[i] = 0.0;
       } else {
-        _surv_rate_predictors[i]->add(_surv_rate_predictors[i-1]->last());
-        _accum_surv_rate_pred[i] = _accum_surv_rate_pred[i-1] + new_pred;
+        // Assume that the prediction for the newly added regions is the same as the
+        // ones at the (current) end of the array. Particularly predictions at the end
+        // of this array fairly seldom get updated, so having a better initial value
+        // that is at least somewhat related to the actual application is preferable.
+        double next_pred = _surv_rate_predictors[i-1]->last();
+        _surv_rate_predictors[i]->add(next_pred);
+        _accum_surv_rate_pred[i] = _accum_surv_rate_pred[i-1] + next_pred;
       }
     }
-    _last_pred = new_pred;
+    _last_pred = _surv_rate_predictors[_num_added_regions-1]->last();
 
     _stats_arrays_length = _num_added_regions;
   }

--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
@@ -73,7 +73,7 @@ void G1SurvRateGroup::stop_adding_regions() {
       _surv_rate_predictors[i] = new TruncatedSeq(10);
       if (i == 0) {
         _surv_rate_predictors[i]->add(InitialSurvivorRate);
-        _accum_surv_rate_pred[i] = 0.0;
+        _accum_surv_rate_pred[i] = InitialSurvivorRate;
       } else {
         // Assume that the prediction for the newly added regions is the same as the
         // ones at the (current) end of the array. Particularly predictions at the end


### PR DESCRIPTION
Hi all,

  please review this fix to recent JDK-8349906 to use the current
survivor rate in the accumulated survivor rate for initializing newly allocated entries as well.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350758](https://bugs.openjdk.org/browse/JDK-8350758): G1: Use actual last prediction in accumulated survivor rate prediction too (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23795/head:pull/23795` \
`$ git checkout pull/23795`

Update a local copy of the PR: \
`$ git checkout pull/23795` \
`$ git pull https://git.openjdk.org/jdk.git pull/23795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23795`

View PR using the GUI difftool: \
`$ git pr show -t 23795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23795.diff">https://git.openjdk.org/jdk/pull/23795.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23795#issuecomment-2687279991)
</details>
