### PR TITLE
8350939: Revisit Windows PDH buffer size calculation for OperatingSystemMXBean

### DIFF
--- a/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
@@ -291,7 +291,7 @@ static const DWORD PDH_PROCESSOR_TIME_IDX = 6;
 static const DWORD PDH_PROCESS_IDX = 230;
 static const DWORD PDH_ID_PROCESS_IDX = 784;
 
-/* useful pdh fmt's */
+/* PDH format patterns, and lengths of their constant component. */
 static const char* const OBJECT_COUNTER_FMT = "\\%s\\%s";
 static const size_t OBJECT_COUNTER_FMT_LEN = 2;
 static const char* const OBJECT_WITH_INSTANCES_COUNTER_FMT = "\\%s(%s)\\%s";
@@ -405,8 +405,8 @@ makeFullCounterPath(const char* const objectName,
     assert(objectName);
     assert(counterName);
 
-    fullCounterPathLen = strlen(objectName);
-    fullCounterPathLen += strlen(counterName);
+    // Always include space for null terminator:
+    fullCounterPathLen = strlen(objectName) + strlen(counterName) + 1;
 
     if (imageName) {
         /*
@@ -429,20 +429,19 @@ makeFullCounterPath(const char* const objectName,
         assert(instance);
 
         fullCounterPathLen += strlen(instance);
-
-        fullCounterPath = malloc(fullCounterPathLen + 1);
+        fullCounterPath = malloc(fullCounterPathLen);
 
         if (!fullCounterPath) {
             return NULL;
         }
 
-        _snprintf(fullCounterPath,
-                  fullCounterPathLen,
-                  PROCESS_OBJECT_INSTANCE_COUNTER_FMT,
-                  objectName,
-                  imageName,
-                  instance,
-                  counterName);
+        snprintf(fullCounterPath,
+                 fullCounterPathLen,
+                 PROCESS_OBJECT_INSTANCE_COUNTER_FMT,
+                 objectName,
+                 imageName,
+                 instance,
+                 counterName);
     } else {
         if (instance) {
             /*
@@ -465,29 +464,27 @@ makeFullCounterPath(const char* const objectName,
             fullCounterPathLen += OBJECT_COUNTER_FMT_LEN;
         }
 
-        fullCounterPath = malloc(fullCounterPathLen + 1);
+        fullCounterPath = malloc(fullCounterPathLen);
 
         if (!fullCounterPath) {
             return NULL;
         }
 
         if (instance) {
-            _snprintf(fullCounterPath,
-                      fullCounterPathLen,
-                      OBJECT_WITH_INSTANCES_COUNTER_FMT,
-                      objectName,
-                      instance,
-                      counterName);
+            snprintf(fullCounterPath,
+                     fullCounterPathLen,
+                     OBJECT_WITH_INSTANCES_COUNTER_FMT,
+                     objectName,
+                     instance,
+                     counterName);
         } else {
-            _snprintf(fullCounterPath,
-                      fullCounterPathLen,
-                      OBJECT_COUNTER_FMT,
-                      objectName,
-                      counterName);
+            snprintf(fullCounterPath,
+                     fullCounterPathLen,
+                     OBJECT_COUNTER_FMT,
+                     objectName,
+                     counterName);
         }
     }
-
-    fullCounterPath[fullCounterPathLen] = '\0';
 
     return fullCounterPath;
 }
@@ -719,10 +716,10 @@ currentQueryIndexForProcess(void) {
             PDH_FMT_COUNTERVALUE counterValue;
             PDH_STATUS res;
 
-            _snprintf(fullIDProcessCounterPath,
-                      MAX_PATH,
-                      pdhIDProcessCounterFmt,
-                      index);
+            snprintf(fullIDProcessCounterPath,
+                     MAX_PATH,
+                     pdhIDProcessCounterFmt,
+                     index);
 
             if (addCounter(tmpQuery, fullIDProcessCounterPath, &handleCounter) != 0) {
                 break;
@@ -1050,24 +1047,22 @@ allocateAndInitializePdhConstants() {
     pdhIDProcessCounterFmtLen += strlen(pdhLocalizedProcessObject);
     pdhIDProcessCounterFmtLen += strlen(pdhLocalizedIDProcessCounter);
     pdhIDProcessCounterFmtLen += PROCESS_OBJECT_INSTANCE_COUNTER_FMT_LEN;
-    pdhIDProcessCounterFmtLen += 2; // "%d"
+    pdhIDProcessCounterFmtLen += 3; // "%d" and '\0'
 
     assert(pdhIDProcessCounterFmtLen < MAX_PATH);
-    pdhIDProcessCounterFmt = malloc(pdhIDProcessCounterFmtLen + 1);
+    pdhIDProcessCounterFmt = malloc(pdhIDProcessCounterFmtLen);
     if (!pdhIDProcessCounterFmt) {
         goto end;
     }
 
     /* "\Process(java#%d)\ID Process" */
-    _snprintf(pdhIDProcessCounterFmt,
-              pdhIDProcessCounterFmtLen,
-              PROCESS_OBJECT_INSTANCE_COUNTER_FMT,
-              pdhLocalizedProcessObject,
-              pdhProcessImageName,
-              "%d",
-              pdhLocalizedIDProcessCounter);
-
-    pdhIDProcessCounterFmt[pdhIDProcessCounterFmtLen] = '\0';
+    snprintf(pdhIDProcessCounterFmt,
+             pdhIDProcessCounterFmtLen,
+             PROCESS_OBJECT_INSTANCE_COUNTER_FMT,
+             pdhLocalizedProcessObject,
+             pdhProcessImageName,
+             "%d",
+             pdhLocalizedIDProcessCounter);
 
     assert(0 == numberOfJavaProcessesAtInitialization);
     currentQueryIndex = currentQueryIndexForProcess();


### PR DESCRIPTION
Following on from JDK-8350820, which backed out the _snprintf to snprintf change (JDK-8336289) in OperatingSystemImpl.c on Windows, because the counter names were being truncated (so CPU monitoring was not possible).

This change moves to snprintf again, but the counter names are not truncated.

snprintf must need the null terminator to fit inside the buffer length given.  It does not, and snprintf truncates (and always add the null terminator).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350939](https://bugs.openjdk.org/browse/JDK-8350939): Revisit Windows PDH buffer size calculation for OperatingSystemMXBean (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23861/head:pull/23861` \
`$ git checkout pull/23861`

Update a local copy of the PR: \
`$ git checkout pull/23861` \
`$ git pull https://git.openjdk.org/jdk.git pull/23861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23861`

View PR using the GUI difftool: \
`$ git pr show -t 23861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23861.diff">https://git.openjdk.org/jdk/pull/23861.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23861#issuecomment-2695060415)
</details>
