### PR TITLE
8350824

### DIFF
--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -253,18 +253,6 @@ TEST_VM_F(AsyncLogTest, droppingMessage) {
   EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
 }
 
-TEST_VM_F(AsyncLogTest, StallingModePreventsDroppedMessages) {
-  if (AsyncLogWriter::instance() == nullptr) {
-    return;
-  }
-  set_log_config(TestLogFileName, "logging=debug");
-  LogConfiguration::AsyncMode prev_mode = LogConfiguration::async_mode();
-  LogConfiguration::set_async_mode(LogConfiguration::AsyncMode::Off);
-  test_asynclog_drop_messages();
-  EXPECT_FALSE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
-  LogConfiguration::set_async_mode(prev_mode);
-}
-
 TEST_VM_F(AsyncLogTest, stdoutOutput) {
   testing::internal::CaptureStdout();
 

--- a/test/hotspot/jtreg/runtime/logging/StressAsyncUL.java
+++ b/test/hotspot/jtreg/runtime/logging/StressAsyncUL.java
@@ -35,19 +35,22 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 public class StressAsyncUL {
-    static void analyze_output(String... args) throws Exception {
+    static void analyze_output(bool stalling_mode, String... args) throws Exception {
         ProcessBuilder pb =
             ProcessTools.createLimitedTestJavaProcessBuilder(args);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
+        if (stalling_mode) {
+            output.shouldNotContain("messages dropped due to async logging");
+        }
     }
     public static void main(String[] args) throws Exception {
-        analyze_output("-Xlog:async:drop", "-Xlog:all=trace", InnerClass.class.getName());
-        analyze_output("-Xlog:async:stall", "-Xlog:all=trace", InnerClass.class.getName());
+        analyze_output(false, "-Xlog:async:drop", "-Xlog:all=trace", InnerClass.class.getName());
+        analyze_output(true, "-Xlog:async:stall", "-Xlog:all=trace", InnerClass.class.getName());
         // Stress test with a very small buffer. Note: Any valid buffer size must be able to hold a flush token.
         // Therefore the size of the buffer cannot be zero.
-        analyze_output("-Xlog:async:drop", "-Xlog:all=trace", "-XX:AsyncLogBufferSize=192", InnerClass.class.getName());
-        analyze_output("-Xlog:async:stall", "-Xlog:all=trace", "-XX:AsyncLogBufferSize=192", InnerClass.class.getName());
+        analyze_output(false, "-Xlog:async:drop", "-Xlog:all=trace", "-XX:AsyncLogBufferSize=192", InnerClass.class.getName());
+        analyze_output(true, "-Xlog:async:stall", "-Xlog:all=trace", "-XX:AsyncLogBufferSize=192", InnerClass.class.getName());
     }
 
     public static class InnerClass {


### PR DESCRIPTION
Hi,

When I added async stalling mode I also added this gtest early in the process, and as tier1/GHA passed I did not look at the test again. However, the test does not run until much deeper in the CI/CD process for us, as that's when we turn on async logging explicitly for all gtests.

Looking at it now, it's clearly buggy. It doesn't check which async mode UL is in, and as `drop` is default, that makes it bound to fail. Besides, the goal of it is to check whether async stalling mode drops messages or not during stress. We already have an excellent test for that in JTReg, and this does run early as it spawns its own VM with the correct asynchronous mode specified. My suggested fix is to delete the gtest and add a dropped message check to the JTReg test instead.