### PR TITLE
8351167: ZGC: Lazily initialize livemap

### DIFF
--- a/src/hotspot/share/gc/z/zLiveMap.hpp
+++ b/src/hotspot/share/gc/z/zLiveMap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zLiveMap.hpp
+++ b/src/hotspot/share/gc/z/zLiveMap.hpp
@@ -42,6 +42,7 @@ private:
   volatile size_t   _live_bytes;
   BitMap::bm_word_t _segment_live_bits;
   BitMap::bm_word_t _segment_claim_bits;
+  size_t            _bitmap_size;
   ZBitMap           _bitmap;
   int               _segment_shift;
 
@@ -64,6 +65,8 @@ private:
   BitMap::idx_t index_to_segment(BitMap::idx_t index) const;
 
   bool claim_segment(BitMap::idx_t segment);
+
+  void allocate_bitmap();
 
   void reset(ZGenerationId id);
   void reset_segment(BitMap::idx_t segment);

--- a/src/hotspot/share/gc/z/zLiveMap.inline.hpp
+++ b/src/hotspot/share/gc/z/zLiveMap.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zLiveMap.inline.hpp
+++ b/src/hotspot/share/gc/z/zLiveMap.inline.hpp
@@ -88,7 +88,7 @@ inline BitMap::idx_t ZLiveMap::next_live_segment(BitMap::idx_t segment) const {
 }
 
 inline BitMap::idx_t ZLiveMap::segment_size() const {
-  return _bitmap.size() / NumSegments;
+  return _bitmap_size / NumSegments;
 }
 
 inline BitMap::idx_t ZLiveMap::index_to_segment(BitMap::idx_t index) const {

--- a/src/hotspot/share/gc/z/zPage.inline.hpp
+++ b/src/hotspot/share/gc/z/zPage.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zPage.inline.hpp
+++ b/src/hotspot/share/gc/z/zPage.inline.hpp
@@ -76,7 +76,7 @@ inline uint32_t ZPage::object_max_count() const {
     return 1;
 
   default:
-    return (uint32_t)(size() >> object_alignment_shift());
+    return checked_cast<uint32_t>(size() >> object_alignment_shift());
   }
 }
 


### PR DESCRIPTION
Memory for the bitmap inside the livemap of a ZPage is currently allocated upon calling its constructor, which adds a latency overhead when allocating pages. As preparation for the Mapped Cache ([JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441)), but also as a standalone improvement, we want to instead lazily initialize the livemap's bitmap.

This patch holds off with allocating memory for the bitmap that the livemap uses until the livemap is written to the first time (i.e. by calling ZLiveMap::set). The effect of this is that the latency impact of allocating the bitmap will only be taken by GC threads and not by mutator threads, since only GC threads mark objects before pushing them onto the mark stack. This improvement will reduce page allocation latencies somewhat.

In addition to lazily allocating the bitmap, I've converted the static C-style cast to a checked cast for `ZPage::object_max_count()`, which is passed as the size to the bitmaps. This is because a value not contained in 32 bits will overflow with the C-style cast and give a too small bitmap when passed to the livemap. This is not an observed issue, just more of a sanity check.

Testing:
* Tiers 1-5
* GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351167](https://bugs.openjdk.org/browse/JDK-8351167): ZGC: Lazily initialize livemap (**Enhancement** - P4)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23907/head:pull/23907` \
`$ git checkout pull/23907`

Update a local copy of the PR: \
`$ git checkout pull/23907` \
`$ git pull https://git.openjdk.org/jdk.git pull/23907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23907`

View PR using the GUI difftool: \
`$ git pr show -t 23907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23907.diff">https://git.openjdk.org/jdk/pull/23907.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23907#issuecomment-2698768292)
</details>
