### PR TITLE
8348657: compiler/loopopts/superword/TestEquivalentInvariants.java timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestEquivalentInvariants.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestEquivalentInvariants.java
@@ -39,7 +39,7 @@ import java.lang.foreign.*;
  *          i.e. where the invariants have the same summands, but in a different order.
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run driver compiler.loopopts.superword.TestEquivalentInvariants
+ * @run driver/timeout=1200 compiler.loopopts.superword.TestEquivalentInvariants
  */
 
 public class TestEquivalentInvariants {


### PR DESCRIPTION
We have experienced higher runtime with extra flags (e.g. `-XComp` and some verification flags). I'm increasing the timeout.

I checked: it does not seem that any specific method takes much more time than others, I suspect that we do not inline well with `-XComp`, and that makes the `MemorySegment` loop code significantly slower.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348657](https://bugs.openjdk.org/browse/JDK-8348657): compiler/loopopts/superword/TestEquivalentInvariants.java timed out (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23914/head:pull/23914` \
`$ git checkout pull/23914`

Update a local copy of the PR: \
`$ git checkout pull/23914` \
`$ git pull https://git.openjdk.org/jdk.git pull/23914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23914`

View PR using the GUI difftool: \
`$ git pr show -t 23914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23914.diff">https://git.openjdk.org/jdk/pull/23914.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23914#issuecomment-2700118348)
</details>
