### PR TITLE
8350916: Remove misleading warning "Cannot dump shared archive while using shared archive"

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -68,9 +68,16 @@ int CDSConfig::get_status() {
 
 void CDSConfig::initialize() {
   if (is_dumping_static_archive() && !is_dumping_final_static_archive()) {
-    if (RequireSharedSpaces) {
-      warning("Cannot dump shared archive while using shared archive");
-    }
+    // Note: -Xshare and -XX:AOTMode flags are mutually exclusive.
+    // - Class workflow: -Xshare:on and -Xshare:dump cannot take effect at the same time.
+    // - JEP 483 workflow: -XX:AOTMode:record and -XX:AOTMode=on cannot take effect at the same time.
+    // So we can never come to here with RequireSharedSpaces==true.
+    assert(!RequireSharedSpaces, "sanity");
+
+    // If dumping the classic archive, or making an AOT training run (dumping a preimage archive),
+    // for sanity, parse all classes from classfiles.
+    // TODO: in the future, if we want to support re-training on top of an existing AOT cache, this
+    // needs to be changed.
     UseSharedSpaces = false;
   }
 

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -69,7 +69,7 @@ int CDSConfig::get_status() {
 void CDSConfig::initialize() {
   if (is_dumping_static_archive() && !is_dumping_final_static_archive()) {
     // Note: -Xshare and -XX:AOTMode flags are mutually exclusive.
-    // - Class workflow: -Xshare:on and -Xshare:dump cannot take effect at the same time.
+    // - Classic workflow: -Xshare:on and -Xshare:dump cannot take effect at the same time.
     // - JEP 483 workflow: -XX:AOTMode:record and -XX:AOTMode=on cannot take effect at the same time.
     // So we can never come to here with RequireSharedSpaces==true.
     assert(!RequireSharedSpaces, "sanity");


### PR DESCRIPTION
Please review this trivial change. I replaced an unreachable `warning()` call with an assert and an explanation in comments.

I verified with running all CDS tests and the assert is never triggered.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350916](https://bugs.openjdk.org/browse/JDK-8350916): Remove misleading warning "Cannot dump shared archive while using shared archive" (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @mScott224 (no known openjdk.org user name / role) Review applies to [207efa30](https://git.openjdk.org/jdk/pull/23836/files/207efa304ffd6f2c581dbc115a6631902dba2187)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23836/head:pull/23836` \
`$ git checkout pull/23836`

Update a local copy of the PR: \
`$ git checkout pull/23836` \
`$ git pull https://git.openjdk.org/jdk.git pull/23836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23836`

View PR using the GUI difftool: \
`$ git pr show -t 23836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23836.diff">https://git.openjdk.org/jdk/pull/23836.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23836#issuecomment-2689748331)
</details>
