### PR TITLE
8350905: Releasing a WeakHandle's referent may extend its lifetime

### DIFF
--- a/src/hotspot/share/gc/shared/stringdedup/stringDedupProcessor.cpp
+++ b/src/hotspot/share/gc/shared/stringdedup/stringDedupProcessor.cpp
@@ -123,7 +123,7 @@ class StringDedup::Processor::ProcessRequest final : public OopClosure {
 
   void release_ref(oop* ref) {
     assert(_release_index < ARRAY_SIZE(_bulk_release), "invariant");
-    NativeAccess<ON_PHANTOM_OOP_REF>::oop_store(ref, nullptr);
+    NativeAccess<ON_PHANTOM_OOP_REF | AS_NO_KEEPALIVE>::oop_store(ref, nullptr);
     _bulk_release[_release_index++] = ref;
     if (_release_index == ARRAY_SIZE(_bulk_release)) {
       _storage->release(_bulk_release, _release_index);

--- a/src/hotspot/share/oops/weakHandle.cpp
+++ b/src/hotspot/share/oops/weakHandle.cpp
@@ -50,7 +50,7 @@ void WeakHandle::release(OopStorage* storage) {
   if (_obj != nullptr) {
     // Clear the WeakHandle.  For race in creating ClassLoaderData, we can release this
     // WeakHandle before it is cleared by GC.
-    NativeAccess<ON_PHANTOM_OOP_REF>::oop_store(_obj, nullptr);
+    NativeAccess<ON_PHANTOM_OOP_REF | AS_NO_KEEPALIVE>::oop_store(_obj, nullptr);
     storage->release(_obj);
     _obj = nullptr;
   }

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -155,7 +155,7 @@ void JNIHandles::destroy_global(jobject handle) {
 void JNIHandles::destroy_weak_global(jweak handle) {
   if (handle != nullptr) {
     oop* oop_ptr = weak_global_ptr(handle);
-    NativeAccess<ON_PHANTOM_OOP_REF>::oop_store(oop_ptr, (oop)nullptr);
+    NativeAccess<ON_PHANTOM_OOP_REF | AS_NO_KEEPALIVE>::oop_store(oop_ptr, (oop)nullptr);
     weak_global_handles()->release(oop_ptr);
   }
 }


### PR DESCRIPTION
When weak handles are cleared, the `nullptr` is stored with the `ON_PHANTOM_OOP_REF` decorator. For concurrent collectors using a SATB barrier, this may cause the referent to be enqueued and marked when it would be otherwise unreachable. The problem is especially acute for Shenandoah's generational mode, in which a young region holding the otherwise unreachable referent, may become trash after the referent is enqueued for old marking. We are proposing that native weak references are cleared with an additional `AS_NO_KEEPALIVE` decorator. This is similar to what was done for j.l.r.WeakReference in [JDK-8240696](https://bugs.openjdk.org/browse/JDK-8240696).

# Testing

GHA, `hotspot_gc_shenandoah`. Additionally, for G1, ZGC, and Shenandoah we've run Extremem, Dacapo, SpecJVM2008, SpecJBB2015, Heapothesys and Diluvian. All executions completed without errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350905](https://bugs.openjdk.org/browse/JDK-8350905): Releasing a WeakHandle's referent may extend its lifetime (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23935/head:pull/23935` \
`$ git checkout pull/23935`

Update a local copy of the PR: \
`$ git checkout pull/23935` \
`$ git pull https://git.openjdk.org/jdk.git pull/23935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23935`

View PR using the GUI difftool: \
`$ git pr show -t 23935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23935.diff">https://git.openjdk.org/jdk/pull/23935.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23935#issuecomment-2704705164)
</details>
