### PR TITLE
8350654: (fs) Files.createTempDirectory should say something about the default file permissions when no file attributes specified

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -860,7 +860,10 @@ public final class Files {
      * file-attributes} to set atomically when creating the directory. Each
      * attribute is identified by its {@link FileAttribute#name name}. If more
      * than one attribute of the same name is included in the array then all but
-     * the last occurrence is ignored.
+     * the last occurrence is ignored. When no file attributes are specified,
+     * then the resulting directory may have more restrictive access
+     * permissions to (non-temporary) directories created by the
+     * {@linkplain Files#createDirectory(Path, FileAttribute<?>...)} method.
      *
      * @param   dir
      *          the path to directory in which to create the directory

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -862,7 +862,7 @@ public final class Files {
      * than one attribute of the same name is included in the array then all but
      * the last occurrence is ignored. When no file attributes are specified,
      * then the resulting directory may have more restrictive access
-     * permissions to (non-temporary) directories created by the
+     * permissions to directories created by the
      * {@linkplain Files#createDirectory(Path, FileAttribute<?>...)} method.
      *
      * @param   dir


### PR DESCRIPTION
Add a sentence clarifying the behavior of `Files.createTempDirectory(Path,String,FileAttribute<?>...)` when no attributes are specified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8350812](https://bugs.openjdk.org/browse/JDK-8350812) to be approved

### Issues
 * [JDK-8350654](https://bugs.openjdk.org/browse/JDK-8350654): (fs) Files.createTempDirectory should say something about the default file permissions when no file attributes specified (**Enhancement** - P4)
 * [JDK-8350812](https://bugs.openjdk.org/browse/JDK-8350812): (fs) Files.createTempDirectory should say something about the default file permissions when no file attributes specified (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23808/head:pull/23808` \
`$ git checkout pull/23808`

Update a local copy of the PR: \
`$ git checkout pull/23808` \
`$ git pull https://git.openjdk.org/jdk.git pull/23808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23808`

View PR using the GUI difftool: \
`$ git pr show -t 23808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23808.diff">https://git.openjdk.org/jdk/pull/23808.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23808#issuecomment-2685905489)
</details>
