### PR TITLE
8351086: (fc) Make java/nio/channels/FileChannel/BlockDeviceSize.java test manual

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -25,6 +25,8 @@
  * @bug 8054029 8313368
  * @requires (os.family == "linux")
  * @summary FileChannel.size() should be equal to RandomAccessFile.size() and > 0 for block devs on Linux
+ * @comment The test must be launched with sudo or the block devices listed in
+ * the BLK_FNAMES array must be readable by the user running the test.
  * @library /test/lib
  * @run main/manual BlockDeviceSize
  */

--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @requires (os.family == "linux")
  * @summary FileChannel.size() should be equal to RandomAccessFile.size() and > 0 for block devs on Linux
  * @library /test/lib
+ * @run main/manual BlockDeviceSize
  */
 
 import java.io.RandomAccessFile;


### PR DESCRIPTION
Change `BlockDeviceSize` to be a manual test for the time being.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351086](https://bugs.openjdk.org/browse/JDK-8351086): (fc) Make java/nio/channels/FileChannel/BlockDeviceSize.java test manual (**Bug** - P4)


### Reviewers
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23877/head:pull/23877` \
`$ git checkout pull/23877`

Update a local copy of the PR: \
`$ git checkout pull/23877` \
`$ git pull https://git.openjdk.org/jdk.git pull/23877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23877`

View PR using the GUI difftool: \
`$ git pr show -t 23877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23877.diff">https://git.openjdk.org/jdk/pull/23877.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23877#issuecomment-2695674571)
</details>
