### PR TITLE
8335708: C2: Compile::verify_graph_edges must start at root and safepoints, just like CCP traversal

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4205,10 +4205,10 @@ void Compile::verify_bidirectional_edges(Unique_Node_List& visited, const Unique
   Node_List nstack(MAX2(stack_size, (uint) OptoNodeListSize));
   if (root_and_safepoints != nullptr) {
     assert(root_and_safepoints->member(_root), "root is not in root_and_safepoints");
-    for (unsigned int i = 0, limit = root_and_safepoints->size(); i < limit; i++) {
+    for (uint i = 0, limit = root_and_safepoints->size(); i < limit; i++) {
       Node* root_or_safepoint = root_and_safepoints->at(i);
-      // If the node is a safepoint, let's check it still has a control input
-      // Lack of control input signified that this node was killed by CCP or
+      // If the node is a safepoint, let's check if it still has a control input
+      // Lack of control input signifies that this node was killed by CCP or
       // recursively by remove_globally_dead_node and it shouldn't be a starting
       // point.
       if (!root_or_safepoint->is_SafePoint() || root_or_safepoint->in(0) != nullptr) {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -417,7 +417,7 @@ void Compile::remove_useless_node(Node* dead) {
 }
 
 // Disconnect all useless nodes by disconnecting those at the boundary.
-void Compile::disconnect_useless_nodes(Unique_Node_List& useful, Unique_Node_List& worklist, Unique_Node_List* root_and_safepoints) {
+void Compile::disconnect_useless_nodes(Unique_Node_List& useful, Unique_Node_List& worklist, const Unique_Node_List* root_and_safepoints) {
   uint next = 0;
   while (next < useful.size()) {
     Node *n = useful.at(next++);
@@ -4199,14 +4199,21 @@ bool Compile::needs_clinit_barrier(ciInstanceKlass* holder, ciMethod* accessing_
 //------------------------------verify_bidirectional_edges---------------------
 // For each input edge to a node (ie - for each Use-Def edge), verify that
 // there is a corresponding Def-Use edge.
-void Compile::verify_bidirectional_edges(Unique_Node_List& visited, Unique_Node_List* root_and_safepoints) {
+void Compile::verify_bidirectional_edges(Unique_Node_List& visited, const Unique_Node_List* root_and_safepoints) const {
   // Allocate stack of size C->live_nodes()/16 to avoid frequent realloc
   uint stack_size = live_nodes() >> 4;
   Node_List nstack(MAX2(stack_size, (uint) OptoNodeListSize));
   if (root_and_safepoints != nullptr) {
     assert(root_and_safepoints->member(_root), "root is not in root_and_safepoints");
     for (unsigned int i = 0, limit = root_and_safepoints->size(); i < limit; i++) {
-      nstack.push(root_and_safepoints->at(i));
+      Node* root_or_safepoint = root_and_safepoints->at(i);
+      // If the node is a safepoint, let's check it still has a control input
+      // Lack of control input signified that this node was killed by CCP or
+      // recursively by remove_globally_dead_node and it shouldn't be a starting
+      // point.
+      if (!root_or_safepoint->is_SafePoint() || root_or_safepoint->in(0) != nullptr) {
+        nstack.push(root_or_safepoint);
+      }
     }
   } else {
     nstack.push(_root);
@@ -4260,7 +4267,7 @@ void Compile::verify_bidirectional_edges(Unique_Node_List& visited, Unique_Node_
 //------------------------------verify_graph_edges---------------------------
 // Walk the Graph and verify that there is a one-to-one correspondence
 // between Use-Def edges and Def-Use edges in the graph.
-void Compile::verify_graph_edges(bool no_dead_code, Unique_Node_List* root_and_safepoints) {
+void Compile::verify_graph_edges(bool no_dead_code, const Unique_Node_List* root_and_safepoints) const {
   if (VerifyGraphEdges) {
     Unique_Node_List visited;
 

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -1229,13 +1229,24 @@ public:
   static void print_intrinsic_statistics() PRODUCT_RETURN;
 
   // Graph verification code
-  // Walk the node list, verifying that there is a one-to-one
-  // correspondence between Use-Def edges and Def-Use edges
-  // The option no_dead_code enables stronger checks that the
-  // graph is strongly connected from root in both directions.
-  // root_and_safepoints is used to give the starting points to
-  // find useful nodes. If not supplied, only root is used.
-  // Giving this makes sense only if no_dead_code == true.
+  // Walk the node list, verifying that there is a one-to-one correspondence
+  // between Use-Def edges and Def-Use edges The option no_dead_code enables
+  // stronger checks that the graph is strongly connected from starting points
+  // in both directions.
+  // root_and_safepoints is used to give the starting points for the traversal.
+  // If not supplied, only root is used. When this check is called after CCP,
+  // we need to start traversal from Root and safepoints, just like CCP does its
+  // own traversal (see PhaseCCP::transform for reasons).
+  //
+  // To call this function, there are 2 ways to go:
+  // - give root_and_safepoints to start traversal everywhere needed (like after CCP),
+  // - if the whole graph is assumed to be reachable from Root's input,
+  //   root_and_safepoints is not needed (like in PhaseRemoveUseless).
+  //
+  // Failure to specify root_and_safepoints in case the graph is not fully
+  // reachable from Root's input make this check unsound (can miss inconsistencies)
+  // and even incomplete (can make up non-existing problems) if no_dead_code is
+  // true.
   void verify_graph_edges(bool no_dead_code = false, const Unique_Node_List* root_and_safepoints = nullptr) const PRODUCT_RETURN;
 
   // Verify bi-directional correspondence of edges

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -1230,7 +1230,7 @@ public:
 
   // Graph verification code
   // Walk the node list, verifying that there is a one-to-one correspondence
-  // between Use-Def edges and Def-Use edges The option no_dead_code enables
+  // between Use-Def edges and Def-Use edges. The option no_dead_code enables
   // stronger checks that the graph is strongly connected from starting points
   // in both directions.
   // root_and_safepoints is used to give the starting points for the traversal.
@@ -1239,7 +1239,7 @@ public:
   // own traversal (see PhaseCCP::transform for reasons).
   //
   // To call this function, there are 2 ways to go:
-  // - give root_and_safepoints to start traversal everywhere needed (like after CCP),
+  // - give root_and_safepoints to start traversal everywhere needed (like after CCP)
   // - if the whole graph is assumed to be reachable from Root's input,
   //   root_and_safepoints is not needed (like in PhaseRemoveUseless).
   //

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -1022,7 +1022,7 @@ public:
 
   void              identify_useful_nodes(Unique_Node_List &useful);
   void              update_dead_node_list(Unique_Node_List &useful);
-  void disconnect_useless_nodes(Unique_Node_List& useful, Unique_Node_List& worklist, Unique_Node_List* root_and_safepoints = nullptr);
+  void disconnect_useless_nodes(Unique_Node_List& useful, Unique_Node_List& worklist, const Unique_Node_List* root_and_safepoints = nullptr);
 
   void              remove_useless_node(Node* dead);
 
@@ -1236,10 +1236,10 @@ public:
   // root_and_safepoints is used to give the starting points to
   // find useful nodes. If not supplied, only root is used.
   // Giving this makes sense only if no_dead_code == true.
-  void verify_graph_edges(bool no_dead_code = false, Unique_Node_List* root_and_safepoints = nullptr) PRODUCT_RETURN;
+  void verify_graph_edges(bool no_dead_code = false, const Unique_Node_List* root_and_safepoints = nullptr) const PRODUCT_RETURN;
 
   // Verify bi-directional correspondence of edges
-  void verify_bidirectional_edges(Unique_Node_List& visited, Unique_Node_List* root_and_safepoints = nullptr);
+  void verify_bidirectional_edges(Unique_Node_List& visited, const Unique_Node_List* root_and_safepoints = nullptr) const;
 
   // End-of-run dumps.
   static void print_statistics() PRODUCT_RETURN;

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -1022,7 +1022,7 @@ public:
 
   void              identify_useful_nodes(Unique_Node_List &useful);
   void              update_dead_node_list(Unique_Node_List &useful);
-  void              disconnect_useless_nodes(Unique_Node_List& useful, Unique_Node_List& worklist);
+  void disconnect_useless_nodes(Unique_Node_List& useful, Unique_Node_List& worklist, Unique_Node_List* root_and_safepoints = nullptr);
 
   void              remove_useless_node(Node* dead);
 
@@ -1233,10 +1233,13 @@ public:
   // correspondence between Use-Def edges and Def-Use edges
   // The option no_dead_code enables stronger checks that the
   // graph is strongly connected from root in both directions.
-  void verify_graph_edges(bool no_dead_code = false) PRODUCT_RETURN;
+  // root_and_safepoints is used to give the starting points to
+  // find useful nodes. If not supplied, only root is used.
+  // Giving this makes sense only if no_dead_code == true.
+  void verify_graph_edges(bool no_dead_code = false, Unique_Node_List* root_and_safepoints = nullptr) PRODUCT_RETURN;
 
   // Verify bi-directional correspondence of edges
-  void verify_bidirectional_edges(Unique_Node_List &visited);
+  void verify_bidirectional_edges(Unique_Node_List& visited, Unique_Node_List* root_and_safepoints = nullptr);
 
   // End-of-run dumps.
   static void print_statistics() PRODUCT_RETURN;

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1740,7 +1740,7 @@ public:
   Unique_Node_List(Unique_Node_List&&) = default;
 
   void remove( Node *n );
-  bool member( Node *n ) { return _in_worklist.test(n->_idx) != 0; }
+  bool member(const Node* n) const { return _in_worklist.test(n->_idx) != 0; }
   VectorSet& member_set(){ return _in_worklist; }
 
   void push(Node* b) {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2110,7 +2110,7 @@ Node *PhaseCCP::transform( Node *n ) {
   C->update_dead_node_list(useful);
   remove_useless_nodes(useful.member_set());
   _worklist.remove_useless_nodes(useful.member_set());
-  C->disconnect_useless_nodes(useful, _worklist);
+  C->disconnect_useless_nodes(useful, _worklist, &_root_and_safepoints);
 
   Node* new_root = node_map[n->_idx];
   assert(new_root->is_Root(), "transformed root node must be a root node");

--- a/test/hotspot/jtreg/compiler/loopopts/Test8335708.java
+++ b/test/hotspot/jtreg/compiler/loopopts/Test8335708.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8335708
  * @summary Crash Compile::verify_graph_edges
+ * @requires vm.debug == true & vm.flavor == "server"
  * @library /test/lib
  *
  * @run main/othervm

--- a/test/hotspot/jtreg/compiler/loopopts/Test8335708.java
+++ b/test/hotspot/jtreg/compiler/loopopts/Test8335708.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8335708
+ * @summary Crash Compile::verify_graph_edges
+ * @library /test/lib
+ *
+ * @run main/othervm
+ *       -XX:-TieredCompilation -XX:+VerifyGraphEdges
+ *       -XX:+StressIGVN -Xcomp
+ *       -XX:CompileCommand=compileonly,compiler.loopopts.Test8335708::mainTest
+ *       compiler.loopopts.Test8335708
+ *
+ */
+
+package compiler.loopopts;
+
+import jdk.test.lib.Utils;
+
+public class Test8335708 {
+    public static void main(String[] args) throws Exception {
+        Thread thread = new Thread() {
+            public void run() {
+                Test8335708 instance = new Test8335708();
+                byte[] a = new byte[997];
+                for (int i = 0; i < 100; ++i) {
+                    instance.mainTest(a, a);
+                }
+            }
+        };
+        // Give thread some time to trigger compilation
+        thread.setDaemon(true);
+        thread.start();
+        Thread.sleep(Utils.adjustTimeout(500));
+    }
+
+    public void mainTest(byte[] a, byte[] b) {
+        int i = 0;
+        while (i < (a.length - 4)) {
+            a[i] = b[i];
+        }
+        while (true) {
+            a[i] = b[i];
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/VerifyGraphEdgesWithDeadCodeCheckFromSafepoints.java
+++ b/test/hotspot/jtreg/compiler/loopopts/VerifyGraphEdgesWithDeadCodeCheckFromSafepoints.java
@@ -24,15 +24,16 @@
 /**
  * @test
  * @bug 8335708
- * @summary Crash Compile::verify_graph_edges
- * @requires vm.debug == true & vm.flavor == "server"
+ * @summary Crash Compile::verify_graph_edges with dead code check when safepoints are reachable but not connected back to Root's inputs
  * @library /test/lib
  *
+ * @run driver compiler.loopopts.VerifyGraphEdgesWithDeadCodeCheckFromSafepoints
  * @run main/othervm
+ *       -XX:+IgnoreUnrecognizedVMOptions
  *       -XX:-TieredCompilation -XX:+VerifyGraphEdges
  *       -XX:+StressIGVN -Xcomp
- *       -XX:CompileCommand=compileonly,compiler.loopopts.Test8335708::mainTest
- *       compiler.loopopts.Test8335708
+ *       -XX:CompileCommand=compileonly,compiler.loopopts.VerifyGraphEdgesWithDeadCodeCheckFromSafepoints::mainTest
+ *       compiler.loopopts.VerifyGraphEdgesWithDeadCodeCheckFromSafepoints
  *
  */
 
@@ -40,11 +41,11 @@ package compiler.loopopts;
 
 import jdk.test.lib.Utils;
 
-public class Test8335708 {
+public class VerifyGraphEdgesWithDeadCodeCheckFromSafepoints {
     public static void main(String[] args) throws Exception {
         Thread thread = new Thread() {
             public void run() {
-                Test8335708 instance = new Test8335708();
+                VerifyGraphEdgesWithDeadCodeCheckFromSafepoints instance = new VerifyGraphEdgesWithDeadCodeCheckFromSafepoints();
                 byte[] a = new byte[997];
                 for (int i = 0; i < 100; ++i) {
                     instance.mainTest(a, a);


### PR DESCRIPTION
In CCP, we transform the nodes going up (toward inputs) starting from root and safepoints because infinite loops can be reachable from the root, but not co-reachable from the root, that is one can follow def-use from root to the loop, but not the use-def from root to loop. For more details, see:
https://github.com/openjdk/jdk/blob/4cf63160ad575d49dbe70f128cd36aba22b8f2ff/src/hotspot/share/opto/phaseX.cpp#L2063-L2070

Since we are specifically marking nodes as useful if they are above a safepoint, the check that no dead nodes must be there anymore must also consider nodes above a safepoint as alive: the same criterion must apply. We should nevertheless not start from a safepoint killed by CCP.

About the test, I use this trick found in `TestInfiniteLoopCCP` because I indeed need a really infinite loop, but I want a terminating test. The crash is not deterministic, as it needs StressIGVN, so I did a bit of stats. Using a little helper script, on 100 runs, 69 runs fail as in the JBS ticket and 31 are successful (so 0 fail in another way). After the fix, I find 100 successes.

And thanks to @eme64  who extracted such a concise reproducer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335708](https://bugs.openjdk.org/browse/JDK-8335708): C2: Compile::verify_graph_edges must start at root and safepoints, just like CCP traversal (**Bug** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**) Review applies to [6f8fce6e](https://git.openjdk.org/jdk/pull/23977/files/6f8fce6e27e111c9a03b3b256c3b25b9817ddd2e)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23977/head:pull/23977` \
`$ git checkout pull/23977`

Update a local copy of the PR: \
`$ git checkout pull/23977` \
`$ git pull https://git.openjdk.org/jdk.git pull/23977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23977`

View PR using the GUI difftool: \
`$ git pr show -t 23977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23977.diff">https://git.openjdk.org/jdk/pull/23977.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23977#issuecomment-2724992710)
</details>
