### PR TITLE
8351017: ChronoUnit.MONTHS.between() not giving correct result when date is in February

### DIFF
--- a/src/java.base/share/classes/java/time/temporal/TemporalUnit.java
+++ b/src/java.base/share/classes/java/time/temporal/TemporalUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,9 +239,15 @@ public interface TemporalUnit {
      * calculated using {@code HOURS.between(startTime, endTime)}.
      * <p>
      * The calculation returns a whole number, representing the number of
-     * complete units between the two temporals.
+     * complete units between the two temporals. If there are smaller unit
+     * fields, their values are considered when determining the final
+     * whole number.
+     *
      * For example, the amount in hours between the times 11:30 and 13:29
-     * will only be one hour as it is one minute short of two hours.
+     * will only be one hour as it is one minute short of two hours, or
+     * the amount in months between the dates 2024-09-29 and 2025-02-28
+     * (the last day in February) will be 4 months as it is one day short
+     * of 5 months.
      * <p>
      * There are two equivalent ways of using this method.
      * The first is to invoke this method directly.


### PR DESCRIPTION
Clarifying the explanation for `TemporalUnit.between()`. There is already an example for the `HOURS` case where the minutes are not enough to make a full hour. Explaining how smaller units contribute to determining the whole number, along with an explicit `MONTHS` example, which was the case reported by the bug submitter, will help users.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351017](https://bugs.openjdk.org/browse/JDK-8351017): ChronoUnit.MONTHS.between() not giving correct result when date is in February (**Bug** - P4)


### Reviewers
 * [Stephen Colebourne](https://openjdk.org/census#scolebourne) (@jodastephen - Author)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23937/head:pull/23937` \
`$ git checkout pull/23937`

Update a local copy of the PR: \
`$ git checkout pull/23937` \
`$ git pull https://git.openjdk.org/jdk.git pull/23937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23937`

View PR using the GUI difftool: \
`$ git pr show -t 23937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23937.diff">https://git.openjdk.org/jdk/pull/23937.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23937#issuecomment-2705182524)
</details>
