### PR TITLE
8351699: Problem list com/sun/jdi/JdbStopInNotificationThreadTest.java with ZGC

### DIFF
--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -37,4 +37,5 @@ sun/tools/jhsdb/SAGetoptTest.java                  8307393   generic-all
 sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java 8307393   generic-all
 sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java 8307393   generic-all
 
-com/sun/jdi/ThreadMemoryLeakTest.java          8307402 generic-all
+com/sun/jdi/ThreadMemoryLeakTest.java              8307402   generic-all
+com/sun/jdi/JdbStopInNotificationThreadTest.java   8351607   linux-all


### PR DESCRIPTION
Put JdbStopInNotificationThreadTest.java on ZGC problem list for all linux platforms. It seems to fail on every linux run with ZGC in our CI.

I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351699](https://bugs.openjdk.org/browse/JDK-8351699): Problem list com/sun/jdi/JdbStopInNotificationThreadTest.java with ZGC (**Sub-task** - P3)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24017/head:pull/24017` \
`$ git checkout pull/24017`

Update a local copy of the PR: \
`$ git checkout pull/24017` \
`$ git pull https://git.openjdk.org/jdk.git pull/24017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24017`

View PR using the GUI difftool: \
`$ git pr show -t 24017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24017.diff">https://git.openjdk.org/jdk/pull/24017.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24017#issuecomment-2718847677)
</details>
