### PR TITLE
8351435: Change the default Console implementation back to the built-in one in `java.base` module

### DIFF
--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleProvider.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ public interface JdkConsoleProvider {
     /**
      * The module name of the JdkConsole default provider.
      */
-    String DEFAULT_PROVIDER_MODULE_NAME = "jdk.internal.le";
+    String DEFAULT_PROVIDER_MODULE_NAME = "java.base";
 
     /**
      * {@return the Console instance, or {@code null} if not available}

--- a/test/jdk/java/io/Console/ConsolePromptTest.java
+++ b/test/jdk/java/io/Console/ConsolePromptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,27 +23,41 @@
 
 /**
  * @test
- * @bug 8331681
+ * @bug 8331681 8351435
  * @summary Verify the java.base's console provider handles the prompt correctly.
  * @library /test/lib
- * @run main/othervm --limit-modules java.base ConsolePromptTest
- * @run main/othervm -Djdk.console=java.base ConsolePromptTest
  */
 
 import java.lang.reflect.Method;
-import java.util.Objects;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 public class ConsolePromptTest {
 
+    private static final List<List<String>> VARIANTS = List.of(
+        List.of("--limit-modules", "java.base"),
+        List.of("-Djdk.console=java.base")
+    );
+
     public static void main(String... args) throws Throwable {
         for (Method m : ConsolePromptTest.class.getDeclaredMethods()) {
             if (m.getName().startsWith("test")) {
-                m.invoke(new ConsolePromptTest());
+                for (List<String> variant : VARIANTS) {
+                    m.invoke(new ConsolePromptTest(variant));
+                }
             }
         }
+    }
+
+    private final List<String> extraParams;
+
+    public ConsolePromptTest(List<String> extraParams) {
+        this.extraParams = extraParams;
     }
 
     void testCorrectOutputReadLine() throws Exception {
@@ -57,34 +71,35 @@ public class ConsolePromptTest {
     void doRunConsoleTest(String testName,
                           String input,
                           String expectedOut) throws Exception {
-        ProcessBuilder builder =
-                ProcessTools.createTestJavaProcessBuilder(ConsoleTest.class.getName(),
-                                                          testName);
-        OutputAnalyzer output = ProcessTools.executeProcess(builder, input);
-
-        output.waitFor();
-
-        if (output.getExitValue() != 0) {
-            throw new AssertionError("Unexpected return value: " + output.getExitValue() +
-                                     ", actualOut: " + output.getStdout() +
-                                     ", actualErr: " + output.getStderr());
+        // check "expect" command availability
+        var expect = Paths.get("/usr/bin/expect");
+        if (!Files.exists(expect) || !Files.isExecutable(expect)) {
+            System.out.println("'expect' command not found. Test ignored.");
+            return;
         }
 
-        String actualOut = output.getStdout();
+        // invoking "expect" command
+        var testSrc = System.getProperty("test.src", ".");
+        var jdkDir = System.getProperty("test.jdk");
 
-        if (!Objects.equals(expectedOut, actualOut)) {
-            throw new AssertionError("Unexpected stdout content. " +
-                                     "Expected: '" + expectedOut + "'" +
-                                     ", got: '" + actualOut + "'");
-        }
+        List<String> command = new ArrayList<>();
 
-        String expectedErr = "";
-        String actualErr = output.getStderr();
+        command.add("expect");
+        command.add("-n");
+        command.add(testSrc + "/consolePrompt.exp");
+        command.add(expectedOut);
+        command.add(jdkDir + "/bin/java");
+        command.addAll(extraParams);
+        command.add("-cp");
+        command.add(System.getProperty("java.class.path"));
+        command.add(ConsoleTest.class.getName());
+        command.add(testName);
 
-        if (!Objects.equals(expectedErr, actualErr)) {
-            throw new AssertionError("Unexpected stderr content. " +
-                                     "Expected: '" + expectedErr + "'" +
-                                     ", got: '" + actualErr + "'");
+        OutputAnalyzer output = ProcessTools.executeProcess(command.toArray(String[]::new));
+        output.reportDiagnosticSummary();
+        var eval = output.getExitValue();
+        if (eval != 0) {
+            throw new RuntimeException("Test failed. Exit value from 'expect' command: " + eval);
         }
     }
 

--- a/test/jdk/java/io/Console/DefaultCharsetTest.java
+++ b/test/jdk/java/io/Console/DefaultCharsetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,15 +26,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @test
- * @bug 8341975
+ * @bug 8341975 8351435
  * @summary Tests the default charset. It should honor `stdout.encoding`
  *          which should be the same as System.out.charset()
  * @modules jdk.internal.le
- * @run junit/othervm -Dstdout.encoding=UTF-8 DefaultCharsetTest
- * @run junit/othervm -Dstdout.encoding=ISO-8859-1 DefaultCharsetTest
- * @run junit/othervm -Dstdout.encoding=US-ASCII DefaultCharsetTest
- * @run junit/othervm -Dstdout.encoding=foo DefaultCharsetTest
- * @run junit/othervm DefaultCharsetTest
+ * @run junit/othervm -Djdk.console=jdk.internal.le -Dstdout.encoding=UTF-8 DefaultCharsetTest
+ * @run junit/othervm -Djdk.console=jdk.internal.le -Dstdout.encoding=ISO-8859-1 DefaultCharsetTest
+ * @run junit/othervm -Djdk.console=jdk.internal.le -Dstdout.encoding=US-ASCII DefaultCharsetTest
+ * @run junit/othervm -Djdk.console=jdk.internal.le -Dstdout.encoding=foo DefaultCharsetTest
+ * @run junit/othervm -Djdk.console=jdk.internal.le DefaultCharsetTest
  */
 public class DefaultCharsetTest {
     @Test

--- a/test/jdk/java/io/Console/LocaleTest.java
+++ b/test/jdk/java/io/Console/LocaleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /**
  * @test
- * @bug 8330276
+ * @bug 8330276 8351435
  * @summary Tests Console methods that have Locale as an argument
  * @library /test/lib
  * @modules jdk.internal.le jdk.localedata
@@ -57,6 +57,7 @@ public class LocaleTest {
         if (args.length == 0) {
             // no arg will launch the child process that actually perform tests
             var pb = ProcessTools.createTestJavaProcessBuilder(
+                    "-Djdk.console=jdk.internal.le",
                     "LocaleTest", "dummy");
             var input = new File(System.getProperty("test.src", "."), "input.txt");
             pb.redirectInput(input);

--- a/test/jdk/java/io/Console/ModuleSelectionTest.java
+++ b/test/jdk/java/io/Console/ModuleSelectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,11 @@
 
 /**
  * @test
- * @bug 8295803 8299689
+ * @bug 8295803 8299689 8351435
  * @summary Tests System.console() returns correct Console (or null) from the expected
  *          module.
  * @modules java.base/java.io:+open
- * @run main/othervm ModuleSelectionTest jdk.internal.le
+ * @run main/othervm ModuleSelectionTest java.base
  * @run main/othervm -Djdk.console=jdk.internal.le ModuleSelectionTest jdk.internal.le
  * @run main/othervm -Djdk.console=java.base ModuleSelectionTest java.base
  * @run main/othervm --limit-modules java.base ModuleSelectionTest java.base

--- a/test/jdk/java/io/Console/consolePrompt.exp
+++ b/test/jdk/java/io/Console/consolePrompt.exp
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+set java [lrange $argv 1 end]
+set expected [lindex $argv 0]
+
+eval spawn $java
+expect -- "$expected"
+send -- "\n"
+expect eof

--- a/test/jdk/java/io/IO/IO.java
+++ b/test/jdk/java/io/IO/IO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,9 +50,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * @test
- * @bug 8305457 8342936
+ * @bug 8305457 8342936 8351435
  * @summary java.io.IO tests
  * @library /test/lib
+ * @modules jdk.internal.le
  * @run junit IO
  */
 @ExtendWith(IO.TimingExtension.class)
@@ -152,7 +153,7 @@ public class IO {
 
         public static Stream<Arguments> args() {
             // cross product: consoles x prompts
-            return Stream.of(null, "gibberish").flatMap(console -> Stream.of(null, "?", "%s", PROMPT_NONE)
+            return Stream.of("jdk.internal.le", "gibberish").flatMap(console -> Stream.of(null, "?", "%s", PROMPT_NONE)
                     .map(prompt -> new String[]{console, prompt}).map(Arguments::of));
         }
     }
@@ -162,7 +163,7 @@ public class IO {
     public void printTest(String mode) throws Exception {
         var file = Path.of(System.getProperty("test.src", "."), "Output.java")
                 .toAbsolutePath().toString();
-        var pb = ProcessTools.createTestJavaProcessBuilder("--enable-preview", file, mode);
+        var pb = ProcessTools.createTestJavaProcessBuilder("-Djdk.console=jdk.internal.le", "--enable-preview", file, mode);
         OutputAnalyzer output = ProcessTools.executeProcess(pb);
         assertEquals(0, output.getExitValue());
         assertTrue(output.getStderr().isEmpty());
@@ -195,7 +196,7 @@ public class IO {
                     }
                     """);
         }
-        var pb = ProcessTools.createTestJavaProcessBuilder("--enable-preview", file.toString());
+        var pb = ProcessTools.createTestJavaProcessBuilder("-Djdk.console=jdk.internal.le", "--enable-preview", file.toString());
         OutputAnalyzer output = ProcessTools.executeProcess(pb);
         assertEquals(0, output.getExitValue());
         assertTrue(output.getStderr().isEmpty());

--- a/test/jdk/jdk/internal/jline/JLineConsoleProviderTest.java
+++ b/test/jdk/jdk/internal/jline/JLineConsoleProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8331535
+ * @bug 8331535 8351435
  * @summary Verify the jdk.internal.le's console provider works properly.
  * @modules jdk.internal.le
  * @library /test/lib
@@ -58,7 +58,7 @@ public class JLineConsoleProviderTest {
                           String input,
                           String expectedOut) throws Exception {
         ProcessBuilder builder =
-                ProcessTools.createTestJavaProcessBuilder(ConsoleTest.class.getName(),
+                ProcessTools.createTestJavaProcessBuilder("-Djdk.console=jdk.internal.le", ConsoleTest.class.getName(),
                                                           testName);
         OutputAnalyzer output = ProcessTools.executeProcess(builder, input);
 

--- a/test/jdk/jdk/internal/jline/RedirectedStdOut.java
+++ b/test/jdk/jdk/internal/jline/RedirectedStdOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8330998
+ * @bug 8330998 8351435
  * @summary Verify that even if the stdout is redirected java.io.Console will
  *          use it for writing.
  * @modules jdk.internal.le
@@ -61,7 +61,7 @@ public class RedirectedStdOut {
     //this test is weaker, but more reliable:
     void runRedirectAllTest() throws Exception {
         ProcessBuilder builder =
-                ProcessTools.createTestJavaProcessBuilder(ConsoleTest.class.getName());
+                ProcessTools.createTestJavaProcessBuilder("-Djdk.console=jdk.internal.le", ConsoleTest.class.getName());
         OutputAnalyzer output = ProcessTools.executeProcess(builder);
 
         output.waitFor();
@@ -153,7 +153,7 @@ public class RedirectedStdOut {
         System.setOut(new PrintStream(new ByteArrayOutputStream()));
 
         ProcessBuilder builder =
-            ProcessTools.createTestJavaProcessBuilder(ConsoleTest.class.getName());
+            ProcessTools.createTestJavaProcessBuilder("-Djdk.console=jdk.internal.le", ConsoleTest.class.getName());
 
         builder.inheritIO();
         builder.redirectOutput(stdout.toFile());


### PR DESCRIPTION
JDK has been using JLine based Console implementation, in JDK20 as opt-in, then in JDK22 as the default. While it has been providing rich functionality for Console, it is increasingly difficult to maintain as a Console implementation. In light of the on-ramp feature (https://bugs.openjdk.org/browse/JDK-8344699), which proposes switching `java.lang.IO` class to use `System.in` and `System.out` instead of Console, reverting the default Console implementation to JDK's built-in one in the java.base module is considered desirable. Some tests are modified along with this change, among them test/jdk/java/io/Console/ConsolePromptTest.java changes were contributed by @lahodaj (thanks!)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8351573](https://bugs.openjdk.org/browse/JDK-8351573) to be approved

### Issues
 * [JDK-8351435](https://bugs.openjdk.org/browse/JDK-8351435): Change the default Console implementation back to the built-in one in `java.base` module (**Enhancement** - P4)
 * [JDK-8351573](https://bugs.openjdk.org/browse/JDK-8351573): Change the default Console implementation back to the built-in one in `java.base` module (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Contributors
 * Jan Lahoda `<jlahoda@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/23993/head:pull/23993` \
`$ git checkout pull/23993`

Update a local copy of the PR: \
`$ git checkout pull/23993` \
`$ git pull https://git.openjdk.org/jdk.git pull/23993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23993`

View PR using the GUI difftool: \
`$ git pr show -t 23993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/23993.diff">https://git.openjdk.org/jdk/pull/23993.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/23993#issuecomment-2715367278)
</details>
