### PR TITLE
8351555: Help section added in JDK-8350638 uses invalid HTML

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
@@ -177,7 +177,7 @@ public class HelpWriter extends HtmlDocletWriter {
         // Keyboard Navigation
         section = newHelpSection(contents.getContent("doclet.help.keyboard_navigation.title"),
                 HtmlIds.HELP_KEYBOARD_NAVIGATION);
-        var  keyboardPara = HtmlTree.P(contents.getContent("doclet.help.keyboard_navigation.intro"));
+        section.add(HtmlTree.P(contents.getContent("doclet.help.keyboard_navigation.intro")));
         var keyboardList = HtmlTree.UL();
         if (options.createIndex()) {
             keyboardList.add(HtmlTree.LI(contents.getContent("doclet.help.keyboard_navigation.index",
@@ -192,7 +192,7 @@ public class HelpWriter extends HtmlDocletWriter {
                 HtmlTree.KBD(Entity.of("uparrow")))));
         keyboardList.add(HtmlTree.LI(contents.getContent("doclet.help.keyboard_navigation.tabs",
                 HtmlTree.KBD(Entity.of("leftarrow")), HtmlTree.KBD(Entity.of("rightarrow")))));
-        navSection.add(section.add(keyboardPara.add(keyboardList)));
+        navSection.add(section.add(keyboardList));
 
         tableOfContents.popNestedList();
 


### PR DESCRIPTION
Please review a change to fix the HTML for the new Keyboard Navigation section added in [JDK-8350638](https://bugs.openjdk.org/browse/JDK-8350638). Instead of adding the `<ul>` element to the `<p>` element, both elements are added to the `<section>` element.