### PR TITLE
8351115: Test AOTClassLinkingVMOptions.java fails after JDK-8348322

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/AOTClassLinkingVMOptions.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/AOTClassLinkingVMOptions.java
@@ -82,7 +82,7 @@ public class AOTClassLinkingVMOptions {
 
         // Dumping with AOTInvokeDynamicLinking disabled
         TestCommon.testDump(appJar, TestCommon.list("Hello"),
-                            "-XX:+AOTClassLinking", "-XX:-AOTInvokeDynamicLinking");
+                            "-XX:+UnlockDiagnosticVMOptions", "-XX:+AOTClassLinking", "-XX:-AOTInvokeDynamicLinking");
 
         testCase("Archived full module graph must be enabled at runtime (with -XX:-AOTInvokeDynamicLinking)");
         TestCommon.run("-cp", appJar, "-Djdk.module.validation=1", "Hello")


### PR DESCRIPTION
Hi all,

Test runtime/cds/appcds/aotClassLinking/AOTClassLinkingVMOptions.java fails "VM option 'AOTInvokeDynamicLinking' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions" after JDK-8348322. This PR add JVM option '-XX:+UnlockDiagnosticVMOptions' to make test run passes.

Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351115](https://bugs.openjdk.org/browse/JDK-8351115): Test AOTClassLinkingVMOptions.java fails after JDK-8348322 (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23883/head:pull/23883` \
`$ git checkout pull/23883`

Update a local copy of the PR: \
`$ git checkout pull/23883` \
`$ git pull https://git.openjdk.org/jdk.git pull/23883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23883`

View PR using the GUI difftool: \
`$ git pr show -t 23883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23883.diff">https://git.openjdk.org/jdk/pull/23883.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23883#issuecomment-2696374573)
</details>
