### PR TITLE
8351842: Test issues on Windows with combination of --enable-linkable-runtime and --with-external-symbols-in-bundles=public

### DIFF
--- a/make/Bundles.gmk
+++ b/make/Bundles.gmk
@@ -125,11 +125,11 @@ define SetupBundleFileBody
 	    && $(TAR) cf - -$(TAR_INCLUDE_PARAM) $$($1_$$d_LIST_FILE) \
 	        $(TAR_IGNORE_EXIT_VALUE) ) \
 	    | ( $(CD) $(SUPPORT_OUTPUTDIR)/bundles/$1/$$($1_SUBDIR) && $(TAR) xf - )$$(NEWLINE) )
-          # Rename stripped pdb files
+          # Rename full pdb files for symbols bundle
           ifeq ($(call isTargetOs, windows)+$(SHIP_DEBUG_SYMBOLS), true+public)
-	    for f in `$(FIND) $(SUPPORT_OUTPUTDIR)/bundles/$1/$$($1_SUBDIR) -name "*.stripped.pdb"`; do \
-	      $(ECHO) Renaming $$$${f} to $$$${f%stripped.pdb}pdb $(LOG_INFO); \
-	      $(MV) $$$${f} $$$${f%stripped.pdb}pdb; \
+	    for f in `$(FIND) $(SUPPORT_OUTPUTDIR)/bundles/$1/$$($1_SUBDIR) -name "*.full.pdb"`; do \
+	      $(ECHO) Renaming $$$${f} to $$$${f%full.pdb}pdb $(LOG_INFO); \
+	      $(MV) $$$${f} $$$${f%full.pdb}pdb; \
 	    done
           endif
           # Unzip any zipped debuginfo files
@@ -223,10 +223,7 @@ ifneq ($(filter product-bundles% legacy-bundles, $(MAKECMDGOALS)), )
     else
       ifeq ($(SHIP_DEBUG_SYMBOLS), public)
         JDK_SYMBOLS_EXCLUDE_PATTERN := \
-            $(filter-out \
-                %.stripped.pdb, \
-                $(filter %.pdb, $(ALL_JDK_FILES)) \
-            )
+            $(filter %.full.pdb, $(ALL_JDK_FILES))
       endif
     endif
   endif
@@ -265,10 +262,7 @@ ifneq ($(filter product-bundles% legacy-bundles, $(MAKECMDGOALS)), )
     else
       ifeq ($(SHIP_DEBUG_SYMBOLS), public)
         JRE_SYMBOLS_EXCLUDE_PATTERN := \
-            $(filter-out \
-                %.stripped.pdb, \
-                $(filter %.pdb, $(ALL_JRE_FILES)) \
-            )
+            $(filter %.full.pdb, $(ALL_JRE_FILES))
       endif
     endif
   endif

--- a/make/CreateJmods.gmk
+++ b/make/CreateJmods.gmk
@@ -60,16 +60,13 @@ $(call FillFindCache, \
 ifneq ($(LIBS_DIR), )
   DEPS += $(call FindFiles, $(LIBS_DIR))
   ifeq ($(call isTargetOs, windows)+$(SHIP_DEBUG_SYMBOLS), true+public)
-    # For public debug symbols on Windows, we have to use stripped pdbs and rename them
-    rename_stripped = $(patsubst %.stripped.pdb,%.pdb,$1)
+    # For public debug symbols on Windows, we have to filter out full pdbs
     LIBS_DIR_FILTERED := $(subst modules_libs,modules_libs_filtered, $(LIBS_DIR))
-    FILES_LIBS := $(filter-out %.pdb, $(call FindFiles, $(LIBS_DIR))) \
-        $(filter %.stripped.pdb, $(call FindFiles, $(LIBS_DIR)))
+    FILES_LIBS := $(filter-out %.full.pdb, $(call FindFiles, $(LIBS_DIR)))
     $(eval $(call SetupCopyFiles, COPY_FILTERED_LIBS, \
         SRC := $(LIBS_DIR), \
         DEST := $(LIBS_DIR_FILTERED), \
         FILES := $(FILES_LIBS), \
-        NAME_MACRO := rename_stripped, \
     ))
     DEPS += $(COPY_FILTERED_LIBS)
     JMOD_FLAGS += --libs $(LIBS_DIR_FILTERED)
@@ -80,16 +77,13 @@ endif
 ifneq ($(CMDS_DIR), )
   DEPS += $(call FindFiles, $(CMDS_DIR))
   ifeq ($(call isTargetOs, windows)+$(SHIP_DEBUG_SYMBOLS), true+public)
-    # For public debug symbols on Windows, we have to use stripped pdbs and rename them
-    rename_stripped = $(patsubst %.stripped.pdb,%.pdb,$1)
+    # For public debug symbols on Windows, we have to filter out full pdbs
     CMDS_DIR_FILTERED := $(subst modules_cmds,modules_cmds_filtered, $(CMDS_DIR))
-    FILES_CMDS := $(filter-out %.pdb, $(call FindFiles, $(CMDS_DIR))) \
-        $(filter %.stripped.pdb, $(call FindFiles, $(CMDS_DIR)))
+    FILES_CMDS := $(filter-out %.full.pdb, $(call FindFiles, $(CMDS_DIR)))
     $(eval $(call SetupCopyFiles, COPY_FILTERED_CMDS, \
         SRC := $(CMDS_DIR), \
         DEST := $(CMDS_DIR_FILTERED), \
         FILES := $(FILES_CMDS), \
-        NAME_MACRO := rename_stripped, \
     ))
     DEPS += $(COPY_FILTERED_CMDS)
     JMOD_FLAGS += --cmds $(CMDS_DIR_FILTERED)

--- a/make/common/native/DebugSymbols.gmk
+++ b/make/common/native/DebugSymbols.gmk
@@ -64,10 +64,11 @@ define CreateDebugSymbols
         endif
 
         ifeq ($(call isTargetOs, windows), true)
-          $1_EXTRA_LDFLAGS += -debug "-pdb:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb" \
-              "-map:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).map"
+          $1_EXTRA_LDFLAGS += -debug "-map:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).map"
           ifeq ($(SHIP_DEBUG_SYMBOLS), public)
-            $1_EXTRA_LDFLAGS += "-pdbstripped:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).stripped.pdb"
+            $1_EXTRA_LDFLAGS += "-pdbstripped:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb" "-pdb:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).full.pdb"
+          else
+            $1_EXTRA_LDFLAGS += "-pdb:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb"
           endif
         endif
 

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -934,7 +934,7 @@ TEST_VM(os, dll_address_to_function_and_library_name) {
     LOG("shorten_paths=%d, demangle=%d, strip_arguments=%d, provide_scratch_buffer=%d",
         shorten_paths, demangle, strip_arguments, provide_scratch_buffer);
 
-    // Should show os::min_page_size in libjvm
+    // Should show Threads::create_vm in libjvm
     addr = CAST_FROM_FN_PTR(address, Threads::create_vm);
     st.reset();
     EXPECT_TRUE(os::print_function_and_library_name(&st, addr,
@@ -942,8 +942,16 @@ TEST_VM(os, dll_address_to_function_and_library_name) {
                                                     sizeof(tmp),
                                                     shorten_paths, demangle,
                                                     strip_arguments));
+
+#ifdef _WINDOWS
+    // On Windows, if no full .pdb file is available, the output can be something like "0x... in ..."
+    if (strncmp(output, "0x", 2) != 0) {
+#endif
     EXPECT_CONTAINS(output, "Threads");
     EXPECT_CONTAINS(output, "create_vm");
+#ifdef _WINDOWS
+    }
+#endif
     EXPECT_CONTAINS(output, "jvm"); // "jvm.dll" or "libjvm.so" or similar
     LOG("%s", output);
 

--- a/test/jdk/jdk/modules/etc/JmodExcludedFiles.java
+++ b/test/jdk/jdk/modules/etc/JmodExcludedFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,10 +82,10 @@ public class JmodExcludedFiles {
                 }
                 if (OperatingSystem.isWindows() && name.endsWith(".pdb")) {
                     // on Windows we check if we should have public symbols through --with-external-symbols-in-bundles=public (JDK-8237192)
-                    String strippedpdb = javaHome + "/bin/" + name.substring(index + 1, name.length() - 4) + ".stripped.pdb";
-                    if (!Files.exists(Paths.get(strippedpdb))) {
+                    String fullpdb = javaHome + "/bin/" + name.substring(index + 1, name.length() - 4) + ".full.pdb";
+                    if (!Files.exists(Paths.get(fullpdb))) {
                         System.err.println("Found symbols in " + jmod + ": " + name +
-                                ". No stripped pdb file " + strippedpdb + " exists.");
+                                ". No full pdb file " + fullpdb + " exists.");
                         return true;
                     }
                 }


### PR DESCRIPTION
This PR addresses an issue that can be observed when building on Windows with configure options `--enable-linkable-runtime` and `--with-external-symbols-in-bundles=public`.

The problem is that with this special build configuration, we build two sets of .pdb files for the binaries. The first set is the standard debug symbols files named <binary-name>.pdb. The second set consists of stripped debug symbols file called <binary-name>.stripped.pdb which have less information but enough to present line numbers in hs-err files.

During build we use the *.stripped.pdb files for compiling the jmods and also the bundle files. However, in the images folder, both sets of .pdb files exist. The tests for runtime linking will now, in the absence of jmod files, pick up the .pdb files (without *stripped*) from images, but in the runtime the hashes of the *stripped* files are stored.

With this change, the standard .pdb files in the `--with-external-symbols-in-bundles=public` configuration are now the stripped files and we create a set of full pdb files named *.full.pdb. Jmods and Bundles still contain the stripped pdb files and we also fix the issue that the debug symbols bundle also contained stripped pdb files so far. With this fix, it will contain the full pdb files and extracting these over a JDK runtime will replace stripped pdbs with full pdbs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351842](https://bugs.openjdk.org/browse/JDK-8351842): Test issues on Windows with combination of --enable-linkable-runtime and --with-external-symbols-in-bundles=public (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24012/head:pull/24012` \
`$ git checkout pull/24012`

Update a local copy of the PR: \
`$ git checkout pull/24012` \
`$ git pull https://git.openjdk.org/jdk.git pull/24012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24012`

View PR using the GUI difftool: \
`$ git pr show -t 24012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24012.diff">https://git.openjdk.org/jdk/pull/24012.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24012#issuecomment-2718383674)
</details>
