### PR TITLE
8350854: Include thread counts in safepoint logging

### DIFF
--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -989,13 +989,16 @@ void SafepointTracing::end() {
      "Reaching safepoint: " JLONG_FORMAT " ns, "
      "At safepoint: " JLONG_FORMAT " ns, "
      "Leaving safepoint: " JLONG_FORMAT " ns, "
-     "Total: " JLONG_FORMAT " ns",
+     "Total: " JLONG_FORMAT " ns, "
+     "Threads: " INT32_FORMAT " runnable, " INT32_FORMAT " total",
       VM_Operation::name(_current_type),
       _last_app_time_ns,
       _last_safepoint_sync_time_ns  - _last_safepoint_begin_time_ns,
       _last_safepoint_leave_time_ns - _last_safepoint_sync_time_ns,
       _last_safepoint_end_time_ns   - _last_safepoint_leave_time_ns,
-      _last_safepoint_end_time_ns   - _last_safepoint_begin_time_ns
+      _last_safepoint_end_time_ns   - _last_safepoint_begin_time_ns,
+      _nof_running,
+      _nof_threads
      );
 
   RuntimeService::record_safepoint_end(_last_safepoint_end_time_ns - _last_safepoint_sync_time_ns);

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -990,7 +990,7 @@ void SafepointTracing::end() {
      "At safepoint: " JLONG_FORMAT " ns, "
      "Leaving safepoint: " JLONG_FORMAT " ns, "
      "Total: " JLONG_FORMAT " ns, "
-     "Threads: " INT32_FORMAT " runnable, " INT32_FORMAT " total",
+     "Threads: %d runnable, %d total",
       VM_Operation::name(_current_type),
       _last_app_time_ns,
       _last_safepoint_sync_time_ns  - _last_safepoint_begin_time_ns,


### PR DESCRIPTION
The PR is to add thread counts in safepoint logging. In recent work, we notice the number of Java thread may affects time to reach/leave safepoint hardly in some cases, but safepoint logging doesn't have thread counts, thread counts are printed only with 'safepoint+stats' log. 

Given in many cases, we only have `safepoint` log enabled, not `safepoint+stats`, it make sense to add thread count to 'safepoint' logging. 

Here is example log output with the change:
```
[15.240s][info][safepoint      ] Safepoint "ShenandoahFinalMarkStartEvac", Time since last: 3527459 ns, Reaching safepoint: 78666 ns, At safepoint: 821625 ns, Leaving safepoint: 1472167 ns, Total: 2372458 ns, Threads: 3 runnable, 1038 total

```

### Test
- [x] Tire1
- [x] Tire2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8350854](https://bugs.openjdk.org/browse/JDK-8350854): Include thread counts in safepoint logging (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23838/head:pull/23838` \
`$ git checkout pull/23838`

Update a local copy of the PR: \
`$ git checkout pull/23838` \
`$ git pull https://git.openjdk.org/jdk.git pull/23838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23838`

View PR using the GUI difftool: \
`$ git pr show -t 23838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23838.diff">https://git.openjdk.org/jdk/pull/23838.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23838#issuecomment-2691012167)
</details>
