### PR TITLE
8351440: Link with -reproducible on macOS

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -100,7 +100,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
   if test "x$OPENJDK_TARGET_OS" = xmacosx && test "x$TOOLCHAIN_TYPE" = xclang; then
     # FIXME: We should really generalize SET_SHARED_LIBRARY_ORIGIN instead.
     OS_LDFLAGS_JVM_ONLY="-Wl,-rpath,@loader_path/. -Wl,-rpath,@loader_path/.."
-    OS_LDFLAGS="-mmacosx-version-min=$MACOSX_VERSION_MIN"
+    OS_LDFLAGS="-mmacosx-version-min=$MACOSX_VERSION_MIN -Wl,-reproducible"
   fi
 
   # Setup debug level-dependent LDFLAGS


### PR DESCRIPTION
Background (from JBS):

Recent versions of Xcode, most likely starting with Xcode 15, do not produce deterministic binaries/libraries out of the box. In particular, the UUID data in the LC_UUID load command is not stable.

After spending some significant time trying to understand why, it turns out that the linker has started including the last modified time stamp of the object files in the (debug?) data and that time stamp data is included in the computed UUID "hash". So even if the rest of the data is the same between two builds, the build time (or, more accurately, the time when the object file gets written to the file system) now affects the UUID and therefore the data of the resulting .dylib files.

It seems (unconfirmed) like this may be an artifact of Xcode 15 using a new linker ("ld-prime") which may or may not be why the behavior has changed.

After spending even more time trying to understand what to do about it I noticed this in the ld man page:

     -reproducible
             By default output content will be deterministic, but small changes in input files such as a compilation time might affect certain data structures in the linked binary. This option instructs ld to create a reproducible output binary by ignoring certain input properties or using alternative algorithms.

And, adding that flag (-Wl,-reproducible to clang) does indeed seem to solve the issue.

Testing:

* Manual verification with both Xcode14.3.1 and Xcode 15.4
* tier1,builds-tier[2-5]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351440](https://bugs.openjdk.org/browse/JDK-8351440): Link with -reproducible on macOS (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23949/head:pull/23949` \
`$ git checkout pull/23949`

Update a local copy of the PR: \
`$ git checkout pull/23949` \
`$ git pull https://git.openjdk.org/jdk.git pull/23949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23949`

View PR using the GUI difftool: \
`$ git pr show -t 23949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23949.diff">https://git.openjdk.org/jdk/pull/23949.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23949#issuecomment-2707555385)
</details>
