### PR TITLE
8347139: [macos] Test tools/jpackage/share/InOutPathTest.java  failed:  "execution error: Finder got an error: AppleEvent timed out."

### DIFF
--- a/test/jdk/tools/jpackage/share/IconTest.java
+++ b/test/jdk/tools/jpackage/share/IconTest.java
@@ -52,7 +52,7 @@ import jdk.jpackage.test.Annotations.Test;
  * @library /test/jdk/tools/jpackage/helpers
  * @build jdk.jpackage.test.*
  * @compile -Xlint:all -Werror IconTest.java
- * @run main/othervm/timeout=540 -Xmx512m
+ * @run main/othervm/timeout=720 -Xmx512m
  *  jdk.jpackage.test.Main
  *  --jpt-run=IconTest
  */

--- a/test/jdk/tools/jpackage/share/InOutPathTest.java
+++ b/test/jdk/tools/jpackage/share/InOutPathTest.java
@@ -50,7 +50,7 @@ import jdk.jpackage.test.TKit;
  * @library /test/jdk/tools/jpackage/helpers
  * @build jdk.jpackage.test.*
  * @compile -Xlint:all -Werror InOutPathTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=720 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=InOutPathTest
  */
 public final class InOutPathTest {


### PR DESCRIPTION
- Fixed by increasing test timeout. Fix verified on host which reproduced issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347139](https://bugs.openjdk.org/browse/JDK-8347139): [macos] Test tools/jpackage/share/InOutPathTest.java  failed:  "execution error: Finder got an error: AppleEvent timed out." (**Bug** - P4)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23816/head:pull/23816` \
`$ git checkout pull/23816`

Update a local copy of the PR: \
`$ git checkout pull/23816` \
`$ git pull https://git.openjdk.org/jdk.git pull/23816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23816`

View PR using the GUI difftool: \
`$ git pr show -t 23816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23816.diff">https://git.openjdk.org/jdk/pull/23816.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23816#issuecomment-2686733152)
</details>
