### PR TITLE
8350818: Improve OperatingSystemMXBean cpu load tests to not accept -1.0 by default

### DIFF
--- a/test/jdk/com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad.java
+++ b/test/jdk/com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class GetProcessCpuLoad {
         double load;
         for(int i=0; i<10; i++) {
             load = mbean.getProcessCpuLoad();
-            if((load<0.0 || load>1.0) && load != -1.0) {
+            if(load<0.0 || load>1.0) {
                 throw new RuntimeException("getProcessCpuLoad() returns " + load
                        +   " which is not in the [0.0,1.0] interval");
             }

--- a/test/jdk/com/sun/management/OperatingSystemMXBean/GetSystemCpuLoad.java
+++ b/test/jdk/com/sun/management/OperatingSystemMXBean/GetSystemCpuLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug     7028071
- * @summary Basic unit test of OperatingSystemMXBean.getProcessCpuLoad()
+ * @summary Basic unit test of OperatingSystemMXBean.getSystemCpuLoad()
  *
  * @run main GetSystemCpuLoad
  */
@@ -39,7 +39,7 @@ public class GetSystemCpuLoad {
         double load;
         for(int i=0; i<10; i++) {
             load = mbean.getSystemCpuLoad();
-            if((load<0.0 || load>1.0) && load != -1.0) {
+            if(load<0.0 || load>1.0) {
                 throw new RuntimeException("getSystemCpuLoad() returns " + load
                        +  " which is not in the [0.0,1.0] interval");
             }


### PR DESCRIPTION
The cpuLoad tests were updated to fail if -1.0 returns to catch bugs like https://bugs.openjdk.org/browse/JDK-8350820

The -1.0 means that JDK can't obtain cpu load. It shouldn't be returned.
If this functionality doesn't work on certain configurations then they should be excluded.

The fix should be pushed after https://bugs.openjdk.org/browse/JDK-8350820
I filed separate PR to backport fix easier.
Also, I haven't changed indentation and didn't change getSystemCpuLoad to getCpuLoad. They return same. 
Might be it would be better. just to rename the whole test later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350818](https://bugs.openjdk.org/browse/JDK-8350818): Improve OperatingSystemMXBean cpu load tests to not accept -1.0 by default (**Enhancement** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23833/head:pull/23833` \
`$ git checkout pull/23833`

Update a local copy of the PR: \
`$ git checkout pull/23833` \
`$ git pull https://git.openjdk.org/jdk.git pull/23833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23833`

View PR using the GUI difftool: \
`$ git pr show -t 23833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23833.diff">https://git.openjdk.org/jdk/pull/23833.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23833#issuecomment-2689392927)
</details>
