### PR TITLE
8350813: Rendering of bulky sound bank from MIDI sequence can cause OutOfMemoryError

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/AudioFileSoundbankReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AudioFileSoundbankReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,6 +88,13 @@ public final class AudioFileSoundbankReader extends SoundbankReader {
             if (totalSize >= Integer.MAX_VALUE - 2) {
                 throw new InvalidMidiDataException(
                         "Can not allocate enough memory to read audio data.");
+            }
+
+            long maximumHeapSize = Runtime.getRuntime().maxMemory() -
+                (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory());
+            if (totalSize > maximumHeapSize) {
+                throw new InvalidMidiDataException(
+                        "Insufficient heap size to render audio data.");
             }
 
             if (ais.getFrameLength() == -1 || totalSize > MEGABYTE) {

--- a/src/java.desktop/share/classes/com/sun/media/sound/AudioFileSoundbankReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AudioFileSoundbankReader.java
@@ -90,8 +90,8 @@ public final class AudioFileSoundbankReader extends SoundbankReader {
                         "Can not allocate enough memory to read audio data.");
             }
 
-            long maximumHeapSize = Runtime.getRuntime().maxMemory() -
-                (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory());
+            long maximumHeapSize = (long) ((Runtime.getRuntime().maxMemory() -
+                    (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())) * 0.9);
             if (totalSize > maximumHeapSize) {
                 throw new InvalidMidiDataException(
                         "Insufficient heap size to render audio data.");

--- a/test/jdk/javax/sound/midi/BulkSoundBank/BulkSoundBank.java
+++ b/test/jdk/javax/sound/midi/BulkSoundBank/BulkSoundBank.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.sound.midi.InvalidMidiDataException;
+import javax.sound.midi.MidiSystem;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+/**
+ * @test
+ * @bug 8350813
+ * @summary Rendering of bulky sound bank from MIDI sequence can cause OutOfMemoryError.
+ * @run main/othervm -Xmx1g BulkSoundBank
+ */
+
+public class BulkSoundBank {
+    static final byte[] midi = {77, 84, 104, 100, 0, 0, 0, 6, 0, 0, 0, 1, 1,
+            -32, 77, 84, 114, 107, 0, 0, 0, 50, 0, -1, 88, 4, 4, 2, 24, 8, 0, -1,
+            81, 3, 7, -95, 32, 0, -112, 60, 64, -125, 96, -128, 60, 64, -125, -44,
+            -51, 32, -112, 48, 64, 1, -128, 48, 64, -127, -64, -45, 127, -112, 60,
+            64, 1, -128, 60, 64, 0, -1, 47, 0};
+
+    public static void main(String[] args) throws IOException {
+        ByteArrayInputStream bis = new ByteArrayInputStream(midi);
+        try {
+            MidiSystem.getSoundbank(bis);
+        } catch (InvalidMidiDataException imda) {
+            System.out.println("Caught InvalidMidiDataException as expected");
+            return;
+        }
+        throw new RuntimeException("Test should throw InvalidMidiDataException but it did not.");
+    }
+}
+


### PR DESCRIPTION
- Check that the calculated audio data size does not exceed available heap memory before committing to the rendering
- Add a test case

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350813](https://bugs.openjdk.org/browse/JDK-8350813): Rendering of bulky sound bank from MIDI sequence can cause OutOfMemoryError (**Bug** - P3)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23814/head:pull/23814` \
`$ git checkout pull/23814`

Update a local copy of the PR: \
`$ git checkout pull/23814` \
`$ git pull https://git.openjdk.org/jdk.git pull/23814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23814`

View PR using the GUI difftool: \
`$ git pr show -t 23814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23814.diff">https://git.openjdk.org/jdk/pull/23814.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23814#issuecomment-2686357271)
</details>
