### PR TITLE
8351897: Extra closing curly brace typos in Javadoc

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -304,9 +304,9 @@ AC_DEFUN([FLAGS_SETUP_QUALITY_CHECKS],
 AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
 [
   if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
-    C_O_FLAG_HIGHEST_JVM="-O3 -mllvm -enable-constraint-elimination=0"
-    C_O_FLAG_HIGHEST="-O3 -mllvm -enable-constraint-elimination=0"
-    C_O_FLAG_HI="-O3 -mllvm -enable-constraint-elimination=0"
+    C_O_FLAG_HIGHEST_JVM="-O3"
+    C_O_FLAG_HIGHEST="-O3"
+    C_O_FLAG_HI="-O3"
     C_O_FLAG_NORM="-O2"
     C_O_FLAG_SIZE="-Os"
     C_O_FLAG_DEBUG="-O0"

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -304,9 +304,9 @@ AC_DEFUN([FLAGS_SETUP_QUALITY_CHECKS],
 AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
 [
   if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
-    C_O_FLAG_HIGHEST_JVM="-O3"
-    C_O_FLAG_HIGHEST="-O3"
-    C_O_FLAG_HI="-O3"
+    C_O_FLAG_HIGHEST_JVM="-O3 -mllvm -enable-constraint-elimination=0"
+    C_O_FLAG_HIGHEST="-O3 -mllvm -enable-constraint-elimination=0"
+    C_O_FLAG_HI="-O3 -mllvm -enable-constraint-elimination=0"
     C_O_FLAG_NORM="-O2"
     C_O_FLAG_SIZE="-Os"
     C_O_FLAG_DEBUG="-O0"

--- a/src/java.base/share/classes/java/lang/classfile/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/package-info.java
@@ -168,7 +168,7 @@
  * <p>
  * For nonstandard attributes, user-provided attribute mappers can be specified
  * through the use of the {@link
- * ClassFile.AttributeMapperOption#of(Function)}}
+ * ClassFile.AttributeMapperOption#of(Function)}
  * classfile option.  Implementations of custom attributes should extend {@link
  * CustomAttribute}.
  *
@@ -185,11 +185,11 @@
  * -- unrecognized or problematic original attributes (default is {@code PASS_ALL_ATTRIBUTES})</li>
  *   <li>{@link ClassFile.ClassHierarchyResolverOption#of(ClassHierarchyResolver)}
  * -- specify a custom class hierarchy resolver used by stack map generation</li>
- *   <li>{@link ClassFile.ConstantPoolSharingOption}}
+ *   <li>{@link ClassFile.ConstantPoolSharingOption}
  * -- share constant pool when transforming (default is {@code SHARED_POOL})</li>
- *   <li>{@link ClassFile.DeadCodeOption}}
+ *   <li>{@link ClassFile.DeadCodeOption}
  * -- patch out unreachable code (default is {@code PATCH_DEAD_CODE})</li>
- *   <li>{@link ClassFile.DeadLabelsOption}}
+ *   <li>{@link ClassFile.DeadLabelsOption}
  * -- filter unresolved labels (default is {@code FAIL_ON_DEAD_LABELS})</li>
  *   <li>{@link ClassFile.DebugElementsOption}
  * -- processing of debug information, such as local variable metadata (default is {@code PASS_DEBUG}) </li>

--- a/src/java.base/share/classes/java/net/NetworkInterface.java
+++ b/src/java.base/share/classes/java/net/NetworkInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -366,7 +366,7 @@ public final class NetworkInterface {
      * this machine.
      *
      * @apiNote This method can be used in combination with
-     * {@link #inetAddresses()}} to obtain a stream of all IP addresses for
+     * {@link #inetAddresses()} to obtain a stream of all IP addresses for
      * this node, for example:
      * <pre> {@code
      * Stream<InetAddress> addrs = NetworkInterface.networkInterfaces()

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -324,7 +324,7 @@ import java.util.Objects;
  *    <tr>
  *       <th scope="row" style="font-weight:normal">{@code unit}
  *       <td>{@link ListFormat#getInstance(Locale, ListFormat.Type, ListFormat.Style)
- *       ListFormat.getInstance}{@code (getLocale()}, {@link ListFormat.Type#UNIT}, {@link ListFormat.Style#FULL}}
+ *       ListFormat.getInstance}{@code (getLocale()}, {@link ListFormat.Type#UNIT}, {@link ListFormat.Style#FULL})
  * </tbody>
  * </table>
  *

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -316,15 +316,15 @@ import java.util.Objects;
  *       <th scope="row" style="font-weight:normal" rowspan=3>{@code list}
  *       <th scope="row" style="font-weight:normal"><i>(none)</i>
  *       <td>{@link ListFormat#getInstance(Locale, ListFormat.Type, ListFormat.Style)
- *       ListFormat.getInstance}{@code (getLocale()}, {@link ListFormat.Type#STANDARD}, {@link ListFormat.Style#FULL})
+ *       ListFormat.getInstance}{@code (getLocale()}, {@link ListFormat.Type#STANDARD}, {@link ListFormat.Style#FULL}{@code )}
  *    <tr>
  *       <th scope="row" style="font-weight:normal">{@code or}
  *       <td>{@link ListFormat#getInstance(Locale, ListFormat.Type, ListFormat.Style)
- *       ListFormat.getInstance}{@code (getLocale()}, {@link ListFormat.Type#OR}, {@link ListFormat.Style#FULL})
+ *       ListFormat.getInstance}{@code (getLocale()}, {@link ListFormat.Type#OR}, {@link ListFormat.Style#FULL}{@code )}
  *    <tr>
  *       <th scope="row" style="font-weight:normal">{@code unit}
  *       <td>{@link ListFormat#getInstance(Locale, ListFormat.Type, ListFormat.Style)
- *       ListFormat.getInstance}{@code (getLocale()}, {@link ListFormat.Type#UNIT}, {@link ListFormat.Style#FULL})
+ *       ListFormat.getInstance}{@code (getLocale()}, {@link ListFormat.Type#UNIT}, {@link ListFormat.Style#FULL}{@code )}
  * </tbody>
  * </table>
  *

--- a/src/java.base/share/classes/java/util/stream/AbstractTask.java
+++ b/src/java.base/share/classes/java/util/stream/AbstractTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -222,7 +222,7 @@ abstract class AbstractTask<P_IN, P_OUT, R,
 
     /**
      * Does nothing; instead, subclasses should use
-     * {@link #setLocalResult(Object)}} to manage results.
+     * {@link #setLocalResult(Object)} to manage results.
      *
      * @param result must be null, or an exception is thrown (this is a safety
      *        tripwire to detect when {@code setRawResult()} is being used

--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -833,7 +833,7 @@ public final class Collectors {
      * The {@code reducing()} collectors are most useful when used in a
      * multi-level reduction, downstream of {@code groupingBy} or
      * {@code partitioningBy}.  To perform a simple reduction on a stream,
-     * use {@link Stream#reduce(Object, BinaryOperator)}} instead.
+     * use {@link Stream#reduce(Object, BinaryOperator)} instead.
      *
      * @param <T> element type for the input and output of the reduction
      * @param identity the identity value for the reduction (also, the value


### PR DESCRIPTION
This PR fixes minor Javadoc typos in a few `java.base` classes. Extra curly braces have been sneaking in.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351897](https://bugs.openjdk.org/browse/JDK-8351897): Extra closing curly brace typos in Javadoc (**Bug** - P5)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24022/head:pull/24022` \
`$ git checkout pull/24022`

Update a local copy of the PR: \
`$ git checkout pull/24022` \
`$ git pull https://git.openjdk.org/jdk.git pull/24022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24022`

View PR using the GUI difftool: \
`$ git pr show -t 24022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24022.diff">https://git.openjdk.org/jdk/pull/24022.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24022#issuecomment-2719507493)
</details>
