### PR TITLE
8351345: [IR Framework] Improve reported disabled IR verification messages

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -597,15 +597,13 @@ public class TestFramework {
             return;
         }
 
-        boolean debugTest, intTest, compTest, irTest, nonWhiteListedTest;
-
-        debugTest = Platform.isDebugBuild();
-        intTest = !Platform.isInt();
-        compTest = !Platform.isComp();
-        irTest = hasIRAnnotations();
+        boolean debugTest = Platform.isDebugBuild();
+        boolean intTest = !Platform.isInt();
+        boolean compTest = !Platform.isComp();
+        boolean irTest = hasIRAnnotations();
         // No IR verification is done if additional non-whitelisted JTreg VM or Javaoptions flag is specified.
         List<String> nonWhiteListedFlags = anyNonWhitelistedJTregVMAndJavaOptsFlags();
-        nonWhiteListedTest = nonWhiteListedFlags.isEmpty();
+        boolean nonWhiteListedTest = nonWhiteListedFlags.isEmpty();
 
         irVerificationPossible = debugTest && intTest && compTest && irTest && nonWhiteListedTest;
         if (irVerificationPossible) {
@@ -617,7 +615,7 @@ public class TestFramework {
             System.out.println("- Not running a debug build (required for PrintIdeal and PrintOptoAssembly)");
         }
         if (!intTest) {
-            System.out.println("- Running with -Xint (use warm-up of 0 instead)");
+            System.out.println("- Running with -Xint (no compilations)");
         }
         if (!compTest) {
             System.out.println("- Running with -Xcomp (use warm-up of 0 instead)");

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -597,32 +597,37 @@ public class TestFramework {
             return;
         }
 
-        boolean debugTest, irTest, nonWhiteListedTest;
+        boolean debugTest, intTest, compTest, irTest, nonWhiteListedTest;
 
-        debugTest = Platform.isDebugBuild() && !Platform.isInt() && !Platform.isComp();
+        debugTest = Platform.isDebugBuild();
+        intTest = !Platform.isInt();
+        compTest = !Platform.isComp();
         irTest = hasIRAnnotations();
         // No IR verification is done if additional non-whitelisted JTreg VM or Javaoptions flag is specified.
         List<String> nonWhiteListedFlags = anyNonWhitelistedJTregVMAndJavaOptsFlags();
         nonWhiteListedTest = nonWhiteListedFlags.isEmpty();
 
-        irVerificationPossible = debugTest && irTest && nonWhiteListedTest;
+        irVerificationPossible = debugTest && intTest && compTest && irTest && nonWhiteListedTest;
         if (irVerificationPossible) {
             return;
         }
 
-        System.out.println("IR verification disabled due to:");
+        System.out.println("IR verification disabled due to the following reason(s):");
         if (!debugTest) {
-            System.out.println("\tnot running a debug build (required for PrintIdeal and PrintOptoAssembly), " +
-                               "running with -Xint, or -Xcomp (use warm-up of 0 instead)");
+            System.out.println("- Not running a debug build (required for PrintIdeal and PrintOptoAssembly)");
         }
-
+        if (!intTest) {
+            System.out.println("- Running with -Xint (use warm-up of 0 instead)");
+        }
+        if (!compTest) {
+            System.out.println("- Running with -Xcomp (use warm-up of 0 instead)");
+        }
         if (!irTest) {
-            System.out.println("\ttest " + testClass + " not specifying any @IR annotations");
+            System.out.println("- Test " + testClass + " not specifying any @IR annotations");
         }
-
         if (!nonWhiteListedTest) {
-            System.out.println("\tusing non-whitelisted JTreg VM or Javaoptions flag(s),");
-            nonWhiteListedFlags.forEach((f) -> System.out.println("\t\t" + f));
+            System.out.println("- Using non-whitelisted JTreg VM or Javaoptions flag(s):");
+            nonWhiteListedFlags.forEach((f) -> System.out.println("  - " + f));
         }
 
         System.out.println("");

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -749,6 +749,7 @@ public class TestFramework {
             // Property flags (prefix -D), -ea and -esa are whitelisted.
             if (!flag.startsWith("-D") && !flag.startsWith("-e") && JTREG_WHITELIST_FLAGS.stream().noneMatch(flag::contains)) {
                 // Found VM flag that is not whitelisted
+                System.out.println("Non-whitelisted JTreg VM or Javaoptions flag: " + flag);
                 return false;
             }
         }


### PR DESCRIPTION
Hi,
Can you help to review this trivial patch?
Currently, it only reports that some flag is non-whitelisted, but does not print out the flag explicitly, but it's helpful to do so.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351345](https://bugs.openjdk.org/browse/JDK-8351345): [IR Framework] Improve reported disabled IR verification messages (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23931/head:pull/23931` \
`$ git checkout pull/23931`

Update a local copy of the PR: \
`$ git checkout pull/23931` \
`$ git pull https://git.openjdk.org/jdk.git pull/23931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23931`

View PR using the GUI difftool: \
`$ git pr show -t 23931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23931.diff">https://git.openjdk.org/jdk/pull/23931.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23931#issuecomment-2703694356)
</details>
