### PR TITLE
8348638: Performance regression in Math.tanh

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_tanh.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_tanh.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2024, Intel Corporation. All rights reserved.
+* Copyright (c) 2024, 2025, Intel Corporation. All rights reserved.
 * Intel Math Library (LIBM) Source Code
 *
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_tanh.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_tanh.cpp
@@ -46,7 +46,7 @@
 //                      for |x| in [23/64,3*2^7)
 // e^{-2*|x|}=2^{-k-f}*2^{-r} ~ 2^{-k}*(Tn+Dn)*(1+p)=(T0+D0)*(1+p)
 //
-// For |x| in [2^{-4},20):
+// For |x| in [2^{-4},22):
 //         2^{-r}-1 ~ p=c1*r+c2*r^2+..+c5*r^5
 //      Let R=1/(1+T0+p*T0), truncated to 35 significant bits
 //  R=1/(1+T0+D0+p*(T0+D0))*(1+eps), |eps|<2^{-33}
@@ -66,7 +66,7 @@
 //
 // For |x|<2^{-64}:  x is returned
 //
-// For |x|>=20: return +/-1
+// For |x|>=22: return +/-1
 //
 // Special cases:
 //  tanh(NaN) = quiet NaN, and raise invalid exception
@@ -328,8 +328,8 @@ address StubGenerator::generate_libmTanh() {
   __ movl(rdx, 32768);
   __ andl(rdx, rcx);
   __ andl(rcx, 32767);
-  __ cmpl(rcx, 16436);
-  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_2_0_1); // Branch only if |x| >= 20
+  __ cmpl(rcx, 16438);
+  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_2_0_1); // Branch only if |x| >= 22
   __ movsd(xmm3, ExternalAddress(HALFMASK), r11 /*rscratch*/);
   __ xorpd(xmm4, xmm4);
   __ movsd(xmm1, ExternalAddress(L2E), r11 /*rscratch*/);
@@ -341,8 +341,8 @@ address StubGenerator::generate_libmTanh() {
   __ andnpd(xmm4, xmm0);
   __ pshufd(xmm5, xmm4, 68);
   __ subl(rcx, 16304);
-  __ cmpl(rcx, 132);
-  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_0_0_1); // Branch only if |x| is not in [2^{-4},20)
+  __ cmpl(rcx, 134);
+  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_0_0_1); // Branch only if |x| is not in [2^{-4},22)
   __ subsd(xmm4, xmm3);
   __ mulsd(xmm3, xmm1);
   __ mulsd(xmm2, xmm5);
@@ -429,7 +429,7 @@ address StubGenerator::generate_libmTanh() {
 
   __ bind(L_2TAG_PACKET_0_0_1);
   __ addl(rcx, 960);
-  __ cmpl(rcx, 1092);
+  __ cmpl(rcx, 1094);
   __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_1_0_1); // Branch only if |x| not in [2^{-64}, 2^{-4})
   __ movdqu(xmm2, ExternalAddress(pv), r11 /*rscratch*/);
   __ pshufd(xmm1, xmm0, 68);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_tanh.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_tanh.cpp
@@ -46,7 +46,7 @@
 //                      for |x| in [23/64,3*2^7)
 // e^{-2*|x|}=2^{-k-f}*2^{-r} ~ 2^{-k}*(Tn+Dn)*(1+p)=(T0+D0)*(1+p)
 //
-// For |x| in [2^{-4},2^5):
+// For |x| in [2^{-4},20):
 //         2^{-r}-1 ~ p=c1*r+c2*r^2+..+c5*r^5
 //      Let R=1/(1+T0+p*T0), truncated to 35 significant bits
 //  R=1/(1+T0+D0+p*(T0+D0))*(1+eps), |eps|<2^{-33}
@@ -66,11 +66,11 @@
 //
 // For |x|<2^{-64}:  x is returned
 //
-// For |x|>=2^32: return +/-1
+// For |x|>=20: return +/-1
 //
 // Special cases:
 //  tanh(NaN) = quiet NaN, and raise invalid exception
-//  tanh(INF) = that INF
+//  tanh(+/-INF) = +/-1
 //  tanh(+/-0) = +/-0
 //
 /******************************************************************************/
@@ -324,6 +324,12 @@ address StubGenerator::generate_libmTanh() {
   __ enter(); // required for proper stackwalking of RuntimeStub frame
 
   __ bind(B1_2);
+  __ pextrw(rcx, xmm0, 3);
+  __ movl(rdx, 32768);
+  __ andl(rdx, rcx);
+  __ andl(rcx, 32767);
+  __ cmpl(rcx, 16436);
+  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_2_0_1); // Branch only if |x| >= 20
   __ movsd(xmm3, ExternalAddress(HALFMASK), r11 /*rscratch*/);
   __ xorpd(xmm4, xmm4);
   __ movsd(xmm1, ExternalAddress(L2E), r11 /*rscratch*/);
@@ -331,16 +337,12 @@ address StubGenerator::generate_libmTanh() {
   __ movl(rax, 32768);
   __ pinsrw(xmm4, rax, 3);
   __ movsd(xmm6,  ExternalAddress(Shifter), r11 /*rscratch*/);
-  __ pextrw(rcx, xmm0, 3);
   __ andpd(xmm3, xmm0);
   __ andnpd(xmm4, xmm0);
   __ pshufd(xmm5, xmm4, 68);
-  __ movl(rdx, 32768);
-  __ andl(rdx, rcx);
-  __ andl(rcx, 32767);
   __ subl(rcx, 16304);
-  __ cmpl(rcx, 144);
-  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_0_0_1);
+  __ cmpl(rcx, 132);
+  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_0_0_1); // Branch only if |x| is not in [2^{-4},20)
   __ subsd(xmm4, xmm3);
   __ mulsd(xmm3, xmm1);
   __ mulsd(xmm2, xmm5);
@@ -427,8 +429,8 @@ address StubGenerator::generate_libmTanh() {
 
   __ bind(L_2TAG_PACKET_0_0_1);
   __ addl(rcx, 960);
-  __ cmpl(rcx, 1104);
-  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_1_0_1);
+  __ cmpl(rcx, 1092);
+  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_1_0_1); // Branch only if |x| not in [2^{-64}, 2^{-4})
   __ movdqu(xmm2, ExternalAddress(pv), r11 /*rscratch*/);
   __ pshufd(xmm1, xmm0, 68);
   __ movdqu(xmm3, ExternalAddress(pv + 16), r11 /*rscratch*/);
@@ -449,11 +451,8 @@ address StubGenerator::generate_libmTanh() {
   __ jmp(B1_4);
 
   __ bind(L_2TAG_PACKET_1_0_1);
-  __ addl(rcx, 15344);
-  __ cmpl(rcx, 16448);
-  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_2_0_1);
   __ cmpl(rcx, 16);
-  __ jcc(Assembler::below, L_2TAG_PACKET_3_0_1);
+  __ jcc(Assembler::below, L_2TAG_PACKET_3_0_1); // Branch only if |x| is denormalized
   __ xorpd(xmm2, xmm2);
   __ movl(rax, 17392);
   __ pinsrw(xmm2, rax, 3);
@@ -468,7 +467,7 @@ address StubGenerator::generate_libmTanh() {
 
   __ bind(L_2TAG_PACKET_2_0_1);
   __ cmpl(rcx, 32752);
-  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_4_0_1);
+  __ jcc(Assembler::aboveEqual, L_2TAG_PACKET_4_0_1); // Branch only if |x| is INF or NaN
   __ xorpd(xmm2, xmm2);
   __ movl(rcx, 15344);
   __ pinsrw(xmm2, rcx, 3);
@@ -489,7 +488,7 @@ address StubGenerator::generate_libmTanh() {
   __ movdl(rcx, xmm2);
   __ orl(rcx, rax);
   __ cmpl(rcx, 0);
-  __ jcc(Assembler::equal, L_2TAG_PACKET_5_0_1);
+  __ jcc(Assembler::equal, L_2TAG_PACKET_5_0_1); // Branch only if |x| is not NaN
   __ addsd(xmm0, xmm0);
 
   __ bind(B1_4);

--- a/test/micro/org/openjdk/bench/java/lang/MathBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/MathBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 package org.openjdk.bench.java.lang;
 
 import java.util.concurrent.TimeUnit;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.CompilerControl;
@@ -35,7 +34,6 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
@@ -63,21 +61,6 @@ public class MathBench {
     public long long1 = 1L, long2 = 2L, long747 = 747L, long13 = 13L;
     public float float1 = 1.0f, float2 = 2.0f, floatNegative99 = -99.0f, float7 = 7.0f, eFloat = 2.718f;
     public double double1 = 1.0d, double2 = 2.0d, double81 = 81.0d, doubleNegative12 = -12.0d, double4Dot1 = 4.1d, double0Dot5 = 0.5d;
-    public static final double constDoubleNegative2 = -2.0d, constDoubleNegative1 = -1.0d, constDouble0 = 0.0d, constDouble1 = 1.0d, constDouble2 = 2.0d;
-
-    @Param("2048")
-    public int tanhInputCount;
-
-    @Param({"0", "1", "2", "3"})
-    public int tanhRangeIndex;
-
-    public double [] tanhPosRandInputs;
-    public double [] tanhNegRandInputs;
-    public int tanhInputIndex = 0;
-    public double tanhRangeInputs[][] = { {0.0, 0x1.0P-55},
-                                          {0x1.0P-55, 1.0},
-                                          {1.0, 22.0},
-                                          {22.0, 1.7976931348623157E308} };
 
     @Setup
     public void setupValues() {
@@ -86,22 +69,6 @@ public class MathBench {
         divisor  = Math.abs(random.nextInt(dividend) + 17);
         longDividend = Math.abs(random.nextLong() + 4711L);
         longDivisor  = Math.abs(random.nextLong() + longDividend);
-
-        // Fill the positive and negative tanh vectors with random values
-        tanhPosRandInputs = new double[tanhInputCount];
-        tanhNegRandInputs = new double[tanhInputCount];
-        for (int i = 0; i < tanhInputCount; i++) {
-            double tanhLowerBound = tanhRangeInputs[tanhRangeIndex][0];
-            double tanhUpperBound = tanhRangeInputs[tanhRangeIndex][1];
-            tanhPosRandInputs[i] = random.nextDouble(tanhLowerBound, tanhUpperBound);
-            tanhNegRandInputs[i] = random.nextDouble(-tanhUpperBound, -tanhLowerBound);
-        }
-    }
-
-    @Setup(Level.Invocation)
-    public void updateIndices() {
-        // Update the tanh index for the next invocation
-        tanhInputIndex = (tanhInputIndex + 1) % tanhInputCount;
     }
 
     @Benchmark
@@ -551,38 +518,6 @@ public class MathBench {
     @Benchmark
     public double  tanhDouble() {
         return  Math.tanh(double1);
-    }
-
-    @Benchmark
-    public double  tanhConstDoubleNegative2() {
-        return  Math.tanh(constDoubleNegative2);
-    }
-
-    @Benchmark
-    public double  tanhConstDoubleNegative1() {
-        return  Math.tanh(constDoubleNegative1);
-    }
-
-    @Benchmark
-    public double  tanhConstDouble0() {
-        return  Math.tanh(constDouble0);
-    }
-
-    @Benchmark
-    public double  tanhConstDouble1() {
-        return  Math.tanh(constDouble1);
-    }
-
-    @Benchmark
-    public double  tanhConstDouble2() {
-        return  Math.tanh(constDouble2);
-    }
-
-    @Benchmark
-    public double  tanhRangeDouble() {
-        double posResult = Math.tanh(tanhPosRandInputs[tanhInputIndex]);
-        double negResult = Math.tanh(tanhNegRandInputs[tanhInputIndex]);
-        return  (posResult + negResult);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/MathBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/MathBench.java
@@ -64,8 +64,10 @@ public class MathBench {
     public float float1 = 1.0f, float2 = 2.0f, floatNegative99 = -99.0f, float7 = 7.0f, eFloat = 2.718f;
     public double double1 = 1.0d, double2 = 2.0d, double81 = 81.0d, doubleNegative12 = -12.0d, double4Dot1 = 4.1d, double0Dot5 = 0.5d;
 
-    @Param({"-2.0", "-1.0", "-0.5", "-0.1", "0.0", "0.1", "0.5", "1.0", "2.0"})
-    public double tanhConstInput;
+    public static final double tanhConstInputs[] = {-2.0, -1.0, -0.5, -0.1, 0.0, 0.1, 0.5, 1.0, 2.0};
+
+    @Param({"0", "1", "2", "3", "4", "5", "6", "7", "8"})
+    public int tanhConstIndex;
 
     @Param("2048")
     public int tanhInputCount;
@@ -101,7 +103,7 @@ public class MathBench {
     }
 
     @Setup(Level.Invocation)
-    public void updateEveryIndex() {
+    public void updateIndices() {
         // Update the tanh index for the next invocation
         tanhInputIndex = (tanhInputIndex + 1) % tanhInputCount;
     }
@@ -552,7 +554,7 @@ public class MathBench {
 
     @Benchmark
     public double  tanhDouble() {
-        return  Math.tanh(tanhConstInput);
+        return  Math.tanh(tanhConstInputs[tanhConstIndex]);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/MathBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/MathBench.java
@@ -63,11 +63,7 @@ public class MathBench {
     public long long1 = 1L, long2 = 2L, long747 = 747L, long13 = 13L;
     public float float1 = 1.0f, float2 = 2.0f, floatNegative99 = -99.0f, float7 = 7.0f, eFloat = 2.718f;
     public double double1 = 1.0d, double2 = 2.0d, double81 = 81.0d, doubleNegative12 = -12.0d, double4Dot1 = 4.1d, double0Dot5 = 0.5d;
-
-    public static final double tanhConstInputs[] = {-2.0, -1.0, -0.5, -0.1, 0.0, 0.1, 0.5, 1.0, 2.0};
-
-    @Param({"0", "1", "2", "3", "4", "5", "6", "7", "8"})
-    public int tanhConstIndex;
+    public static final double constDoubleNegative2 = -2.0d, constDoubleNegative1 = -1.0d, constDouble0 = 0.0d, constDouble1 = 1.0d, constDouble2 = 2.0d;
 
     @Param("2048")
     public int tanhInputCount;
@@ -554,7 +550,32 @@ public class MathBench {
 
     @Benchmark
     public double  tanhDouble() {
-        return  Math.tanh(tanhConstInputs[tanhConstIndex]);
+        return  Math.tanh(double1);
+    }
+
+    @Benchmark
+    public double  tanhConstDoubleNegative2() {
+        return  Math.tanh(constDoubleNegative2);
+    }
+
+    @Benchmark
+    public double  tanhConstDoubleNegative1() {
+        return  Math.tanh(constDoubleNegative1);
+    }
+
+    @Benchmark
+    public double  tanhConstDouble0() {
+        return  Math.tanh(constDouble0);
+    }
+
+    @Benchmark
+    public double  tanhConstDouble1() {
+        return  Math.tanh(constDouble1);
+    }
+
+    @Benchmark
+    public double  tanhConstDouble2() {
+        return  Math.tanh(constDouble2);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/MathBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/MathBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 package org.openjdk.bench.java.lang;
 
 import java.util.concurrent.TimeUnit;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.CompilerControl;
@@ -62,6 +63,18 @@ public class MathBench {
     public float float1 = 1.0f, float2 = 2.0f, floatNegative99 = -99.0f, float7 = 7.0f, eFloat = 2.718f;
     public double double1 = 1.0d, double2 = 2.0d, double81 = 81.0d, doubleNegative12 = -12.0d, double4Dot1 = 4.1d, double0Dot5 = 0.5d;
 
+    @Param("2048")
+    public int tanhValueCount;
+
+    @Param("0")
+    public double tanhBound1;
+
+    @Param("2.7755575615628914E-17")
+    public double tanhBound2;
+
+    public double [] tanhPosVector;
+    public double [] tanhNegVector;
+
     @Setup
     public void setupValues() {
         Random random = new Random(seed);
@@ -69,6 +82,14 @@ public class MathBench {
         divisor  = Math.abs(random.nextInt(dividend) + 17);
         longDividend = Math.abs(random.nextLong() + 4711L);
         longDivisor  = Math.abs(random.nextLong() + longDividend);
+
+        // Fill the positive and negative tanh vectors with random values
+        tanhPosVector = new double[tanhValueCount];
+        tanhNegVector = new double[tanhValueCount];
+        for (int i = 0; i < tanhValueCount; i++) {
+            tanhPosVector[i] = random.nextDouble(tanhBound1, tanhBound2);
+            tanhNegVector[i] = random.nextDouble(-tanhBound2, -tanhBound1);
+        }
     }
 
     @Benchmark
@@ -518,6 +539,15 @@ public class MathBench {
     @Benchmark
     public double  tanhDouble() {
         return  Math.tanh(double1);
+    }
+
+    @Benchmark
+    public double  tanhRangeDouble() {
+        double sum = 0.0;
+        for (int i = 0; i < tanhValueCount; i++) {
+            sum += Math.tanh(tanhPosVector[i]) + Math.tanh(tanhNegVector[i]);
+        }
+        return sum;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/TanhPerf.java
+++ b/test/micro/org/openjdk/bench/java/lang/TanhPerf.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Random;
+
+public class TanhPerf {
+
+    @Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.MILLISECONDS)
+    @Measurement(iterations = 4, time = 5, timeUnit = TimeUnit.MILLISECONDS)
+    @Fork(2)
+    @BenchmarkMode(Mode.Throughput)
+    @State(Scope.Thread)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public static class TanhPerfRanges {
+        public static int tanhInputCount = 2048;
+
+        @Param({"0", "1", "2", "3"})
+        public int tanhRangeIndex;
+
+        public double [] tanhPosRandInputs;
+        public double [] tanhNegRandInputs;
+        public int       tanhInputIndex = 0;
+        public double    tanhRangeInputs[][] = {{0.0, 0x1.0P-55}, {0x1.0P-55, 1.0}, {1.0, 22.0}, {22.1, 1.7976931348623157E308} };
+
+        @Setup
+        public void setupValues() {
+            Random random = new Random(1023);
+
+            // Fill the positive and negative tanh vectors with random values
+            tanhPosRandInputs = new double[tanhInputCount];
+            tanhNegRandInputs = new double[tanhInputCount];
+
+            for (int i = 0; i < tanhInputCount; i++) {
+                double tanhLowerBound = tanhRangeInputs[tanhRangeIndex][0];
+                double tanhUpperBound = tanhRangeInputs[tanhRangeIndex][1];
+                tanhPosRandInputs[i] = random.nextDouble(tanhLowerBound, tanhUpperBound);
+                tanhNegRandInputs[i] = random.nextDouble(-tanhUpperBound, -tanhLowerBound);
+            }
+        }
+
+        @Benchmark
+        @OperationsPerInvocation(2048)
+        public double  tanhPosRangeDouble() {
+            double res = 0.0;
+            for (int i = 0; i < tanhInputCount; i++) {
+                res += Math.tanh(tanhPosRandInputs[i]);
+            }
+            return res;
+        }
+
+        @Benchmark
+        @OperationsPerInvocation(2048)
+        public double  tanhNegRangeDouble() {
+            double res = 0.0;
+            for (int i = 0; i < tanhInputCount; i++) {
+                res += Math.tanh(tanhNegRandInputs[i]);
+            }
+            return res;
+        }
+    }
+
+    @Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
+    @Fork(2)
+    @BenchmarkMode(Mode.Throughput)
+    @State(Scope.Thread)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public static class TanhPerfConstant {
+        public static final double constDoubleTiny  = 0x1.0P-57;
+        public static final double constDoubleSmall = 0x1.0P-54;
+        public static final double constDouble1     = 1.0;
+        public static final double constDouble21    = 21.0;
+        public static final double constDoubleLarge = 23.0;
+
+        @Benchmark
+        public double  tanhConstDoubleTiny() {
+            return  Math.tanh(constDoubleTiny);
+        }
+
+        @Benchmark
+        public double  tanhConstDoubleSmall() {
+            return  Math.tanh(constDoubleSmall);
+        }
+
+        @Benchmark
+        public double  tanhConstDouble1() {
+            return  Math.tanh(constDouble1);
+        }
+
+        @Benchmark
+        public double  tanhConstDouble21() {
+            return  Math.tanh(constDouble21);
+        }
+
+        @Benchmark
+        public double  tanhConstDoubleLarge() {
+            return  Math.tanh(constDoubleLarge);
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(TanhPerfRanges.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+
+        opt = new OptionsBuilder()
+                .include(TanhPerfConstant.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
The changes described below are meant to resolve the performance regression introduced by the **x86_64 tanh** double precision floating point scalar intrinsic in #20657. Additionally, a new set of micro-benchmarks are included to check the performance of specific input value ranges to help prevent regressions in the future.

1. Check and handle high magnitude input values before those in other ranges. If found, **+/- 1** is returned almost immediately without having to go through too many computations or branches.
2. Reduce the lower bound of the input range that triggers a quick **+/- 1** return from **|x| >= 32** to **|x| >= 22**. This new endpoint is the exact value required for correctness that's used by the original OpenJDK implementation.

The results of all tests posted below were captured with an [Intel® Xeon 6761P](https://www.intel.com/content/www/us/en/products/sku/241842/intel-xeon-6761p-processor-336m-cache-2-50-ghz/specifications.html) using [OpenJDK v25-b15](https://github.com/openjdk/jdk/releases/tag/jdk-25%2B15) as the baseline version. The term _baseline1_ refers to runs with the intrinsic enabled and _baseline2_ refers to runs with the intrinsic disabled.

For the first set of performance data collected with the new built-in range micro-benchmark, see the tables below.  Each result is the mean of 8 individual runs, and the input ranges used match those in the bug report with two additional ones included. In all scenarios, the changes increase throughput values over _baseline1_. The uplift over _baseline1_ is quite significant for the high value (100, 1000, 10000, 100000) scenarios. When comparing against _baseline2_, the changes have significant uplift with the lower value inputs (1, 2, 10, 20, 100). However, they significantly lag behind _baseline2_ when the high value inputs (1000, 10000, 100000) are used.

| Input range(s)        | Baseline1 (ops/s) | Change (ops/s) | Change vs baseline1 (%) |
| :-------------------: | :-----------------: | :----------------: | :-------------------------: |
| [-1, 1]                     | 103342                | 103705              | +0.35                              |
| [-2, 2]                     | 99977                  | 100819              | +0.84                              |
| [-10, 10]                 | 99147                  | 100240              | +1.10                              |
| [-20, 20]                 | 99419                  | 99492                | +0.07                              |
| [-100, 100]             | 211935                | 302493              | +42.73                            |
| [-1000, 1000]         | 351433                | 473414              | +34.71                            |
| [-10000, 10000]     | 385111                | 500086              | +29.86                            |
| [-100000, 100000] | 385282                | 496482              | +28.86                            |

| Input range(s)        | Baseline2 (ops/s) | Change (ops/s) | Change vs baseline2 (%) |
| :-------------------: | :-----------------: | :----------------: | :-------------------------: |
| [-1, 1]                     | 98863                  | 103705              | +4.90                              |
| [-2, 2]                     | 86395                  | 100819              | +16.70                            |
| [-10, 10]                 | 76306                  | 100240              | +31.37                            |
| [-20, 20]                 | 75361                  | 99492                | +32.02                            |
| [-100, 100]             | 246487                | 302493              | +22.72                            |
| [-1000, 1000]         | 528518                | 473414              | -10.43                             |
| [-10000, 10000]     | 741077                | 500086              | -32.52                             |
| [-100000, 100000] | 1143458              | 496482              | -56.58                             |

For the second set of performance data collected with the new built in range micro-benchmark, see the tables below. Each result is the mean of 8 individual runs, and the input ranges used match those from the original Java implementation. Overall, the changes provide a significant uplift over _baseline1_ with the high input ranges, which is expected. However, there is a small reduction in throughput relative to _baseline1_ when very small input values are used due to the extra instructions required. When comparing against _baseline2_, the modified intrinsic significantly outperforms for the inputs (**2^-55 <= |x| <= 22**) that require heavy compute. However, the other inputs that trigger fast path returns still perform much better with _baseline2_ - especially the very small values.

| Input range(s)                   | Baseline1 (ops/s) | Change (ops/s) | Change vs baseline1 (%) |
| :---------------------------: | :-----------------: | :----------------: | :-------------------------: |
| [-2^(-55), 2^(-55)]            | 378100                | 365083             | -3.44                                |
| [-2^(-55), -1], [2^(-55), 1] | 102207                | 103634             | +1.40                               |
| [-22, -1], [1, 22]                 | 100503                | 99087               | -1.41                                |
| [-32, -22], [22, 32]             | 100240                | 501171             | +399.97                           |
| (-INF, -22], [22, INF)          | 386535                | 500196             | +29.41                             |

| Input range(s)                   | Baseline2 (ops/s) | Change (ops/s) | Change vs baseline2 (%) |
| :---------------------------: | :-----------------: | :----------------: | :-------------------------: |
| [-2^(-55), 2^(-55)]            | 1222331              | 365083              | -70.13                             |
| [-2^(-55), -1], [2^(-55), 1] | 99043                  | 103634              | +4.64                              |
| [-22, -1], [1, 22]                 | 74562                  | 99087                | +32.89                            |
| [-32, -22], [22, 32]             | 1496889              | 501171              | -66.52                             |
| (-INF, -22], [22, INF)          | 1490684              | 500196              | -66.45                             |

Finally, the `jtreg:test/jdk/java/lang/Math/HyperbolicTests.java` test passed with the changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348638](https://bugs.openjdk.org/browse/JDK-8348638): Performance regression in Math.tanh (**Bug** - P3)


### Reviewers
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**) Review applies to [ced66426](https://git.openjdk.org/jdk/pull/23889/files/ced66426c65f534304f625479407063dca4b8bb4)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23889/head:pull/23889` \
`$ git checkout pull/23889`

Update a local copy of the PR: \
`$ git checkout pull/23889` \
`$ git pull https://git.openjdk.org/jdk.git pull/23889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23889`

View PR using the GUI difftool: \
`$ git pr show -t 23889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23889.diff">https://git.openjdk.org/jdk/pull/23889.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23889#issuecomment-2744734510)
</details>
