### PR TITLE
8350767: Fix -Wzero-as-null-pointer-constant warnings in nsk jni stress tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ Java_nsk_stress_jni_JNIter001_jnistress (JNIEnv *env, jobject jobj, jstring jstr
   for (j = 0; j < DIGESTLENGTH; j++) {
     digest[j] = 0;
   }
-  element->str[allocs] = env->GetStringUTFChars(jstr, 0); CE
+  element->str[allocs] = env->GetStringUTFChars(jstr, nullptr); CE
   if (strlen(element->str[allocs]) != (size_t) env->GetStringUTFLength(jstr)) {
     printf("Length is wrong in string No. %d\n", allocs);
   } else {
@@ -177,7 +177,7 @@ Java_nsk_stress_jni_JNIter001_jnistress1(JNIEnv *env, jobject jobj, jstring jstr
   for (j = 0; j < DIGESTLENGTH; j++) {
     digest[j] = 0;
   }
-  javachars->str[index] = env->GetStringChars(jstr, 0); CE
+  javachars->str[index] = env->GetStringChars(jstr, nullptr); CE
   javachars->size[index] = env->GetStringUTFLength(jstr); CE
   elem_len = javachars->size[index];
   len += elem_len;

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress003.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,14 +171,14 @@ Java_nsk_stress_jni_JNIter003_jniBodyChangeArray (JNIEnv *env, jobject jobj,
 
   /* Take the elements from Java arrays into native buffers */
   /* Use Get<Type>ArrayElements */
-  boolOrig = env->GetBooleanArrayElements((jbooleanArray) arrayOrig[BOOL], 0); CE
-  byteOrig = env->GetByteArrayElements((jbyteArray) arrayOrig[BYTE], 0); CE
-  charOrig = env->GetCharArrayElements((jcharArray) arrayOrig[CHAR], 0); CE
-  shortOrig = env->GetShortArrayElements((jshortArray) arrayOrig[SHORT], 0); CE
-  intOrig = env->GetIntArrayElements((jintArray) arrayOrig[INT], 0); CE
-  longOrig = env->GetLongArrayElements((jlongArray) arrayOrig[LONG], 0); CE
-  floatOrig = env->GetFloatArrayElements((jfloatArray) arrayOrig[FLOAT], 0); CE
-  doubleOrig = env->GetDoubleArrayElements((jdoubleArray) arrayOrig[DOUBLE], 0); CE
+  boolOrig = env->GetBooleanArrayElements((jbooleanArray) arrayOrig[BOOL], nullptr); CE
+  byteOrig = env->GetByteArrayElements((jbyteArray) arrayOrig[BYTE], nullptr); CE
+  charOrig = env->GetCharArrayElements((jcharArray) arrayOrig[CHAR], nullptr); CE
+  shortOrig = env->GetShortArrayElements((jshortArray) arrayOrig[SHORT], nullptr); CE
+  intOrig = env->GetIntArrayElements((jintArray) arrayOrig[INT], nullptr); CE
+  longOrig = env->GetLongArrayElements((jlongArray) arrayOrig[LONG], nullptr); CE
+  floatOrig = env->GetFloatArrayElements((jfloatArray) arrayOrig[FLOAT], nullptr); CE
+  doubleOrig = env->GetDoubleArrayElements((jdoubleArray) arrayOrig[DOUBLE], nullptr); CE
 
   /* Alloc some memory for cloned arrays buffers */
   boolClone = (jboolean *)c_malloc(env, SIZE(BOOL) * sizeof(jboolean));

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress004.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,13 +47,13 @@ Java_nsk_stress_jni_JNIter004_CheckSum (JNIEnv *env, jobject jobj, jstring jstr)
     digest[i] = 0;
   }
   str = (char *)c_malloc(env, len * sizeof(char));
-  /*     const char *threadName = env->GetStringUTFChars(jstr, 0); */
+  /*     const char *threadName = env->GetStringUTFChars(jstr, nullptr); */
 
   CHECK(env->MonitorEnter(jobj));
   if (upper == 0) {
     tmp = (jchar *) c_malloc(env, DIGESTLENGTH * sizeof(char));
   }
-  critstr = env->GetStringCritical(jstr, 0); CE
+  critstr = env->GetStringCritical(jstr, nullptr); CE
   for (i = 0; i < len; i++) {
     str[i] = (char) critstr[i];
   }
@@ -101,7 +101,7 @@ Java_nsk_stress_jni_JNIter004_CheckCompare (JNIEnv *env, jobject jobj, jstring j
     return JNI_FALSE;
   }
   tmp = (jchar *)c_malloc(env, DIGESTLENGTH * sizeof(char));
-  critstr = env->GetStringCritical(jstr, 0); CE
+  critstr = env->GetStringCritical(jstr, nullptr); CE
   for (i = 0; i < strlen; i++) {
     str[i] = (char) critstr[i];
   }
@@ -121,7 +121,7 @@ Java_nsk_stress_jni_JNIter004_CheckCompare (JNIEnv *env, jobject jobj, jstring j
   /* Compare  */
   /*     env->MonitorEnter(jobj); */
 
-  ch = (jchar *)env->GetPrimitiveArrayCritical(cArr, 0); CE
+  ch = (jchar *)env->GetPrimitiveArrayCritical(cArr, nullptr); CE
 
   printf("Comparing: ");
   for (i = 0; i < len; i++) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress006.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ extern "C" {
 JNIEXPORT jboolean JNICALL
 Java_nsk_stress_jni_JNIter006_refs (JNIEnv *env, jobject jobj, jobject tobj, jint LIMIT) {
 
-  static jobject *globRefsArray = 0;
+  static jobject *globRefsArray = nullptr;
   static int upper = 0;
 
   jclass clazz;

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress007.cpp
@@ -32,7 +32,7 @@ Java_nsk_stress_jni_JNIter007_incCount (JNIEnv *env, jobject jobj, jstring name)
   jclass clazz;
   jfieldID fld;
   jint value;
-  const char *str = env->GetStringUTFChars(name, 0); CE
+  const char *str = env->GetStringUTFChars(name, nullptr); CE
 
   CHECK(env->MonitorEnter(jobj));
   clazz = env->GetObjectClass(jobj); CE


### PR DESCRIPTION
Please review this change to remove uses of literal zero as a null pointer
constant in nsk jni stress tests.

Testing: mach5 tier1
Locally tested (linux-x64) with -Wzero-as-null-pointer-constant enabled to
verify the warnings associated with this code were removed.
