### PR TITLE
8351081: Off-by-one error in ShenandoahCardCluster

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -402,7 +402,7 @@ public:
 
   ShenandoahCardCluster(ShenandoahDirectCardMarkRememberedSet* rs) {
     _rs = rs;
-    _object_starts = NEW_C_HEAP_ARRAY(crossing_info, rs->total_cards(), mtGC);
+    _object_starts = NEW_C_HEAP_ARRAY(crossing_info, rs->total_cards() + 1, mtGC); // the +1 is to account for card table guarding entry
     for (size_t i = 0; i < rs->total_cards(); i++) {
       _object_starts[i].short_word = 0;
     }


### PR DESCRIPTION
Given certain values for the variables in [this expression](https://github.com/openjdk/jdk/blob/a87dd1a75f78cf872df49bea83ba48af8acfa2fd/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp#L173) the result of the computation can be equal to `_ rs->total_cards()` which will lead to segmentation fault, for instance in [starts_object(card_at_end)](https://github.com/openjdk/jdk/blob/a87dd1a75f78cf872df49bea83ba48af8acfa2fd/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp#L393). The problem happens, though, because the `_object_starts` array doesn't have a [guarding entry](https://github.com/openjdk/jdk/blob/a87dd1a75f78cf872df49bea83ba48af8acfa2fd/src/hotspot/share/gc/shenandoah/shenandoahCardTable.cpp#L37) at the end. This pull request adjusts the allocation of `_object_starts` to include an additional entry at the end to account for this situation.

Tested with JTREG tier 1-4, x86_64 & AArch64 on Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351081](https://bugs.openjdk.org/browse/JDK-8351081): Off-by-one error in ShenandoahCardCluster (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23882/head:pull/23882` \
`$ git checkout pull/23882`

Update a local copy of the PR: \
`$ git checkout pull/23882` \
`$ git pull https://git.openjdk.org/jdk.git pull/23882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23882`

View PR using the GUI difftool: \
`$ git pr show -t 23882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23882.diff">https://git.openjdk.org/jdk/pull/23882.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23882#issuecomment-2696141970)
</details>
