### PR TITLE
8350841: ProblemList jdk/incubator/vector/Long256VectorTests.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -749,7 +749,7 @@ sun/tools/jstat/jstatLineCounts4.sh                             8248691,8268211 
 
 jdk/incubator/vector/ShortMaxVectorTests.java                   8306592 generic-i586
 jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-x64
-jdk/incubator/vector/Long256VectorTests.java                    8350840 x64
+jdk/incubator/vector/Long256VectorTests.java                    8350840 generic-x64
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -749,6 +749,7 @@ sun/tools/jstat/jstatLineCounts4.sh                             8248691,8268211 
 
 jdk/incubator/vector/ShortMaxVectorTests.java                   8306592 generic-i586
 jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-x64
+jdk/incubator/vector/Long256VectorTests.java                    8350840 x64
 
 ############################################################################
 


### PR DESCRIPTION
I am problem listing the test because of this bug:

[JDK-8350840](https://bugs.openjdk.org/browse/JDK-8350840) C2: x64 Assembler::vpcmpeqq assert: failed: XMM register should be 0-15

It seems to fail on x64 with AVX512 only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350841](https://bugs.openjdk.org/browse/JDK-8350841): ProblemList jdk/incubator/vector/Long256VectorTests.java (**Sub-task** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23818/head:pull/23818` \
`$ git checkout pull/23818`

Update a local copy of the PR: \
`$ git checkout pull/23818` \
`$ git pull https://git.openjdk.org/jdk.git pull/23818/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23818`

View PR using the GUI difftool: \
`$ git pr show -t 23818`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23818.diff">https://git.openjdk.org/jdk/pull/23818.diff</a>

</details>
