### PR TITLE
8350954: Fix repetitions of the word "the" in gc component comments

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentRefine.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentRefine.cpp
@@ -268,7 +268,7 @@ public:
   size_t sampled_code_root_rs_length() const { return _sampled_code_root_rs_length; }
 };
 
-// Adjust the target length (in regions) of the young gen, based on the the
+// Adjust the target length (in regions) of the young gen, based on the
 // current length of the remembered sets.
 //
 // At the end of the GC G1 determines the length of the young gen based on

--- a/src/hotspot/share/gc/z/zLiveMap.inline.hpp
+++ b/src/hotspot/share/gc/z/zLiveMap.inline.hpp
@@ -222,7 +222,7 @@ inline BitMap::idx_t ZLiveMap::find_base_bit_in_segment(BitMap::idx_t start, Bit
   }
 
   // The bitmaps contain pairs of bits to deal with strongly marked vs only
-  // finalizable marked. Align down to get the the first bit position.
+  // finalizable marked. Align down to get the first bit position.
   return bit & ~BitMap::idx_t(1);
 }
 

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -669,9 +669,9 @@ private:
     // moved them over to the current bitmap.
     //
     // If the young generation runs multiple cycles while the old generation is
-    // relocating, then the first cycle will have consume the the old remset,
+    // relocating, then the first cycle will have consumed the old remset,
     // bits and moved associated objects to a new old page. The old relocation
-    // could find either the the two bitmaps. So, either it will find the original
+    // could find either of the two bitmaps. So, either it will find the original
     // remset bits for the page, or it will find an empty bitmap for the page. It
     // doesn't matter for correctness, because the young generation marking has
     // already taken care of the bits.
@@ -865,7 +865,7 @@ private:
     start_in_place_relocation_prepare_remset(from_page);
 
     if (promotion) {
-      // Register the the promotion
+      // Register the promotion
       ZGeneration::young()->in_place_relocate_promote(from_page, to_page);
       ZGeneration::young()->register_in_place_relocate_promoted(from_page);
     }

--- a/src/hotspot/share/gc/z/zUncoloredRoot.hpp
+++ b/src/hotspot/share/gc/z/zUncoloredRoot.hpp
@@ -51,7 +51,7 @@
 // The zaddress_unsafe type is used to hold uncolored oops that the GC needs
 // to process before it is safe to use. E.g. the original object might have
 // been relocated and the address needs to be updated. The zaddress type
-// denotes that this pointer refers the the correct address of the object.
+// denotes that this pointer refers to the correct address of the object.
 
 class ZUncoloredRoot : public AllStatic {
 private:


### PR DESCRIPTION
Hi all,

  please review this trivial change that fixes "the the" repetitions (and in this case grammar/wording) in the gc related sources.

If you think it's not worth fixing, I am okay with that and just retract the change.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350954](https://bugs.openjdk.org/browse/JDK-8350954): Fix repetitions of the word "the" in gc component comments (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23859/head:pull/23859` \
`$ git checkout pull/23859`

Update a local copy of the PR: \
`$ git checkout pull/23859` \
`$ git pull https://git.openjdk.org/jdk.git pull/23859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23859`

View PR using the GUI difftool: \
`$ git pr show -t 23859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23859.diff">https://git.openjdk.org/jdk/pull/23859.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23859#issuecomment-2694167598)
</details>
