### PR TITLE
8350858: [IR Framework] Some tests failed on Cascade Lake

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/VMInfo.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/VMInfo.java
@@ -42,7 +42,7 @@ public class VMInfo {
     private final Map<String, String> keyValueMap;
 
     private static final Pattern CPU_SKYLAKE_PATTERN =
-            Pattern.compile("family 6 model 85 stepping (\\d) ");
+            Pattern.compile("family 6 model 85 stepping (\\d+) ");
 
     public VMInfo(Map<String, String> map) {
         this.keyValueMap = map;


### PR DESCRIPTION
I found some vector tests failed on my Cascade Lake machine.

The root cause is the CPU_SKYLAKE_PATTERN can not handle cpu with 2-digits stepping. The failed cpu model is
```bash
lscpu
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                96
On-line CPU(s) list:   0-95
Thread(s) per core:    1
Core(s) per socket:    24
Socket(s):             4
NUMA node(s):          1
Vendor ID:             GenuineIntel
CPU family:            6
Model:                 85
Model name:            Intel(R) Xeon(R) Gold 6348H CPU @ 2.30GHz
Stepping:              11
CPU MHz:               2300.000
CPU max MHz:           4200.0000
CPU min MHz:           1000.0000
BogoMIPS:              4600.00
Virtualization:        VT-x
L1d cache:             32K
L1i cache:             32K
L2 cache:              1024K
L3 cache:              33792K
NUMA node0 CPU(s):     0-95
Flags:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 invpcid_single intel_ppin ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm cqm mpx rdt_a avx512f avx512dq rdseed adx smap clflushopt clwb intel_pt avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local avx512_bf16 dtherm ida arat pln pts pku ospke avx512_vnni md_clear flush_l1d arch_capabilities
```

The fix is trival.

PS, In vestigation, I found the vector size is different between auto-vectorization(32-bytes) and vector-api(64-bytes) in cascade cake machine. I'm wondering if it's a legacy code. And can we make them as a unique size?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350858](https://bugs.openjdk.org/browse/JDK-8350858): [IR Framework] Some tests failed on Cascade Lake (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23824/head:pull/23824` \
`$ git checkout pull/23824`

Update a local copy of the PR: \
`$ git checkout pull/23824` \
`$ git pull https://git.openjdk.org/jdk.git pull/23824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23824`

View PR using the GUI difftool: \
`$ git pr show -t 23824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23824.diff">https://git.openjdk.org/jdk/pull/23824.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23824#issuecomment-2687945059)
</details>
