### PR TITLE
8350663: AArch64: Enable UseSignumIntrinsic by default

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -161,9 +161,6 @@ void VM_Version::initialize() {
         (_model == CPU_MODEL_AMPERE_1A || _model == CPU_MODEL_AMPERE_1B)) {
       FLAG_SET_DEFAULT(CodeEntryAlignment, 32);
     }
-    if (FLAG_IS_DEFAULT(UseSignumIntrinsic)) {
-      FLAG_SET_DEFAULT(UseSignumIntrinsic, true);
-    }
   }
 
   // ThunderX
@@ -243,7 +240,7 @@ void VM_Version::initialize() {
     }
   }
 
-  if (_cpu == CPU_ARM) {
+  if (_features & (CPU_FP | CPU_ASIMD)) {
     if (FLAG_IS_DEFAULT(UseSignumIntrinsic)) {
       FLAG_SET_DEFAULT(UseSignumIntrinsic, true);
     }


### PR DESCRIPTION
According to tests on Arm CPUs Neoverse-N1/N2/V1/V2 and Ampere-Altra/AmpereOne, `-XX:+UseSignumIntrinsic` can provide consistent positive performance boost on singnum microbenchmarks (1-4,5,7 in below list) and no obvious regression (ops/s change <0.1%) on other relevant tests (6,9-12). In addition, "_Apple M1 shows no regression with signum intrinsics_" (verified by @theRealAph). So, it can be the time to enable this UseSignumIntrinsic flag by default for aarch64-port. By the way, x86 and riscv ports have already configured it on by default. 

Tests: passed JTReg tier1 tests on Ampere-1A, no regression found, and particularly checked test results of two signum cases (13,14), both are in good state.

```
1. org.openjdk.bench.java.lang.MathBench.signumDouble
2. org.openjdk.bench.java.lang.MathBench.signumFloat
3. org.openjdk.bench.java.lang.StrictMathBench.sigNumDouble
4. org.openjdk.bench.java.lang.StrictMathBench.signumFloat
5. org.openjdk.bench.vm.compiler.Signum._1_signumFloatTest
6. org.openjdk.bench.vm.compiler.Signum._2_overheadFloat
7. org.openjdk.bench.vm.compiler.Signum._3_signumDoubleTest
8. org.openjdk.bench.vm.compiler.Signum._4_overheadDouble
9. org.openjdk.bench.vm.compiler.Signum._5_copySignFloatTest
10. org.openjdk.bench.vm.compiler.Signum._6_overheadCopySignFloat
11. org.openjdk.bench.vm.compiler.Signum._7_copySignDoubleTest
12. org.openjdk.bench.vm.compiler.Signum._8_overheadCopySignDouble
13. JTReg: compiler/vectorization/TestSignumVector.java
14. JTReg: compiler/intrinsics/math/TestSignumIntrinsic.java

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350663](https://bugs.openjdk.org/browse/JDK-8350663): AArch64: Enable UseSignumIntrinsic by default (**Enhancement** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23893/head:pull/23893` \
`$ git checkout pull/23893`

Update a local copy of the PR: \
`$ git checkout pull/23893` \
`$ git pull https://git.openjdk.org/jdk.git pull/23893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23893`

View PR using the GUI difftool: \
`$ git pr show -t 23893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23893.diff">https://git.openjdk.org/jdk/pull/23893.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23893#issuecomment-2697233830)
</details>
