### PR TITLE
8351154: Use -ftrivial-auto-var-init=pattern for clang too

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -482,7 +482,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   else
     DEBUG_CFLAGS_JDK="-DDEBUG"
 
-    if test "x$TOOLCHAIN_TYPE" = xgcc; then
+    if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang ; then
       INIT_PATTERN_FLAG="-ftrivial-auto-var-init=pattern"
       FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [$INIT_PATTERN_FLAG],
           IF_TRUE: [


### PR DESCRIPTION
This is a trivial (no pun intended) follow-up to [JDK-8345627](https://bugs.openjdk.org/browse/JDK-8345627), which just enables the -ftrivial-auto-var-init=pattern on debug builds for clang too. In contrast to gcc, the clang option did not trigger any additional warnings, so it is just about enabling the flag for debug builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351154](https://bugs.openjdk.org/browse/JDK-8351154): Use -ftrivial-auto-var-init=pattern for clang too (**Enhancement** - P3)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23892/head:pull/23892` \
`$ git checkout pull/23892`

Update a local copy of the PR: \
`$ git checkout pull/23892` \
`$ git pull https://git.openjdk.org/jdk.git pull/23892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23892`

View PR using the GUI difftool: \
`$ git pr show -t 23892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23892.diff">https://git.openjdk.org/jdk/pull/23892.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23892#issuecomment-2697228208)
</details>
