### PR TITLE
4466930: JTable.selectAll boundary handling

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -2146,7 +2146,8 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         return getRowSelectionAllowed() && getColumnSelectionAllowed();
     }
 
-    private void selectRows(ListSelectionModel selModel, int rowCount) {
+    private void selectRows(int rowCount) {
+        ListSelectionModel selModel = selectionModel;
         selModel.setValueIsAdjusting(true);
         int oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), true);
         int oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), true);
@@ -2159,7 +2160,8 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         selModel.setValueIsAdjusting(false);
     }
 
-    private void selectColumns(ListSelectionModel  selModel, int columnCount) {
+    private void selectColumns(int columnCount) {
+        ListSelectionModel selModel = columnModel.getSelectionModel();
         selModel.setValueIsAdjusting(true);
         int oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), false);
         int oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), false);
@@ -2176,7 +2178,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      *  Selects all rows, columns, and cells in the table.
      */
     public void selectAll() {
-        ListSelectionModel selModel;
         int rowCount = getRowCount();
         int columnCount = getColumnCount();
 
@@ -2185,16 +2186,12 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             removeEditor();
         }
         if (rowCount > 0 && columnCount > 0) {
-            selModel = selectionModel;
-            selectRows(selModel, rowCount);
-            selModel = columnModel.getSelectionModel();
-            selectColumns(selModel, columnCount);
+            selectRows(rowCount);
+            selectColumns(columnCount);
         } else if (rowCount > 0 && columnCount == 0) {
-            selModel = selectionModel;
-            selectRows(selModel, rowCount);
+            selectRows(rowCount);
         } else if (columnCount > 0  && rowCount == 0) {
-            selModel = columnModel.getSelectionModel();
-            selectColumns(selModel, columnCount);
+            selectColumns(columnCount);
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -2146,6 +2146,33 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         return getRowSelectionAllowed() && getColumnSelectionAllowed();
     }
 
+    private void selectRows(ListSelectionModel selModel, int rowCount) {
+        selModel.setValueIsAdjusting(true);
+        int oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), true);
+        int oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), true);
+
+        setRowSelectionInterval(0, rowCount-1);
+
+        // this is done to restore the anchor and lead
+        SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
+
+        selModel.setValueIsAdjusting(false);
+    }
+
+    private void selectColumns(TableColumnModel  columnModel, int columnCount) {
+        ListSelectionModel selModel = columnModel.getSelectionModel();
+        selModel.setValueIsAdjusting(true);
+        int oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), false);
+        int oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), false);
+
+        setColumnSelectionInterval(0, columnCount-1);
+
+        // this is done to restore the anchor and lead
+        SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
+
+        selModel.setValueIsAdjusting(false);
+    }
+
     /**
      *  Selects all rows, columns, and cells in the table.
      */
@@ -2162,53 +2189,12 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             removeEditor();
         }
         if (rowCount > 0 && columnCount > 0) {
-            selModel = selectionModel;
-            selModel.setValueIsAdjusting(true);
-            oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), true);
-            oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), true);
-
-            setRowSelectionInterval(0, getRowCount()-1);
-
-            // this is done to restore the anchor and lead
-            SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
-
-            selModel.setValueIsAdjusting(false);
-
-            selModel = columnModel.getSelectionModel();
-            selModel.setValueIsAdjusting(true);
-            oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), false);
-            oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), false);
-
-            setColumnSelectionInterval(0, getColumnCount()-1);
-
-            // this is done to restore the anchor and lead
-            SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
-
-            selModel.setValueIsAdjusting(false);
+            selectRows(selectionModel, rowCount);
+            selectColumns(columnModel, columnCount);
         } else if (rowCount > 0 && columnCount == 0) {
-            selModel = selectionModel;
-            selModel.setValueIsAdjusting(true);
-            oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), true);
-            oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), true);
-
-            setRowSelectionInterval(0, getRowCount()-1);
-
-            // this is done to restore the anchor and lead
-            SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
-
-            selModel.setValueIsAdjusting(false);
+            selectRows(selectionModel, rowCount);
         } else if (columnCount > 0  && rowCount == 0) {
-            selModel = columnModel.getSelectionModel();
-            selModel.setValueIsAdjusting(true);
-            oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), false);
-            oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), false);
-
-            setColumnSelectionInterval(0, getColumnCount()-1);
-
-            // this is done to restore the anchor and lead
-            SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
-
-            selModel.setValueIsAdjusting(false);
+            selectColumns(columnModel, columnCount);
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -2151,7 +2151,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         int oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), true);
         int oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), true);
 
-        setRowSelectionInterval(0, rowCount-1);
+        setRowSelectionInterval(0, rowCount - 1);
 
         // this is done to restore the anchor and lead
         SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
@@ -2165,7 +2165,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         int oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), false);
         int oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), false);
 
-        setColumnSelectionInterval(0, columnCount-1);
+        setColumnSelectionInterval(0, columnCount - 1);
 
         // this is done to restore the anchor and lead
         SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
@@ -2177,10 +2177,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      *  Selects all rows, columns, and cells in the table.
      */
     public void selectAll() {
-        int oldLead;
-        int oldAnchor;
-        ListSelectionModel selModel;
-
         int rowCount = getRowCount();
         int columnCount = getColumnCount();
 

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -2189,9 +2189,13 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             selectRows(rowCount);
             selectColumns(columnCount);
         } else if (rowCount > 0 && columnCount == 0) {
-            selectRows(rowCount);
+            if (getRowSelectionAllowed()) {
+                selectRows(rowCount);
+            }
         } else if (columnCount > 0  && rowCount == 0) {
-            selectColumns(columnCount);
+            if (getColumnSelectionAllowed()) {
+                selectColumns(columnCount);
+            }
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -2154,11 +2154,14 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         int oldAnchor;
         ListSelectionModel selModel;
 
+        int rowCount = getRowCount();
+        int columnCount = getColumnCount();
+
         // If I'm currently editing, then I should stop editing
         if (isEditing()) {
             removeEditor();
         }
-        if (getRowCount() > 0 && getColumnCount() > 0) {
+        if (rowCount > 0 && columnCount > 0) {
             selModel = selectionModel;
             selModel.setValueIsAdjusting(true);
             oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), true);
@@ -2182,7 +2185,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
 
             selModel.setValueIsAdjusting(false);
-        } else if (getRowCount() > 0 && getColumnCount() == 0) {
+        } else if (rowCount > 0 && columnCount == 0) {
             selModel = selectionModel;
             selModel.setValueIsAdjusting(true);
             oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), true);
@@ -2194,7 +2197,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
 
             selModel.setValueIsAdjusting(false);
-        } else if (getColumnCount() > 0  && getRowCount() == 0) {
+        } else if (columnCount > 0  && rowCount == 0) {
             selModel = columnModel.getSelectionModel();
             selModel.setValueIsAdjusting(true);
             oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), false);

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -2188,14 +2188,12 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         if (rowCount > 0 && columnCount > 0) {
             selectRows(rowCount);
             selectColumns(columnCount);
-        } else if (rowCount > 0 && columnCount == 0) {
-            if (getRowSelectionAllowed()) {
-                selectRows(rowCount);
-            }
-        } else if (columnCount > 0  && rowCount == 0) {
-            if (getColumnSelectionAllowed()) {
-                selectColumns(columnCount);
-            }
+        } else if (rowCount > 0 && columnCount == 0
+                   && getRowSelectionAllowed()) {
+            selectRows(rowCount);
+        } else if (columnCount > 0  && rowCount == 0
+                   && getColumnSelectionAllowed()) {
+            selectColumns(columnCount);
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -2159,8 +2159,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
         selModel.setValueIsAdjusting(false);
     }
 
-    private void selectColumns(TableColumnModel  columnModel, int columnCount) {
-        ListSelectionModel selModel = columnModel.getSelectionModel();
+    private void selectColumns(ListSelectionModel  selModel, int columnCount) {
         selModel.setValueIsAdjusting(true);
         int oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), false);
         int oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), false);
@@ -2177,6 +2176,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      *  Selects all rows, columns, and cells in the table.
      */
     public void selectAll() {
+        ListSelectionModel selModel;
         int rowCount = getRowCount();
         int columnCount = getColumnCount();
 
@@ -2185,12 +2185,16 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             removeEditor();
         }
         if (rowCount > 0 && columnCount > 0) {
-            selectRows(selectionModel, rowCount);
-            selectColumns(columnModel, columnCount);
+            selModel = selectionModel;
+            selectRows(selModel, rowCount);
+            selModel = columnModel.getSelectionModel();
+            selectColumns(selModel, columnCount);
         } else if (rowCount > 0 && columnCount == 0) {
-            selectRows(selectionModel, rowCount);
+            selModel = selectionModel;
+            selectRows(selModel, rowCount);
         } else if (columnCount > 0  && rowCount == 0) {
-            selectColumns(columnModel, columnCount);
+            selModel = columnModel.getSelectionModel();
+            selectColumns(selModel, columnCount);
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2150,15 +2150,15 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      *  Selects all rows, columns, and cells in the table.
      */
     public void selectAll() {
+        int oldLead;
+        int oldAnchor;
+        ListSelectionModel selModel;
+
         // If I'm currently editing, then I should stop editing
         if (isEditing()) {
             removeEditor();
         }
         if (getRowCount() > 0 && getColumnCount() > 0) {
-            int oldLead;
-            int oldAnchor;
-            ListSelectionModel selModel;
-
             selModel = selectionModel;
             selModel.setValueIsAdjusting(true);
             oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), true);
@@ -2171,6 +2171,30 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
 
             selModel.setValueIsAdjusting(false);
 
+            selModel = columnModel.getSelectionModel();
+            selModel.setValueIsAdjusting(true);
+            oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), false);
+            oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), false);
+
+            setColumnSelectionInterval(0, getColumnCount()-1);
+
+            // this is done to restore the anchor and lead
+            SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
+
+            selModel.setValueIsAdjusting(false);
+        } else if (getRowCount() > 0 && getColumnCount() == 0) {
+            selModel = selectionModel;
+            selModel.setValueIsAdjusting(true);
+            oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), true);
+            oldAnchor = getAdjustedIndex(selModel.getAnchorSelectionIndex(), true);
+
+            setRowSelectionInterval(0, getRowCount()-1);
+
+            // this is done to restore the anchor and lead
+            SwingUtilities2.setLeadAnchorWithoutSelection(selModel, oldLead, oldAnchor);
+
+            selModel.setValueIsAdjusting(false);
+        } else if (getColumnCount() > 0  && getRowCount() == 0) {
             selModel = columnModel.getSelectionModel();
             selModel.setValueIsAdjusting(true);
             oldLead = getAdjustedIndex(selModel.getLeadSelectionIndex(), false);

--- a/test/jdk/javax/swing/JTable/TestTableSelectAll.java
+++ b/test/jdk/javax/swing/JTable/TestTableSelectAll.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4466930
+ * @key headful
+ * @summary Verifies selectAll selects all available rows and columns
+ *          irrespective of presence of columns and rows respectively
+ * @run main TestTableSelectAll
+ */
+
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+
+public class TestTableSelectAll {
+
+    public static void main(String[] args) throws Exception {
+
+        boolean colSelNoRow, colSelWithRow;
+
+        // TableModel with no rows, but 10 columns
+        DefaultTableModel data = new DefaultTableModel(0, 10);
+
+        JTable table = new JTable(data);
+
+        // columns can be selected
+        table.setColumnSelectionAllowed(true);
+        table.setRowSelectionAllowed(false);
+
+        table.selectAll();
+
+        colSelNoRow = table.isColumnSelected(0);
+
+        // After selectAll(), I would expect all columns to be selected, no matter
+        // whether there are rows or not.
+        System.out.println("Column 0 is selected: "+ colSelNoRow);
+
+        data.addRow(new Object[0]);
+
+        table.selectAll();
+
+        colSelWithRow = table.isColumnSelected(0);
+        System.out.println("Column 0 is selected: "+ colSelWithRow);
+
+        if (!(colSelNoRow && colSelWithRow)) {
+            throw new RuntimeException("selectAll did not select column");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JTable/TestTableSelectAll.java
+++ b/test/jdk/javax/swing/JTable/TestTableSelectAll.java
@@ -37,6 +37,11 @@ public class TestTableSelectAll {
 
     public static void main(String[] args) throws Exception {
 
+        testColumnSelect();
+        testRowSelect();
+    }
+
+    private static void testColumnSelect() {
         boolean colSelNoRow, colSelWithRow;
 
         // TableModel with no rows, but 10 columns
@@ -65,6 +70,37 @@ public class TestTableSelectAll {
 
         if (!(colSelNoRow && colSelWithRow)) {
             throw new RuntimeException("selectAll did not select column");
+        }
+    }
+
+    private static void testRowSelect() {
+        boolean rowSelNoColumn, rowSelWithColumn;
+
+        // TableModel with 10 rows, but no columns
+        DefaultTableModel data = new DefaultTableModel(10, 0);
+
+        JTable table = new JTable(data);
+
+        // columns can be selected
+        table.setRowSelectionAllowed(true);
+        table.setColumnSelectionAllowed(false);
+
+        table.selectAll();
+
+        rowSelNoColumn = table.isRowSelected(0);
+
+        // After selectAll(), I would expect all rows to be selected, no matter
+        // whether there are columns or not.
+        System.out.println("Row 0 is selected: "+ rowSelNoColumn);
+
+        data.addColumn(new Object[0]);
+        table.selectAll();
+
+        rowSelWithColumn = table.isRowSelected(0);
+        System.out.println("Row 0 is selected: "+ rowSelWithColumn);
+
+        if (!(rowSelNoColumn && rowSelWithColumn)) {
+            throw new RuntimeException("selectAll did not select row");
         }
     }
 }

--- a/test/jdk/javax/swing/JTable/TestTableSelectAll.java
+++ b/test/jdk/javax/swing/JTable/TestTableSelectAll.java
@@ -24,7 +24,6 @@
 /*
  * @test
  * @bug 4466930
- * @key headful
  * @summary Verifies selectAll selects all available rows and columns
  *          irrespective of presence of columns and rows respectively
  * @run main TestTableSelectAll

--- a/test/jdk/javax/swing/JTable/TestTableSelectAll.java
+++ b/test/jdk/javax/swing/JTable/TestTableSelectAll.java
@@ -42,7 +42,8 @@ public class TestTableSelectAll {
     }
 
     private static void testColumnSelect() {
-        boolean colSelNoRow, colSelWithRow;
+        boolean colSelNoRow;
+        boolean colSelWithRow;
 
         // TableModel with no rows, but 10 columns
         DefaultTableModel data = new DefaultTableModel(0, 10);
@@ -59,14 +60,14 @@ public class TestTableSelectAll {
 
         // After selectAll(), I would expect all columns to be selected, no matter
         // whether there are rows or not.
-        System.out.println("Column 0 is selected: "+ colSelNoRow);
+        System.out.println("Column 0 is selected: " + colSelNoRow);
 
         data.addRow(new Object[0]);
 
         table.selectAll();
 
         colSelWithRow = table.isColumnSelected(0);
-        System.out.println("Column 0 is selected: "+ colSelWithRow);
+        System.out.println("Column 0 is selected: " + colSelWithRow);
 
         if (!(colSelNoRow && colSelWithRow)) {
             throw new RuntimeException("selectAll did not select column");
@@ -74,14 +75,15 @@ public class TestTableSelectAll {
     }
 
     private static void testRowSelect() {
-        boolean rowSelNoColumn, rowSelWithColumn;
+        boolean rowSelNoColumn;
+        boolean rowSelWithColumn;
 
         // TableModel with 10 rows, but no columns
         DefaultTableModel data = new DefaultTableModel(10, 0);
 
         JTable table = new JTable(data);
 
-        // columns can be selected
+        // rows can be selected
         table.setRowSelectionAllowed(true);
         table.setColumnSelectionAllowed(false);
 
@@ -91,13 +93,13 @@ public class TestTableSelectAll {
 
         // After selectAll(), I would expect all rows to be selected, no matter
         // whether there are columns or not.
-        System.out.println("Row 0 is selected: "+ rowSelNoColumn);
+        System.out.println("Row 0 is selected: " + rowSelNoColumn);
 
         data.addColumn(new Object[0]);
         table.selectAll();
 
         rowSelWithColumn = table.isRowSelected(0);
-        System.out.println("Row 0 is selected: "+ rowSelWithColumn);
+        System.out.println("Row 0 is selected: " + rowSelWithColumn);
 
         if (!(rowSelNoColumn && rowSelWithColumn)) {
             throw new RuntimeException("selectAll did not select row");


### PR DESCRIPTION
JTable.selectAll doesn't do anything if there are no rows or no columns. 
But it should still select all columns if there are no rows and the other way round. 
It is seen that isColumnSelected() will return false for all columns after calling selectAll() if there happened to be no rows.

Fix is made to select all columns even if there are no rows and similarly for rows if there are no columns.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4466930](https://bugs.openjdk.org/browse/JDK-4466930): JTable.selectAll boundary handling (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**) Review applies to [50c27140](https://git.openjdk.org/jdk/pull/24025/files/50c27140bbace5758520cf8192522d30ba8ac002)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24025/head:pull/24025` \
`$ git checkout pull/24025`

Update a local copy of the PR: \
`$ git checkout pull/24025` \
`$ git pull https://git.openjdk.org/jdk.git pull/24025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24025`

View PR using the GUI difftool: \
`$ git pr show -t 24025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24025.diff">https://git.openjdk.org/jdk/pull/24025.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24025#issuecomment-2720348725)
</details>
