### PR TITLE
8346194: Improve G1 pre-barrier C2 cost estimate

### DIFF
--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -294,8 +294,8 @@ uint G1BarrierSetC2::estimated_barrier_size(const Node* node) const {
     // actually inlined into the main code stream.
     // The slow path is laid out separately and does not
     // directly affect performance.
-    // It has a cost of 4 (Cmp, Bool, If, IfProj).
-    nodes += 4;
+    // It has a cost of 6 (AddP, LoadB, Cmp, Bool, If, IfProj).
+    nodes += 6;
   }
   if ((barrier_data & G1C2BarrierPost) != 0) {
     nodes += 60;

--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -287,15 +287,15 @@ bool G1BarrierSetC2::expand_barriers(Compile* C, PhaseIterGVN& igvn) const {
 }
 
 uint G1BarrierSetC2::estimated_barrier_size(const Node* node) const {
-  // These Ideal node counts are extracted from the pre-matching Ideal graph
-  // generated when compiling the following method with early barrier expansion:
-  //   static void write(MyObject obj1, Object o) {
-  //     obj1.o1 = o;
-  //   }
   uint8_t barrier_data = MemNode::barrier_data(node);
   uint nodes = 0;
   if ((barrier_data & G1C2BarrierPre) != 0) {
-    nodes += 50;
+    // Only consider the fast path for the barrier that is
+    // actually inlined into the main code stream.
+    // The slow path is laid out separately and does not
+    // directly affect performance.
+    // It has a cost of 4 (Cmp, Bool, If, IfProj).
+    nodes += 4;
   }
   if ((barrier_data & G1C2BarrierPost) != 0) {
     nodes += 60;


### PR DESCRIPTION
Hi all,

  please review this change that modifies pre-barrier node costs for loop-unrolling to only consider the fast path. The reasoning is similar to zgc (and the new costs as well): only the part of the barrier inlined into the main code stream, as the slow path is laid out separately and does/should not directly affect performance (particularly if there is no marking going on).

There are no differences/impact in performance since the post barrier cost is still very large, which fill be fixed elsewhere.

Testing: gha, perf testing standalone (neither micros nor actual benchmarks give any difference outside of variance), testing with JDK-8342382

Hth,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346194](https://bugs.openjdk.org/browse/JDK-8346194): Improve G1 pre-barrier C2 cost estimate (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Contributors
 * Roberto Castañeda Lozano `<rcastanedalo@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23862/head:pull/23862` \
`$ git checkout pull/23862`

Update a local copy of the PR: \
`$ git checkout pull/23862` \
`$ git pull https://git.openjdk.org/jdk.git pull/23862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23862`

View PR using the GUI difftool: \
`$ git pr show -t 23862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23862.diff">https://git.openjdk.org/jdk/pull/23862.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23862#issuecomment-2694234244)
</details>
