### PR TITLE
8351082: Remove dead code for estimating CDS archive size

### DIFF
--- a/src/hotspot/share/classfile/compactHashtable.cpp
+++ b/src/hotspot/share/classfile/compactHashtable.cpp
@@ -72,19 +72,6 @@ CompactHashtableWriter::~CompactHashtableWriter() {
   FREE_C_HEAP_ARRAY(GrowableArray<Entry>*, _buckets);
 }
 
-size_t CompactHashtableWriter::estimate_size(int num_entries) {
-  int num_buckets = calculate_num_buckets(num_entries);
-  size_t bucket_bytes = ArchiveBuilder::ro_array_bytesize<u4>(num_buckets + 1);
-
-  // In worst case, we have no VALUE_ONLY_BUCKET_TYPE, so each entry takes 2 slots
-  int entries_space = 2 * num_entries;
-  size_t entry_bytes = ArchiveBuilder::ro_array_bytesize<u4>(entries_space);
-
-  return bucket_bytes
-       + entry_bytes
-       + SimpleCompactHashtable::calculate_header_size();
-}
-
 // Add a symbol entry to the temporary hash table
 void CompactHashtableWriter::add(unsigned int hash, u4 value) {
   int index = hash % _num_buckets;

--- a/src/hotspot/share/classfile/compactHashtable.hpp
+++ b/src/hotspot/share/classfile/compactHashtable.hpp
@@ -134,8 +134,6 @@ private:
 
 public:
   void dump(SimpleCompactHashtable *cht, const char* table_name);
-
-  static size_t estimate_size(int num_entries);
 };
 #endif // INCLUDE_CDS
 

--- a/src/hotspot/share/classfile/moduleEntry.hpp
+++ b/src/hotspot/share/classfile/moduleEntry.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,7 +207,6 @@ public:
   void load_from_archive(ClassLoaderData* loader_data);
   void restore_archived_oops(ClassLoaderData* loader_data);
   void clear_archived_oops();
-  void update_oops_in_archived_module(int root_oop_index);
   static void verify_archived_module_entries() PRODUCT_RETURN;
 #endif
 };

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -705,13 +705,6 @@ void SymbolTable::copy_shared_symbol_table(GrowableArray<Symbol*>* symbols,
   }
 }
 
-size_t SymbolTable::estimate_size_for_archive() {
-  if (_items_count > (size_t)max_jint) {
-    fatal("Too many symbols to be archived: %zu", _items_count);
-  }
-  return CompactHashtableWriter::estimate_size(int(_items_count));
-}
-
 void SymbolTable::write_to_archive(GrowableArray<Symbol*>* symbols) {
   CompactHashtableWriter writer(int(_items_count), ArchiveBuilder::symbol_stats());
   copy_shared_symbol_table(symbols, &writer);

--- a/src/hotspot/share/classfile/symbolTable.hpp
+++ b/src/hotspot/share/classfile/symbolTable.hpp
@@ -161,7 +161,6 @@ private:
   static void copy_shared_symbol_table(GrowableArray<Symbol*>* symbols,
                                        CompactHashtableWriter* ch_table);
 public:
-  static size_t estimate_size_for_archive() NOT_CDS_RETURN_(0);
   static void write_to_archive(GrowableArray<Symbol*>* symbols) NOT_CDS_RETURN;
   static void serialize_shared_table_header(SerializeClosure* soc,
                                             bool is_static_archive = true) NOT_CDS_RETURN;

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -294,7 +294,6 @@ public:
   static void set_excluded_locked(InstanceKlass* k);
   static bool warn_excluded(InstanceKlass* k, const char* reason);
   static void dumptime_classes_do(class MetaspaceClosure* it);
-  static size_t estimate_size_for_archive();
   static void write_to_archive(bool is_static_archive = true);
   static void adjust_lambda_proxy_class_dictionary();
   static void serialize_dictionary_headers(class SerializeClosure* soc,


### PR DESCRIPTION
Please review this trivial changeset that removes dead code that are no longer called after [JDK-8340416](https://bugs.openjdk.org/browse/JDK-8340416) "Remove ArchiveBuilder::estimate_archive_size()"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351082](https://bugs.openjdk.org/browse/JDK-8351082): Remove dead code for estimating CDS archive size (**Enhancement** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23874/head:pull/23874` \
`$ git checkout pull/23874`

Update a local copy of the PR: \
`$ git checkout pull/23874` \
`$ git pull https://git.openjdk.org/jdk.git pull/23874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23874`

View PR using the GUI difftool: \
`$ git pr show -t 23874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23874.diff">https://git.openjdk.org/jdk/pull/23874.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23874#issuecomment-2695598500)
</details>
