### PR TITLE
JDK-8351074: Disallow null prefix and suffix in DecimalFormat

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ import java.text.spi.NumberFormatProvider;
 import java.util.ArrayList;
 import java.util.Currency;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -2812,8 +2813,10 @@ public class DecimalFormat extends NumberFormat {
      * <P>Examples: +123, $123, sFr123
      *
      * @param newValue the new positive prefix
+     * @throws NullPointerException if {@code newValue} is {@code null}
      */
     public void setPositivePrefix (String newValue) {
+        Objects.requireNonNull(newValue, "prefix must not be null");
         positivePrefix = newValue;
         posPrefixPattern = null;
         positivePrefixFieldPositions = null;
@@ -2854,8 +2857,10 @@ public class DecimalFormat extends NumberFormat {
      * <P>Examples: -123, ($123) (with negative suffix), sFr-123
      *
      * @param newValue the new negative prefix
+     * @throws NullPointerException if {@code newValue} is {@code null}
      */
     public void setNegativePrefix (String newValue) {
+        Objects.requireNonNull(newValue, "prefix must not be null");
         negativePrefix = newValue;
         negPrefixPattern = null;
         fastPathCheckNeeded = true;
@@ -2895,8 +2900,10 @@ public class DecimalFormat extends NumberFormat {
      * <P>Example: 123%
      *
      * @param newValue the new positive suffix
+     * @throws NullPointerException if {@code newValue} is {@code null}
      */
     public void setPositiveSuffix (String newValue) {
+        Objects.requireNonNull(newValue, "suffix must not be null");
         positiveSuffix = newValue;
         posSuffixPattern = null;
         fastPathCheckNeeded = true;
@@ -2936,8 +2943,10 @@ public class DecimalFormat extends NumberFormat {
      * <P>Examples: 123%
      *
      * @param newValue the new negative suffix
+     * @throws NullPointerException if {@code newValue} is {@code null}
      */
     public void setNegativeSuffix (String newValue) {
+        Objects.requireNonNull(newValue, "suffix must not be null");
         negativeSuffix = newValue;
         negSuffixPattern = null;
         fastPathCheckNeeded = true;

--- a/test/jdk/java/text/Format/DecimalFormat/AffixTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/AffixTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8327640
+ * @summary Test input value check for DecimalFormat affix setter methods
+ * @run junit AffixTest
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.text.DecimalFormat;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AffixTest {
+
+    @Test
+    public void nullPrefixTest() {
+        assertThrows(NullPointerException.class, () -> new DecimalFormat().setPositivePrefix(null));
+        assertThrows(NullPointerException.class, () -> new DecimalFormat().setNegativePrefix(null));
+    }
+
+    @Test
+    public void nullSuffixTest() {
+        assertThrows(NullPointerException.class, () -> new DecimalFormat().setPositiveSuffix(null));
+        assertThrows(NullPointerException.class, () -> new DecimalFormat().setNegativeSuffix(null));
+    }
+}


### PR DESCRIPTION
Please review this PR and associated CSR which disallows passing null to 4 `DecimalFormat` prefix/suffix setter methods.

Currently these setters do not check the input String for null. When the prefix/suffix is null, any such DecimalFormat instances are effectively non-functional as it will throw NPE for most operations.