### PR TITLE
8286204: [Accessibility,macOS,VoiceOver] VoiceOver reads the spinner value 10 as 1 when user iterates to 10 for the first time on macOS

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
@@ -2632,7 +2632,9 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
         public void insertUpdate(DocumentEvent e) {
             final Integer pos = e.getOffset();
             if (SwingUtilities.isEventDispatchThread()) {
-                firePropertyChange(ACCESSIBLE_TEXT_PROPERTY, null, pos);
+                if (!(getAccessibleContext().getAccessibleParent() instanceof JSpinner.NumberEditor)) {
+                    firePropertyChange(ACCESSIBLE_TEXT_PROPERTY, null, pos);
+                }
             } else {
                 Runnable doFire = new Runnable() {
                     public void run() {
@@ -2654,7 +2656,9 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
         public void removeUpdate(DocumentEvent e) {
             final Integer pos = e.getOffset();
             if (SwingUtilities.isEventDispatchThread()) {
-                firePropertyChange(ACCESSIBLE_TEXT_PROPERTY, null, pos);
+                if (!(getAccessibleContext().getAccessibleParent() instanceof JSpinner.NumberEditor)) {
+                    firePropertyChange(ACCESSIBLE_TEXT_PROPERTY, null, pos);
+                }
             } else {
                 Runnable doFire = new Runnable() {
                     public void run() {


### PR DESCRIPTION
VoiceOver is unable to announce the correct value for spinner. For JSpinner with maximum value of more than 10, VO announce 10 as 1, 20 as 2 and so on. Probable reason is the "ACCESSIBLE_TEXT_PROPERTY" fired by accessible JTextComponent that leads to wrong range value invoked for accessibility API by VO.
Workaround fix is to ensure "ACCESSIBLE_TEXT_PROPOERTY" is not fired in case of JSpinner with numeric values.

Since the fix is in Java Component, verified fix with JAWS on windows. I don't see any side effects in announcement.

CI pipeline testing is ok for the proposed fix.