### PR TITLE
8353489: Increase timeout and improve Windows compatibility in test/jdk/java/lang/ProcessBuilder/Basic.java

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -1840,7 +1840,9 @@ public class Basic {
         // Test Runtime.exec(...envp...) with envstrings without any `='
         //----------------------------------------------------------------
         try {
-            String[] cmdp = Windows.is() ? new String[]{"cmd", "/c", "echo/"} : new String[]{"echo"};
+            // In Windows CMD (`cmd.exe`), `echo/` outputs a newline (i.e., an empty line).
+            // Wrapping it with `cmd.exe /c` ensures compatibility in both native Windows and Cygwin environments.
+            String[] cmdp = Windows.is() ? new String[]{"cmd.exe", "/c", "echo/"} : new String[]{"echo"};
             String[] envp = {"Hello", "World"}; // Yuck!
             Process p = Runtime.getRuntime().exec(cmdp, envp);
             equal(commandOutput(p), "\n");

--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -1840,7 +1840,7 @@ public class Basic {
         // Test Runtime.exec(...envp...) with envstrings without any `='
         //----------------------------------------------------------------
         try {
-            String[] cmdp = Windows.is() ? new String[]{"cmd", "/c", "echo."} : new String[]{"echo"};
+            String[] cmdp = Windows.is() ? new String[]{"cmd", "/c", "echo/"} : new String[]{"echo"};
             String[] envp = {"Hello", "World"}; // Yuck!
             Process p = Runtime.getRuntime().exec(cmdp, envp);
             equal(commandOutput(p), "\n");

--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,8 @@
  * @requires !vm.musl
  * @requires vm.flagless
  * @library /test/lib
- * @run main/othervm/native/timeout=300 Basic
- * @run main/othervm/native/timeout=300 -Djdk.lang.Process.launchMechanism=fork Basic
+ * @run main/othervm/native/timeout=360 Basic
+ * @run main/othervm/native/timeout=360 -Djdk.lang.Process.launchMechanism=fork Basic
  * @author Martin Buchholz
  */
 
@@ -55,7 +55,6 @@ import java.lang.ProcessHandle;
 import static java.lang.ProcessBuilder.Redirect.*;
 
 import java.io.*;
-import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -207,7 +206,7 @@ public class Basic {
 
     private static final Runtime runtime = Runtime.getRuntime();
 
-    private static final String[] winEnvCommand = {"cmd.exe", "/c", "set"};
+    private static final String[] winEnvCommand = {"cmd.exe", "/d", "/c", "set"};
 
     private static String winEnvFilter(String env) {
         return env.replaceAll("\r", "")
@@ -1841,7 +1840,7 @@ public class Basic {
         // Test Runtime.exec(...envp...) with envstrings without any `='
         //----------------------------------------------------------------
         try {
-            String[] cmdp = {"echo"};
+            String[] cmdp = Windows.is() ? new String[]{"cmd", "/c", "echo."} : new String[]{"echo"};
             String[] envp = {"Hello", "World"}; // Yuck!
             Process p = Runtime.getRuntime().exec(cmdp, envp);
             equal(commandOutput(p), "\n");


### PR DESCRIPTION
This PR proposes three improvements to the `Basic.java` test:

1. Increase Timeout
   - The current timeout is insufficient when running the test in IntelliJ IDEA.
   - I propose increasing it by one minute.
   - The timeout value was last modified on May 13, 2010 (commit [56131863a71c](https://github.com/openjdk/jdk/commit/56131863a71ca552d0a881364bd2b3581e13f058)) and has remained unchanged since then.

2. Fix Incompatibility with Windows (Cygwin vs. Native)
    - One of the tests executes the `echo` command.
    - This works in Cygwin but fails when running the test in a pure Windows environment (e.g., IntelliJ IDEA).
    - I propose replacing echo with `cmd /c echo/`, which produces the same output (a single newline) in Windows, ensuring compatibility.

3. Prevent Autorun Scripts in the `cmd /c set` Command
    - The test runs `cmd /c set`, but in Windows, this may trigger autorun scripts.
    - I propose adding the `/d` options to prevent autorun scripts from affecting the test results.

These changes improve test reliability and ensure compatibility across different environments.
Testing:
- Verified that the test runs successfully in IntelliJ IDEA without timeout issues.
- Confirmed that `cmd /c echo/` produces the expected output in Windows.
- Ensured that `cmd /d /c set` correctly lists environment variables without executing autorun scripts.

# Detailed Description

## echo
The following test fails in a clean Windows environment (e.g., when run from IntelliJ IDEA without Cygwin):
```
//----------------------------------------------------------------
// Test Runtime.exec(...envp...) with envstrings without any `='
//----------------------------------------------------------------
```
with following error:
```
Cannot run program "echo": CreateProcess error=2, The system cannot find the file specified
```

If we try to run `echo` as a process in Windows, for example from IntelliJ IDEA, we get the error above, because Windows does not have such an executable, but instead this is a command of the Command Processor (CMD).

The `echo.` command with the `.` works the same way as calling `echo` without parameters in Unix — it outputs an empty line. Was implemented using the analogous `echo/` command to avoid compatibility issues.

See: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/echo

To ensure that the `echo/` command is supported in Cygwin, we need to invoke it via `cmd /c`, because Cygwin has its own executable "echo".

## cmd.exe /c set
 The following test fails in a Windows environment under specific conditions:
```
//----------------------------------------------------------------
// Test Runtime.exec(...envp...)
// Check for sort order of environment variables on Windows.
//----------------------------------------------------------------
```
with following error:
```
>'+=+
BAZ=GORP
CONDA_BAT=C:\\.......\\miniconda3\\condabin\\conda.bat
CONDA_EXE=C:\\........\\miniconda3\\Scripts\\conda.exe
CONDA_SHLVL=0
FOO=BAR
PATH=C:\\.........\\miniconda3\\condabin;
QUUX=
SystemRoot=C:\\WINDOWS
_=_
~=~
'< not equal to '+=+
BAZ=GORP
FOO=BAR
QUUX=
SystemRoot=C:\\WINDOWS
_=_
~=~
'
```

**Reason**
In my environment, Miniconda was installed, which adds a script execution to the **autorun** of `cmd`. This script sets additional environment variables that break this test.  

To reproduce this bug, you can manually add a custom script to the autorun. I have described the steps in detail in my article: [AutoRun for Windows Command Processor (cmd.exe)](https://www.linkedin.com/pulse/autorun-windows-command-processor-cmdexe-oleksii-sylichenko-fofif).

## Changes

- increase timeout by one minute
- remove unused import

**For Windows**
- add `/d` to `winEnvCommand` - to disable the execution of AutoRun commands
- replace `echo` with `cmd /c echo.`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353489](https://bugs.openjdk.org/browse/JDK-8353489): Increase timeout and improve Windows compatibility in test/jdk/java/lang/ProcessBuilder/Basic.java (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23933/head:pull/23933` \
`$ git checkout pull/23933`

Update a local copy of the PR: \
`$ git checkout pull/23933` \
`$ git pull https://git.openjdk.org/jdk.git pull/23933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23933`

View PR using the GUI difftool: \
`$ git pr show -t 23933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23933.diff">https://git.openjdk.org/jdk/pull/23933.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23933#issuecomment-2772020969)
</details>
