### PR TITLE
8351419: java.net.http: Cleanup links in HttpResponse and module-info API doc comments

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -383,7 +383,7 @@ public interface HttpResponse<T> {
          * BodySubscribers#fromLineSubscriber(Subscriber, Function, Charset, String)
          * BodySubscribers.fromLineSubscriber(subscriber, s -> null, charset, null)},
          * with the given {@code subscriber}.
-         * The {@link Charset charset} used to decode the response body bytes is
+         * The {@linkplain Charset charset} used to decode the response body bytes is
          * obtained from the HTTP response headers as specified by {@link #ofString()},
          * and lines are delimited in the manner of {@link BufferedReader#readLine()}.
          *
@@ -429,7 +429,7 @@ public interface HttpResponse<T> {
          * BodySubscribers#fromLineSubscriber(Subscriber, Function, Charset, String)
          * BodySubscribers.fromLineSubscriber(subscriber, finisher, charset, lineSeparator)},
          * with the given {@code subscriber}, {@code finisher} function, and line separator.
-         * The {@link Charset charset} used to decode the response body bytes is
+         * The {@linkplain  Charset charset} used to decode the response body bytes is
          * obtained from the HTTP response headers as specified by {@link #ofString()}.
          *
          * <p> The given {@code finisher} function is applied after the given
@@ -619,7 +619,7 @@ public interface HttpResponse<T> {
          * Returns a {@code BodyHandler<Stream<String>>} that returns a
          * {@link BodySubscriber BodySubscriber}{@code <Stream<String>>} obtained
          * from {@link BodySubscribers#ofLines(Charset) BodySubscribers.ofLines(charset)}.
-         * The {@link Charset charset} used to decode the response body bytes is
+         * The {@linkplain Charset charset} used to decode the response body bytes is
          * obtained from the HTTP response headers as specified by {@link #ofString()},
          * and lines are delimited in the manner of {@link BufferedReader#readLine()}.
          *
@@ -715,7 +715,7 @@ public interface HttpResponse<T> {
          * To ensure that all resources associated with the
          * corresponding exchange are properly released the caller must
          * subscribe to the publisher and conform to the rules outlined in
-         * {@linkplain BodySubscribers#ofPublisher()}
+         * {@link BodySubscribers#ofPublisher()}
          *
          * @return a {@linkplain HttpClient##streaming publishing} response body handler
          *
@@ -896,7 +896,7 @@ public interface HttpResponse<T> {
      * BodySubscriber} should ensure to {@linkplain Flow.Subscription#request
      * request} more data until one of {@link #onComplete() onComplete} or
      * {@link #onError(Throwable) onError} are signalled, or {@link
-     * Flow.Subscription#request cancel} its {@linkplain
+     * Flow.Subscription#cancel cancel} its {@linkplain
      * #onSubscribe(Flow.Subscription) subscription} if unable or unwilling to
      * do so. Calling {@code cancel} before exhausting the response body data
      * may cause the underlying HTTP connection to be closed and prevent it
@@ -916,7 +916,7 @@ public interface HttpResponse<T> {
          * Returns a {@code CompletionStage} which when completed will return
          * the response body object. This method can be called at any time
          * relative to the other {@link Flow.Subscriber} methods and is invoked
-         * using the client's {@link HttpClient#executor() executor}.
+         * using the client's {@linkplain HttpClient#executor() executor}.
          *
          * @return a CompletionStage for the response body
          */
@@ -962,7 +962,7 @@ public interface HttpResponse<T> {
      *  the resources associated with the request and the client to be {@linkplain
      *  HttpClient##closing eventually reclaimed}.
      *  Some other implementations are {@linkplain  Publisher publishers} which need to be
-     *  {@link BodySubscribers#ofPublisher() subscribed} in order for their associated
+     *  {@linkplain BodySubscribers#ofPublisher() subscribed} in order for their associated
      *  resources to be released and for the associated request to {@linkplain
      *  HttpClient##closing run to completion}.
      *
@@ -1159,7 +1159,7 @@ public interface HttpResponse<T> {
          * Returns a {@code BodySubscriber} which provides the incoming body
          * data to the provided Consumer of {@code Optional<byte[]>}. Each
          * call to {@link Consumer#accept(java.lang.Object) Consumer.accept()}
-         * will contain a non empty {@code Optional}, except for the final
+         * will contain a non-empty {@code Optional}, except for the final
          * invocation after all body data has been read, when the {@code
          * Optional} will be empty.
          *

--- a/src/java.net.http/share/classes/module-info.java
+++ b/src/java.net.http/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,8 +139,9 @@
  * simultaneously.
  * </li>
  * <li><p><b>{@systemProperty jdk.httpclient.receiveBufferSize}</b> (default: operating system
- * default)<br>The HTTP client <a href="../java.base/java/net/StandardSocketOptions.html#SO_RCVBUF">
- * socket receive buffer size</a> in bytes.
+ * default)<br>The HTTP client {@linkplain java.nio.channels.SocketChannel socket}
+ * {@linkplain java.net.StandardSocketOptions#SO_RCVBUF receive buffer size} in bytes.
+ * Values less than or equal to zero are ignored.
  * </li>
  * <li><p><b>{@systemProperty jdk.httpclient.redirects.retrylimit}</b> (default: 5)<br>
  * The maximum number of attempts to send a HTTP request when redirected or any failure occurs
@@ -158,8 +159,8 @@
  * authentication.
  * </li>
  * <li><p><b>{@systemProperty jdk.httpclient.sendBufferSize}</b> (default: operating system
- * default)<br>The HTTP client socket
- * <a href="../java.base/java/net/StandardSocketOptions.html#SO_SNDBUF">send buffer size</a>.
+ * default)<br>The HTTP client {@linkplain java.nio.channels.SocketChannel socket}
+ * {@linkplain java.net.StandardSocketOptions#SO_SNDBUF send buffer size} in bytes.
  * Values less than or equal to zero are ignored.
  * </li>
  * <li><p><b>{@systemProperty jdk.internal.httpclient.disableHostnameVerification}</b> (default:


### PR DESCRIPTION
This is a trivial doc cleanup. HttpResponse and module-info have a few links that should use {@linkplain } instead of {@link } or <href>. Also I noticed one link target mismatch, and some clarification missing in the send/receive buffer properties. 