### PR TITLE
8349516: StAXStream2SAX.handleCharacters() fails on empty CDATA

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/StAXStream2SAX.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/StAXStream2SAX.java
@@ -275,9 +275,6 @@ public class StAXStream2SAX implements XMLReader, Locator {
     }
 
     private void handleCharacters() throws XMLStreamException {
-
-        // workaround for bugid 5046319 - switch over to commented section
-        // below when it is fixed.
         int textLength = staxStreamReader.getTextLength();
         char[] chars = new char[textLength];
 
@@ -290,19 +287,6 @@ public class StAXStream2SAX implements XMLReader, Locator {
         } catch (SAXException e) {
             throw new XMLStreamException(e);
         }
-
-
-//        int start = 0;
-//        int len;
-//        do {
-//            len = staxStreamReader.getTextCharacters(start, buf, 0, buf.length);
-//            start += len;
-//            try {
-//                _sax.characters(buf, 0, len);
-//            } catch (SAXException e) {
-//                throw new XMLStreamException(e);
-//            }
-//        } while (len == buf.length);
     }
 
     private void handleEndElement() throws XMLStreamException {

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/StAXStream2SAX.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/StAXStream2SAX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -281,7 +281,9 @@ public class StAXStream2SAX implements XMLReader, Locator {
         int textLength = staxStreamReader.getTextLength();
         char[] chars = new char[textLength];
 
-        staxStreamReader.getTextCharacters(0, chars, 0, textLength);
+        if (textLength > 0) {
+            staxStreamReader.getTextCharacters(0, chars, 0, textLength);
+        }
 
         try {
             _sax.characters(chars, 0, chars.length);

--- a/test/jaxp/javax/xml/jaxp/unittest/validation/ValidationTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/validation/ValidationTest.java
@@ -143,12 +143,15 @@ public class ValidationTest {
     }
 
     /**
-     * Verifies the bug fix for 8349516. The fix adds a guard against empty text
-     * since calling StreamReader.getTextCharacters with textLength=0 will result
-     * in IndexOutOfBoundsException.
+     * Verifies the bug fix for 8349516, which adds a guard against empty text.
+     * Prior to the fix, calling {@link XMLStreamReader#getTextCharacters() XMLStreamReader#getTextCharacters()}
+     * with {@code length = 0} resulted in an {@code IndexOutOfBoundsException}.
      *
-     * @throws Exception if the test fails, in which case the parser throws
-     * IndexOutOfBoundsException.
+     * This test ensures that the fix prevents such an exception.
+     *
+     * @throws Exception if the test fails due to unexpected issues, such as errors
+     * in creating the schema or reader, or validation errors other than the
+     * {@code IndexOutOfBoundsException}.
      */
     @Test
     public void testValidationWithStAX() throws Exception {


### PR DESCRIPTION
Fix handleCharacters by adding a guard to zero length and letting the rest of the process continue (e.g. closing tags and etc).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349516](https://bugs.openjdk.org/browse/JDK-8349516): StAXStream2SAX.handleCharacters() fails on empty CDATA (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23847/head:pull/23847` \
`$ git checkout pull/23847`

Update a local copy of the PR: \
`$ git checkout pull/23847` \
`$ git pull https://git.openjdk.org/jdk.git pull/23847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23847`

View PR using the GUI difftool: \
`$ git pr show -t 23847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23847.diff">https://git.openjdk.org/jdk/pull/23847.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23847#issuecomment-2691223558)
</details>
