### PR TITLE
8337593: Using actual RegisterMap instead of copy

### DIFF
--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -97,7 +97,7 @@ vframe* vframe::sender() const {
   if (_fr.is_empty()) return nullptr;
   if (_fr.is_entry_frame() && _fr.is_first_frame()) return nullptr;
 
-  RegisterMap temp_map = *register_map();
+  RegisterMap temp_map = register_map_actual();
   frame s = _fr.real_sender(&temp_map);
   if (s.is_first_frame()) return nullptr;
   return vframe::new_vframe(&s, &temp_map, thread());

--- a/src/hotspot/share/runtime/vframe.hpp
+++ b/src/hotspot/share/runtime/vframe.hpp
@@ -75,6 +75,7 @@ class vframe: public ResourceObj {
 // ???? Does this need to be a copy?
   frame*             frame_pointer() { return &_fr;       }
   const RegisterMap* register_map() const { return &_reg_map; }
+  const RegisterMap register_map_actual() const { return _reg_map; }
   JavaThread*        thread()       const { return _thread;   }
   stackChunkOop      stack_chunk()  const { return _chunk(); /*_reg_map.stack_chunk();*/ }
 


### PR DESCRIPTION
_[Not ready. Work in progress. Draft pull request to verify tests]_
Notes:
On a sample application's profiler using VM_ThreadDump, 24.52% (of VM thread) CPU cycle was spent on copying RegisterMap. Pass by value seems to perform better.

https://github.com/openjdk/jdk/blob/5dc9723c8172e288872f744bac5fd2342475767a/src/hotspot/share/runtime/vframe.cpp#L97

Testing
1. tier 1 / tier 2 tests passed. 

Appreciate feedback incase there is impact to other VM operations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8337593](https://bugs.openjdk.org/browse/JDK-8337593)

### Issue
 * [JDK-8337593](https://bugs.openjdk.org/browse/JDK-8337593): Investigate VM_ThreadDump performance (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23918/head:pull/23918` \
`$ git checkout pull/23918`

Update a local copy of the PR: \
`$ git checkout pull/23918` \
`$ git pull https://git.openjdk.org/jdk.git pull/23918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23918`

View PR using the GUI difftool: \
`$ git pr show -t 23918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23918.diff">https://git.openjdk.org/jdk/pull/23918.diff</a>

</details>
