### PR TITLE
8351087: Combine scratch object tables in heapShared.cpp

### DIFF
--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -284,8 +284,7 @@ private:
   static GrowableArrayCHeap<OopHandle, mtClassShared>* _root_segments;
   static int _root_segment_max_size_elems;
   static OopHandle _scratch_basic_type_mirrors[T_VOID+1];
-  static MetaspaceObjToOopHandleTable* _scratch_java_mirror_table;
-  static MetaspaceObjToOopHandleTable* _scratch_references_table;
+  static MetaspaceObjToOopHandleTable* _scratch_objects_table;
 
   static void init_seen_objects_table() {
     assert(_seen_objects_table == nullptr, "must be");
@@ -406,7 +405,7 @@ private:
   static objArrayOop scratch_resolved_references(ConstantPool* src);
   static void add_scratch_resolved_references(ConstantPool* src, objArrayOop dest) NOT_CDS_JAVA_HEAP_RETURN;
   static void init_dumping() NOT_CDS_JAVA_HEAP_RETURN;
-  static void init_scratch_objects(TRAPS) NOT_CDS_JAVA_HEAP_RETURN;
+  static void init_scratch_objects_for_basic_type_mirrors(TRAPS) NOT_CDS_JAVA_HEAP_RETURN;
   static void init_box_classes(TRAPS) NOT_CDS_JAVA_HEAP_RETURN;
   static bool is_heap_region(int idx) {
     CDS_JAVA_HEAP_ONLY(return (idx == MetaspaceShared::hp);)

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -572,7 +572,7 @@ void Universe::initialize_basic_type_mirrors(TRAPS) {
       }
     }
     if (CDSConfig::is_dumping_heap()) {
-      HeapShared::init_scratch_objects(CHECK);
+      HeapShared::init_scratch_objects_for_basic_type_mirrors(CHECK);
     }
 }
 


### PR DESCRIPTION
Please review this trivial change. The two tables `_scratch_java_mirror_table` and `_scratch_references_table` are always disjoint. So we can simply combine them into a single table.

I am running tiers 1-5 for sanity sake.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351087](https://bugs.openjdk.org/browse/JDK-8351087): Combine scratch object tables in heapShared.cpp (**Enhancement** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23876/head:pull/23876` \
`$ git checkout pull/23876`

Update a local copy of the PR: \
`$ git checkout pull/23876` \
`$ git pull https://git.openjdk.org/jdk.git pull/23876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23876`

View PR using the GUI difftool: \
`$ git pr show -t 23876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23876.diff">https://git.openjdk.org/jdk/pull/23876.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23876#issuecomment-2695650703)
</details>
