### PR TITLE
8350909: [JMH] test ThreadOnSpinWaitShared failed for 2 threads config

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWaitSharedCounter.java
+++ b/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWaitSharedCounter.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 3)


### PR DESCRIPTION
The scope was updated to support multithread configuration (jmh option '-t 2') . No other changes needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350909](https://bugs.openjdk.org/browse/JDK-8350909): [JMH] test ThreadOnSpinWaitShared failed for 2 threads config (**Enhancement** - P4)


### Reviewers
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)
 * [Derek White](https://openjdk.org/census#drwhite) (@dwhite-intel - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23834/head:pull/23834` \
`$ git checkout pull/23834`

Update a local copy of the PR: \
`$ git checkout pull/23834` \
`$ git pull https://git.openjdk.org/jdk.git pull/23834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23834`

View PR using the GUI difftool: \
`$ git pr show -t 23834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23834.diff">https://git.openjdk.org/jdk/pull/23834.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23834#issuecomment-2689490637)
</details>
