### PR TITLE
8351280: Mark Assertion Predicates useless instead of replacing them by a constant directly

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4506,8 +4506,7 @@ void PhaseIdealLoop::eliminate_useless_template_assertion_predicates(Unique_Node
     OpaqueTemplateAssertionPredicateNode* opaque_node =
         C->template_assertion_predicate_opaq_node(i - 1)->as_OpaqueTemplateAssertionPredicate();
     if (!useful_predicates.member(opaque_node)) { // not in the useful list
-      opaque_node->mark_useless();
-      _igvn._worklist.push(opaque_node);
+      opaque_node->mark_useless(_igvn);
     }
   }
 }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4586,8 +4586,7 @@ void PhaseIdealLoop::eliminate_useless_multiversion_if() {
         // We cannot hack the node directly, otherwise the slow_loop will complain that it cannot
         // find the multiversioning opaque node. Instead, we mark the opaque node as useless, and
         // it can be constant folded during IGVN.
-        opaque->mark_useless();
-        _igvn._worklist.push(opaque);
+        opaque->mark_useless(_igvn);
       }
     }
   }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4501,13 +4501,13 @@ void PhaseIdealLoop::collect_useful_template_assertion_predicates_for_loop(Ideal
   }
 }
 
-void PhaseIdealLoop::eliminate_useless_template_assertion_predicates(Unique_Node_List& useful_predicates) {
+void PhaseIdealLoop::eliminate_useless_template_assertion_predicates(Unique_Node_List& useful_predicates) const {
   for (int i = C->template_assertion_predicate_count(); i > 0; i--) {
     OpaqueTemplateAssertionPredicateNode* opaque_node =
         C->template_assertion_predicate_opaq_node(i - 1)->as_OpaqueTemplateAssertionPredicate();
     if (!useful_predicates.member(opaque_node)) { // not in the useful list
-      ConINode* one = intcon(1);
-      _igvn.replace_node(opaque_node, one);
+      opaque_node->mark_useless();
+      _igvn._worklist.push(opaque_node);
     }
   }
 }

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1453,7 +1453,7 @@ public:
   void eliminate_useless_template_assertion_predicates();
   void collect_useful_template_assertion_predicates(Unique_Node_List& useful_predicates);
   static void collect_useful_template_assertion_predicates_for_loop(IdealLoopTree* loop, Unique_Node_List& useful_predicates);
-  void eliminate_useless_template_assertion_predicates(Unique_Node_List& useful_predicates);
+  void eliminate_useless_template_assertion_predicates(Unique_Node_List& useful_predicates) const;
 
   void eliminate_useless_zero_trip_guard();
   void eliminate_useless_multiversion_if();

--- a/src/hotspot/share/opto/opaquenode.cpp
+++ b/src/hotspot/share/opto/opaquenode.cpp
@@ -136,11 +136,6 @@ void OpaqueTemplateAssertionPredicateNode::dump_spec(outputStream* st) const {
 }
 #endif // NOT PRODUCT
 
-// Avoid that a useless OpaqueInitializedAssertionPredicateNode is commoned up with a useful one.
-bool OpaqueInitializedAssertionPredicateNode::cmp(const Node &n) const {
-  return _useless == n.as_OpaqueInitializedAssertionPredicate()->is_useless();
-}
-
 const Type* OpaqueInitializedAssertionPredicateNode::Value(PhaseGVN* phase) const {
   if (_useless) {
     return TypeInt::ONE;

--- a/src/hotspot/share/opto/opaquenode.cpp
+++ b/src/hotspot/share/opto/opaquenode.cpp
@@ -128,6 +128,11 @@ const Type* OpaqueTemplateAssertionPredicateNode::Value(PhaseGVN* phase) const {
   return phase->type(in(1));
 }
 
+void OpaqueTemplateAssertionPredicateNode::mark_useless(PhaseIterGVN& igvn) {
+  _useless = true;
+  igvn._worklist.push(this);
+}
+
 #ifndef PRODUCT
 void OpaqueTemplateAssertionPredicateNode::dump_spec(outputStream* st) const {
   if (_useless) {

--- a/src/hotspot/share/opto/opaquenode.cpp
+++ b/src/hotspot/share/opto/opaquenode.cpp
@@ -82,6 +82,12 @@ IfNode* OpaqueZeroTripGuardNode::if_node() const {
   return iff->as_If();
 }
 
+void OpaqueMultiversioningNode::mark_useless(PhaseIterGVN& igvn) {
+  assert(_is_delayed_slow_loop, "must still be delayed");
+  _useless = true;
+  igvn._worklist.push(this);
+}
+
 Node* OpaqueMultiversioningNode::Identity(PhaseGVN* phase) {
   // Constant fold the multiversion_if. Since the slow_loop is still delayed,
   // i.e. we have not yet added any possibly failing condition, we can just

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -196,7 +196,11 @@ class OpaqueInitializedAssertionPredicateNode : public Node {
   // and then clean this node up in the next IGVN phase by checking this flag in Value().
   bool _useless;
 
-  virtual bool cmp(const Node& n) const;
+  // OpaqueInitializedAssertionPredicateNode are unique to an Initialized Assertion Predicate expression and should never
+  // common up. Thus, we return NO_HASH here.
+  virtual uint hash() const {
+    return NO_HASH;
+  }
 
  public:
   OpaqueInitializedAssertionPredicateNode(BoolNode* bol, Compile* C) : Node(nullptr, bol),

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -179,10 +179,7 @@ class OpaqueTemplateAssertionPredicateNode : public Node {
     return _useless;
   }
 
-  void mark_useless() {
-    _useless = true;
-  }
-
+  void mark_useless(PhaseIterGVN& igvn);
   NOT_PRODUCT(void dump_spec(outputStream* st) const);
 };
 

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -110,6 +110,7 @@ public:
     init_class_id(Class_OpaqueMultiversioning);
   }
   virtual int Opcode() const;
+  virtual Node* Identity(PhaseGVN* phase);
   virtual const Type* bottom_type() const { return TypeInt::BOOL; }
   bool is_delayed_slow_loop() const { return _is_delayed_slow_loop; }
 
@@ -118,12 +119,7 @@ public:
     _is_delayed_slow_loop = false;
   }
 
-  void mark_useless() {
-    assert(_is_delayed_slow_loop, "must still be delayed");
-    _useless = true;
-  }
-
-  virtual Node* Identity(PhaseGVN* phase);
+  void mark_useless(PhaseIterGVN& igvn);
   NOT_PRODUCT(virtual void dump_spec(outputStream* st) const;)
 };
 

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,33 +152,71 @@ class OpaqueNotNullNode : public Node {
 // after loop opts and thus is never converted to actual code. In the post loop opts IGVN phase, the
 // OpaqueTemplateAssertionPredicateNode is replaced by true in order to fold the Template Assertion Predicate away.
 class OpaqueTemplateAssertionPredicateNode : public Node {
+  // When splitting a loop or when the associated loop dies, the Template Assertion Predicate with this
+  // OpaqueTemplateAssertionPredicateNode also needs to be removed. We set this flag and then clean this node up in the
+  // next IGVN phase by checking this flag in Value().
+  bool _useless;
+
+  // OpaqueTemplateAssertionPredicateNodes are unique to a Template Assertion Predicate expression and should never
+  // common up. We still make sure of that by returning NO_HASH here.
+  virtual uint hash() const {
+    return NO_HASH;
+  }
+
  public:
-  OpaqueTemplateAssertionPredicateNode(BoolNode* bol) : Node(nullptr, bol) {
+  OpaqueTemplateAssertionPredicateNode(BoolNode* bol) : Node(nullptr, bol),
+      _useless(false) {
     init_class_id(Class_OpaqueTemplateAssertionPredicate);
   }
 
   virtual int Opcode() const;
+  virtual uint size_of() const { return sizeof(*this); }
   virtual Node* Identity(PhaseGVN* phase);
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual const Type* bottom_type() const { return TypeInt::BOOL; }
+
+  bool is_useless() const {
+    return _useless;
+  }
+
+  void mark_useless() {
+    _useless = true;
+  }
+
+  NOT_PRODUCT(void dump_spec(outputStream* st) const);
 };
 
 // This node is used for Initialized Assertion Predicate BoolNodes. Initialized Assertion Predicates must always evaluate
-// to true. During  macro expansion, we replace the OpaqueInitializedAssertionPredicateNodes with true in product builds
+// to true. During macro expansion, we replace the OpaqueInitializedAssertionPredicateNodes with true in product builds
 // such that the actually unneeded checks are folded and do not end up in the emitted code. In debug builds, we keep the
 // actual checks as additional verification code (i.e. removing OpaqueInitializedAssertionPredicateNodes and use the
 // BoolNode inputs instead).
 class OpaqueInitializedAssertionPredicateNode : public Node {
+  // When updating a loop in Loop Unrolling, we forcefully kill old Initialized Assertion Predicates. We set this flag
+  // and then clean this node up in the next IGVN phase by checking this flag in Value().
+  bool _useless;
+
+  virtual bool cmp(const Node& n) const;
+
  public:
-  OpaqueInitializedAssertionPredicateNode(BoolNode* bol, Compile* C) : Node(nullptr, bol) {
+  OpaqueInitializedAssertionPredicateNode(BoolNode* bol, Compile* C) : Node(nullptr, bol),
+      _useless(false) {
     init_class_id(Class_OpaqueInitializedAssertionPredicate);
     init_flags(Flag_is_macro);
     C->add_macro_node(this);
   }
 
   virtual int Opcode() const;
+  virtual uint size_of() const { return sizeof(*this); }
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual const Type* bottom_type() const { return TypeInt::BOOL; }
+
+  bool is_useless() const {
+    return _useless;
+  }
+
+  void mark_useless(PhaseIterGVN& igvn);
+  NOT_PRODUCT(void dump_spec(outputStream* st) const);
 };
 
 //------------------------------ProfileBooleanNode-------------------------------

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -222,10 +222,8 @@ InitializedAssertionPredicate TemplateAssertionPredicate::initialize(PhaseIdealL
 
 // Kills this Template Assertion Predicate by marking the associated OpaqueTemplateAssertionPredicate node useless.
 // It will then be folded away in the next IGVN round.
-void TemplateAssertionPredicate::kill(const PhaseIterGVN& igvn) const {
-  OpaqueTemplateAssertionPredicateNode* opaque_node = this->opaque_node();
-  opaque_node->mark_useless();
-  igvn._worklist.push(opaque_node);
+void TemplateAssertionPredicate::kill(PhaseIterGVN& igvn) const {
+  opaque_node()->mark_useless(igvn);
 }
 
 #ifdef ASSERT

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -220,10 +220,12 @@ InitializedAssertionPredicate TemplateAssertionPredicate::initialize(PhaseIdealL
   return initialized_assertion_predicate;
 }
 
-// Kills the Template Assertion Predicate by setting the condition to true. Will be folded away in the next IGVN round.
-void TemplateAssertionPredicate::kill(PhaseIdealLoop* phase) const {
-  ConINode* true_con = phase->intcon(1);
-  phase->igvn().replace_input_of(_if_node, 1, true_con);
+// Kills this Template Assertion Predicate by marking the associated OpaqueTemplateAssertionPredicate node useless.
+// It will then be folded away in the next IGVN round.
+void TemplateAssertionPredicate::kill(const PhaseIterGVN& igvn) const {
+  OpaqueTemplateAssertionPredicateNode* opaque_node = this->opaque_node();
+  opaque_node->mark_useless();
+  igvn._worklist.push(opaque_node);
 }
 
 #ifdef ASSERT
@@ -303,9 +305,10 @@ bool InitializedAssertionPredicate::is_predicate(const Node* node) {
   return if_node->in(1)->is_OpaqueInitializedAssertionPredicate();
 }
 
-void InitializedAssertionPredicate::kill(PhaseIdealLoop* phase) const {
-  Node* true_con = phase->intcon(1);
-  phase->igvn().replace_input_of(_if_node, 1, true_con);
+// Kills this Initialized Assertion Predicate by marking the associated OpaqueInitializedAssertionPredicate node useless.
+// It will then be folded away in the next IGVN round.
+void InitializedAssertionPredicate::kill(PhaseIterGVN& igvn) const {
+  opaque_node()->mark_useless(igvn);
 }
 
 #ifdef ASSERT
@@ -1084,7 +1087,7 @@ void CloneUnswitchedLoopPredicatesVisitor::visit(const TemplateAssertionPredicat
 
   _clone_predicate_to_true_path_loop.clone_template_assertion_predicate(template_assertion_predicate);
   _clone_predicate_to_false_path_loop.clone_template_assertion_predicate(template_assertion_predicate);
-  template_assertion_predicate.kill(_phase);
+  template_assertion_predicate.kill(_phase->igvn());
 }
 
 // Update the Template Assertion Predicate by setting a new input for the OpaqueLoopStrideNode. Create a new
@@ -1099,6 +1102,16 @@ void UpdateStrideForAssertionPredicates::visit(const TemplateAssertionPredicate&
   InitializedAssertionPredicate initialized_assertion_predicate =
       initialize_from_updated_template(template_assertion_predicate);
   connect_initialized_assertion_predicate(template_tail_control_out, initialized_assertion_predicate);
+}
+
+// Kill the old Initialized Assertion Predicates with old strides before unrolling. The new Initialized Assertion
+// Predicates are inserted after the Template Assertion Predicate which ensures that we are not accidentally visiting
+// and killing a newly created Initialized Assertion Predicate here.
+void UpdateStrideForAssertionPredicates::visit(const InitializedAssertionPredicate& initialized_assertion_predicate) {
+  if (initialized_assertion_predicate.is_last_value()) {
+    // Only Last Value Initialized Assertion Predicates need to be killed and updated.
+    initialized_assertion_predicate.kill(_phase->igvn());
+  }
 }
 
 // Replace the input to OpaqueLoopStrideNode with 'new_stride' and leave the other nodes unchanged.

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -414,7 +414,7 @@ class TemplateAssertionPredicate : public Predicate {
   InitializedAssertionPredicate initialize(PhaseIdealLoop* phase) const;
   void rewire_loop_data_dependencies(IfTrueNode* target_predicate, const NodeInLoopBody& data_in_loop_body,
                                      const PhaseIdealLoop* phase) const;
-  void kill(const PhaseIterGVN& igvn) const;
+  void kill(PhaseIterGVN& igvn) const;
   static bool is_predicate(const Node* maybe_success_proj);
 
 #ifdef ASSERT

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -403,6 +403,10 @@ class TemplateAssertionPredicate : public Predicate {
     return _if_node->assertion_predicate_type() == AssertionPredicateType::LastValue;
   }
 
+  bool is_useless() const {
+    return opaque_node()->is_useless();
+  }
+
   TemplateAssertionPredicate clone(Node* new_control, PhaseIdealLoop* phase) const;
   TemplateAssertionPredicate clone_and_replace_opaque_input(Node* new_control, Node* new_opaque_input,
                                                             PhaseIdealLoop* phase) const;
@@ -410,8 +414,8 @@ class TemplateAssertionPredicate : public Predicate {
   InitializedAssertionPredicate initialize(PhaseIdealLoop* phase) const;
   void rewire_loop_data_dependencies(IfTrueNode* target_predicate, const NodeInLoopBody& data_in_loop_body,
                                      const PhaseIdealLoop* phase) const;
-  void kill(PhaseIdealLoop* phase) const;
-  static bool is_predicate(const Node* node);
+  void kill(const PhaseIterGVN& igvn) const;
+  static bool is_predicate(const Node* maybe_success_proj);
 
 #ifdef ASSERT
   static void verify(IfTrueNode* template_assertion_predicate_success_proj) {
@@ -456,8 +460,12 @@ class InitializedAssertionPredicate : public Predicate {
     return _if_node->assertion_predicate_type() == AssertionPredicateType::LastValue;
   }
 
-  void kill(PhaseIdealLoop* phase) const;
-  static bool is_predicate(const Node* node);
+  bool is_useless() const {
+    return opaque_node()->is_useless();
+  }
+
+  void kill(PhaseIterGVN& igvn) const;
+  static bool is_predicate(const Node* maybe_success_proj);
 
 #ifdef ASSERT
   static void verify(IfTrueNode* initialized_assertion_predicate_success_proj) {
@@ -652,44 +660,78 @@ class InitializedAssertionPredicateCreator : public StackObj {
 
 // This class iterates through all predicates of a Regular Predicate Block and applies the given visitor to each.
 class RegularPredicateBlockIterator : public StackObj {
-  Node* const _start_node;
+  Node* _current_node;
   const Deoptimization::DeoptReason _deopt_reason;
 
  public:
   RegularPredicateBlockIterator(Node* start_node, Deoptimization::DeoptReason deopt_reason)
-      : _start_node(start_node),
+      : _current_node(start_node),
         _deopt_reason(deopt_reason) {}
   NONCOPYABLE(RegularPredicateBlockIterator);
 
   // Skip all predicates by just following the inputs. We do not call any user provided visitor.
-  Node* skip_all() const {
+  Node* skip_all() {
     PredicateVisitor do_nothing; // No real visits, just do nothing.
     return for_each(do_nothing);
   }
 
   // Walk over all predicates of this block (if any) and apply the given 'predicate_visitor' to each predicate.
   // Returns the entry to the earliest predicate.
-  Node* for_each(PredicateVisitor& predicate_visitor) const {
-    Node* current = _start_node;
+  Node* for_each(PredicateVisitor& predicate_visitor) {
     while (predicate_visitor.should_continue()) {
-      if (TemplateAssertionPredicate::is_predicate(current)) {
-        TemplateAssertionPredicate template_assertion_predicate(current->as_IfTrue());
-        predicate_visitor.visit(template_assertion_predicate);
-        current = template_assertion_predicate.entry();
-      } else if (RuntimePredicate::is_predicate(current, _deopt_reason)) {
-        RuntimePredicate runtime_predicate(current->as_IfProj());
-        predicate_visitor.visit(runtime_predicate);
-        current = runtime_predicate.entry();
-      } else if (InitializedAssertionPredicate::is_predicate(current)) {
-        InitializedAssertionPredicate initialized_assertion_predicate(current->as_IfTrue());
-        predicate_visitor.visit(initialized_assertion_predicate);
-        current = initialized_assertion_predicate.entry();
-      } else {
-        // Either a Parse Predicate or not a Regular Predicate. In both cases, the node does not belong to this block.
-        break;
+      if (process_template_assertion_predicate(predicate_visitor)) {
+        continue;
       }
+
+      if (process_runtime_predicate(predicate_visitor)) {
+        continue;
+      }
+
+      if (process_initialized_assertion_predicate(predicate_visitor)) {
+        continue;
+      }
+      // Either a Parse Predicate or not a Regular Predicate. In both cases, the node does not belong to this block.
+      break;
     }
-    return current;
+    return _current_node;
+  }
+
+  bool process_template_assertion_predicate(PredicateVisitor& predicate_visitor) {
+    if (!TemplateAssertionPredicate::is_predicate(_current_node)) {
+      return false;
+    }
+
+    TemplateAssertionPredicate template_assertion_predicate(_current_node->as_IfTrue());
+    if (!template_assertion_predicate.is_useless()) {
+      // Only visit if not useless. Otherwise, just skip over it to possibly process other predicates above.
+      predicate_visitor.visit(template_assertion_predicate);
+    }
+    _current_node = template_assertion_predicate.entry();
+    return true;
+  }
+
+  bool process_runtime_predicate(PredicateVisitor& predicate_visitor) {
+    if (!RuntimePredicate::is_predicate(_current_node, _deopt_reason)) {
+      return false;
+    }
+    RuntimePredicate runtime_predicate(_current_node->as_IfProj());
+    predicate_visitor.visit(runtime_predicate);
+    _current_node = runtime_predicate.entry();
+    return true;
+  }
+
+  bool process_initialized_assertion_predicate(PredicateVisitor& predicate_visitor) {
+    if (!InitializedAssertionPredicate::is_predicate(_current_node)) {
+      return false;
+    }
+
+    InitializedAssertionPredicate initialized_assertion_predicate(_current_node->as_IfTrue());
+    if (!initialized_assertion_predicate.is_useless()) {
+      // Only visit if not useless. Otherwise, just skip over it to possibly process other predicates above.
+      predicate_visitor.visit(initialized_assertion_predicate);
+    }
+    _current_node = initialized_assertion_predicate.entry();
+    return true;
   }
 };
 
@@ -697,7 +739,7 @@ class RegularPredicateBlockIterator : public StackObj {
 class PredicateBlockIterator : public StackObj {
   Node* const _start_node;
   const ParsePredicate _parse_predicate; // Could be missing.
-  const RegularPredicateBlockIterator _regular_predicate_block_iterator;
+  RegularPredicateBlockIterator _regular_predicate_block_iterator;
 
  public:
   PredicateBlockIterator(Node* start_node, Deoptimization::DeoptReason deopt_reason)
@@ -707,7 +749,7 @@ class PredicateBlockIterator : public StackObj {
 
   // Walk over all predicates of this block (if any) and apply the given 'predicate_visitor' to each predicate.
   // Returns the entry to the earliest predicate.
-  Node* for_each(PredicateVisitor& predicate_visitor) const {
+  Node* for_each(PredicateVisitor& predicate_visitor) {
     if (!predicate_visitor.should_continue()) {
       return _start_node;
     }
@@ -731,20 +773,20 @@ class PredicateIterator : public StackObj {
   // Apply the 'predicate_visitor' for each predicate found in the predicate chain started at the provided node.
   // Returns the entry to the earliest predicate.
   Node* for_each(PredicateVisitor& predicate_visitor) const {
-    Node* current = _start_node;
-    PredicateBlockIterator loop_limit_check_predicate_iterator(current, Deoptimization::Reason_loop_limit_check);
-    current = loop_limit_check_predicate_iterator.for_each(predicate_visitor);
-    PredicateBlockIterator auto_vectorization_check_iterator(current, Deoptimization::Reason_auto_vectorization_check);
-    current = auto_vectorization_check_iterator.for_each(predicate_visitor);
+    Node* current_node = _start_node;
+    PredicateBlockIterator loop_limit_check_predicate_iterator(current_node, Deoptimization::Reason_loop_limit_check);
+    current_node = loop_limit_check_predicate_iterator.for_each(predicate_visitor);
+    PredicateBlockIterator auto_vectorization_check_iterator(current_node, Deoptimization::Reason_auto_vectorization_check);
+    current_node = auto_vectorization_check_iterator.for_each(predicate_visitor);
     if (UseLoopPredicate) {
       if (UseProfiledLoopPredicate) {
-        PredicateBlockIterator profiled_loop_predicate_iterator(current, Deoptimization::Reason_profile_predicate);
-        current = profiled_loop_predicate_iterator.for_each(predicate_visitor);
+        PredicateBlockIterator profiled_loop_predicate_iterator(current_node, Deoptimization::Reason_profile_predicate);
+        current_node = profiled_loop_predicate_iterator.for_each(predicate_visitor);
       }
-      PredicateBlockIterator loop_predicate_iterator(current, Deoptimization::Reason_predicate);
-      current = loop_predicate_iterator.for_each(predicate_visitor);
+      PredicateBlockIterator loop_predicate_iterator(current_node, Deoptimization::Reason_predicate);
+      current_node = loop_predicate_iterator.for_each(predicate_visitor);
     }
-    return current;
+    return current_node;
   }
 };
 
@@ -1193,15 +1235,6 @@ class UpdateStrideForAssertionPredicates : public PredicateVisitor {
   using PredicateVisitor::visit;
 
   void visit(const TemplateAssertionPredicate& template_assertion_predicate) override;
-
-  // Kill the old Initialized Assertion Predicates with old strides before unrolling. The new Initialized Assertion
-  // Predicates are inserted after the Template Assertion Predicate which ensures that we are not accidentally visiting
-  // and killing a newly created Initialized Assertion Predicate here.
-  void visit(const InitializedAssertionPredicate& initialized_assertion_predicate) override {
-    if (initialized_assertion_predicate.is_last_value()) {
-      // Only Last Value Initialized Assertion Predicates need to be killed and updated.
-      initialized_assertion_predicate.kill(_phase);
-    }
-  }
+  void visit(const InitializedAssertionPredicate& initialized_assertion_predicate) override;
 };
 #endif // SHARE_OPTO_PREDICATES_HPP


### PR DESCRIPTION
This patch is a preparatory patch for fixing https://github.com/openjdk/jdk/pull/23823 (already out for review) without relying on predicate matching during IGVN (currently proposed matching with IGVN but after looking into it and further discussions with @rwestrel, we think it's best to do it outside IGVN).

### Update Assertion Predicate Killing Mechanism
The main contribution of this patch is to update the killing mechanism of Assertion Predicates. Currently, we kill an Assertion Predicate by replacing its `Opaque*AssertionPredicate` node with `ConI [int:1]`. This creates problems in our predicate matching code (see for example, [JDK-8350637](https://bugs.openjdk.org/browse/JDK-8350637)). To fix this and prepare for https://github.com/openjdk/jdk/pull/23823, we move to a different approach. 

#### Mark Opaque*AssertionPredicate` Nodes Useless
Instead of directly inserting constants, we mark `Opaque*AssertionPredicate` nodes useless when we find that an Assertion Predicate should be removed. In the next IGVN phase, we are folding it by taking the success path. This requires the following updates:
- Introduce `_useless` flags at `Opaque*AssertionPredicate` nodes and associated mark methods.
  - Check the flags in `Value()` and return `TypeInt::ONE` if we find them useless.
- Adding `cmp()` method for `OpaqueInitializedAssertionPredicate` to avoid commoning up a useless with a useful node.
- `OpaqueTemplateAssertionPredicate` nodes are by design unique to the Template Assertion Predicate because they have non-hashable `OpaqueLoop*` nodes on their input paths. I still added `hash()` that returns `NO_HASH` as an additional guarantee/contract.

#### Update Predicate Iteration Code
To make this new approach work, we need to update the predicate iteration code. We still match Assertion Predicates with an `OpaqueAssertion*Node` to skip over them but we skip to call the `visit()` method since there should not be any work to be done for killed Assertion Predicates. This includes the additional change:
- Refactoring `RegularPredicateBlockIterator::for_each()` which became bigger. I extracted some methods and decided to use a field instead of a local variable. This meant that I also had to remove `const` from the `for_each()` methods which I think is fine for a method that does iterations and needs to do some book keeping.

#### Other Updates
I've also applied some small refactorings of touched code.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351280](https://bugs.openjdk.org/browse/JDK-8351280): Mark Assertion Predicates useless instead of replacing them by a constant directly (**Sub-task** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23941/head:pull/23941` \
`$ git checkout pull/23941`

Update a local copy of the PR: \
`$ git checkout pull/23941` \
`$ git pull https://git.openjdk.org/jdk.git pull/23941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23941`

View PR using the GUI difftool: \
`$ git pr show -t 23941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23941.diff">https://git.openjdk.org/jdk/pull/23941.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23941#issuecomment-2705797857)
</details>
