### PR TITLE
8350851: ZGC: Reduce size of ZAddressOffsetMax scaling data structures

### DIFF
--- a/src/hotspot/share/gc/z/zIndexDistributor.hpp
+++ b/src/hotspot/share/gc/z/zIndexDistributor.hpp
@@ -24,6 +24,8 @@
 #ifndef SHARE_GC_Z_ZINDEXDISTRIBUTOR_HPP
 #define SHARE_GC_Z_ZINDEXDISTRIBUTOR_HPP
 
+#include <utilities/globalDefinitions.hpp>
+
 class ZIndexDistributor {
 private:
   void* _strategy;
@@ -39,6 +41,10 @@ public:
 
   template <typename Function>
   void do_indices(Function function);
+
+  // Returns a count that is max_count or larger and upholds the requirements
+  // for using the ZIndexDistributor strategy specfied by ZIndexDistributorStrategy
+  static size_t get_count(size_t max_count);
 };
 
 #endif // SHARE_GC_Z_ZINDEXDISTRIBUTOR_HPP

--- a/src/hotspot/share/gc/z/zMemory.cpp
+++ b/src/hotspot/share/gc/z/zMemory.cpp
@@ -100,6 +100,18 @@ zoffset ZMemoryManager::peek_low_address() const {
   return zoffset(UINTPTR_MAX);
 }
 
+zoffset_end ZMemoryManager::peak_high_address_end() const {
+  ZLocker<ZLock> locker(&_lock);
+
+  const ZMemory* const area = _freelist.last();
+  if (area != nullptr) {
+    return area->end();
+  }
+
+  // Out of memory
+  return zoffset_end(UINTPTR_MAX);
+}
+
 zoffset ZMemoryManager::alloc_low_address(size_t size) {
   ZLocker<ZLock> locker(&_lock);
 

--- a/src/hotspot/share/gc/z/zMemory.hpp
+++ b/src/hotspot/share/gc/z/zMemory.hpp
@@ -86,6 +86,7 @@ public:
   void register_callbacks(const Callbacks& callbacks);
 
   zoffset peek_low_address() const;
+  zoffset_end peak_high_address_end() const;
   zoffset alloc_low_address(size_t size);
   zoffset alloc_low_address_at_most(size_t size, size_t* allocated);
   zoffset alloc_high_address(size_t size);

--- a/src/hotspot/share/gc/z/zPageTable.cpp
+++ b/src/hotspot/share/gc/z/zPageTable.cpp
@@ -23,13 +23,22 @@
 
 #include "gc/z/zAddress.hpp"
 #include "gc/z/zGranuleMap.inline.hpp"
+#include "gc/z/zIndexDistributor.inline.hpp"
 #include "gc/z/zPage.inline.hpp"
 #include "gc/z/zPageTable.inline.hpp"
 #include "runtime/orderAccess.hpp"
 #include "utilities/debug.hpp"
 
+static size_t get_max_offset_for_map() {
+  // The page table has (ZAddressOffsetMax >> ZGranuleSizeShift) slots
+  const size_t max_count = ZAddressOffsetMax >> ZGranuleSizeShift;
+  const size_t required_count = ZIndexDistributor::get_count(max_count);
+
+  return required_count << ZGranuleSizeShift;
+}
+
 ZPageTable::ZPageTable()
-  : _map(ZAddressOffsetMax) {}
+  : _map(get_max_offset_for_map()) {}
 
 void ZPageTable::insert(ZPage* page) {
   const zoffset offset = page->start();

--- a/src/hotspot/share/gc/z/zPageTable.hpp
+++ b/src/hotspot/share/gc/z/zPageTable.hpp
@@ -45,6 +45,8 @@ private:
 public:
   ZPageTable();
 
+  int count() const;
+
   ZPage* get(zaddress addr) const;
   ZPage* get(volatile zpointer* p) const;
 

--- a/src/hotspot/share/gc/z/zPageTable.inline.hpp
+++ b/src/hotspot/share/gc/z/zPageTable.inline.hpp
@@ -32,6 +32,15 @@
 #include "gc/z/zPage.inline.hpp"
 #include "gc/z/zPageAllocator.inline.hpp"
 
+#include <limits>
+
+inline int ZPageTable::count() const {
+  const size_t size = _map._size;
+  assert(size <= std::numeric_limits<int>::max(), "Invalid page table size");
+
+  return static_cast<int>(size);
+}
+
 inline ZPage* ZPageTable::get(zaddress addr) const {
   assert(!is_null(addr), "Invalid address");
   return _map.get(ZAddress::offset(addr));
@@ -64,7 +73,7 @@ inline bool ZPageTableIterator::next(ZPage** page) {
 
 inline ZPageTableParallelIterator::ZPageTableParallelIterator(const ZPageTable* table)
   : _table(table),
-    _index_distributor(int(ZAddressOffsetMax >> ZGranuleSizeShift)) {}
+    _index_distributor(table->count()) {}
 
 template <typename Function>
 inline void ZPageTableParallelIterator::do_pages(Function function) {

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -48,6 +48,9 @@ ZVirtualMemoryManager::ZVirtualMemoryManager(size_t max_capacity)
     return;
   }
 
+  // Set ZAddressOffsetMax to the highest address end available after reservation
+  ZAddressOffsetMax = untype(highest_available_address_end());
+
   // Initialize platform specific parts after reserving address space
   pd_initialize_after_reserve();
 

--- a/src/hotspot/share/gc/z/zVirtualMemory.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.hpp
@@ -77,6 +77,7 @@ public:
 
   size_t reserved() const;
   zoffset lowest_available_address() const;
+  zoffset_end highest_available_address_end() const;
 
   ZVirtualMemory alloc(size_t size, bool force_low_address);
   void free(const ZVirtualMemory& vmem);

--- a/src/hotspot/share/gc/z/zVirtualMemory.inline.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.inline.hpp
@@ -65,4 +65,8 @@ inline zoffset ZVirtualMemoryManager::lowest_available_address() const {
   return _manager.peek_low_address();
 }
 
+inline zoffset_end ZVirtualMemoryManager::highest_available_address_end() const {
+  return _manager.peak_high_address_end();
+}
+
 #endif // SHARE_GC_Z_ZVIRTUALMEMORY_INLINE_HPP


### PR DESCRIPTION
ZAddressOffsetMax is used to scale a few of our BitMap and GranuleMap data structures. ZAddressOffsetMax is initialised to an upper limit, prior to reserving the virtual address space for the heap. After the reservation, the largest address offset that can be encountered may be much lower.

I propose we scale ZAddressOffsetMax down after our heap reservation is complete, to the actual max value an zoffset_end is allowed to be.

Doing this gives us two benefits. Firstly the assertions and type checks will be stricter, and will exercise code paths that otherwise only occur when using a 16TB heap. Secondly we can reduce the size of the data structures which scale with ZAddressOffsetMax. (For most OSs the extra memory of these data structures do not really matter as they are not page'd in. But they are accounted for both on the OS, allocator and NMT layers).

The page table, uses ZIndexDistributor to iterate and distribute indices. The different strategies have different requirements on the alignment of the size of the range it distribute across. My proposed implementation simply aligns up the page table size to this alignment requirement. As it is the least intrusive change, at the cost of some larger data structure than strictly required. The alternative would be to extend ZIndexDistributor with support for any alignment on the range, or condition the use of the distributed indices based on if they are less than the size.

The data structures can also be larger than required if we fail to reserve the heap starting at our heap base. However this is a very rare occurrence, and while it would be nice to extend our asserts to check for a "ZAddressOffsetMin", I'll leave that for a future enhancement.

Testing:
 * ZGC specific tasks, tier 1 through tier 8 on Oracle Supported platforms
   * with `ZIndexDistributorStrategy=0`, and
   * with `ZIndexDistributorStrategy=1`
 * GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350851](https://bugs.openjdk.org/browse/JDK-8350851): ZGC: Reduce size of ZAddressOffsetMax scaling data structures (**Enhancement** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23822/head:pull/23822` \
`$ git checkout pull/23822`

Update a local copy of the PR: \
`$ git checkout pull/23822` \
`$ git pull https://git.openjdk.org/jdk.git pull/23822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23822`

View PR using the GUI difftool: \
`$ git pr show -t 23822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23822.diff">https://git.openjdk.org/jdk/pull/23822.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23822#issuecomment-2687871837)
</details>
