### PR TITLE
8344892: beans/finder/MethodFinder.findMethod incorrectly returns null

### DIFF
--- a/src/java.desktop/share/classes/com/sun/beans/finder/MethodFinder.java
+++ b/src/java.desktop/share/classes/com/sun/beans/finder/MethodFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/com/sun/beans/finder/MethodFinder.java
+++ b/src/java.desktop/share/classes/com/sun/beans/finder/MethodFinder.java
@@ -77,8 +77,7 @@ public final class MethodFinder extends AbstractFinder<Method> {
         Signature signature = new Signature(type, name, args);
 
         try {
-            Method method = CACHE.get(signature);
-            return (method != null) ? method : CACHE.create(signature);
+            return CACHE.get(signature);
         }
         catch (SignatureException exception) {
             throw exception.toNoSuchMethodException("Method '" + name + "' is not found");

--- a/src/java.desktop/share/classes/com/sun/beans/finder/MethodFinder.java
+++ b/src/java.desktop/share/classes/com/sun/beans/finder/MethodFinder.java
@@ -78,7 +78,7 @@ public final class MethodFinder extends AbstractFinder<Method> {
 
         try {
             Method method = CACHE.get(signature);
-            return (method == null) ? method : CACHE.create(signature);
+            return (method != null) ? method : CACHE.create(signature);
         }
         catch (SignatureException exception) {
             throw exception.toNoSuchMethodException("Method '" + name + "' is not found");


### PR DESCRIPTION
During the [JDK-8344891 Remove uses of sun.misc.ReflectUtil in java.desktop](https://bugs.openjdk.org/browse/JDK-8344891) it was discovered that `beans/finder/MethodFinder.findMethod' incorrectly returned null if a signature was not in the cache and added it to the cache if it was already there:

```java
Method method = CACHE.get(signature);
return (method == null) ? method : CACHE.create(signature);
```
This resulted in a [significant drop in performance](https://bugs.openjdk.org/browse/JDK-8350573).

----

Before ReflectUtil was removed, it worked by coincidence:

```java
Method method = CACHE.get(signature);
return (method == null) || isPackageAccessible(method.getDeclaringClass()) ? method : CACHE.create(signature);
```



1. `Cache#get` non-obviously creates a value in Cache, this in turn allowed us to avoid the NPE in the `(method == null) || isPackageAccessible(method.getDeclaringClass())` condition


https://github.com/openjdk/jdk/blob/d6c4be672f6348f8ed985416ed90d0447f5d5bb3/src/java.desktop/share/classes/com/sun/beans/util/Cache.java#L120-L126

2. `isPackageAccessible(method.getDeclaringClass())` was evaluated as true

This is how we previously returned the cached value.

---

So the solution is obvious:

```java
Method method = CACHE.get(signature);
return (method != null) ? method : CACHE.create(signature);
```

Testing is green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344892](https://bugs.openjdk.org/browse/JDK-8344892): beans/finder/MethodFinder.findMethod incorrectly returns null (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23845/head:pull/23845` \
`$ git checkout pull/23845`

Update a local copy of the PR: \
`$ git checkout pull/23845` \
`$ git pull https://git.openjdk.org/jdk.git pull/23845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23845`

View PR using the GUI difftool: \
`$ git pr show -t 23845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23845.diff">https://git.openjdk.org/jdk/pull/23845.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23845#issuecomment-2690822948)
</details>
