### PR TITLE
8351444: Shenandoah: Class Unloading may encounter recycled oops

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -122,9 +122,6 @@ inline oop ShenandoahBarrierSet::load_reference_barrier(DecoratorSet decorators,
   }
 
   // Allow runtime to see unreachable objects that are visited during concurrent class-unloading.
-  // Note that this may also interfere with the DeadCounterClosure when visiting weak oop storage,
-  // but it does not seem to be a problem in practice because the dead count callbacks do not care
-  // about the precise number of dead objects (only that there are dead objects).
   if ((decorators & AS_NO_KEEPALIVE) != 0 &&
       _heap->is_concurrent_weak_root_in_progress() &&
       !_heap->marking_context()->is_marked(obj)) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -121,7 +121,10 @@ inline oop ShenandoahBarrierSet::load_reference_barrier(DecoratorSet decorators,
     return nullptr;
   }
 
-  // Allow resurrection of unreachable objects that are visited during concurrent class-unloading.
+  // Allow runtime to see unreachable objects that are visited during concurrent class-unloading.
+  // Note that this may also interfere with the DeadCounterClosure when visiting weak oop storage,
+  // but it does not seem to be a problem in practice because the dead count callbacks do not care
+  // about the precise number of dead objects (only that there are dead objects).
   if ((decorators & AS_NO_KEEPALIVE) != 0 &&
       _heap->is_concurrent_weak_root_in_progress() &&
       !_heap->marking_context()->is_marked(obj)) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -121,14 +121,12 @@ inline oop ShenandoahBarrierSet::load_reference_barrier(DecoratorSet decorators,
     return nullptr;
   }
 
-  // Allow resurrection of unreachable objects that are visited during
-  // concurrent class-unloading. Note, this breaks oop storage counting of
-  // dead objects.
-  // if ((decorators & AS_NO_KEEPALIVE) != 0 &&
-  //     _heap->is_evacuation_in_progress() &&
-  //     !_heap->marking_context()->is_marked(obj)) {
-  //   return obj;
-  // }
+  // Allow resurrection of unreachable objects that are visited during concurrent class-unloading.
+  if ((decorators & AS_NO_KEEPALIVE) != 0 &&
+      _heap->is_concurrent_weak_root_in_progress() &&
+      !_heap->marking_context()->is_marked(obj)) {
+    return obj;
+  }
 
   oop fwd = load_reference_barrier(obj);
   if (load_addr != nullptr && fwd != obj) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -124,11 +124,11 @@ inline oop ShenandoahBarrierSet::load_reference_barrier(DecoratorSet decorators,
   // Allow resurrection of unreachable objects that are visited during
   // concurrent class-unloading. Note, this breaks oop storage counting of
   // dead objects.
-//  if ((decorators & AS_NO_KEEPALIVE) != 0 &&
-//      _heap->is_evacuation_in_progress() &&
-//      !_heap->marking_context()->is_marked(obj)) {
-//    return obj;
-//  }
+  // if ((decorators & AS_NO_KEEPALIVE) != 0 &&
+  //     _heap->is_evacuation_in_progress() &&
+  //     !_heap->marking_context()->is_marked(obj)) {
+  //   return obj;
+  // }
 
   oop fwd = load_reference_barrier(obj);
   if (load_addr != nullptr && fwd != obj) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -126,6 +126,7 @@ inline oop ShenandoahBarrierSet::load_reference_barrier(DecoratorSet decorators,
   if ((decorators & AS_NO_KEEPALIVE) != 0 &&
       _heap->is_evacuation_in_progress() &&
       !_heap->marking_context()->is_marked(obj)) {
+    fatal("Returning doomed from-space object: " PTR_FORMAT, p2i(obj));
     return obj;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -121,14 +121,14 @@ inline oop ShenandoahBarrierSet::load_reference_barrier(DecoratorSet decorators,
     return nullptr;
   }
 
-  // Prevent resurrection of unreachable objects that are visited during
-  // concurrent class-unloading.
-  if ((decorators & AS_NO_KEEPALIVE) != 0 &&
-      _heap->is_evacuation_in_progress() &&
-      !_heap->marking_context()->is_marked(obj)) {
-    fatal("Returning doomed from-space object: " PTR_FORMAT, p2i(obj));
-    return obj;
-  }
+  // Allow resurrection of unreachable objects that are visited during
+  // concurrent class-unloading. Note, this breaks oop storage counting of
+  // dead objects.
+//  if ((decorators & AS_NO_KEEPALIVE) != 0 &&
+//      _heap->is_evacuation_in_progress() &&
+//      !_heap->marking_context()->is_marked(obj)) {
+//    return obj;
+//  }
 
   oop fwd = load_reference_barrier(obj);
   if (load_addr != nullptr && fwd != obj) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -171,7 +171,7 @@ ShenandoahRegionPartitions::ShenandoahRegionPartitions(size_t max_regions, Shena
 }
 
 inline bool ShenandoahFreeSet::can_allocate_from(ShenandoahHeapRegion *r) const {
-  return r->is_empty() || (r->is_trash() && !_heap->is_concurrent_weak_root_in_progress());
+  return r->is_empty() || r->is_trash();
 }
 
 inline bool ShenandoahFreeSet::can_allocate_from(size_t idx) const {
@@ -997,11 +997,6 @@ HeapWord* ShenandoahFreeSet::allocate_aligned_plab(size_t size, ShenandoahAllocR
 
 HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, ShenandoahAllocRequest& req, bool& in_new_region) {
   assert (has_alloc_capacity(r), "Performance: should avoid full regions on this path: %zu", r->index());
-  if (_heap->is_concurrent_weak_root_in_progress() && r->is_trash()) {
-    // We cannot use this region for allocation when weak roots are in progress because the collector may need
-    // to reference unmarked oops during concurrent classunloading.
-    return nullptr;
-  }
   HeapWord* result = nullptr;
   r->try_recycle_under_lock();
   in_new_region = r->is_empty();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -817,18 +817,31 @@ size_t ShenandoahHeap::initial_capacity() const {
 }
 
 bool ShenandoahHeap::is_in(const void* p) const {
-  if (is_in_reserved(p)) {
-    if (is_full_gc_move_in_progress()) {
-      // Full GC move is running, we do not have a consistent region
-      // information yet. But we know the pointer is in heap.
-      return true;
-    }
-    // Now check if we point to a live section in active region.
-    ShenandoahHeapRegion* r = heap_region_containing(p);
-    return (r->is_active() && p < r->top());
-  } else {
+  if (!is_in_reserved(p)) {
     return false;
   }
+
+  if (is_full_gc_move_in_progress()) {
+    // Full GC move is running, we do not have a consistent region
+    // information yet. But we know the pointer is in heap.
+    return true;
+  }
+
+  // Now check if we point to a live section in active region.
+  const ShenandoahHeapRegion* r = heap_region_containing(p);
+  if (p >= r->top()) {
+    return false;
+  }
+
+  if (r->is_active()) {
+    return true;
+  }
+
+  // The region is trash, but won't be recycled until after concurrent weak
+  // roots. We also don't allow mutators to allocate from trash regions
+  // during weak roots. Concurrent class unloading may access unmarked oops
+  // in trash regions.
+  return r->is_trash() && is_concurrent_weak_root_in_progress();
 }
 
 void ShenandoahHeap::notify_soft_max_changed() {


### PR DESCRIPTION
Unloading classes may require a walk of unreachable oops. For this reason, it is not safe to recycle memory before class unloading is complete. This complements existing code to prevent mutators from recycling trash regions while weak roots is in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351444](https://bugs.openjdk.org/browse/JDK-8351444): Shenandoah: Class Unloading may encounter recycled oops (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23951/head:pull/23951` \
`$ git checkout pull/23951`

Update a local copy of the PR: \
`$ git checkout pull/23951` \
`$ git pull https://git.openjdk.org/jdk.git pull/23951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23951`

View PR using the GUI difftool: \
`$ git pr show -t 23951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23951.diff">https://git.openjdk.org/jdk/pull/23951.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23951#issuecomment-2707528442)
</details>
