### PR TITLE
8350808: Small typos in JShell method SnippetEvent.toString()

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/SnippetEvent.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SnippetEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,9 +148,9 @@ public class SnippetEvent {
                 ",previousStatus=" + previousStatus +
                 ",status=" + status +
                 ",isSignatureChange=" + isSignatureChange +
-                ",causeSnippet" + causeSnippet +
-                (value == null? "" : "value=" + value) +
-                (exception == null? "" : "exception=" + exception) +
+                ",causeSnippet=" + causeSnippet +
+                (value == null? "" : ",value=" + value) +
+                (exception == null? "" : ",exception=" + exception) +
                 ")";
     }
 }

--- a/test/langtools/jdk/jshell/SnippetEventToStringTest.java
+++ b/test/langtools/jdk/jshell/SnippetEventToStringTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8350808
+ * @summary Check for proper formatting of SnippetEvent.toString()
+ * @run testng SnippetEventToStringTest
+ */
+
+import java.util.Map;
+import java.util.List;
+
+import jdk.jshell.JShell;
+import jdk.jshell.SnippetEvent;
+import jdk.jshell.execution.LocalExecutionControlProvider;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+public class SnippetEventToStringTest {
+
+    @DataProvider(name = "cases")
+    public String[][] sourceLevels() {
+        return new String[][] {
+            { "*",                              ",causeSnippet=null" },
+            { "123",                            ",value=123" },
+            { "throw new Exception(\"foo\");",  ",exception=jdk.jshell.EvalException: foo" }
+        };
+    }
+
+    @Test(dataProvider = "cases")
+    private void verifySnippetEvent(String source, String match) {
+        try (JShell jsh = JShell.builder().executionEngine(new LocalExecutionControlProvider(), Map.of()).build()) {
+            List<SnippetEvent> result = jsh.eval(source);
+            assertEquals(result.size(), 1);
+            String string = result.get(0).toString();
+            if (!string.contains(match))
+                throw new AssertionError(String.format("\"%s\" not found in \"%s\"", match, string));
+        }
+    }
+}


### PR DESCRIPTION
This PR which fixes three small typos in the method `SnippetEvent.toString()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350808](https://bugs.openjdk.org/browse/JDK-8350808): Small typos in JShell method SnippetEvent.toString() (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23809/head:pull/23809` \
`$ git checkout pull/23809`

Update a local copy of the PR: \
`$ git checkout pull/23809` \
`$ git pull https://git.openjdk.org/jdk.git pull/23809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23809`

View PR using the GUI difftool: \
`$ git pr show -t 23809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23809.diff">https://git.openjdk.org/jdk/pull/23809.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23809#issuecomment-2686038735)
</details>
