### PR TITLE
8333578: Fix uses of overaligned types induced by ZCACHE_ALIGNED

### DIFF
--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -220,9 +220,10 @@ size_t ZArguments::heap_virtual_to_physical_ratio() {
 }
 
 CollectedHeap* ZArguments::create_heap() {
-  // ZCollectedHeap has an alignment >= ZCacheLineSize, which may be larger than
-  // std::max_align_t. Instead of using operator new, align the storage manually
-  // and construct the ZCollectedHeap using operator placement new
+  // ZCollectedHeap has an alignment greater than or equal to ZCacheLineSize,
+  // which may be larger than std::max_align_t. Instead of using operator new,
+  // align the storage manually and construct the ZCollectedHeap using operator
+  // placement new.
 
   static_assert(alignof(ZCollectedHeap) >= ZCacheLineSize,
                 "ZCollectedHeap is no longer ZCacheLineSize aligned");

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -21,12 +21,13 @@
  * questions.
  */
 
+#include "gc/shared/gcArguments.hpp"
 #include "gc/z/zAddressSpaceLimit.hpp"
 #include "gc/z/zArguments.hpp"
 #include "gc/z/zCollectedHeap.hpp"
 #include "gc/z/zGlobals.hpp"
 #include "gc/z/zHeuristics.hpp"
-#include "gc/shared/gcArguments.hpp"
+#include "gc/z/zUtils.inline.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
@@ -219,7 +220,20 @@ size_t ZArguments::heap_virtual_to_physical_ratio() {
 }
 
 CollectedHeap* ZArguments::create_heap() {
-  return new ZCollectedHeap();
+  // ZCollectedHeap has an alignment >= ZCacheLineSize, which may be larger than
+  // std::max_align_t. Instead of using operator new, align the storage manually
+  // and construct the ZCollectedHeap using operator placement new
+
+  static_assert(alignof(ZCollectedHeap) >= ZCacheLineSize,
+                "ZCollectedHeap is no longer ZCacheLineSize aligned");
+
+  // Allocate aligned storage for ZCollectedHeap
+  const size_t alignment = alignof(ZCollectedHeap);
+  const size_t size = sizeof(ZCollectedHeap);
+  void* const addr = reinterpret_cast<void*>(ZUtils::alloc_aligned_unfreeable(alignment, size));
+
+  // Construct ZCollectedHeap in the aligned storage
+  return ::new (addr) ZCollectedHeap();
 }
 
 bool ZArguments::is_supported() const {


### PR DESCRIPTION
The only directly heap allocated, constructed object of types that are overaligned because of ZCACHE_ALIGNED is ZCollectedHeap. The other are either in static storage or contained in (and constructed as part of) ZCollectedHeap. So we only need to fix ZCollectedHeap allocation. 

As the CollectedHeap is only ever created once and is never destroyed, we can simply align the allocation and create an unfreeable pointer.

This implementation imposes that `ZCacheLineSize` is a power of two, but we already have this requirement elsewhere (e.g. `ZContendedStorage`).

Testing:
 * tier 1 through tier 5 Oracle supported platforms
 * GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333578](https://bugs.openjdk.org/browse/JDK-8333578): Fix uses of overaligned types induced by ZCACHE_ALIGNED (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) Review applies to [2c13edcd](https://git.openjdk.org/jdk/pull/23885/files/2c13edcd4168a4243eb1d2373db275526e0266cb)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23885/head:pull/23885` \
`$ git checkout pull/23885`

Update a local copy of the PR: \
`$ git checkout pull/23885` \
`$ git pull https://git.openjdk.org/jdk.git pull/23885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23885`

View PR using the GUI difftool: \
`$ git pr show -t 23885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23885.diff">https://git.openjdk.org/jdk/pull/23885.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23885#issuecomment-2696530457)
</details>
