### PR TITLE
8350786: Some java/lang jtreg tests miss requires vm.hasJFR

### DIFF
--- a/test/jdk/java/lang/Thread/ThreadSleepEvent.java
+++ b/test/jdk/java/lang/Thread/ThreadSleepEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/Thread/ThreadSleepEvent.java
+++ b/test/jdk/java/lang/Thread/ThreadSleepEvent.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @summary Test that Thread.sleep emits a JFR jdk.ThreadSleep event
+ * @requires vm.hasJFR
  * @modules jdk.jfr
  * @run junit ThreadSleepEvent
  */

--- a/test/jdk/java/lang/Thread/virtual/JfrEvents.java
+++ b/test/jdk/java/lang/Thread/virtual/JfrEvents.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @summary Basic test for JFR jdk.VirtualThreadXXX events
- * @requires vm.continuations
+ * @requires vm.continuations & vm.hasJFR
  * @modules jdk.jfr java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @run junit/othervm/native --enable-native-access=ALL-UNNAMED JfrEvents

--- a/test/jdk/java/lang/Thread/virtual/MonitorPinnedEvents.java
+++ b/test/jdk/java/lang/Thread/virtual/MonitorPinnedEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/Thread/virtual/MonitorPinnedEvents.java
+++ b/test/jdk/java/lang/Thread/virtual/MonitorPinnedEvents.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Test JFR jdk.VirtualThreadPinned event recorded for contended monitor enter
  *     and Object.wait when pinned
- * @requires vm.continuations
+ * @requires vm.continuations & vm.hasJFR
  * @modules jdk.jfr jdk.management
  * @library /test/lib
  * @run junit/othervm --enable-native-access=ALL-UNNAMED MonitorPinnedEvents


### PR DESCRIPTION
While testing a bit with a minimal JVM, it has been noticed that some java/lang jtreg tests use jfr but do not declare it with a "requires vm.hasJFR" ; that leads to test errors in a JVM setup with no JFR .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350786](https://bugs.openjdk.org/browse/JDK-8350786): Some java/lang jtreg tests miss requires vm.hasJFR (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23805/head:pull/23805` \
`$ git checkout pull/23805`

Update a local copy of the PR: \
`$ git checkout pull/23805` \
`$ git pull https://git.openjdk.org/jdk.git pull/23805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23805`

View PR using the GUI difftool: \
`$ git pr show -t 23805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23805.diff">https://git.openjdk.org/jdk/pull/23805.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23805#issuecomment-2685480631)
</details>
