### PR TITLE
8351661: NMT: VMATree should support separate call-stacks for reserve and commit operations

### DIFF
--- a/src/hotspot/share/nmt/nmtNativeCallStackStorage.hpp
+++ b/src/hotspot/share/nmt/nmtNativeCallStackStorage.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,17 +43,14 @@
 class NativeCallStackStorage : public CHeapObjBase {
 public:
   using StackIndex = int;
-
-private:
   constexpr static const StackIndex invalid = std::numeric_limits<StackIndex>::max() - 1;
 
-public:
   static bool equals(const StackIndex a, const StackIndex b) {
     return a == b;
   }
 
   static bool is_invalid(StackIndex a) {
-    return a == invalid;
+    return a == invalid || a < 0;
   }
 
 private:

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -91,10 +91,11 @@ private:
   private:
     // Store the type and mem_tag as two bytes
     uint8_t type_tag[2];
-    NativeCallStackStorage::StackIndex sidx;
+    NativeCallStackStorage::StackIndex sidx;       // call-stack of all operations
+    NativeCallStackStorage::StackIndex second_idx; // call-stack when committing/uncommitting the start-node of a reserved region
 
   public:
-    IntervalState() : type_tag{0,0}, sidx() {}
+    IntervalState() : type_tag{0,0}, sidx(), second_idx(NativeCallStackStorage::invalid) {}
     IntervalState(const StateType type, const RegionData data) {
       assert(!(type == StateType::Released) || data.mem_tag == mtNone, "Released state-type must have memory tag mtNone");
       type_tag[0] = static_cast<uint8_t>(type);
@@ -119,7 +120,19 @@ private:
     }
 
     NativeCallStackStorage::StackIndex stack() const {
-     return sidx;
+      return sidx;
+    }
+
+    NativeCallStackStorage::StackIndex second_stack() const {
+      return second_idx;
+    }
+
+    void set_stack(NativeCallStackStorage::StackIndex idx) {
+      sidx = idx;
+    }
+
+    void set_second_stack(NativeCallStackStorage::StackIndex idx) {
+      second_idx = idx;
     }
   };
 


### PR DESCRIPTION
In NMT detail mode, we need to have separate call-stacks for Reserve and Commit operations.
This PR adds a second stack to every node that will be used when committing (and uncommitting) the start node of a reserved region.