### PR TITLE
8351377: Fix the ProblemList for com/sun/management/OperatingSystemMXBean cpuLoad tests on AIX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -537,11 +537,9 @@ java/io/IO/IO.java                                              8337935 linux-pp
 
 # jdk_management
 
-com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad.java 8030957 aix-all
-com/sun/management/OperatingSystemMXBean/GetSystemCpuLoad.java  8030957 aix-all
-
-com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad.java 8351002 windows-all
-com/sun/management/OperatingSystemMXBean/GetSystemCpuLoad.java  8351002 windows-all
+# First bug for AIX, second for Windows
+com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad.java 8030957,8351002 aix-all,windows-all
+com/sun/management/OperatingSystemMXBean/GetSystemCpuLoad.java  8030957,8351002 aix-all,windows-all
 
 java/lang/management/MemoryMXBean/Pending.java                  8158837 generic-all
 java/lang/management/MemoryMXBean/PendingAllGC.sh               8158837 generic-all


### PR DESCRIPTION
Corrected the multiple PL entries as they need to be  in a single entry per test.

Verified Windows part works so assuming AIX part will too.

Paging @ArnoZeller 

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351377](https://bugs.openjdk.org/browse/JDK-8351377): Fix the ProblemList for com/sun/management/OperatingSystemMXBean cpuLoad tests on AIX (**Bug** - P3)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23940/head:pull/23940` \
`$ git checkout pull/23940`

Update a local copy of the PR: \
`$ git checkout pull/23940` \
`$ git pull https://git.openjdk.org/jdk.git pull/23940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23940`

View PR using the GUI difftool: \
`$ git pr show -t 23940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23940.diff">https://git.openjdk.org/jdk/pull/23940.diff</a>

</details>
