### PR TITLE
8353190: Use "/native" Run Option for TestAvailableProcessors Execution

### DIFF
--- a/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
@@ -31,7 +31,7 @@
  * @requires vm.flagless
  * @library /test/lib
  * @compile GetAvailableProcessors.java
- * @run testng/othervm/native --enable-native-access=ALL-UNNAMED TestAvailableProcessors
+ * @run testng/othervm/native TestAvailableProcessors
  */
 
 import java.io.IOException;

--- a/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,18 +31,14 @@
  * @requires vm.flagless
  * @library /test/lib
  * @compile GetAvailableProcessors.java
- * @run testng TestAvailableProcessors
+ * @run testng/othervm/native --enable-native-access=ALL-UNNAMED TestAvailableProcessors
  */
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.HashSet;
 import java.util.Set;
 
-import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -172,12 +168,8 @@ public class TestAvailableProcessors {
 
     @Test
     private static void testProcessorAvailability() throws IOException {
-        // Launch GetProcessorInfo.exe to gather processor counts
-        Path nativeGetProcessorInfo = Paths.get(Utils.TEST_NATIVE_PATH)
-            .resolve("GetProcessorInfo.exe")
-            .toAbsolutePath();
-
-        var processBuilder = new ProcessBuilder(nativeGetProcessorInfo.toString());
+        // Launch "<nativepath>/GetProcessorInfo.exe" to gather processor counts
+        var processBuilder = new ProcessBuilder("GetProcessorInfo.exe");
         var outputAnalyzer= new OutputAnalyzer(processBuilder.start());
         outputAnalyzer.shouldHaveExitValue(0);
         outputAnalyzer.shouldContain(totalProcessorCountMessage);


### PR DESCRIPTION
Currently, the test executes the program using `test.nativepath`, but it relies on path resolution. I propose following standard conventions in this case and running the test with the `/native` option instead.

With this change:
- Path resolution is no longer required.
- If `nativepath` is not specified at runtime, a standard error message will be printed to the console.

This improves consistency and simplifies the test execution process.

I kindly ask the original author of the test @swesonga and those who reviewed the original pull request  #17576 for this test to take a look at this PR: @jdksjolen and @dholmes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353190](https://bugs.openjdk.org/browse/JDK-8353190): Use "/native" Run Option for TestAvailableProcessors Execution (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23803/head:pull/23803` \
`$ git checkout pull/23803`

Update a local copy of the PR: \
`$ git checkout pull/23803` \
`$ git pull https://git.openjdk.org/jdk.git pull/23803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23803`

View PR using the GUI difftool: \
`$ git pr show -t 23803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23803.diff">https://git.openjdk.org/jdk/pull/23803.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23803#issuecomment-2762094229)
</details>
