### PR TITLE
8351374: Improve comment about queue.remove timeout in CleanerImpl.run

### DIFF
--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,8 +135,13 @@ public final class CleanerImpl implements Runnable {
                 mlThread.eraseThreadLocals();
             }
             try {
-                // Wait for a Ref, with a timeout to avoid getting hung
-                // due to a race with clear/clean
+                // Wait for a Ref, with a timeout to avoid a potential hang.
+                // The Cleaner may become unreachable and its cleanable run,
+                // while there are registered cleanables for other objects.
+                // If the application cleans all remaining cleanables, there
+                // won't be any references enqueued to unblock this.  Using a
+                // timeout is simpler than unblocking this by having cleaning
+                // of the last registered cleanable enqueue a dummy reference.
                 Cleanable ref = (Cleanable) queue.remove(60 * 1000L);
                 if (ref != null) {
                     ref.clean();

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -138,10 +138,11 @@ public final class CleanerImpl implements Runnable {
                 // Wait for a Ref, with a timeout to avoid a potential hang.
                 // The Cleaner may become unreachable and its cleanable run,
                 // while there are registered cleanables for other objects.
-                // If the application cleans all remaining cleanables, there
-                // won't be any references enqueued to unblock this.  Using a
-                // timeout is simpler than unblocking this by having cleaning
-                // of the last registered cleanable enqueue a dummy reference.
+                // If the application explicitly calls clean() on all remaining
+                // Cleanables, there won't be any references enqueued to unblock
+                // this.  Using a timeout is simpler than unblocking this by
+                // having cleaning of the last registered cleanable enqueue a
+                // dummy reference.
                 Cleanable ref = (Cleanable) queue.remove(60 * 1000L);
                 if (ref != null) {
                     ref.clean();


### PR DESCRIPTION
Please review this revision of a previously puzzling comment intending to
provide the rationale for a bit of non-obvious code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351374](https://bugs.openjdk.org/browse/JDK-8351374): Improve comment about queue.remove timeout in CleanerImpl.run (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [68c2579c](https://git.openjdk.org/jdk/pull/23952/files/68c2579cc8a32fea9fd3f6e7434584716418510f)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23952/head:pull/23952` \
`$ git checkout pull/23952`

Update a local copy of the PR: \
`$ git checkout pull/23952` \
`$ git pull https://git.openjdk.org/jdk.git pull/23952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23952`

View PR using the GUI difftool: \
`$ git pr show -t 23952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23952.diff">https://git.openjdk.org/jdk/pull/23952.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23952#issuecomment-2707695170)
</details>
