### PR TITLE
8351606: Use build_platform for graphviz dependency

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1237,7 +1237,7 @@ var getJibProfilesDependencies = function (input, common) {
             organization: common.organization,
             ext: "tar.gz",
             revision: "9.0.0+1.0",
-            module: "graphviz-" + input.target_platform,
+            module: "graphviz-" + input.build_platform,
             configure_args: "DOT=" + input.get("graphviz", "install_path") + "/dot",
             environment_path: input.get("graphviz", "install_path")
         },


### PR DESCRIPTION
Background (from JBS):

graphviz is run during the build, and needs the build_platform variant rather than target_platform.

Testing:

tier1,builds-tier[2-5]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351606](https://bugs.openjdk.org/browse/JDK-8351606): Use build_platform for graphviz dependency (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23976/head:pull/23976` \
`$ git checkout pull/23976`

Update a local copy of the PR: \
`$ git checkout pull/23976` \
`$ git pull https://git.openjdk.org/jdk.git pull/23976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23976`

View PR using the GUI difftool: \
`$ git pr show -t 23976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23976.diff">https://git.openjdk.org/jdk/pull/23976.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23976#issuecomment-2712091641)
</details>
