### PR TITLE
8350194: Last 2 parameters of ReturnNode::ReturnNode are swapped in the declaration

### DIFF
--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -116,8 +116,7 @@ public:
 // Return from subroutine node
 class ReturnNode : public Node {
 public:
-  ReturnNode(uint edges, Node *cntrl, Node *i_o, Node *memory, Node *frameptr,
-             Node *retadr);
+  ReturnNode(uint edges, Node* cntrl, Node* i_o, Node* memory, Node* frameptr, Node* retadr);
   virtual int Opcode() const;
   virtual bool  is_CFG() const { return true; }
   virtual uint hash() const { return NO_HASH; }  // CFG nodes do not hash

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -116,7 +116,8 @@ public:
 // Return from subroutine node
 class ReturnNode : public Node {
 public:
-  ReturnNode( uint edges, Node *cntrl, Node *i_o, Node *memory, Node *retadr, Node *frameptr );
+  ReturnNode(uint edges, Node *cntrl, Node *i_o, Node *memory, Node *frameptr,
+             Node *retadr);
   virtual int Opcode() const;
   virtual bool  is_CFG() const { return true; }
   virtual uint hash() const { return NO_HASH; }  // CFG nodes do not hash


### PR DESCRIPTION
The last two parameters in the declaration of ReturnNode::ReturnNode, `frameptr` and `retadr` were swapped in the declaration compared to the definition. This commit makes the declaration consistent with the definition and the two usages in [`GraphKit::gen_stub()`](https://github.com/openjdk/jdk/blob/5c552a9d64c8116161cb9ef4c777e75a2602a75b/src/hotspot/share/opto/generateOptoStub.cpp#L267) and [`Compile::return_values()`](https://github.com/openjdk/jdk/blob/5c552a9d64c8116161cb9ef4c777e75a2602a75b/src/hotspot/share/opto/parse1.cpp#L879).

Tests: tiers 1 through 3 passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350194](https://bugs.openjdk.org/browse/JDK-8350194): Last 2 parameters of ReturnNode::ReturnNode are swapped in the declaration (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23927/head:pull/23927` \
`$ git checkout pull/23927`

Update a local copy of the PR: \
`$ git checkout pull/23927` \
`$ git pull https://git.openjdk.org/jdk.git pull/23927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23927`

View PR using the GUI difftool: \
`$ git pr show -t 23927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23927.diff">https://git.openjdk.org/jdk/pull/23927.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23927#issuecomment-2707067404)
</details>
