### PR TITLE
8346888: [ubsan] block.cpp:1617:30: runtime error: 9.97582e+36 is outside the range of representable values of type 'int'

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1612,10 +1612,9 @@ void PhaseBlockLayout::find_edges() {
         if (b->succ_fall_through(j)) {
           Block *target = b->non_connector_successor(j);
           float freq = b->_freq * b->succ_prob(j);
-          float f_from_pct = (100 * freq) / b->_freq;
+          int from_pct = (int) ((100 * freq) / b->_freq);
           float f_to_pct = (100 * freq) / target->_freq;
-          int from_pct = (f_from_pct < (float)INT_MAX) ? (int)f_from_pct : INT_MAX;
-          int to_pct = (f_to_pct < (float)INT_MAX) ? (int)f_to_pct : INT_MAX;
+          int to_pct = (f_to_pct < 100.0) ? (int)f_to_pct : 100;
           edges->append(new CFGEdge(b, target, freq, from_pct, to_pct));
         }
       }

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1612,8 +1612,10 @@ void PhaseBlockLayout::find_edges() {
         if (b->succ_fall_through(j)) {
           Block *target = b->non_connector_successor(j);
           float freq = b->_freq * b->succ_prob(j);
-          int from_pct = (int) ((100 * freq) / b->_freq);
-          int to_pct = (int) ((100 * freq) / target->_freq);
+          float f_from_pct = (100 * freq) / b->_freq;
+          float f_to_pct = (100 * freq) / target->_freq;
+          int from_pct = (f_from_pct < (float)INT_MAX) ? (int)f_from_pct : INT_MAX;
+          int to_pct = (f_to_pct < (float)INT_MAX) ? (int)f_to_pct : INT_MAX;
           edges->append(new CFGEdge(b, target, freq, from_pct, to_pct));
         }
       }


### PR DESCRIPTION
When running jtreg tests on macOS aarch64 with ubsan - enabled binaries, in the test
java/foreign/TestHandshake
this error/warning is reported :
 
jdk/src/hotspot/share/opto/block.cpp:1617:30: runtime error: 9.97582e+36 is outside the range of representable values of type 'int'
UndefinedBehaviorSanitizer:DEADLYSIGNAL
UndefinedBehaviorSanitizer: nested bug in the same thread, aborting.
 
Seems it happens in this calculation (float value does not fit into an int) : int to_pct = (int) ((100 * freq) / target->_freq);

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346888](https://bugs.openjdk.org/browse/JDK-8346888): [ubsan] block.cpp:1617:30: runtime error: 9.97582e+36 is outside the range of representable values of type 'int' (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23962/head:pull/23962` \
`$ git checkout pull/23962`

Update a local copy of the PR: \
`$ git checkout pull/23962` \
`$ git pull https://git.openjdk.org/jdk.git pull/23962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23962`

View PR using the GUI difftool: \
`$ git pr show -t 23962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23962.diff">https://git.openjdk.org/jdk/pull/23962.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23962#issuecomment-2710643506)
</details>
