### PR TITLE
8350835: C2 SuperWord: assert/wrong result when using Float.float16ToFloat with byte instead of short input

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1497,7 +1497,9 @@ int VectorCastNode::opcode(int sopc, BasicType bt, bool is_signed) {
   // Handle special case for to/from Half Float conversions
   switch (sopc) {
     case Op_ConvHF2F:
-      assert(bt == T_SHORT, "");
+      if (!is_signed || (bt != T_SHORT)) {
+        return 0;
+      }
       return Op_VectorCastHF2F;
     case Op_ConvF2HF:
       assert(bt == T_FLOAT, "");

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16ToFloatConv.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16ToFloatConv.java
@@ -23,6 +23,7 @@
 
 /**
 * @test
+* @key randomness
 * @bug 8350835
 * @summary Test bug fix for JDK-8350835 discovered through Template Framework
 * @requires vm.compiler2.enabled
@@ -33,15 +34,17 @@
 package compiler.vectorization;
 
 import compiler.lib.ir_framework.*;
+import jdk.test.lib.Utils;
 import java.util.Random; 
 
 public class TestFloat16ToFloatConv {
-    public static Random RANDOM = new Random();
-    public static byte[] aB = new byte[1000];
-    public static short[] aS = new short[1000];
-    public static int[] aI = new int[1000];
-    public static long[] aL = new long[1000];
-    public static float[] goldB, goldS, goldI, goldL;
+    private static final Random RANDOM = Utils.getRandomInstance();
+    private static final int SIZE = 1024;
+    private static byte[] aB = new byte[SIZE];
+    private static short[] aS = new short[SIZE];
+    private static int[] aI = new int[SIZE];
+    private static long[] aL = new long[SIZE];
+    private static float[] goldB, goldS, goldI, goldL;
 
     static {
         for (int i = 0; i < aB.length; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16ToFloatConv.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16ToFloatConv.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+* @test
+* @bug 8350835
+* @summary Test bug fix for JDK-8350835 discovered through Template Framework
+* @requires vm.compiler2.enabled
+* @library /test/lib /
+* @run main/othervm -XX:-TieredCompilation -XX:CompileOnly=compiler.vectorization.TestFloat16ToFloatConv::test* compiler.vectorization.TestFloat16ToFloatConv
+*/
+
+package compiler.vectorization;
+
+import compiler.lib.ir_framework.*;
+import java.util.Random; 
+
+public class TestFloat16ToFloatConv {
+    public static Random RANDOM = new Random();
+    public static byte[] aB = new byte[1000];
+    public static short[] aS = new short[1000];
+    public static int[] aI = new int[1000];
+    public static long[] aL = new long[1000];
+    public static float[] goldB, goldS, goldI, goldL;
+
+    static {
+        for (int i = 0; i < aB.length; i++) {
+            aB[i] = (byte)RANDOM.nextInt();
+            aS[i] = (short)RANDOM.nextInt();
+            aI[i] = RANDOM.nextInt();
+            aL[i] = RANDOM.nextLong();
+        }
+        goldB = testByteKernel(aB);
+        goldS = testShortKernel(aS);
+        goldI = testIntKernel(aI);
+        goldL = testLongKernel(aL);
+    }
+    
+    @Test
+    public static float[] testByteKernel(byte[] barr) {
+        float[] res = new float[barr.length];
+        for (int i = 0; i < barr.length; i++) {
+            res[i] = Float.float16ToFloat(barr[i]);
+        }
+        return res;
+    }
+
+    @Test
+    public static float[] testShortKernel(short[] sarr) {
+        float[] res = new float[sarr.length];
+        for (int i = 0; i < sarr.length; i++) {
+            res[i] = Float.float16ToFloat(sarr[i]);
+        }
+        return res;
+    }
+
+    @Test
+    public static float[] testIntKernel(int[] iarr) {
+        float[] res = new float[iarr.length];
+        for (int i = 0; i < iarr.length; i++) {
+            res[i] = Float.float16ToFloat((short)iarr[i]);
+        }
+        return res;
+    }
+
+    @Test
+    public static float[] testLongKernel(long[] larr) {
+        float[] res = new float[larr.length];
+        for (int i = 0; i < larr.length; i++) {
+            res[i] = Float.float16ToFloat((short)larr[i]);
+        }
+        return res;
+    }
+
+    public static void checkResult(float[] res, float[] gold) {
+        for (int i = 0; i < res.length; i++) {
+            if (Float.floatToIntBits(res[i]) != Float.floatToIntBits(gold[i])) {
+                throw new RuntimeException("wrong value: " + Float.floatToRawIntBits(res[i]) + " " + Float.floatToRawIntBits(gold[i]));
+            }
+        }
+    }
+
+    @Run(test = {"testByteKernel"})
+    public static void testByte() {
+        float[] farr = testByteKernel(aB);
+        checkResult(farr, goldB);
+    }
+
+    @Run(test = {"testShortKernel"})
+    public static void testShort() {
+        float[] farr = testShortKernel(aS);
+        checkResult(farr, goldS);
+    }
+
+    @Run(test = {"testIntKernel"})
+    public static void testInt() {
+        float[] farr = testIntKernel(aI);
+        checkResult(farr, goldI);
+    }
+
+    @Run(test = {"testLongKernel"})
+    public static void testLong() {
+        float[] farr = testLongKernel(aL);
+        checkResult(farr, goldL);
+    }
+
+    public static void main(String [] args) {
+        TestFramework.run(TestFloat16ToFloatConv.class);
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16ToFloatConv.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16ToFloatConv.java
@@ -35,7 +35,7 @@ package compiler.vectorization;
 
 import compiler.lib.ir_framework.*;
 import jdk.test.lib.Utils;
-import java.util.Random; 
+import java.util.Random;
 
 public class TestFloat16ToFloatConv {
     private static final Random RANDOM = Utils.getRandomInstance();
@@ -58,7 +58,7 @@ public class TestFloat16ToFloatConv {
         goldI = testIntKernel(aI);
         goldL = testLongKernel(aL);
     }
-    
+
     @Test
     public static float[] testByteKernel(byte[] barr) {
         float[] res = new float[barr.length];


### PR DESCRIPTION
Float.float16ToFloat generates wrong vectorized code in product build and asserts in fastdebug/debug when argument is of type byte, int, or long array. The short term solution is to not auto vectorize in these cases.

Review comments are welcome.

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350835](https://bugs.openjdk.org/browse/JDK-8350835): C2 SuperWord: assert/wrong result when using Float.float16ToFloat with byte instead of short input (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [4ebb47a7](https://git.openjdk.org/jdk/pull/23939/files/4ebb47a75a74946834d2800564eddd5e3b850c1d)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23939/head:pull/23939` \
`$ git checkout pull/23939`

Update a local copy of the PR: \
`$ git checkout pull/23939` \
`$ git pull https://git.openjdk.org/jdk.git pull/23939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23939`

View PR using the GUI difftool: \
`$ git pr show -t 23939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23939.diff">https://git.openjdk.org/jdk/pull/23939.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23939#issuecomment-2705371045)
</details>
