### PR TITLE
8347321: [ubsan] CGGlyphImages.m:553:30: runtime error: nan is outside the range of representable values of type 'unsigned long'

### DIFF
--- a/src/java.desktop/macosx/classes/sun/font/CStrike.java
+++ b/src/java.desktop/macosx/classes/sun/font/CStrike.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,6 +101,17 @@ public final class CStrike extends PhysicalStrike {
 
         final double[] glyphTx = new double[6];
         desc.glyphTx.getMatrix(glyphTx);
+
+        for (int i = 0; i < 6; i++) {
+            if (Double.isFinite(glyphTx[i])) {
+                continue;
+            }
+            for (int j = 0; j < 6; j++) {
+                glyphTx[j] = 0;
+            }
+            invDevTx = null;
+            break;
+        }
 
         final double[] invDevTxMatrix = new double[6];
         if (invDevTx == null) {


### PR DESCRIPTION
The font tests that fail use non-finite or NaN float values.
In such cases, no visible rendering is expected and the NaNTransform test does pass with empty shapes, but we can filter out these invalid floats before they get to native.
The macOS class that handles the font strike can check for these and replace them.
Since you can't observe a difference unless you can get ubsan to work (not easy) and that is a build option, so not something we can use in testing, there' s no regression test update here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347321](https://bugs.openjdk.org/browse/JDK-8347321): [ubsan] CGGlyphImages.m:553:30: runtime error: nan is outside the range of representable values of type 'unsigned long' (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23855/head:pull/23855` \
`$ git checkout pull/23855`

Update a local copy of the PR: \
`$ git checkout pull/23855` \
`$ git pull https://git.openjdk.org/jdk.git pull/23855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23855`

View PR using the GUI difftool: \
`$ git pr show -t 23855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23855.diff">https://git.openjdk.org/jdk/pull/23855.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23855#issuecomment-2693360001)
</details>
