### PR TITLE
8224968: javax/swing/JColorChooser/Test6827032.java times out in Windows 10

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -686,8 +686,6 @@ javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
-javax/swing/JColorChooser/Test6827032.java 8224968 windows-x64
-
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8293001 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
 sanity/client/SwingSet/src/EditorPaneDemoTest.java 8212240 linux-x64


### PR DESCRIPTION
**Problem:**

The test hangs intermittently when run on Windows. (In some cases, handling the timeout takes 2 hours.)

Thread dump shows no AWT threads, yet jtreg harness still waits for the test thread to finish, in particular it waits for [`StreamCopier`](https://github.com/openjdk/jtreg/blob/759946dedbafa423552851ecb98bc3bb8dcf30ec/src/share/classes/com/sun/javatest/regtest/exec/ProcessCommand.java#L279-L281). See `threaddump.log` attached to the bug and [my comment](https://bugs.openjdk.org/browse/JDK-8224968?focusedId=14757188&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14757188) for more details.

**Fix, or Workaround:**

Drag mouse for a short while.

In my testing on CI, the `javax/swing/JColorChooser/Test6827032.java` failed on Windows *3 times* out of 6 runs with 20 repeats (`JTREG=REPEAT_COUNT=20`) without the fix.

There have been no failures after the fix in 10 runs with 20 repeats.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8224968](https://bugs.openjdk.org/browse/JDK-8224968): javax/swing/JColorChooser/Test6827032.java times out in Windows 10 (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23846/head:pull/23846` \
`$ git checkout pull/23846`

Update a local copy of the PR: \
`$ git checkout pull/23846` \
`$ git pull https://git.openjdk.org/jdk.git pull/23846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23846`

View PR using the GUI difftool: \
`$ git pr show -t 23846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23846.diff">https://git.openjdk.org/jdk/pull/23846.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23846#issuecomment-2690990878)
</details>
