### PR TITLE
8351309: test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java fails on static-jdk

### DIFF
--- a/make/StaticLibs.gmk
+++ b/make/StaticLibs.gmk
@@ -50,10 +50,6 @@ endif
 STATIC_LIB_MODULES := $(patsubst $(SUPPORT_OUTPUTDIR)/modules_static-libs/%, \
     %, $(wildcard $(SUPPORT_OUTPUTDIR)/modules_static-libs/*))
 
-# Filter out libjsig by default. Statically linking libjsig causes signal
-# chaining being enabled by default on static JDK.
-EXCLUDED_STATIC_LIBS = jsig
-
 # Filter out known broken libraries. This is a temporary measure until
 # proper support for these libraries can be provided.
 ifeq ($(call isTargetOs, linux), true)
@@ -74,10 +70,8 @@ else ifeq ($(call isTargetOs, windows), true)
   BROKEN_STATIC_LIBS += dt_shmem
 endif
 
-EXCLUDED_STATIC_LIBS += $(BROKEN_STATIC_LIBS)
-
 $(foreach module, $(STATIC_LIB_MODULES), \
-    $(eval LIBS_$(module) := $(filter-out $(EXCLUDED_STATIC_LIBS), $(shell cat \
+    $(eval LIBS_$(module) := $(filter-out $(BROKEN_STATIC_LIBS), $(shell cat \
     $(SUPPORT_OUTPUTDIR)/modules_static-libs/$(module)/module-included-libs.txt))) \
 )
 

--- a/make/StaticLibs.gmk
+++ b/make/StaticLibs.gmk
@@ -50,6 +50,10 @@ endif
 STATIC_LIB_MODULES := $(patsubst $(SUPPORT_OUTPUTDIR)/modules_static-libs/%, \
     %, $(wildcard $(SUPPORT_OUTPUTDIR)/modules_static-libs/*))
 
+# Filter out libjsig by default. Statically linking libjsig causes signal
+# chaining being enabled by default on static JDK.
+EXCLUDED_STATIC_LIBS = jsig
+
 # Filter out known broken libraries. This is a temporary measure until
 # proper support for these libraries can be provided.
 ifeq ($(call isTargetOs, linux), true)
@@ -70,8 +74,10 @@ else ifeq ($(call isTargetOs, windows), true)
   BROKEN_STATIC_LIBS += dt_shmem
 endif
 
+EXCLUDED_STATIC_LIBS += $(BROKEN_STATIC_LIBS)
+
 $(foreach module, $(STATIC_LIB_MODULES), \
-    $(eval LIBS_$(module) := $(filter-out $(BROKEN_STATIC_LIBS), $(shell cat \
+    $(eval LIBS_$(module) := $(filter-out $(EXCLUDED_STATIC_LIBS), $(shell cat \
     $(SUPPORT_OUTPUTDIR)/modules_static-libs/$(module)/module-included-libs.txt))) \
 )
 

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -124,6 +124,7 @@ ifeq ($(call isTargetOsType, unix), true)
       DISABLED_WARNINGS_clang_jsig.c := unused-but-set-variable, \
       LIBS_linux := $(LIBDL), \
       LIBS_aix := $(LIBDL), \
+      ONLY_EXPORTED := true, \
   ))
 
   TARGETS += $(BUILD_LIBJSIG)


### PR DESCRIPTION
Please review this PR that excludes `libjsig` from being statically linked with `static-jdk` `java` launcher by default. Please see details in https://bugs.openjdk.org/browse/JDK-8351309 description and comments. Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351309](https://bugs.openjdk.org/browse/JDK-8351309): test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java fails on static-jdk (**Bug** - P4)


### Reviewers
 * [Man Cao](https://openjdk.org/census#manc) (@caoman - Committer)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [9e1aac2e](https://git.openjdk.org/jdk/pull/23924/files/9e1aac2e3c5a0a976e4fd9588852f6962346478c)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23924/head:pull/23924` \
`$ git checkout pull/23924`

Update a local copy of the PR: \
`$ git checkout pull/23924` \
`$ git pull https://git.openjdk.org/jdk.git pull/23924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23924`

View PR using the GUI difftool: \
`$ git pr show -t 23924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23924.diff">https://git.openjdk.org/jdk/pull/23924.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23924#issuecomment-2702277912)
</details>
