### PR TITLE
8351277: Remove pipewire from AIX build

### DIFF
--- a/make/modules/java.desktop/lib/AwtLibraries.gmk
+++ b/make/modules/java.desktop/lib/AwtLibraries.gmk
@@ -220,9 +220,13 @@ ifeq ($(call isTargetOs, windows macosx)+$(ENABLE_HEADLESS_ONLY), false+false)
       common/font \
       common/java2d/opengl \
       common/java2d/x11 \
-      libpipewire/include \
       java.base:libjvm \
       #
+
+  # exclude pipewire from the AIX build, no Wayland support
+  ifeq ($(call isTargetOs, aix), false)
+    LIBAWT_XAWT_EXTRA_HEADER_DIRS += libpipewire/include
+  endif
 
   ifeq ($(call isTargetOs, linux), true)
     ifeq ($(DISABLE_XRENDER), true)

--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1100,6 +1100,20 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_getRGBPixelsImpl
 #else
 JNIEXPORT void JNICALL
 Java_sun_awt_screencast_ScreencastHelper_closeSession(JNIEnv *env, jclass cls) {
+}
+
+JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_getRGBPixelsImpl(
+        JNIEnv *env,
+        jclass cls,
+        jint jx,
+        jint jy,
+        jint jwidth,
+        jint jheight,
+        jintArray pixelArray,
+        jintArray affectedScreensBoundsArray,
+        jstring jtoken
+) {
+    return -1; /* RESULT_ERROR */
 }
 
 JNIEXPORT jboolean JNICALL Java_sun_awt_screencast_ScreencastHelper_loadPipewire(

--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -30,6 +30,8 @@
 #include <dlfcn.h>
 #include "jni_util.h"
 #include "awt.h"
+
+#ifndef _AIX
 #include "screencast_pipewire.h"
 
 struct pw_buffer *(*fp_pw_stream_dequeue_buffer)(struct pw_stream *stream);
@@ -1095,3 +1097,14 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_getRGBPixelsImpl
     releaseToken(env, jtoken, token);
     return 0;
 }
+#else
+JNIEXPORT void JNICALL
+Java_sun_awt_screencast_ScreencastHelper_closeSession(JNIEnv *env, jclass cls) {
+}
+
+JNIEXPORT jboolean JNICALL Java_sun_awt_screencast_ScreencastHelper_loadPipewire(
+        JNIEnv *env, jclass cls, jboolean screencastDebug
+) {
+    return JNI_FALSE;
+}
+#endif

--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_portal.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_portal.c
@@ -29,7 +29,10 @@
 #include <string.h>
 #include <pwd.h>
 #include <unistd.h>
+
+#ifndef _AIX
 #include "screencast_pipewire.h"
+
 #include "screencast_portal.h"
 
 extern volatile bool isGtkMainThread;
@@ -925,3 +928,4 @@ int getPipewireFd(const gchar *token,
     DEBUG_SCREENCAST("pwFd %i\n", pipewireFd);
     return pipewireFd;
 }
+#endif

--- a/src/java.desktop/unix/native/libpipewire/include/spa/utils/endian.h
+++ b/src/java.desktop/unix/native/libpipewire/include/spa/utils/endian.h
@@ -18,10 +18,6 @@
 #define bswap_16 _byteswap_ushort
 #define bswap_32 _byteswap_ulong
 #define bswap_64 _byteswap_uint64
-#elif defined(AIX)
-#include <sys/machine.h>
-#define __BIG_ENDIAN      BIG_ENDIAN
-#define __BYTE_ORDER      BIG_ENDIAN
 #else
 #include <endian.h>
 #include <byteswap.h>


### PR DESCRIPTION
Seems Wayland is not supported on AIX, so we most likely do not need to build pipewire on AIX and can remove it from the build.
Reason is that pipewire updates can break the AIX build, so better avoid it if possible.

To check if it works, I move the 'pipewire/include' folder away, and the build still worked on AIX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8351277](https://bugs.openjdk.org/browse/JDK-8351277): Remove pipewire from AIX build (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24009/head:pull/24009` \
`$ git checkout pull/24009`

Update a local copy of the PR: \
`$ git checkout pull/24009` \
`$ git pull https://git.openjdk.org/jdk.git pull/24009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24009`

View PR using the GUI difftool: \
`$ git pr show -t 24009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24009.diff">https://git.openjdk.org/jdk/pull/24009.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24009#issuecomment-2718178362)
</details>
