### PR TITLE
8351662: [Test] RISC-V: enable bunch of IR test

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeIntIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeIntIdealizationTests.java
@@ -31,7 +31,7 @@ import compiler.lib.ir_framework.*;
  * @summary Test that Ideal transformations of RotateLeftNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.RotateLeftNodeIntIdealizationTests
- * @requires os.arch == "x86_64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseZbb == true)
+ * @requires os.arch == "x86_64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.cpu.features ~= ".*zbb.*")
  */
 public class RotateLeftNodeIntIdealizationTests {
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeLongIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeLongIdealizationTests.java
@@ -31,7 +31,7 @@ import compiler.lib.ir_framework.*;
  * @summary Test that Ideal transformations of RotateLeftNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.RotateLeftNodeLongIdealizationTests
- * @requires os.arch == "x86_64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseZbb == true)
+ * @requires os.arch == "x86_64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.cpu.features ~= ".*zbb.*")
  */
 public class RotateLeftNodeLongIdealizationTests {
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVecCountingDownLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVecCountingDownLoop.java
@@ -29,7 +29,7 @@ import compiler.lib.ir_framework.*;
  * @test
  * @bug 8284981
  * @summary Auto-vectorization enhancement for special counting down loops
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="riscv64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestAutoVecCountingDownLoop
  */

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java
@@ -31,7 +31,7 @@ import compiler.lib.ir_framework.*;
  * @summary Auto-vectorization enhancement for two-dimensional array operations
  * @requires ((os.arch == "x86" | os.arch == "i386") & (vm.opt.UseSSE == "null" | vm.opt.UseSSE >= 2))
  *           | (os.arch != "x86" & os.arch != "i386" & os.arch != "riscv64")
- *           | (os.arch == "riscv64" & vm.opt.UseRVV == true)
+ *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestAutoVectorization2DArray
  */

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIRAbs.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIRAbs.java
@@ -30,7 +30,7 @@ import compiler.lib.ir_framework.*;
  * @test
  * @bug 8276673 8280089
  * @summary Test abs nodes optimization in C2.
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="riscv64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestIRAbs
  */

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestMinMaxIdentities.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestMinMaxIdentities.java
@@ -143,13 +143,15 @@ public class TestMinMaxIdentities {
     // Floats
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"}, counts = { IRNode.MIN_F, "1" })
+    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"}, counts = { IRNode.MIN_F, "1" })
+    @IR(applyIfPlatform = { "riscv64", "true" }, counts = { IRNode.MIN_F, "1" })
     public float floatMinMin(float a, float b) {
         return Math.min(a, Math.min(a, b));
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"}, counts = { IRNode.MAX_F, "1" })
+    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"}, counts = { IRNode.MAX_F, "1" })
+    @IR(applyIfPlatform = { "riscv64", "true" }, counts = { IRNode.MAX_F, "1" })
     public float floatMaxMax(float a, float b) {
         return Math.max(a, Math.max(a, b));
     }
@@ -157,13 +159,15 @@ public class TestMinMaxIdentities {
     // Doubles
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"}, counts = { IRNode.MIN_D, "1" })
+    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"}, counts = { IRNode.MIN_D, "1" })
+    @IR(applyIfPlatform = { "riscv64", "true" }, counts = { IRNode.MIN_D, "1" })
     public double doubleMinMin(double a, double b) {
         return Math.min(a, Math.min(a, b));
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"}, counts = { IRNode.MAX_D, "1" })
+    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"}, counts = { IRNode.MAX_D, "1" })
+    @IR(applyIfPlatform = { "riscv64", "true" }, counts = { IRNode.MAX_D, "1" })
     public double doubleMaxMax(double a, double b) {
         return Math.max(a, Math.max(a, b));
     }
@@ -171,25 +175,29 @@ public class TestMinMaxIdentities {
     // Float and double identities that cannot be simplified due to NaN
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"}, counts = { IRNode.MIN_F, "1", IRNode.MAX_F, "1" })
+    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"}, counts = { IRNode.MIN_F, "1", IRNode.MAX_F, "1" })
+    @IR(applyIfPlatform = { "riscv64", "true" }, counts = { IRNode.MIN_F, "1", IRNode.MAX_F, "1" })
     public float floatMinMax(float a, float b) {
         return Math.min(a, Math.max(a, b));
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"}, counts = { IRNode.MIN_F, "1", IRNode.MAX_F, "1" })
+    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"}, counts = { IRNode.MIN_F, "1", IRNode.MAX_F, "1" })
+    @IR(applyIfPlatform = { "riscv64", "true" }, counts = { IRNode.MIN_F, "1", IRNode.MAX_F, "1" })
     public float floatMaxMin(float a, float b) {
         return Math.max(a, Math.min(a, b));
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"}, counts = { IRNode.MIN_D, "1", IRNode.MAX_D, "1" })
+    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"}, counts = { IRNode.MIN_D, "1", IRNode.MAX_D, "1" })
+    @IR(applyIfPlatform = { "riscv64", "true" }, counts = { IRNode.MIN_D, "1", IRNode.MAX_D, "1" })
     public double doubleMinMax(double a, double b) {
         return Math.min(a, Math.max(a, b));
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true", "rvv", "true"}, counts = { IRNode.MIN_D, "1", IRNode.MAX_D, "1" })
+    @IR(applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"}, counts = { IRNode.MIN_D, "1", IRNode.MAX_D, "1" })
+    @IR(applyIfPlatform = { "riscv64", "true" }, counts = { IRNode.MIN_D, "1", IRNode.MAX_D, "1" })
     public double doubleMaxMin(double a, double b) {
         return Math.max(a, Math.min(a, b));
     }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPhiDuplicatedConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPhiDuplicatedConversion.java
@@ -114,13 +114,13 @@ public class TestPhiDuplicatedConversion {
     }
 
     @Test
-    @IR(counts = {IRNode.CONV, "1"}, applyIfCPUFeatureOr = {"f16c", "true", "avx512vl", "true", "asimd", "true"})
+    @IR(counts = {IRNode.CONV, "1"}, applyIfCPUFeatureOr = {"f16c", "true", "avx512vl", "true", "asimd", "true", "rvv", "true"})
     public static short float2HalfFloat(boolean c, float a, float b) {
         return c ? Float.floatToFloat16(a) : Float.floatToFloat16(b);
     }
 
     @Test
-    @IR(counts = {IRNode.CONV, "1"}, applyIfCPUFeatureOr = {"f16c", "true", "avx512vl", "true", "asimd", "true"})
+    @IR(counts = {IRNode.CONV, "1"}, applyIfCPUFeatureOr = {"f16c", "true", "avx512vl", "true", "asimd", "true", "rvv", "true"})
     public static float halfFloat2Float(boolean c, short a, short b) {
         return c ? Float.float16ToFloat(a) : Float.float16ToFloat(b);
     }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
@@ -166,7 +166,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: offsets are badly aligned (UNSAFE.ARRAY_BYTE_BASE_OFFSET is 4 byte aligned, but not 8 byte aligned).
     //         might get fixed with JDK-8325155.
@@ -184,7 +184,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong1b(byte[] dest, long[] src) {
@@ -200,7 +200,7 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     public static void testByteLong1c(byte[] dest, long[] src) {
         long base = 64; // make sure it is big enough and 8 byte aligned (required for 32-bit)
         for (int i = 0; i < src.length - 8; i++) {
@@ -215,7 +215,7 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong1d(byte[] dest, long[] src) {
@@ -241,7 +241,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: offsets are badly aligned (UNSAFE.ARRAY_BYTE_BASE_OFFSET is 4 byte aligned, but not 8 byte aligned).
     //         might get fixed with JDK-8325155.
@@ -259,7 +259,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong2b(byte[] dest, long[] src) {
@@ -282,7 +282,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: offsets are badly aligned (UNSAFE.ARRAY_BYTE_BASE_OFFSET is 4 byte aligned, but not 8 byte aligned).
     //         might get fixed with JDK-8325155.
@@ -300,7 +300,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong3b(byte[] dest, long[] src) {
@@ -322,7 +322,7 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"})
     // 32-bit: offsets are badly aligned (UNSAFE.ARRAY_BYTE_BASE_OFFSET is 4 byte aligned, but not 8 byte aligned).
@@ -336,7 +336,7 @@ public class TestVectorizationMismatchedAccess {
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"})
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
@@ -357,7 +357,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: offsets are badly aligned (UNSAFE.ARRAY_BYTE_BASE_OFFSET is 4 byte aligned, but not 8 byte aligned).
     //         might get fixed with JDK-8325155.
@@ -375,7 +375,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong5b(byte[] dest, long[] src, int start, int stop) {
@@ -399,7 +399,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: offsets are badly aligned (UNSAFE.ARRAY_BYTE_BASE_OFFSET is 4 byte aligned, but not 8 byte aligned).
     //         might get fixed with JDK-8325155.
@@ -417,7 +417,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteByte1b(byte[] dest, byte[] src) {
@@ -440,7 +440,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: offsets are badly aligned (UNSAFE.ARRAY_BYTE_BASE_OFFSET is 4 byte aligned, but not 8 byte aligned).
     //         might get fixed with JDK-8325155.
@@ -458,7 +458,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"})
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteByte2b(byte[] dest, byte[] src) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMultiInvar.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMultiInvar.java
@@ -33,7 +33,7 @@ import java.util.Random;
 /*
  * @test
  * @bug 8300257
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "riscv64")
  * @summary C2: vectorization fails on some simple Memory Segment loops
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
@@ -65,7 +65,7 @@ public class TestVectorizationNotRun {
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" },
         applyIfOr = { "UseCompactObjectHeaders", "false", "AlignVector", "false" },
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     public static void test(byte[] dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
             if ((i < 0) || (8 > sizeBytes - i)) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
@@ -32,7 +32,7 @@ import jdk.test.lib.Utils;
  * @test
  * @bug 8283091
  * @summary Auto-vectorization enhancement for type conversion between different data sizes.
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch=="aarch64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch=="aarch64" | os.arch=="riscv64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestVectorizeTypeConversion
  */

--- a/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022, 2025, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,9 @@ import jdk.test.lib.Utils;
  * @summary Auto-vectorization enhancement for integer Math.max/Math.min operations
  * @library /test/lib /
  * @requires vm.compiler2.enabled
- * @requires (os.simpleArch == "x64" & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3))
- *           | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseRVV == true)
+ * @requires (os.simpleArch == "x64" & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3)) |
+ *           os.arch == "aarch64" |
+ *           (os.simpleArch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @run driver compiler.c2.irTests.TestAutoVecIntMinMax
  */
 

--- a/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
@@ -72,7 +72,7 @@ public class TestBufferVectorization {
                   IRNode.LOAD_VECTOR_I, ">0",
                   IRNode.ADD_VI,        ">0",
                   IRNode.STORE_VECTOR,  ">0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     public static void testArray(int[] array) {
         for(int k = 0; k < array.length; k++) {
             array[k] += 1;
@@ -110,7 +110,7 @@ public class TestBufferVectorization {
                   IRNode.LOAD_VECTOR_I, ">0",
                   IRNode.ADD_VI,        ">0",
                   IRNode.STORE_VECTOR,  ">0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     public static void testArrayOffset(int[] array, int offset) {
         int l = array.length - offset;
         for(int k = 0; k < l; k++) {
@@ -131,7 +131,7 @@ public class TestBufferVectorization {
                   IRNode.LOAD_VECTOR_I, ">0",
                   IRNode.ADD_VI,        ">0",
                   IRNode.STORE_VECTOR,  ">0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     public static void testBuffer(IntBuffer buffer) {
         for (int k = 0; k < buffer.limit(); k++) {
             buffer.put(k, buffer.get(k) + 1);
@@ -151,7 +151,7 @@ public class TestBufferVectorization {
                   IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_ANY, ">0",
                   IRNode.ADD_VI,        IRNode.VECTOR_SIZE_ANY, ">0",
                   IRNode.STORE_VECTOR,                          ">0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIf = {"AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"})
     // VECTOR_SIZE_ANY: Unrolling does not always seem to go far enough to reach maximum vector size.
@@ -226,7 +226,7 @@ public class TestBufferVectorization {
                   IRNode.LOAD_VECTOR_I, ">0",
                   IRNode.ADD_VI,        ">0",
                   IRNode.STORE_VECTOR,  ">0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     public static void testArrayView(byte[] b_arr) {
         for (int k = 0; k < b_arr.length; k += 4) {
             int v = (int) VH_arr_view.get(b_arr, k);

--- a/test/hotspot/jtreg/compiler/vectorization/TestOptionVectorizeIR.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestOptionVectorizeIR.java
@@ -222,7 +222,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.ADD_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test2(int[] data) {
        for (int j = 0; j < RANGE - 1; j++) {
            // Only vectorizes if forced, because of offset by 1
@@ -233,7 +233,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.REPLICATE_I, "> 0", IRNode.ADD_VI, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test3(int[] data, int A, int B) {
        for (int j = 0; j < RANGE - 1; j++) {
            // Only vectorizes if forced, because of offset by 1
@@ -275,7 +275,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test10(long[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 2];
@@ -285,7 +285,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test11(long[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 1];
@@ -349,7 +349,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.ADD_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test20(short[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 2];
@@ -359,7 +359,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.ADD_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test21(short[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 1];
@@ -422,7 +422,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.ADD_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test30(byte[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 2];
@@ -432,7 +432,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.ADD_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test31(byte[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 1];
@@ -495,7 +495,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.ADD_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test40(char[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 2];
@@ -505,7 +505,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.ADD_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test41(char[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 1];
@@ -567,7 +567,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.ADD_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test50(float[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 2];
@@ -577,7 +577,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.ADD_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test51(float[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 1];
@@ -639,7 +639,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.ADD_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test60(double[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 2];
@@ -649,7 +649,7 @@ public class TestOptionVectorizeIR {
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.ADD_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test61(double[] data) {
        for (int j = 2; j < RANGE - 2; j++) {
            data[j] += data[j + 1];

--- a/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestPopulateIndex.java
@@ -27,7 +27,8 @@
 * @summary Test vectorization of loop induction variable usage in the loop
 * @requires vm.compiler2.enabled
 * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
-*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*")
+*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*") |
+*           (os.simpleArch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
 * @library /test/lib /
 * @run driver compiler.vectorization.TestPopulateIndex
 */

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayCopyTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayCopyTest.java
@@ -75,7 +75,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
 
     // ---------------- Simple Copy ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public byte[] copyByteArray() {
         byte[] res = new byte[SIZE];
@@ -86,7 +86,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public short[] copyShortArray() {
         short[] res = new short[SIZE];
@@ -97,7 +97,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public char[] copyCharArray() {
         char[] res = new char[SIZE];
@@ -108,7 +108,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] copyIntArray() {
         int[] res = new int[SIZE];
@@ -119,7 +119,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public long[] copyLongArray() {
         long[] res = new long[SIZE];
@@ -130,7 +130,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public float[] copyFloatArray() {
         float[] res = new float[SIZE];
@@ -141,7 +141,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public double[] copyDoubleArray() {
         double[] res = new double[SIZE];
@@ -153,7 +153,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
 
     // ---------------- Multiple Copies ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public float[] chainedCopy() {
         float[] res1 = new float[SIZE];
@@ -165,7 +165,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] copy2ArraysSameSize() {
         int[] res1 = new int[SIZE];
@@ -178,7 +178,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public double[] copy2ArraysDifferentSizes() {
         int[] res1 = new int[SIZE];
@@ -192,7 +192,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
 
     // ---------------- Copy Between Signed & Unsigned ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public char[] copyFromSignedToUnsigned() {
         char[] res = new char[SIZE];
@@ -203,7 +203,7 @@ public class ArrayCopyTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public short[] copyFromUnsignedToSigned() {
         short[] res = new short[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
@@ -36,7 +36,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.ArrayIndexFillTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "riscv64")
  * @requires vm.compiler2.enabled
  */
 
@@ -60,7 +60,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public byte[] fillByteArray() {
         byte[] res = new byte[SIZE];
@@ -71,7 +71,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public short[] fillShortArray() {
         short[] res = new short[SIZE];
@@ -82,7 +82,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public char[] fillCharArray() {
         char[] res = new char[SIZE];
@@ -93,7 +93,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public int[] fillIntArray() {
         int[] res = new int[SIZE];
@@ -104,7 +104,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, "=0"})
     // The ConvI2L can be split through the AddI, creating a mix of
     // ConvI2L(AddI) and AddL(ConvI2L) cases, which do not vectorize.
@@ -118,7 +118,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     // The variable init/limit has the consequence that we do not split
     // the ConvI2L through the AddI.
@@ -131,7 +131,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, "=0"})
     // See: JDK-8332878
     public float[] fillFloatArray() {
@@ -143,7 +143,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public float[] fillFloatArray2() {
         float[] res = new float[SIZE];
@@ -154,7 +154,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, "=0"})
     // See: JDK-8332878
     public double[] fillDoubleArray() {
@@ -166,7 +166,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public double[] fillDoubleArray2() {
         double[] res = new double[SIZE];
@@ -177,7 +177,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public short[] fillShortArrayWithShortIndex() {
         short[] res = new short[SIZE];
@@ -188,7 +188,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public int[] fillMultipleArraysDifferentTypes1() {
         int[] res1 = new int[SIZE];
@@ -201,7 +201,7 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.POPULATE_INDEX, ">0"})
     public char[] fillMultipleArraysDifferentTypes2() {
         int[] res1 = new int[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayInvariantFillTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayInvariantFillTest.java
@@ -41,7 +41,7 @@
  *                   -XX:+OptimizeFill
  *                   compiler.vectorization.runner.ArrayInvariantFillTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "riscv64")
  * @requires vm.compiler2.enabled
  */
 
@@ -70,10 +70,10 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
 
     // ---------------- Simple Fill ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_B, ">0"})
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "true"},
         counts = {IRNode.REPLICATE_B, "0"})
     public byte[] fillByteArray() {
@@ -85,10 +85,10 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_S, ">0"})
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "true"},
         counts = {IRNode.REPLICATE_S, "0"})
     public short[] fillShortArray() {
@@ -100,10 +100,10 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_S, ">0"})
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "true"},
         counts = {IRNode.REPLICATE_S, "0"})
     public char[] fillCharArray() {
@@ -115,10 +115,10 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_I, ">0"})
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "true"},
         counts = {IRNode.REPLICATE_I, "0"})
     public int[] fillIntArray() {
@@ -130,7 +130,7 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.REPLICATE_L, ">0"})
     public long[] fillLongArray() {
         long[] res = new long[SIZE];
@@ -141,10 +141,10 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_F, ">0"})
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "true"},
         counts = {IRNode.REPLICATE_F, "0"})
     public float[] fillFloatArray() {
@@ -156,7 +156,7 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.REPLICATE_D, ">0"})
     public double[] fillDoubleArray() {
         double[] res = new double[SIZE];
@@ -168,7 +168,7 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
 
     // ---------------- Fill With Type Change ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.REPLICATE_L, ">0"})
     public long[] fillLongArrayWithInt() {
         long[] res = new long[SIZE];
@@ -179,7 +179,7 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.REPLICATE_L, ">0"})
     public long[] fillLongArrayWithUnsigned() {
         long[] res = new long[SIZE];
@@ -190,7 +190,7 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.REPLICATE_L, ">0"})
     public long[] fillLongArrayWithFloat() {
         long[] res = new long[SIZE];
@@ -201,10 +201,10 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_I, ">0"})
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIf = {"OptimizeFill", "true"},
         counts = {IRNode.REPLICATE_I, "0"})
     public int[] fillIntArrayWithDouble() {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
@@ -188,7 +188,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     // ---------------- Convert I/L to F/D ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.VECTOR_CAST_I2F, IRNode.VECTOR_SIZE + "min(max_int, max_float)", ">0"})
     public float[] convertIntToFloat() {
         float[] res = new float[SIZE];
@@ -199,7 +199,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.VECTOR_CAST_I2D, IRNode.VECTOR_SIZE + "min(max_int, max_double)", ">0"})
     public double[] convertIntToDouble() {
         double[] res = new double[SIZE];
@@ -210,7 +210,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx512dq", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx512dq", "true", "rvv", "true"},
         counts = {IRNode.VECTOR_CAST_L2F, IRNode.VECTOR_SIZE + "min(max_long, max_float)", ">0"})
     public float[] convertLongToFloat() {
         float[] res = new float[SIZE];
@@ -221,7 +221,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true", "rvv", "true"},
         counts = {IRNode.VECTOR_CAST_L2D, IRNode.VECTOR_SIZE + "min(max_long, max_double)", ">0"})
     public double[] convertLongToDouble() {
         double[] res = new double[SIZE];
@@ -233,7 +233,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     // ---------------- Convert Subword-I to F/D ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         applyIfOr = {"AlignVector", "false", "UseCompactObjectHeaders", "false"},
         counts = {IRNode.VECTOR_CAST_S2F, IRNode.VECTOR_SIZE + "min(max_short, max_float)", ">0"})
     public float[] convertShortToFloat() {
@@ -252,7 +252,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         applyIf = {"MaxVectorSize", ">=32"},
         counts = {IRNode.VECTOR_CAST_S2D, IRNode.VECTOR_SIZE + "min(max_short, max_double)", ">0"})
     public double[] convertShortToDouble() {
@@ -291,7 +291,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     // ---------------- Convert F/D to I/L ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.VECTOR_CAST_F2I, IRNode.VECTOR_SIZE + "min(max_float, max_int)", ">0"})
     public int[] convertFloatToInt() {
         int[] res = new int[SIZE];
@@ -302,7 +302,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true", "rvv", "true"},
         counts = {IRNode.VECTOR_CAST_F2L, IRNode.VECTOR_SIZE + "min(max_float, max_long)", ">0"})
     public long[] convertFloatToLong() {
         long[] res = new long[SIZE];
@@ -313,7 +313,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.VECTOR_CAST_D2I, IRNode.VECTOR_SIZE + "min(max_double, max_int)", ">0"})
     public int[] convertDoubleToInt() {
         int[] res = new int[SIZE];
@@ -324,7 +324,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true", "rvv", "true"},
         counts = {IRNode.VECTOR_CAST_D2L, IRNode.VECTOR_SIZE + "min(max_double, max_long)", ">0"})
     public long[] convertDoubleToLong() {
         long[] res = new long[SIZE];
@@ -336,7 +336,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     // ---------------- Convert F/D to Subword-I ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         applyIfOr = {"AlignVector", "false", "UseCompactObjectHeaders", "false"},
         counts = {IRNode.VECTOR_CAST_F2S, IRNode.VECTOR_SIZE + "min(max_float, max_short)", ">0"})
     public short[] convertFloatToShort() {
@@ -355,7 +355,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
         applyIfOr = {"AlignVector", "false", "UseCompactObjectHeaders", "false"},
         counts = {IRNode.VECTOR_CAST_F2S, IRNode.VECTOR_SIZE + "min(max_float, max_char)", ">0"})
     public char[] convertFloatToChar() {
@@ -374,7 +374,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx", "true", "rvv", "true"},
         applyIf = {"MaxVectorSize", ">=32"},
         counts = {IRNode.VECTOR_CAST_D2S, IRNode.VECTOR_SIZE + "min(max_double, max_short)", ">0"})
     public short[] convertDoubleToShort() {
@@ -386,7 +386,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx", "true", "rvv", "true"},
         applyIf = {"MaxVectorSize", ">=32"},
         counts = {IRNode.VECTOR_CAST_D2S, IRNode.VECTOR_SIZE + "min(max_double, max_char)", ">0"})
     public char[] convertDoubleToChar() {
@@ -399,7 +399,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     // ---------------- Convert Between F & D ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.VECTOR_CAST_F2D, IRNode.VECTOR_SIZE + "min(max_float, max_double)", ">0"})
     public double[] convertFloatToDouble() {
         double[] res = new double[SIZE];
@@ -410,7 +410,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.VECTOR_CAST_D2F, IRNode.VECTOR_SIZE + "min(max_double, max_float)", ">0"})
     public float[] convertDoubleToFloat() {
         float[] res = new float[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicBooleanOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicBooleanOpTest.java
@@ -73,7 +73,7 @@ public class BasicBooleanOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         phase = CompilePhase.BEFORE_MACRO_EXPANSION,
         counts = {IRNode.AND_VB, ">0"})
     public boolean[] vectorAnd() {
@@ -85,7 +85,7 @@ public class BasicBooleanOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.OR_VB, ">0"})
     public boolean[] vectorOr() {
         boolean[] res = new boolean[SIZE];
@@ -96,7 +96,7 @@ public class BasicBooleanOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.XOR_VB, ">0"})
     public boolean[] vectorXor() {
         boolean[] res = new boolean[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
@@ -66,7 +66,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     // ---------------- Arithmetic ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.SUB_VB, ">0"})
     public byte[] vectorNeg() {
         byte[] res = new byte[SIZE];
@@ -77,7 +77,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "ssse3", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "ssse3", "true", "rvv", "true"},
         counts = {IRNode.ABS_VB, ">0"})
     public byte[] vectorAbs() {
         byte[] res = new byte[SIZE];
@@ -88,7 +88,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.ADD_VB, ">0"})
     public byte[] vectorAdd() {
         byte[] res = new byte[SIZE];
@@ -99,7 +99,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.SUB_VB, ">0"})
     public byte[] vectorSub() {
         byte[] res = new byte[SIZE];
@@ -110,7 +110,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.MUL_VB, ">0"})
     public byte[] vectorMul() {
         byte[] res = new byte[SIZE];
@@ -121,7 +121,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.MUL_VB, ">0", IRNode.ADD_VB, ">0"})
     public byte[] vectorMulAdd() {
         byte[] res = new byte[SIZE];
@@ -132,7 +132,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.MUL_VB, ">0", IRNode.SUB_VB, ">0"})
     public byte[] vectorMulSub() {
         byte[] res = new byte[SIZE];
@@ -144,7 +144,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     // ---------------- Logic ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.XOR_VB, ">0"})
     public byte[] vectorNot() {
         byte[] res = new byte[SIZE];
@@ -155,7 +155,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.AND_VB, ">0"})
     public byte[] vectorAnd() {
         byte[] res = new byte[SIZE];
@@ -166,7 +166,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.OR_VB, ">0"})
     public byte[] vectorOr() {
         byte[] res = new byte[SIZE];
@@ -177,7 +177,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.XOR_VB, ">0"})
     public byte[] vectorXor() {
         byte[] res = new byte[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
@@ -66,7 +66,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     // ---------------- Arithmetic ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.SUB_VS, ">0"})
     public char[] vectorNeg() {
         char[] res = new char[SIZE];
@@ -77,7 +77,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "ssse3", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "ssse3", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     @IR(failOn = {IRNode.ABS_VI, IRNode.ABS_VB, IRNode.ABS_VL}) // AVS_VC does not exist
     public char[] vectorAbs() {
@@ -89,7 +89,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.ADD_VS, ">0"}) // char add same as for short
     public char[] vectorAdd() {
         char[] res = new char[SIZE];
@@ -100,7 +100,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.SUB_VS, ">0"})
     public char[] vectorSub() {
         char[] res = new char[SIZE];
@@ -111,7 +111,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.MUL_VS, ">0"})
     public char[] vectorMul() {
         char[] res = new char[SIZE];
@@ -122,7 +122,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.MUL_VS, ">0",
                   IRNode.ADD_VS, ">0"}) // char add same as for short
     public char[] vectorMulAdd() {
@@ -134,7 +134,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.MUL_VS, ">0", IRNode.SUB_VS, ">0"})
     public char[] vectorMulSub() {
         char[] res = new char[SIZE];
@@ -146,7 +146,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     // ---------------- Logic ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.XOR_VS, ">0"})
     public char[] vectorNot() {
         char[] res = new char[SIZE];
@@ -157,7 +157,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.AND_VS, ">0"})
     public char[] vectorAnd() {
         char[] res = new char[SIZE];
@@ -168,7 +168,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.OR_VS, ">0"})
     public char[] vectorOr() {
         char[] res = new char[SIZE];
@@ -179,7 +179,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.XOR_VS, ">0"})
     public char[] vectorXor() {
         char[] res = new char[SIZE];
@@ -225,10 +225,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     // ------------- ReverseBytes -------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
-        counts = {IRNode.REVERSE_BYTES_VS, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"zvbb", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "zvbb", "true"},
         counts = {IRNode.REVERSE_BYTES_VS, ">0"})
     public char[] reverseBytesWithChar() {
         char[] res = new char[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
@@ -126,7 +126,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     // ---------------- Arithmetic ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse", "true", "rvv", "true"},
         counts = {IRNode.NEG_VF, ">0"})
     public float[] vectorNeg() {
         float[] res = new float[SIZE];
@@ -137,7 +137,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse", "true", "rvv", "true"},
         counts = {IRNode.ABS_VF, ">0"})
     public float[] vectorAbs() {
         float[] res = new float[SIZE];
@@ -148,7 +148,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.SQRT_VF, ">0"})
     public float[] vectorSqrt() {
         float[] res = new float[SIZE];
@@ -159,7 +159,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.ADD_VF, ">0"})
     public float[] vectorAdd() {
         float[] res = new float[SIZE];
@@ -170,7 +170,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.SUB_VF, ">0"})
     public float[] vectorSub() {
         float[] res = new float[SIZE];
@@ -181,7 +181,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.MUL_VF, ">0"})
     public float[] vectorMul() {
         float[] res = new float[SIZE];
@@ -192,7 +192,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.DIV_VF, ">0"})
     public float[] vectorDiv() {
         float[] res = new float[SIZE];
@@ -203,7 +203,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.MAX_VF, ">0"})
     public float[] vectorMax() {
         float[] res = new float[SIZE];
@@ -214,7 +214,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true", "rvv", "true"},
         counts = {IRNode.MIN_VF, ">0"})
     public float[] vectorMin() {
         float[] res = new float[SIZE];
@@ -229,6 +229,8 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
         counts = {IRNode.FMA_VF, ">0", IRNode.VFMLA, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VF, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"},
+        counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorMulAdd() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -242,6 +244,8 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
         counts = {IRNode.FMA_VF, ">0", IRNode.VFMLS, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VF, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"},
+        counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorMulSub1() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -254,6 +258,8 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeature = {"asimd", "true"},
         counts = {IRNode.FMA_VF, ">0", IRNode.VFMLS, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
+        counts = {IRNode.FMA_VF, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"},
         counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorMulSub2() {
         float[] res = new float[SIZE];
@@ -270,6 +276,8 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
         counts = {IRNode.VFNMLA, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VF, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"},
+        counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorNegateMulAdd1() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -285,6 +293,8 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
         counts = {IRNode.VFNMLA, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
         counts = {IRNode.FMA_VF, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"},
+        counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorNegateMulAdd2() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -297,6 +307,8 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeature = {"asimd", "true"},
         counts = {IRNode.FMA_VF, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
+        counts = {IRNode.FMA_VF, ">0"})
+    @IR(applyIfCPUFeature = {"rvv", "true"},
         counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorNegateMulSub() {
         float[] res = new float[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
@@ -65,7 +65,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     // ---------------- Arithmetic ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.SUB_VL, ">0"})
     public long[] vectorNeg() {
         long[] res = new long[SIZE];
@@ -76,7 +76,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512vl", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512vl", "true", "rvv", "true"},
         counts = {IRNode.ABS_VL, ">0"})
     public long[] vectorAbs() {
         long[] res = new long[SIZE];
@@ -87,7 +87,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.ADD_VL, ">0"})
     public long[] vectorAdd() {
         long[] res = new long[SIZE];
@@ -98,7 +98,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.SUB_VL, ">0"})
     public long[] vectorSub() {
         long[] res = new long[SIZE];
@@ -109,7 +109,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx512dq", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx512dq", "true", "rvv", "true"},
         counts = {IRNode.MUL_VL, ">0"})
     public long[] vectorMul() {
         long[] res = new long[SIZE];
@@ -120,9 +120,9 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.ADD_VL, ">0"})
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.MUL_VL, ">0"})
     public long[] vectorMulAdd() {
         long[] res = new long[SIZE];
@@ -133,7 +133,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.MUL_VL, ">0", IRNode.SUB_VL, ">0"})
     public long[] vectorMulSub() {
         long[] res = new long[SIZE];
@@ -145,7 +145,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     // ---------------- Logic ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.XOR_VL, ">0"})
     public long[] vectorNot() {
         long[] res = new long[SIZE];
@@ -156,7 +156,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.AND_VL, ">0"})
     public long[] vectorAnd() {
         long[] res = new long[SIZE];
@@ -167,7 +167,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.OR_VL, ">0"})
     public long[] vectorOr() {
         long[] res = new long[SIZE];
@@ -178,7 +178,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.XOR_VL, ">0"})
     public long[] vectorXor() {
         long[] res = new long[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
@@ -66,7 +66,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     // ---------------- Arithmetic ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.SUB_VS, ">0"})
     public short[] vectorNeg() {
         short[] res = new short[SIZE];
@@ -77,7 +77,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "ssse3", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "ssse3", "true", "rvv", "true"},
         counts = {IRNode.ABS_VS, ">0"})
     public short[] vectorAbs() {
         short[] res = new short[SIZE];
@@ -88,7 +88,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.ADD_VS, ">0"})
     public short[] vectorAdd() {
         short[] res = new short[SIZE];
@@ -99,7 +99,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.SUB_VS, ">0"})
     public short[] vectorSub() {
         short[] res = new short[SIZE];
@@ -110,7 +110,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.MUL_VS, ">0"})
     public short[] vectorMul() {
         short[] res = new short[SIZE];
@@ -121,7 +121,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.MUL_VS, ">0", IRNode.ADD_VS, ">0"})
     public short[] vectorMulAdd() {
         short[] res = new short[SIZE];
@@ -132,7 +132,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.MUL_VS, ">0", IRNode.SUB_VS, ">0"})
     public short[] vectorMulSub() {
         short[] res = new short[SIZE];
@@ -144,7 +144,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     // ---------------- Logic ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.XOR_VS, ">0"})
     public short[] vectorNot() {
         short[] res = new short[SIZE];
@@ -155,7 +155,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.AND_VS, ">0"})
     public short[] vectorAnd() {
         short[] res = new short[SIZE];
@@ -166,7 +166,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.OR_VS, ">0"})
     public short[] vectorOr() {
         short[] res = new short[SIZE];
@@ -177,7 +177,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.XOR_VS, ">0"})
     public short[] vectorXor() {
         short[] res = new short[SIZE];
@@ -247,10 +247,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     // ------------- ReverseBytes -------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
-        counts = {IRNode.REVERSE_BYTES_VS, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"zvbb", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "zvbb", "true"},
         counts = {IRNode.REVERSE_BYTES_VS, ">0"})
     public short[] reverseBytesWithShort() {
         short[] res = new short[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopCombinedOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopCombinedOpTest.java
@@ -111,7 +111,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_I, "> 0"})
     public int[] opWithConstant() {
@@ -123,7 +123,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_I, "> 0"})
     public int[] opWithLoopInvariant() {
@@ -135,7 +135,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_I, "> 0"})
     public int[] opWithConstantAndLoopInvariant() {
@@ -147,7 +147,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_I, "> 0"})
     public int[] multipleOps() {
@@ -159,7 +159,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_I, "> 0"})
     public int[] multipleOpsWithMultipleConstants() {
@@ -171,7 +171,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_I, "> 0"})
     // With sse2, the MulI does not vectorize. This means we have vectorized stores
@@ -190,7 +190,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_I, "> 0"})
     public int[] multipleStoresWithCommonSubExpression() {
@@ -206,7 +206,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIfOr = { "UseCompactObjectHeaders", "false", "AlignVector", "false"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_S, "> 0",
@@ -239,7 +239,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIfOr = { "UseCompactObjectHeaders", "false", "AlignVector", "false"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_ANY, "> 0",
@@ -274,7 +274,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_S, IRNode.VECTOR_SIZE_ANY, "> 0",
                   IRNode.LOAD_VECTOR_L,                         "> 0"})
@@ -289,7 +289,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         applyIfOr = { "UseCompactObjectHeaders", "false", "AlignVector", "false"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_S, "> 0",
@@ -322,7 +322,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         applyIfOr = { "UseCompactObjectHeaders", "false", "AlignVector", "false"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_S, "> 0",
@@ -355,7 +355,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         applyIfOr = { "UseCompactObjectHeaders", "false", "AlignVector", "false"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_S, "> 0",
@@ -372,7 +372,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse3", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse3", "true", "rvv", "true"},
         applyIfOr = { "UseCompactObjectHeaders", "false", "AlignVector", "false"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_S, "> 0",
@@ -446,7 +446,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         applyIfOr = { "UseCompactObjectHeaders", "false", "AlignVector", "false"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] manuallyUnrolledStride2() {
@@ -468,7 +468,7 @@ public class LoopCombinedOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0",
                   IRNode.LOAD_VECTOR_I, "> 0"})
     public int partialVectorizableLoop() {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopControlFlowTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopControlFlowTest.java
@@ -64,7 +64,7 @@ public class LoopControlFlowTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] loopInvariantCondition() {
         int[] res = new int[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopLiveOutNodesTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopLiveOutNodesTest.java
@@ -68,7 +68,7 @@ public class LoopLiveOutNodesTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int SimpleIvUsed() {
         int i = 0;
@@ -80,7 +80,7 @@ public class LoopLiveOutNodesTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int indexedByIvUsed() {
         int i = 0;
@@ -92,7 +92,7 @@ public class LoopLiveOutNodesTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int ivUsedMultiple() {
         int i = 0;
@@ -104,7 +104,7 @@ public class LoopLiveOutNodesTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int ivUsedComplexExpr() {
         int i = 0;
@@ -116,7 +116,7 @@ public class LoopLiveOutNodesTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] ivUsedAnotherLoop() {
         int i = 0;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopRangeStrideTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopRangeStrideTest.java
@@ -36,7 +36,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.LoopRangeStrideTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "riscv64")
  * @requires vm.compiler2.enabled
  */
 
@@ -79,7 +79,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] nonConstantRange() {
         int[] res = new int[SIZE];
@@ -90,7 +90,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] crossZeroRange() {
         int[] res = new int[SIZE];
@@ -101,7 +101,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] nonEqualTestRange() {
         int[] res = new int[SIZE];
@@ -112,7 +112,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] shortInductionLoop() {
         int[] res = new int[SIZE];
@@ -123,7 +123,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] whileLoop() {
         int[] res = new int[SIZE];
@@ -136,7 +136,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] doWhileLoop() {
         int[] res = new int[SIZE];
@@ -177,7 +177,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] countDownLoop() {
         int[] res = new int[SIZE];
@@ -198,7 +198,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
 
     // ---------- Stride with scale ----------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] countupLoopWithNegScale() {
         int[] res = new int[SIZE];
@@ -209,7 +209,7 @@ public class LoopRangeStrideTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] countDownLoopWithNegScale() {
         int[] res = new int[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
@@ -35,7 +35,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.LoopReductionOpTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "riscv64")
  * @requires vm.compiler2.enabled
  *
  */
@@ -78,7 +78,7 @@ public class LoopReductionOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse3", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse3", "true", "rvv", "true"},
         counts = {IRNode.LOAD_VECTOR_I, ">0",
                   IRNode.ADD_REDUCTION_V, ">0"})
     public int reductionAddSumOfArray() {
@@ -119,7 +119,7 @@ public class LoopReductionOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true", "rvv", "true"},
         counts = {IRNode.LOAD_VECTOR_I, ">0",
                   IRNode.ADD_REDUCTION_V, ">0"})
     public int reductionAddSumOfMultiple() {
@@ -175,9 +175,9 @@ public class LoopReductionOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
-    @IR(applyIfCPUFeatureOr = {"avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
         counts = {IRNode.ADD_REDUCTION_V, ">0"})
     public long reductionWithNonReductionDifferentSizes() {
         long res = 0L;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/MultipleLoopsTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/MultipleLoopsTest.java
@@ -63,7 +63,7 @@ public class MultipleLoopsTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] consecutiveLoops() {
         int[] res1 = new int[SIZE];
@@ -82,7 +82,7 @@ public class MultipleLoopsTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] consecutiveLoopsNested() {
         int[] res = new int[SIZE];
@@ -98,7 +98,7 @@ public class MultipleLoopsTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] nestedLoopOuterNonCounted() {
         int i = 1;
@@ -114,7 +114,7 @@ public class MultipleLoopsTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] nestedLoopIndexCompute() {
         int[] res = new int[SIZE];
@@ -127,7 +127,7 @@ public class MultipleLoopsTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public float reductionLoopWithAnotherReductionInput() {
         float res = 0.0F;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/StripMinedLoopTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/StripMinedLoopTest.java
@@ -60,7 +60,7 @@ public class StripMinedLoopTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     public int[] stripMinedVectorLoop() {
         int[] res = new int[SIZE];


### PR DESCRIPTION
Hi,
Can you help to review this patch?

There are bunch of IR test not enabled on riscv, it's good to enable them, because enabling them will help to:
1. cover the test gap
2. find out potential missing intrinsics.

This patch also changes cpu features from `vm.opt.UseXxx` to `xxx`, as it's easier to find out these tests in the future.

NOTE: There are still some other test should be enabled, but currently they fail when simply enable them, they will be further investigated, later could be enabled in other PRs with additional code change/implementation if it's feasible.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351662](https://bugs.openjdk.org/browse/JDK-8351662): [Test] RISC-V: enable bunch of IR test (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Antonios Printezis](https://openjdk.org/census#tonyp) (@gctony - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23985/head:pull/23985` \
`$ git checkout pull/23985`

Update a local copy of the PR: \
`$ git checkout pull/23985` \
`$ git pull https://git.openjdk.org/jdk.git pull/23985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23985`

View PR using the GUI difftool: \
`$ git pr show -t 23985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23985.diff">https://git.openjdk.org/jdk/pull/23985.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23985#issuecomment-2714458692)
</details>
