### PR TITLE
8350840: C2: x64 Assembler::vpcmpeqq assert: failed: XMM register should be 0-15

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -6857,7 +6857,7 @@ void C2_MacroAssembler::vpsign_extend_dq(BasicType elem_bt, XMMRegister dst, XMM
 
 void C2_MacroAssembler::vpgenmax_value(BasicType elem_bt, XMMRegister dst, XMMRegister allones, int vlen_enc, bool compute_allones) {
   if (compute_allones) {
-    if (vlen_enc == Assembler::AVX_512bit) {
+    if (VM_Version::supports_avx512vl() || vlen_enc == Assembler::AVX_512bit) {
       vpternlogd(allones, 0xff, allones, allones, vlen_enc);
     } else {
       vpcmpeqq(allones, allones, allones, vlen_enc);
@@ -6873,7 +6873,7 @@ void C2_MacroAssembler::vpgenmax_value(BasicType elem_bt, XMMRegister dst, XMMRe
 
 void C2_MacroAssembler::vpgenmin_value(BasicType elem_bt, XMMRegister dst, XMMRegister allones, int vlen_enc, bool compute_allones) {
   if (compute_allones) {
-    if (vlen_enc == Assembler::AVX_512bit) {
+    if (VM_Version::supports_avx512vl() || vlen_enc == Assembler::AVX_512bit) {
       vpternlogd(allones, 0xff, allones, allones, vlen_enc);
     } else {
       vpcmpeqq(allones, allones, allones, vlen_enc);

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -749,7 +749,6 @@ sun/tools/jstat/jstatLineCounts4.sh                             8248691,8268211 
 
 jdk/incubator/vector/ShortMaxVectorTests.java                   8306592 generic-i586
 jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-x64
-jdk/incubator/vector/Long256VectorTests.java                    8350840 generic-x64
 
 ############################################################################
 


### PR DESCRIPTION
This bug fix patch addressed an assertion failure due to unexpected register operand encoding.
AVX2 flavour of instruction "vpcmpeqq" expects to operate over XMM registers from lower register bank (0-15), in this case, the register mask associated with the destination vector operand of the matcher pattern also includes registers from the higher bank.

The issue can be reliably reproduced if we modify the static allocation order of XMM register through AD file change.
Existing bug [JDK-8343294](https://bugs.openjdk.org/browse/JDK-8343294) already tracks the requirement to randomize the allocation ordering.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350840](https://bugs.openjdk.org/browse/JDK-8350840): C2: x64 Assembler::vpcmpeqq assert: failed: XMM register should be 0-15 (**Bug** - P3)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23979/head:pull/23979` \
`$ git checkout pull/23979`

Update a local copy of the PR: \
`$ git checkout pull/23979` \
`$ git pull https://git.openjdk.org/jdk.git pull/23979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23979`

View PR using the GUI difftool: \
`$ git pr show -t 23979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23979.diff">https://git.openjdk.org/jdk/pull/23979.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23979#issuecomment-2713662380)
</details>
