### PR TITLE
8351556: Optimize Location.locationFor/isModuleOrientedLocation

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -170,7 +170,7 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
          * @since 9
          */
         default boolean isModuleOrientedLocation() {
-            return getName().matches("\\bMODULE\\b");
+            return StandardLocation.computeIsModuleOrientedLocation(getName());
         }
     }
 

--- a/src/java.compiler/share/classes/javax/tools/StandardLocation.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardLocation.java
@@ -151,7 +151,7 @@ public enum StandardLocation implements Location {
         // Need to create the cache entry.
         Location newLoc = null;
 
-        // See if this is one of the standard Locations.
+        // See if this is one of the known Locations first.
         for (Location location : values()) {
             if (location.getName().equals(name)) {
                 newLoc = location;
@@ -159,7 +159,7 @@ public enum StandardLocation implements Location {
             }
         }
 
-        // Compute the fitting instance for non-standard location, if needed.
+        // Compute the fitting instance for unknown location, if needed.
         if (newLoc == null) {
             boolean isOutputLocation = name.endsWith("_OUTPUT");
             boolean isModuleOrientedLocation = computeIsModuleOrientedLocation(name);
@@ -170,7 +170,7 @@ public enum StandardLocation implements Location {
             };
         }
 
-        // Thread-safe install
+        // Thread-safe install.
         Location exist = LOCATIONS.putIfAbsent(name, newLoc);
         return (exist != null) ? exist : newLoc;
     }

--- a/test/langtools/tools/javac/api/location/LocationFor.java
+++ b/test/langtools/tools/javac/api/location/LocationFor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8351556
+ * @summary Test Location.locationFor
+ * @modules java.compiler jdk.compiler
+ * @run main LocationFor
+ */
+
+import javax.tools.JavaFileManager.Location;
+import javax.tools.StandardLocation;
+
+public class LocationFor {
+
+    public static void main(String... args) throws Exception {
+        // Non-output, non-module location.
+        {
+            Location loc = StandardLocation.locationFor("MY_LOCATION");
+            assertFalse(loc.isOutputLocation());
+            assertFalse(loc.isModuleOrientedLocation());
+        }
+
+        // Output, non-module location.
+        {
+            Location loc = StandardLocation.locationFor("MY_LOCATION_OUTPUT");
+            assertTrue(loc.isOutputLocation());
+            assertFalse(loc.isModuleOrientedLocation());
+        }
+
+        // Non-output, module location.
+        {
+            Location loc = StandardLocation.locationFor("MODULE");
+            assertFalse(loc.isOutputLocation());
+            assertTrue(loc.isModuleOrientedLocation());
+        }
+
+        // Output, module location.
+        if (false) { // JDK-8351561
+            Location loc = StandardLocation.locationFor("MODULE_OUTPUT");
+            assertTrue(loc.isOutputLocation());
+            assertTrue(loc.isModuleOrientedLocation());
+        }
+
+        // Test standard locations identity.
+        for (Location loc : StandardLocation.values()) {
+            Location cached = StandardLocation.locationFor(loc.getName());
+            assertTrue(loc == cached);
+        }
+    }
+
+    private static void assertFalse(boolean cond) {
+        if (cond) {
+            throw new AssertionError("Assertion failed");
+        }
+    }
+
+    private static void assertTrue(boolean cond) {
+        if (!cond) {
+            throw new AssertionError("Assertion failed");
+        }
+    }
+
+}

--- a/test/micro/org/openjdk/bench/javax/tools/LocationFor.java
+++ b/test/micro/org/openjdk/bench/javax/tools/LocationFor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.javax.tools;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+import javax.tools.JavaFileManager.Location;
+import javax.tools.StandardLocation;
+
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class LocationFor {
+
+    @Benchmark
+    public void standard(Blackhole bh) {
+        for (Location loc : StandardLocation.values()) {
+            bh.consume(StandardLocation.locationFor(loc.getName()));
+        }
+    }
+
+    @Benchmark
+    public Location custom() {
+        return StandardLocation.locationFor("MY_LOCATION");
+    }
+
+}

--- a/test/micro/org/openjdk/bench/javax/tools/LocationProps.java
+++ b/test/micro/org/openjdk/bench/javax/tools/LocationProps.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.javax.tools;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+import javax.tools.JavaFileManager.Location;
+import javax.tools.StandardLocation;
+
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class LocationProps {
+
+    @Benchmark
+    public void standard(Blackhole bh) {
+        for (Location loc : StandardLocation.values()) {
+            bh.consume(loc.getName());
+            bh.consume(loc.isModuleOrientedLocation());
+            bh.consume(loc.isOutputLocation());
+        }
+    }
+
+    @Benchmark
+    public void custom(Blackhole bh) {
+        Location loc = StandardLocation.locationFor("MY_LOCATION");
+        bh.consume(loc.getName());
+        bh.consume(loc.isModuleOrientedLocation());
+        bh.consume(loc.isOutputLocation());
+    }
+
+}


### PR DESCRIPTION
Leyden's JavacBenchApp benchmarks shows ~1% of time of the very first iteration is spent doing `Pattern.compile` in `Location.isModuleOrientedLocation`. Additionally, `Pattern.compile` becomes hot and requires JIT compilation, which eats CPU time. We can do better.

This improvement naturally spills over to `Location.locationFor`.

Things we do:
 1. Avoid `putIfAbsent` on fast-path.
 2. Lazily cache `Pattern` and reuse for all related paths.
 3. Capture output/module flags ahead of time, instead of recomputing them.
 4. (for interpreter/startup benefit) Use direct class type instead of interface.

There is also a little matching bug ([JDK-8351561](https://bugs.openjdk.org/browse/JDK-8351561)), which this performance improvement would retain.

Additional testing:
 - [x] New regression test still works
 - [x] New benchmark shows improvements
 - [x] Linux x86_64 server fastdebug/release, `langtools_all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8351556](https://bugs.openjdk.org/browse/JDK-8351556): Optimize Location.locationFor/isModuleOrientedLocation (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23973/head:pull/23973` \
`$ git checkout pull/23973`

Update a local copy of the PR: \
`$ git checkout pull/23973` \
`$ git pull https://git.openjdk.org/jdk.git pull/23973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23973`

View PR using the GUI difftool: \
`$ git pr show -t 23973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23973.diff">https://git.openjdk.org/jdk/pull/23973.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23973#issuecomment-2711472533)
</details>
