### PR TITLE
8351505: (fs) Typo in the documentation of java.nio.file.spi.FileSystemProvider.getFileSystem()

### DIFF
--- a/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
+++ b/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,7 +244,7 @@ public abstract class FileSystemProvider {
      *
      * <p> This method returns a reference to a {@code FileSystem} that was
      * created by invoking the {@link #newFileSystem(URI,Map) newFileSystem(URI,Map)}
-     * method. File systems created the {@link #newFileSystem(Path,Map)
+     * method. File systems created by the {@link #newFileSystem(Path,Map)
      * newFileSystem(Path,Map)} method are not returned by this method.
      * The file system is identified by its {@code URI}. Its exact form
      * is highly provider dependent. In the case of the default provider the URI's


### PR DESCRIPTION
Correct the indicated typo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351505](https://bugs.openjdk.org/browse/JDK-8351505): (fs) Typo in the documentation of java.nio.file.spi.FileSystemProvider.getFileSystem() (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23968/head:pull/23968` \
`$ git checkout pull/23968`

Update a local copy of the PR: \
`$ git checkout pull/23968` \
`$ git pull https://git.openjdk.org/jdk.git pull/23968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23968`

View PR using the GUI difftool: \
`$ git pr show -t 23968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23968.diff">https://git.openjdk.org/jdk/pull/23968.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23968#issuecomment-2711219456)
</details>
