### PR TITLE
8287749: Re-enable javadoc -serialwarn option

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -98,14 +98,14 @@ JAVA_WARNINGS_ARE_ERRORS ?= -Werror
 
 # The initial set of options for javadoc
 JAVADOC_OPTIONS := -use -keywords -notimestamp \
-    -encoding ISO-8859-1 -docencoding UTF-8 -breakiterator \
+    -serialwarn -encoding ISO-8859-1 -docencoding UTF-8 -breakiterator \
     -splitIndex --system none -javafx --expand-requires transitive \
     --override-methods=summary
 
 # The reference options must stay stable to allow for comparisons across the
 # development cycle.
 REFERENCE_OPTIONS := -XDignore.symbol.file=true -use -keywords -notimestamp \
-    -encoding ISO-8859-1 -breakiterator -splitIndex --system none \
+    -serialwarn -encoding ISO-8859-1 -breakiterator -splitIndex --system none \
     -html5 -javafx --expand-requires transitive
 
 # Should we add DRAFT stamps to the generated javadoc?

--- a/make/scripts/genExceptions.sh
+++ b/make/scripts/genExceptions.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -70,6 +70,8 @@ __END__
 
     /**
      * The $ARG_PHRASE.
+     *
+     * @serial
      */
     private $ARG_TYPE $ARG_ID;
 


### PR DESCRIPTION
Please review a simple build change to re-enable the `-serialwarn` javadoc option for normal and reference API docs. The option was removed in [JDK-8252717](https://bugs.openjdk.org/browse/JDK-8252717) to avoid warnings for missing `@serial` tags which have since been added in [JDK-8286931](https://bugs.openjdk.org/browse/JDK-8286931). 

I tested normal and reference docs builds, both run without warning and the generated documentation is unchanged. The `@serial` tag in the Exception template is required and also does not affect javadoc output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287749](https://bugs.openjdk.org/browse/JDK-8287749): Re-enable javadoc -serialwarn option (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23802/head:pull/23802` \
`$ git checkout pull/23802`

Update a local copy of the PR: \
`$ git checkout pull/23802` \
`$ git pull https://git.openjdk.org/jdk.git pull/23802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23802`

View PR using the GUI difftool: \
`$ git pr show -t 23802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23802.diff">https://git.openjdk.org/jdk/pull/23802.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23802#issuecomment-2685145255)
</details>
