### PR TITLE
8351542: LIBMANAGEMENT_OPTIMIZATION remove special optimization settings

### DIFF
--- a/make/modules/java.management/Lib.gmk
+++ b/make/modules/java.management/Lib.gmk
@@ -27,19 +27,9 @@
 
 include LibCommon.gmk
 
-################################################################################
-## Build libmanagement
-################################################################################
-
-LIBMANAGEMENT_OPTIMIZATION := HIGH
-ifeq ($(call isTargetOs, linux)+$(COMPILE_WITH_DEBUG_SYMBOLS), true+true)
-  LIBMANAGEMENT_OPTIMIZATION := LOW
-endif
-
 $(eval $(call SetupJdkLibrary, BUILD_LIBMANAGEMENT, \
     NAME := management, \
-    OPTIMIZATION := $(LIBMANAGEMENT_OPTIMIZATION), \
-    DISABLED_WARNINGS_gcc_VMManagementImpl.c := unused-variable, \
+    OPTIMIZATION := HIGH, \
     DISABLED_WARNINGS_clang_VMManagementImpl.c := unused-variable, \
     JDK_LIBS := java.base:libjava java.base:libjvm, \
     LIBS_aix := -lperfstat, \

--- a/make/modules/java.management/Lib.gmk
+++ b/make/modules/java.management/Lib.gmk
@@ -27,6 +27,10 @@
 
 include LibCommon.gmk
 
+################################################################################
+## Build libmanagement
+################################################################################
+
 $(eval $(call SetupJdkLibrary, BUILD_LIBMANAGEMENT, \
     NAME := management, \
     OPTIMIZATION := HIGH, \

--- a/make/modules/java.management/Lib.gmk
+++ b/make/modules/java.management/Lib.gmk
@@ -34,6 +34,7 @@ include LibCommon.gmk
 $(eval $(call SetupJdkLibrary, BUILD_LIBMANAGEMENT, \
     NAME := management, \
     OPTIMIZATION := HIGH, \
+    DISABLED_WARNINGS_gcc_VMManagementImpl.c := unused-variable, \
     DISABLED_WARNINGS_clang_VMManagementImpl.c := unused-variable, \
     JDK_LIBS := java.base:libjava java.base:libjvm, \
     LIBS_aix := -lperfstat, \

--- a/make/modules/jdk.management/Lib.gmk
+++ b/make/modules/jdk.management/Lib.gmk
@@ -38,14 +38,9 @@ ifeq ($(call isTargetOs, windows), true)
   LIBMANAGEMENT_EXT_CFLAGS := -DPSAPI_VERSION=1
 endif
 
-LIBMANAGEMENT_EXT_OPTIMIZATION := HIGH
-ifeq ($(call isTargetOs, linux)+$(COMPILE_WITH_DEBUG_SYMBOLS), true+true)
-  LIBMANAGEMENT_EXT_OPTIMIZATION := LOW
-endif
-
 $(eval $(call SetupJdkLibrary, BUILD_LIBMANAGEMENT_EXT, \
     NAME := management_ext, \
-    OPTIMIZATION := $(LIBMANAGEMENT_EXT_OPTIMIZATION), \
+    OPTIMIZATION := HIGH, \
     DISABLED_WARNINGS_gcc_DiagnosticCommandImpl.c := unused-variable, \
     DISABLED_WARNINGS_clang_DiagnosticCommandImpl.c := unused-variable, \
     DISABLED_WARNINGS_clang_UnixOperatingSystem.c := format-nonliteral, \

--- a/src/java.management/share/native/libmanagement/VMManagementImpl.c
+++ b/src/java.management/share/native/libmanagement/VMManagementImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,6 @@ Java_sun_management_VMManagementImpl_getVersion0
 
     unsigned int major = ((unsigned int) jmm_version & 0x0FFF0000) >> 16;
     unsigned int minor = ((unsigned int) jmm_version & 0xFF00) >> 8;
-
-    // for internal use
-    unsigned int micro = (unsigned int) jmm_version & 0xFF;
-
     snprintf(buf, sizeof(buf), "%d.%d", major, minor);
     version_string = (*env)->NewStringUTF(env, buf);
     return version_string;
@@ -64,7 +60,7 @@ Java_sun_management_VMManagementImpl_initOptionalSupportFields
   (JNIEnv *env, jclass cls)
 {
     jmmOptionalSupport mos;
-    jint ret = jmm_interface->GetOptionalSupport(env, &mos);
+    jmm_interface->GetOptionalSupport(env, &mos);
 
     jboolean value;
 

--- a/src/java.management/share/native/libmanagement/VMManagementImpl.c
+++ b/src/java.management/share/native/libmanagement/VMManagementImpl.c
@@ -38,11 +38,12 @@ Java_sun_management_VMManagementImpl_getVersion0
     char buf[MAX_VERSION_LEN];
     jstring version_string = NULL;
 
+    unsigned int major = ((unsigned int) jmm_version & 0x0FFF0000) >> 16;
+    unsigned int minor = ((unsigned int) jmm_version & 0xFF00) >> 8;
+
     // for internal use
     unsigned int micro = (unsigned int) jmm_version & 0xFF;
 
-    unsigned int major = ((unsigned int) jmm_version & 0x0FFF0000) >> 16;
-    unsigned int minor = ((unsigned int) jmm_version & 0xFF00) >> 8;
     snprintf(buf, sizeof(buf), "%d.%d", major, minor);
     version_string = (*env)->NewStringUTF(env, buf);
     return version_string;

--- a/src/java.management/share/native/libmanagement/VMManagementImpl.c
+++ b/src/java.management/share/native/libmanagement/VMManagementImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,9 @@ Java_sun_management_VMManagementImpl_getVersion0
     char buf[MAX_VERSION_LEN];
     jstring version_string = NULL;
 
+    // for internal use
+    unsigned int micro = (unsigned int) jmm_version & 0xFF;
+
     unsigned int major = ((unsigned int) jmm_version & 0x0FFF0000) >> 16;
     unsigned int minor = ((unsigned int) jmm_version & 0xFF00) >> 8;
     snprintf(buf, sizeof(buf), "%d.%d", major, minor);
@@ -60,7 +63,7 @@ Java_sun_management_VMManagementImpl_initOptionalSupportFields
   (JNIEnv *env, jclass cls)
 {
     jmmOptionalSupport mos;
-    jmm_interface->GetOptionalSupport(env, &mos);
+    jint ret = jmm_interface->GetOptionalSupport(env, &mos);
 
     jboolean value;
 


### PR DESCRIPTION
On Linux there are some special settings for LIBMANAGEMENT_OPTIMIZATION that are most likely not needed any more and could be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351542](https://bugs.openjdk.org/browse/JDK-8351542): LIBMANAGEMENT_OPTIMIZATION remove special optimization settings (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23966/head:pull/23966` \
`$ git checkout pull/23966`

Update a local copy of the PR: \
`$ git checkout pull/23966` \
`$ git pull https://git.openjdk.org/jdk.git pull/23966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23966`

View PR using the GUI difftool: \
`$ git pr show -t 23966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23966.diff">https://git.openjdk.org/jdk/pull/23966.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23966#issuecomment-2711034510)
</details>
