### PR TITLE
8350685: java/lang/System/SecurityManagerWarnings.java fails with --enable-preview

### DIFF
--- a/test/jdk/java/lang/System/SecurityManagerWarnings.java
+++ b/test/jdk/java/lang/System/SecurityManagerWarnings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,8 +53,7 @@ public class SecurityManagerWarnings {
 
             JarUtils.createJarFile(Path.of("a.jar"),
                     Path.of(testClasses),
-                    Path.of("SecurityManagerWarnings.class"),
-                    Path.of("A.class"));
+                    Path.of(testClasses));
 
             failLateTest(null, "a.jar");
         } else {
@@ -72,8 +71,8 @@ public class SecurityManagerWarnings {
         }
     }
 
-    // When -Djava.security.manager is not set, or set to "allow",
-    // or "disallow", JVM starts but setSecurityManager will fail.
+    // When -Djava.security.manager is not set or set to "disallow",
+    // JVM starts but setSecurityManager will fail.
     static void failLateTest(String prop, String cp) throws Exception {
         run(prop, cp)
                 .shouldNotHaveExitValue(0)


### PR DESCRIPTION
Please review this fix to a test that fails when run with --enable-preview. This fix is to add all the necessary utility classes imported by the test to the JAR file, and not just the test classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350685](https://bugs.openjdk.org/browse/JDK-8350685): java/lang/System/SecurityManagerWarnings.java fails with --enable-preview (**Bug** - P4) ⚠️ Issue is not open.


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23864/head:pull/23864` \
`$ git checkout pull/23864`

Update a local copy of the PR: \
`$ git checkout pull/23864` \
`$ git pull https://git.openjdk.org/jdk.git pull/23864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23864`

View PR using the GUI difftool: \
`$ git pr show -t 23864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23864.diff">https://git.openjdk.org/jdk/pull/23864.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23864#issuecomment-2694422124)
</details>
