### PR TITLE
8348261: assert(n->is_Mem()) failed: memory node required

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4712,13 +4712,21 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
       if (n == nullptr) {
         continue;
       }
+    } else if (n->Opcode() == Op_StrInflatedCopy) {
+      // Check direct uses of StrInflatedCopy.
+      // It is memory type Node - no special SCMemProj node.
     } else if (n->Opcode() == Op_StrCompressedCopy ||
                n->Opcode() == Op_EncodeISOArray) {
       // get the memory projection
       n = n->find_out_with(Op_SCMemProj);
       assert(n != nullptr && n->Opcode() == Op_SCMemProj, "memory projection required");
     } else {
+#ifdef ASSERT
+      if (!n->is_Mem()) {
+        n->dump();
+      }
       assert(n->is_Mem(), "memory node required.");
+#endif
       Node *addr = n->in(MemNode::Address);
       const Type *addr_t = igvn->type(addr);
       if (addr_t == Type::TOP) {


### PR DESCRIPTION
Add missing check for StrInflatedCopy intrinsic in C2 Escape Analysis.

Very rare case since we not usually use Latin1.inflate(). In failing case we inline both paths in [String.getBytes()](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/lang/String.java#L4808) and eliminate `TreeMap$EntryIterator allocation:

```
        # java.lang.String::getBytes @ bci:40 (line 4812) L[0]=rsp + #64 L[1]=rsp + #132 L[2]=rsp + #120 L[3]=rsp + #124 STK[0]=rsp + #128 STK[1]=#0 STK[2]=rsp + #132 STK[3]=rsp + #120 STK[4]=rsp + #164
        # java.lang.AbstractStringBuilder::putStringAt @ bci:15 (line 1754) L[0]=rsp + #0 L[1]=rsp + #120 L[2]=rsp + #64
        # java.lang.AbstractStringBuilder::append @ bci:30 (line 592) L[0]=rsp + #0 L[1]=rsp + #64 L[2]=rsp + #28
        # java.lang.StringBuilder::append @ bci:2 (line 179) L[0]=rsp + #0 L[1]=rsp + #64
        # java.lang.StringBuilder::append @ bci:5 (line 173) L[0]=rsp + #0 L[1]=rsp + #32
        # sun.util.locale.LocaleExtensions::toID @ bci:100 (line 206) L[0]=RBP L[1]=rsp + #0 L[2]=rsp + #8 L[3]=#ScObj0 L[4]=rsp + #16 L[5]=rsp + #24 L[6]=rsp + #32
        # ScObj0 java/util/TreeMap$EntryIterator={ [expectedModCount :0]=rsp + #140, [next :1]=rsp + #176, [lastReturned :2]=rsp + #16, [this$0 :3]=rsp + #168 }
```

Unfortunately I was not able to create standalone test - it seems requires very particular frequencies of executed paths and used features/flags. The fix was verified with compilation replay file from the bug report.

I am running testing and will let you know results.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348261](https://bugs.openjdk.org/browse/JDK-8348261): assert(n-&gt;is_Mem()) failed: memory node required (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23938/head:pull/23938` \
`$ git checkout pull/23938`

Update a local copy of the PR: \
`$ git checkout pull/23938` \
`$ git pull https://git.openjdk.org/jdk.git pull/23938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23938`

View PR using the GUI difftool: \
`$ git pr show -t 23938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23938.diff">https://git.openjdk.org/jdk/pull/23938.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23938#issuecomment-2705265356)
</details>
