### PR TITLE
8351392: C2 crash: failed: Expected Bool, but got OpaqueMultiversioning

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -791,7 +791,8 @@ Node *PhaseIdealLoop::conditional_move( Node *region ) {
     // Ignore Template Assertion Predicates with OpaqueTemplateAssertionPredicate nodes.
     return nullptr;
   }
-  if (bol->is_OpaqueMultiversioning() && bol->as_OpaqueMultiversioning()->is_useless()) {
+  if (bol->is_OpaqueMultiversioning()) {
+    assert(bol->as_OpaqueMultiversioning()->is_useless(), "Must be useless, i.e. fast main loop has already disappeared.");
     // Ignore multiversion_if that just lost its loops. The OpaqueMultiversioning is marked useless,
     // and will make the multiversion_if constant fold in the next IGVN round.
     return nullptr;

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -791,6 +791,11 @@ Node *PhaseIdealLoop::conditional_move( Node *region ) {
     // Ignore Template Assertion Predicates with OpaqueTemplateAssertionPredicate nodes.
     return nullptr;
   }
+  if (bol->is_OpaqueMultiversioning() && bol->as_OpaqueMultiversioning()->is_useless()) {
+    // Ignore multiversion_if that just lost its loops. The OpaqueMultiversioning is marked useless,
+    // and will make the multiversion_if constant fold in the next IGVN round.
+    return nullptr;
+  }
   if (!bol->is_Bool()) {
     assert(false, "Expected Bool, but got %s", NodeClassNames[bol->Opcode()]);
     return nullptr;

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -112,7 +112,7 @@ public:
   virtual int Opcode() const;
   virtual const Type* bottom_type() const { return TypeInt::BOOL; }
   bool is_delayed_slow_loop() const { return _is_delayed_slow_loop; }
-  bool is_useless() const { return _useless; }
+  DEBUG_ONLY( bool is_useless() const { return _useless; } )
 
   void notify_slow_loop_that_it_can_resume_optimizations() {
     assert(!_useless, "must still be useful");

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -112,6 +112,7 @@ public:
   virtual int Opcode() const;
   virtual const Type* bottom_type() const { return TypeInt::BOOL; }
   bool is_delayed_slow_loop() const { return _is_delayed_slow_loop; }
+  bool is_useless() const { return _useless; }
 
   void notify_slow_loop_that_it_can_resume_optimizations() {
     assert(!_useless, "must still be useful");

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMultiversionRemoveUselessSlowLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMultiversionRemoveUselessSlowLoop.java
@@ -121,4 +121,30 @@ public class TestMultiversionRemoveUselessSlowLoop {
             instanceCount = iFld1;
         }
     }
+
+    class Unloaded {
+        static void unloaded() {}
+    }
+    static int f;
+
+    // The outer loop is eventually Multiversioned, then PreMainPost and Unroll.
+    // Then the loops disappear during IGVN, and in the next loop-opts phase, the
+    // OpaqueMultiversioning is marked useless, but then we already run
+    // PhaseIdealLoop::conditional_move before the next IGVN round,  and find a
+    // useless OpaqueMultiversioning instead of a BoolNode.
+    @Test
+    @Arguments(values = { Argument.NUMBER_42 })
+    static void testCrash2(int y) {
+        int x = 53446;
+        for (int i = 12; i < 376; i++) {
+            if (x != 0) {
+                // Uncommon trap because the class is not yet loaded.
+                Unloaded.unloaded();
+            }
+            for (int k = 1; k < 4; k++) {
+                y += 1;
+            }
+            x += f;
+        }
+    }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMultiversionRemoveUselessSlowLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMultiversionRemoveUselessSlowLoop.java
@@ -130,7 +130,7 @@ public class TestMultiversionRemoveUselessSlowLoop {
     // The outer loop is eventually Multiversioned, then PreMainPost and Unroll.
     // Then the loops disappear during IGVN, and in the next loop-opts phase, the
     // OpaqueMultiversioning is marked useless, but then we already run
-    // PhaseIdealLoop::conditional_move before the next IGVN round,  and find a
+    // PhaseIdealLoop::conditional_move before the next IGVN round, and find a
     // useless OpaqueMultiversioning instead of a BoolNode.
     @Test
     @Arguments(values = { Argument.NUMBER_42 })


### PR DESCRIPTION
With https://github.com/openjdk/jdk/pull/23865 I mark the `OpaqueMultiversioning` useless once there are no loops for the multiversioning any more. The idea was that this way the `multiversion_if` would be folded away once the loops are gone, and then we should not encounter the `OpaqueMultiversioning` in `PhaseIdealLoop::conditional_move`.

But there is a case where we do not remove the `OpaqueMultiversioning` fast enough, see the attached regression test:
- The loops disappear during IGVN.
- At the beginning of the next loop-opts we mark the `OpaqueMultiversioning` as useless.
- Later during loop-opts we encounter the useless `OpaqueMultiversioning` in `PhaseIdealLoop::conditional_move`, and assert.
- But in the IGVN after this loop-opts phase we would have constant folded the `OpaqueMultiversioning` and `multiversion_if` anyway... we just did not get there fast enough ;)

Hence I propose to just create an explicit bailout for useless `OpaqueMultiversioning` nodes in `PhaseIdealLoop::conditional_move`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351392](https://bugs.openjdk.org/browse/JDK-8351392): C2 crash: failed: Expected Bool, but got OpaqueMultiversioning (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23943/head:pull/23943` \
`$ git checkout pull/23943`

Update a local copy of the PR: \
`$ git checkout pull/23943` \
`$ git pull https://git.openjdk.org/jdk.git pull/23943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23943`

View PR using the GUI difftool: \
`$ git pr show -t 23943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23943.diff">https://git.openjdk.org/jdk/pull/23943.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23943#issuecomment-2706147672)
</details>
