### PR TITLE
8350572: ZGC: Enhance z_verify_safepoints_are_blocked interactions with VMError

### DIFF
--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -53,6 +53,7 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/preserveException.hpp"
 #include "utilities/resourceHash.hpp"
+#include "utilities/vmError.hpp"
 
 #ifdef ASSERT
 
@@ -60,6 +61,13 @@
 // with callers to this function. Typically used to verify that object oops
 // and headers are safe to access.
 void z_verify_safepoints_are_blocked() {
+  if (VMError::is_error_reported_in_current_thread()) {
+    // The current thread has crashed and is creating an error report.
+    // This may occur from any thread state, skip the safepoint_are_blocked
+    // verification.
+    return;
+  }
+
   Thread* current = Thread::current();
 
   if (current->is_ConcurrentGC_thread()) {


### PR DESCRIPTION
If VMError reporting is triggered from a disallowed  thread state `z_verify_safepoints_are_blocked` will cause reentrant assertions to be triggered, when for example when loading the thread oop as part of thread printing. This extends the verification to be ignored if triggered from the thread doing the error reporting. In most cases performing the load barriers from disallowed thread states during error reporting will work.

Testing:
 - tier 1 Oracle supported platforms
 - GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350572](https://bugs.openjdk.org/browse/JDK-8350572): ZGC: Enhance z_verify_safepoints_are_blocked interactions with VMError (**Bug** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23820/head:pull/23820` \
`$ git checkout pull/23820`

Update a local copy of the PR: \
`$ git checkout pull/23820` \
`$ git pull https://git.openjdk.org/jdk.git pull/23820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23820`

View PR using the GUI difftool: \
`$ git pr show -t 23820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23820.diff">https://git.openjdk.org/jdk/pull/23820.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23820#issuecomment-2687658999)
</details>
