### PR TITLE
8351651: Cleanup LockStack::is_owning_thread

### DIFF
--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -76,11 +76,19 @@ uint32_t LockStack::end_offset() {
 }
 
 #ifndef PRODUCT
+bool LockStack::is_owning_thread(JavaThread* current) const {
+ JavaThread* thread = JavaThread::cast(current);
+ bool is_owning = &thread->lock_stack() == this;
+ assert(is_owning == (get_thread() == thread), "is_owning sanity");
+ return is_owning;
+}
+
 void LockStack::verify(const char* msg) const {
   assert(LockingMode == LM_LIGHTWEIGHT, "never use lock-stack when light weight locking is disabled");
   assert((_top <= end_offset()), "lockstack overflow: _top %d end_offset %d", _top, end_offset());
   assert((_top >= start_offset()), "lockstack underflow: _top %d start_offset %d", _top, start_offset());
-  if (SafepointSynchronize::is_at_safepoint() || (Thread::current()->is_Java_thread() && is_owning_thread())) {
+  Thread* current = Thread::current();
+  if (SafepointSynchronize::is_at_safepoint() || (current->is_Java_thread() && is_owning_thread(JavaThread::cast(current)))) {
     int top = to_index(_top);
     for (int i = 0; i < top; i++) {
       assert(_base[i] != nullptr, "no zapped before top");

--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -77,9 +77,8 @@ uint32_t LockStack::end_offset() {
 
 #ifndef PRODUCT
 bool LockStack::is_owning_thread(JavaThread* current) const {
- JavaThread* thread = JavaThread::cast(current);
- bool is_owning = &thread->lock_stack() == this;
- assert(is_owning == (get_thread() == thread), "is_owning sanity");
+ bool is_owning = &current->lock_stack() == this;
+ assert(is_owning == (get_thread() == current), "is_owning sanity");
  return is_owning;
 }
 

--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -77,9 +77,9 @@ uint32_t LockStack::end_offset() {
 
 #ifndef PRODUCT
 bool LockStack::is_owning_thread(JavaThread* current) const {
- bool is_owning = &current->lock_stack() == this;
- assert(is_owning == (get_thread() == current), "is_owning sanity");
- return is_owning;
+  bool is_owning = &current->lock_stack() == this;
+  assert(is_owning == (get_thread() == current), "is_owning sanity");
+  return is_owning;
 }
 
 void LockStack::verify(const char* msg) const {

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -67,7 +67,7 @@ class LockStack {
   inline JavaThread* get_thread() const;
 
   // Tests if the calling thread is the thread that owns this lock-stack.
-  bool is_owning_thread(JavaThread* current) const PRODUCT_RETURN_({ return false; })
+  NOT_PRODUCT(bool is_owning_thread(JavaThread* current) const;)
 
   // Verifies consistency of the lock-stack.
   void verify(const char* msg) const PRODUCT_RETURN;

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -67,7 +67,7 @@ class LockStack {
   inline JavaThread* get_thread() const;
 
   // Tests if the calling thread is the thread that owns this lock-stack.
-  bool is_owning_thread(JavaThread* current) const PRODUCT_RETURN;
+  bool is_owning_thread(JavaThread* current) const PRODUCT_RETURN_({ return false; })
 
   // Verifies consistency of the lock-stack.
   void verify(const char* msg) const PRODUCT_RETURN;

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -67,7 +67,7 @@ class LockStack {
   inline JavaThread* get_thread() const;
 
   // Tests if the calling thread is the thread that owns this lock-stack.
-  NOT_PRODUCT(bool is_owning_thread(JavaThread* current) const;)
+  bool is_owning_thread(JavaThread* current) const;
 
   // Verifies consistency of the lock-stack.
   void verify(const char* msg) const PRODUCT_RETURN;

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ class LockStack {
   inline JavaThread* get_thread() const;
 
   // Tests if the calling thread is the thread that owns this lock-stack.
-  bool is_owning_thread() const;
+  bool is_owning_thread(JavaThread* current) const PRODUCT_RETURN;
 
   // Verifies consistency of the lock-stack.
   void verify(const char* msg) const PRODUCT_RETURN;

--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,17 +53,6 @@ JavaThread* LockStack::get_thread() const {
 
 inline bool LockStack::is_full() const {
   return to_index(_top) == CAPACITY;
-}
-
-inline bool LockStack::is_owning_thread() const {
-  Thread* current = Thread::current();
-  if (current->is_Java_thread()) {
-    JavaThread* thread = JavaThread::cast(current);
-    bool is_owning = &thread->lock_stack() == this;
-    assert(is_owning == (get_thread() == thread), "is_owning sanity");
-    return is_owning;
-  }
-  return false;
 }
 
 inline void LockStack::push(oop o) {

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -407,10 +407,6 @@ bool ObjectSynchronizer::quick_enter_legacy(oop obj, BasicLock* lock, JavaThread
     return false;  // Slow path
   }
 
-  if (LockingMode == LM_LIGHTWEIGHT) {
-    return LightweightSynchronizer::quick_enter(obj, lock, current);
-  }
-
   assert(LockingMode == LM_LEGACY, "legacy mode below");
 
   const markWord mark = obj->mark();

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -407,6 +407,10 @@ bool ObjectSynchronizer::quick_enter_legacy(oop obj, BasicLock* lock, JavaThread
     return false;  // Slow path
   }
 
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    return LightweightSynchronizer::quick_enter(obj, lock, current);
+  }
+
   assert(LockingMode == LM_LEGACY, "legacy mode below");
 
   const markWord mark = obj->mark();


### PR DESCRIPTION
This is a minor mostly trivial change I found while reading through code looking for something else.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351651](https://bugs.openjdk.org/browse/JDK-8351651): Cleanup LockStack::is_owning_thread (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23981/head:pull/23981` \
`$ git checkout pull/23981`

Update a local copy of the PR: \
`$ git checkout pull/23981` \
`$ git pull https://git.openjdk.org/jdk.git pull/23981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23981`

View PR using the GUI difftool: \
`$ git pr show -t 23981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23981.diff">https://git.openjdk.org/jdk/pull/23981.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23981#issuecomment-2713974693)
</details>
