### PR TITLE
8351665: Remove unused UseNUMA in os_aix.cpp

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -839,13 +839,6 @@ bool os::create_attached_thread(JavaThread* thread) {
 
   thread->set_osthread(osthread);
 
-  if (UseNUMA) {
-    int lgrp_id = os::numa_get_group_id();
-    if (lgrp_id != -1) {
-      thread->set_lgrp_id(lgrp_id);
-    }
-  }
-
   // initialize signal mask for this thread
   // and save the caller's signal mask
   PosixSignals::hotspot_sigmask(thread);


### PR DESCRIPTION
We have some UseNUMA related coding in os_aix.cpp that is not needed.
UseNUMA is set to false on AIX (with FLAG_SET_ERGO).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351665](https://bugs.openjdk.org/browse/JDK-8351665): Remove unused UseNUMA in os_aix.cpp (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23991/head:pull/23991` \
`$ git checkout pull/23991`

Update a local copy of the PR: \
`$ git checkout pull/23991` \
`$ git pull https://git.openjdk.org/jdk.git pull/23991/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23991`

View PR using the GUI difftool: \
`$ git pr show -t 23991`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23991.diff">https://git.openjdk.org/jdk/pull/23991.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23991#issuecomment-2715042034)
</details>
