### PR TITLE
4745837: Make grouping usage during parsing apparent in relevant NumberFormat methods

### DIFF
--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -891,9 +891,8 @@ public abstract class NumberFormat extends Format  {
      * <ul>
      *   <li> Formatting {@code 1234567} with grouping on returns {@code "1,234,567"}
      *   <li> Parsing {@code "1,234,567"} with grouping off returns {@code 1}
-     *   <li> Parsing {@code "1,234,567"} with grouping off and an implementation that
-     *        implements strict parsing with {@link #isStrict()} returning {@code true}
-     *        throws {@code ParseException}
+     *   <li> Parsing {@code "1,234,567"} with grouping off when {@link #isStrict()}
+     *        returns {@code true} throws {@code ParseException}
      * </ul>
      *
      * @return {@code true} if grouping is used;

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -884,15 +884,22 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Returns true if grouping is used in this format. This applies to both
-     * formatting and parsing. For example, in the English locale, with grouping on,
-     * the number 1234567 might be formatted as "1,234,567". For the same format
-     * with grouping off, the String "1,234,567" might be parsed as 1.
-     * The grouping separator as well as the size of each group
-     * is locale dependent and is determined by sub-classes of NumberFormat.
+     * formatting and parsing. The grouping separator as well as the size of each
+     * group is locale dependent and is determined by sub-classes of NumberFormat.
+     * For example, consider a {@code NumberFormat} that expects a "{@code ,}"
+     * grouping separator symbol with a grouping size of 3.
+     * <ul>
+     *   <li> Formatting {@code 1234567} with grouping on returns {@code "1,234,567"}
+     *   <li> Parsing {@code "1,234,567"} with grouping off returns {@code 1}
+     *   <li> Parsing {@code "1,234,567"} with grouping off and an implementation that
+     *        implements strict parsing with {@link #isStrict()} returning {@code true}
+     *        throws {@code ParseException}
+     * </ul>
      *
      * @return {@code true} if grouping is used;
      *         {@code false} otherwise
      * @see #setGroupingUsed
+     * @see ##leniency Leniency Section
      */
     public boolean isGroupingUsed() {
         return groupingUsed;

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -883,9 +883,11 @@ public abstract class NumberFormat extends Format  {
     }
 
     /**
-     * Returns true if grouping is used in this format. For example, in the
-     * English locale, with grouping on, the number 1234567 might be formatted
-     * as "1,234,567". The grouping separator as well as the size of each group
+     * Returns true if grouping is used in this format. This applies to both
+     * formatting and parsing. For example, in the English locale, with grouping on,
+     * the number 1234567 might be formatted as "1,234,567". For the same format
+     * with grouping off, the String "1,234,567" might be parsed as 1.
+     * The grouping separator as well as the size of each group
      * is locale dependent and is determined by sub-classes of NumberFormat.
      *
      * @return {@code true} if grouping is used;
@@ -898,6 +900,7 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Set whether or not grouping will be used in this format.
+     * This applies to both formatting and parsing.
      *
      * @param newValue {@code true} if grouping is used;
      *                 {@code false} otherwise


### PR DESCRIPTION
Please review this PR which clarifies some behavior regarding NumberFormat grouping specifically in the grouping related methods.

Please see the corresponding CSR for further detail. Note that an alternative would be to specify this at the DecimalFormat level, allowing NumberFormat subclasses to define this behavior how they want. IMO, I would expect `setGroupingUsed(boolean)` to affect both; a subclass could define `(is|set)(Parsing|Formatting)GroupingUsed` if need be, thus the proposed solution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8350706](https://bugs.openjdk.org/browse/JDK-8350706) to be approved

### Issues
 * [JDK-4745837](https://bugs.openjdk.org/browse/JDK-4745837): Make grouping usage during parsing apparent in relevant NumberFormat methods (**Bug** - P4)
 * [JDK-8350706](https://bugs.openjdk.org/browse/JDK-8350706): Make grouping usage during parsing apparent in relevant NumberFormat methods (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23813/head:pull/23813` \
`$ git checkout pull/23813`

Update a local copy of the PR: \
`$ git checkout pull/23813` \
`$ git pull https://git.openjdk.org/jdk.git pull/23813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23813`

View PR using the GUI difftool: \
`$ git pr show -t 23813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23813.diff">https://git.openjdk.org/jdk/pull/23813.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23813#issuecomment-2686340684)
</details>
