### PR TITLE
8350931: RISC-V: remove unnecessary src register for fp_sqrt_d/f

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -4097,21 +4097,19 @@ pipe_class fp_div_d(fRegD dst, fRegD src1, fRegD src2)
   FPU    : S5;
 %}
 
-pipe_class fp_sqrt_s(fRegF dst, fRegF src1, fRegF src2)
+pipe_class fp_sqrt_s(fRegF dst, fRegF src)
 %{
   single_instruction;
-  src1   : S1(read);
-  src2   : S2(read);
+  src    : S1(read);
   dst    : S5(write);
   DECODE : ID;
   FPU    : S5;
 %}
 
-pipe_class fp_sqrt_d(fRegD dst, fRegD src1, fRegD src2)
+pipe_class fp_sqrt_d(fRegD dst, fRegD src)
 %{
   single_instruction;
-  src1   : S1(read);
-  src2   : S2(read);
+  src    : S1(read);
   dst    : S5(write);
   DECODE : ID;
   FPU    : S5;


### PR DESCRIPTION
Hi,
Can you review this simple patch?
It remove the unnecessary src register for fp_sqrt_d/f pipe_class, as sqrt has only one src register.
Thanks