### PR TITLE
8351902: RISC-V: Several tests fail after JDK-8351145

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnSupportedCPU.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8035968
  * @summary Verify UseMD5Intrinsics option processing on supported CPU.
+ *          ( Disable this test on riscv, because on riscv UseMD5Intrinsics depends on !AvoidUnalignedAccesses. )
  * @library /test/lib /
  * @requires vm.flagless
  * @requires os.arch != "riscv64"

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnSupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify UseMD5Intrinsics option processing on supported CPU.
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires os.arch != "riscv64"
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify UseSHA1Intrinsics option processing on supported CPU.
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires os.arch != "riscv64"
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8035968
  * @summary Verify UseSHA1Intrinsics option processing on supported CPU.
+ *          ( Disable this test on riscv, because on riscv UseSHA1Intrinsics depends on !AvoidUnalignedAccesses. )
  * @library /test/lib /
  * @requires vm.flagless
  * @requires os.arch != "riscv64"

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnSupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify UseSHA option processing on supported CPU.
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires os.arch != "riscv64"
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnSupportedCPU.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8035968
  * @summary Verify UseSHA option processing on supported CPU.
+ *          ( Disable this test on riscv, because on riscv UseSHA could depend UseSHA1Intrinsics which depends on !AvoidUnalignedAccesses. )
  * @library /test/lib /
  * @requires vm.flagless
  * @requires os.arch != "riscv64"


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?
These client tests seems not that useful to me, so the simple solution could be just disable them on riscv.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351902](https://bugs.openjdk.org/browse/JDK-8351902): RISC-V: Several tests fail after JDK-8351145 (**Bug** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer) Review applies to [19b55777](https://git.openjdk.org/jdk/pull/24027/files/19b55777e4c4a02169a76ad3bd01f1d2a4d899ce)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24027/head:pull/24027` \
`$ git checkout pull/24027`

Update a local copy of the PR: \
`$ git checkout pull/24027` \
`$ git pull https://git.openjdk.org/jdk.git pull/24027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24027`

View PR using the GUI difftool: \
`$ git pr show -t 24027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24027.diff">https://git.openjdk.org/jdk/pull/24027.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24027#issuecomment-2720492840)
</details>
