### PR TITLE
8351241: Require minimum gcc version 12

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -601,7 +601,7 @@ to compile successfully without issues.</p>
 <p>All compilers are expected to be able to handle the C11 language
 standard for C, and C++14 for C++.</p>
 <h3 id="gcc">gcc</h3>
-<p>The minimum accepted version of gcc is 10.0. Older versions will not
+<p>The minimum accepted version of gcc is 12.0. Older versions will not
 be accepted by <code>configure</code>.</p>
 <p>The JDK is currently known to compile successfully with gcc version
 13.2 or newer.</p>

--- a/doc/building.md
+++ b/doc/building.md
@@ -401,7 +401,7 @@ C, and C++14 for C++.
 
 ### gcc
 
-The minimum accepted version of gcc is 10.0. Older versions will not be accepted
+The minimum accepted version of gcc is 12.0. Older versions will not be accepted
 by `configure`.
 
 The JDK is currently known to compile successfully with gcc version 13.2 or

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -50,7 +50,7 @@ TOOLCHAIN_DESCRIPTION_microsoft="Microsoft Visual Studio"
 
 # Minimum supported versions, empty means unspecified
 TOOLCHAIN_MINIMUM_VERSION_clang="13.0"
-TOOLCHAIN_MINIMUM_VERSION_gcc="10.0"
+TOOLCHAIN_MINIMUM_VERSION_gcc="12.0"
 TOOLCHAIN_MINIMUM_VERSION_microsoft="19.28.0.0" # VS2019 16.8, aka MSVC 14.28
 
 # Minimum supported linker versions, empty means unspecified


### PR DESCRIPTION
Hi all,

After [JDK-8345627](https://bugs.openjdk.org/browse/JDK-8345627), the minumum gcc version should be 12. [JDK-8345627](https://bugs.openjdk.org/browse/JDK-8345627) add gcc compile option -ftrivial-auto-var-init=pattern for debug build, -ftrivial-auto-var-init=pattern gcc option was supported since [gcc12](https://gcc.gnu.org/gcc-12/changes.html#uninitialized).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351241](https://bugs.openjdk.org/browse/JDK-8351241): Require minimum gcc version 12 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23913/head:pull/23913` \
`$ git checkout pull/23913`

Update a local copy of the PR: \
`$ git checkout pull/23913` \
`$ git pull https://git.openjdk.org/jdk.git pull/23913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23913`

View PR using the GUI difftool: \
`$ git pr show -t 23913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23913.diff">https://git.openjdk.org/jdk/pull/23913.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23913#issuecomment-2700083720)
</details>
