### PR TITLE
8351689: -Xshare:dump with default classlist fails on static JDK

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -866,7 +866,7 @@ void MetaspaceShared::preload_classes(TRAPS) {
   const char* filesep = os::file_separator();
 
   jio_snprintf(default_classlist, JVM_MAXPATHLEN, "%s%slib%sclasslist",
-               Arguments::get_java_home(), filesep, filesep); 
+               Arguments::get_java_home(), filesep, filesep);
   if (SharedClassListFile == nullptr) {
     classlist_path = default_classlist;
   } else {

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -860,13 +860,17 @@ void MetaspaceShared::adjust_heap_sizes_for_dumping() {
 }
 #endif // INCLUDE_CDS_JAVA_HEAP && _LP64
 
+void MetaspaceShared::get_default_classlist(char* default_classlist, const size_t buf_size) {
+  const char* filesep = os::file_separator();
+  jio_snprintf(default_classlist, buf_size, "%s%slib%sclasslist",
+               Arguments::get_java_home(), filesep, filesep);
+}
+
 void MetaspaceShared::preload_classes(TRAPS) {
   char default_classlist[JVM_MAXPATHLEN];
   const char* classlist_path;
-  const char* filesep = os::file_separator();
 
-  jio_snprintf(default_classlist, JVM_MAXPATHLEN, "%s%slib%sclasslist",
-               Arguments::get_java_home(), filesep, filesep);
+  get_default_classlist(default_classlist, JVM_MAXPATHLEN);
   if (SharedClassListFile == nullptr) {
     classlist_path = default_classlist;
   } else {
@@ -921,9 +925,7 @@ void MetaspaceShared::preload_and_dump_impl(StaticArchiveBuilder& builder, TRAPS
   if (CDSConfig::is_dumping_preimage_static_archive()) {
     log_info(cds)("Reading lambda form invokers from JDK default classlist ...");
     char default_classlist[JVM_MAXPATHLEN];
-    const char* filesep = os::file_separator();
-    jio_snprintf(default_classlist, JVM_MAXPATHLEN, "%s%slib%sclasslist",
-                 Arguments::get_java_home(), filesep, filesep);
+    get_default_classlist(default_classlist, JVM_MAXPATHLEN);
     struct stat statbuf;
     if (os::stat(default_classlist, &statbuf) == 0) {
       ClassListParser::parse_classlist(default_classlist,

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -860,38 +860,13 @@ void MetaspaceShared::adjust_heap_sizes_for_dumping() {
 }
 #endif // INCLUDE_CDS_JAVA_HEAP && _LP64
 
-void MetaspaceShared::get_default_classlist(char* default_classlist, const size_t buf_size) {
-  // Construct the path to the class list (in jre/lib)
-  // Walk up two directories from the location of the VM and
-  // optionally tack on "lib" (depending on platform)
-  os::jvm_path(default_classlist, (jint)(buf_size));
-  for (int i = 0; i < 3; i++) {
-    char *end = strrchr(default_classlist, *os::file_separator());
-    if (end != nullptr) *end = '\0';
-  }
-  size_t classlist_path_len = strlen(default_classlist);
-  if (classlist_path_len >= 3) {
-    if (strcmp(default_classlist + classlist_path_len - 3, "lib") != 0) {
-      if (classlist_path_len < buf_size - 4) {
-        jio_snprintf(default_classlist + classlist_path_len,
-                     buf_size - classlist_path_len,
-                     "%slib", os::file_separator());
-        classlist_path_len += 4;
-      }
-    }
-  }
-  if (classlist_path_len < buf_size - 10) {
-    jio_snprintf(default_classlist + classlist_path_len,
-                 buf_size - classlist_path_len,
-                 "%sclasslist", os::file_separator());
-  }
-}
-
 void MetaspaceShared::preload_classes(TRAPS) {
   char default_classlist[JVM_MAXPATHLEN];
   const char* classlist_path;
+  const char* filesep = os::file_separator();
 
-  get_default_classlist(default_classlist, sizeof(default_classlist));
+  jio_snprintf(default_classlist, JVM_MAXPATHLEN, "%s%slib%sclasslist",
+               Arguments::get_java_home(), filesep, filesep); 
   if (SharedClassListFile == nullptr) {
     classlist_path = default_classlist;
   } else {
@@ -946,7 +921,9 @@ void MetaspaceShared::preload_and_dump_impl(StaticArchiveBuilder& builder, TRAPS
   if (CDSConfig::is_dumping_preimage_static_archive()) {
     log_info(cds)("Reading lambda form invokers from JDK default classlist ...");
     char default_classlist[JVM_MAXPATHLEN];
-    get_default_classlist(default_classlist, sizeof(default_classlist));
+    const char* filesep = os::file_separator();
+    jio_snprintf(default_classlist, JVM_MAXPATHLEN, "%s%slib%sclasslist",
+                 Arguments::get_java_home(), filesep, filesep);
     struct stat statbuf;
     if (os::stat(default_classlist, &statbuf) == 0) {
       ClassListParser::parse_classlist(default_classlist,

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -195,5 +195,6 @@ private:
                                      ReservedSpace& class_space_rs);
   static MapArchiveResult map_archive(FileMapInfo* mapinfo, char* mapped_base_address, ReservedSpace rs);
   static void unmap_archive(FileMapInfo* mapinfo);
+  static void get_default_classlist(char* default_classlist, const size_t buf_size);
 };
 #endif // SHARE_CDS_METASPACESHARED_HPP

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -195,6 +195,5 @@ private:
                                      ReservedSpace& class_space_rs);
   static MapArchiveResult map_archive(FileMapInfo* mapinfo, char* mapped_base_address, ReservedSpace rs);
   static void unmap_archive(FileMapInfo* mapinfo);
-  static void get_default_classlist(char* default_classlist, const size_t buf_size);
 };
 #endif // SHARE_CDS_METASPACESHARED_HPP


### PR DESCRIPTION
Please review the change to use `Arguments::get_java_home` to resolve the default classlist path. This avoids the complication of walking up the directory from libjvm and the subtle handling for '/lib' dir, which is what `MetaspaceShared::get_default_classlist` needs to do. This fixes the failure on static JDK for running `-Xshare:dump` with the default classlist. Please see more details in https://bugs.openjdk.org/browse/JDK-8351689.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351689](https://bugs.openjdk.org/browse/JDK-8351689): -Xshare:dump with default classlist fails on static JDK (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24000/head:pull/24000` \
`$ git checkout pull/24000`

Update a local copy of the PR: \
`$ git checkout pull/24000` \
`$ git pull https://git.openjdk.org/jdk.git pull/24000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24000`

View PR using the GUI difftool: \
`$ git pr show -t 24000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24000.diff">https://git.openjdk.org/jdk/pull/24000.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24000#issuecomment-2715736541)
</details>
