### PR TITLE
8351327: -XX:AOTMode=record interferes with application execution

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -561,7 +561,7 @@ bool CDSConfig::is_dumping_final_static_archive() {
 
 bool CDSConfig::allow_only_single_java_thread() {
   // See comments in JVM_StartThread()
-  return is_dumping_static_archive();
+  return is_dumping_classic_static_archive() || is_dumping_final_static_archive();
 }
 
 bool CDSConfig::is_using_archive() {

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -823,8 +823,10 @@ void MetaspaceShared::preload_and_dump(TRAPS) {
 
   if (CDSConfig::new_aot_flags_used()) {
     if (CDSConfig::is_dumping_preimage_static_archive()) {
+      // We are in the JVM that runs the training run. Continue execution,
+      // so that it can finish all clean-up and return the correct exit
+      // code to the OS.
       tty->print_cr("AOTConfiguration recorded: %s", AOTConfiguration);
-      vm_exit(0);
     } else {
       // The JLI launcher only recognizes the "old" -Xshare:dump flag.
       // When the new -XX:AOTMode=create flag is used, we can't return

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/TrainingRun.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/TrainingRun.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary -XX:AOTMode=record should not interfere with app execution: (1) thread creation; (2) exit code
+ * @bug 8351327
+ * @requires vm.cds.supports.aot.class.linking
+ * @comment work around JDK-8345635
+ * @requires !vm.jvmci.enabled
+ * @library /test/jdk/lib/testlibrary /test/lib
+ * @build TrainingRun
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar MyTestApp
+ * @run driver TrainingRun AOT
+ */
+
+import jdk.test.lib.cds.CDSAppTester;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TrainingRun {
+    static final String appJar = ClassFileInstaller.getJarPath("app.jar");
+    static final String mainClass = "MyTestApp";
+
+    public static void main(String[] args) throws Exception {
+        (new Tester()).run(args);
+    }
+
+    static class Tester extends CDSAppTester {
+        public Tester() {
+            super(mainClass);
+
+            // CDSAppTester usually wants the app to return exit value 0, but this test
+            // checks whether the training run can return 2.
+            setCheckExitValue(false);
+        }
+
+        @Override
+        public String classpath(RunMode runMode) {
+            return appJar;
+        }
+
+        @Override
+        public String[] appCommandLine(RunMode runMode) {
+            return new String[] {
+                mainClass,
+            };
+        }
+
+        @Override
+        public void checkExecution(OutputAnalyzer out, RunMode runMode) {
+            if (runMode.isApplicationExecuted()) {
+                out.shouldHaveExitValue(2);
+                out.shouldContain("Hello: x is 1");
+            }
+        }
+    }
+}
+
+class MyTestApp {
+    volatile static int x = 0;
+
+    public static void main(String args[]) throws Exception {
+        Thread t = new Thread(() -> {
+                x = 1;
+        });
+        t.start();
+        t.join();
+
+        if (x != 1) {
+            throw new RuntimeException("x should be 1 but is " + x);
+        }
+        System.out.println("Hello: x is " + x);
+        System.out.println("I am calling System.exit(2)");
+        System.exit(2);
+    }
+}


### PR DESCRIPTION
Since [JDK-8348426](https://bugs.openjdk.org/browse/JDK-8348426), If `-XX:AOTMode=record` is specified in the command-line, the application's behavior is affected in the following 2 ways:

1. The application is not able to launch new Threads.
2. The exit code is ignored and becomes zero.

The fixes are simple and I also added a test case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351327](https://bugs.openjdk.org/browse/JDK-8351327): -XX:AOTMode=record interferes with application execution (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24003/head:pull/24003` \
`$ git checkout pull/24003`

Update a local copy of the PR: \
`$ git checkout pull/24003` \
`$ git pull https://git.openjdk.org/jdk.git pull/24003/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24003`

View PR using the GUI difftool: \
`$ git pr show -t 24003`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24003.diff">https://git.openjdk.org/jdk/pull/24003.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24003#issuecomment-2716240912)
</details>
