### PR TITLE
8350771: Fix -Wzero-as-null-pointer-constant warning in nsk/monitoring ThreadController utility

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -465,8 +465,8 @@ extern "C" {
                 return env->NewStringUTF("TIMED_WAITING");
             }
         // should never reach
-        assert(0);
-        return 0;
+        assert(false);
+        return nullptr;
     }
 
     /*


### PR DESCRIPTION
Please review this trivial change to remove a use of literal zero as a null
pointer constant in an nsk test utility.

Testing: mach5 tier1
Locally tested (linux-x64) with -Wzero-as-null-pointer-constant enabled to
verify the warnings associated with this code were removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350771](https://bugs.openjdk.org/browse/JDK-8350771): Fix -Wzero-as-null-pointer-constant warning in nsk/monitoring ThreadController utility (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23800/head:pull/23800` \
`$ git checkout pull/23800`

Update a local copy of the PR: \
`$ git checkout pull/23800` \
`$ git pull https://git.openjdk.org/jdk.git pull/23800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23800`

View PR using the GUI difftool: \
`$ git pr show -t 23800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23800.diff">https://git.openjdk.org/jdk/pull/23800.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23800#issuecomment-2684820670)
</details>
