### PR TITLE
8351145: RISC-V: only enable some crypto intrinsic when AvoidUnalignedAccess == false

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -126,10 +126,6 @@ void VM_Version::common_initialize() {
     FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
   }
 
-  if (FLAG_IS_DEFAULT(UsePoly1305Intrinsics)) {
-    FLAG_SET_DEFAULT(UsePoly1305Intrinsics, true);
-  }
-
   if (FLAG_IS_DEFAULT(UseCopySignIntrinsic)) {
       FLAG_SET_DEFAULT(UseCopySignIntrinsic, true);
   }
@@ -151,6 +147,10 @@ void VM_Version::common_initialize() {
   if (FLAG_IS_DEFAULT(AvoidUnalignedAccesses)) {
     FLAG_SET_DEFAULT(AvoidUnalignedAccesses,
       unaligned_access.value() != MISALIGNED_FAST);
+  }
+
+  if (FLAG_IS_DEFAULT(UsePoly1305Intrinsics) && !AvoidUnalignedAccesses) {
+    FLAG_SET_DEFAULT(UsePoly1305Intrinsics, true);
   }
 
   // See JDK-8026049
@@ -314,7 +314,7 @@ void VM_Version::c2_initialize() {
     FLAG_SET_DEFAULT(UseMontgomerySquareIntrinsic, true);
   }
 
-  if (FLAG_IS_DEFAULT(UseMD5Intrinsics)) {
+  if (FLAG_IS_DEFAULT(UseMD5Intrinsics) && !AvoidUnalignedAccesses) {
     FLAG_SET_DEFAULT(UseMD5Intrinsics, true);
   }
 
@@ -365,7 +365,7 @@ void VM_Version::c2_initialize() {
 
   // SHA-1, no RVV required though.
   if (UseSHA) {
-    if (FLAG_IS_DEFAULT(UseSHA1Intrinsics)) {
+    if (FLAG_IS_DEFAULT(UseSHA1Intrinsics) && !AvoidUnalignedAccesses) {
       FLAG_SET_DEFAULT(UseSHA1Intrinsics, true);
     }
   } else if (UseSHA1Intrinsics) {


### PR DESCRIPTION
Hi,
Can you help to review the patch?

Depending whether a cpu supports fast misaligned access or not, the misaligned access can impact the performance a lot.
Some crypto intrinsic implementation on riscv do not consider data alignment and just use `ld` to load input byte array, and seems there is no way to do it, the main reason is that at java API level, the input byte array to these JVM intrinsic could be part of a real java array, so the input byte array could be 1/2...7 byte aligned.
And with the introduction of COH, it would be even complicated to do the input data alignment.

So, for the consistency of performance, seems it's better to disable these intrinsics when AvoidUnalignedAccess == true.
And the user can still enable the intrinsics explicitly on a CPU with AvoidUnalignedAccess == true if they want so.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351145](https://bugs.openjdk.org/browse/JDK-8351145): RISC-V: only enable some crypto intrinsic when AvoidUnalignedAccess == false (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23903/head:pull/23903` \
`$ git checkout pull/23903`

Update a local copy of the PR: \
`$ git checkout pull/23903` \
`$ git pull https://git.openjdk.org/jdk.git pull/23903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23903`

View PR using the GUI difftool: \
`$ git pr show -t 23903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23903.diff">https://git.openjdk.org/jdk/pull/23903.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23903#issuecomment-2698213277)
</details>
