### PR TITLE
8351012: Serial GC: Reverse location of young and tenured generations

### DIFF
--- a/src/hotspot/share/gc/serial/serial_globals.hpp
+++ b/src/hotspot/share/gc/serial/serial_globals.hpp
@@ -35,6 +35,10 @@
           "When disabled, informs the GC to shrink the java heap directly"  \
           " to the target size at the next full GC rather than requiring"   \
           " smaller steps during multiple full GCs.")                       \
+                                                                            \
+  product(bool, SwapSerialGCGenerations, false, EXPERIMENTAL,               \
+          "When enabled, informs the GC to place the tenured region before" \
+          " the young region in memory.")                                   \
 
 // end of GC_SERIAL_FLAGS
 


### PR DESCRIPTION
[JDK-8351011](https://bugs.openjdk.org/browse/JDK-8351011) proposes using a single VirtualSpace for the young and tenured generations to simplify sizing the heap when using automatic heap sizing. The typical case is that after a full collection, the young generation is empty. With a single VirtualSpace serving both young and tenured generations, it is easier to resize the heap regions without needing to move data around when the young generation is placed after the tenured generation. Expansion and contraction of the committed heap memory is straightforward in this case, e.g. reducing the size of the young generation can be done by uncommitting from the end of the single VirtualSpace holding the entire heap. This PR adds an experimental product flag for swapping the order of the young and tenured generations in memory.