### PR TITLE
8349099: java/awt/Headless/HeadlessMalfunctionTest.java fails on CI with Compilation error

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -462,7 +462,6 @@ java/awt/PopupMenu/PopupMenuLocation.java 8259913,8315878 windows-all,macosx-aar
 java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java 8238720,8324782 windows-all,macosx-all
 java/awt/GridLayout/ChangeGridSize/ChangeGridSize.java   8238720,8324782 windows-all,macosx-all
 java/awt/event/MouseEvent/FrameMouseEventAbsoluteCoordsTest/FrameMouseEventAbsoluteCoordsTest.java 8238720 windows-all
-java/awt/Headless/HeadlessMalfunctionTest.java 8349099 generic-all
 
 # Several tests which fail sometimes on macos11
 java/awt/Window/MainKeyWindowTest/TestMainKeyWindow.java 8265985 macosx-all

--- a/test/jdk/java/awt/Headless/HeadlessMalfunctionAgent.java
+++ b/test/jdk/java/awt/Headless/HeadlessMalfunctionAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Headless/HeadlessMalfunctionAgent.java
+++ b/test/jdk/java/awt/Headless/HeadlessMalfunctionAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,12 +20,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import jdk.internal.org.objectweb.asm.ClassReader;
-import jdk.internal.org.objectweb.asm.ClassVisitor;
-import jdk.internal.org.objectweb.asm.ClassWriter;
-import jdk.internal.org.objectweb.asm.MethodVisitor;
-import jdk.internal.org.objectweb.asm.Opcodes;
 
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.MethodModel;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.security.ProtectionDomain;
@@ -37,34 +34,31 @@ public class HeadlessMalfunctionAgent {
 
     public static void premain(String agentArgs, Instrumentation inst) {
         inst.addTransformer(new ClassFileTransformer() {
-
             @Override
-            public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
-                                    ProtectionDomain pd, byte[] cb) {
-                if ("java/awt/GraphicsEnvironment".equals(className)) {
-                    System.out.println("Transforming java.awt.GraphicsEnvironment.");
-                    try {
-                        final ClassReader cr = new ClassReader(cb);
-                        final ClassWriter cw = new ClassWriter(cr, 0);
-                        cr.accept(new ClassVisitor(Opcodes.ASM9, cw) {
-
-                            @Override
-                            public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
-                                                             String[] exceptions) {
-                                if ("isHeadless".equals(name) && "()Z".equals(descriptor)) {
-                                    System.out.println("isHeadless removed from java.awt.GraphicsEnvironment.");
-                                    // WHACK! Remove the isHeadless method.
-                                    return null;
-                                }
-                                return super.visitMethod(access, name, descriptor, signature, exceptions);
-                            }
-                        }, 0);
-                        return cw.toByteArray();
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
+            public byte[] transform(ClassLoader loader,
+                                    String className,
+                                    Class<?> classBeingRedefined,
+                                    ProtectionDomain pd,
+                                    byte[] cb) {
+                if (!"java/awt/GraphicsEnvironment".equals(className)) {
+                    return null;
                 }
-                return null;
+                System.out.println("Transforming java.awt.GraphicsEnvironment.");
+                try {
+                    return ClassFile.of().transformClass(ClassFile.of().parse(cb), (classBuilder, element) -> {
+                        if (element instanceof MethodModel method) {
+                            if ("isHeadless".equals(method.methodName().stringValue()) &&
+                                    "()Z".equals(method.methodType().stringValue())) {
+                                System.out.println("isHeadless removed from java.awt.GraphicsEnvironment.");
+                                return;
+                            }
+                        }
+                        classBuilder.with(element);
+                    });
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return null;
+                }
             }
         });
     }

--- a/test/jdk/java/awt/Headless/HeadlessMalfunctionTest.java
+++ b/test/jdk/java/awt/Headless/HeadlessMalfunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Headless/HeadlessMalfunctionTest.java
+++ b/test/jdk/java/awt/Headless/HeadlessMalfunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,12 +33,10 @@ import java.nio.file.Path;
  * @bug 8336382
  * @summary Test that in absence of isHeadless method, the JDK throws a meaningful error message.
  * @library /test/lib
- * @modules java.base/jdk.internal.org.objectweb.asm
  * @build HeadlessMalfunctionAgent
  * @run driver  jdk.test.lib.helpers.ClassFileInstaller
  *              HeadlessMalfunctionAgent
  *              HeadlessMalfunctionAgent$1
- *              HeadlessMalfunctionAgent$1$1
  * @run driver HeadlessMalfunctionTest
  */
 public class HeadlessMalfunctionTest {
@@ -49,8 +47,7 @@ public class HeadlessMalfunctionTest {
         final ProcessBuilder pbJar = new ProcessBuilder()
                 .command(JDKToolFinder.getJDKTool("jar"), "cmf", "MANIFEST.MF", "agent.jar",
                         "HeadlessMalfunctionAgent.class",
-                        "HeadlessMalfunctionAgent$1.class",
-                        "HeadlessMalfunctionAgent$1$1.class");
+                        "HeadlessMalfunctionAgent$1.class");
         ProcessTools.executeProcess(pbJar).shouldHaveExitValue(0);
 
         // Run test

--- a/test/jdk/java/awt/Headless/HeadlessMalfunctionTest.java
+++ b/test/jdk/java/awt/Headless/HeadlessMalfunctionTest.java
@@ -32,7 +32,7 @@ import java.nio.file.Path;
  * @test
  * @bug 8336382
  * @summary Test that in absence of isHeadless method, the JDK throws a meaningful error message.
- * @library /test/
+ * @library /test/lib
  * @requires os.family == "linux"
  * @build HeadlessMalfunctionAgent
  * @run driver  jdk.test.lib.helpers.ClassFileInstaller

--- a/test/jdk/java/awt/Headless/HeadlessMalfunctionTest.java
+++ b/test/jdk/java/awt/Headless/HeadlessMalfunctionTest.java
@@ -32,7 +32,8 @@ import java.nio.file.Path;
  * @test
  * @bug 8336382
  * @summary Test that in absence of isHeadless method, the JDK throws a meaningful error message.
- * @library /test/lib
+ * @library /test/
+ * @requires os.family == "linux"
  * @build HeadlessMalfunctionAgent
  * @run driver  jdk.test.lib.helpers.ClassFileInstaller
  *              HeadlessMalfunctionAgent
@@ -58,9 +59,10 @@ public class HeadlessMalfunctionTest {
         final OutputAnalyzer output = ProcessTools.executeProcess(pbJava);
         // Unpatched JDK logs: "FATAL ERROR in native method: Could not allocate library name"
         // Patched should mention that isHeadless is missing, log message differs between OSes;
-        // e.g. LWCToolkit toolkit path on MacOS logs "java.lang.NoSuchMethodError: 'boolean java.awt.GraphicsEnvironment.isHeadless()'"
-        // Linux logs "FATAL ERROR in native method: GetStaticMethodID isHeadless failed"
-        output.shouldContain("isHeadless");
+        // e.g. LWCToolkit toolkit path on MacOS and Win32GraphicsEnvironment code path on Windows
+        // logs "java.lang.NoSuchMethodError: 'boolean java.awt.GraphicsEnvironment.isHeadless()'",
+        // whereas Linux logs "FATAL ERROR in native method: GetStaticMethodID isHeadless failed"
+        output.shouldContain("FATAL ERROR in native method: GetStaticMethodID isHeadless failed");
         output.shouldNotHaveExitValue(0);
     }
 

--- a/test/jdk/java/awt/Headless/HeadlessMalfunctionTest.java
+++ b/test/jdk/java/awt/Headless/HeadlessMalfunctionTest.java
@@ -52,14 +52,15 @@ public class HeadlessMalfunctionTest {
 
         // Run test
         final ProcessBuilder pbJava = ProcessTools.createTestJavaProcessBuilder(
-                "--add-opens",
-                "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
                 "-javaagent:agent.jar",
                 "HeadlessMalfunctionTest$Runner"
         );
         final OutputAnalyzer output = ProcessTools.executeProcess(pbJava);
         // Unpatched JDK logs: "FATAL ERROR in native method: Could not allocate library name"
-        output.shouldContain("FATAL ERROR in native method: GetStaticMethodID isHeadless failed");
+        // Patched should mention that isHeadless is missing, log message differs between OSes;
+        // e.g. LWCToolkit toolkit path on MacOS logs "java.lang.NoSuchMethodError: 'boolean java.awt.GraphicsEnvironment.isHeadless()'"
+        // Linux logs "FATAL ERROR in native method: GetStaticMethodID isHeadless failed"
+        output.shouldContain("isHeadless");
         output.shouldNotHaveExitValue(0);
     }
 


### PR DESCRIPTION
Removed objectweb.asm for bytecode manipulation and uses JEP 484 classfile API.

Test passes on Linux amd64 so far:
```
TIME=`date +%s`;
mkdir -p test.${TIME}/jdk/JTwork test.${TIME}/jdk/JTreport; 
jtreg -a -ignore:quiet -w:test.${TIME}/jdk/JTwork -r:test.${TIME}/jdk/JTreport -jdk:/home/karm/workspaceRH/jdk/build/linux-x86_64-server-release/images/graal-builder-jdk/ /home/karm/workspaceRH/jdk/test/jdk/java/awt/Headless/

Test results: passed: 15
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349099](https://bugs.openjdk.org/browse/JDK-8349099): java/awt/Headless/HeadlessMalfunctionTest.java fails on CI with Compilation error (**Bug** - P3)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**) Review applies to [f3294bd5](https://git.openjdk.org/jdk/pull/23852/files/f3294bd509d5f0a4c2c0c38bb645b2cd42868938)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [f3294bd5](https://git.openjdk.org/jdk/pull/23852/files/f3294bd509d5f0a4c2c0c38bb645b2cd42868938)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23852/head:pull/23852` \
`$ git checkout pull/23852`

Update a local copy of the PR: \
`$ git checkout pull/23852` \
`$ git pull https://git.openjdk.org/jdk.git pull/23852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23852`

View PR using the GUI difftool: \
`$ git pr show -t 23852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23852.diff">https://git.openjdk.org/jdk/pull/23852.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23852#issuecomment-2692495389)
</details>
