### PR TITLE
8319192: Remove javax.swing.plaf.synth.SynthLookAndFeel.load(URL url)

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -604,55 +604,7 @@ public class SynthLookAndFeel extends BasicLookAndFeel {
         }
 
         new SynthParser().parse(input, (DefaultSynthStyleFactory) factory,
-                                null, resourceBase, defaultsMap);
-    }
-
-    /**
-     * Loads the set of <code>SynthStyle</code>s that will be used by
-     * this <code>SynthLookAndFeel</code>. Path based resources are resolved
-     * relatively to the specified <code>URL</code> of the style. For example
-     * an <code>Image</code> would be resolved by
-     * <code>new URL(synthFile, path)</code>. Refer to
-     * <a href="doc-files/synthFileFormat.html">Synth File Format</a> for more
-     * information.
-     * <p>
-     * Whilst this API may be safe for loading local resources that are
-     * delivered with a {@code LookAndFeel} or application, and so have an
-     * equal level of trust with application code, using it to load from
-     * remote resources, particularly any which may have a lower level of
-     * trust, is strongly discouraged.
-     * The alternative mechanisms to load styles from an {@code InputStream}
-     * {@linkplain #load(InputStream, Class)}
-     * using resources co-located with the application or by providing a
-     * {@code SynthStyleFactory} to
-     * {@linkplain #setStyleFactory setStyleFactory(SynthStyleFactory)}
-     * are preferred.
-     * Consequently this method is deprecated and will be removed in a future
-     * release.
-     *
-     * @param url the <code>URL</code> to load the set of
-     *     <code>SynthStyle</code> from
-     * @throws ParseException if there is an error in parsing
-     * @throws IllegalArgumentException if synthSet is <code>null</code>
-     * @throws IOException if synthSet cannot be opened as an <code>InputStream</code>
-     * @since 1.6
-     * @deprecated Use {@link #load(InputStream, Class)} or
-     * {@link #setStyleFactory setStyleFactory(SynthStyleFactory)} instead
-     */
-    @Deprecated(since = "21", forRemoval = true)
-    public void load(URL url) throws ParseException, IOException {
-        if (url == null) {
-            throw new IllegalArgumentException(
-                "You must supply a valid Synth set URL");
-        }
-
-        if (defaultsMap == null) {
-            defaultsMap = new HashMap<String, Object>();
-        }
-
-        InputStream input = url.openStream();
-        new SynthParser().parse(input, (DefaultSynthStyleFactory) factory,
-                                url, null, defaultsMap);
+                                resourceBase, defaultsMap);
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLookAndFeel.java
@@ -45,7 +45,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-import java.net.URL;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Locale;

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthParser.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthParser.java
@@ -34,7 +34,6 @@ import java.awt.Toolkit;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.text.ParseException;

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthParser.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthParser.java
@@ -220,8 +220,6 @@ class SynthParser extends DefaultHandler {
                 "You must supply an InputStream, StyleFactory and Class");
         }
 
-        assert(classResourceBase != null);
-
         _factory = factory;
         _classResourceBase = classResourceBase;
         _defaultsMap = defaultsMap;

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthParser.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthParser.java
@@ -166,11 +166,6 @@ class SynthParser extends DefaultHandler {
     private Map<String,Object> _mapping;
 
     /**
-     * Based URL used to resolve paths.
-     */
-    private URL _urlResourceBase;
-
-    /**
      * Based class used to resolve paths.
      */
     private Class<?> _classResourceBase;
@@ -213,26 +208,23 @@ class SynthParser extends DefaultHandler {
      *
      * @param inputStream XML document containing the styles to read
      * @param factory DefaultSynthStyleFactory that new styles are added to
-     * @param urlResourceBase the URL used to resolve any resources, such as Images
      * @param classResourceBase the Class used to resolve any resources, such as Images
      * @param defaultsMap Map that UIDefaults properties are placed in
      */
     public void parse(InputStream inputStream,
                       DefaultSynthStyleFactory factory,
-                      URL urlResourceBase, Class<?> classResourceBase,
+                      Class<?> classResourceBase,
                       Map<String, Object> defaultsMap)
                       throws ParseException, IllegalArgumentException {
-        if (inputStream == null || factory == null ||
-            (urlResourceBase == null && classResourceBase == null)) {
+        if (inputStream == null || factory == null || classResourceBase == null) {
             throw new IllegalArgumentException(
-                "You must supply an InputStream, StyleFactory and Class or URL");
+                "You must supply an InputStream, StyleFactory and Class");
         }
 
-        assert(!(urlResourceBase != null && classResourceBase != null));
+        assert(classResourceBase != null);
 
         _factory = factory;
         _classResourceBase = classResourceBase;
-        _urlResourceBase = urlResourceBase;
         _defaultsMap = defaultsMap;
         try {
             try {
@@ -255,17 +247,7 @@ class SynthParser extends DefaultHandler {
      * Returns the path to a resource.
      */
     private URL getResource(String path) {
-        if (_classResourceBase != null) {
-            return _classResourceBase.getResource(path);
-        } else {
-            try {
-                @SuppressWarnings("deprecation")
-                var result = new URL(_urlResourceBase, path);
-                return result;
-            } catch (MalformedURLException mue) {
-                return null;
-            }
-        }
+        return _classResourceBase.getResource(path);
     }
 
     /**
@@ -294,20 +276,7 @@ class SynthParser extends DefaultHandler {
     private DocumentHandler getHandler() {
         if (_handler == null) {
             _handler = new DocumentHandler();
-            if (_urlResourceBase != null) {
-                // getHandler() is never called before parse() so it is safe
-                // to create a URLClassLoader with _resourceBase.
-                //
-                // getResource(".") is called to ensure we have the directory
-                // containing the resources in the case the resource base is a
-                // .class file.
-                URL[] urls = new URL[] { getResource(".") };
-                ClassLoader parent = Thread.currentThread().getContextClassLoader();
-                ClassLoader urlLoader = new URLClassLoader(urls, parent);
-                _handler.setClassLoader(urlLoader);
-            } else {
-                _handler.setClassLoader(_classResourceBase.getClassLoader());
-            }
+            _handler.setClassLoader(_classResourceBase.getClassLoader());
 
             for (String key : _mapping.keySet()) {
                 _handler.setVariable(key, _mapping.get(key));

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/doc-files/synthFileFormat.html
@@ -53,9 +53,7 @@ div.example {
       necessary to create your own look and feel. A synth file is
       loaded by way of the <A
         HREF="../../../../../javax/swing/plaf/synth/SynthLookAndFeel.html#load(java.io.InputStream,java.lang.Class)">
-      SynthLookAndFeel.load(InputStream, Class)</a> or
-      <a href="../../../../../javax/swing/plaf/synth/SynthLookAndFeel.html#load(java.net.URL)">
-        SynthLookAndFeel.load(URL)</a> methods.
+      SynthLookAndFeel.load(InputStream, Class)</a> method.
       The following example uses the <code>load</code> method to configure
       a <code>SynthLookAndFeel</code> and sets it as the current look
       and feel:
@@ -70,36 +68,6 @@ div.example {
     <p>
       This example loads the look and feel from an input stream, using
       the specified class as the resource base to resolve paths.
-    </p>
-    <p>
-      It is also possible to load a look and feel from an arbitrary URL
-      as in the following example.
-    </p>
-    <div class="example">
-      <pre>
-  SynthLookAndFeel laf = new SynthLookAndFeel();
-  laf.load(new URL("file:///C:/java/synth/laf/laf.xml"));
-  UIManager.setLookAndFeel(laf);
-      </pre>
-    </div>
-    <p>
-      The method <a
-        href="../../../../../javax/swing/plaf/synth/SynthLookAndFeel.html#load(java.net.URL)">
-      SynthLookAndFeel.load(URL)</a> can be used, for instance, to load a look
-      and feel from any of the following:
-    </p>
-    <ul>
-      <li>File, e.g. <code>file:///C:/java/synth/laf/laf.xml</code></li>
-      <li>Web server, e.g. <code>http://host/laf.xml</code></li>
-      <li>JAR file, e.g.
-        <code>jar:file:///C:/synth-laf.jar!/laf.xml</code></li>
-      <li>Remote JAR file, e.g.
-        <code>jar:http://host/synth-laf.jar!/laf.xml</code></li>
-    </ul>
-    <p>Note: Synth's file format allows for the definition of code to be executed.
-       Loading any code from a remote location should be used only
-       with extreme caution from a trusted source over a secure connection.
-       It is strongly discouraged for an application or a LookAndFeel to do so.
     </p>
     <p>
       While the DTD for synth is specified, the parser is not validating.
@@ -880,10 +848,9 @@ div.example {
 	a direction or orientation. If this is not specified the image is
 	used for all directions.</dd>
       <dt><a id="imagePainter.path"><samp>path</samp></a></dt>
-      <dd>Path to the image.  If SynthLookAndFeel.load is
-    passed a Class this will use the Class method getResource (with the
-    Class supplied to the load method). If load is passed a URL this will use the
-    URL constructor URL(context, path) to resolve the path.</dd>
+      <dd>Path to the image.  SynthLookAndFeel.load 
+    will use the Class method getResource (with the
+    Class supplied to the load method) to resolve the path.
       <dt><a id="imagePainter.sourceInsets"><samp>sourceInsets</samp></a></dt>
       <dd>Insets on the source image. This is top, left, bottom, right with
 	each component separated by a space.</dd>


### PR DESCRIPTION
Back in JDK 21 we deprecated-for-removal SynthLookAndFeel.load(URL) and targeted it to be removed under this bug ID in JDK 25 .. which is now here.

No open tests needed to be updated to accommodate this removal 
I did find one closed manual test, written to explicitly test this API back when it was added, and I'll need to remove that, but it doesn't affect this PR.

There will be a CSR (and probably a release note too).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8351238](https://bugs.openjdk.org/browse/JDK-8351238) to be approved

### Issues
 * [JDK-8319192](https://bugs.openjdk.org/browse/JDK-8319192): Remove javax.swing.plaf.synth.SynthLookAndFeel.load(URL url) (**Bug** - P4)
 * [JDK-8351238](https://bugs.openjdk.org/browse/JDK-8351238): Remove javax.swing.plaf.synth.SynthLookAndFeel.load(URL url) (**CSR**)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23909/head:pull/23909` \
`$ git checkout pull/23909`

Update a local copy of the PR: \
`$ git checkout pull/23909` \
`$ git pull https://git.openjdk.org/jdk.git pull/23909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23909`

View PR using the GUI difftool: \
`$ git pr show -t 23909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23909.diff">https://git.openjdk.org/jdk/pull/23909.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23909#issuecomment-2699301104)
</details>
