### PR TITLE
8350956: Fix repetitions of the word "the" in compiler component comments

### DIFF
--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -62,7 +62,7 @@ inline void frame::init(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, add
   if (original_pc != nullptr) {
     _pc = original_pc;
     assert(_cb->as_nmethod()->insts_contains_inclusive(_pc),
-           "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
+           "original PC must be in the main code section of the compiled method (or must be immediately following it)");
     _deopt_state = is_deoptimized;
   } else {
     _deopt_state = not_deoptimized;

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4472,7 +4472,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
       }
     } else if (n->is_AddP()) {
       if (has_reducible_merge_base(n->as_AddP(), reducible_merges)) {
-        // This AddP will go away when we reduce the the Phi
+        // This AddP will go away when we reduce the Phi
         continue;
       }
       Node* addp_base = get_addp_base(n);

--- a/src/hotspot/share/opto/vectorization.hpp
+++ b/src/hotspot/share/opto/vectorization.hpp
@@ -445,7 +445,7 @@ private:
 // types (byte, char, short). In the C2 IR, their operations are
 // done with full int type with 4 byte precision (e.g. AddI, MulI).
 // Example:  char a,b,c;  a = (char)(b + c);
-// However, if we can prove the the upper bits are only truncated,
+// However, if we can prove the upper bits are only truncated,
 // and the lower bits for the narrower type computed correctly, we
 // can compute the operations in the narrower type directly (e.g we
 // perform the AddI or MulI with 1 or 2 bytes). This allows us to


### PR DESCRIPTION
Hi all,

  please review this trivial change that fixes "the the" repetitions in the
compiler related sources.

If you think it's not worth fixing, I am okay with that and just retract the change.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350956](https://bugs.openjdk.org/browse/JDK-8350956): Fix repetitions of the word "the" in compiler component comments (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23858/head:pull/23858` \
`$ git checkout pull/23858`

Update a local copy of the PR: \
`$ git checkout pull/23858` \
`$ git pull https://git.openjdk.org/jdk.git pull/23858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23858`

View PR using the GUI difftool: \
`$ git pr show -t 23858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23858.diff">https://git.openjdk.org/jdk/pull/23858.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23858#issuecomment-2694166990)
</details>
