### PR TITLE
8350811: [JMH] test foreign.StrLenTest failed with StringIndexOutOfBoundsException for size=451

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class StrLenTest extends CLayouts {
     SegmentAllocator arenaAllocator;
     SlicingPool pool;
 
-    @Param({"5", "20", "100"})
+    @Param({"5", "20", "100", "451"})
     public int size;
     public String str;
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -144,8 +144,9 @@ public class StrLenTest extends CLayouts {
                  fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
                  mollit anim id est laborum.
                 """;
-        while (lorem.length() < size)
+        while (lorem.length() < size) {
             lorem += lorem;
+        }
         return lorem.substring(0, size);
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -54,8 +54,8 @@ public class StrLenTest extends CLayouts {
     Arena arena = Arena.ofConfined();
 
     SegmentAllocator segmentAllocator;
-    SegmentAllocator arenaAllocator = new RingAllocator(arena);
-    SlicingPool pool = new SlicingPool();
+    SegmentAllocator arenaAllocator;
+    SlicingPool pool;
 
     @Param({"5", "20", "100"})
     public int size;
@@ -76,6 +76,8 @@ public class StrLenTest extends CLayouts {
     @Setup
     public void setup() {
         str = makeString(size);
+        arenaAllocator = new RingAllocator(arena, size + 1);
+        pool = new SlicingPool(size + 1);
         segmentAllocator = SegmentAllocator.prefixAllocator(arena.allocate(size + 1, 1));
     }
 
@@ -142,6 +144,8 @@ public class StrLenTest extends CLayouts {
                  fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
                  mollit anim id est laborum.
                 """;
+        while (lorem.length() < size)
+            lorem += lorem;
         return lorem.substring(0, size);
     }
 
@@ -150,8 +154,8 @@ public class StrLenTest extends CLayouts {
         SegmentAllocator current;
         long rem;
 
-        public RingAllocator(Arena session) {
-            this.segment = session.allocate(1024, 1);
+        public RingAllocator(Arena session, int size) {
+            this.segment = session.allocate(size, 1);
             reset();
         }
 
@@ -173,8 +177,12 @@ public class StrLenTest extends CLayouts {
     }
 
     static class SlicingPool {
-        final MemorySegment pool = Arena.ofAuto().allocate(1024);
+        final MemorySegment pool;
         boolean isAcquired = false;
+
+        public SlicingPool(int size) {
+            this.pool = Arena.ofAuto().allocate(size);
+        }
 
         public Arena acquire() {
             if (isAcquired) {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 @Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class ToCStringTest extends CLayouts {
 
-    @Param({"5", "20", "100", "200"})
+    @Param({"5", "20", "100", "200", "451"})
     public int size;
     public String str;
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
@@ -97,6 +97,7 @@ public class ToCStringTest extends CLayouts {
                  fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
                  mollit anim id est laborum.
                 """;
+        while (lorem.length() < size) lorem += lorem;
         return lorem.substring(0, size);
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
@@ -97,7 +97,9 @@ public class ToCStringTest extends CLayouts {
                  fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
                  mollit anim id est laborum.
                 """;
-        while (lorem.length() < size) lorem += lorem;
+        while (lorem.length() < size) {
+            lorem += lorem;
+        }
         return lorem.substring(0, size);
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class ToJavaStringTest {
 
     private MemorySegment strSegment;
 
-    @Param({"5", "20", "100", "200"})
+    @Param({"5", "20", "100", "200", "451"})
     int size;
 
     static {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
@@ -58,6 +58,7 @@ public class ToJavaStringTest {
     @Setup
     public void setup() {
         var arena = Arena.ofAuto();
+        while (LOREM.length() < size) LOREM += LOREM;
         strSegment = arena.allocateFrom(LOREM.substring(0, size));
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
@@ -58,7 +58,9 @@ public class ToJavaStringTest {
     @Setup
     public void setup() {
         var arena = Arena.ofAuto();
-        while (LOREM.length() < size) LOREM += LOREM;
+        while (LOREM.length() < size) {
+            LOREM += LOREM;
+        }
         strSegment = arena.allocateFrom(LOREM.substring(0, size));
     }
 


### PR DESCRIPTION
test setup was updated to generate data of requested size.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350811](https://bugs.openjdk.org/browse/JDK-8350811): [JMH] test foreign.StrLenTest failed with StringIndexOutOfBoundsException for size=451 (**Enhancement** - P4)


### Reviewers
 * [Volodymyr Paprotski](https://openjdk.org/census#vpaprotski) (@vpaprotsk - Author) Review applies to [69207701](https://git.openjdk.org/jdk/pull/23873/files/6920770118c6533c9e618bad1d6fb883dd6de3da)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) Review applies to [69207701](https://git.openjdk.org/jdk/pull/23873/files/6920770118c6533c9e618bad1d6fb883dd6de3da)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23873/head:pull/23873` \
`$ git checkout pull/23873`

Update a local copy of the PR: \
`$ git checkout pull/23873` \
`$ git pull https://git.openjdk.org/jdk.git pull/23873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23873`

View PR using the GUI difftool: \
`$ git pr show -t 23873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23873.diff">https://git.openjdk.org/jdk/pull/23873.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23873#issuecomment-2695469086)
</details>
