### PR TITLE
8297531: sun/security/krb5/MicroTime.java fails with "Exception: What? only 100 musec precision?"

### DIFF
--- a/test/jdk/sun/security/krb5/MicroTime.java
+++ b/test/jdk/sun/security/krb5/MicroTime.java
@@ -23,12 +23,10 @@
 /*
  * @test
  * @bug 6882687 8011124
- * @library /test/lib
  * @summary KerberosTime too imprecise
  * @modules java.security.jgss/sun.security.krb5.internal
  */
 
-import jtreg.SkippedException;
 import sun.security.krb5.internal.KerberosTime;
 
 public class MicroTime {
@@ -46,10 +44,10 @@ public class MicroTime {
                 count++;
             }
         }
-        // We believe a nice KerberosTime can at least tell the
-        // difference of 100 musec.
-        if (count < 10000) {
-            throw new SkippedException("What? only " + (1000000/count) +
+        // Before this change, KerberosTime was implemented in milliseconds.
+        // Now there should be more.
+        if (count < 1001) {
+            throw new Exception("What? only " + (1000000/count) +
                     " musec precision?");
         }
     }

--- a/test/jdk/sun/security/krb5/MicroTime.java
+++ b/test/jdk/sun/security/krb5/MicroTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,12 @@
 /*
  * @test
  * @bug 6882687 8011124
+ * @library /test/lib
  * @summary KerberosTime too imprecise
  * @modules java.security.jgss/sun.security.krb5.internal
  */
 
+import jtreg.SkippedException;
 import sun.security.krb5.internal.KerberosTime;
 
 public class MicroTime {
@@ -47,7 +49,7 @@ public class MicroTime {
         // We believe a nice KerberosTime can at least tell the
         // difference of 100 musec.
         if (count < 10000) {
-            throw new Exception("What? only " + (1000000/count) +
+            throw new SkippedException("What? only " + (1000000/count) +
                     " musec precision?");
         }
     }

--- a/test/jdk/sun/security/krb5/MicroTime.java
+++ b/test/jdk/sun/security/krb5/MicroTime.java
@@ -44,8 +44,9 @@ public class MicroTime {
                 count++;
             }
         }
-        // Before this change, KerberosTime was implemented in milliseconds.
-        // Now there should be more.
+        // Before JDK-6882687, KerberosTime was measured in milliseconds.
+        // Now it's in microseconds. We should be able to record more than
+        // 1000 distinct KerberosTime values within one second.
         if (count < 1001) {
             throw new Exception("What? only " + (1000000/count) +
                     " musec precision?");


### PR DESCRIPTION
Loosen the check; the modified test is sufficient to demonstrate sub-millisecond precision.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297531](https://bugs.openjdk.org/browse/JDK-8297531): sun/security/krb5/MicroTime.java fails with "Exception: What? only 100 musec precision?" (**Bug** - P3)


### Reviewers
 * [Artur Barashev](https://openjdk.org/census#abarashev) (@artur-oracle - Author) Review applies to [2c569f4c](https://git.openjdk.org/jdk/pull/23867/files/2c569f4cabfc7ba76017697625833490a0cdda52)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23867/head:pull/23867` \
`$ git checkout pull/23867`

Update a local copy of the PR: \
`$ git checkout pull/23867` \
`$ git pull https://git.openjdk.org/jdk.git pull/23867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23867`

View PR using the GUI difftool: \
`$ git pr show -t 23867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23867.diff">https://git.openjdk.org/jdk/pull/23867.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23867#issuecomment-2694972461)
</details>
