### PR TITLE
8351881: Tidy complains about missing "alt" attribute

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
@@ -110,11 +110,13 @@ public class TableOfContents {
                 .add(HtmlTree.SPAN(writer.contents.hideSidebar).add(Entity.NO_BREAK_SPACE))
                 .add(HtmlTree.of(HtmlTag.IMG)
                         .put(HtmlAttr.SRC, writer.pathToRoot.resolve(DocPaths.RESOURCE_FILES)
-                                .resolve(DocPaths.LEFT_SVG).getPath())));
+                                .resolve(DocPaths.LEFT_SVG).getPath())
+                        .put(HtmlAttr.ALT, writer.contents.hideSidebar.toString())));
         content.add(HtmlTree.BUTTON(HtmlStyles.showSidebar)
                 .add(HtmlTree.of(HtmlTag.IMG)
                         .put(HtmlAttr.SRC, writer.pathToRoot.resolve(DocPaths.RESOURCE_FILES)
-                                .resolve(DocPaths.RIGHT_SVG).getPath()))
+                                .resolve(DocPaths.RIGHT_SVG).getPath())
+                        .put(HtmlAttr.ALT, writer.contents.showSidebar.toString()))
                 .add(HtmlTree.SPAN(Entity.NO_BREAK_SPACE).add(writer.contents.showSidebar)));
         return content;
     }


### PR DESCRIPTION
Please review this change to add missing "alt" attributes to the left and right pointing angles used in the sidebar hide/show buttons and prevent `jdkCheckHtml.java` from failing.

TIA.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351881](https://bugs.openjdk.org/browse/JDK-8351881): Tidy complains about missing "alt" attribute (**Bug** - P4)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24016/head:pull/24016` \
`$ git checkout pull/24016`

Update a local copy of the PR: \
`$ git checkout pull/24016` \
`$ git pull https://git.openjdk.org/jdk.git pull/24016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24016`

View PR using the GUI difftool: \
`$ git pr show -t 24016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24016.diff">https://git.openjdk.org/jdk/pull/24016.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24016#issuecomment-2718717792)
</details>
