### PR TITLE
8351639: Improve debuggability of test/langtools/jdk/jshell/JdiHangingListenExecutionControlTest.java test

### DIFF
--- a/test/langtools/jdk/jshell/JdiHangingListenExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiHangingListenExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,11 @@ public class JdiHangingListenExecutionControlTest {
             System.err.printf("Unexpected return value: %s\n",
                     HangingRemoteAgent.state(false, null).eval("33;"));
         } catch (IllegalStateException ex) {
-            assertTrue(ex.getMessage().startsWith(EXPECTED_ERROR), ex.getMessage());
+            if (!ex.getMessage().startsWith(EXPECTED_ERROR)) {
+                // unexpected message in the exception, rethrow the original exception
+                throw ex;
+            }
+            // received expected exception
             return;
         }
         fail("Expected IllegalStateException");


### PR DESCRIPTION
Can I please get a review of this test-only change which proposes to improve the debuggability of `test/langtools/jdk/jshell/JdiHangingListenExecutionControlTest.java` when it fails intermittently?

This test has failed a few times in the CI and as noted in the description of https://bugs.openjdk.org/browse/JDK-8351639, the failure happens when the test doesn't find the expected exception message in the `IllegalStateException` that gets thrown. When I initially filed that issue, I thought the (unexpected) exception message wasn't being printed. But turns out the `assertTrue(...)` call does indeed print the original exception message:

> Launching JShell execution engine threw: Failed remote listen: java.util.concurrent.ExecutionException: com.sun.jdi.connect.TransportTimeoutException: timeout waiting for connection @ com.sun.jdi.SocketListen (defaults: timeout=, port=, localAddress=) -- {timeout=timeout=8000, port=port=59547, localAddress=localAddress=}

Even so, I think the proposed change in this PR to rethrow the original exception and thus have the entire exception stacktrace available for analysis would be useful for any such failures in future.

The test continues to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351639](https://bugs.openjdk.org/browse/JDK-8351639): Improve debuggability of test/langtools/jdk/jshell/JdiHangingListenExecutionControlTest.java test (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23978/head:pull/23978` \
`$ git checkout pull/23978`

Update a local copy of the PR: \
`$ git checkout pull/23978` \
`$ git pull https://git.openjdk.org/jdk.git pull/23978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23978`

View PR using the GUI difftool: \
`$ git pr show -t 23978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23978.diff">https://git.openjdk.org/jdk/pull/23978.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23978#issuecomment-2713647931)
</details>
