### PR TITLE
8351861: RISC-V: add simple assert at arrays_equals_v

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2614,6 +2614,7 @@ void C2_MacroAssembler::clear_array_v(Register base, Register cnt) {
 
 void C2_MacroAssembler::arrays_equals_v(Register a1, Register a2, Register result,
                                         Register cnt1, int elem_size) {
+  assert(elem_size == 1 || elem_size == 2, "must be char or byte");
   Label DONE;
   Register tmp1 = t0;
   Register tmp2 = t1;

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2615,6 +2615,8 @@ void C2_MacroAssembler::clear_array_v(Register base, Register cnt) {
 void C2_MacroAssembler::arrays_equals_v(Register a1, Register a2, Register result,
                                         Register cnt1, int elem_size) {
   assert(elem_size == 1 || elem_size == 2, "must be char or byte");
+  assert_different_registers(a1, a2, result, cnt1, t0, t1);
+
   Label DONE;
   Register tmp1 = t0;
   Register tmp2 = t1;


### PR DESCRIPTION
Hi,
Can you help to review this trivial patch?

`arrays_equals_v` and `arrays_equals` are 2 versions of the same node `AryEqNode`, input `elem_size` should be the same, so should share the same assert of `elem_size`, this also make the code below more clear.
Although at the same time, we could do the similar thing like https://github.com/openjdk/jdk/pull/24006, but as the code of `arrays_equals_v` and `arrays_equals` seems not require the input must be a byte[] (although in the java level a string's payload is indeed a byte[]), so I'll just leave if as is.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351861](https://bugs.openjdk.org/browse/JDK-8351861): RISC-V: add simple assert at arrays_equals_v (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24008/head:pull/24008` \
`$ git checkout pull/24008`

Update a local copy of the PR: \
`$ git checkout pull/24008` \
`$ git pull https://git.openjdk.org/jdk.git pull/24008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24008`

View PR using the GUI difftool: \
`$ git pr show -t 24008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24008.diff">https://git.openjdk.org/jdk/pull/24008.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24008#issuecomment-2718164907)
</details>
