### PR TITLE
8351294: (fs) Minor verbiage correction for Files.createTemp{Directory,File}

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -764,7 +764,7 @@ public final class Files {
      * is identified by its {@link FileAttribute#name name}. If more than one
      * attribute of the same name is included in the array then all but the last
      * occurrence is ignored. When no file attributes are specified, then the
-     * resulting file may have more restrictive access permissions to files
+     * resulting file may have more restrictive access permissions than files
      * created by the {@link java.io.File#createTempFile(String,String,File)}
      * method.
      *
@@ -862,7 +862,7 @@ public final class Files {
      * than one attribute of the same name is included in the array then all but
      * the last occurrence is ignored. When no file attributes are specified,
      * then the resulting directory may have more restrictive access
-     * permissions to directories created by the
+     * permissions than directories created by the
      * {@linkplain Files#createDirectory(Path, FileAttribute<?>...)} method.
      *
      * @param   dir


### PR DESCRIPTION
Modernize some verbiage from the Pliocene epoch: "to" becomes "than".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351294](https://bugs.openjdk.org/browse/JDK-8351294): (fs) Minor verbiage correction for Files.createTemp{Directory,File} (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23919/head:pull/23919` \
`$ git checkout pull/23919`

Update a local copy of the PR: \
`$ git checkout pull/23919` \
`$ git pull https://git.openjdk.org/jdk.git pull/23919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23919`

View PR using the GUI difftool: \
`$ git pr show -t 23919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23919.diff">https://git.openjdk.org/jdk/pull/23919.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23919#issuecomment-2701678122)
</details>
