### PR TITLE
8219408: Tests should handle ${} in the view of jtreg "smart action"

### DIFF
--- a/test/jdk/com/sun/security/auth/login/ConfigFile/TEST.properties
+++ b/test/jdk/com/sun/security/auth/login/ConfigFile/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8219408 is fixed
-allowSmartActionArgs=false

--- a/test/jdk/java/security/Security/SecurityPropFile/TEST.properties
+++ b/test/jdk/java/security/Security/SecurityPropFile/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8219408 is fixed
-allowSmartActionArgs=false

--- a/test/jdk/javax/security/auth/login/TEST.properties
+++ b/test/jdk/javax/security/auth/login/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8219408 is fixed
-allowSmartActionArgs=false

--- a/test/jdk/sun/security/util/Resources/TEST.properties
+++ b/test/jdk/sun/security/util/Resources/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8219408 is fixed
-allowSmartActionArgs=false


### PR DESCRIPTION
In this PR I removed TEST.properties files that disabled smart action tags. It is safe to remove the entire file: the smart action tags was the only directive in them. I verified the affected tests pass successfully.