### PR TITLE
8341641: Make %APPDATA% and %LOCALAPPDATA% env variables available in *.cfg files

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/TokenReplace.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/TokenReplace.java
@@ -109,7 +109,7 @@ public final class TokenReplace {
         this.tokens = tokens;
         regexps = new ArrayList<>();
 
-        for(;;) {
+        for (;;) {
             final var tokenCut = TokenCut.createFromOrderedTokens(tokens);
             regexps.add(Pattern.compile(Stream.of(tokenCut.main()).map(Pattern::quote).collect(joining("|", "(", ")"))));
 

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/TokenReplace.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/util/TokenReplace.java
@@ -42,6 +42,12 @@ import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+/**
+ * Class to replace tokens in strings.
+ * <p>
+ * Single instance holds a list of tokens. Tokens can be substrings of each other.
+ * The implementation performs greedy replacement: longer tokens are replaced first.
+ */
 public final class TokenReplace {
 
     private record TokenCut(String[] main, String[] sub) {
@@ -153,12 +159,12 @@ public final class TokenReplace {
     @Override
     public boolean equals(Object obj) {
         // Auto generated code
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
             return false;
-        if (getClass() != obj.getClass())
-            return false;
+        }
         TokenReplace other = (TokenReplace) obj;
         return Arrays.equals(tokens, other.tokens);
     }

--- a/src/jdk.jpackage/share/man/jpackage.md
+++ b/src/jdk.jpackage/share/man/jpackage.md
@@ -219,11 +219,34 @@ The `jpackage` tool will take as input a Java application and a Java run-time im
 
     This option can be used multiple times.
 
+    Value can contain substrings that will be expanded at runtime.
+    Two types of such substrings are supported: environment variables
+    and "APPDIR", "BINDIR", and "ROOTDIR" tokens.
+
+    An expandable substring should be enclosed between the dollar
+    sign character ($) and the first following non-alphanumeric
+    character. Alternatively, it can be enclosed between "${" and "}"
+    substrings.
+
+    Expandable substrings are case-sensitive on Unix and
+    case-insensitive on Windows. No string expansion occurs if the
+    referenced environment variable is undefined.
+
+    Environment variables with names "APPDIR", "BINDIR", and "ROOTDIR"
+    will be ignored, and these expandable substrings will be
+    replaced by values calculated by the app launcher.
+
+    Prefix the dollar sign character with the backslash character (\)
+    to prevent substring expansion.
+
 <a id="option-java-options">`--java-options` *options*</a>
 
 :   Options to pass to the Java runtime
 
     This option can be used multiple times.
+
+    Value can contain substrings that will be substituted at runtime,
+    such as for the --arguments option.
 
 <a id="option-main-class">`--main-class` *class-name*</a>
 

--- a/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
@@ -164,9 +164,9 @@ CfgFile* AppLauncher::createCfgFile() const {
                                 << cfgFilePath << "\"");
 
     CfgFile::Macros macros;
-    macros[_T("$APPDIR")] = appDirPath;
-    macros[_T("$BINDIR")] = FileUtils::dirname(launcherPath);
-    macros[_T("$ROOTDIR")] = imageRoot;
+    macros[_T("APPDIR")] = appDirPath;
+    macros[_T("BINDIR")] = FileUtils::dirname(launcherPath);
+    macros[_T("ROOTDIR")] = imageRoot;
     std::unique_ptr<CfgFile> dummy(new CfgFile());
     CfgFile::load(cfgFilePath).expandMacros(macros).swap(*dummy);
     return dummy.release();

--- a/src/jdk.jpackage/share/native/applauncher/CfgFile.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/CfgFile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jpackage/share/native/applauncher/CfgFile.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/CfgFile.cpp
@@ -25,13 +25,16 @@
 
 #include "kludge_c++11.h"
 
+#include <set>
 #include <fstream>
 #include <algorithm>
 #include "CfgFile.h"
+#include "SysInfo.h"
 #include "Log.h"
 #include "Toolbox.h"
 #include "FileUtils.h"
 #include "ErrorHandling.h"
+#include "StringProcessing.h"
 
 
 const CfgFile::Properties& CfgFile::getProperties(
@@ -60,37 +63,81 @@ CfgFile& CfgFile::setPropertyValue(const SectionName& sectionName,
 
 namespace {
 
-tstring expandMacros(const tstring& str, const CfgFile::Macros& macros) {
-    tstring reply = str;
-    CfgFile::Macros::const_iterator it = macros.begin();
-    const CfgFile::Macros::const_iterator end = macros.end();
-    for (; it != end; ++it) {
-        reply = tstrings::replace(reply, it->first, it->second);
+template <typename CfgFileType, typename OpType>
+void iterateProperties(CfgFileType& cfgFile, OpType& op) {
+    for (auto mapIt = cfgFile.begin(), mapEnd = cfgFile.end(); mapIt != mapEnd; ++mapIt) {
+        for (auto propertyIt = mapIt->second.begin(), propertyEnd = mapIt->second.end(); propertyIt != propertyEnd; ++propertyIt) {
+            for (auto strIt = propertyIt->second.begin(), strEnd = propertyIt->second.end(); strIt != strEnd; ++strIt) {
+                op(strIt);
+            }
+        }
     }
-    return reply;
 }
+
+struct tokenize_strings {
+    void operator () (tstring_array::const_iterator& strIt) {
+        const auto tokens = StringProcessing::tokenize(*strIt);
+        values.push_back(tokens);
+    }
+
+    std::set<tstring> variableNames() const {
+        std::set<tstring> allVariableNames;
+        for (auto it = values.begin(), end = values.end(); it != end; ++it) {
+            const auto variableNames = StringProcessing::extractVariableNames(*it);
+            allVariableNames.insert(variableNames.begin(), variableNames.end());
+        }
+
+        return allVariableNames;
+    }
+
+    std::vector<StringProcessing::TokenizedString> values;
+};
+
+class expand_macros {
+public:
+    expand_macros(const CfgFile::Macros& m,
+        std::vector<StringProcessing::TokenizedString>::iterator iter) : macros(m), curTokenizedString(iter) {
+    }
+
+    void operator () (tstring_array::iterator& strIt) {
+        StringProcessing::expandVariables(*curTokenizedString, macros);
+        auto newStr = StringProcessing::stringify(*curTokenizedString);
+        ++curTokenizedString;
+        if (*strIt != newStr) {
+            LOG_TRACE(tstrings::any() << "Map [" << *strIt << "] into [" << newStr << "]");
+        }
+        strIt->swap(newStr);
+    }
+
+private:
+    const CfgFile::Macros& macros;
+    std::vector<StringProcessing::TokenizedString>::iterator curTokenizedString;
+};
 
 } // namespace
 
 CfgFile CfgFile::expandMacros(const Macros& macros) const {
     CfgFile copyCfgFile = *this;
 
-    PropertyMap::iterator mapIt = copyCfgFile.data.begin();
-    const PropertyMap::iterator mapEnd = copyCfgFile.data.end();
-    for (; mapIt != mapEnd; ++mapIt) {
-        Properties::iterator propertyIt = mapIt->second.begin();
-        const Properties::iterator propertyEnd = mapIt->second.end();
-        for (; propertyIt != propertyEnd; ++propertyIt) {
-            tstring_array::iterator strIt = propertyIt->second.begin();
-            const tstring_array::iterator strEnd = propertyIt->second.end();
-            for (; strIt != strEnd; ++strIt) {
-                tstring newValue;
-                while ((newValue = ::expandMacros(*strIt, macros)) != *strIt) {
-                    strIt->swap(newValue);
-                }
+    tokenize_strings tokenizedStrings;
+    iterateProperties(static_cast<const CfgFile::PropertyMap&>(copyCfgFile.data), tokenizedStrings);
+
+    Macros allMacros(macros);
+
+    const auto variableNames = tokenizedStrings.variableNames();
+    for (auto it = variableNames.begin(), end = variableNames.end(); it != end; ++it) {
+        if (macros.find(*it) == macros.end()) {
+            // Not one of the reserved macro names. Assuming an environment variable.
+            const auto envVarName = *it;
+            if (SysInfo::isEnvVariableSet(envVarName)) {
+                const auto envVarValue = SysInfo::getEnvVariable(envVarName);
+                allMacros[envVarName] = envVarValue;
             }
         }
     }
+
+    expand_macros expandMacros(allMacros, tokenizedStrings.values.begin());
+    iterateProperties(copyCfgFile.data, expandMacros);
 
     return copyCfgFile;
 }

--- a/src/jdk.jpackage/share/native/applauncher/CfgFile.h
+++ b/src/jdk.jpackage/share/native/applauncher/CfgFile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jpackage/share/native/applauncher/CfgFile.h
+++ b/src/jdk.jpackage/share/native/applauncher/CfgFile.h
@@ -27,8 +27,7 @@
 #ifndef CfgFile_h
 #define CfgFile_h
 
-#include <map>
-#include "tstrings.h"
+#include "StringProcessing.h"
 
 
 class CfgFile {
@@ -90,7 +89,7 @@ public:
         std::swap(empty, other.empty);
     }
 
-    typedef std::map<tstring, tstring> Macros;
+    typedef StringProcessing::VariableValues Macros;
 
     /**
      * Returns copy of this instance with the given macros and environment variables expanded.

--- a/src/jdk.jpackage/share/native/applauncher/CfgFile.h
+++ b/src/jdk.jpackage/share/native/applauncher/CfgFile.h
@@ -93,7 +93,7 @@ public:
     typedef std::map<tstring, tstring> Macros;
 
     /**
-     * Returns copy of this instance with the given macros expanded.
+     * Returns copy of this instance with the given macros and environment variables expanded.
      */
     CfgFile expandMacros(const Macros& macros) const;
 

--- a/src/jdk.jpackage/share/native/applauncher/StringProcessing.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/StringProcessing.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "kludge_c++11.h"
+
+#include <algorithm>
+#include "StringProcessing.h"
+
+
+namespace StringProcessing {
+
+namespace {
+
+class TokenBuilder {
+public:
+    TokenBuilder(const tstring& v): cur(v.c_str()) {
+    }
+
+    void addNextToken(tstring::const_pointer end, TokenType type, TokenizedString& tokens) {
+        if (end != cur) {
+            const auto value = tstring(cur, end - cur);
+            cur = end;
+            tokens.push_back(Token(type, value));
+        }
+    }
+
+private:
+    tstring::const_pointer cur;
+};
+
+bool isValidVariableFirstChar(tstring::value_type chr) {
+    if ('A' <= chr && chr <= 'Z') {
+        return true;
+    } else if ('a' <= chr && chr <= 'z') {
+        return true;
+    } else if ('_' == chr) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool isValidVariableOtherChar(tstring::value_type chr) {
+    if (isValidVariableFirstChar(chr)) {
+        return true;
+    } else if ('0' <= chr && chr <= '9') {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+} //  namespace
+
+TokenizedString tokenize(const tstring& str) {
+    TokenizedString tokens;
+    TokenBuilder tb(str);
+    tstring::const_pointer cur = str.c_str();
+    const tstring::const_pointer end = cur + str.length();
+    while (cur != end) {
+        if (*cur == '\\' && cur + 1 != end) {
+            const auto maybeNextToken = cur++;
+            if (*cur == '\\' || *cur == '$') {
+                tb.addNextToken(maybeNextToken, STRING, tokens);
+                tb.addNextToken(++cur, ESCAPED_CHAR, tokens);
+                continue;
+            }
+        } else if (*cur == '$' && cur + 1 != end) {
+            const auto maybeNextToken = cur++;
+            bool variableFound = false;
+            if (*cur == '{') {
+                do {
+                    cur++;
+                } while (cur != end && *cur != '}');
+                if (cur != end) {
+                    variableFound = true;
+                    cur++;
+                }
+            } else if (isValidVariableFirstChar(*cur)) {
+                variableFound = true;
+                do {
+                    cur++;
+                } while (cur != end && isValidVariableOtherChar(*cur));
+            } else {
+                continue;
+            }
+            if (variableFound) {
+                tb.addNextToken(maybeNextToken, STRING, tokens);
+                tb.addNextToken(cur, VARIABLE, tokens);
+            }
+        } else {
+            ++cur;
+        }
+    }
+    tb.addNextToken(cur, STRING, tokens);
+    return tokens;
+}
+
+
+tstring stringify(const TokenizedString& tokens) {
+    tstringstream ss;
+    TokenizedString::const_iterator it = tokens.begin();
+    const TokenizedString::const_iterator end = tokens.end();
+    for (; it != end; ++it) {
+        if (it->type() == ESCAPED_CHAR) {
+            ss << it->value().substr(1);
+        } else {
+            ss << it->value();
+        }
+    }
+    return ss.str();
+}
+
+
+namespace {
+
+tstring getVariableName(const tstring& str) {
+    if (tstrings::endsWith(str, _T("}"))) {
+        // ${VAR}
+        return str.substr(2, str.length() - 3);
+    } else {
+        // $VAR
+        return str.substr(1);
+    }
+}
+
+} // namespace
+
+VariableNameList extractVariableNames(const TokenizedString& tokens) {
+    VariableNameList reply;
+
+    TokenizedString::const_iterator it = tokens.begin();
+    const TokenizedString::const_iterator end = tokens.end();
+    for (; it != end; ++it) {
+        if (it->type() == VARIABLE) {
+            reply.push_back(getVariableName(it->value()));
+        }
+    }
+
+    std::sort(reply.begin(), reply.end());
+    reply.erase(std::unique(reply.begin(), reply.end()), reply.end());
+    return reply;
+}
+
+
+void expandVariables(TokenizedString& tokens, const VariableValues& variableValues) {
+    TokenizedString::iterator it = tokens.begin();
+    const TokenizedString::iterator end = tokens.end();
+    for (; it != end; ++it) {
+        if (it->type() == VARIABLE) {
+            const auto entry = variableValues.find(getVariableName(it->value()));
+            if (entry != variableValues.end()) {
+                auto newToken = Token(STRING, entry->second);
+                std::swap(*it, newToken);
+            }
+        }
+    }
+}
+
+} // namespace StringProcessing

--- a/src/jdk.jpackage/share/native/applauncher/StringProcessing.h
+++ b/src/jdk.jpackage/share/native/applauncher/StringProcessing.h
@@ -59,7 +59,16 @@ private:
 
 typedef std::vector<Token> TokenizedString;
 typedef std::vector<tstring> VariableNameList;
+#ifdef _WIN32
+struct less_ignore_case {
+    bool operator() (const tstring& x, const tstring& y) const {
+        return std::less<tstring>()(tstrings::toLower(x), tstrings::toLower(y));
+    }
+};
+typedef std::map<tstring, tstring, less_ignore_case> VariableValues;
+#else
 typedef std::map<tstring, tstring> VariableValues;
+#endif
 
 TokenizedString tokenize(const tstring& str);
 

--- a/src/jdk.jpackage/share/native/applauncher/StringProcessing.h
+++ b/src/jdk.jpackage/share/native/applauncher/StringProcessing.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+#ifndef StringProcessor_h
+#define StringProcessor_h
+
+#include <map>
+#include "tstrings.h"
+
+
+namespace StringProcessing {
+
+enum TokenType {
+    STRING,
+    VARIABLE,
+    ESCAPED_CHAR
+};
+
+class Token {
+public:
+    Token(TokenType type, const tstring& str): theType(type), theStr(str) {
+    }
+
+    TokenType type() const {
+        return theType;
+    }
+
+    const tstring& value() const {
+        return theStr;
+    }
+
+private:
+    TokenType theType;
+    tstring theStr;
+};
+
+typedef std::vector<Token> TokenizedString;
+typedef std::vector<tstring> VariableNameList;
+typedef std::map<tstring, tstring> VariableValues;
+
+TokenizedString tokenize(const tstring& str);
+
+tstring stringify(const TokenizedString& tokens);
+
+VariableNameList extractVariableNames(const TokenizedString& tokens);
+
+void expandVariables(TokenizedString& tokens, const VariableValues& variableValues);
+
+} // namespace StringProcessing
+
+#endif // StringProcessor_h

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/AdditionalLauncher.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/AdditionalLauncher.java
@@ -22,6 +22,9 @@
  */
 package jdk.jpackage.test;
 
+import static java.util.stream.Collectors.toMap;
+import static jdk.jpackage.internal.util.function.ThrowingFunction.toFunction;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -35,11 +38,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import static jdk.jpackage.internal.util.function.ExceptionBox.rethrowUnchecked;
 import jdk.jpackage.internal.util.function.ThrowingBiConsumer;
-import static jdk.jpackage.internal.util.function.ThrowingFunction.toFunction;
 
 public class AdditionalLauncher {
 
@@ -393,11 +393,9 @@ public class AdditionalLauncher {
         PropertyFile(Path path) throws IOException {
             data = Files.readAllLines(path).stream().map(str -> {
                 return str.split("=", 2);
-            }).collect(
-                    Collectors.toMap(tokens -> tokens[0], tokens -> tokens[1],
-                            (oldValue, newValue) -> {
-                                return newValue;
-                            }));
+            }).collect(toMap(tokens -> tokens[0], tokens -> tokens[1], (oldValue, newValue) -> {
+                return newValue;
+            }));
         }
 
         public boolean isPropertySet(String name) {
@@ -419,11 +417,9 @@ public class AdditionalLauncher {
     }
 
     private static String resolveVariables(JPackageCommand cmd, String str) {
-        var map = Map.of(
-                "$APPDIR", cmd.appLayout().appDirectory(),
-                "$ROOTDIR",
-                cmd.isImagePackageType() ? cmd.outputBundle() : cmd.appInstallationDirectory(),
-                "$BINDIR", cmd.appLayout().launchersDirectory());
+        var map = Stream.of(JPackageCommand.Macro.values()).collect(toMap(x -> {
+            return String.format("$%s", x.name());
+        }, cmd::macroValue));
         for (var e : map.entrySet()) {
             str = str.replaceAll(Pattern.quote(e.getKey()),
                     Matcher.quoteReplacement(e.getValue().toString()));

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -859,6 +859,32 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
         return this;
     }
 
+    public static enum Macro {
+        APPDIR(cmd -> {
+            return cmd.appLayout().appDirectory().toString();
+        }),
+        BINDIR(cmd -> {
+            return cmd.appLayout().launchersDirectory().toString();
+        }),
+        ROOTDIR(cmd -> {
+            return (cmd.isImagePackageType() ? cmd.outputBundle() : cmd.appInstallationDirectory()).toString();
+        });
+
+        private Macro(Function<JPackageCommand, String> getValue) {
+            this.getValue = Objects.requireNonNull(getValue);
+        }
+
+        String value(JPackageCommand cmd) {
+            return getValue.apply(cmd);
+        }
+
+        private final Function<JPackageCommand, String> getValue;
+    }
+
+    public String macroValue(Macro macro) {
+        return macro.value(this);
+    }
+
     public static enum AppLayoutAssert {
         APP_IMAGE_FILE(JPackageCommand::assertAppImageFile),
         PACKAGE_FILE(JPackageCommand::assertPackageFile),

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/util/TokenReplaceTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/util/TokenReplaceTest.java
@@ -181,7 +181,7 @@ public class TokenReplaceTest {
         ).map(TestSpec.Builder::create);
     }
 
-    private final static class CountingSupplier implements Supplier<Object> {
+    private static final class CountingSupplier implements Supplier<Object> {
 
         CountingSupplier(Object value, int expectedCount) {
             this.value = value;

--- a/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/util/TokenReplaceTest.java
+++ b/test/jdk/tools/jpackage/junit/share/jdk.jpackage/jdk/jpackage/internal/util/TokenReplaceTest.java
@@ -181,7 +181,7 @@ public class TokenReplaceTest {
         ).map(TestSpec.Builder::create);
     }
 
-    private static final class CountingSupplier implements Supplier<Object> {
+    private final static class CountingSupplier implements Supplier<Object> {
 
         CountingSupplier(Object value, int expectedCount) {
             this.value = value;

--- a/test/jdk/tools/jpackage/share/AppLauncherSubstTest.java
+++ b/test/jdk/tools/jpackage/share/AppLauncherSubstTest.java
@@ -82,7 +82,6 @@ public class AppLauncherSubstTest {
             private Map<String, String> env = new HashMap<>();
         }
 
-
         public TestSpec {
             Objects.requireNonNull(str);
             Objects.requireNonNull(expectedStr);
@@ -96,6 +95,17 @@ public class AppLauncherSubstTest {
                 final var macro = token.substring(2, token.length() - 2);
                 return Path.of(cmd.macroValue(Macro.valueOf(macro))).toAbsolutePath();
             });
+        }
+
+        @Override
+        public String toString() {
+            final var sb = new StringBuilder();
+            sb.append("str=").append(str);
+            sb.append(", expect=").append(expectedStr);
+            if (!env.isEmpty()) {
+                sb.append(", env=").append(env);
+            }
+            return sb.toString();
         }
 
         private final static TokenReplace MACROS = new TokenReplace(Stream.of(Macro.values()).map(macro -> {
@@ -125,9 +135,7 @@ public class AppLauncherSubstTest {
                 .setExecutable(cmd.appLauncherPath().toAbsolutePath())
                 .addArguments("--print-sys-prop=" + TEST_PROP);
 
-        spec.env().forEach((envVarName, envVarValue) -> {
-            launcherExec.setEnvVar(envVarName, envVarValue);
-        });
+        spec.env().forEach(launcherExec::setEnvVar);
 
         final var resolvedExpectedStr = spec.resolveExpectedStr(cmd);
         final var actualStr = configureAndExecute(0, launcherExec).getFirstLineOfOutput().substring((TEST_PROP + "=").length());

--- a/test/jdk/tools/jpackage/share/AppLauncherSubstTest.java
+++ b/test/jdk/tools/jpackage/share/AppLauncherSubstTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import static jdk.jpackage.test.HelloApp.configureAndExecute;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import jdk.jpackage.internal.util.TokenReplace;
+import jdk.jpackage.test.Annotations.ParameterSupplier;
+import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.Executor;
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.JPackageCommand.Macro;
+import jdk.jpackage.test.TKit;
+
+/*
+ * @test
+ * @summary Tests environment variables substitution by jpackage launcher
+ * @bug 8341641
+ * @library /test/jdk/tools/jpackage/helpers
+ * @build jdk.jpackage.test.*
+ * @build AppLauncherSubstTest
+ * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=AppLauncherSubstTest
+ */
+public class AppLauncherSubstTest {
+
+    record TestSpec(String str, String expectedStr, Map<String, String> env) {
+
+        static class Builder {
+
+            Builder str(String v) {
+                str = v;
+                return this;
+            }
+
+            Builder expect(String v) {
+                expectedStr = v;
+                return this;
+            }
+
+            Builder var(String name, String value) {
+                env.put(name, value);
+                return this;
+            }
+
+            TestSpec create() {
+                return new TestSpec(str, Optional.ofNullable(expectedStr).orElse(str), env);
+            }
+
+            private String str;
+            private String expectedStr;
+            private Map<String, String> env = new HashMap<>();
+        }
+
+
+        public TestSpec {
+            Objects.requireNonNull(str);
+            Objects.requireNonNull(expectedStr);
+            Objects.requireNonNull(env);
+            env.entrySet().forEach(Objects::requireNonNull);
+        }
+
+        public String resolveExpectedStr(JPackageCommand cmd) {
+            return MACROS.applyTo(expectedStr, token -> {
+                // @@APPDIR@@ -> APPDIR
+                final var macro = token.substring(2, token.length() - 2);
+                return Path.of(cmd.macroValue(Macro.valueOf(macro))).toAbsolutePath();
+            });
+        }
+
+        private final static TokenReplace MACROS = new TokenReplace(Stream.of(Macro.values()).map(macro -> {
+            return String.format("@@%s@@", macro);
+        }).toArray(String[]::new));
+    }
+
+    @Test
+    @ParameterSupplier
+    public static void test(TestSpec spec) throws IOException {
+        final var cmd = JPackageCommand.helloAppImage(TEST_APP_JAVA + "*Hello")
+                .ignoreFakeRuntime()
+                .setArgumentValue("--java-options", "-D" + TEST_PROP + "=");
+
+        cmd.execute();
+
+        // Manually edit main launcher config file. Don't do it directly because
+        // jpackage doesn't pass the value of `--java-options` option as-is into the config file.
+        final var cfgFile = cmd.appLauncherCfgPath(null);
+        TKit.createTextFile(cfgFile, Files.readAllLines(cfgFile).stream().map(line -> {
+            return TEST_PROP_REGEXP.matcher(line).replaceFirst(Matcher.quoteReplacement(spec.str()));
+        }));
+
+        final var launcherExec = new Executor()
+                .saveOutput()
+                .dumpOutput()
+                .setExecutable(cmd.appLauncherPath().toAbsolutePath())
+                .addArguments("--print-sys-prop=" + TEST_PROP);
+
+        spec.env().forEach((envVarName, envVarValue) -> {
+            launcherExec.setEnvVar(envVarName, envVarValue);
+        });
+
+        final var resolvedExpectedStr = spec.resolveExpectedStr(cmd);
+        final var actualStr = configureAndExecute(0, launcherExec).getFirstLineOfOutput().substring((TEST_PROP + "=").length());
+
+        if (TKit.isWindows() && !resolvedExpectedStr.equals(spec.expectedStr())) {
+            TKit.assertEquals(resolvedExpectedStr.toLowerCase(), actualStr.toLowerCase(), "Check the property value is as expected [lowercase]");
+        } else {
+            TKit.assertEquals(resolvedExpectedStr, actualStr, "Check the property value is as expected");
+        }
+    }
+
+    public static Collection<Object[]> test() {
+        return Stream.of(
+                testSpec(""),
+                testSpec("$ONE ${TWO} ${ONE} $TWO ONE TWO").expect("one two one two ONE TWO").var("ONE", "one").var("TWO", "two"),
+                testSpec("\\$FOO\\\\$FOO\\${FOO}\\\\${FOO}").expect("$FOO\\BAR${FOO}\\BAR").var("FOO", "BAR"),
+                testSpec("$FOO-$BAR").expect("$FOO-").var("BAR", ""),
+                testSpec("${BINDIR}${APPDIR}${ROOTDIR}").expect("@@BINDIR@@@@APPDIR@@@@ROOTDIR@@").var("BINDIR", "a").var("APPDIR", "b").var("ROOTDIR", "c"),
+                testSpec("$BINDIR$APPDIR$ROOTDIR").expect("@@BINDIR@@@@APPDIR@@@@ROOTDIR@@"),
+                testSpec("$BINDIR2$APPDIR2$ROOTDIR2").expect("$BINDIR2$APPDIR2$ROOTDIR2")
+        ).map(TestSpec.Builder::create).map(v -> {
+            return new Object[] {v};
+        }).toList();
+    }
+
+    private static TestSpec.Builder testSpec(String str) {
+        return new TestSpec.Builder().str(str);
+    }
+
+    private static final Path TEST_APP_JAVA = TKit.TEST_SRC_ROOT.resolve("apps/PrintEnv.java");
+
+    private static final String TEST_PROP = "jdk.jpackage.test.Property";
+    private static final Pattern TEST_PROP_REGEXP = Pattern.compile("(?<=" + Pattern.quote(TEST_PROP) + "=).*");
+}


### PR DESCRIPTION
jpackage app laucnher will expand environment variables in .cfg files.

Previously jpackage app launcher only replaced `$APPDIR`, `$BINDIR`, and `$ROOTDIR` tokens with the corresponding path values. With this patch, any environment variable can be expanded. The syntax is shell-like `$ENV_VAR_NAME` or `${ENV_VAR_NAME}`. If `$ENV_VAR_NAME` syntax is used, the variable name stops at the first character outside of `[a-zA-Z0-9_]` character range. If `${ENV_VAR_NAME}` syntax is used, the variable name stops at the first `}` character after `${` substring. E.g:
| String    | Variables | Variable Values | Expanded String | Note |
| -------- | ------- |------- |------- |------- |
| <pre>Welcome $USER!</pre>  | <pre>USER</pre> | <pre>USER=John</pre> | <pre>Welcome John!</pre> ||
| <pre>Welcome $USER!</pre>  | <pre>USER</pre> | <pre>not set</pre> | <pre>Welcome $USER!</pre> | Unset variables are not expanded. |
| <pre>Welcome $USER2</pre> | <pre>USER2</pre>   | <pre>USER2=John</pre> | <pre>Welcome John!</pre> ||
| <pre>Welcome ${USER}2!</pre> | <pre>USER</pre>  | <pre>USER=John</pre> | <pre>Welcome John2!</pre> ||
| <pre>Welcome $USER-2!</pre> | <pre>USER</pre>   | <pre>USER=John</pre> | <pre>Welcome John-2!</pre> ||
| <pre>Welcome ${USER-2}!</pre> | <pre>USER-2</pre>   | <pre>USER-2=John</pre> | <pre>Welcome John!</pre> | `USER-2` is likely to be an invalid env variable name, but jpackage launcher is not validating names. |

`\$` character combination prevents variable expansion:
| String    | Variables | Variable Values | Expanded String |
| -------- | ------- |------- |------- |
| <pre>Hello \\$A! Bye $B</pre>  | B | <pre>B=John</pre> | <pre>Hello $A! Bye John</pre> |
| <pre>Hello \\${A}! Bye $B</pre>  | B | <pre>B=John</pre> | <pre>Hello ${A}! Bye John</pre> |

`\\` character combination escapes `\`:
| String    | Variables | Variable Values | Expanded String |
| -------- | ------- |------- |------- |
| <pre>Hello \\\\$A! Bye $B</pre>  | A, B | <pre>A=Ana</pre><pre>B=John</pre> | <pre>Hello \\Ana! Bye John</pre> |

If `\` character is not followed by another `\` character or `$` character, it is interpreted as a regular character:
| String    | Expanded string |
| -------- | ------- |
|<pre>a\\b\\c</pre>|<pre>a\\b\\c</pre>|


Expansion is non-recursive:
| String    | Variables | Variable Values | Expanded String | Note |
| -------- | ------- |------- |------- |------- |
| <pre>Hello $A!</pre>  | A | <pre>A=$B</pre><pre>B=John</pre> | <pre>Hello $B</pre> | Variable "B" will not be expanded |

Values of `APPDIR`, `BINDIR`, and `ROOTDIR` environment variables are ignored, and these names are substituted by values calculated by jpackage app launcher as previously.

`$APPDIR` is equivalent to `${APPDIR}`.
`$BINDIR` is equivalent to `${BINDIR}`.
`$ROOTDIR` is equivalent to `${ROOTDIR}`.

You will find two entities dealing with token replacement in this patch:
 - StringProcessing.cpp/.h - code that performs variable substitution in .cfg files;
 - TokenReplace.java - helper class for jpackage tests. It will be later used with other jpackage tests and to implement [jdk.jpackage.internal.OverridableResource.substitute()](https://github.com/openjdk/jdk/blob/11a37c829c12d064874416a7b242596cf23972e5/src/jdk.jpackage/share/classes/jdk/jpackage/internal/OverridableResource.java#L305) method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8351447](https://bugs.openjdk.org/browse/JDK-8351447) to be approved

### Issues
 * [JDK-8341641](https://bugs.openjdk.org/browse/JDK-8341641): Make %APPDATA% and %LOCALAPPDATA% env variables available in *.cfg files (**Enhancement** - P4)
 * [JDK-8351447](https://bugs.openjdk.org/browse/JDK-8351447): Make %APPDATA% and %LOCALAPPDATA% env variables available in *.cfg files (**CSR**)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23923/head:pull/23923` \
`$ git checkout pull/23923`

Update a local copy of the PR: \
`$ git checkout pull/23923` \
`$ git pull https://git.openjdk.org/jdk.git pull/23923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23923`

View PR using the GUI difftool: \
`$ git pr show -t 23923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23923.diff">https://git.openjdk.org/jdk/pull/23923.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23923#issuecomment-2702466986)
</details>
