### PR TITLE
8350866: [x86] Add C1 intrinsics for CRC32-C

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1131,7 +1131,73 @@ void LIRGenerator::do_update_CRC32(Intrinsic* x) {
 }
 
 void LIRGenerator::do_update_CRC32C(Intrinsic* x) {
-  Unimplemented();
+  assert(UseCRC32CIntrinsics, "need AVX and LCMUL instructions support");
+  LIR_Opr result = rlock_result(x);
+
+  switch (x->id()) {
+    case vmIntrinsics::_updateBytesCRC32C:
+    case vmIntrinsics::_updateDirectByteBufferCRC32C: {
+      bool is_updateBytes = (x->id() == vmIntrinsics::_updateBytesCRC32C);
+
+      LIRItem crc(x->argument_at(0), this);
+      LIRItem buf(x->argument_at(1), this);
+      LIRItem off(x->argument_at(2), this);
+      LIRItem end(x->argument_at(3), this);
+      buf.load_item();
+      off.load_nonconstant();
+      end.load_nonconstant();
+
+      // len = end - off
+      LIR_Opr len  = end.result();
+      LIR_Opr tmpA = new_register(T_INT);
+      LIR_Opr tmpB = new_register(T_INT);
+      __ move(end.result(), tmpA);
+      __ move(off.result(), tmpB);
+      __ sub(tmpA, tmpB, tmpA);
+      len = tmpA;
+
+      LIR_Opr index = off.result();
+      int offset = is_updateBytes ? arrayOopDesc::base_offset_in_bytes(T_BYTE) : 0;
+      if (off.result()->is_constant()) {
+        index = LIR_OprFact::illegalOpr;
+        offset += off.result()->as_jint();
+      }
+      LIR_Opr base_op = buf.result();
+      LIR_Address* a = nullptr;
+
+      if (index->is_valid()) {
+        LIR_Opr tmp = new_register(T_LONG);
+        __ convert(Bytecodes::_i2l, index, tmp);
+        index = tmp;
+        __ add(index, LIR_OprFact::intptrConst(offset), index);
+        a = new LIR_Address(base_op, index, T_BYTE);
+      } else {
+        a = new LIR_Address(base_op, offset, T_BYTE);
+      }
+
+      BasicTypeList signature(3);
+      signature.append(T_INT);
+      signature.append(T_ADDRESS);
+      signature.append(T_INT);
+      CallingConvention* cc = frame_map()->c_calling_convention(&signature);
+      const LIR_Opr result_reg = result_register_for(x->type());
+
+      LIR_Opr arg1 = cc->at(0),
+              arg2 = cc->at(1),
+              arg3 = cc->at(2);
+
+      crc.load_item_force(arg1);
+      __ leal(LIR_OprFact::address(a), arg2);
+      __ move(len, arg3);
+
+      __ call_runtime_leaf(StubRoutines::updateBytesCRC32C(), LIR_OprFact::illegalOpr, result_reg, cc->args());
+      __ move(result_reg, result);
+      break;
+    }
+    default: {
+      ShouldNotReachHere();
+    }
+  }
 }
 
 void LIRGenerator::do_vectorizedMismatch(Intrinsic* x) {

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1054,7 +1054,7 @@ void LIRGenerator::do_ArrayCopy(Intrinsic* x) {
 }
 
 void LIRGenerator::do_update_CRC32(Intrinsic* x) {
-  assert(UseCRC32Intrinsics, "need AVX and LCMUL instructions support");
+  assert(UseCRC32Intrinsics, "need AVX and CLMUL instructions support");
   // Make all state_for calls early since they can emit code
   LIR_Opr result = rlock_result(x);
   int flags = 0;
@@ -1131,7 +1131,7 @@ void LIRGenerator::do_update_CRC32(Intrinsic* x) {
 }
 
 void LIRGenerator::do_update_CRC32C(Intrinsic* x) {
-  assert(UseCRC32CIntrinsics, "need AVX and LCMUL instructions support");
+  assert(UseCRC32CIntrinsics, "need AVX and CLMUL instructions support");
   LIR_Opr result = rlock_result(x);
 
   switch (x->id()) {

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1166,11 +1166,7 @@ void LIRGenerator::do_update_CRC32C(Intrinsic* x) {
       LIR_Address* a = nullptr;
 
       if (index->is_valid()) {
-        LIR_Opr tmp = new_register(T_LONG);
-        __ convert(Bytecodes::_i2l, index, tmp);
-        index = tmp;
-        __ add(index, LIR_OprFact::intptrConst(offset), index);
-        a = new LIR_Address(base_op, index, T_BYTE);
+        a = new LIR_Address(base_op, index, offset, T_BYTE);
       } else {
         a = new LIR_Address(base_op, offset, T_BYTE);
       }
@@ -1190,7 +1186,7 @@ void LIRGenerator::do_update_CRC32C(Intrinsic* x) {
       __ leal(LIR_OprFact::address(a), arg2);
       __ move(len, arg3);
 
-      __ call_runtime_leaf(StubRoutines::updateBytesCRC32C(), LIR_OprFact::illegalOpr, result_reg, cc->args());
+      __ call_runtime_leaf(StubRoutines::updateBytesCRC32C(), getThreadTemp(), result_reg, cc->args());
       __ move(result_reg, result);
       break;
     }

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1166,6 +1166,9 @@ void LIRGenerator::do_update_CRC32C(Intrinsic* x) {
       LIR_Address* a = nullptr;
 
       if (index->is_valid()) {
+        LIR_Opr tmp = new_register(T_LONG);
+        __ convert(Bytecodes::_i2l, index, tmp);
+        index = tmp;
         a = new LIR_Address(base_op, index, offset, T_BYTE);
       } else {
         a = new LIR_Address(base_op, offset, T_BYTE);

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -222,7 +222,7 @@ bool Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
   case vmIntrinsics::_updateCRC32:
   case vmIntrinsics::_updateBytesCRC32:
   case vmIntrinsics::_updateByteBufferCRC32:
-#if defined(S390) || defined(PPC64) || defined(AARCH64)
+#if defined(S390) || defined(PPC64) || defined(AARCH64) || defined(AMD64)
   case vmIntrinsics::_updateBytesCRC32C:
   case vmIntrinsics::_updateDirectByteBufferCRC32C:
 #endif

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6552,7 +6552,7 @@ bool LibraryCallKit::inline_vectorizedHashCode() {
  * int java.util.zip.CRC32.update(int crc, int b)
  */
 bool LibraryCallKit::inline_updateCRC32() {
-  assert(UseCRC32Intrinsics, "need AVX and LCMUL instructions support");
+  assert(UseCRC32Intrinsics, "need AVX and CLMUL instructions support");
   assert(callee()->signature()->size() == 2, "update has 2 parameters");
   // no receiver since it is static method
   Node* crc  = argument(0); // type: int
@@ -6587,7 +6587,7 @@ bool LibraryCallKit::inline_updateCRC32() {
  * int java.util.zip.CRC32.updateBytes(int crc, byte[] buf, int off, int len)
  */
 bool LibraryCallKit::inline_updateBytesCRC32() {
-  assert(UseCRC32Intrinsics, "need AVX and LCMUL instructions support");
+  assert(UseCRC32Intrinsics, "need AVX and CLMUL instructions support");
   assert(callee()->signature()->size() == 4, "updateBytes has 4 parameters");
   // no receiver since it is static method
   Node* crc     = argument(0); // type: int
@@ -6631,7 +6631,7 @@ bool LibraryCallKit::inline_updateBytesCRC32() {
  * int java.util.zip.CRC32.updateByteBuffer(int crc, long buf, int off, int len)
  */
 bool LibraryCallKit::inline_updateByteBufferCRC32() {
-  assert(UseCRC32Intrinsics, "need AVX and LCMUL instructions support");
+  assert(UseCRC32Intrinsics, "need AVX and CLMUL instructions support");
   assert(callee()->signature()->size() == 5, "updateByteBuffer has 4 parameters and one is long");
   // no receiver since it is static method
   Node* crc     = argument(0); // type: int


### PR DESCRIPTION
Local benchmarks show good improvements for the crc32c intrinsification:


without intrinsic (master):

```
$JDK/java -DmsgSize=5120 -XX:TieredStopAtLevel=1 -Xcomp TestCRC32C 300000
 offset = 0
msgSize = 5120 bytes
  iters = 300000
-------------------------------------------------------
CRCs: crc = 0cbca9c8, crcReference = 0cbca9c8
CRC32C.update(byte[]) runtime = 1.186507782 seconds
CRC32C.update(byte[]) throughput = 1294.5553525244388 MB/s
CRCs: crc = 0cbca9c8, crcReference = 0cbca9c8
-------------------------------------------------------
CRCs: crc = 0cbca9c8, crcReference = 0cbca9c8
CRC32C.update(ByteBuffer) runtime = 1.355515648 seconds
CRC32C.update(ByteBuffer) throughput = 1133.1481139788364 MB/s
CRCs: crc = 0cbca9c8, crcReference = 0cbca9c8
-------------------------------------------------------
```

with intrinsic:

```
$JDK/java -DmsgSize=5120 -XX:TieredStopAtLevel=1 -Xcomp TestCRC32C 300000
 offset = 0
msgSize = 5120 bytes
  iters = 300000
-------------------------------------------------------
CRCs: crc = 0cbca9c8, crcReference = 0cbca9c8
CRC32C.update(byte[]) runtime = 0.065003188 seconds
CRC32C.update(byte[]) throughput = 23629.610289267657 MB/s
CRCs: crc = 0cbca9c8, crcReference = 0cbca9c8
-------------------------------------------------------
CRCs: crc = 0cbca9c8, crcReference = 0cbca9c8
CRC32C.update(ByteBuffer) runtime = 0.072310133 seconds
CRC32C.update(ByteBuffer) throughput = 21241.836189127185 MB/s
CRCs: crc = 0cbca9c8, crcReference = 0cbca9c8
-------------------------------------------------------
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350866](https://bugs.openjdk.org/browse/JDK-8350866): [x86] Add C1 intrinsics for CRC32-C (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23826/head:pull/23826` \
`$ git checkout pull/23826`

Update a local copy of the PR: \
`$ git checkout pull/23826` \
`$ git pull https://git.openjdk.org/jdk.git pull/23826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23826`

View PR using the GUI difftool: \
`$ git pr show -t 23826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23826.diff">https://git.openjdk.org/jdk/pull/23826.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23826#issuecomment-2702162313)
</details>
