### PR TITLE
8351876: RISC-V: enable and fix some float round tests

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java
@@ -26,8 +26,8 @@
  * @bug 8279508
  * @summary Auto-vectorize Math.round API
  * @requires vm.compiler2.enabled
- * @requires vm.cpu.features ~= ".*avx.*"
- * @requires os.simpleArch == "x64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx.*") |
+ *           (os.simpleArch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @library /test/lib /
  * @run driver compiler.vectorization.TestRoundVectFloat
  */
@@ -49,7 +49,13 @@ public class TestRoundVectFloat {
   }
 
   @Test
-  @IR(applyIf = {"UseAVX", " > 1"}, counts = {IRNode.ROUND_VF , " > 0 "})
+  @IR(applyIfPlatform = {"x64", "true"},
+      applyIf = {"UseAVX", " > 1"},
+      counts = {IRNode.ROUND_VF , " > 0 "})
+  @IR(applyIfPlatform = {"riscv64", "true"},
+      applyIfCPUFeature = {"rvv", "true"},
+      applyIf = {"MaxVectorSize", ">= 32"},
+      counts = {IRNode.ROUND_VF , " > 0 "})
   public void test_round_float(int[] iout, float[] finp) {
       for (int i = 0; i < finp.length; i+=1) {
           iout[i] = Math.round(finp[i]);

--- a/test/hotspot/jtreg/compiler/vectorization/TestRoundVectRiscv64.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestRoundVectRiscv64.java
@@ -53,7 +53,8 @@ public class TestRoundVectRiscv64 {
   }
 
   @Test
-  @IR(counts = {IRNode.ROUND_VD, "> 0"})
+  @IR(counts = {IRNode.ROUND_VD, "> 0"},
+      applyIf = {"MaxVectorSize", ">= 64"})
   public void test_round_double(long[] lout, double[] dinp) {
       for (int i = 0; i < lout.length; i+=1) {
           lout[i] = Math.round(dinp[i]);
@@ -73,7 +74,8 @@ public class TestRoundVectRiscv64 {
   }
 
   @Test
-  @IR(counts = {IRNode.ROUND_VF, "> 0"})
+  @IR(counts = {IRNode.ROUND_VF, "> 0"},
+      applyIf = {"MaxVectorSize", ">= 32"})
   public void test_round_float(int[] iout, float[] finp) {
       for (int i = 0; i < finp.length; i+=1) {
           iout[i] = Math.round(finp[i]);


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?
It's a follow-up of https://github.com/openjdk/jdk/pull/23985.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351876](https://bugs.openjdk.org/browse/JDK-8351876): RISC-V: enable and fix some float round tests (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24015/head:pull/24015` \
`$ git checkout pull/24015`

Update a local copy of the PR: \
`$ git checkout pull/24015` \
`$ git pull https://git.openjdk.org/jdk.git pull/24015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24015`

View PR using the GUI difftool: \
`$ git pr show -t 24015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24015.diff">https://git.openjdk.org/jdk/pull/24015.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24015#issuecomment-2718557297)
</details>
