### PR TITLE
8350542: Optional.orElseThrow(Supplier) does not specify behavior when supplier returns null

### DIFF
--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -394,7 +394,7 @@ public final class Optional<T> {
      * @return the value, if present
      * @throws X if no value is present
      * @throws NullPointerException if no value is present and the exception
-     *         supplying function or produces a {@code null} result 
+     *         supplying function or produces a {@code null} result
      */
     public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
         if (value != null) {

--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -394,7 +394,7 @@ public final class Optional<T> {
      * @return the value, if present
      * @throws X if no value is present
      * @throws NullPointerException if no value is present and the exception
-     *         supplying function or produces a {@code null} result
+     *         supplying function is {@code null} or produces a {@code null} result
      */
     public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
         if (value != null) {

--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -394,7 +394,7 @@ public final class Optional<T> {
      * @return the value, if present
      * @throws X if no value is present
      * @throws NullPointerException if no value is present and the exception
-     *         supplying function or its result is {@code null}
+     *         supplying function or produces a {@code null} result 
      */
     public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
         if (value != null) {

--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -393,7 +393,7 @@ public final class Optional<T> {
      *        exception to be thrown
      * @return the value, if present
      * @throws X if no value is present
-     * @throws NullPointerException if no value is present and the exception 
+     * @throws NullPointerException if no value is present and the exception
      *         supplying function or its result is {@code null}
      */
     public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {

--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -393,8 +393,8 @@ public final class Optional<T> {
      *        exception to be thrown
      * @return the value, if present
      * @throws X if no value is present
-     * @throws NullPointerException if no value is present and the exception
-     *          supplying function is {@code null}
+     * @throws NullPointerException if no value is present and the exception 
+     *         supplying function or its result is {@code null}
      */
     public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
         if (value != null) {


### PR DESCRIPTION
Javadoc for java.util.Optional.orElseThrow(Supplier) misses mentioning of another possible cause of a NullPointerException - when the exception supplying function returns a null result.
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8354953](https://bugs.openjdk.org/browse/JDK-8354953) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ The pull request body must not be empty.

### Issues
 * [JDK-8350542](https://bugs.openjdk.org/browse/JDK-8350542): Optional.orElseThrow(Supplier) does not specify behavior when supplier returns null (**Enhancement** - P4)
 * [JDK-8354953](https://bugs.openjdk.org/browse/JDK-8354953): Optional.orElseThrow(Supplier) does not specify behavior when supplier returns null (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23905/head:pull/23905` \
`$ git checkout pull/23905`

Update a local copy of the PR: \
`$ git checkout pull/23905` \
`$ git pull https://git.openjdk.org/jdk.git pull/23905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23905`

View PR using the GUI difftool: \
`$ git pr show -t 23905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23905.diff">https://git.openjdk.org/jdk/pull/23905.diff</a>

</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8354953](https://bugs.openjdk.org/browse/JDK-8354953) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8350542](https://bugs.openjdk.org/browse/JDK-8350542): Optional.orElseThrow(Supplier) does not specify behavior when supplier returns null (**Enhancement** - P4)
 * [JDK-8354953](https://bugs.openjdk.org/browse/JDK-8354953): Optional.orElseThrow(Supplier) does not specify behavior when supplier returns null (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23905/head:pull/23905` \
`$ git checkout pull/23905`

Update a local copy of the PR: \
`$ git checkout pull/23905` \
`$ git pull https://git.openjdk.org/jdk.git pull/23905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23905`

View PR using the GUI difftool: \
`$ git pr show -t 23905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23905.diff">https://git.openjdk.org/jdk/pull/23905.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23905#issuecomment-2836703908)
</details>
