### PR TITLE
8350485: C2: factor out common code in Node::grow() and Node::out_grow()

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -664,15 +664,15 @@ void Node::destruct(PhaseValues* phase) {
   }
 }
 
-// Resize input or output array to grow it the next larger power-of-2 bigger
+// Resize input or output array to grow it to the next larger power-of-2 bigger
 // than len.
-void Node::resize_array(Node**& array, node_idx_t& max_size, uint len, bool is_input_array) {
+void Node::resize_array(Node**& array, node_idx_t& max_size, uint len, bool needs_clearing) {
   Arena* arena = Compile::current()->node_arena();
   uint new_max = max_size;
   if (new_max == 0) {
     max_size = 4;
     array = (Node**)arena->Amalloc(4 * sizeof(Node*));
-    if (is_input_array) {
+    if (needs_clearing) {
       array[0] = nullptr;
       array[1] = nullptr;
       array[2] = nullptr;
@@ -681,20 +681,15 @@ void Node::resize_array(Node**& array, node_idx_t& max_size, uint len, bool is_i
     return;
   }
   new_max = next_power_of_2(len);
-  // Trimming to limit allows a uint8 to handle up to 255 edges.
-  // Previously I was using only powers-of-2 which peaked at 128 edges.
-  //if( new_max >= limit ) new_max = limit-1;
-  if (!is_input_array) {
-    assert(array != nullptr && array != NO_OUT_ARRAY, "out must have sensible value");
-  }
+  assert(needs_clearing || (array != nullptr && array != NO_OUT_ARRAY), "out must have sensible value");
   array = (Node**)arena->Arealloc(array, max_size * sizeof(Node*), new_max * sizeof(Node*));
-  if (is_input_array) {
+  if (needs_clearing) {
     Copy::zero_to_bytes(&array[max_size], (new_max - max_size) * sizeof(Node*)); // null all new space
   }
   max_size = new_max;               // Record new max length
   // This assertion makes sure that Node::_max is wide enough to
   // represent the numerical value of new_max.
-  assert(max_size == new_max && max_size > len, "int width of _max is too small");
+  assert(max_size > len, "int width of _max or _outmax is too small");
 }
 
 //------------------------------grow-------------------------------------------
@@ -705,7 +700,7 @@ void Node::grow(uint len) {
 
 //-----------------------------out_grow----------------------------------------
 // Grow the input array, making space for more edges
-void Node::out_grow( uint len ) {
+void Node::out_grow(uint len) {
   assert(!is_top(), "cannot grow a top node's out array");
   resize_array(_out, _outmax, len, false);
 }

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -664,33 +664,32 @@ void Node::destruct(PhaseValues* phase) {
   }
 }
 
-//------------------------------resize_array-------------------------------------------
- // Resize input or output array to grow it the next larger power-of-2 bigger
+// Resize input or output array to grow it the next larger power-of-2 bigger
 // than len.
-void Node::resize_array( Node**& array, node_idx_t& max_size, uint len, bool is_in) {
+void Node::resize_array(Node**& array, node_idx_t& max_size, uint len, bool is_input_array) {
   Arena* arena = Compile::current()->node_arena();
   uint new_max = max_size;
-  if( new_max == 0 ) {
+  if (new_max == 0) {
     max_size = 4;
-    array = (Node**)arena->Amalloc(4*sizeof(Node*));
-    if(is_in){
+    array = (Node**)arena->Amalloc(4 * sizeof(Node*));
+    if (is_input_array) {
       array[0] = nullptr;
       array[1] = nullptr;
       array[2] = nullptr;
       array[3] = nullptr;
     }
-      return;
+    return;
   }
   new_max = next_power_of_2(len);
   // Trimming to limit allows a uint8 to handle up to 255 edges.
   // Previously I was using only powers-of-2 which peaked at 128 edges.
   //if( new_max >= limit ) new_max = limit-1;
-  if(!is_in){
+  if (!is_input_array) {
     assert(array != nullptr && array != NO_OUT_ARRAY, "out must have sensible value");
   }
-  array = (Node**)arena->Arealloc(array, max_size*sizeof(Node*), new_max*sizeof(Node*));
-  if(is_in){
-    Copy::zero_to_bytes(&array[max_size], (new_max-max_size)*sizeof(Node*)); // null all new space
+  array = (Node**)arena->Arealloc(array, max_size * sizeof(Node*), new_max * sizeof(Node*));
+  if (is_input_array) {
+    Copy::zero_to_bytes(&array[max_size], (new_max - max_size) * sizeof(Node*)); // null all new space
   }
   max_size = new_max;               // Record new max length
   // This assertion makes sure that Node::_max is wide enough to

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -665,48 +665,48 @@ void Node::destruct(PhaseValues* phase) {
 }
 
 //------------------------------resize_array-------------------------------------------
- // Resize input or output array to grow it the next larger power-of-2 bigger
+// Resize input or output array to grow it to the next larger power-of-2 bigger
 // than len.
-void Node::resize_array( Node**& array, node_idx_t& max_size, uint len, bool is_in) {
-  Arena* arena = Compile::current()->node_arena();
+void Node::resize_array(Node **&array, node_idx_t &max_size, uint len, bool is_in) {
+  Arena *arena = Compile::current()->node_arena();
   uint new_max = max_size;
-  if( new_max == 0 ) {
+  if (new_max == 0) {
     max_size = 4;
-    array = (Node**)arena->Amalloc(4*sizeof(Node*));
-    if(is_in){
+    array = (Node **)arena->Amalloc(4 * sizeof(Node *));
+    if (is_in) {
       array[0] = nullptr;
       array[1] = nullptr;
       array[2] = nullptr;
       array[3] = nullptr;
     }
-      return;
+    return;
   }
   new_max = next_power_of_2(len);
   // Trimming to limit allows a uint8 to handle up to 255 edges.
   // Previously I was using only powers-of-2 which peaked at 128 edges.
-  //if( new_max >= limit ) new_max = limit-1;
-  if(!is_in){
-    assert(array != nullptr && array != NO_OUT_ARRAY, "out must have sensible value");
+  // if( new_max >= limit ) new_max = limit-1;
+  if (!is_in) {
+    assert(array != nullptr && array != NO_OUT_ARRAY,
+           "out must have sensible value");
   }
-  array = (Node**)arena->Arealloc(array, max_size*sizeof(Node*), new_max*sizeof(Node*));
-  if(is_in){
-    Copy::zero_to_bytes(&array[max_size], (new_max-max_size)*sizeof(Node*)); // null all new space
+  array = (Node **)arena->Arealloc(array, max_size * sizeof(Node *), new_max * sizeof(Node *));
+  if (is_in) {
+    Copy::zero_to_bytes(&array[max_size], (new_max - max_size) * sizeof(Node *)); // null all new space
   }
-  max_size = new_max;               // Record new max length
+  max_size = new_max; // Record new max length
   // This assertion makes sure that Node::_max is wide enough to
   // represent the numerical value of new_max.
-  assert(max_size == new_max && max_size > len, "int width of _max is too small");
+  assert(max_size == new_max && max_size > len,
+         "int width of _max is too small");
 }
 
 //------------------------------grow-------------------------------------------
 // Grow the input array, making space for more edges
-void Node::grow(uint len) {
-  resize_array(_in, _max, len, true);
-}
+void Node::grow(uint len) { resize_array(_in, _max, len, true); }
 
 //-----------------------------out_grow----------------------------------------
 // Grow the input array, making space for more edges
-void Node::out_grow( uint len ) {
+void Node::out_grow(uint len) {
   assert(!is_top(), "cannot grow a top node's out array");
   resize_array(_out, _outmax, len, false);
 }

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -665,48 +665,48 @@ void Node::destruct(PhaseValues* phase) {
 }
 
 //------------------------------resize_array-------------------------------------------
-// Resize input or output array to grow it to the next larger power-of-2 bigger
+ // Resize input or output array to grow it the next larger power-of-2 bigger
 // than len.
-void Node::resize_array(Node **&array, node_idx_t &max_size, uint len, bool is_in) {
-  Arena *arena = Compile::current()->node_arena();
+void Node::resize_array( Node**& array, node_idx_t& max_size, uint len, bool is_in) {
+  Arena* arena = Compile::current()->node_arena();
   uint new_max = max_size;
-  if (new_max == 0) {
+  if( new_max == 0 ) {
     max_size = 4;
-    array = (Node **)arena->Amalloc(4 * sizeof(Node *));
-    if (is_in) {
+    array = (Node**)arena->Amalloc(4*sizeof(Node*));
+    if(is_in){
       array[0] = nullptr;
       array[1] = nullptr;
       array[2] = nullptr;
       array[3] = nullptr;
     }
-    return;
+      return;
   }
   new_max = next_power_of_2(len);
   // Trimming to limit allows a uint8 to handle up to 255 edges.
   // Previously I was using only powers-of-2 which peaked at 128 edges.
-  // if( new_max >= limit ) new_max = limit-1;
-  if (!is_in) {
-    assert(array != nullptr && array != NO_OUT_ARRAY,
-           "out must have sensible value");
+  //if( new_max >= limit ) new_max = limit-1;
+  if(!is_in){
+    assert(array != nullptr && array != NO_OUT_ARRAY, "out must have sensible value");
   }
-  array = (Node **)arena->Arealloc(array, max_size * sizeof(Node *), new_max * sizeof(Node *));
-  if (is_in) {
-    Copy::zero_to_bytes(&array[max_size], (new_max - max_size) * sizeof(Node *)); // null all new space
+  array = (Node**)arena->Arealloc(array, max_size*sizeof(Node*), new_max*sizeof(Node*));
+  if(is_in){
+    Copy::zero_to_bytes(&array[max_size], (new_max-max_size)*sizeof(Node*)); // null all new space
   }
-  max_size = new_max; // Record new max length
+  max_size = new_max;               // Record new max length
   // This assertion makes sure that Node::_max is wide enough to
   // represent the numerical value of new_max.
-  assert(max_size == new_max && max_size > len,
-         "int width of _max is too small");
+  assert(max_size == new_max && max_size > len, "int width of _max is too small");
 }
 
 //------------------------------grow-------------------------------------------
 // Grow the input array, making space for more edges
-void Node::grow(uint len) { resize_array(_in, _max, len, true); }
+void Node::grow(uint len) {
+  resize_array(_in, _max, len, true);
+}
 
 //-----------------------------out_grow----------------------------------------
 // Grow the input array, making space for more edges
-void Node::out_grow(uint len) {
+void Node::out_grow( uint len ) {
   assert(!is_top(), "cannot grow a top node's out array");
   resize_array(_out, _outmax, len, false);
 }

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -337,7 +337,7 @@ protected:
   void out_grow( uint len );
   // Resize input or output array to grow it the next larger power-of-2 bigger
   // than len.
-  void resize_array(Node **&array, node_idx_t &max_size, uint len, bool is_in);
+  void resize_array(Node**& array, node_idx_t& max_size, uint len, bool is_input_array);
 
 public:
   // Each Node is assigned a unique small/dense number. This number is used

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -335,9 +335,9 @@ protected:
   void grow( uint len );
   // Grow the output array to the next larger power-of-2 bigger than len.
   void out_grow( uint len );
-  // Resize input or output array to grow it the next larger power-of-2 bigger
-  // than len.
-  void resize_array(Node**& array, node_idx_t& max_size, uint len, bool is_input_array);
+  // Resize input or output array to grow it to the next larger power-of-2
+  // bigger than len.
+  void resize_array(Node**& array, node_idx_t& max_size, uint len, bool needs_clearing);
 
 public:
   // Each Node is assigned a unique small/dense number. This number is used

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -335,8 +335,11 @@ protected:
   void grow( uint len );
   // Grow the output array to the next larger power-of-2 bigger than len.
   void out_grow( uint len );
+  // Resize input or output array to grow it the next larger power-of-2 bigger
+  // than len.
+  void resize_array(Node **&array, node_idx_t &max_size, uint len, bool is_in);
 
- public:
+public:
   // Each Node is assigned a unique small/dense number. This number is used
   // to index into auxiliary arrays of data and bit vectors.
   // The value of _idx can be changed using the set_idx() method.


### PR DESCRIPTION
Node:grow() and Node::out_grow() are copy-pasted from each other and their core logic could be factored out into a third function or at least cleaned up. Hence,the fix includes a function Node::array_resize() that implements the core logic of Node::grow() and Node::out_grow(). 

 Link to Github action which had no failures :  https://github.com/sarannat/jdk/actions/runs/13677508359

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350485](https://bugs.openjdk.org/browse/JDK-8350485): C2: factor out common code in Node::grow() and Node::out_grow() (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23928/head:pull/23928` \
`$ git checkout pull/23928`

Update a local copy of the PR: \
`$ git checkout pull/23928` \
`$ git pull https://git.openjdk.org/jdk.git pull/23928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23928`

View PR using the GUI difftool: \
`$ git pr show -t 23928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23928.diff">https://git.openjdk.org/jdk/pull/23928.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23928#issuecomment-2710191351)
</details>
