### PR TITLE
8351484: Race condition in max stats in MonitorList::add 

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -80,7 +80,7 @@ void MonitorList::add(ObjectMonitor* m) {
   size_t old_max;
   do {
     old_max = Atomic::load(&_max);
-    if (count < old_max) {
+    if (count <= old_max) {
       break;
     }
   } while (Atomic::cmpxchg(&_max, old_max, count, memory_order_relaxed) != old_max);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -76,10 +76,14 @@ void MonitorList::add(ObjectMonitor* m) {
     m->set_next_om(head);
   } while (Atomic::cmpxchg(&_head, head, m) != head);
 
-  size_t count = Atomic::add(&_count, 1u);
-  if (count > max()) {
-    Atomic::inc(&_max);
-  }
+  size_t count = Atomic::add(&_count, 1u, memory_order_relaxed);
+  size_t old_max;
+  do {
+    old_max = Atomic::load(&_max);
+    if (count < old_max) {
+      break;
+    }
+  } while (Atomic::cmpxchg(&_max, old_max, count, memory_order_relaxed) != old_max);
 }
 
 size_t MonitorList::count() const {

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -47,6 +47,7 @@ private:
   volatile size_t _max;
 
 public:
+  MonitorList() : _head(nullptr), _count(0), _max(0) {};
   void add(ObjectMonitor* monitor);
   size_t unlink_deflated(size_t deflated_count,
                          GrowableArray<ObjectMonitor*>* unlinked_list,

--- a/test/hotspot/gtest/runtime/test_synchronizer.cpp
+++ b/test/hotspot/gtest/runtime/test_synchronizer.cpp
@@ -82,13 +82,15 @@ TEST_VM(SynchronizerTest, monitorListStats) {
   oop obj = vmClasses::Byte_klass()->allocate_instance(THREAD);
 
   // Test various combinations of thread counts, including single-threaded test.
-  for (int threads = 1; threads <= 16; threads++) {
+  static const int MIN_THREADS = 1;
+  static const int MAX_THREADS = 16;
+  static const int OM_PER_THREAD = 1000;
+
+  for (int threads = MIN_THREADS; threads <= MAX_THREADS; threads *= 2) {
     MonitorList list;
 
-    static const size_t OM_PER_THREAD = 1000;
-
     auto work = [&](Thread*, int) {
-      for (size_t c = 0; c < OM_PER_THREAD; c++) {
+      for (int c = 0; c < OM_PER_THREAD; c++) {
         list.add(new ObjectMonitor(obj));
       }
     };
@@ -96,7 +98,7 @@ TEST_VM(SynchronizerTest, monitorListStats) {
     workers.doit();
     workers.join();
 
-    EXPECT_EQ(list.count(), threads*OM_PER_THREAD);
-    EXPECT_EQ(list.max(), threads*OM_PER_THREAD);
+    EXPECT_EQ(list.count(), (size_t)(threads*OM_PER_THREAD));
+    EXPECT_EQ(list.max(), (size_t)(threads*OM_PER_THREAD));
   }
 }

--- a/test/hotspot/gtest/runtime/test_synchronizer.cpp
+++ b/test/hotspot/gtest/runtime/test_synchronizer.cpp
@@ -81,6 +81,9 @@ TEST_VM(SynchronizerTest, monitorListStats) {
   // as long as it is correct.
   oop obj = vmClasses::Byte_klass()->allocate_instance(THREAD);
 
+  HandleMark hm(THREAD);
+  Handle h_obj(THREAD, obj);
+
   // Test various combinations of thread counts, including single-threaded test.
   static const int MIN_THREADS = 1;
   static const int MAX_THREADS = 16;
@@ -91,7 +94,7 @@ TEST_VM(SynchronizerTest, monitorListStats) {
 
     auto work = [&](Thread*, int) {
       for (int c = 0; c < OM_PER_THREAD; c++) {
-        list.add(new ObjectMonitor(obj));
+        list.add(new ObjectMonitor(h_obj()));
       }
     };
     TestThreadGroup<decltype(work)> workers{work, threads};

--- a/test/hotspot/gtest/runtime/test_synchronizer.cpp
+++ b/test/hotspot/gtest/runtime/test_synchronizer.cpp
@@ -77,6 +77,8 @@ TEST_VM(SynchronizerTest, monitorListStats) {
   ThreadInVMfromNative invm(THREAD);
   ResourceMark rm(THREAD);
 
+  // Something to reference in OM. It makes no difference which oop it is,
+  // as long as it is correct.
   oop obj = vmClasses::Byte_klass()->allocate_instance(THREAD);
 
   // Test various combinations of thread counts, including single-threaded test.


### PR DESCRIPTION
See bug for the description of the race. New gtest test case reliably catches fire on my 5950X desktop without this fix.

I needed to add the proper constructor for `MonitorList` to make it testable. In our regular code, it is statically allocated, so its fields are implicitly initialized.

I also made counter updates `_relaxed` for completeness.

Additional testing:
 - [x] Linux x86_64 server fastdebug, new test now passes
 - [x] Linux x86_64 server fastdebug, `all`
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351484](https://bugs.openjdk.org/browse/JDK-8351484): Race condition in max stats in MonitorList::add (**Bug** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23961/head:pull/23961` \
`$ git checkout pull/23961`

Update a local copy of the PR: \
`$ git checkout pull/23961` \
`$ git pull https://git.openjdk.org/jdk.git pull/23961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23961`

View PR using the GUI difftool: \
`$ git pr show -t 23961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23961.diff">https://git.openjdk.org/jdk/pull/23961.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23961#issuecomment-2710285798)
</details>
