### PR TITLE
8351839: RISC-V: Fix base offset calculation introduced in JDK-8347489

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1385,8 +1385,7 @@ void C2_MacroAssembler::string_compare_long_same_encoding(Register result, Regis
                                                   const int STUB_THRESHOLD, Label *STUB, Label *SHORT_STRING, Label *DONE) {
   Label TAIL_CHECK, TAIL, NEXT_WORD, DIFFERENCE;
 
-  const int base_offset = isLL ? arrayOopDesc::base_offset_in_bytes(T_BYTE)
-                               : arrayOopDesc::base_offset_in_bytes(T_CHAR);
+  const int base_offset = arrayOopDesc::base_offset_in_bytes(T_BYTE);
   assert((base_offset % (UseCompactObjectHeaders ? 4 :
                         (UseCompressedClassPointers ? 8 : 4))) == 0, "Must be");
 
@@ -1480,7 +1479,7 @@ void C2_MacroAssembler::string_compare_long_different_encoding(Register result, 
                                                const int STUB_THRESHOLD, Label *STUB, Label *DONE) {
   Label TAIL, NEXT_WORD, DIFFERENCE;
 
-  const int base_offset = arrayOopDesc::base_offset_in_bytes(T_CHAR);
+  const int base_offset = arrayOopDesc::base_offset_in_bytes(T_BYTE);
   assert((base_offset % (UseCompactObjectHeaders ? 4 :
                           (UseCompressedClassPointers ? 8 : 4))) == 0, "Must be");
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2436,8 +2436,7 @@ class StubGenerator: public StubCodeGenerator {
                              Register strL, Register strU, Label& DIFF) {
     const Register tmp = x30, tmpLval = x12;
 
-    int base_offset = arrayOopDesc::base_offset_in_bytes(T_CHAR);
-
+    int base_offset = arrayOopDesc::base_offset_in_bytes(T_BYTE);
     assert((base_offset % (UseCompactObjectHeaders ? 4 :
                            (UseCompressedClassPointers ? 8 : 4))) == 0, "Must be");
 
@@ -2495,25 +2494,21 @@ class StubGenerator: public StubCodeGenerator {
     const Register result = x10, str1 = x11, str2 = x13, cnt2 = x14,
                    tmp1 = x28, tmp2 = x29, tmp3 = x30, tmp4 = x12;
 
-    int base_offset1 = arrayOopDesc::base_offset_in_bytes(T_BYTE);
-    int base_offset2 = arrayOopDesc::base_offset_in_bytes(T_CHAR);
-
-    assert((base_offset1 % (UseCompactObjectHeaders ? 4 :
-                            (UseCompressedClassPointers ? 8 : 4))) == 0, "Must be");
-    assert((base_offset2 % (UseCompactObjectHeaders ? 4 :
-                            (UseCompressedClassPointers ? 8 : 4))) == 0, "Must be");
+    int base_offset = arrayOopDesc::base_offset_in_bytes(T_BYTE);
+    assert((base_offset % (UseCompactObjectHeaders ? 4 :
+                           (UseCompressedClassPointers ? 8 : 4))) == 0, "Must be");
 
     Register strU = isLU ? str2 : str1,
              strL = isLU ? str1 : str2,
              tmpU = isLU ? tmp2 : tmp1, // where to keep U for comparison
              tmpL = isLU ? tmp1 : tmp2; // where to keep L for comparison
 
-    if (AvoidUnalignedAccesses && (base_offset1 % 8) != 0) {
+    if (AvoidUnalignedAccesses && (base_offset % 8) != 0) {
       // Load 4 bytes from strL to make sure main loop is 8-byte aligned
       // cnt2 is >= 68 here, no need to check it for >= 0
       __ lwu(tmpL, Address(strL));
       __ addi(strL, strL, wordSize / 2);
-      __ load_long_misaligned(tmpU, Address(strU), tmp4, (base_offset2 % 8) != 0 ? 4 : 8);
+      __ load_long_misaligned(tmpU, Address(strU), tmp4, (base_offset % 8) != 0 ? 4 : 8);
       __ addi(strU, strU, wordSize);
       __ inflate_lo32(tmp3, tmpL);
       __ mv(tmpL, tmp3);


### PR DESCRIPTION
As discussed in https://github.com/openjdk/jdk/pull/23633#discussion_r1974591975, there is no need to distinuish `T_BYTE` and `T_CHAR` when calculating base offset for strings.
The reason is that the low-level character storage used for both Latin1 and UTF16 strings is always a byte array [1].
So we should always use `T_BYTE` for both cases. This won't make a difference on the calculated base offset for now.
But it's better to fix this for code readability purposes. Sanity tested on linux-riscv64 w/wo COH.

[1] https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/lang/String.java#L160

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351839](https://bugs.openjdk.org/browse/JDK-8351839): RISC-V: Fix base offset calculation introduced in JDK-8347489 (**Bug** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24006/head:pull/24006` \
`$ git checkout pull/24006`

Update a local copy of the PR: \
`$ git checkout pull/24006` \
`$ git pull https://git.openjdk.org/jdk.git pull/24006/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24006`

View PR using the GUI difftool: \
`$ git pr show -t 24006`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24006.diff">https://git.openjdk.org/jdk/pull/24006.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24006#issuecomment-2717637266)
</details>
