### PR TITLE
8351382: New test containers/docker/TestMemoryWithSubgroups.java is failing

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
@@ -53,6 +53,9 @@ public class TestMemoryWithSubgroups {
     }
 
     static boolean isRootless() throws Exception {
+        // Docker and Podman have different INFO structures.
+        // The node path for Podman is .Host.Security.Rootless, that also holds for
+        // Podman emulating Docker CLI. The node path for Docker is .SecurityOptions.
         return (getEngineInfo("{{.Host.Security.Rootless}}").contains("true") ||
                 getEngineInfo("{{.SecurityOptions}}").contains("name=rootless"));
     }

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
@@ -49,23 +49,12 @@ public class TestMemoryWithSubgroups {
 
     static String getEngineInfo(String format) throws Exception {
         return DockerTestUtils.execute(Container.ENGINE_COMMAND, "info", "-f", format)
-            .shouldHaveExitValue(0)
             .getStdout();
     }
 
-    static boolean isPodman() {
-        return Container.ENGINE_COMMAND.endsWith("podman");
-    }
-
-    static boolean isDocker() {
-        return Container.ENGINE_COMMAND.endsWith("docker");
-    }
-
     static boolean isRootless() throws Exception {
-        return (isDocker() &&
-                getEngineInfo("{{.SecurityOptions}}").contains("name=rootless")) || (
-                isPodman() &&
-                getEngineInfo("{{.Host.Security.Rootless}}").contains("true"));
+        return (getEngineInfo("{{.Host.Security.Rootless}}").contains("true") ||
+                getEngineInfo("{{.SecurityOptions}}").contains("name=rootless"));
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.test.lib.Container;
 import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.containers.docker.DockerRunOptions;
@@ -55,6 +56,14 @@ public class TestMemoryWithSubgroups {
         if (!DockerTestUtils.canTestDocker()) {
             System.out.println("Unable to run docker tests.");
             return;
+        }
+        if (DockerTestUtils.execute(Container.ENGINE_COMMAND,
+                                    "info",
+                                    "-f", "{{println .SecurityOptions}}")
+                .shouldHaveExitValue(0)
+                .getStdout()
+                .contains("name=rootless")) {
+            throw new SkippedException("Test skipped in rootless mode");
         }
         Common.prepareWhiteBox();
         DockerTestUtils.buildJdkContainerImage(imageName);


### PR DESCRIPTION
The new test fails in rootless Docker mode after [JDK-8343191](https://bugs.openjdk.org/browse/JDK-8343191):

containers/docker/TestMemoryWithSubgroups.java

[STDERR]
```
Resource limits are not supported and ignored on cgroups V1 rootless systems
```
[STDOUT]
```
mkdir: cannot create directory '/sys/fs/cgroup/memory/test': Permission denied
sh: /sys/fs/cgroup/memory/test/memory.limit_in_bytes: No such file or directory
sh: /sys/fs/cgroup/memory/test/cgroup.procs: No such file or directory
```
The test TestMemoryWithSubgroups.java uses `--privileged` mode to modify process' cgroup, that has no effect in rootless mode. The test has to be skiped.

The fix is to query `info -f {{println .SecurityOptions}}` and check whether it has `name=rootless` in the output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351382](https://bugs.openjdk.org/browse/JDK-8351382): New test containers/docker/TestMemoryWithSubgroups.java is failing (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23948/head:pull/23948` \
`$ git checkout pull/23948`

Update a local copy of the PR: \
`$ git checkout pull/23948` \
`$ git pull https://git.openjdk.org/jdk.git pull/23948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23948`

View PR using the GUI difftool: \
`$ git pr show -t 23948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23948.diff">https://git.openjdk.org/jdk/pull/23948.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23948#issuecomment-2707344120)
</details>
