### PR TITLE
8351138: Running subset of gtests gets error printing result information

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -539,12 +539,11 @@ define SetupRunGtestTestBody
 	  $$(if $$($1_PASSED), , $$(eval $1_PASSED := 0)) \
 	  $$(eval $1_SKIPPED := $$(shell $$(AWK) \
 	      '/YOU HAVE [0-9]+ DISABLED TEST/ { \
-	          if (match($$$$0, /[0-9]+/, arr)) { \
-	            print arr[0]; \
+	          if (match($$$$0, /YOU HAVE ([0-9]+) DISABLED TEST/, arr)) { \
+	            print arr[1]; \
 	            found=1; \
-	          } \
-	          if (!found) { print 0; } \
-	      }' \
+	          } } END \
+	          { if (!found) print 0; }' \
 	      $$($1_RESULT_FILE))) \
 	  $$(eval $1_FAILED := $$(shell $$(AWK) '/\[  FAILED  \] .* tests?, \
 	      listed below/ { print $$$$4 }' $$($1_RESULT_FILE))) \


### PR DESCRIPTION
Hi all,

This PR fix the makefile bug when there is no gtest 'disable tests' will report syntax error.

Before this PR makefile used below command to get the 'disable tests' number, when there is no 'YOU HAVE [0-9]+ DISABLED TEST' string line in gtest result file gtest.txt, this gawk command will not print anything, so shell report syntax error later.

```shell
gawk '/YOU HAVE [0-9]+ DISABLED TEST/ { if (match($0, /[0-9]+/, arr)) { print arr[0]; found=1; } if (!found) { print 0; } }' build/linux-x86_64-server-release/test-results/gtest_Align_server/gtest.txt
```

After this PR makefile will use below command to get the 'disable tests' number.

```shell
gawk '/YOU HAVE [0-9]+ DISABLED TEST/ { if (match($0, /YOU HAVE ([0-9]+) DISABLED TEST/, arr)) { print arr[1]; found=1; } } END { if (!found) print 0; }' build/linux-x86_64-server-release/test-results/gtest_Align_server/gtest.txt
```

Additional testing:

- [ ] make test TEST=gtest:Align > test-Alian.log
- [ ] time make test TEST=gtest > test-all.log

[test-all.log](https://github.com/user-attachments/files/19074190/test-all.log)
[test-Alian.log](https://github.com/user-attachments/files/19074189/test-Alian.log)

