### PR TITLE
8350578: Refactor useless Parse and Template Assertion Predicate elimination code by using a PredicateVisitor

### DIFF
--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
 #include "opto/multnode.hpp"
 #include "opto/node.hpp"
 #include "opto/opcodes.hpp"
+#include "opto/predicates_enums.hpp"
 #include "opto/type.hpp"
 
 // Portions of code courtesy of Clifford Click
@@ -59,10 +60,6 @@ class     SCMemProjNode;
 class PhaseIdealLoop;
 enum class AssertionPredicateType;
 enum class PredicateState;
-
-// The success projection of a Parse Predicate is always an IfTrueNode and the uncommon projection an IfFalseNode
-typedef IfTrueNode ParsePredicateSuccessProj;
-typedef IfFalseNode ParsePredicateUncommonProj;
 
 //------------------------------RegionNode-------------------------------------
 // The class of RegionNodes, which can be mapped to basic blocks in the
@@ -501,11 +498,23 @@ class ParsePredicateNode : public IfNode {
     return _deopt_reason;
   }
 
-  bool is_useless() const;
+  bool is_useless() const {
+    return _predicate_state == PredicateState::Useless;
+  }
+
   void mark_useless(PhaseIterGVN& igvn);
-  void mark_maybe_useful();
-  bool is_useful() const;
-  void mark_useful();
+
+  void mark_maybe_useful() {
+    _predicate_state = PredicateState::MaybeUseful;
+  }
+
+  bool is_useful() const {
+    return _predicate_state == PredicateState::Useful;
+  }
+
+  void mark_useful() {
+    _predicate_state = PredicateState::Useful;
+  }
 
   // Return the uncommon trap If projection of this Parse Predicate.
   ParsePredicateUncommonProj* uncommon_proj() const {

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -490,7 +490,7 @@ class ParsePredicateNode : public IfNode {
 
   // When a Parse Predicate loses its connection to a loop head, it will be marked useless by
   // EliminateUselessPredicates and cleaned up by Value(). It can also become useless when cloning it to both loops
-  // during loop multiversioning - we no longer use the old version.
+  // during Loop Multiversioning - we no longer use the old version.
   PredicateState _predicate_state;
  public:
   ParsePredicateNode(Node* control, Deoptimization::DeoptReason deopt_reason, PhaseGVN* gvn);

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -451,7 +451,8 @@ void Compile::disconnect_useless_nodes(Unique_Node_List& useful, Unique_Node_Lis
 
   remove_useless_nodes(_macro_nodes,        useful); // remove useless macro nodes
   remove_useless_nodes(_parse_predicates,   useful); // remove useless Parse Predicate nodes
-  remove_useless_nodes(_template_assertion_predicate_opaques, useful); // remove useless Assertion Predicate opaque nodes
+  // Remove useless Template Assertion Predicate opaque nodes
+  remove_useless_nodes(_template_assertion_predicate_opaques, useful);
   remove_useless_nodes(_expensive_nodes,    useful); // remove useless expensive nodes
   remove_useless_nodes(_for_post_loop_igvn, useful); // remove useless node recorded for post loop opts IGVN pass
   remove_useless_unstable_if_traps(useful);          // remove useless unstable_if traps

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -67,6 +67,7 @@
 #include "opto/mulnode.hpp"
 #include "opto/narrowptrnode.hpp"
 #include "opto/node.hpp"
+#include "opto/opaquenode.hpp"
 #include "opto/opcodes.hpp"
 #include "opto/output.hpp"
 #include "opto/parse.hpp"
@@ -394,7 +395,7 @@ void Compile::remove_useless_node(Node* dead) {
     remove_expensive_node(dead);
   }
   if (dead->is_OpaqueTemplateAssertionPredicate()) {
-    remove_template_assertion_predicate_opaq(dead);
+    remove_template_assertion_predicate_opaque(dead->as_OpaqueTemplateAssertionPredicate());
   }
   if (dead->is_ParsePredicate()) {
     remove_parse_predicate(dead->as_ParsePredicate());
@@ -450,7 +451,7 @@ void Compile::disconnect_useless_nodes(Unique_Node_List& useful, Unique_Node_Lis
 
   remove_useless_nodes(_macro_nodes,        useful); // remove useless macro nodes
   remove_useless_nodes(_parse_predicates,   useful); // remove useless Parse Predicate nodes
-  remove_useless_nodes(_template_assertion_predicate_opaqs, useful); // remove useless Assertion Predicate opaque nodes
+  remove_useless_nodes(_template_assertion_predicate_opaques, useful); // remove useless Assertion Predicate opaque nodes
   remove_useless_nodes(_expensive_nodes,    useful); // remove useless expensive nodes
   remove_useless_nodes(_for_post_loop_igvn, useful); // remove useless node recorded for post loop opts IGVN pass
   remove_useless_unstable_if_traps(useful);          // remove useless unstable_if traps
@@ -648,7 +649,7 @@ Compile::Compile(ciEnv* ci_env, ciMethod* target, int osr_bci,
       _intrinsics(comp_arena(), 0, 0, nullptr),
       _macro_nodes(comp_arena(), 8, 0, nullptr),
       _parse_predicates(comp_arena(), 8, 0, nullptr),
-      _template_assertion_predicate_opaqs(comp_arena(), 8, 0, nullptr),
+      _template_assertion_predicate_opaques(comp_arena(), 8, 0, nullptr),
       _expensive_nodes(comp_arena(), 8, 0, nullptr),
       _for_post_loop_igvn(comp_arena(), 8, 0, nullptr),
       _unstable_if_traps(comp_arena(), 8, 0, nullptr),
@@ -1824,8 +1825,7 @@ void Compile::mark_parse_predicate_nodes_useless(PhaseIterGVN& igvn) {
   }
   for (int i = 0; i < parse_predicate_count(); i++) {
     ParsePredicateNode* parse_predicate = _parse_predicates.at(i);
-    parse_predicate->mark_useless();
-    igvn._worklist.push(parse_predicate);
+    parse_predicate->mark_useless(igvn);
   }
   _parse_predicates.clear();
 }

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -371,7 +371,8 @@ class Compile : public Phase {
   GrowableArray<CallGenerator*> _intrinsics;    // List of intrinsics.
   GrowableArray<Node*>  _macro_nodes;           // List of nodes which need to be expanded before matching.
   GrowableArray<ParsePredicateNode*> _parse_predicates; // List of Parse Predicates.
-  // List of OpaqueTemplateAssertionPredicateNode nodes for Template Assertion Predicates.
+  // List of OpaqueTemplateAssertionPredicateNode nodes for Template Assertion Predicates which can be seen as list
+  // of Template Assertion Predicates themselves.
   GrowableArray<OpaqueTemplateAssertionPredicateNode*>  _template_assertion_predicate_opaques;
   GrowableArray<Node*>  _expensive_nodes;       // List of nodes that are expensive to compute and that we'd better not let the GVN freely common
   GrowableArray<Node*>  _for_post_loop_igvn;    // List of nodes for IGVN after loop opts are over
@@ -697,11 +698,6 @@ public:
   int           coarsened_count()         const { return _coarsened_locks.length(); }
 
   Node*         macro_node(int idx)       const { return _macro_nodes.at(idx); }
-  ParsePredicateNode* parse_predicate(int idx) const { return _parse_predicates.at(idx); }
-
-  OpaqueTemplateAssertionPredicateNode* template_assertion_predicate_opaque(int idx) const {
-    return _template_assertion_predicate_opaques.at(idx);
-  }
 
   Node*         expensive_node(int idx)   const { return _expensive_nodes.at(idx); }
 

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -71,6 +71,7 @@ class Node_List;
 class Node_Notes;
 class NodeHash;
 class NodeCloneInfo;
+class OpaqueTemplateAssertionPredicateNode;
 class OptoReg;
 class ParsePredicateNode;
 class PhaseCFG;
@@ -371,7 +372,7 @@ class Compile : public Phase {
   GrowableArray<Node*>  _macro_nodes;           // List of nodes which need to be expanded before matching.
   GrowableArray<ParsePredicateNode*> _parse_predicates; // List of Parse Predicates.
   // List of OpaqueTemplateAssertionPredicateNode nodes for Template Assertion Predicates.
-  GrowableArray<Node*>  _template_assertion_predicate_opaqs;
+  GrowableArray<OpaqueTemplateAssertionPredicateNode*>  _template_assertion_predicate_opaques;
   GrowableArray<Node*>  _expensive_nodes;       // List of nodes that are expensive to compute and that we'd better not let the GVN freely common
   GrowableArray<Node*>  _for_post_loop_igvn;    // List of nodes for IGVN after loop opts are over
   GrowableArray<UnstableIfTrap*> _unstable_if_traps;        // List of ifnodes after IGVN
@@ -681,17 +682,25 @@ public:
   static IdealGraphPrinter* debug_network_printer() { return _debug_network_printer; }
 #endif
 
+  const GrowableArray<ParsePredicateNode*>& parse_predicates() const {
+    return _parse_predicates;
+  }
+
+  const GrowableArray<OpaqueTemplateAssertionPredicateNode*>& template_assertion_predicate_opaques() const {
+    return _template_assertion_predicate_opaques;
+  }
+
   int           macro_count()             const { return _macro_nodes.length(); }
   int           parse_predicate_count()   const { return _parse_predicates.length(); }
-  int           template_assertion_predicate_count() const { return _template_assertion_predicate_opaqs.length(); }
+  int           template_assertion_predicate_count() const { return _template_assertion_predicate_opaques.length(); }
   int           expensive_count()         const { return _expensive_nodes.length(); }
   int           coarsened_count()         const { return _coarsened_locks.length(); }
 
   Node*         macro_node(int idx)       const { return _macro_nodes.at(idx); }
   ParsePredicateNode* parse_predicate(int idx) const { return _parse_predicates.at(idx); }
 
-  Node* template_assertion_predicate_opaq_node(int idx) const {
-    return _template_assertion_predicate_opaqs.at(idx);
+  OpaqueTemplateAssertionPredicateNode* template_assertion_predicate_opaque(int idx) const {
+    return _template_assertion_predicate_opaques.at(idx);
   }
 
   Node*         expensive_node(int idx)   const { return _expensive_nodes.at(idx); }
@@ -728,15 +737,15 @@ public:
     }
   }
 
-  void add_template_assertion_predicate_opaq(Node* n) {
-    assert(!_template_assertion_predicate_opaqs.contains(n),
+  void add_template_assertion_predicate_opaque(OpaqueTemplateAssertionPredicateNode* n) {
+    assert(!_template_assertion_predicate_opaques.contains(n),
            "Duplicate entry in Template Assertion Predicate OpaqueTemplateAssertionPredicate list");
-    _template_assertion_predicate_opaqs.append(n);
+    _template_assertion_predicate_opaques.append(n);
   }
 
-  void remove_template_assertion_predicate_opaq(Node* n) {
+  void remove_template_assertion_predicate_opaque(OpaqueTemplateAssertionPredicateNode* n) {
     if (template_assertion_predicate_count() > 0) {
-      _template_assertion_predicate_opaqs.remove_if_existing(n);
+      _template_assertion_predicate_opaques.remove_if_existing(n);
     }
   }
   void add_coarsened_locks(GrowableArray<AbstractLockNode*>& locks);

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -2223,9 +2223,8 @@ const Type* ParsePredicateNode::Value(PhaseGVN* phase) const {
   }
   if (_predicate_state == PredicateState::Useless || phase->C->post_loop_opts_phase()) {
     return TypeTuple::IFTRUE;
-  } else {
-    return bottom_type();
   }
+  return bottom_type();
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -31,7 +31,7 @@
 #include "opto/connode.hpp"
 #include "opto/loopnode.hpp"
 #include "opto/phaseX.hpp"
-#include "opto/predicates.hpp"
+#include "opto/predicates_enums.hpp"
 #include "opto/runtime.hpp"
 #include "opto/rootnode.hpp"
 #include "opto/subnode.hpp"
@@ -2186,25 +2186,9 @@ ParsePredicateNode::ParsePredicateNode(Node* control, Deoptimization::DeoptReaso
 #endif // ASSERT
 }
 
-bool ParsePredicateNode::is_useless() const {
-  return _predicate_state == PredicateState::Useless;
-}
-
 void ParsePredicateNode::mark_useless(PhaseIterGVN& igvn) {
   _predicate_state = PredicateState::Useless;
   igvn._worklist.push(this);
-}
-
-void ParsePredicateNode::mark_maybe_useful() {
-  _predicate_state = PredicateState::MaybeUseful;
-}
-
-bool ParsePredicateNode::is_useful() const {
-  return _predicate_state == PredicateState::Useful;
-}
-
-void ParsePredicateNode::mark_useful() {
-  _predicate_state = PredicateState::Useful;
 }
 
 Node* ParsePredicateNode::uncommon_trap() const {

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4399,116 +4399,13 @@ void PhaseIdealLoop::log_loop_tree() {
 
 // Eliminate all Parse and Template Assertion Predicates that are not associated with a loop anymore. The eliminated
 // predicates will be removed during the next round of IGVN.
-void PhaseIdealLoop::eliminate_useless_predicates() {
+void PhaseIdealLoop::eliminate_useless_predicates() const {
   if (C->parse_predicate_count() == 0 && C->template_assertion_predicate_count() == 0) {
     return; // No predicates left.
   }
 
-  eliminate_useless_parse_predicates();
-  eliminate_useless_template_assertion_predicates();
-}
-
-// Eliminate all Parse Predicates that do not belong to a loop anymore by marking them useless. These will be removed
-// during the next round of IGVN.
-void PhaseIdealLoop::eliminate_useless_parse_predicates() {
-  mark_all_parse_predicates_useless();
-  if (C->has_loops()) {
-    mark_loop_associated_parse_predicates_useful();
-  }
-  add_useless_parse_predicates_to_igvn_worklist();
-}
-
-void PhaseIdealLoop::mark_all_parse_predicates_useless() const {
-  for (int i = 0; i < C->parse_predicate_count(); i++) {
-    C->parse_predicate(i)->mark_useless();
-  }
-}
-
-void PhaseIdealLoop::mark_loop_associated_parse_predicates_useful() {
-  for (LoopTreeIterator iterator(_ltree_root); !iterator.done(); iterator.next()) {
-    IdealLoopTree* loop = iterator.current();
-    if (loop->can_apply_loop_predication()) {
-      mark_useful_parse_predicates_for_loop(loop);
-    }
-  }
-}
-
-// This visitor marks all visited Parse Predicates useful.
-class ParsePredicateUsefulMarker : public PredicateVisitor {
- public:
-  using PredicateVisitor::visit;
-
-  void visit(const ParsePredicate& parse_predicate) override {
-    parse_predicate.head()->mark_useful();
-  }
-};
-
-void PhaseIdealLoop::mark_useful_parse_predicates_for_loop(IdealLoopTree* loop) {
-  Node* entry = loop->_head->as_Loop()->skip_strip_mined()->in(LoopNode::EntryControl);
-  const PredicateIterator predicate_iterator(entry);
-  ParsePredicateUsefulMarker useful_marker;
-  predicate_iterator.for_each(useful_marker);
-}
-
-void PhaseIdealLoop::add_useless_parse_predicates_to_igvn_worklist() {
-  for (int i = 0; i < C->parse_predicate_count(); i++) {
-    ParsePredicateNode* parse_predicate_node = C->parse_predicate(i);
-    if (parse_predicate_node->is_useless()) {
-      _igvn._worklist.push(parse_predicate_node);
-    }
-  }
-}
-
-
-// Eliminate all Template Assertion Predicates that do not belong to their originally associated loop anymore by
-// replacing the OpaqueTemplateAssertionPredicate node of the If node with true. These nodes will be removed during the
-// next round of IGVN.
-void PhaseIdealLoop::eliminate_useless_template_assertion_predicates() {
-  Unique_Node_List useful_predicates;
-  if (C->has_loops()) {
-    collect_useful_template_assertion_predicates(useful_predicates);
-  }
-  eliminate_useless_template_assertion_predicates(useful_predicates);
-}
-
-void PhaseIdealLoop::collect_useful_template_assertion_predicates(Unique_Node_List& useful_predicates) {
-  for (LoopTreeIterator iterator(_ltree_root); !iterator.done(); iterator.next()) {
-    IdealLoopTree* loop = iterator.current();
-    if (loop->can_apply_loop_predication()) {
-      collect_useful_template_assertion_predicates_for_loop(loop, useful_predicates);
-    }
-  }
-}
-
-void PhaseIdealLoop::collect_useful_template_assertion_predicates_for_loop(IdealLoopTree* loop,
-                                                                           Unique_Node_List &useful_predicates) {
-  Node* entry = loop->_head->as_Loop()->skip_strip_mined()->in(LoopNode::EntryControl);
-  const Predicates predicates(entry);
-  if (UseProfiledLoopPredicate) {
-    const PredicateBlock* profiled_loop_predicate_block = predicates.profiled_loop_predicate_block();
-    if (profiled_loop_predicate_block->has_parse_predicate()) {
-      ParsePredicateSuccessProj* parse_predicate_proj = profiled_loop_predicate_block->parse_predicate_success_proj();
-      get_opaque_template_assertion_predicate_nodes(parse_predicate_proj, useful_predicates);
-    }
-  }
-
-  if (UseLoopPredicate) {
-    const PredicateBlock* loop_predicate_block = predicates.loop_predicate_block();
-    if (loop_predicate_block->has_parse_predicate()) {
-      ParsePredicateSuccessProj* parse_predicate_proj = loop_predicate_block->parse_predicate_success_proj();
-      get_opaque_template_assertion_predicate_nodes(parse_predicate_proj, useful_predicates);
-    }
-  }
-}
-
-void PhaseIdealLoop::eliminate_useless_template_assertion_predicates(Unique_Node_List& useful_predicates) const {
-  for (int i = C->template_assertion_predicate_count(); i > 0; i--) {
-    OpaqueTemplateAssertionPredicateNode* opaque_node =
-        C->template_assertion_predicate_opaq_node(i - 1)->as_OpaqueTemplateAssertionPredicate();
-    if (!useful_predicates.member(opaque_node)) { // not in the useful list
-      opaque_node->mark_useless(_igvn);
-    }
-  }
+  EliminateUselessPredicates eliminate_useless_predicates(_igvn, _ltree_root);
+  eliminate_useless_predicates.eliminate();
 }
 
 // If a post or main loop is removed due to an assert predicate, the opaque that guards the loop is not needed anymore

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1442,18 +1442,7 @@ public:
   void eliminate_hoisted_range_check(IfTrueNode* hoisted_check_proj, IfTrueNode* template_assertion_predicate_proj);
 
   // Helper function to collect predicate for eliminating the useless ones
-  void eliminate_useless_predicates();
-
-  void eliminate_useless_parse_predicates();
-  void mark_all_parse_predicates_useless() const;
-  void mark_loop_associated_parse_predicates_useful();
-  static void mark_useful_parse_predicates_for_loop(IdealLoopTree* loop);
-  void add_useless_parse_predicates_to_igvn_worklist();
-
-  void eliminate_useless_template_assertion_predicates();
-  void collect_useful_template_assertion_predicates(Unique_Node_List& useful_predicates);
-  static void collect_useful_template_assertion_predicates_for_loop(IdealLoopTree* loop, Unique_Node_List& useful_predicates);
-  void eliminate_useless_template_assertion_predicates(Unique_Node_List& useful_predicates) const;
+  void eliminate_useless_predicates() const;
 
   void eliminate_useless_zero_trip_guard();
   void eliminate_useless_multiversion_if();

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -511,6 +511,9 @@ Node *Node::clone() const {
   if (n->is_ParsePredicate()) {
     C->add_parse_predicate(n->as_ParsePredicate());
   }
+  if (n->is_OpaqueTemplateAssertionPredicate()) {
+    C->add_template_assertion_predicate_opaque(n->as_OpaqueTemplateAssertionPredicate());
+  }
 
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   bs->register_potential_barrier_node(n);
@@ -607,7 +610,7 @@ void Node::destruct(PhaseValues* phase) {
     compile->remove_expensive_node(this);
   }
   if (is_OpaqueTemplateAssertionPredicate()) {
-    compile->remove_template_assertion_predicate_opaq(this);
+    compile->remove_template_assertion_predicate_opaque(as_OpaqueTemplateAssertionPredicate());
   }
   if (is_ParsePredicate()) {
     compile->remove_parse_predicate(as_ParsePredicate());

--- a/src/hotspot/share/opto/opaquenode.cpp
+++ b/src/hotspot/share/opto/opaquenode.cpp
@@ -141,25 +141,9 @@ const Type* OpaqueTemplateAssertionPredicateNode::Value(PhaseGVN* phase) const {
   return phase->type(in(1));
 }
 
-bool OpaqueTemplateAssertionPredicateNode::is_useless() const {
-  return _predicate_state == PredicateState::Useless;
-}
-
 void OpaqueTemplateAssertionPredicateNode::mark_useless(PhaseIterGVN& igvn) {
   _predicate_state = PredicateState::Useless;
   igvn._worklist.push(this);
-}
-
-void OpaqueTemplateAssertionPredicateNode::mark_maybe_useful() {
-  _predicate_state = PredicateState::MaybeUseful;
-}
-
-bool OpaqueTemplateAssertionPredicateNode::is_useful() const {
-  return _predicate_state == PredicateState::Useful;
-}
-
-void OpaqueTemplateAssertionPredicateNode::mark_useful() {
-  _predicate_state = PredicateState::Useful;
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/opaquenode.cpp
+++ b/src/hotspot/share/opto/opaquenode.cpp
@@ -112,6 +112,11 @@ const Type* OpaqueNotNullNode::Value(PhaseGVN* phase) const {
   return phase->type(in(1));
 }
 
+OpaqueTemplateAssertionPredicateNode::OpaqueTemplateAssertionPredicateNode(BoolNode* bol): Node(nullptr, bol),
+  _predicate_state(PredicateState::Useful) {
+  init_class_id(Class_OpaqueTemplateAssertionPredicate);
+}
+
 Node* OpaqueTemplateAssertionPredicateNode::Identity(PhaseGVN* phase) {
   if (!phase->C->post_loop_opts_phase()) {
     // Record Template Assertion Predicates for post loop opts IGVN. We can remove them when there is no more loop
@@ -123,7 +128,9 @@ Node* OpaqueTemplateAssertionPredicateNode::Identity(PhaseGVN* phase) {
 }
 
 const Type* OpaqueTemplateAssertionPredicateNode::Value(PhaseGVN* phase) const {
-  if (_useless || phase->C->post_loop_opts_phase()) {
+  assert(_predicate_state != PredicateState::MaybeUseful, "should only be MaybeUseful when eliminating useless "
+                                                          "predicates during loop opts");
+  if (is_useless() || phase->C->post_loop_opts_phase()) {
     // Template Assertion Predicates only serve as templates to create Initialized Assertion Predicates when splitting
     // a loop during loop opts. They are not used anymore once loop opts are over and can then be removed. They feed
     // into the bool input of an If node and can thus be replaced by the success path to let the Template Assertion
@@ -134,14 +141,30 @@ const Type* OpaqueTemplateAssertionPredicateNode::Value(PhaseGVN* phase) const {
   return phase->type(in(1));
 }
 
+bool OpaqueTemplateAssertionPredicateNode::is_useless() const {
+  return _predicate_state == PredicateState::Useless;
+}
+
 void OpaqueTemplateAssertionPredicateNode::mark_useless(PhaseIterGVN& igvn) {
-  _useless = true;
+  _predicate_state = PredicateState::Useless;
   igvn._worklist.push(this);
+}
+
+void OpaqueTemplateAssertionPredicateNode::mark_maybe_useful() {
+  _predicate_state = PredicateState::MaybeUseful;
+}
+
+bool OpaqueTemplateAssertionPredicateNode::is_useful() const {
+  return _predicate_state == PredicateState::Useful;
+}
+
+void OpaqueTemplateAssertionPredicateNode::mark_useful() {
+  _predicate_state = PredicateState::Useful;
 }
 
 #ifndef PRODUCT
 void OpaqueTemplateAssertionPredicateNode::dump_spec(outputStream* st) const {
-  if (_useless) {
+  if (is_useless()) {
     st->print("#useless ");
   }
 }

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -26,6 +26,7 @@
 #define SHARE_OPTO_OPAQUENODE_HPP
 
 #include "opto/node.hpp"
+#include "opto/predicates_enums.hpp"
 #include "opto/subnode.hpp"
 
 enum class PredicateState;
@@ -171,11 +172,24 @@ class OpaqueTemplateAssertionPredicateNode : public Node {
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual const Type* bottom_type() const { return TypeInt::BOOL; }
 
-  bool is_useless() const;
+
+  bool is_useless() const {
+    return _predicate_state == PredicateState::Useless;
+  }
+
   void mark_useless(PhaseIterGVN& igvn);
-  void mark_maybe_useful();
-  bool is_useful() const;
-  void mark_useful();
+
+  void mark_maybe_useful() {
+    _predicate_state = PredicateState::MaybeUseful;
+  }
+
+  bool is_useful() const {
+    return _predicate_state == PredicateState::Useful;
+  }
+
+  void mark_useful() {
+    _predicate_state = PredicateState::Useful;
+  }
 
   NOT_PRODUCT(void dump_spec(outputStream* st) const);
 };

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -26,10 +26,10 @@
 #define SHARE_OPTO_OPAQUENODE_HPP
 
 #include "opto/node.hpp"
-#include "opto/opcodes.hpp"
-#include "subnode.hpp"
+#include "opto/subnode.hpp"
 
 enum class PredicateState;
+
 //------------------------------Opaque1Node------------------------------------
 // A node to prevent unwanted optimizations.  Allows constant folding.
 // Stops value-numbering, Ideal calls or Identity functions.

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -29,6 +29,7 @@
 #include "opto/opcodes.hpp"
 #include "subnode.hpp"
 
+enum class PredicateState;
 //------------------------------Opaque1Node------------------------------------
 // A node to prevent unwanted optimizations.  Allows constant folding.
 // Stops value-numbering, Ideal calls or Identity functions.
@@ -149,10 +150,11 @@ class OpaqueNotNullNode : public Node {
 // after loop opts and thus is never converted to actual code. In the post loop opts IGVN phase, the
 // OpaqueTemplateAssertionPredicateNode is replaced by true in order to fold the Template Assertion Predicate away.
 class OpaqueTemplateAssertionPredicateNode : public Node {
+
   // When splitting a loop or when the associated loop dies, the Template Assertion Predicate with this
   // OpaqueTemplateAssertionPredicateNode also needs to be removed. We set this flag and then clean this node up in the
   // next IGVN phase by checking this flag in Value().
-  bool _useless;
+  PredicateState _predicate_state;
 
   // OpaqueTemplateAssertionPredicateNodes are unique to a Template Assertion Predicate expression and should never
   // common up. We still make sure of that by returning NO_HASH here.
@@ -161,10 +163,7 @@ class OpaqueTemplateAssertionPredicateNode : public Node {
   }
 
  public:
-  OpaqueTemplateAssertionPredicateNode(BoolNode* bol) : Node(nullptr, bol),
-      _useless(false) {
-    init_class_id(Class_OpaqueTemplateAssertionPredicate);
-  }
+  OpaqueTemplateAssertionPredicateNode(BoolNode* bol);
 
   virtual int Opcode() const;
   virtual uint size_of() const { return sizeof(*this); }
@@ -172,11 +171,12 @@ class OpaqueTemplateAssertionPredicateNode : public Node {
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual const Type* bottom_type() const { return TypeInt::BOOL; }
 
-  bool is_useless() const {
-    return _useless;
-  }
-
+  bool is_useless() const;
   void mark_useless(PhaseIterGVN& igvn);
+  void mark_maybe_useful();
+  bool is_useful() const;
+  void mark_useful();
+
   NOT_PRODUCT(void dump_spec(outputStream* st) const);
 };
 

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -336,7 +336,7 @@ bool InitializedAssertionPredicate::has_halt(const IfTrueNode* success_proj) {
   }
   return false;
 }
-#endif
+#endif // ASSERT
 
 // Kills this Initialized Assertion Predicate by marking the associated OpaqueInitializedAssertionPredicate node useless.
 // It will then be folded away in the next IGVN round.
@@ -1174,7 +1174,7 @@ void UpdateStrideForAssertionPredicates::connect_initialized_assertion_predicate
 // Do the following to find and eliminate useless Parse and Template Assertion Predicates:
 // 1. Mark all Parse and Template Assertion Predicates "maybe useful".
 // 2. Walk through the loop tree and iterate over all Predicates above each loop head. All found Parse and Template
-//    Assertion Predicates are marked "useful"
+//    Assertion Predicates are marked "useful".
 // 3. Those Parse and Template Assertion Predicates that are still marked "maybe useful" are now marked "useless" and
 //    removed in the next round of IGVN.
 //

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -1182,14 +1182,14 @@ void UpdateStrideForAssertionPredicates::connect_initialized_assertion_predicate
 // better suited for this kind of graph surgery. We also not want to replace conditions with a constant to avoid
 // interference with Predicate matching code when iterating through them.
 void EliminateUselessPredicates::eliminate() const {
-  mark_all_predicates_non_useful();
+  mark_all_predicates_maybe_useful();
   if (C->has_loops()) {
     mark_loop_associated_predicates_useful();
   }
-  mark_non_useful_predicates_useless();
+  mark_maybe_useful_predicates_useless();
 }
 
-void EliminateUselessPredicates::mark_all_predicates_non_useful() const {
+void EliminateUselessPredicates::mark_all_predicates_maybe_useful() const {
   mark_predicates_on_list_maybe_useful(_parse_predicates);
   mark_predicates_on_list_maybe_useful(_template_assertion_predicate_opaques);
 }
@@ -1232,13 +1232,14 @@ void EliminateUselessPredicates::mark_useful_predicates_for_loop(IdealLoopTree* 
   predicate_iterator.for_each(predicate_useful_marker_visitor);
 }
 
-void EliminateUselessPredicates::mark_non_useful_predicates_useless() const {
-  mark_non_useful_predicates_on_list_useless(_parse_predicates);
-  mark_non_useful_predicates_on_list_useless(_template_assertion_predicate_opaques);
+// All Predicates still being marked MaybeUseful could not be found and thus are now marked useless.
+void EliminateUselessPredicates::mark_maybe_useful_predicates_useless() const {
+  mark_maybe_useful_predicates_on_list_useless(_parse_predicates);
+  mark_maybe_useful_predicates_on_list_useless(_template_assertion_predicate_opaques);
 }
 
 template<class PredicateList>
-void EliminateUselessPredicates::mark_non_useful_predicates_on_list_useless(
+void EliminateUselessPredicates::mark_maybe_useful_predicates_on_list_useless(
     const PredicateList& predicate_list) const {
   for (int i = 0; i < predicate_list.length(); i++) {
     auto predicate_node = predicate_list.at(i);

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -51,7 +51,7 @@ bool AssertionPredicate::is_predicate(const Node* maybe_success_proj) {
   if (!may_be_assertion_predicate_if(maybe_success_proj)) {
     return false;
   }
-  return has_assertion_predicate_opaque(maybe_success_proj) && has_halt(maybe_success_proj);
+  return has_assertion_predicate_opaque(maybe_success_proj) && has_halt(maybe_success_proj->as_IfTrue());
 }
 
 // Check if the If node of `predicate_proj` has an OpaqueTemplateAssertionPredicate (Template Assertion Predicate) or
@@ -63,8 +63,8 @@ bool AssertionPredicate::has_assertion_predicate_opaque(const Node* predicate_pr
 }
 
 // Check if the other projection (UCT projection) of `success_proj` has a Halt node as output.
-bool AssertionPredicate::has_halt(const Node* success_proj) {
-  ProjNode* other_proj = success_proj->as_IfProj()->other_if_proj();
+bool AssertionPredicate::has_halt(const IfTrueNode* success_proj) {
+  ProjNode* other_proj = success_proj->other_if_proj();
   return other_proj->outcnt() == 1 && other_proj->unique_out()->Opcode() == Op_Halt;
 }
 
@@ -88,6 +88,11 @@ ParsePredicate ParsePredicate::clone_to_unswitched_loop(Node* new_control, const
                                                                                Op_ParsePredicate, is_false_path_loop);
   NOT_PRODUCT(trace_cloned_parse_predicate(is_false_path_loop, success_proj));
   return ParsePredicate(success_proj, _parse_predicate_node->deopt_reason());
+}
+
+// Kills this Parse Predicate by marking it useless. Will be folded away in the next IGVN round.
+void ParsePredicate::kill(PhaseIterGVN& igvn) const {
+  _parse_predicate_node->mark_useless(igvn);
 }
 
 #ifndef PRODUCT
@@ -161,13 +166,16 @@ void TemplateAssertionPredicate::rewire_loop_data_dependencies(IfTrueNode* targe
   }
 }
 
-// Template Assertion Predicates always have the dedicated OpaqueTemplateAssertionPredicate to identify them.
-bool TemplateAssertionPredicate::is_predicate(const Node* node) {
-  if (!may_be_assertion_predicate_if(node)) {
+// A Template Assertion Predicate always has a dedicated OpaqueTemplateAssertionPredicate to identify it.
+bool TemplateAssertionPredicate::is_predicate(const Node* maybe_success_proj) {
+  if (!may_be_assertion_predicate_if(maybe_success_proj)) {
     return false;
   }
-  IfNode* if_node = node->in(0)->as_If();
-  return if_node->in(1)->is_OpaqueTemplateAssertionPredicate();
+  IfNode* if_node = maybe_success_proj->in(0)->as_If();
+  bool is_template_assertion_predicate = if_node->in(1)->is_OpaqueTemplateAssertionPredicate();
+  assert(!is_template_assertion_predicate || AssertionPredicate::has_halt(maybe_success_proj->as_IfTrue()),
+         "Template Assertion Predicate must have a Halt Node on the failing path");
+  return is_template_assertion_predicate;
 }
 
 // Clone this Template Assertion Predicate without modifying any OpaqueLoop*Node inputs.
@@ -293,15 +301,37 @@ void InitializedAssertionPredicate::verify() const {
 }
 #endif // ASSERT
 
-// Initialized Assertion Predicates always have the dedicated OpaqueInitiailizedAssertionPredicate node to identify
-// them.
-bool InitializedAssertionPredicate::is_predicate(const Node* node) {
-  if (!may_be_assertion_predicate_if(node)) {
+// An Initialized Assertion Predicate always has a dedicated OpaqueInitializedAssertionPredicate node to identify it.
+bool InitializedAssertionPredicate::is_predicate(const Node* maybe_success_proj) {
+  if (!may_be_assertion_predicate_if(maybe_success_proj)) {
     return false;
   }
-  IfNode* if_node = node->in(0)->as_If();
-  return if_node->in(1)->is_OpaqueInitializedAssertionPredicate();
+  IfNode* if_node = maybe_success_proj->in(0)->as_If();
+  bool is_initialized_assertion_predicate = if_node->in(1)->is_OpaqueInitializedAssertionPredicate();
+  assert(!is_initialized_assertion_predicate || has_halt(maybe_success_proj->as_IfTrue()),
+         "Initialized Assertion Predicate must have a Halt Node on the failing path");
+  return is_initialized_assertion_predicate;
 }
+
+#ifdef ASSERT
+bool InitializedAssertionPredicate::has_halt(const IfTrueNode* success_proj) {
+  ProjNode* other_proj = success_proj->other_if_proj();
+  if (other_proj->outcnt() != 1) {
+    return false;
+  }
+
+  Node* out = other_proj->unique_out();
+  // Either the Halt node is directly the unique output.
+  if (out->is_Halt()) {
+    return true;
+  }
+  // Or we have a Region that merges serval paths to a single Halt node.
+  if (out->is_Region() && out->outcnt() == 2) {
+    return out->find_out_with(Op_Halt);
+  }
+  return false;
+}
+#endif // ASSERT
 
 // Kills this Initialized Assertion Predicate by marking the associated OpaqueInitializedAssertionPredicate node useless.
 // It will then be folded away in the next IGVN round.
@@ -619,7 +649,7 @@ class AssertionPredicateExpressionCreator : public StackObj {
  private:
   OpaqueTemplateAssertionPredicateNode* create_opaque_node(Node* new_control, BoolNode* bool_for_expression) const {
     OpaqueTemplateAssertionPredicateNode* new_expression = new OpaqueTemplateAssertionPredicateNode(bool_for_expression);
-    _phase->C->add_template_assertion_predicate_opaq(new_expression);
+    _phase->C->add_template_assertion_predicate_opaque(new_expression);
     _phase->register_new_node(new_expression, new_control);
     return new_expression;
   }
@@ -1133,5 +1163,80 @@ void UpdateStrideForAssertionPredicates::connect_initialized_assertion_predicate
     _phase->replace_loop_entry(new_control_out->as_Loop(), initialized_assertion_predicate_success_proj);
   } else {
     _phase->replace_control(new_control_out, initialized_assertion_predicate_success_proj);
+  }
+}
+
+// First do the following to find useless Parse and Template Assertion Predicates:
+// 1. Mark all predicates useless
+// 2. Walk through the loop tree and iterate over all predicates above each head. All found predicates are marked
+//    useful.
+// 3. Those predicates that are still useless are removed in the next round of IGVN.
+//
+// Note that we only mark predicates useless and not actually replace them now. We leave this work for IGVN which is
+// better suited for graph surgery.
+void EliminateUselessPredicates::eliminate() const {
+  mark_all_predicates_non_useful();
+  if (C->has_loops()) {
+    mark_loop_associated_predicates_useful();
+  }
+  add_useless_predicates_to_igvn_worklist();
+}
+
+void EliminateUselessPredicates::mark_all_predicates_non_useful() const {
+  mark_predicates_on_list_maybe_useful(_parse_predicates);
+  mark_predicates_on_list_maybe_useful(_template_assertion_predicate_opaques);
+}
+
+template<class PredicateList>
+void EliminateUselessPredicates::mark_predicates_on_list_maybe_useful(const PredicateList& predicate_list) {
+  for (int i = 0; i < predicate_list.length(); i++) {
+    predicate_list.at(i)->mark_maybe_useful();
+  }
+}
+
+void EliminateUselessPredicates::mark_loop_associated_predicates_useful() const {
+  for (LoopTreeIterator iterator(_ltree_root); !iterator.done(); iterator.next()) {
+    IdealLoopTree* loop = iterator.current();
+    if (loop->can_apply_loop_predication()) {
+      mark_useful_predicates_for_loop(loop);
+    }
+  }
+}
+
+// This visitor marks all visited Parse and Template Assertion Predicates useful.
+class PredicateUsefulMarker : public PredicateVisitor {
+  public:
+  using PredicateVisitor::visit;
+
+  void visit(const ParsePredicate& parse_predicate) override {
+    parse_predicate.head()->mark_useful();
+  }
+
+  // We actually mark the associated OpaqueTemplateAssertionPredicate node useful.
+  void visit(const TemplateAssertionPredicate& template_assertion_predicate) override {
+    template_assertion_predicate.opaque_node()->mark_useful();
+  }
+};
+
+void EliminateUselessPredicates::mark_useful_predicates_for_loop(IdealLoopTree* loop) {
+  Node* entry = loop->_head->as_Loop()->skip_strip_mined()->in(LoopNode::EntryControl);
+  const PredicateIterator predicate_iterator(entry);
+  PredicateUsefulMarker useful_marker;
+  predicate_iterator.for_each(useful_marker);
+}
+
+void EliminateUselessPredicates::add_useless_predicates_to_igvn_worklist() const {
+  add_useless_predicates_on_list_to_ignv_worklist(_parse_predicates);
+  add_useless_predicates_on_list_to_ignv_worklist(_template_assertion_predicate_opaques);
+}
+
+template<class PredicateList>
+void EliminateUselessPredicates::add_useless_predicates_on_list_to_ignv_worklist(
+  const PredicateList& predicate_list) const {
+  for (int i = 0; i < predicate_list.length(); i++) {
+    auto predicate_node = predicate_list.at(i);
+    if (!predicate_node->is_useful()) {
+      predicate_node->mark_useless(_igvn);
+    }
   }
 }

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -210,6 +210,18 @@ enum class AssertionPredicateType {
   FinalIv
 };
 
+enum class PredicateState {
+  // The Predicate is useless and will be cleaned up in the next round of IGVN. A useless Predicate is not visited
+  // anymore by PredicateVisitors. If a Predicate loses its connection to a loop head, it will be marked useless by
+  // EliminateUselessPredicates and cleaned up by Value().
+  Useless,
+  // This state is used by EliminateUselessPredicates to temporarily mark a Predicate as neither useless nor useful.
+  // Outside EliminateUselessPredicates, a Predicate should never be MaybeUseful.
+  MaybeUseful,
+  // Default state: The Predicate is useful and will be visited by PredicateVisitors.
+  Useful
+};
+
 // Interface to represent a C2 predicate. A predicate is always represented by two CFG nodes:
 // - An If node (head)
 // - An IfProj node representing the success projection of the If node (tail).
@@ -273,9 +285,10 @@ class AssertionPredicates : public StackObj {
 // - An Initialized Assertion Predicate.
 class AssertionPredicate : public StackObj {
   static bool has_assertion_predicate_opaque(const Node* predicate_proj);
-  static bool has_halt(const Node* success_proj);
  public:
+
   static bool is_predicate(const Node* maybe_success_proj);
+  static bool has_halt(const IfTrueNode* success_proj);
 };
 
 // Utility class representing a Regular Predicate which is either a Runtime Predicate or an Assertion Predicate.
@@ -311,10 +324,11 @@ class ParsePredicate : public Predicate {
     return _entry;
   }
 
-  // This Parse Predicate is valid if the node passed to the constructor is a projection of a ParsePredicateNode and the
-  // deopt_reason of the uncommon trap of the ParsePredicateNode matches the passed deopt_reason to the constructor.
+  // This Parse Predicate is valid if the node passed to the constructor is a projection of a ParsePredicateNode, the
+  // deopt_reason of the uncommon trap of the ParsePredicateNode matches the passed deopt_reason to the constructor and
+  // it is not marked useless.
   bool is_valid() const {
-    return _parse_predicate_node != nullptr;
+    return _parse_predicate_node != nullptr && !_parse_predicate_node->is_useless();
   }
 
   ParsePredicateNode* head() const override {
@@ -330,11 +344,7 @@ class ParsePredicate : public Predicate {
   ParsePredicate clone_to_unswitched_loop(Node* new_control, bool is_false_path_loop,
                                           PhaseIdealLoop* phase) const;
 
-  // Kills this Parse Predicate by marking it useless. Will be folded away in the next IGVN round.
-  void kill(const PhaseIterGVN& igvn) const {
-    _parse_predicate_node->mark_useless();
-    igvn._worklist.push(_parse_predicate_node);
-  }
+  void kill(PhaseIterGVN& igvn) const;
 };
 
 // Class to represent a Runtime Predicate which always has an associated UCT on the failing path.
@@ -432,6 +442,8 @@ class TemplateAssertionPredicate : public Predicate {
 class InitializedAssertionPredicate : public Predicate {
   IfTrueNode* const _success_proj;
   IfNode* const _if_node;
+
+  DEBUG_ONLY(static bool has_halt(const IfTrueNode* success_proj);)
 
  public:
   explicit InitializedAssertionPredicate(IfTrueNode* success_proj)
@@ -1237,4 +1249,37 @@ class UpdateStrideForAssertionPredicates : public PredicateVisitor {
   void visit(const TemplateAssertionPredicate& template_assertion_predicate) override;
   void visit(const InitializedAssertionPredicate& initialized_assertion_predicate) override;
 };
+
+// Eliminate all useless Parse and Template Assertion Predicates. They become useless when they can no longer be found
+// from a loop head. We mark these useless to clean them up later during IGVN. A predicate that is marked useless will
+// no longer be visited by a PredicateVisitor.
+class EliminateUselessPredicates : public StackObj {
+  Compile* const C;
+  const GrowableArray<ParsePredicateNode*>& _parse_predicates;
+  const GrowableArray<OpaqueTemplateAssertionPredicateNode*>& _template_assertion_predicate_opaques;
+  PhaseIterGVN& _igvn;
+  IdealLoopTree* const _ltree_root;
+
+  void mark_all_predicates_non_useful() const;
+  template <class PredicateList>
+  static void mark_predicates_on_list_maybe_useful(const PredicateList& predicate_list);
+
+  void mark_loop_associated_predicates_useful() const;
+  static void mark_useful_predicates_for_loop(IdealLoopTree* loop);
+
+  void add_useless_predicates_to_igvn_worklist() const;
+  template <class PredicateList>
+  void add_useless_predicates_on_list_to_ignv_worklist(const PredicateList& predicate_list) const;
+
+ public:
+  EliminateUselessPredicates(PhaseIterGVN& igvn, IdealLoopTree* ltree_root)
+      : C(igvn.C), _parse_predicates(igvn.C->parse_predicates()),
+        _template_assertion_predicate_opaques(igvn.C->template_assertion_predicate_opaques()),
+        _igvn(igvn),
+        _ltree_root(ltree_root) {}
+
+  void eliminate() const;
+};
+
+
 #endif // SHARE_OPTO_PREDICATES_HPP

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -27,6 +27,7 @@
 
 #include "opto/cfgnode.hpp"
 #include "opto/opaquenode.hpp"
+#include "opto/predicates_enums.hpp"
 
 class IdealLoopTree;
 class InitializedAssertionPredicate;
@@ -199,28 +200,6 @@ class TemplateAssertionPredicate;
  *   [For Range Check Elimination Check k: Two Templates + one Initialized Assertion Predicate]
  * Main Loop Head
  */
-
-// Assertion Predicates are either emitted to check the initial value of a range check in the first iteration or the last
-// value of a range check in the last iteration of a loop.
-enum class AssertionPredicateType {
-  None, // Not an Assertion Predicate
-  InitValue,
-  LastValue,
-  // Used for the Initialized Assertion Predicate emitted during Range Check Elimination for the final IV value.
-  FinalIv
-};
-
-enum class PredicateState {
-  // The Predicate is useless and will be cleaned up in the next round of IGVN. A useless Predicate is not visited
-  // anymore by PredicateVisitors. If a Predicate loses its connection to a loop head, it will be marked useless by
-  // EliminateUselessPredicates and cleaned up by the Value() methods of the associated Predicate IR nodes.
-  Useless,
-  // This state is used by EliminateUselessPredicates to temporarily mark a Predicate as neither useless nor useful.
-  // Outside EliminateUselessPredicates, a Predicate should never be MaybeUseful.
-  MaybeUseful,
-  // Default state: The Predicate is useful and will be visited by PredicateVisitors.
-  Useful
-};
 
 // Interface to represent a C2 predicate. A predicate is always represented by two CFG nodes:
 // - An If node (head)

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -1239,16 +1239,16 @@ class EliminateUselessPredicates : public StackObj {
   PhaseIterGVN& _igvn;
   IdealLoopTree* const _ltree_root;
 
-  void mark_all_predicates_non_useful() const;
+  void mark_all_predicates_maybe_useful() const;
   template <class PredicateList>
   static void mark_predicates_on_list_maybe_useful(const PredicateList& predicate_list);
 
   void mark_loop_associated_predicates_useful() const;
   static void mark_useful_predicates_for_loop(IdealLoopTree* loop);
 
-  void mark_non_useful_predicates_useless() const;
+  void mark_maybe_useful_predicates_useless() const;
   template <class PredicateList>
-  void mark_non_useful_predicates_on_list_useless(const PredicateList& predicate_list) const;
+  void mark_maybe_useful_predicates_on_list_useless(const PredicateList& predicate_list) const;
 
  public:
   EliminateUselessPredicates(PhaseIterGVN& igvn, IdealLoopTree* ltree_root)

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -443,6 +443,8 @@ class InitializedAssertionPredicate : public Predicate {
   IfTrueNode* const _success_proj;
   IfNode* const _if_node;
 
+  DEBUG_ONLY(static bool has_halt(const IfTrueNode* success_proj);)
+
  public:
   explicit InitializedAssertionPredicate(IfTrueNode* success_proj)
       : _success_proj(success_proj),

--- a/src/hotspot/share/opto/predicates_enums.hpp
+++ b/src/hotspot/share/opto/predicates_enums.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_OPTO_PREDICATES_ENUMS_HPP
+#define SHARE_OPTO_PREDICATES_ENUMS_HPP
+
+// The success projection of a Parse Predicate is always an IfTrueNode and the uncommon projection an IfFalseNode
+typedef IfTrueNode ParsePredicateSuccessProj;
+typedef IfFalseNode ParsePredicateUncommonProj;
+
+// Assertion Predicates are either emitted to check the initial value of a range check in the first iteration or the last
+// value of a range check in the last iteration of a loop.
+enum class AssertionPredicateType {
+  None, // Not an Assertion Predicate
+  InitValue,
+  LastValue,
+  // Used for the Initialized Assertion Predicate emitted during Range Check Elimination for the final IV value.
+  FinalIv
+};
+
+enum class PredicateState {
+  // The Predicate is useless and will be cleaned up in the next round of IGVN. A useless Predicate is not visited
+  // anymore by PredicateVisitors. If a Predicate loses its connection to a loop head, it will be marked useless by
+  // EliminateUselessPredicates and cleaned up by the Value() methods of the associated Predicate IR nodes.
+  Useless,
+  // This state is used by EliminateUselessPredicates to temporarily mark a Predicate as neither useless nor useful.
+  // Outside EliminateUselessPredicates, a Predicate should never be MaybeUseful.
+  MaybeUseful,
+  // Default state: The Predicate is useful and will be visited by PredicateVisitors.
+  Useful
+};
+
+#endif // SHARE_OPTO_PREDICATES_ENUMS_HPP


### PR DESCRIPTION
This patch cleans the Parse and Template Assertion Predicate elimination code up. We now use a single `PredicateVisitor` and share code in a new `EliminateUselessPredicates` class which contains the code previously found in `PhaseIdealLoop::eliminate_useless_predicates()`.

### Unified Logic to Clean Up Parse and Template Assertion Predicates
We now use the following algorithm:
https://github.com/openjdk/jdk/blob/5e4b6ca0ddafa80eee60690caacd257b74305d4e/src/hotspot/share/opto/predicates.cpp#L1174-L1179

This is different from the old algorithm where we used a single boolean state `_useless`. But that does no longer work because when we first mark Template Assertion Predicates useless, we are no longer visiting them when iterating through predicates:

https://github.com/openjdk/jdk/blob/a21fa463c4f8d067c18c09a072f3cdfa772aea5e/src/hotspot/share/opto/predicates.hpp#L704-L708

We therefore require a third state. Thus, I introduced a new tri-state `PredicateState` that provides a special `MaybeUseful` value which we can set each Predicate to.

#### Ignoring Useless Parse Predicates
While working on this patch, I've noticed that we are always visiting Parse Predicates - even when they useless. We should change that to align it with what we have for the other Predicates (changed in JDK-8351280). To make this work, we also replace the `_useless` state in `ParsePredicateNode` with a new `PredicateState`.

#### Sharing Code for Parse and Template Assertion Predicates
With all the mentioned changes in place, I could nicely share code for the elimination of Parse and Template Assertion Predicates in `EliminateUselessPredicates` by using templates. The following additional changes were required:

- Changing the template parameter of `_template_assertion_predicate_opaques` to the more specific `OpaqueTemplateAssertionPredicateNode` type.
- Adding accessor methods to get the Predicate lists from `Compile`.
- Updating `ParsePredicate::mark_useless()` to pass in `PhaseIterGVN`, as done for Assertion Predicates

Note that we still do not directly replace the useless Predicates but rather mark them useless as initiated by JDK-8351280.

### Other Included Changes
- During the various refactoring steps, I somehow dropped the code to add newly cloned Template Assertion Predicate to the `_template_assertion_predicate_opaques` list. It was done directly in the old cloning methods. This is not relevant for correctness but could hinder some optimizations. I've added the code now in `Node::clone()` to make sure we do not miss any Template Assertion Predicates (similar to what we do for Parse Predicates already):
https://github.com/openjdk/jdk/blob/5e4b6ca0ddafa80eee60690caacd257b74305d4e/src/hotspot/share/opto/node.cpp#L514-L516
- Adding verification code to `TemplateAssertionPredicate::is_predicate()` and `InitializedAssertionPredicate::is_predicate()` to verify that when we find an `Opaque*AssertionPredicate` node that we also find the associated `Halt` node.
- Some small refactorings here and there like renamings.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350578](https://bugs.openjdk.org/browse/JDK-8350578): Refactor useless Parse and Template Assertion Predicate elimination code by using a PredicateVisitor (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [1508a3be](https://git.openjdk.org/jdk/pull/24013/files/1508a3be11c856aa26f46f805de93f5a8577c7f8)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**) Review applies to [1508a3be](https://git.openjdk.org/jdk/pull/24013/files/1508a3be11c856aa26f46f805de93f5a8577c7f8)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24013/head:pull/24013` \
`$ git checkout pull/24013`

Update a local copy of the PR: \
`$ git checkout pull/24013` \
`$ git pull https://git.openjdk.org/jdk.git pull/24013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24013`

View PR using the GUI difftool: \
`$ git pr show -t 24013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24013.diff">https://git.openjdk.org/jdk/pull/24013.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24013#issuecomment-2720161001)
</details>
