### PR TITLE
8351348: x86_64: remove redundant supports_float16 check

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4102,14 +4102,12 @@ void StubGenerator::generate_initial_stubs() {
     StubRoutines::_updateBytesCRC32C = generate_updateBytesCRC32C(supports_clmul);
   }
 
-  if (VM_Version::supports_float16()) {
-    // For results consistency both intrinsics should be enabled.
-    // vmIntrinsics checks InlineIntrinsics flag, no need to check it here.
-    if (vmIntrinsics::is_intrinsic_available(vmIntrinsics::_float16ToFloat) &&
-        vmIntrinsics::is_intrinsic_available(vmIntrinsics::_floatToFloat16)) {
-      StubRoutines::_hf2f = generate_float16ToFloat();
-      StubRoutines::_f2hf = generate_floatToFloat16();
-    }
+  // For results consistency both intrinsics should be enabled.
+  // vmIntrinsics checks InlineIntrinsics flag, no need to check it here.
+  if (vmIntrinsics::is_intrinsic_available(vmIntrinsics::_float16ToFloat) &&
+      vmIntrinsics::is_intrinsic_available(vmIntrinsics::_floatToFloat16)) {
+    StubRoutines::_hf2f = generate_float16ToFloat();
+    StubRoutines::_f2hf = generate_floatToFloat16();
   }
 
   generate_libm_stubs();


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?
`supports_float16()` is invoked in `is_intrinsic_available -> is_intrinsic_supported`, so there is no need to call it explicitly.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351348](https://bugs.openjdk.org/browse/JDK-8351348): x86_64: remove redundant supports_float16 check (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23932/head:pull/23932` \
`$ git checkout pull/23932`

Update a local copy of the PR: \
`$ git checkout pull/23932` \
`$ git pull https://git.openjdk.org/jdk.git pull/23932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23932`

View PR using the GUI difftool: \
`$ git pr show -t 23932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23932.diff">https://git.openjdk.org/jdk/pull/23932.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23932#issuecomment-2703844248)
</details>
