### PR TITLE
8351233: [ASAN] avx2-emu-funcs.hpp:151:20: error: ‘D.82188’ is used uninitialized

### DIFF
--- a/src/java.base/linux/native/libsimdsort/avx2-emu-funcs.hpp
+++ b/src/java.base/linux/native/libsimdsort/avx2-emu-funcs.hpp
@@ -127,9 +127,9 @@ void avx2_emu_mask_compressstoreu32(void *base_addr,
     T *leftStore = (T *)base_addr;
 
     int32_t shortMask = convert_avx2_mask_to_int(k);
-    const __m256i &perm = _mm256_loadu_si256(
+    const __m256i perm = _mm256_loadu_si256(
         (const __m256i *)avx2_compressstore_lut32_perm[shortMask].data());
-    const __m256i &left = _mm256_loadu_si256(
+    const __m256i left = _mm256_loadu_si256(
         (const __m256i *)avx2_compressstore_lut32_left[shortMask].data());
 
     typename vtype::reg_t temp = vtype::permutevar(reg, perm);
@@ -148,7 +148,7 @@ int avx2_double_compressstore32(void *left_addr, void *right_addr,
     T *rightStore = (T *)right_addr;
 
     int32_t shortMask = convert_avx2_mask_to_int(k);
-    const __m256i &perm = _mm256_loadu_si256(
+    const __m256i perm = _mm256_loadu_si256(
         (const __m256i *)avx2_compressstore_lut32_perm[shortMask].data());
 
     typename vtype::reg_t temp = vtype::permutevar(reg, perm);


### PR DESCRIPTION
Hi all,

The return type of function `const __m256i &perm` is `__m256i`, so `const __m256i &perm` should be replaced as 'const __m256i perm'.

The function implementation in gcc/clang compiler header:

1. gcc: lib/gcc/x86_64-pc-linux-gnu/14.2.0/include/avxintrin.h

```c
extern __inline __m256i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
_mm256_loadu_si256 (__m256i_u const *__P)
{
  return *__P;
}
```

2. clang: lib64/clang/17/include/avxintrin.h

```c
static __inline __m256i __DEFAULT_FN_ATTRS
_mm256_loadu_si256(__m256i_u const *__p)
{
  struct __loadu_si256 {
    __m256i_u __v;
  } __attribute__((__packed__, __may_alias__));
  return ((const struct __loadu_si256*)__p)->__v;
}
```

Additional testing:

- [x] jtreg tests(include tier1/2/3 etc.) on linux-x64(AMD EPYC 9T24 96-Core Processor) with release build
- [x] jtreg tests(include tier1/2/3 etc.) on linux-x64(AMD EPYC 9T24 96-Core Processor) with fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351233](https://bugs.openjdk.org/browse/JDK-8351233): [ASAN] avx2-emu-funcs.hpp:151:20: error: ‘D.82188’ is used uninitialized (**Bug** - P3)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23925/head:pull/23925` \
`$ git checkout pull/23925`

Update a local copy of the PR: \
`$ git checkout pull/23925` \
`$ git pull https://git.openjdk.org/jdk.git pull/23925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23925`

View PR using the GUI difftool: \
`$ git pr show -t 23925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23925.diff">https://git.openjdk.org/jdk/pull/23925.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23925#issuecomment-2702731511)
</details>
