### PR TITLE
8350915: [JMH] test SocketChannelConnectionSetup failed for 2 threads config

### DIFF
--- a/test/micro/org/openjdk/bench/java/net/SocketChannelConnectionSetup.java
+++ b/test/micro/org/openjdk/bench/java/net/SocketChannelConnectionSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,8 @@
 package org.openjdk.bench.java.net;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
-import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.file.*;
@@ -80,7 +77,6 @@ public class SocketChannelConnectionSetup {
 
 
     private ServerSocketChannel getInetServerSocketChannel() throws IOException {
-        InetAddress iaddr = InetAddress.getLoopbackAddress();
         return ServerSocketChannel.open().bind(null);
     }
 
@@ -97,11 +93,11 @@ public class SocketChannelConnectionSetup {
     }
 
     @TearDown(Level.Trial)
-    public void afterRun() throws IOException, InterruptedException {
+    public void afterRun() throws IOException {
         ssc.close();
         if (family.equals("unix")) {
-            Files.delete(socket);
-            Files.delete(Path.of(tempDir));
+            Files.deleteIfExists(socket);
+            Files.deleteIfExists(Path.of(tempDir));
         }
     }
 


### PR DESCRIPTION
Fixes deletion of non-existent (i.e., already-deleted) files in `SocketChannelConnectionSetup`. Confirmed the fix using

```
make build-microbenchmark
build/linux-x64/jdk/bin/java \
  -jar build/linux-x64/images/test/micro/benchmarks.jar \
  -f 1 -wi 1 -i 1 -t 2 SocketChannelConnectionSetup
```

Note the `-t 2` in the JMH arguments – this was triggering the reported `NoSuchFileException`.

`make test TEST=micro:SocketChannelConnectionSetup` is passing as expected too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350915](https://bugs.openjdk.org/browse/JDK-8350915): [JMH] test SocketChannelConnectionSetup failed for 2 threads config (**Enhancement** - P4)


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23843/head:pull/23843` \
`$ git checkout pull/23843`

Update a local copy of the PR: \
`$ git checkout pull/23843` \
`$ git pull https://git.openjdk.org/jdk.git pull/23843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23843`

View PR using the GUI difftool: \
`$ git pr show -t 23843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23843.diff">https://git.openjdk.org/jdk/pull/23843.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23843#issuecomment-2690585390)
</details>
