### PR TITLE
8350623: Fix -Wzero-as-null-pointer-constant warnings in nsk native test utilities

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/native_thread.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/native_thread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,7 +98,11 @@ void* procedure(void* t) {
     thread->started  = 1;
     thread->status   = thread->procedure(thread->context);
     thread->finished = 1;
+#ifdef windows
     return 0;
+#else // !windows
+    return nullptr;
+#endif
 }
 
 /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_list.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_list.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,7 +109,7 @@ int nsk_list_remove(const void *plist, int ind) {
             list_info->arr[i - 1] = list_info->arr[i];
         }
     }
-    list_info->arr[--list_info->elements_count] = 0;
+    list_info->arr[--list_info->elements_count] = nullptr;
 
     return NSK_TRUE;
 }


### PR DESCRIPTION
Please review this trivial change to remove a use of literal zero as a null
pointer constant.

Testing: mach5 tier1
Locally tested (linux-x64) with -Wzero-as-null-pointer-constant enabled to
verify the warnings associated with this code were removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350623](https://bugs.openjdk.org/browse/JDK-8350623): Fix -Wzero-as-null-pointer-constant warnings in nsk native test utilities (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23797/head:pull/23797` \
`$ git checkout pull/23797`

Update a local copy of the PR: \
`$ git checkout pull/23797` \
`$ git pull https://git.openjdk.org/jdk.git pull/23797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23797`

View PR using the GUI difftool: \
`$ git pr show -t 23797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23797.diff">https://git.openjdk.org/jdk/pull/23797.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23797#issuecomment-2684776550)
</details>
