### PR TITLE
8351216: Store NUMA node count

### DIFF
--- a/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
@@ -26,10 +26,7 @@
 
 void ZNUMA::pd_initialize() {
   _enabled = false;
-}
-
-uint32_t ZNUMA::count() {
-  return 1;
+  _count = 1;
 }
 
 uint32_t ZNUMA::id() {

--- a/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
@@ -32,15 +32,10 @@
 
 void ZNUMA::pd_initialize() {
   _enabled = UseNUMA;
-}
 
-uint32_t ZNUMA::count() {
-  if (!_enabled) {
-    // NUMA support not enabled
-    return 1;
-  }
-
-  return os::Linux::numa_max_node() + 1;
+  _count = UseNUMA
+    ? os::Linux::numa_max_node() + 1
+    : 1;
 }
 
 uint32_t ZNUMA::id() {
@@ -65,7 +60,7 @@ uint32_t ZNUMA::memory_id(uintptr_t addr) {
     fatal("Failed to get NUMA id for memory at " PTR_FORMAT " (%s)", addr, err.to_string());
   }
 
-  assert(id < count(), "Invalid NUMA id");
+  assert(id < _count, "Invalid NUMA id");
 
   return id;
 }

--- a/src/hotspot/os/windows/gc/z/zNUMA_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zNUMA_windows.cpp
@@ -25,10 +25,7 @@
 
 void ZNUMA::pd_initialize() {
   _enabled = false;
-}
-
-uint32_t ZNUMA::count() {
-  return 1;
+  _count = 1;
 }
 
 uint32_t ZNUMA::id() {

--- a/src/hotspot/share/gc/z/zNUMA.cpp
+++ b/src/hotspot/share/gc/z/zNUMA.cpp
@@ -25,13 +25,14 @@
 #include "gc/z/zNUMA.hpp"
 
 bool ZNUMA::_enabled;
+uint32_t ZNUMA::_count;
 
 void ZNUMA::initialize() {
   pd_initialize();
 
   log_info_p(gc, init)("NUMA Support: %s", to_string());
   if (_enabled) {
-    log_info_p(gc, init)("NUMA Nodes: %u", count());
+    log_info_p(gc, init)("NUMA Nodes: %u", _count);
   }
 }
 

--- a/src/hotspot/share/gc/z/zNUMA.hpp
+++ b/src/hotspot/share/gc/z/zNUMA.hpp
@@ -29,7 +29,8 @@
 
 class ZNUMA : public AllStatic {
 private:
-  static bool _enabled;
+  static bool     _enabled;
+  static uint32_t _count;
 
   static void pd_initialize();
 

--- a/src/hotspot/share/gc/z/zNUMA.inline.hpp
+++ b/src/hotspot/share/gc/z/zNUMA.inline.hpp
@@ -30,4 +30,8 @@ inline bool ZNUMA::is_enabled() {
   return _enabled;
 }
 
+inline uint32_t ZNUMA::count() {
+  return _count;
+}
+
 #endif // SHARE_GC_Z_ZNUMA_INLINE_HPP

--- a/src/hotspot/share/gc/z/zPageCache.cpp
+++ b/src/hotspot/share/gc/z/zPageCache.cpp
@@ -23,7 +23,7 @@
 
 #include "gc/z/zGlobals.hpp"
 #include "gc/z/zList.inline.hpp"
-#include "gc/z/zNUMA.hpp"
+#include "gc/z/zNUMA.inline.hpp"
 #include "gc/z/zPage.inline.hpp"
 #include "gc/z/zPageCache.hpp"
 #include "gc/z/zStat.hpp"


### PR DESCRIPTION
To avoid calling into `os::Linux::max_numa_node()` and in turn libnuma on every count lookup, I propose we instead store the count statically inside ZNUMA. This is perfectly fine since the value that we get from libnuma is configured once during initialization and never change during runtime.

The count is set during platform dependent initialization and the getter is now defined in the common code in ZNUMA.cpp. On operating systems that ZGC does not support NUMA for (BSD and Windows) we keep the current behavior by setting the count to 1.

This is also preparation work for the Mapped Cache ([JDK-8350441](https://bugs.openjdk.org/browse/JDK-8350441)).

Testing:
* Tiers 1-3
* GHA
* Verify that the count is set on a Linux system with NUMA hardware