### PR TITLE
8349984: (jdeps) jdeps can use String.repeat instead of String.replaceAll

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -790,8 +790,8 @@ class JdepsTask {
                     String replacementApiTitle = getMessage("public.api.replacement.column.header");
                     log.format("%-40s %s%n", internalApiTitle, replacementApiTitle);
                     log.format("%-40s %s%n",
-                               internalApiTitle.replaceAll(".", "-"),
-                               replacementApiTitle.replaceAll(".", "-"));
+                               "-".repeat(internalApiTitle.length()),
+                               "_".repeat(replacementApiTitle.length()));
                     jdkInternals.entrySet()
                         .forEach(e -> {
                             String key = e.getKey();

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -790,8 +790,8 @@ class JdepsTask {
                     String replacementApiTitle = getMessage("public.api.replacement.column.header");
                     log.format("%-40s %s%n", internalApiTitle, replacementApiTitle);
                     log.format("%-40s %s%n",
-                               "-".repeat(internalApiTitle.length()),
-                               "_".repeat(replacementApiTitle.length()));
+                               "-".repeat(internalApiTitle.codePointCount(0, internalApiTitle.length())),
+                               "-".repeat(replacementApiTitle.codePointCount(0, replacementApiTitle.length())));
                     jdkInternals.entrySet()
                         .forEach(e -> {
                             String key = e.getKey();

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
@@ -300,7 +300,7 @@ public final class ImageResourcesTree {
                 return null;
             }
             String pkg = removeRadical(path, module + "/");
-            return pkg.replace("/", ".");
+            return pkg.replace('/', '.');
         }
 
         public String removeRadical(Node node) {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
@@ -300,7 +300,7 @@ public final class ImageResourcesTree {
                 return null;
             }
             String pkg = removeRadical(path, module + "/");
-            return pkg.replaceAll("/", ".");
+            return pkg.replace("/", ".");
         }
 
         public String removeRadical(Node node) {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
@@ -217,7 +217,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
             available = Stream.concat(module.entries()
                                         .map(md -> p.matcher(md.path()))
                                         .filter(Matcher::matches)
-                                        .map(m -> m.group("tag").replace("_", "-")),
+                                        .map(m -> m.group("tag").replace('_', '-')),
                                     Stream.of(jaJPJPTag, thTHTHTag, "und"))
                 .distinct()
                 .sorted()
@@ -250,7 +250,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
             return List.of();
         }
 
-        List<String> files = new ArrayList<>(includeLocaleFiles(tag.replace("-", "_")));
+        List<String> files = new ArrayList<>(includeLocaleFiles(tag.replace('-', '_')));
 
         // Add Thai BreakIterator related data files
         if (tag.equals("th")) {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
@@ -217,7 +217,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
             available = Stream.concat(module.entries()
                                         .map(md -> p.matcher(md.path()))
                                         .filter(Matcher::matches)
-                                        .map(m -> m.group("tag").replaceAll("_", "-")),
+                                        .map(m -> m.group("tag").replace("_", "-")),
                                     Stream.of(jaJPJPTag, thTHTHTag, "und"))
                 .distinct()
                 .sorted()
@@ -250,7 +250,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
             return List.of();
         }
 
-        List<String> files = new ArrayList<>(includeLocaleFiles(tag.replaceAll("-", "_")));
+        List<String> files = new ArrayList<>(includeLocaleFiles(tag.replace("-", "_")));
 
         // Add Thai BreakIterator related data files
         if (tag.equals("th")) {


### PR DESCRIPTION
JDK-8349989: jlink can use String.replace instead of String.replaceAll

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349984](https://bugs.openjdk.org/browse/JDK-8349984): (jdeps) jdeps can use String.repeat instead of String.replaceAll (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23954/head:pull/23954` \
`$ git checkout pull/23954`

Update a local copy of the PR: \
`$ git checkout pull/23954` \
`$ git pull https://git.openjdk.org/jdk.git pull/23954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23954`

View PR using the GUI difftool: \
`$ git pr show -t 23954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23954.diff">https://git.openjdk.org/jdk/pull/23954.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23954#issuecomment-2707784522)
</details>
