### PR TITLE
8325132: CDS: Make sure the ArchiveRelocationMode is always printed in the log

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1166,7 +1166,7 @@ void MetaspaceShared::initialize_runtime_shared_and_meta_spaces() {
     log_info(cds)("Core region alignment: %zu", static_mapinfo->core_region_alignment());
     dynamic_mapinfo = open_dynamic_archive();
 
-    log_info(cds)("ArchiveRelocationMode = %d", ArchiveRelocationMode);
+    log_info(cds)("ArchiveRelocationMode: %d", ArchiveRelocationMode);
 
     // First try to map at the requested address
     result = map_archives(static_mapinfo, dynamic_mapinfo, true);

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1166,6 +1166,8 @@ void MetaspaceShared::initialize_runtime_shared_and_meta_spaces() {
     log_info(cds)("Core region alignment: %zu", static_mapinfo->core_region_alignment());
     dynamic_mapinfo = open_dynamic_archive();
 
+    log_info(cds)("ArchiveRelocationMode = %d", ArchiveRelocationMode);
+
     // First try to map at the requested address
     result = map_archives(static_mapinfo, dynamic_mapinfo, true);
     if (result == MAP_ARCHIVE_MMAP_FAILURE) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
@@ -78,7 +78,7 @@ public class ArchiveRelocationTest {
                         output.shouldContain("ArchiveRelocationMode == 1: always map archive(s) at an alternative address")
                               .shouldContain("Try to map archive(s) at an alternative address");
                     } else {
-                        output.shouldContain("ArchiveRelocationMode = 0");
+                        output.shouldContain("ArchiveRelocationMode: 0");
                     }
                 });
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
@@ -61,8 +61,8 @@ public class ArchiveRelocationTest {
 
         String appJar = ClassFileInstaller.getJarPath("hello.jar");
         String mainClass = "Hello";
-        String forceRelocation = "-XX:ArchiveRelocationMode=1";
-        String runRelocArg  = run_reloc  ? forceRelocation : "-showversion";
+        String noRelocation = "-XX:ArchiveRelocationMode=0";
+        String runRelocArg  = run_reloc  ? "-showversion" : noRelocation;
         String logArg = "-Xlog:cds=debug,cds+reloc=debug,cds+heap";
         String unlockArg = "-XX:+UnlockDiagnosticVMOptions";
         String nmtArg = "-XX:NativeMemoryTracking=detail";
@@ -75,7 +75,10 @@ public class ArchiveRelocationTest {
         TestCommon.run("-cp", appJar, unlockArg, runRelocArg, logArg,  mainClass)
             .assertNormalExit(output -> {
                     if (run_reloc) {
-                        output.shouldContain("Try to map archive(s) at an alternative address");
+                        output.shouldContain("ArchiveRelocationMode == 1: always map archive(s) at an alternative address")
+                              .shouldContain("Try to map archive(s) at an alternative address");
+                    } else {
+                        output.shouldContain("ArchiveRelocationMode = 0");
                     }
                 });
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
@@ -61,8 +61,8 @@ public class ArchiveRelocationTest {
 
         String appJar = ClassFileInstaller.getJarPath("hello.jar");
         String mainClass = "Hello";
-        String noRelocation = "-XX:ArchiveRelocationMode=0";
-        String runRelocArg  = run_reloc  ? "-showversion" : noRelocation;
+        String maybeRelocation = "-XX:ArchiveRelocationMode=0";
+        String runRelocArg  = run_reloc  ? "-showversion" : maybeRelocation;
         String logArg = "-Xlog:cds=debug,cds+reloc=debug,cds+heap";
         String unlockArg = "-XX:+UnlockDiagnosticVMOptions";
         String nmtArg = "-XX:NativeMemoryTracking=detail";

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
@@ -128,14 +128,14 @@ public class TestSerialGCWithCDS {
                               "Hello");
         out.shouldNotContain(errMsg);
 
-        System.out.println("2. Exec with " + execGC + " and test ArchiveRelocationMode");
+        System.out.println("2. Exec with " + execGC + " and test ArchiveRelocationMode=0");
         out = TestCommon.exec(helloJar,
                               execGC,
                               small1,
                               small2,
                               coops,
                               "-Xlog:cds,cds+heap",
-                              "-XX:ArchiveRelocationMode=1", // always relocate shared metadata
+                              "-XX:ArchiveRelocationMode=0", // don't relocate shared metadata
                               "Hello");
         out.shouldNotContain(errMsg);
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
@@ -135,7 +135,7 @@ public class TestSerialGCWithCDS {
                               small2,
                               coops,
                               "-Xlog:cds,cds+heap",
-                              "-XX:ArchiveRelocationMode=0", // don't relocate shared metadata
+                              "-XX:ArchiveRelocationMode=0", // may relocate shared metadata
                               "Hello");
         out.shouldNotContain(errMsg);
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
@@ -89,7 +89,7 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
 
         String runtimeMsg = "Try to map archive(s) at an alternative address";
         String unlockArg = "-XX:+UnlockDiagnosticVMOptions";
-        String relocationModeMsg = "ArchiveRelocationMode = 0";
+        String relocationModeMsg = "ArchiveRelocationMode: 0";
 
         // (1) Dump base archive (static)
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
@@ -79,9 +79,9 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
 
         String appJar = ClassFileInstaller.getJarPath("hello.jar");
         String mainClass = "Hello";
-        String forceRelocation = "-XX:ArchiveRelocationMode=1";
-        String dumpTopRelocArg  = dump_top_reloc  ? forceRelocation : "-showversion";
-        String runRelocArg      = run_reloc       ? forceRelocation : "-showversion";
+        String noRelocation = "-XX:ArchiveRelocationMode=0";
+        String dumpTopRelocArg  = dump_top_reloc  ? "-showversion" : noRelocation;
+        String runRelocArg      = run_reloc       ? "-showversion" : noRelocation;
         String logArg = "-Xlog:cds=debug,cds+reloc=debug";
 
         String baseArchiveName = getNewArchiveName("base");
@@ -89,6 +89,7 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
 
         String runtimeMsg = "Try to map archive(s) at an alternative address";
         String unlockArg = "-XX:+UnlockDiagnosticVMOptions";
+        String noRelocationMsg = "ArchiveRelocationMode = 0";
 
         // (1) Dump base archive (static)
 
@@ -105,6 +106,8 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
             .assertNormalExit(output -> {
                     if (dump_top_reloc) {
                         output.shouldContain(runtimeMsg);
+                    } else {
+                        output.shouldContain(noRelocationMsg);
                     }
                 });
 
@@ -116,6 +119,8 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
             .assertNormalExit(output -> {
                     if (run_reloc) {
                         output.shouldContain(runtimeMsg);
+                    } else {
+                        output.shouldContain(noRelocationMsg);
                     }
                 });
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
@@ -79,9 +79,9 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
 
         String appJar = ClassFileInstaller.getJarPath("hello.jar");
         String mainClass = "Hello";
-        String noRelocation = "-XX:ArchiveRelocationMode=0";
-        String dumpTopRelocArg  = dump_top_reloc  ? "-showversion" : noRelocation;
-        String runRelocArg      = run_reloc       ? "-showversion" : noRelocation;
+        String maybeRelocation = "-XX:ArchiveRelocationMode=0";
+        String dumpTopRelocArg  = dump_top_reloc  ? "-showversion" : maybeRelocation;
+        String runRelocArg      = run_reloc       ? "-showversion" : maybeRelocation;
         String logArg = "-Xlog:cds=debug,cds+reloc=debug";
 
         String baseArchiveName = getNewArchiveName("base");
@@ -89,7 +89,7 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
 
         String runtimeMsg = "Try to map archive(s) at an alternative address";
         String unlockArg = "-XX:+UnlockDiagnosticVMOptions";
-        String noRelocationMsg = "ArchiveRelocationMode = 0";
+        String relocationModeMsg = "ArchiveRelocationMode = 0";
 
         // (1) Dump base archive (static)
 
@@ -107,7 +107,7 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
                     if (dump_top_reloc) {
                         output.shouldContain(runtimeMsg);
                     } else {
-                        output.shouldContain(noRelocationMsg);
+                        output.shouldContain(relocationModeMsg);
                     }
                 });
 
@@ -120,7 +120,7 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
                     if (run_reloc) {
                         output.shouldContain(runtimeMsg);
                     } else {
-                        output.shouldContain(noRelocationMsg);
+                        output.shouldContain(relocationModeMsg);
                     }
                 });
     }


### PR DESCRIPTION
Always include the ArchiveRelocationMode in the CDS info log. Before this fix, ArchiveRelocationMode is not in the log if it is set to 0.
The ArchiveRelocationMode default value was set to 1 about 2 years ago. Some tests need to be updated accordingly.

Testing:

- ran the modified tests manually on linux-x64
- tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325132](https://bugs.openjdk.org/browse/JDK-8325132): CDS: Make sure the ArchiveRelocationMode is always printed in the log (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23878/head:pull/23878` \
`$ git checkout pull/23878`

Update a local copy of the PR: \
`$ git checkout pull/23878` \
`$ git pull https://git.openjdk.org/jdk.git pull/23878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23878`

View PR using the GUI difftool: \
`$ git pr show -t 23878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23878.diff">https://git.openjdk.org/jdk/pull/23878.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23878#issuecomment-2699188541)
</details>
