### PR TITLE
JDK-8350952: Remove some non present files from OPT_SPEED_SRC list

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -224,11 +224,9 @@ ifeq ($(call check-jvm-feature, opt-size), true)
       frame_ppc.cpp \
       frame_s390.cpp \
       frame_x86.cpp \
-      genCollectedHeap.cpp \
       generation.cpp \
       growableArray.cpp \
       handles.cpp \
-      hashtable.cpp \
       heap.cpp \
       icache.cpp \
       icache_arm.cpp \
@@ -246,7 +244,6 @@ ifeq ($(call check-jvm-feature, opt-size), true)
       linkResolver.cpp \
       klass.cpp \
       klassVtable.cpp \
-      markSweep.cpp \
       memRegion.cpp \
       memoryPool.cpp \
       method.cpp \


### PR DESCRIPTION
JvmFeatures.gmk contains a file list OPT_SPEED_SRC , the list contains files that have to be optimized for speed when the other files are optimized for binary size.
However some non present files are mentioned and should be removed e.g.
genCollectedHeap.cpp
hashtable.cpp
markSweep.cpp
Maybe they were present in old releases.