### PR TITLE
8346470: Improve WriteBarrier JMH to have old-to-young refs

### DIFF
--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -124,7 +124,7 @@ public abstract class WriteBarrier {
 
     @Setup(Level.Iteration)
     public void setupIteration() {
-        // Reallocate each iteration to ensure they are in young gen
+        // Reallocate target objects each iteration to ensure they are in young gen.
         youngArraySmall = new Object[NUM_REFERENCES_SMALL];
         youngArrayLarge = new Object[NUM_REFERENCES_LARGE];
         youngRef = new Object();

--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -183,7 +183,6 @@ public abstract class WriteBarrier {
         }
     }
 
-
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void testArrayWriteBarrierFastPathOldToYoungLarge() {

--- a/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/WriteBarrier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,6 @@ public abstract class WriteBarrier {
     private int[] indicesLarge;
 
     private Object[] youngArraySmall;
-
     private Object[] youngArrayLarge;
 
     private Object nullRef;
@@ -132,12 +131,6 @@ public abstract class WriteBarrier {
         this.youngHead = new Referencer();
         this.youngTail = new Referencer();
     }
-
-//    @TearDown(Level.Iteration)
-//    public void tearDownIteration() {
-//        System.gc();
-//    }
-
 
     private int get_random() {
         m_z = 36969 * (m_z & 65535) + (m_z >> 16);


### PR DESCRIPTION
Adds new cases based on the existing ones using an extra iteration setup to allocate into young gen, allowing to test old-to-young stores etc, where the existing code is all old-to-old.

Here is a run on a standard OCI A1.160 with JDK 25:
```
Benchmark                                                                         Mode  Cnt     Score    Error  Units
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathNullLarge          avgt   12  3448.826 ±  1.620  ns/op
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathNullSmall          avgt   12    63.740 ±  0.151  ns/op
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathNullYoungLarge     avgt   12  3448.353 ±  0.860  ns/op
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathNullYoungSmall     avgt   12    63.565 ±  0.132  ns/op
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathOldToYoungLarge    avgt   12  4476.390 ±  0.930  ns/op
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathOldToYoungSmall    avgt   12    73.517 ±  0.082  ns/op
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathRealLarge          avgt   12  3103.911 ±  2.079  ns/op
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathRealSmall          avgt   12    57.549 ±  0.512  ns/op
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathYoungToOldLarge    avgt   12  9587.762 ±  2.044  ns/op
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathYoungToOldSmall    avgt   12   157.244 ±  0.169  ns/op
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathYoungToYoungLarge  avgt   12  3103.191 ±  1.100  ns/op
WriteBarrier.WithDefaultUnrolling.testArrayWriteBarrierFastPathYoungToYoungSmall  avgt   12    57.392 ±  0.624  ns/op
WriteBarrier.WithDefaultUnrolling.testFieldWriteBarrierFastPath                   avgt   12     2.668 ±  0.001  ns/op
WriteBarrier.WithDefaultUnrolling.testFieldWriteBarrierFastPathYoungRef           avgt   12     9.337 ±  0.001  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathNullLarge              avgt   12  3449.234 ±  1.840  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathNullSmall              avgt   12    63.720 ±  0.079  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathNullYoungLarge         avgt   12  3448.055 ±  0.665  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathNullYoungSmall         avgt   12    63.555 ±  0.116  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathOldToYoungLarge        avgt   12  4476.646 ±  1.560  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathOldToYoungSmall        avgt   12    73.525 ±  0.070  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathRealLarge              avgt   12  3104.395 ±  1.537  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathRealSmall              avgt   12    57.766 ±  0.136  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathYoungToOldLarge        avgt   12  9586.585 ±  1.086  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathYoungToOldSmall        avgt   12   157.147 ±  0.128  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathYoungToYoungLarge      avgt   12  3103.531 ±  0.883  ns/op
WriteBarrier.WithoutUnrolling.testArrayWriteBarrierFastPathYoungToYoungSmall      avgt   12    57.669 ±  0.620  ns/op
WriteBarrier.WithoutUnrolling.testFieldWriteBarrierFastPath                       avgt   12     2.668 ±  0.001  ns/op
WriteBarrier.WithoutUnrolling.testFieldWriteBarrierFastPathYoungRef               avgt   12     9.337 ±  0.001  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346470](https://bugs.openjdk.org/browse/JDK-8346470): Improve WriteBarrier JMH to have old-to-young refs (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24010/head:pull/24010` \
`$ git checkout pull/24010`

Update a local copy of the PR: \
`$ git checkout pull/24010` \
`$ git pull https://git.openjdk.org/jdk.git pull/24010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24010`

View PR using the GUI difftool: \
`$ git pr show -t 24010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24010.diff">https://git.openjdk.org/jdk/pull/24010.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24010#issuecomment-2718354078)
</details>
