### PR TITLE
8351891: Disable TestBreakSignalThreadDump.java#with_jsig and XCheckJSig.java on static JDK

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/TestBreakSignalThreadDump.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestBreakSignalThreadDump.java
@@ -36,6 +36,7 @@
  * @bug 8292695
  * @summary Check that Ctrl-\ causes HotSpot VM to print a full thread dump when signal chaining is used.
  * @requires os.family != "windows" & os.family != "aix"
+ * @requires !jdk.static
  * @library /vmTestbase
  *          /test/lib
  * @run driver TestBreakSignalThreadDump load_libjsig

--- a/test/hotspot/jtreg/runtime/XCheckJniJsig/XCheckJSig.java
+++ b/test/hotspot/jtreg/runtime/XCheckJniJsig/XCheckJSig.java
@@ -29,6 +29,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @requires os.family == "linux" | os.family == "mac"
+ * @requires !jdk.static
  * @run driver XCheckJSig
  */
 


### PR DESCRIPTION
Please review this change that disables TestBreakSignalThreadDump.java#with_jsig and XCheckJSig.java on static JDK. Thanks