### PR TITLE
8351938: C2: Print compilation bailouts with PrintCompilation compile command

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2374,7 +2374,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
     if (CompilationLog::log() != nullptr) {
       CompilationLog::log()->log_failure(thread, task, failure_reason, retry_message);
     }
-    if (PrintCompilation) {
+    if (PrintCompilation || task->directive()->PrintCompilationOption) {
       FormatBufferResource msg = retry_message != nullptr ?
         FormatBufferResource("COMPILE SKIPPED: %s (%s)", failure_reason, retry_message) :
         FormatBufferResource("COMPILE SKIPPED: %s",      failure_reason);


### PR DESCRIPTION
We currently only print a compilation bailout with `-XX:+PrintCompilation`:
```
7782 90 b 4 Test::main (19 bytes)
7792 90 b 4 Test::main (19 bytes) COMPILE SKIPPED: StressBailout
```
But not when using `-XX:CompileCommand=printcompilation,*::*`. This patch enables this.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351938](https://bugs.openjdk.org/browse/JDK-8351938): C2: Print compilation bailouts with PrintCompilation compile command (**Enhancement** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Galder Zamarreño](https://openjdk.org/census#galder) (@galderz - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24031/head:pull/24031` \
`$ git checkout pull/24031`

Update a local copy of the PR: \
`$ git checkout pull/24031` \
`$ git pull https://git.openjdk.org/jdk.git pull/24031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24031`

View PR using the GUI difftool: \
`$ git pr show -t 24031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24031.diff">https://git.openjdk.org/jdk/pull/24031.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24031#issuecomment-2721059585)
</details>
