### PR TITLE
8351077: Shenandoah: Update comments in ShenandoahConcurrentGC::op_reset_after_collect

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1230,9 +1230,9 @@ void ShenandoahConcurrentGC::op_reset_after_collect() {
 
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational()) {
-    // Valid bitmap of young generation is needed by concurrent weak references phase of old GC cycle,
-    // because it is possible that there is soft reference in old generation with the referent in young generation;
-    // therefore mark bitmap of young generation can't be reset if there will be old GC after the concurrent GC cycle.
+    // If we are in the midst of an old gc bootstrap or an old marking, we want to leave the mark bit map of
+    // the young generation intact. In particular, reference processing in the old generation may potentially
+    // need the reachability of a young generation referent of a Reference object in the old generation.
     if (!_do_old_gc_bootstrap && !heap->is_concurrent_old_mark_in_progress()) {
       heap->young_generation()->reset_mark_bitmap<false>();
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1230,11 +1230,9 @@ void ShenandoahConcurrentGC::op_reset_after_collect() {
 
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational()) {
-    // Resetting bitmaps of young gen when bootstrap old GC or there is preempted old GC
-    // causes crash due to remembered set violation, hence condition is added to fix the crash.
-    // Assuming bitmaps of young gen are not used at all after the cycle, the crash should not
-    // have happend, it seems to tickle a bug in remembered set scan. Root causing and fixing of the bug
-    // will be tracked via ticket https://bugs.openjdk.org/browse/JDK-8347371
+    // Valid bitmap of young generation is needed by concurrent weak references phase of old GC cycle,
+    // because it is possible that there is soft reference in old generation with the referent in young generation;
+    // therefore mark bitmap of young generation can't be reset if there will be old GC after the concurrent GC cycle.
     if (!_do_old_gc_bootstrap && !heap->is_concurrent_old_mark_in_progress()) {
       heap->young_generation()->reset_mark_bitmap<false>();
     }


### PR DESCRIPTION
This is a trivial PR to update the code comments in ShenandoahConcurrentGC::op_reset_after_collect.

After doing more test and analysis, we have a better understanding why reset bitmap of young gen after concurrent cycle may cause crash if there is pending old GC cycle to execute: When there is soft reference in old gen, but the referent is in young, reseting bitmap of young will cause wrong state of the soft reference, which may lead to expected cashes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351077](https://bugs.openjdk.org/browse/JDK-8351077): Shenandoah: Update comments in ShenandoahConcurrentGC::op_reset_after_collect (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**) Review applies to [3764bf7d](https://git.openjdk.org/jdk/pull/23872/files/3764bf7d41619a2b51bb860e7ae4005e7f8c0e37)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23872/head:pull/23872` \
`$ git checkout pull/23872`

Update a local copy of the PR: \
`$ git checkout pull/23872` \
`$ git pull https://git.openjdk.org/jdk.git pull/23872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23872`

View PR using the GUI difftool: \
`$ git pr show -t 23872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23872.diff">https://git.openjdk.org/jdk/pull/23872.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23872#issuecomment-2695444015)
</details>
