### PR TITLE
8351871: Disable JIT compiler when dumping AOT cache with -XX:+AOTClassLinking

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -480,7 +480,12 @@ bool CDSConfig::check_vm_args_consistency(bool patch_mod_javabase, bool mode_fla
 
   if (is_dumping_static_archive()) {
     if (is_dumping_preimage_static_archive()) {
-      // Don't tweak execution mode
+      // Don't tweak execution mode -- we are in the app's training run so we want to respect the
+      // app's command-line as much as possible. JDK-8351778 doesn't apply as metaspaceShared.cpp
+      // will not patch Java heap objects during the training run.
+    } else if (AOTClassLinking) {
+      // Work around JDK-8351778 -- JIT may get confused after metaspaceShared.cpp patches heap objects.
+      Arguments::set_mode_flags(Arguments::_int);
     } else if (!mode_flag_cmd_line) {
       // By default, -Xshare:dump runs in interpreter-only mode, which is required for deterministic archive.
       //


### PR DESCRIPTION
Since [JDK-8348426](https://bugs.openjdk.org/browse/JDK-8348426), when creating the AOT cache with -XX:AOTMode=create, at the very end of normal Java execution, right before we enter the safepoint VM_PopulateDumpSharedSpace, we reset the states of a few Java objects.

Such reset operations can cause the JIT to observe inconsistent states.

While working on a proper fix, this PR is a work-around that disable the JIT during AOT cache creation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351871](https://bugs.openjdk.org/browse/JDK-8351871): Disable JIT compiler when dumping AOT cache with -XX:+AOTClassLinking (**Sub-task** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24019/head:pull/24019` \
`$ git checkout pull/24019`

Update a local copy of the PR: \
`$ git checkout pull/24019` \
`$ git pull https://git.openjdk.org/jdk.git pull/24019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24019`

View PR using the GUI difftool: \
`$ git pr show -t 24019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24019.diff">https://git.openjdk.org/jdk/pull/24019.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24019#issuecomment-2718989246)
</details>
