### PR TITLE
8351673: Clean up a case of if (LockingMode == LM_LIGHTWEIGHT) in a legacy-only locking mode function

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -407,10 +407,6 @@ bool ObjectSynchronizer::quick_enter_legacy(oop obj, BasicLock* lock, JavaThread
     return false;  // Slow path
   }
 
-  if (LockingMode == LM_LIGHTWEIGHT) {
-    return LightweightSynchronizer::quick_enter(obj, lock, current);
-  }
-
   assert(LockingMode == LM_LEGACY, "legacy mode below");
 
   const markWord mark = obj->mark();


### PR DESCRIPTION
See title for description.
Tested with tier1-4 with PR https://github.com/openjdk/jdk/pull/23981

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351673](https://bugs.openjdk.org/browse/JDK-8351673): Clean up a case of if (LockingMode == LM_LIGHTWEIGHT) in a legacy-only locking mode function (**Enhancement** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23990/head:pull/23990` \
`$ git checkout pull/23990`

Update a local copy of the PR: \
`$ git checkout pull/23990` \
`$ git pull https://git.openjdk.org/jdk.git pull/23990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23990`

View PR using the GUI difftool: \
`$ git pr show -t 23990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23990.diff">https://git.openjdk.org/jdk/pull/23990.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23990#issuecomment-2714931955)
</details>
