### PR TITLE
8350595: jshell <TAB> completion on arrays does not work for clone()

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -54,10 +54,12 @@ import com.sun.tools.javac.api.JavacScope;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.CompletionFailure;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ClassType;
+import com.sun.tools.javac.code.Type.MethodType;
 import com.sun.tools.javac.parser.Scanner;
 import com.sun.tools.javac.parser.ScannerFactory;
 import com.sun.tools.javac.parser.Tokens.Token;
@@ -1073,7 +1075,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
                 if (jlObject != null) {
                     result.addAll(membersOf(at, jlObject));
                 }
-                result.add(createArrayLengthSymbol(at, site));
+                result.addAll(createArraySymbols(at, site));
                 if (shouldGenerateDotClassItem)
                     result.add(createDotClassSymbol(at, site));
                 return result;
@@ -1161,11 +1163,21 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
         return existing;
     }
 
-    private Element createArrayLengthSymbol(AnalyzeTask at, TypeMirror site) {
-        Name length = Names.instance(at.getContext()).length;
-        Type intType = Symtab.instance(at.getContext()).intType;
+    private List<Element> createArraySymbols(AnalyzeTask at, TypeMirror site) {
+        Symtab syms = Symtab.instance(at.getContext());
+        Names names = Names.instance(at.getContext());
+        Name length = names.length;
+        Name clone = names.clone;
+        Type lengthType = syms.intType;
+        Type cloneType = new MethodType(com.sun.tools.javac.util.List.<Type>nil(),
+                                        (Type) site,
+                                        com.sun.tools.javac.util.List.<Type>nil(),
+                                        syms.methodClass);
 
-        return new VarSymbol(Flags.PUBLIC | Flags.FINAL, length, intType, ((Type) site).tsym);
+        return List.of(
+                new VarSymbol(Flags.PUBLIC | Flags.FINAL, length, lengthType, ((Type) site).tsym),
+                new MethodSymbol(Flags.PUBLIC | Flags.FINAL, clone, cloneType, ((Type) site).tsym)
+        );
     }
 
     private Element createDotClassSymbol(AnalyzeTask at, TypeMirror site) {

--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8131025 8141092 8153761 8145263 8131019 8175886 8176184 8176241 8176110 8177466 8197439 8221759 8234896 8240658 8278039 8286206 8296789 8314662 8326333
+ * @bug 8131025 8141092 8153761 8145263 8131019 8175886 8176184 8176241 8176110 8177466 8197439 8221759 8234896 8240658 8278039 8286206 8296789 8314662 8326333 8326333
  * @summary Test Completion and Documentation
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -812,13 +812,16 @@ public class CompletionSuggestionTest extends KullaTesting {
     }
 
     //JDK-8326333: verify completion returns sensible output for arrays:
+    //JDK-8326333: jshell <TAB> completion on arrays is incomplete
     public void testArray() {
         assertEval("String[] strs = null;");
         assertCompletion("strs.to|", "toString()");
         assertCompletion("strs.le|", "length");
+        assertCompletion("strs.cl|", "clone()");
         assertEval("int[] ints = null;");
         assertCompletion("ints.no|", "notify()", "notifyAll()");
         assertCompletion("ints.le|", "length");
+        assertCompletion("ints.cl|", "clone()");
         assertCompletion("String[].|", "class");
     }
 }


### PR DESCRIPTION
Adding the `clone()` method to JShell's code completion for arrays.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8350595: jshell <TAB> completion on arrays does not work for clone()`

### Issue
 * [JDK-8350595](https://bugs.openjdk.org/browse/JDK-8350595): jshell &lt;TAB&gt; completion on arrays does not work for clone() (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23899/head:pull/23899` \
`$ git checkout pull/23899`

Update a local copy of the PR: \
`$ git checkout pull/23899` \
`$ git pull https://git.openjdk.org/jdk.git pull/23899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23899`

View PR using the GUI difftool: \
`$ git pr show -t 23899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23899.diff">https://git.openjdk.org/jdk/pull/23899.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23899#issuecomment-2697619146)
</details>
