### PR TITLE
8350964: Add an ArtifactResolver.fetch(clazz) method

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -31,7 +31,6 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
@@ -63,7 +62,6 @@ import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
-import jdk.test.lib.artifacts.ArtifactResolverException;
 import jtreg.SkippedException;
 
 public abstract class PKCS11Test {

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -715,7 +715,7 @@ public abstract class PKCS11Test {
         return data;
     }
 
-    private static Path fetchNssLib(String osId, Path libraryName) {
+    private static Path fetchNssLib(String osId, Path libraryName) throws IOException {
         switch (osId) {
             case "Windows-amd64-64":
                 return fetchNssLib(WINDOWS_X64.class, libraryName);
@@ -744,23 +744,9 @@ public abstract class PKCS11Test {
         }
     }
 
-    private static Path fetchNssLib(Class<?> clazz, Path libraryName) {
-        Path path = null;
-        try {
-            Path p = ArtifactResolver.resolve(clazz).entrySet().stream()
-                    .findAny().get().getValue();
-            path = findNSSLibrary(p, libraryName);
-        } catch (ArtifactResolverException | IOException e) {
-            Throwable cause = e.getCause();
-            if (cause == null) {
-                System.out.println("Cannot resolve artifact, "
-                        + "please check if JIB jar is present in classpath.");
-            } else {
-                throw new RuntimeException("Fetch artifact failed: " + clazz
-                        + "\nPlease make sure the artifact is available.", e);
-            }
-        }
-        return path;
+    private static Path fetchNssLib(Class<?> clazz, Path libraryName) throws IOException {
+        Path p = ArtifactResolver.fetchOne(clazz);
+        return findNSSLibrary(p, libraryName);
     }
 
     private static Path findNSSLibrary(Path path, Path libraryName) throws IOException {

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -232,10 +232,6 @@ public abstract class PKCS11Test {
 
     static String getNSSLibDir(String library) throws Exception {
         Path libPath = getNSSLibPath(library);
-        if (libPath == null) {
-            return null;
-        }
-
         String libDir = String.valueOf(libPath.getParent()) + File.separatorChar;
         System.out.println("nssLibDir: " + libDir);
         System.setProperty("pkcs11test.nss.libdir", libDir);
@@ -249,12 +245,7 @@ public abstract class PKCS11Test {
     static Path getNSSLibPath(String library) throws Exception {
         String osid = getOsId();
         Path libraryName = Path.of(System.mapLibraryName(library));
-        Path nssLibPath = fetchNssLib(osid, libraryName);
-        if (nssLibPath == null) {
-            throw new SkippedException("Warning: unsupported OS: " + osid
-                    + ", please initialize NSS library location, skipping test");
-        }
-        return nssLibPath;
+        return fetchNssLib(osid, libraryName);
     }
 
     private static String getOsId() {
@@ -740,7 +731,7 @@ public abstract class PKCS11Test {
                     return fetchNssLib(LINUX_AARCH64.class, libraryName);
                 }
             default:
-                return null;
+                throw new SkippedException("Unsupported OS: " + osId);
         }
     }
 

--- a/test/jdk/sun/security/pkcs11/SecmodTest.java
+++ b/test/jdk/sun/security/pkcs11/SecmodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/pkcs11/SecmodTest.java
+++ b/test/jdk/sun/security/pkcs11/SecmodTest.java
@@ -46,7 +46,7 @@ public class SecmodTest extends PKCS11Test {
         useNSS();
         LIBPATH = getNSSLibDir();
         // load all the libraries except libnss3 into memory
-        if ((LIBPATH == null) || (!loadNSPR(LIBPATH))) {
+        if (!loadNSPR(LIBPATH)) {
             throw new SkippedException("Failed to load NSS libraries");
         }
 

--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -82,16 +82,6 @@ public class KeytoolOpensslInteropTest {
         boolean generatePKCS12 = Boolean.parseBoolean(args[0]);
         if (generatePKCS12) {
             String opensslPath = OpensslArtifactFetcher.getOpensslPath();
-            if (opensslPath == null) {
-                String exMsg = "Can't find the version: "
-                        + OpensslArtifactFetcher.getTestOpensslBundleVersion()
-                        + " of openssl binary on this machine, please install"
-                        + " and set openssl path with property 'test.openssl.path'";
-                throw new SkippedException(exMsg);
-            }
-
-            // if the current version of openssl is available, perform all
-            // keytool <-> openssl interop tests
             generateInitialKeystores(opensslPath);
             testWithJavaCommands();
             testWithOpensslCommands(opensslPath);

--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -81,16 +81,15 @@ public class KeytoolOpensslInteropTest {
     public static void main(String[] args) throws Throwable {
         boolean generatePKCS12 = Boolean.parseBoolean(args[0]);
         if (generatePKCS12) {
-            String opensslPath;
-            try {
-                opensslPath = OpensslArtifactFetcher.getOpensslPath();
-            } catch (IOException exc) {
+            String opensslPath = OpensslArtifactFetcher.getOpensslPath();
+            if (opensslPath == null) {
                 String exMsg = "Can't find the version: "
                         + OpensslArtifactFetcher.getTestOpensslBundleVersion()
                         + " of openssl binary on this machine, please install"
                         + " and set openssl path with property 'test.openssl.path'";
-                throw new SkippedException(exMsg, exc);
+                throw new SkippedException(exMsg);
             }
+
             // if the current version of openssl is available, perform all
             // keytool <-> openssl interop tests
             generateInitialKeystores(opensslPath);

--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -81,20 +81,21 @@ public class KeytoolOpensslInteropTest {
     public static void main(String[] args) throws Throwable {
         boolean generatePKCS12 = Boolean.parseBoolean(args[0]);
         if (generatePKCS12) {
+            String opensslPath;
             try {
-                String opensslPath = OpensslArtifactFetcher.getOpensslPath();
-                // if the current version of openssl is available, perform all
-                // keytool <-> openssl interop tests
-                generateInitialKeystores(opensslPath);
-                testWithJavaCommands();
-                testWithOpensslCommands(opensslPath);
+                opensslPath = OpensslArtifactFetcher.getOpensslPath();
             } catch (IOException exc) {
                 String exMsg = "Can't find the version: "
                         + OpensslArtifactFetcher.getTestOpensslBundleVersion()
                         + " of openssl binary on this machine, please install"
                         + " and set openssl path with property 'test.openssl.path'";
-                throw new SkippedException(exMsg);
+                throw new SkippedException(exMsg, exc);
             }
+            // if the current version of openssl is available, perform all
+            // keytool <-> openssl interop tests
+            generateInitialKeystores(opensslPath);
+            testWithJavaCommands();
+            testWithOpensslCommands(opensslPath);
         } else {
             // since this scenario is using preexisting PKCS12, skip all
             // openssl command dependent tests

--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -56,7 +56,6 @@ import jdk.test.lib.SecurityTools;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.security.OpensslArtifactFetcher;
-import jtreg.SkippedException;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -81,14 +81,14 @@ public class KeytoolOpensslInteropTest {
     public static void main(String[] args) throws Throwable {
         boolean generatePKCS12 = Boolean.parseBoolean(args[0]);
         if (generatePKCS12) {
-            String opensslPath = OpensslArtifactFetcher.getOpensslPath();
-            if (opensslPath != null) {
+            try {
+                String opensslPath = OpensslArtifactFetcher.getOpensslPath();
                 // if the current version of openssl is available, perform all
                 // keytool <-> openssl interop tests
                 generateInitialKeystores(opensslPath);
                 testWithJavaCommands();
                 testWithOpensslCommands(opensslPath);
-            } else {
+            } catch (IOException exc) {
                 String exMsg = "Can't find the version: "
                         + OpensslArtifactFetcher.getTestOpensslBundleVersion()
                         + " of openssl binary on this machine, please install"

--- a/test/jdk/sun/security/provider/acvp/Launcher.java
+++ b/test/jdk/sun/security/provider/acvp/Launcher.java
@@ -106,7 +106,7 @@ public class Launcher {
 
     public static void main(String[] args) throws Exception {
 
-        Path archivePath = fetchACVPServerTests(ACVP_SERVER_TESTS.class);
+        Path archivePath = ArtifactResolver.fetchOne(ACVP_SERVER_TESTS.class);
         System.out.println("Data path: " + archivePath);
 
         if (PROVIDER != null) {
@@ -175,14 +175,6 @@ public class Launcher {
             throw re;
         } catch (Exception e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    private static Path fetchACVPServerTests(Class<?> clazz) {
-        try {
-            return ArtifactResolver.fetchOne(clazz);
-        } catch (IOException e) {
-            throw new SkippedException("Fetch artifact failed: " + clazz, e);
         }
     }
 

--- a/test/jdk/sun/security/provider/acvp/Launcher.java
+++ b/test/jdk/sun/security/provider/acvp/Launcher.java
@@ -24,9 +24,7 @@
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
 import jdk.test.lib.json.JSONValue;
-import jtreg.SkippedException;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.security.Provider;

--- a/test/jdk/sun/security/provider/acvp/Launcher.java
+++ b/test/jdk/sun/security/provider/acvp/Launcher.java
@@ -23,10 +23,10 @@
 
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
-import jdk.test.lib.artifacts.ArtifactResolverException;
 import jdk.test.lib.json.JSONValue;
 import jtreg.SkippedException;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.security.Provider;
@@ -180,15 +180,8 @@ public class Launcher {
 
     private static Path fetchACVPServerTests(Class<?> clazz) {
         try {
-            return ArtifactResolver.resolve(clazz).entrySet().stream()
-                    .findAny().get().getValue();
-        } catch (ArtifactResolverException e) {
-            Throwable cause = e.getCause();
-            if (cause == null) {
-                throw new SkippedException("Cannot resolve artifact, "
-                        + "please check if JIB jar is present in classpath.", e);
-            }
-
+            return ArtifactResolver.fetchOne(clazz);
+        } catch (IOException e) {
             throw new SkippedException("Fetch artifact failed: " + clazz, e);
         }
     }

--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
@@ -84,7 +84,7 @@ public class ArtifactResolver {
      * local copy of the artifact and the system property must be set as specified
      * above.
      *
-     * @param clazz a class annotated with {@link jdk.test.lib.artifacts.Artifact}
+     * @param klass a class annotated with {@link jdk.test.lib.artifacts.Artifact}
      * @return the local path to the artifact. If the artifact is a compressed
      * file that gets unpacked, this path will point to the root
      * directory of the uncompressed file.
@@ -95,16 +95,14 @@ public class ArtifactResolver {
             return ArtifactResolver.resolve(klass).entrySet().stream()
                     .findAny().get().getValue();
         } catch (ArtifactResolverException e) {
-            Throwable cause = e.getCause();
-            if (cause == null) {
-                // if property doesn't exist
-                throw new IOException("Cannot resolve artifact, "
-                        + "please check if JIB jar is present in classpath.");
+            Artifact artifact = klass.getAnnotation(Artifact.class);
+            String message;
+            if (artifact != null) {
+                message = "Cannot find the artifact " + artifact.name();
             } else {
-                // can't get it from the repository
-                throw new IOException("Fetch artifact failed: " + klass
-                        + "\nPlease make sure the artifact is available.", e);
+                message = "Class " + klass.getName() + " missing @Artifact annotation.";
             }
+            throw new IOException(message);
         }
     }
 

--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
@@ -25,7 +25,6 @@ package jdk.test.lib.artifacts;
 
 import jtreg.SkippedException;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -75,11 +74,12 @@ public class ArtifactResolver {
      * Retrieve an artifact/library/file from a repository or local file system.
      * <p>
      * Artifacts are defined with the {@link jdk.test.lib.artifacts.Artifact}
-     * annotation. The file name should have the format ARTIFACT_NAME-VERSION.EXT
+     * annotation.
      * <p>
      * If you have a local version of a dependency that you want to use, you can
-     * specify that by setting the System property:
-     * <code>jdk.test.lib.artifacts.ARTIFACT_NAME</code>
+     * specify that by setting the system property:
+     * <code>jdk.test.lib.artifacts.ARTIFACT_NAME</code>. Where ARTIFACT_NAME
+     * is the name field of the Artifact annotation.
      * <p>
      * Generally, tests that use this method should be run with <code>make test</code>.
      * However, tests can also be run with <code>jtreg</code> but you must have a
@@ -89,7 +89,7 @@ public class ArtifactResolver {
      * @param klass a class annotated with {@link jdk.test.lib.artifacts.Artifact}
      * @return the local path to the artifact. If the artifact is a compressed
      * file that gets unpacked, this path will point to the root
-     * directory of the uncompressed file.
+     * directory of the uncompressed file(s).
      * @throws SkippedException thrown if the artifact cannot be found
      */
     public static Path fetchOne(Class<?> klass) {

--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
@@ -23,6 +23,8 @@
 
 package jdk.test.lib.artifacts;
 
+import jtreg.SkippedException;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -88,21 +90,15 @@ public class ArtifactResolver {
      * @return the local path to the artifact. If the artifact is a compressed
      * file that gets unpacked, this path will point to the root
      * directory of the uncompressed file.
-     * @throws IOException thrown if the artifact cannot be found
+     * @throws SkippedException thrown if the artifact cannot be found
      */
-    public static Path fetchOne(Class<?> klass) throws IOException {
+    public static Path fetchOne(Class<?> klass) {
         try {
             return ArtifactResolver.resolve(klass).entrySet().stream()
                     .findAny().get().getValue();
         } catch (ArtifactResolverException e) {
             Artifact artifact = klass.getAnnotation(Artifact.class);
-            String message;
-            if (artifact != null) {
-                message = "Cannot find the artifact " + artifact.name();
-            } else {
-                message = "Class " + klass.getName() + " missing @Artifact annotation.";
-            }
-            throw new IOException(message);
+            throw new SkippedException("Cannot find the artifact " + artifact.name(), e);
         }
     }
 

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -23,13 +23,12 @@
 
 package jdk.test.lib.security;
 
-import java.io.IOException;
-
 import java.nio.file.Path;
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
+import jtreg.SkippedException;
 
 public class OpensslArtifactFetcher {
 
@@ -49,6 +48,7 @@ public class OpensslArtifactFetcher {
            and return that path, if download fails then return null.
      *
      * @return openssl binary path of the current version
+     * @throws SkippedException if a valid version of OpenSSL cannot be found
      */
     public static String getOpensslPath() {
         String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
@@ -75,7 +75,16 @@ public class OpensslArtifactFetcher {
                 path = fetchOpenssl(MACOSX_AARCH64.class);
             }
         }
-        return verifyOpensslVersion(path, OPENSSL_BUNDLE_VERSION) ? path : null;
+
+        if (!verifyOpensslVersion(path, OPENSSL_BUNDLE_VERSION)) {
+            String exMsg = "Can't find the version: "
+                    + OpensslArtifactFetcher.getTestOpensslBundleVersion()
+                    + " of openssl binary on this machine, please install"
+                    + " and set openssl path with property 'test.openssl.path'";
+            throw new SkippedException(exMsg);
+        } else {
+            return path;
+        }
     }
 
     private static String getOpensslFromSystemProp(String version) {

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -23,14 +23,13 @@
 
 package jdk.test.lib.security;
 
-import java.io.File;
+import java.io.IOException;
 
 import java.nio.file.Path;
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
-import jdk.test.lib.artifacts.ArtifactResolverException;
 
 public class OpensslArtifactFetcher {
 
@@ -51,7 +50,7 @@ public class OpensslArtifactFetcher {
      *
      * @return openssl binary path of the current version
      */
-    public static String getOpensslPath() {
+    public static String getOpensslPath() throws IOException {
         String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
         if (path != null) {
             return path;
@@ -111,24 +110,10 @@ public class OpensslArtifactFetcher {
         return false;
     }
 
-    private static String fetchOpenssl(Class<?> clazz) {
-        String path = null;
-        try {
-            path = ArtifactResolver.resolve(clazz).entrySet().stream()
-                    .findAny().get().getValue() + File.separator + "openssl"
-                    + File.separator + "bin" + File.separator + "openssl";
-            System.out.println("path: " + path);
-        } catch (ArtifactResolverException e) {
-            Throwable cause = e.getCause();
-            if (cause == null) {
-                System.out.println("Cannot resolve artifact, "
-                        + "please check if JIB jar is present in classpath.");
-            } else {
-                throw new RuntimeException("Fetch artifact failed: " + clazz
-                        + "\nPlease make sure the artifact is available.", e);
-            }
-        }
-        return path;
+    private static String fetchOpenssl(Class<?> clazz) throws IOException {
+        return ArtifactResolver.fetchOne(clazz)
+                .resolve("openssl", "bin", "openssl")
+                .toString();
     }
 
     // retrieve the provider directory path from <OPENSSL_HOME>/bin/openssl

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -50,7 +50,7 @@ public class OpensslArtifactFetcher {
      *
      * @return openssl binary path of the current version
      */
-    public static String getOpensslPath() throws IOException {
+    public static String getOpensslPath() {
         String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
         if (path != null) {
             return path;
@@ -110,7 +110,7 @@ public class OpensslArtifactFetcher {
         return false;
     }
 
-    private static String fetchOpenssl(Class<?> clazz) throws IOException {
+    private static String fetchOpenssl(Class<?> clazz) {
         return ArtifactResolver.fetchOne(clazz)
                 .resolve("openssl", "bin", "openssl")
                 .toString();


### PR DESCRIPTION
In this PR, I created a new method, `ArtifactResolver.fetchOne()`, to consolidate duplicate code across tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350964](https://bugs.openjdk.org/browse/JDK-8350964): Add an ArtifactResolver.fetch(clazz) method (**Enhancement** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23989/head:pull/23989` \
`$ git checkout pull/23989`

Update a local copy of the PR: \
`$ git checkout pull/23989` \
`$ git pull https://git.openjdk.org/jdk.git pull/23989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23989`

View PR using the GUI difftool: \
`$ git pr show -t 23989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23989.diff">https://git.openjdk.org/jdk/pull/23989.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23989#issuecomment-2714758250)
</details>
