### PR TITLE
8350982: -server|-client causes fatal exception on static JDK

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2805,6 +2805,14 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
           return JNI_EINVAL;
         }
       }
+    } else if (match_option(option, "-server") ||
+               match_option(option, "-client")) {
+      // On regular JDK, '-server|-client' options are processed and removed
+      // from command-line arguments by CheckJvmType (see
+      // src/java.base/share/native/libjli/java.c). When running on static JDK,
+      // we may encounter the '-server|-client' options here, since CheckJvmType
+      // is not called. Ignore the options and don't report an 'Unrecognized option'
+      // error.
     // Unknown option
     } else if (is_bad_option(option, args->ignoreUnrecognized)) {
       return JNI_ERR;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2805,14 +2805,6 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, JVMFlagOrigin
           return JNI_EINVAL;
         }
       }
-    } else if (match_option(option, "-server") ||
-               match_option(option, "-client")) {
-      // On regular JDK, '-server|-client' options are processed and removed
-      // from command-line arguments by CheckJvmType (see
-      // src/java.base/share/native/libjli/java.c). When running on static JDK,
-      // we may encounter the '-server|-client' options here, since CheckJvmType
-      // is not called. Ignore the options and don't report an 'Unrecognized option'
-      // error.
     // Unknown option
     } else if (is_bad_option(option, args->ignoreUnrecognized)) {
       return JNI_ERR;

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
@@ -26,6 +26,7 @@
  * @bug 8319784
  * @summary Check that the JVM is able to dump the heap even when there are ReduceAllocationMerge in the scope.
  * @library /test/lib /
+ * @requires vm.flavor == "server" & !vm.emulatedClient
  * @run main/othervm compiler.c2.TestReduceAllocationAndHeapDump
  */
 
@@ -45,7 +46,6 @@ public class TestReduceAllocationAndHeapDump {
             }
 
             String[] dumperArgs = {
-                "-server",
                 "-XX:CompileThresholdScaling=0.01",
                 "-XX:+HeapDumpAfterFullGC",
                 "-XX:HeapDumpPath=" + dumpDirectory.getAbsolutePath(),

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndLoadKlass.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndLoadKlass.java
@@ -36,7 +36,6 @@
  *                   -XX:-UseCompressedClassPointers
  *                   -Xbatch
  *                   -Xcomp
- *                   -server
  *                   compiler.c2.TestReduceAllocationAndLoadKlass
  */
 

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNonExactAllocate.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNonExactAllocate.java
@@ -36,7 +36,6 @@
  *                   -XX:-TieredCompilation
  *                   -Xbatch
  *                   -Xcomp
- *                   -server
  *                   compiler.c2.TestReduceAllocationAndNonExactAllocate
  */
 

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNullableLoads.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNullableLoads.java
@@ -30,7 +30,7 @@
  * @compile -XDstringConcat=inline TestReduceAllocationAndNullableLoads.java
  * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndNullableLoads*::*
  *                   -XX:CompileCommand=dontinline,*TestReduceAllocationAndNullableLoads*::*
- *                   -XX:-TieredCompilation -Xcomp -server
+ *                   -XX:-TieredCompilation -Xcomp
  *                   compiler.c2.TestReduceAllocationAndNullableLoads
  */
 

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndPointerComparisons.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndPointerComparisons.java
@@ -28,7 +28,7 @@
  * @requires vm.flagless & vm.compiler2.enabled & vm.opt.final.EliminateAllocations
  * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndPointerComparisons*::*
  *                   -XX:CompileCommand=dontinline,*TestReduceAllocationAndPointerComparisons*::*
- *                   -XX:-TieredCompilation -Xcomp -server
+ *                   -XX:-TieredCompilation -Xcomp
  *                   compiler.c2.TestReduceAllocationAndPointerComparisons
  * @run main compiler.c2.TestReduceAllocationAndPointerComparisons
  */

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestIterativeEA.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestIterativeEA.java
@@ -40,7 +40,7 @@ public class TestIterativeEA {
 
   public static void main(String[] args) throws Exception {
     ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
-                "-server", "-XX:-TieredCompilation", "-Xbatch", "-XX:+PrintEliminateAllocations",
+                 "-XX:-TieredCompilation", "-Xbatch", "-XX:+PrintEliminateAllocations",
                  Launcher.class.getName());
 
     OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndNonReduciblePhi.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndNonReduciblePhi.java
@@ -35,7 +35,6 @@
  *                   -XX:CompileCommand=inline,*Point*::*
  *                   -XX:CompileCommand=exclude,*::dummy*
  *                   -Xbatch
- *                   -server
  *                   compiler.escapeAnalysis.TestReduceAllocationAndNonReduciblePhi
  *
  * @run main compiler.escapeAnalysis.TestReduceAllocationAndNonReduciblePhi

--- a/test/hotspot/jtreg/compiler/inlining/InlineBimorphicVirtualCallAfterMorphismChanged.java
+++ b/test/hotspot/jtreg/compiler/inlining/InlineBimorphicVirtualCallAfterMorphismChanged.java
@@ -29,6 +29,7 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @requires vm.flagless
+ * @requires vm.flavor == "server" & !vm.emulatedClient
  *
  * @run driver compiler.inlining.InlineBimorphicVirtualCallAfterMorphismChanged
  */
@@ -93,7 +94,7 @@ public class InlineBimorphicVirtualCallAfterMorphismChanged {
 
     private static void test(String option) throws Exception {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
-            "-server", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
+            "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
             "-XX:CompileCommand=compileonly,*::callSiteHolder", option,
             AbstractBase.class.getName()
         );

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestMinMaxIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestMinMaxIntrinsics.java
@@ -34,7 +34,7 @@
 * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
 *
 * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
-*                   -server -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
+*                   -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
 *                   compiler.intrinsics.math.TestMinMaxIntrinsics
 */
 

--- a/test/hotspot/jtreg/compiler/profiling/TestTypeProfiling.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestTypeProfiling.java
@@ -39,13 +39,13 @@
   * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
   *                   -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
   *                   -XX:CompileThreshold=10000
-  *                   -server -XX:-TieredCompilation -XX:TypeProfileLevel=020
+  *                   -XX:-TieredCompilation -XX:TypeProfileLevel=020
   *                   -XX:+UnlockExperimentalVMOptions -XX:PerMethodSpecTrapLimit=5000 -XX:PerMethodTrapLimit=100
   *                    compiler.profiling.TestTypeProfiling
   * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
   *                   -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
   *                   -XX:CompileThreshold=10000
-  *                   -server -XX:-TieredCompilation -XX:TypeProfileLevel=200
+  *                   -XX:-TieredCompilation -XX:TypeProfileLevel=200
   *                   -XX:+UnlockExperimentalVMOptions -XX:PerMethodSpecTrapLimit=5000 -XX:PerMethodTrapLimit=100
   *                    compiler.profiling.TestTypeProfiling
   */

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithG1.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithG1.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  * @requires vm.gc.G1
  * @requires vm.flavor == "server" & !vm.emulatedClient
  * @summary Stress the G1 GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -server -XX:+UseG1GC gc.stress.gcbasher.TestGCBasherWithG1 120000
+ * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -XX:+UseG1GC gc.stress.gcbasher.TestGCBasherWithG1 120000
  */
 public class TestGCBasherWithG1 {
     public static void main(String[] args) throws IOException {

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithParallel.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithParallel.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  * @requires vm.gc.Parallel
  * @requires vm.flavor == "server" & !vm.emulatedClient
  * @summary Stress the Parallel GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -server -XX:+UseParallelGC -XX:-UseGCOverheadLimit gc.stress.gcbasher.TestGCBasherWithParallel 120000
+ * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -XX:+UseParallelGC -XX:-UseGCOverheadLimit gc.stress.gcbasher.TestGCBasherWithParallel 120000
  */
 public class TestGCBasherWithParallel {
     public static void main(String[] args) throws IOException {

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithSerial.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithSerial.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  * @requires vm.gc.Serial
  * @requires vm.flavor == "server" & !vm.emulatedClient
  * @summary Stress the Serial GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -server -XX:+UseSerialGC gc.stress.gcbasher.TestGCBasherWithSerial 120000
+ * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -XX:+UseSerialGC gc.stress.gcbasher.TestGCBasherWithSerial 120000
  */
 public class TestGCBasherWithSerial {
     public static void main(String[] args) throws IOException {

--- a/test/hotspot/jtreg/runtime/CDSCompressedKPtrs/XShareAuto.java
+++ b/test/hotspot/jtreg/runtime/CDSCompressedKPtrs/XShareAuto.java
@@ -25,8 +25,7 @@
  * @test
  * @requires vm.cds
  * @requires vm.flagless
- * @bug 8005933
- * @summary -Xshare:auto is the default when -Xshare is not specified
+ * @summary -Xshare:auto is the default
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/CDSCompressedKPtrs/XShareAuto.java
+++ b/test/hotspot/jtreg/runtime/CDSCompressedKPtrs/XShareAuto.java
@@ -40,7 +40,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class XShareAuto {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
-            "-server", "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+UnlockDiagnosticVMOptions",
             "-XX:SharedArchiveFile=./XShareAuto.jsa", "-Xshare:dump", "-Xlog:cds");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("Loading classes to share");


### PR DESCRIPTION
Please review the `Arguments::parse_each_vm_init_arg` change to ignore`-server|-client` options, which avoids unrecognized option error on static JDK. 

On regular JDK, '-server|-client' options are processed/removed from command-line arguments by `CheckJvmType` during `CreateExecutionEnvironment`. That happens before `Arguments::parse_each_vm_init_arg` is called. With jvm.cfg setting, only server vm is known and client is ignored. So specifying '-server' and '-client' in command-line is really a no-op. 

On static JDK, the VM is statically linked with the launcher, and `CreateExecutionEnvironment` & `CheckJvmType` are not called. As the result, `Arguments::parse_each_vm_init_arg` could see `-server|-client` when running on static JDK, if the options are specified in the command line.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350982](https://bugs.openjdk.org/browse/JDK-8350982): -server|-client causes fatal exception on static JDK (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [3189513d](https://git.openjdk.org/jdk/pull/23881/files/3189513db2a579427d55e062a137eea31b5e1a5e)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23881/head:pull/23881` \
`$ git checkout pull/23881`

Update a local copy of the PR: \
`$ git checkout pull/23881` \
`$ git pull https://git.openjdk.org/jdk.git pull/23881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23881`

View PR using the GUI difftool: \
`$ git pr show -t 23881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23881.diff">https://git.openjdk.org/jdk/pull/23881.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23881#issuecomment-2695975057)
</details>
