### PR TITLE
8350983: JShell LocalExecutionControl only needs stopCheck() on backward branches

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import java.lang.classfile.ClassFile;
@@ -96,13 +97,13 @@ public class LocalExecutionControl extends DirectExecutionControl {
         return cc.transformClass(cc.parse(classFile),
                         ClassTransform.transformingMethodBodies(
                             CodeTransform.ofStateful(() -> {
-                                HashSet<Label> priorLabels = new HashSet<>();
+                                Set<Label> priorLabels = new HashSet<>();
                                 return (builder, element) -> {
                                     switch (element) {
-                                    case LabelTarget target -> priorLabels.add(target.label());
-                                    case BranchInstruction branch when priorLabels.contains(branch.target())
-                                        -> builder.invokestatic(CD_Cancel, "stopCheck", ConstantDescs.MTD_void);
-                                    default -> { }
+                                        case LabelTarget target -> priorLabels.add(target.label());
+                                        case BranchInstruction branch when priorLabels.contains(branch.target())
+                                            -> builder.invokestatic(CD_Cancel, "stopCheck", ConstantDescs.MTD_void);
+                                        default -> { }
                                     }
                                     builder.with(element);
                                 };


### PR DESCRIPTION
JShell's `LocalExecutionControl` ensures a running eval thread can be stopped by `JShell.stop()` by inserting an invocation of `stopCheck()` at every branch point in the bytecode of loaded classfiles.

However, this same guarantee can be provided by invoking `stopCheck()` only at backward branches and not at forward branches. By doing this, the performance and size impact on the executing code can be reduced.

Fortunately the new ClassFile API makes this kind of modification easy 👍

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8350983](https://bugs.openjdk.org/browse/JDK-8350983): JShell LocalExecutionControl only needs stopCheck() on backward branches (**Enhancement** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23850/head:pull/23850` \
`$ git checkout pull/23850`

Update a local copy of the PR: \
`$ git checkout pull/23850` \
`$ git pull https://git.openjdk.org/jdk.git pull/23850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23850`

View PR using the GUI difftool: \
`$ git pr show -t 23850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23850.diff">https://git.openjdk.org/jdk/pull/23850.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23850#issuecomment-2691892532)
</details>
