### PR TITLE
Update ThreadLocal.java

### DIFF
--- a/src/java.base/share/classes/java/lang/ThreadLocal.java
+++ b/src/java.base/share/classes/java/lang/ThreadLocal.java
@@ -68,8 +68,8 @@ import jdk.internal.misc.TerminatingThreadLocal;
  * }
  * </pre>
  * <p>Each thread holds an implicit reference to its copy of a thread-local
- * variable as long as the thread is alive and the {@code ThreadLocal}
- * instance is accessible; after a thread goes away, all of its copies of
+ * variable as long as the thread is alive and the thread-local variable is
+ * accessible (referenced); after a thread goes away, all of its copies of
  * thread-local instances are subject to garbage collection (unless other
  * references to these copies exist).
  * @param <T> the type of the thread local's value


### PR DESCRIPTION
`ThreadLocal` instance is just a getter and setter and itself does not refer to the thread local variable or the thread local map.

So it does not matter whether the `ThreadLocal` instance is accessible or not for the thread-local variable accessibility.


Also make clear that accessible means referenced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23848/head:pull/23848` \
`$ git checkout pull/23848`

Update a local copy of the PR: \
`$ git checkout pull/23848` \
`$ git pull https://git.openjdk.org/jdk.git pull/23848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23848`

View PR using the GUI difftool: \
`$ git pr show -t 23848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23848.diff">https://git.openjdk.org/jdk/pull/23848.diff</a>

</details>
