### PR TITLE
8351925: JFR: Microsecond time format precision for JFR tool

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -59,7 +59,7 @@ import jdk.jfr.internal.util.ValueFormatter;
  */
 public final class PrettyWriter extends EventPrintWriter {
     private static final String TYPE_OLD_OBJECT = Type.TYPES_PREFIX + "OldObject";
-    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS (yyyy-MM-dd)");
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSS (yyyy-MM-dd)");
     private static final Long ZERO = 0L;
     private boolean showIds;
     private RecordedEvent currentEvent;


### PR DESCRIPTION
Currently, JFR tool formats the times with millisecond precision:

```
jdk.ThreadSleep {
  startTime = 10:48:56.668 (2025-03-13)
  duration = 100 ms
  time = 100 ms
  eventThread = "main" (javaThreadId = 3)
  stackTrace = [...]
}
```

In modern world, a lot can happen within a millisecond. So it would be better to default to microsecond precision. Both timesources supported by JFR (RDTSC and os::elapsed_counter()) have enough enough precision to satisfy microsecond output, so microseconds are meaningful.

After the patch:

```
jdk.ThreadSleep {
  startTime = 11:23:32.314580 (2025-03-13)
  duration = 100 ms
  time = 100 ms
  eventThread = "main" (javaThreadId = 3)
  stackTrace = [...]
}
```

I think durations should also be more precise -- for example to compute the endTime precisely from (startTime+duration), but that is a more controversial/style question, so I would like to handle it separately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351925](https://bugs.openjdk.org/browse/JDK-8351925): JFR: Microsecond time format precision for JFR tool (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24029/head:pull/24029` \
`$ git checkout pull/24029`

Update a local copy of the PR: \
`$ git checkout pull/24029` \
`$ git pull https://git.openjdk.org/jdk.git pull/24029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24029`

View PR using the GUI difftool: \
`$ git pr show -t 24029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24029.diff">https://git.openjdk.org/jdk/pull/24029.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24029#issuecomment-2720750053)
</details>
