### PR TITLE
8352249: Remove incidental whitespace in traditional doc comments

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
@@ -1071,7 +1071,7 @@ public class JavacTrees extends DocTrees {
             }
 
             @Override
-            public Comment stripWhitespace() {
+            public Comment stripIndent() {
                 return this;
             }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
@@ -1071,6 +1071,11 @@ public class JavacTrees extends DocTrees {
             }
 
             @Override
+            public Comment stripWhitespace() {
+                return this;
+            }
+
+            @Override
             public JCDiagnostic.DiagnosticPosition getPos() {
                 return null;
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -158,7 +158,7 @@ public class DocCommentParser {
         this.fac = fac;
         this.diags = fac.log.diags;
         this.diagSource = diagSource;
-        this.comment = comment;
+        this.comment = comment.stripWhitespace();
         names = fac.names;
         this.isHtmlFile = isHtmlFile;
         textKind = isHtmlFile ? DocTree.Kind.TEXT : getTextKind(comment);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -158,7 +158,7 @@ public class DocCommentParser {
         this.fac = fac;
         this.diags = fac.log.diags;
         this.diagSource = diagSource;
-        this.comment = comment.stripWhitespace();
+        this.comment = comment.stripIndent();
         names = fac.names;
         this.isHtmlFile = isHtmlFile;
         textKind = isHtmlFile ? DocTree.Kind.TEXT : getTextKind(comment);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -1271,7 +1271,7 @@ public class JavaTokenizer extends UnicodeReader {
          *
          * @return comment with removed whitespace or this comment
          */
-        public Comment stripWhitespace() {
+        public Comment stripIndent() {
             return this;
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -1265,10 +1265,21 @@ public class JavaTokenizer extends UnicodeReader {
             return null;
         }
 
+        /**
+         * Return a version of this comment with incidental whitespace removed,
+         * or this comment if the operation is not supported.
+         *
+         * @return comment with removed whitespace or this comment
+         */
         public Comment stripWhitespace() {
             return this;
         }
 
+        /**
+         * Return the diagnostic position of this comment.
+         *
+         * @return diagnostic position
+         */
         public DiagnosticPosition getPos() {
             return pos;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -1265,6 +1265,10 @@ public class JavaTokenizer extends UnicodeReader {
             return null;
         }
 
+        public Comment stripWhitespace() {
+            return this;
+        }
+
         public DiagnosticPosition getPos() {
             return pos;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
@@ -423,14 +423,13 @@ public class JavadocTokenizer extends JavaTokenizer {
                     assert(Character.isWhitespace(txt.charAt(startOfLine)));
                     startOfLine++;
                 }
-                int next = startOfLine;
-                while (next < len - 1 && txt.charAt(next) != '\n') {
-                    next++;
+                i = startOfLine;
+                while (i < len - 1 && txt.charAt(i) != '\n') {
+                    i++;
                 }
 
                 strippedMap.add(sb.length(), startOfLine);
-                sb.append(txt, startOfLine, next + 1);
-                i = next;
+                sb.append(txt, startOfLine, i + 1);
             }
 
             text = sb.toString();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
@@ -415,14 +415,18 @@ public class JavadocTokenizer extends JavaTokenizer {
             StringBuilder sb = new StringBuilder(len);
             int startOfLine;
 
-            for (int i = 0; i < len - 1; i++) {
+            for (int i = 0; i < len; i++) {
                 startOfLine = i;
-                while (startOfLine < len - 1
+                while (startOfLine < len
                         && startOfLine < i + indent
                         && txt.charAt(startOfLine) != '\n') {
                     assert(Character.isWhitespace(txt.charAt(startOfLine)));
                     startOfLine++;
                 }
+                if (startOfLine == len) {
+                    break;
+                }
+
                 i = startOfLine;
                 while (i < len - 1 && txt.charAt(i) != '\n') {
                     i++;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
@@ -172,7 +172,7 @@ public class JavadocTokenizer extends JavaTokenizer {
         }
 
         @Override
-        public Comment stripWhitespace() {
+        public Comment stripIndent() {
             return StrippedComment.of(this);
         }
     }
@@ -476,7 +476,7 @@ public class JavadocTokenizer extends JavaTokenizer {
         }
 
         @Override
-        public Comment stripWhitespace() {
+        public Comment stripIndent() {
             return this;
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
@@ -391,7 +391,7 @@ public class JavadocTokenizer extends JavaTokenizer {
             int len = txt.length();
             int indent = Integer.MAX_VALUE;
 
-            for (int i = 0; i < len - 1; i++) {
+            for (int i = 0; i < len; i++) {
                 int next;
                 boolean inIndent = true;
                 for (next = i; next < len; next++) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
@@ -362,8 +362,8 @@ public class JavadocTokenizer extends JavaTokenizer {
 
     /**
      * A Comment derived from a JavadocComment with leading whitespace removed from all lines.
-     * The original comment's offsetMap is used to translate comment locations to positions
-     * in the source file.
+     * A new OffsetMap is used in combination with the OffsetMap of the original comment to
+     * translate comment locations to positions in the source file.
      *
      * Note: This class assumes new lines are encoded as {@code '\n'}, which is the case
      * for comments created by {@code JavadocTokenizer}.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
@@ -281,7 +281,7 @@ public class Tokens {
         }
 
         String getText();
-        Comment stripWhitespace();
+        Comment stripIndent();
         JCDiagnostic.DiagnosticPosition getPos();
         int getSourcePos(int index);
         CommentStyle getStyle();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
@@ -281,6 +281,7 @@ public class Tokens {
         }
 
         String getText();
+        Comment stripWhitespace();
         JCDiagnostic.DiagnosticPosition getPos();
         int getSourcePos(int index);
         CommentStyle getStyle();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
@@ -345,7 +345,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
             print('{');
             printTagName(node);
             String body = node.getBody().getBody();
-            if (!body.isEmpty() && !Character.isWhitespace(body.charAt(0))) {
+            if (!body.isEmpty() && body.charAt(0) != '\n') {
                 print(' ');
             }
             print(node.getBody());

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocTreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocTreeMaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocTreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocTreeMaker.java
@@ -237,6 +237,9 @@ public class DocTreeMaker implements DocTreeFactory {
             }
 
             @Override
+            public Comment stripWhitespace() { return this; }
+
+            @Override
             public CommentStyle getStyle() {
                 throw new UnsupportedOperationException(getClass() + ".getStyle");
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocTreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocTreeMaker.java
@@ -237,7 +237,7 @@ public class DocTreeMaker implements DocTreeFactory {
             }
 
             @Override
-            public Comment stripWhitespace() { return this; }
+            public Comment stripIndent() { return this; }
 
             @Override
             public CommentStyle getStyle() {

--- a/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
+++ b/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,8 +133,8 @@ public class TestAutoHeaderId extends JavadocTester {
                     """,
                 """
                     <h2 id="3-0-multi-line-heading-with-extra-whitespace-heading"> 3.0 Multi-line
-                           heading   with extra
-                                     whitespace</h2>""");
+                          heading   with extra
+                                    whitespace</h2>""");
     }
 
     private void checkSearchIndex() {

--- a/test/langtools/jdk/javadoc/doclet/testBreakIterator/TestBreakIterator.java
+++ b/test/langtools/jdk/javadoc/doclet/testBreakIterator/TestBreakIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,16 +70,16 @@ public class TestBreakIterator extends JavadocTester {
         checkOutput("pkg/BreakIteratorTest.html", true,
                 """
                     <div class="block">with an anchor for the
-                     <a href="../index-all.html">top level index</a>.</div>""");
+                    <a href="../index-all.html">top level index</a>.</div>""");
 
         checkOutput("pkg/BreakIteratorTest.html", true,
                 """
                     <div class="block">A constant indicating that the keyLocation is indeterminate
-                     or not relevant.</div>""");
+                    or not relevant.</div>""");
 
         checkOutput("pkg/BreakIteratorTest.html", true,
                 """
                     <div class="block">Inline tags <i><a href="../index-all.html">extending
-                     beyond the first sentence.</a></i></div>""");
+                    beyond the first sentence.</a></i></div>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testCRLineSeparator/TestCRLineSeparator.java
+++ b/test/langtools/jdk/javadoc/doclet/testCRLineSeparator/TestCRLineSeparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class TestCRLineSeparator extends JavadocTester {
 
         checkOutput("pkg/MyClass.html", true,
                 "Line 1\n"
-                + " Line 2");
+                + "Line 2");
     }
 
     // recursively copy files from fromDir to toDir, replacing newlines

--- a/test/langtools/jdk/javadoc/doclet/testDirectedInheritance/TestDirectedInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testDirectedInheritance/TestDirectedInheritance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testDirectedInheritance/TestDirectedInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testDirectedInheritance/TestDirectedInheritance.java
@@ -220,8 +220,8 @@ public class TestDirectedInheritance extends JavadocTester {
         checkExit(Exit.OK);
         new OutputChecker("x/E1.html").check("""
                 <div class="block">E1: main description
-                 I2: main description
-                 I1: main description</div>""", """
+                I2: main description
+                I1: main description</div>""", """
                 <dt>Throws:</dt>
                 <dd><code>F</code> - E1: description of an exception</dd>
                 <dd><code>F</code> - I2: first description of an exception</dd>

--- a/test/langtools/jdk/javadoc/doclet/testDocRootLink/TestDocRootLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocRootLink/TestDocRootLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,10 +59,10 @@ public class TestDocRootLink extends JavadocTester {
                 Refer <a href="../../technotes/guides/index.html">Here</a>""",
             """
                 This <a href="../pkg2/C2.html">Here</a> should not be replaced
-                 with an absolute link.""",
+                with an absolute link.""",
             """
                 Testing <a href="../technotes/guides/index.html">Link 1</a> and
-                 <a href="../pkg2/C2.html">Link 2</a>.""");
+                <a href="../pkg2/C2.html">Link 2</a>.""");
 
         checkOutput("pkg1/package-summary.html", true,
             """
@@ -102,10 +102,10 @@ public class TestDocRootLink extends JavadocTester {
                 Refer <a href="http://download.oracle.com/javase/7/docs/technotes/guides/index.html">Here</a>""",
             """
                 This <a href="../pkg1/C1.html">Here</a> should not be replaced
-                 with an absolute link.""",
+                with an absolute link.""",
             """
                 Testing <a href="../technotes/guides/index.html">Link 1</a> and
-                 <a href="../pkg1/C1.html">Link 2</a>.""");
+                <a href="../pkg1/C1.html">Link 2</a>.""");
 
         checkOutput("pkg2/package-summary.html", true,
             """

--- a/test/langtools/jdk/javadoc/doclet/testDocTreeDiags/MyTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocTreeDiags/MyTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testDocTreeDiags/MyTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocTreeDiags/MyTaglet.java
@@ -155,6 +155,7 @@ public class MyTaglet implements Taglet {
                 assert (s.length() > 2 * pad + 3) : ">>>" + s + "<<<";
                 int mid = s.length() / 2;
                 String detail = s.substring(mid - pad, mid) + "[" + s.charAt(mid) + "]" + s.substring(mid + 1, mid + pad + 1);
+                assert (!detail.contains("\n")) : "Can't handle newline in details";
                 // The diagnostic is reported at a position in a range of characters
                 // in the middle of the string; the characters are encoded within the
                 // message of the diagnostic, with {@code [ ]} surrounding the character

--- a/test/langtools/jdk/javadoc/doclet/testDocTreeDiags/TestDocTreeDiags.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocTreeDiags/TestDocTreeDiags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testDocTreeDiags/TestDocTreeDiags.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocTreeDiags/TestDocTreeDiags.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8268420
+ * @bug      8268420 8352249
  * @summary  new Reporter method to report a diagnostic within a DocTree node
  * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool

--- a/test/langtools/jdk/javadoc/doclet/testDocTreeDiags/TestDocTreeDiags.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocTreeDiags/TestDocTreeDiags.java
@@ -98,7 +98,7 @@ public class TestDocTreeDiags extends JavadocTester {
                         /**
                          * Sentence for method m(). More details for the method.
                          * Embedded {@link java.lang.Object} link.
-                         * And another <!-- unusual comment --> strange comment.
+                         * And yet another <!-- unusual comment --> strange comment.
                          * @scanMe
                          */
                          public void m() { }

--- a/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/TestGenericTypeLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/TestGenericTypeLink.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug     8177280 8262992 8259499 8307377
+ * @bug     8177280 8262992 8259499 8307377 8352249
  * @summary see and link tag syntax should allow generic types
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool

--- a/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/TestGenericTypeLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/TestGenericTypeLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,13 +56,13 @@ public class TestGenericTypeLink extends JavadocTester {
                     ist.html" title="class or interface in java.util" class="external-link">List</a>&lt\
                     ;<a href="http://example.com/docs/api/java.base/java/lang/String.html" title="class\
                      or interface in java.lang" class="external-link">String</a>&gt;</code>
-                     <a href="http://example.com/docs/api/java.base/java/util/List.html" title="class o\
+                    <a href="http://example.com/docs/api/java.base/java/util/List.html" title="class o\
                     r interface in java.util" class="external-link">List</a>&lt;? extends <a href="http\
                     ://example.com/docs/api/java.base/java/lang/CharSequence.html" title="class or inte\
                     rface in java.lang" class="external-link">CharSequence</a>&gt;
-                     <a href="#someMethod(java.util.List,int)"><code>someMethod(ArrayList&lt;Integer&gt\
+                    <a href="#someMethod(java.util.List,int)"><code>someMethod(ArrayList&lt;Integer&gt\
                     ;, int)</code></a>
-                     <a href="#otherMethod(java.util.Map,double)"><code>otherMethod(Map&lt;String, Stri\
+                    <a href="#otherMethod(java.util.Map,double)"><code>otherMethod(Map&lt;String, Stri\
                     ngBuilder&gt;, double)</code></a></div>
                     """,
 
@@ -99,7 +99,7 @@ public class TestGenericTypeLink extends JavadocTester {
                     ttp://example.com/docs/api/java.base/java/lang/String.html" title="class or interfa\
                     ce in java.lang" class="external-link">String</a>, <a href="A.SomeException.htm\
                     l" title="class in pkg1">A.SomeException</a>&gt;</code>
-                     <a href="http://example.com/docs/api/java.base/java/util/Map.html" title="class or\
+                    <a href="http://example.com/docs/api/java.base/java/util/Map.html" title="class or\
                      interface in java.util" class="external-link">link to generic type with label</a>\
                     </div>""",
                 """
@@ -172,13 +172,11 @@ public class TestGenericTypeLink extends JavadocTester {
                     <pre><code>java.util.Foo&lt;String&gt;</code></pre>
                     </details>
 
-                    \s
                     <details class="invalid-tag">
                     <summary>invalid reference</summary>
                     <pre>Baz&lt;Object&gt;</pre>
                     </details>
 
-                    \s
                     <details class="invalid-tag">
                     <summary>invalid reference</summary>
                     <pre><code>#b(List&lt;Integer&gt;)</code></pre>

--- a/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,15 +184,15 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd><code>test</code> - boolean value</dd>
                     <dt>Throws:</dt>
                     <dd><code>java.lang.IllegalArgumentException</code> - if the <code>owner</code>'s
-                         <code>GraphicsConfiguration</code> is not from a screen device</dd>
+                        <code>GraphicsConfiguration</code> is not from a screen device</dd>
                     <dd><code>java.awt.HeadlessException</code></dd>
                     </dl>""",
                 """
                     <dl class="notes">
                     <dt>Parameters:</dt>
                     <dd><code>undecorated</code> - <code>true</code> if no decorations are
-                             to be enabled;
-                             <code>false</code> if decorations are to be enabled.</dd>
+                            to be enabled;
+                            <code>false</code> if decorations are to be enabled.</dd>
                     <dt>Since:</dt>
                     <dd>1.4</dd>
                     <dt>See Also:</dt>
@@ -238,7 +238,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                 """
                     <span class="deprecated-label">Deprecated.</span>
                     <div class="deprecation-comment">As of JDK version 1.5, replaced by
-                     <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
+                    <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
                     </div>
                     <div class="block">This field indicates whether the C1 is undecorated.</div>
                     <dl class="notes">
@@ -254,7 +254,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                 """
                     <span class="deprecated-label">Deprecated.</span>
                     <div class="deprecation-comment">As of JDK version 1.5, replaced by
-                     <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
+                    <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
                     </div>
                     <div class="block">Reads the object stream.</div>
                     <dl class="notes">
@@ -303,15 +303,15 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <dd><code>test</code> - boolean value</dd>
                     <dt>Throws:</dt>
                     <dd><code>java.lang.IllegalArgumentException</code> - if the <code>owner</code>'s
-                         <code>GraphicsConfiguration</code> is not from a screen device</dd>
+                        <code>GraphicsConfiguration</code> is not from a screen device</dd>
                     <dd><code>java.awt.HeadlessException</code></dd>
                     </dl>""",
                 """
                     <dl class="notes">
                     <dt>Parameters:</dt>
                     <dd><code>undecorated</code> - <code>true</code> if no decorations are
-                             to be enabled;
-                             <code>false</code> if decorations are to be enabled.</dd>
+                            to be enabled;
+                            <code>false</code> if decorations are to be enabled.</dd>
                     <dt>Since:</dt>
                     <dd>1.4</dd>
                     <dt>See Also:</dt>
@@ -348,7 +348,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                 """
                     <span class="deprecated-label">Deprecated.</span>
                     <div class="deprecation-comment">As of JDK version 1.5, replaced by
-                     <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
+                    <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
                     </div>
                     <div class="block">This field indicates whether the C1 is undecorated.</div>
                     <dl class="notes">
@@ -364,7 +364,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                 """
                     <span class="deprecated-label">Deprecated.</span>
                     <div class="deprecation-comment">As of JDK version 1.5, replaced by
-                     <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
+                    <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
                     </div>
                     <div class="block">Reads the object stream.</div>
                     <dl class="notes">
@@ -412,13 +412,13 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <pre>boolean undecorated</pre>
                     <div class="deprecation-block"><span class="deprecated-label">Deprecated.</span>
                     <div class="deprecation-comment">As of JDK version 1.5, replaced by
-                     <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
+                    <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
                     </div>
                     </li>""",
                 """
                     <span class="deprecated-label">Deprecated.</span>
                     <div class="deprecation-comment">As of JDK version 1.5, replaced by
-                     <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
+                    <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
                     </div>
                     </li>""");
     }

--- a/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 6786690 6820360 8025633 8026567 8175200 8183511 8186332 8074407 8182765
- *      8230136
+ *      8230136 8352249
  * @summary This test verifies the nesting of definition list tags.
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTag/TestHtmlTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTag/TestHtmlTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,46 +116,46 @@ public class TestHtmlTag extends JavadocTester {
         checkOutput("pkg3/A.DatatypeFactory.html", true,
                 """
                     <div class="block"><p>
-                     Factory that creates new <code>javax.xml.datatype</code>
-                     <code>Object</code>s that map XML to/from Java <code>Object</code>s.</p>
+                    Factory that creates new <code>javax.xml.datatype</code>
+                    <code>Object</code>s that map XML to/from Java <code>Object</code>s.</p>
 
-                     <p id="DatatypeFactory.newInstance">
-                     A new instance of the <code>DatatypeFactory</code> is created through the
-                     <a href="#newInstance()"><code>newInstance()</code></a> method that uses the following implementation
-                     resolution mechanisms to determine an implementation:</p>
-                     <ol>
-                     <li>
-                     If the system property specified by <a href="#DATATYPEFACTORY_PROPERTY"><code>DATATYPEFACTORY_PROPERTY</code></a>,
-                     "<code>javax.xml.datatype.DatatypeFactory</code>", exists, a class with
-                     the name of the property value is instantiated. Any Exception thrown
-                     during the instantiation process is wrapped as a
-                     <code>IllegalStateException</code>.
-                     </li>
-                     <li>
-                     If the file ${JAVA_HOME}/lib/jaxp.properties exists, it is loaded in a
-                     <code>Properties</code> <code>Object</code>. The
-                     <code>Properties</code> <code>Object </code> is then queried for the
-                     property as documented in the prior step and processed as documented in
-                     the prior step.
-                     </li>
-                     <li>
-                     Uses the service-provider loading facilities, defined by the
-                     <code>ServiceLoader</code> class, to attempt to locate and load an
-                     implementation of the service using the default loading mechanism:
-                     the service-provider loading facility will use the current thread's context class loader
-                     to attempt to load the service. If the context class loader is null, the system class loader will be used.
-                     <br>
-                     In case of <code>service configuration error</code> a
-                     <code>DatatypeConfigurationException</code> will be thrown.
-                     </li>
-                     <li>
-                     The final mechanism is to attempt to instantiate the <code>Class</code>
-                     specified by <a href="#DATATYPEFACTORY_IMPLEMENTATION_CLASS"><code>DATATYPEFACT\
+                    <p id="DatatypeFactory.newInstance">
+                    A new instance of the <code>DatatypeFactory</code> is created through the
+                    <a href="#newInstance()"><code>newInstance()</code></a> method that uses the following implementation
+                    resolution mechanisms to determine an implementation:</p>
+                    <ol>
+                    <li>
+                    If the system property specified by <a href="#DATATYPEFACTORY_PROPERTY"><code>DATATYPEFACTORY_PROPERTY</code></a>,
+                    "<code>javax.xml.datatype.DatatypeFactory</code>", exists, a class with
+                    the name of the property value is instantiated. Any Exception thrown
+                    during the instantiation process is wrapped as a
+                    <code>IllegalStateException</code>.
+                    </li>
+                    <li>
+                    If the file ${JAVA_HOME}/lib/jaxp.properties exists, it is loaded in a
+                    <code>Properties</code> <code>Object</code>. The
+                    <code>Properties</code> <code>Object </code> is then queried for the
+                    property as documented in the prior step and processed as documented in
+                    the prior step.
+                    </li>
+                    <li>
+                    Uses the service-provider loading facilities, defined by the
+                    <code>ServiceLoader</code> class, to attempt to locate and load an
+                    implementation of the service using the default loading mechanism:
+                    the service-provider loading facility will use the current thread's context class loader
+                    to attempt to load the service. If the context class loader is null, the system class loader will be used.
+                    <br>
+                    In case of <code>service configuration error</code> a
+                    <code>DatatypeConfigurationException</code> will be thrown.
+                    </li>
+                    <li>
+                    The final mechanism is to attempt to instantiate the <code>Class</code>
+                    specified by <a href="#DATATYPEFACTORY_IMPLEMENTATION_CLASS"><code>DATATYPEFACT\
                     ORY_IMPLEMENTATION_CLASS</code></a>. Any Exception
-                     thrown during the instantiation process is wrapped as a
-                     <code>IllegalStateException</code>.
-                     </li>
-                     </ol></div>""");
+                    thrown during the instantiation process is wrapped as a
+                    <code>IllegalStateException</code>.
+                    </li>
+                    </ol></div>""");
 
         checkOutput("pkg3/A.ActivationDesc.html", true,
                 """
@@ -164,21 +164,21 @@ public class TestHtmlTag extends JavadocTester {
                     <span class="extends-implements">extends java.lang.Object
                     implements java.io.Serializable</span></div>
                     <div class="block">An activation descriptor contains the information necessary to activate
-                     an object: <ul>
-                     <li> the object's group identifier,
-                     <li> the object's fully-qualified class name,
-                     <li> the object's code location (the location of the class), a codebase
-                     URL path,
-                     <li> the object's restart "mode", and,
-                     <li> a "marshalled" object that can contain object specific
-                     initialization data. </ul>
+                    an object: <ul>
+                    <li> the object's group identifier,
+                    <li> the object's fully-qualified class name,
+                    <li> the object's code location (the location of the class), a codebase
+                    URL path,
+                    <li> the object's restart "mode", and,
+                    <li> a "marshalled" object that can contain object specific
+                    initialization data. </ul>
 
-                     <p>
-                     A descriptor registered with the activation system can be used to
-                     recreate/activate the object specified by the descriptor. The
-                     <code>MarshalledObject</code> in the object's descriptor is passed as the
-                     second argument to the remote object's constructor for object to use
-                     during reinitialization/activation.</div>""");
+                    <p>
+                    A descriptor registered with the activation system can be used to
+                    recreate/activate the object specified by the descriptor. The
+                    <code>MarshalledObject</code> in the object's descriptor is passed as the
+                    second argument to the remote object's constructor for object to use
+                    during reinitialization/activation.</div>""");
 
         checkOutput("pkg3/A.ActivationGroupID.html", true,
                 """
@@ -187,16 +187,16 @@ public class TestHtmlTag extends JavadocTester {
                     <span class="extends-implements">extends java.lang.Object
                     implements java.io.Serializable</span></div>
                     <div class="block">The identifier for a registered activation group serves several purposes:
-                     <ul>
-                     <li>identifies the group uniquely within the activation system, and
-                     <li>contains a reference to the group's activation system so that the
-                     group can contact its activation system when necessary.</ul><p>
+                    <ul>
+                    <li>identifies the group uniquely within the activation system, and
+                    <li>contains a reference to the group's activation system so that the
+                    group can contact its activation system when necessary.</ul><p>
 
-                     The <code>ActivationGroupID</code> is returned from the call to
-                     <code>ActivationSystem.registerGroup</code> and is used to identify the
-                     group within the activation system. This group id is passed as one of the
-                     arguments to the activation group's special constructor when an
-                     activation group is created/recreated.</div>
+                    The <code>ActivationGroupID</code> is returned from the call to
+                    <code>ActivationSystem.registerGroup</code> and is used to identify the
+                    group within the activation system. This group id is passed as one of the
+                    arguments to the activation group's special constructor when an
+                    activation group is created/recreated.</div>
                     <dl class="notes">""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTag/TestHtmlTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTag/TestHtmlTag.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6786682 4649116 8182765 8261976
+ * @bug 6786682 4649116 8182765 8261976 8352249
  * @summary This test verifies the use of lang attribute by <HTML>.
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ public class TestJavaFX extends JavadocTester {
                     r-name-link">rate</a></code></div>
                     <div class="col-last odd-row-color">
                     <div class="block">Defines the direction/speed at which the <code>Timeline</code> is expected to
-                     be played.</div>""",
+                    be played.</div>""",
                 "<dt>Default value:</dt>",
                 """
                     <dt>Since:</dt>
@@ -154,7 +154,7 @@ public class TestJavaFX extends JavadocTester {
                     span class="return-type"><a href="C.DoubleProperty.html" title="class in pkg1">C\
                     .DoubleProperty</a></span>&nbsp;<span class="element-name">rateProperty</span></div>
                     <div class="block">Defines the direction/speed at which the <code>Timeline</code> is expected to
-                     be played. This is the second line.</div>""",
+                    be played. This is the second line.</div>""",
                 """
                     <section class="detail" id="setRate(double)">
                     <h3>setRate</h3>
@@ -166,7 +166,7 @@ public class TestJavaFX extends JavadocTester {
                     <dl class="notes">
                     <dt>Property description:</dt>
                     <dd>Defines the direction/speed at which the <code>Timeline</code> is expected to
-                     be played. This is the second line.</dd>
+                    be played. This is the second line.</dd>
                     <dt>Default value:</dt>
                     <dd>11</dd>
                     <dt>Parameters:</dt>
@@ -184,7 +184,7 @@ public class TestJavaFX extends JavadocTester {
                     <dl class="notes">
                     <dt>Property description:</dt>
                     <dd>Defines the direction/speed at which the <code>Timeline</code> is expected to
-                     be played. This is the second line.</dd>
+                    be played. This is the second line.</dd>
                     <dt>Default value:</dt>
                     <dd>11</dd>
                     <dt>Returns:</dt>

--- a/test/langtools/jdk/javadoc/doclet/testLeadingSpaces/LeadingSpaces.java
+++ b/test/langtools/jdk/javadoc/doclet/testLeadingSpaces/LeadingSpaces.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4232882 8014636
+ * @bug 4232882 8014636 8352249
  * @summary Javadoc strips all of the leading spaces when the comment
  *    does not begin with a star.  This RFE allows users to
  *    begin their comment without a leading star without leading

--- a/test/langtools/jdk/javadoc/doclet/testLeadingSpaces/LeadingSpaces.java
+++ b/test/langtools/jdk/javadoc/doclet/testLeadingSpaces/LeadingSpaces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,13 +54,14 @@ public class LeadingSpaces extends JavadocTester {
         checkExit(Exit.OK);
         checkOutput("LeadingSpaces.html", true,
                   """
-                      \s       1
-                                2
-                                  3
-                                    4
-                                      5
-                                        6
-                                          7""");
+                      <pre>
+                       1
+                         2
+                           3
+                             4
+                               5
+                                 6
+                                   7""");
     }
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,13 +104,13 @@ public class TestLinkOption extends JavadocTester {
                     <dd>
                     <ul class="tag-list-long">
                     <li><a href="http://www.ietf.org/rfc/rfc2279.txt"><i>RFC&nbsp;2279: UTF-8, a
-                     transformation format of ISO 10646</i></a></li>
+                    transformation format of ISO 10646</i></a></li>
                     <li><a href="http://www.ietf.org/rfc/rfc2373.txt"><i>RFC&nbsp;2373: IPv6 Addressing
-                     Architecture</i></a></li>
+                    Architecture</i></a></li>
                     <li><a href="http://www.ietf.org/rfc/rfc2396.txt"><i>RFC&nbsp;2396: Uniform
-                     Resource Identifiers (URI): Generic Syntax</i></a></li>
+                    Resource Identifiers (URI): Generic Syntax</i></a></li>
                     <li><a href="http://www.ietf.org/rfc/rfc2732.txt"><i>RFC&nbsp;2732: Format for
-                     Literal IPv6 Addresses in URLs</i></a></li>
+                    Literal IPv6 Addresses in URLs</i></a></li>
                     <li><a href="C.html">A nearby file</a></li>
                     </ul>
                     </dd>
@@ -167,11 +167,11 @@ public class TestLinkOption extends JavadocTester {
                     ass="element-name type-name-label">A</span>
                     <span class="extends-implements">extends java.lang.Object</span></div>
                     <div class="block">Test links.
-                     <br>
-                     <a href="../../out2/pkg2/C2.html" title="class or interface in pkg2" class="ext\
+                    <br>
+                    <a href="../../out2/pkg2/C2.html" title="class or interface in pkg2" class="ext\
                     ernal-link"><code>link to pkg2.C2</code></a>
-                     <br>
-                     <a href="../../out1/mylib/lang/StringBuilderChild.html" title="class or interfa\
+                    <br>
+                    <a href="../../out1/mylib/lang/StringBuilderChild.html" title="class or interfa\
                     ce in mylib.lang" class="external-link"><code>link to mylib.lang.StringBuilderCh\
                     ild</code></a>.</div>
                     """
@@ -192,11 +192,11 @@ public class TestLinkOption extends JavadocTester {
                     ass="element-name type-name-label">A</span>
                     <span class="extends-implements">extends java.lang.Object</span></div>
                     <div class="block">Test links.
-                     <br>
-                     <a href="../../copy/out2/pkg2/C2.html" title="class or interface in pkg2" class\
+                    <br>
+                    <a href="../../copy/out2/pkg2/C2.html" title="class or interface in pkg2" class\
                     ="external-link"><code>link to pkg2.C2</code></a>
-                     <br>
-                     <a href="../../copy/out1/mylib/lang/StringBuilderChild.html" title="class or in\
+                    <br>
+                    <a href="../../copy/out1/mylib/lang/StringBuilderChild.html" title="class or in\
                     terface in mylib.lang" class="external-link"><code>link to mylib.lang.StringBuil\
                     derChild</code></a>.</div>
                     """

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTaglet.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      4732864 6280605 7064544 8014636 8016328 8025633 8071982 8182765
- *           8274781 8345664
+ *           8274781 8345664 8352249
  * @summary  Make sure that you can link from one member to another using
  *           non-qualified name, furthermore, ensure the right one is linked.
  * @library  ../../lib

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,31 +53,31 @@ public class TestLinkTaglet extends JavadocTester {
         checkOutput("pkg/package-summary.html", true,
                 """
                     Qualified Link: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
-                     Unqualified Link1: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
-                     Unqualified Link2: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
-                     Qualified Link: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(pkg.\
+                    Unqualified Link1: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
+                    Unqualified Link2: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
+                    Qualified Link: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(pkg.\
                     C.InnerC, pkg.C.InnerC2)</code></a>.<br/>
-                     Unqualified Link: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(C.InnerC, C.InnerC2)</code></a>.<br/>
-                     Unqualified Link: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(InnerC, InnerC2)</code></a>.<br/>
-                     Link w/o Signature: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(C.InnerC, C.InnerC2)</code></a>.<br/>
-                     Package Link: <a href="package-summary.html"><code>pkg</code></a>.<br/>""");
+                    Unqualified Link: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(C.InnerC, C.InnerC2)</code></a>.<br/>
+                    Unqualified Link: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(InnerC, InnerC2)</code></a>.<br/>
+                    Link w/o Signature: <a href="C.html#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>C.method(C.InnerC, C.InnerC2)</code></a>.<br/>
+                    Package Link: <a href="package-summary.html"><code>pkg</code></a>.<br/>""");
         checkOutput("pkg/C.html", true,
                 """
                     Qualified Link: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
-                     Unqualified Link1: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
-                     Unqualified Link2: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
-                     Qualified Link: <a href="#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>method(pkg.\
+                    Unqualified Link1: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
+                    Unqualified Link2: <a href="C.InnerC.html" title="class in pkg"><code>C.InnerC</code></a>.<br/>
+                    Qualified Link: <a href="#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>method(pkg.\
                     C.InnerC, pkg.C.InnerC2)</code></a>.<br/>
-                     Unqualified Link: <a href="#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>method(C.InnerC, C.InnerC2)</code></a>.<br/>
-                     Unqualified Link: <a href="#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>method(InnerC, InnerC2)</code></a>.<br/>
-                     Link w/o Signature: <a href="#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>method(C.InnerC, C.InnerC2)</code></a>.<br/>
-                     Package Link: <a href="package-summary.html"><code>pkg</code></a>.<br/>""");
+                    Unqualified Link: <a href="#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>method(C.InnerC, C.InnerC2)</code></a>.<br/>
+                    Unqualified Link: <a href="#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>method(InnerC, InnerC2)</code></a>.<br/>
+                    Link w/o Signature: <a href="#method(pkg.C.InnerC,pkg.C.InnerC2)"><code>method(C.InnerC, C.InnerC2)</code></a>.<br/>
+                    Package Link: <a href="package-summary.html"><code>pkg</code></a>.<br/>""");
 
         checkOutput("pkg/C.InnerC.html", true,
                 """
                     Link to member in outer class: <a href="C.html#MEMBER"><code>C.MEMBER</code></a> <br/>
-                     Link to member in inner class: <a href="C.InnerC2.html#MEMBER2"><code>C.InnerC2.MEMBER2</code></a> <br/>
-                     Link to another inner class: <a href="C.InnerC2.html" title="class in pkg"><code>C.InnerC2</code></a>""");
+                    Link to member in inner class: <a href="C.InnerC2.html#MEMBER2"><code>C.InnerC2.MEMBER2</code></a> <br/>
+                    Link to another inner class: <a href="C.InnerC2.html" title="class in pkg"><code>C.InnerC2</code></a>""");
 
         checkOutput("pkg/C.InnerC2.html", true,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletPrimitive.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletPrimitive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletPrimitive.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletPrimitive.java
@@ -74,13 +74,13 @@ public class TestLinkTagletPrimitive extends JavadocTester {
         checkOutput("C.html", true,
                 """
                     <div class="block">Comment.
-                     Byte:\s
+                    Byte:\s
                     <details class="invalid-tag">
                     <summary>invalid reference</summary>
                     <pre><code>byte</code></pre>
                     </details>
 
-                     Void:\s
+                    Void:\s
                     <details class="invalid-tag">
                     <summary>invalid reference</summary>
                     <pre><code>void</code></pre>
@@ -119,13 +119,13 @@ public class TestLinkTagletPrimitive extends JavadocTester {
         checkOutput("C.html", true,
                 """
                     <div class="block">Comment.
-                     Double:\s
+                    Double:\s
                     <details class="invalid-tag">
                     <summary>invalid reference</summary>
                     <pre><code>double</code></pre>
                     </details>
 
-                     Void:\s
+                    Void:\s
                     <details class="invalid-tag">
                     <summary>invalid reference</summary>
                     <pre><code>void</code></pre>
@@ -172,7 +172,7 @@ public class TestLinkTagletPrimitive extends JavadocTester {
         checkOutput("C.html", true,
                 """
                     <div class="block">Comment.
-                     Byte[]:\s
+                    Byte[]:\s
                     <details class="invalid-tag">
                     <summary>invalid reference</summary>
                     <pre><code>byte[]</code></pre>
@@ -209,7 +209,7 @@ public class TestLinkTagletPrimitive extends JavadocTester {
         checkOutput("C.html", true,
                 """
                     <div class="block">Comment.
-                     Double[]:\s
+                    Double[]:\s
                     <details class="invalid-tag">
                     <summary>invalid reference</summary>
                     <pre><code>double[]</code></pre>

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletWithModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletWithModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletWithModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletWithModule.java
@@ -73,17 +73,17 @@ public class TestLinkTagletWithModule extends JavadocTester {
         checkOutput("m3/com/m3/app/App.html", true,
                 """
                     <div class="block"><a href="../../../../m1/module-summary.html"><code>m1</code></a>
-                     <a href="../../../../m1/module-summary.html"><code>m1</code></a>
-                     <a href="../../../../m1/com/m1/lib/package-summary.html"><code>package link</code></a>
-                     <a href="../../../../m1/com/m1/lib/Lib.html" title="class in com.m1.lib"><code>Lib</code></a>
-                     <a href="../../../../m1/com/m1/lib/Lib.html#method(java.lang.String)"><code>Lib.method(String)</code></a>
-                     <a href="../../../../m1/com/m1/lib/Lib.html#method(java.lang.String)"><code>Lib.method(String)</code></a>
-                     <a href="../../../../m2/module-summary.html">m2</a>
-                     <a href="../../../../m2/module-summary.html">m2</a>
-                     <a href="../../../../m2/com/m2/lib/package-summary.html">com.m2.lib</a>
-                     <a href="../../../../m2/com/m2/lib/Lib.html" title="class in com.m2.lib">Lib</a>
-                     <a href="../../../../m2/com/m2/lib/Lib.html#method(java.lang.String)">class link</a>
-                     <a href="../../../../m2/com/m2/lib/Lib.html#method(java.lang.String)">Lib.method(String)</a></div>
+                    <a href="../../../../m1/module-summary.html"><code>m1</code></a>
+                    <a href="../../../../m1/com/m1/lib/package-summary.html"><code>package link</code></a>
+                    <a href="../../../../m1/com/m1/lib/Lib.html" title="class in com.m1.lib"><code>Lib</code></a>
+                    <a href="../../../../m1/com/m1/lib/Lib.html#method(java.lang.String)"><code>Lib.method(String)</code></a>
+                    <a href="../../../../m1/com/m1/lib/Lib.html#method(java.lang.String)"><code>Lib.method(String)</code></a>
+                    <a href="../../../../m2/module-summary.html">m2</a>
+                    <a href="../../../../m2/module-summary.html">m2</a>
+                    <a href="../../../../m2/com/m2/lib/package-summary.html">com.m2.lib</a>
+                    <a href="../../../../m2/com/m2/lib/Lib.html" title="class in com.m2.lib">Lib</a>
+                    <a href="../../../../m2/com/m2/lib/Lib.html#method(java.lang.String)">class link</a>
+                    <a href="../../../../m2/com/m2/lib/Lib.html#method(java.lang.String)">Lib.method(String)</a></div>
                     """);
     }
 
@@ -105,21 +105,21 @@ public class TestLinkTagletWithModule extends JavadocTester {
         checkOutput("m3/com/m3/app/App.html", true,
                 """
                     <div class="block"><a href="../../../../../out1/m1/module-summary.html" class="external-link"><code>m1</code></a>
-                     <a href="../../../../../out1/m1/module-summary.html" class="external-link"><code>m1</code></a>
-                     <a href="../../../../../out1/m1/com/m1/lib/package-summary.html" class="external-link"><code>package link</code></a>
-                     <a href="../../../../../out1/m1/com/m1/lib/Lib.html" title="class or interface in com.m1.lib"\
+                    <a href="../../../../../out1/m1/module-summary.html" class="external-link"><code>m1</code></a>
+                    <a href="../../../../../out1/m1/com/m1/lib/package-summary.html" class="external-link"><code>package link</code></a>
+                    <a href="../../../../../out1/m1/com/m1/lib/Lib.html" title="class or interface in com.m1.lib"\
                      class="external-link"><code>Lib</code></a>
-                     <a href="../../../../../out1/m1/com/m1/lib/Lib.html#method(java.lang.String)" title="class or\
+                    <a href="../../../../../out1/m1/com/m1/lib/Lib.html#method(java.lang.String)" title="class or\
                      interface in com.m1.lib" class="external-link"><code>Lib.method(String)</code></a>
-                     <a href="../../../../../out1/m1/com/m1/lib/Lib.html#method(java.lang.String)" title="class or\
+                    <a href="../../../../../out1/m1/com/m1/lib/Lib.html#method(java.lang.String)" title="class or\
                      interface in com.m1.lib" class="external-link"><code>Lib.method(String)</code></a>
-                     <a href="../../../../../out1/m2/module-summary.html" class="external-link">m2</a>
-                     <a href="../../../../../out1/m2/module-summary.html" class="external-link">m2</a>
-                     <a href="../../../../../out1/m2/com/m2/lib/package-summary.html" class="external-link">m2/com.m2.lib</a>
-                     <a href="../../../../../out1/m2/com/m2/lib/Lib.html" title="class or interface in com.m2.lib" class="external-link">Lib</a>
-                     <a href="../../../../../out1/m2/com/m2/lib/Lib.html#method(java.lang.String)" title="class or\
+                    <a href="../../../../../out1/m2/module-summary.html" class="external-link">m2</a>
+                    <a href="../../../../../out1/m2/module-summary.html" class="external-link">m2</a>
+                    <a href="../../../../../out1/m2/com/m2/lib/package-summary.html" class="external-link">m2/com.m2.lib</a>
+                    <a href="../../../../../out1/m2/com/m2/lib/Lib.html" title="class or interface in com.m2.lib" class="external-link">Lib</a>
+                    <a href="../../../../../out1/m2/com/m2/lib/Lib.html#method(java.lang.String)" title="class or\
                      interface in com.m2.lib" class="external-link">class link</a>
-                     <a href="../../../../../out1/m2/com/m2/lib/Lib.html#method(java.lang.String)" title="class or\
+                    <a href="../../../../../out1/m2/com/m2/lib/Lib.html#method(java.lang.String)" title="class or\
                      interface in com.m2.lib" class="external-link">Lib.method(String)</a></div>
                     """);
     }
@@ -136,13 +136,13 @@ public class TestLinkTagletWithModule extends JavadocTester {
         checkOutput("com.ex2/com/ex2/B.html", true,
                 """
                     <div class="block"><a href="../../../com.ex1/com/ex1/package-summary.html"><code>package link</code></a>
-                     <a href="../../../com.ex1/module-summary.html"><code>module link</code></a>
-                     <a href="../../../com.ex1/com/ex1/package-summary.html"><code>com.ex1</code></a>
-                     <a href="../../../com.ex1/com/ex1/A.html" title="class in com.ex1"><code>class link</code></a>
-                     <a href="../../../com.ex1/com/ex1/A.html#m()"><code>A.m()</code></a>
-                     <a href="../../../com.ex1/com/ex1/A.html#m()"><code>A.m()</code></a>
-                     <a href="package-summary.html"><code>com.ex2</code></a>
-                     <a href="../../module-summary.html"><code>com.ex2</code></a></div>
+                    <a href="../../../com.ex1/module-summary.html"><code>module link</code></a>
+                    <a href="../../../com.ex1/com/ex1/package-summary.html"><code>com.ex1</code></a>
+                    <a href="../../../com.ex1/com/ex1/A.html" title="class in com.ex1"><code>class link</code></a>
+                    <a href="../../../com.ex1/com/ex1/A.html#m()"><code>A.m()</code></a>
+                    <a href="../../../com.ex1/com/ex1/A.html#m()"><code>A.m()</code></a>
+                    <a href="package-summary.html"><code>com.ex2</code></a>
+                    <a href="../../module-summary.html"><code>com.ex2</code></a></div>
                     """);
     }
 
@@ -162,13 +162,13 @@ public class TestLinkTagletWithModule extends JavadocTester {
         checkOutput("com.ex2/com/ex2/B.html", true,
                 """
                     <div class="block"><a href="../../../../out1/com.ex1/com/ex1/package-summary.html" class="external-link"><code>package link</code></a>
-                     <a href="../../../../out1/com.ex1/module-summary.html" class="external-link"><code>module link</code></a>
-                     <a href="../../../../out1/com.ex1/com/ex1/package-summary.html" class="external-link"><code>com.ex1/com.ex1</code></a>
-                     <a href="../../../../out1/com.ex1/com/ex1/A.html" title="class or interface in com.ex1" class="external-link"><code>class link</code></a>
-                     <a href="../../../../out1/com.ex1/com/ex1/A.html#m()" title="class or interface in com.ex1" class="external-link"><code>A.m()</code></a>
-                     <a href="../../../../out1/com.ex1/com/ex1/A.html#m()" title="class or interface in com.ex1" class="external-link"><code>A.m()</code></a>
-                     <a href="package-summary.html"><code>com.ex2</code></a>
-                     <a href="../../module-summary.html"><code>com.ex2</code></a></div>
+                    <a href="../../../../out1/com.ex1/module-summary.html" class="external-link"><code>module link</code></a>
+                    <a href="../../../../out1/com.ex1/com/ex1/package-summary.html" class="external-link"><code>com.ex1/com.ex1</code></a>
+                    <a href="../../../../out1/com.ex1/com/ex1/A.html" title="class or interface in com.ex1" class="external-link"><code>class link</code></a>
+                    <a href="../../../../out1/com.ex1/com/ex1/A.html#m()" title="class or interface in com.ex1" class="external-link"><code>A.m()</code></a>
+                    <a href="../../../../out1/com.ex1/com/ex1/A.html#m()" title="class or interface in com.ex1" class="external-link"><code>A.m()</code></a>
+                    <a href="package-summary.html"><code>com.ex2</code></a>
+                    <a href="../../module-summary.html"><code>com.ex2</code></a></div>
                     """);
     }
     void generateSources() throws Exception {

--- a/test/langtools/jdk/javadoc/doclet/testLiteralCodeInPre/TestLiteralCodeInPre.java
+++ b/test/langtools/jdk/javadoc/doclet/testLiteralCodeInPre/TestLiteralCodeInPre.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8002387 8014636 8078320 8175200 8186332
+ * @bug      8002387 8014636 8078320 8175200 8186332 8352249
  * @summary  Improve rendered HTML formatting for {@code}
  * @library  ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool

--- a/test/langtools/jdk/javadoc/doclet/testLiteralCodeInPre/TestLiteralCodeInPre.java
+++ b/test/langtools/jdk/javadoc/doclet/testLiteralCodeInPre/TestLiteralCodeInPre.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,45 +70,45 @@ public class TestLiteralCodeInPre extends JavadocTester {
                 """
                     typical_usage_code</span>()</div>
                     <div class="block">Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                     Example:  <pre><code>
-                       line 0 @Override
-                       line 1 &lt;T&gt; void m(T t) {
-                       line 2     // do something with T
-                       line 3 }
-                     </code></pre>
-                     and so it goes.</div>""",
+                    Example:  <pre><code>
+                      line 0 @Override
+                      line 1 &lt;T&gt; void m(T t) {
+                      line 2     // do something with T
+                      line 3 }
+                    </code></pre>
+                    and so it goes.</div>""",
                 """
                     typical_usage_literal</span>()</div>
                     <div class="block">Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                     Example:  <pre>
-                       line 0 @Override
-                       line 1 &lt;T&gt; void m(T t) {
-                       line 2     // do something with T
-                       line 3 }
-                     </pre>
-                     and so it goes.</div>""",
+                    Example:  <pre>
+                      line 0 @Override
+                      line 1 &lt;T&gt; void m(T t) {
+                      line 2     // do something with T
+                      line 3 }
+                    </pre>
+                    and so it goes.</div>""",
                 """
                     recommended_usage_literal</span>()</div>
                     <div class="block">Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                     Example:  <pre>
-                       line 0 @Override
-                       line 1 &lt;T&gt; void m(T t) {
-                       line 2     // do something with T
-                       line 3 } </pre>
-                     and so it goes.</div>""",
+                    Example:  <pre>
+                      line 0 @Override
+                      line 1 &lt;T&gt; void m(T t) {
+                      line 2     // do something with T
+                      line 3 } </pre>
+                    and so it goes.</div>""",
                 """
                     <div class="block">Test for html in pre, note the spaces
-                     <PRE>
-                     <b>id           </b>
-                     </PRE></div>""",
+                    <PRE>
+                    <b>id           </b>
+                    </PRE></div>""",
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="return-type">void</span>&nbsp;<span class="element-name">htmlAttrInPre1</span>()</\
                     div>
                     <div class="block">More html tag outliers.
-                     <pre>
-                     @Override
-                     <code> some.function() </code>
-                     </pre></div>""");
+                    <pre>
+                    @Override
+                    <code> some.function() </code>
+                    </pre></div>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -889,11 +889,11 @@ public class TestModules extends JavadocTester {
                      href="moduletags/module-summary.html">moduletags</a></div>
                     <div class="col-last odd-row-color all-modules-table all-modules-table-tab1">
                     <div class="block">This is a test description for the moduletags module.<br>
-                     Type Link: <a href="moduletags/testpkgmdltags/TestClassInModuleTags.html" title\
+                    Type Link: <a href="moduletags/testpkgmdltags/TestClassInModuleTags.html" title\
                     ="class in testpkgmdltags"><code>TestClassInModuleTags</code></a>.<br>
-                     Member Link: <a href="moduletags/testpkgmdltags/TestClassInModuleTags.html#test\
+                    Member Link: <a href="moduletags/testpkgmdltags/TestClassInModuleTags.html#test\
                     Method(java.lang.String)"><code>TestClassInModuleTags.testMethod(String)</code></a>.<br>
-                     Package Link: <a href="moduletags/testpkgmdltags/package-summary.html"><code>testpkgmdltags</code></a>.<br></div>
+                    Package Link: <a href="moduletags/testpkgmdltags/package-summary.html"><code>testpkgmdltags</code></a>.<br></div>
                     </div>""");
         checkOutput("moduleA/module-summary.html", true,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,7 @@ public class TestPreview extends JavadocTester {
                     reRecord.html#preview-preview.CoreRecord">PREVIEW</a></sup>, <a href="CoreRecor\
                     d.html" title="class in preview"><code>core record</code></a><sup class="previe\
                     w-mark"><a href="CoreRecord.html#preview-preview.CoreRecord">PREVIEW</a></sup>,
-                     <a href="CoreRecord.html" title="class in preview">CoreRecord</a>, <a href="Co\
+                    <a href="CoreRecord.html" title="class in preview">CoreRecord</a>, <a href="Co\
                     reRecord.html" title="class in preview">core record</a>.</div>""",
                 """
                     <li><a href="CoreRecord.html" title="class in preview"><code>CoreRecord</code><\

--- a/test/langtools/jdk/javadoc/doclet/testRecordLinks/TestRecordLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecordLinks/TestRecordLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testRecordLinks/TestRecordLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecordLinks/TestRecordLinks.java
@@ -82,7 +82,7 @@ public class TestRecordLinks  extends JavadocTester {
                     """,
                 """
                     <div class="block"><a href="#foo()"><code>foo()</code></a>
-                     <a href="JavadocTest.Bar.html" title="class in example"><code>JavadocTest.Bar</code></a></div>
+                    <a href="JavadocTest.Bar.html" title="class in example"><code>JavadocTest.Bar</code></a></div>
                     """);
 
         checkOutput("example/JavadocTest.Bar.html", true,
@@ -91,7 +91,7 @@ public class TestRecordLinks  extends JavadocTester {
                     """,
                 """
                     <div class="block"><a href="#bar()"><code>bar()</code></a>
-                     <a href="JavadocTest.Foo.html" title="class in example"><code>JavadocTest.Foo</code></a></div>
+                    <a href="JavadocTest.Foo.html" title="class in example"><code>JavadocTest.Foo</code></a></div>
                     """);
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testRelativeLinks/TestRelativeModuleLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testRelativeLinks/TestRelativeModuleLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,26 +90,26 @@ public class TestRelativeModuleLinks extends JavadocTester {
         checkOutput("index.html", true,
                 """
                 <div class="block"><a href="./ma/doc-files/file.html">relative module link</a>,
-                 <a href="./ma/module-summary.html#module-fragment">fragment module link</a>.</div>""");
+                <a href="./ma/module-summary.html#module-fragment">fragment module link</a>.</div>""");
 
         // Index page
         checkOutput("index-all.html", true,
                 """
                 <div class="block"><a href="./ma/doc-files/file.html">relative module link</a>,
-                 <a href="./ma/module-summary.html#module-fragment">fragment module link</a>.</div>""");
+                <a href="./ma/module-summary.html#module-fragment">fragment module link</a>.</div>""");
 
         // Own module page
         checkOutput("ma/module-summary.html", true,
                 """
                 <div class="block"><a href="doc-files/file.html">relative module link</a>,
-                 <a href="#module-fragment">fragment module link</a>.
-                 <a id="module-fragment">Module fragment</a>.</div>""");
+                <a href="#module-fragment">fragment module link</a>.
+                <a id="module-fragment">Module fragment</a>.</div>""");
 
         // Other module page
         checkOutput("mb/module-summary.html", true,
                 """
                 <div class="block"><a href="../ma/doc-files/file.html">relative module link</a>,
-                 <a href="../ma/module-summary.html#module-fragment">fragment module link</a>.</div>""");
+                <a href="../ma/module-summary.html#module-fragment">fragment module link</a>.</div>""");
     }
 }
 

--- a/test/langtools/jdk/javadoc/doclet/testSerializedFormDeprecationInfo/TestSerializedFormDeprecationInfo.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedFormDeprecationInfo/TestSerializedFormDeprecationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testSerializedFormDeprecationInfo/TestSerializedFormDeprecationInfo.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedFormDeprecationInfo/TestSerializedFormDeprecationInfo.java
@@ -107,7 +107,7 @@ public class TestSerializedFormDeprecationInfo extends JavadocTester {
                 """
                     <span class="deprecated-label">Deprecated.</span>
                     <div class="deprecation-comment">As of JDK version 1.5, replaced by
-                     <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
+                    <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
                     </div>
                     <div class="block">This field indicates whether the C1 is undecorated.</div>
                     <dl class="notes">
@@ -123,7 +123,7 @@ public class TestSerializedFormDeprecationInfo extends JavadocTester {
                 """
                     <span class="deprecated-label">Deprecated.</span>
                     <div class="deprecation-comment">As of JDK version 1.5, replaced by
-                     <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
+                    <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
                     </div>
                     <div class="block">Reads the object stream.</div>
                     <dl class="notes">
@@ -146,13 +146,13 @@ public class TestSerializedFormDeprecationInfo extends JavadocTester {
                     <pre>boolean undecorated</pre>
                     <div class="deprecation-block"><span class="deprecated-label">Deprecated.</span>
                     <div class="deprecation-comment">As of JDK version 1.5, replaced by
-                     <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
+                    <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
                     </div>
                     </li>""",
                 """
                     <span class="deprecated-label">Deprecated.</span>
                     <div class="deprecation-comment">As of JDK version 1.5, replaced by
-                     <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
+                    <a href="pkg1/C1.html#setUndecorated(boolean)"><code>setUndecorated(boolean)</code></a>.</div>
                     </div>
                     </li>""");
     }

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetUnnamedPackage.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetUnnamedPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,10 +87,9 @@ public class TestSnippetUnnamedPackage extends SnippetTester {
         checkOutput("C.html", useSourcePath,
                 """
                         Before.
-                        \s
                         %s
 
-                         After.""".formatted(getSnippetHtmlRepresentation("C.html",
+                        After.""".formatted(getSnippetHtmlRepresentation("C.html",
                         "public class S { }", Optional.of("java"), Optional.of("snippet-C1"))));
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetUnnamedPackage.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetUnnamedPackage.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8284037
+ * @bug 8284037 8352249
  * @summary Snippet-files subdirectory not automatically detected when in unnamed package
  * @library /tools/lib ../../lib
  * @modules jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/jdk/javadoc/doclet/testSourceTab/SingleTab/C.java
+++ b/test/langtools/jdk/javadoc/doclet/testSourceTab/SingleTab/C.java
@@ -23,8 +23,8 @@
 
 /**
  * <pre>
- *\tThis source
- * \tis indented
+ * \tThis source
+ *  \tis indented
  * \twith tabs.
  * </pre>
  */

--- a/test/langtools/jdk/javadoc/doclet/testSourceTab/SingleTab/C.java
+++ b/test/langtools/jdk/javadoc/doclet/testSourceTab/SingleTab/C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testSourceTab/SingleTab/C.java
+++ b/test/langtools/jdk/javadoc/doclet/testSourceTab/SingleTab/C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2004, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
@@ -144,13 +144,13 @@ public class TestStylesheet extends JavadocTester {
                     <link rel="stylesheet" type="text/css" href="../resource-files/stylesheet.css">""",
                 """
                     <div class="block">Test comment for a class which has an <a name="named_anchor">anchor_with_name</a> and
-                     an <a id="named_anchor1">anchor_with_id</a>.</div>""");
+                    an <a id="named_anchor1">anchor_with_id</a>.</div>""");
 
         checkOutput("pkg/package-summary.html", true,
                 """
                     <div class="col-last even-row-color class-summary class-summary-tab2">
                     <div class="block">Test comment for a class which has an <a name="named_anchor">anchor_with_name</a> and
-                     an <a id="named_anchor1">anchor_with_id</a>.</div>
+                    an <a id="named_anchor1">anchor_with_id</a>.</div>
                     </div>""");
 
         checkOutput("index.html", true,

--- a/test/langtools/tools/javac/doctree/AtEscapeTest.java
+++ b/test/langtools/tools/javac/doctree/AtEscapeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/doctree/AtEscapeTest.java
+++ b/test/langtools/tools/javac/doctree/AtEscapeTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8300914
+ * @bug 8300914 8352249
  * @summary Allow `@` as an escape in documentation comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/AtEscapeTest.java
+++ b/test/langtools/tools/javac/doctree/AtEscapeTest.java
@@ -41,11 +41,11 @@ class AtEscapeTest {
      */
     void escape_block_tag() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc|_]
-    Escape[ESCAPE, pos:6, @]
-    Text[TEXT, pos:8, tag|_def]
+    Text[TEXT, pos:0, abc|]
+    Escape[ESCAPE, pos:4, @]
+    Text[TEXT, pos:6, tag|def]
   body: empty
   block tags: empty
 ]
@@ -56,11 +56,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     void escape_inline_tag() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_{]
-    Escape[ESCAPE, pos:6, @]
-    Text[TEXT, pos:8, tag}_def]
+    Text[TEXT, pos:0, abc_{]
+    Escape[ESCAPE, pos:5, @]
+    Text[TEXT, pos:7, tag}_def]
   body: empty
   block tags: empty
 ]
@@ -71,11 +71,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     void escape_end_comment() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_/*_def_*]
-    Escape[ESCAPE, pos:13, /]
-    Text[TEXT, pos:15, _ghi]
+    Text[TEXT, pos:0, abc_/*_def_*]
+    Escape[ESCAPE, pos:12, /]
+    Text[TEXT, pos:14, _ghi]
   body: empty
   block tags: empty
 ]
@@ -87,11 +87,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     void escape_asterisk() { }
 /*
-DocComment[DOC_COMMENT, pos:5
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:5, abc|_____]
-    Escape[ESCAPE, pos:14, *]
-    Text[TEXT, pos:16, _def|_____ghi]
+    Text[TEXT, pos:0, abc|]
+    Escape[ESCAPE, pos:4, *]
+    Text[TEXT, pos:6, _def|ghi]
   body: empty
   block tags: empty
 ]
@@ -104,11 +104,11 @@ DocComment[DOC_COMMENT, pos:5
      */
     void not_escaped_tag() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: 1
-    Text[TEXT, pos:7, not_an_escaped_tag_@@tag;|_xyz.]
+    Text[TEXT, pos:5, not_an_escaped_tag_@@tag;|xyz.]
   block tags: empty
 ]
 */
@@ -120,11 +120,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     void not_escaped_asterisk() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: 1
-    Text[TEXT, pos:7, not_an_escaped_asterisk_@*;|_xyz.]
+    Text[TEXT, pos:5, not_an_escaped_asterisk_@*;|xyz.]
   block tags: empty
 ]
 */
@@ -136,11 +136,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     void not_escaped_solidus() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: 1
-    Text[TEXT, pos:7, not_an_escaped_solidus_@/.|_xyz.]
+    Text[TEXT, pos:5, not_an_escaped_solidus_@/.|xyz.]
   block tags: empty
 ]
 */

--- a/test/langtools/tools/javac/doctree/AttrTest.java
+++ b/test/langtools/tools/javac/doctree/AttrTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,20 +39,20 @@ class AttrTest {
      */
     void unquoted_attr() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:a
       attributes: 1
-        Attribute[ATTRIBUTE, pos:4
+        Attribute[ATTRIBUTE, pos:3
           name: name
           vkind: UNQUOTED
           value: 1
-            Text[TEXT, pos:9, unquoted]
+            Text[TEXT, pos:8, unquoted]
         ]
     ]
-    Text[TEXT, pos:18, foo]
-    EndElement[END_ELEMENT, pos:21, a]
+    Text[TEXT, pos:17, foo]
+    EndElement[END_ELEMENT, pos:20, a]
   body: empty
   block tags: empty
 ]
@@ -63,20 +63,20 @@ DocComment[DOC_COMMENT, pos:1
      */
     void hyphened_attr() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:a
       attributes: 1
-        Attribute[ATTRIBUTE, pos:4
+        Attribute[ATTRIBUTE, pos:3
           name: name-test
           vkind: UNQUOTED
           value: 1
-            Text[TEXT, pos:14, hyphened]
+            Text[TEXT, pos:13, hyphened]
         ]
     ]
-    Text[TEXT, pos:23, foo]
-    EndElement[END_ELEMENT, pos:26, a]
+    Text[TEXT, pos:22, foo]
+    EndElement[END_ELEMENT, pos:25, a]
   body: empty
   block tags: empty
 ]
@@ -87,20 +87,20 @@ DocComment[DOC_COMMENT, pos:1
      */
     void double_quoted_attr() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:a
       attributes: 1
-        Attribute[ATTRIBUTE, pos:4
+        Attribute[ATTRIBUTE, pos:3
           name: name
           vkind: DOUBLE
           value: 1
-            Text[TEXT, pos:10, double_quoted]
+            Text[TEXT, pos:9, double_quoted]
         ]
     ]
-    Text[TEXT, pos:25, foo]
-    EndElement[END_ELEMENT, pos:28, a]
+    Text[TEXT, pos:24, foo]
+    EndElement[END_ELEMENT, pos:27, a]
   body: empty
   block tags: empty
 ]
@@ -111,20 +111,20 @@ DocComment[DOC_COMMENT, pos:1
      */
     void single_quoted_attr() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:a
       attributes: 1
-        Attribute[ATTRIBUTE, pos:4
+        Attribute[ATTRIBUTE, pos:3
           name: name
           vkind: SINGLE
           value: 1
-            Text[TEXT, pos:10, single_quoted]
+            Text[TEXT, pos:9, single_quoted]
         ]
     ]
-    Text[TEXT, pos:25, foo]
-    EndElement[END_ELEMENT, pos:28, a]
+    Text[TEXT, pos:24, foo]
+    EndElement[END_ELEMENT, pos:27, a]
   body: empty
   block tags: empty
 ]
@@ -135,16 +135,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void numeric_attr() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:hr
       attributes: 1
-        Attribute[ATTRIBUTE, pos:5
+        Attribute[ATTRIBUTE, pos:4
           name: size
           vkind: DOUBLE
           value: 1
-            Text[TEXT, pos:11, 3]
+            Text[TEXT, pos:10, 3]
         ]
     ]
   body: empty
@@ -157,17 +157,17 @@ DocComment[DOC_COMMENT, pos:1
      */
     void docRoot_attr() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:a
       attributes: 1
-        Attribute[ATTRIBUTE, pos:4
+        Attribute[ATTRIBUTE, pos:3
           name: href
           vkind: DOUBLE
           value: 2
-            DocRoot[DOC_ROOT, pos:10]
-            Text[TEXT, pos:20, /index.html]
+            DocRoot[DOC_ROOT, pos:9]
+            Text[TEXT, pos:19, /index.html]
         ]
     ]
   body: empty
@@ -180,18 +180,18 @@ DocComment[DOC_COMMENT, pos:1
      */
     void entity_attr() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:a
       attributes: 1
-        Attribute[ATTRIBUTE, pos:4
+        Attribute[ATTRIBUTE, pos:3
           name: name
           vkind: DOUBLE
           value: 3
-            Text[TEXT, pos:10, abc]
-            Entity[ENTITY, pos:13, quot]
-            Text[TEXT, pos:19, def]
+            Text[TEXT, pos:9, abc]
+            Entity[ENTITY, pos:12, quot]
+            Text[TEXT, pos:18, def]
         ]
     ]
   body: empty
@@ -204,12 +204,12 @@ DocComment[DOC_COMMENT, pos:1
      */
     void no_value_attr() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:hr
       attributes: 1
-        Attribute[ATTRIBUTE, pos:5
+        Attribute[ATTRIBUTE, pos:4
           name: noshade
           vkind: EMPTY
           value: null
@@ -225,17 +225,17 @@ DocComment[DOC_COMMENT, pos:1
      */
     void self_closing_attr_1() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    StartElement[START_ELEMENT, pos:5
+    Text[TEXT, pos:0, abc_]
+    StartElement[START_ELEMENT, pos:4
       name:hr
       attributes: 1
-        Attribute[ATTRIBUTE, pos:9
+        Attribute[ATTRIBUTE, pos:8
           name: size
           vkind: SINGLE
           value: 1
-            Text[TEXT, pos:15, 3]
+            Text[TEXT, pos:14, 3]
         ]
     ]
   body: empty
@@ -248,17 +248,17 @@ DocComment[DOC_COMMENT, pos:1
      */
     void self_closing_attr_2() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    StartElement[START_ELEMENT, pos:5
+    Text[TEXT, pos:0, abc_]
+    StartElement[START_ELEMENT, pos:4
       name:hr
       attributes: 1
-        Attribute[ATTRIBUTE, pos:9
+        Attribute[ATTRIBUTE, pos:8
           name: size
           vkind: UNQUOTED
           value: 1
-            Text[TEXT, pos:14, 3]
+            Text[TEXT, pos:13, 3]
         ]
     ]
   body: empty
@@ -271,14 +271,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void unterminated_attr_eoi() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4
       code: compiler.err.dc.malformed.html
       body: <
     ]
-    Text[TEXT, pos:6, hr_size="3]
+    Text[TEXT, pos:5, hr_size="3]
   body: empty
   block tags: empty
 ]
@@ -290,19 +290,19 @@ DocComment[DOC_COMMENT, pos:1
      */
     void unterminated_attr_block() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4
       code: compiler.err.dc.malformed.html
       body: <
     ]
-    Text[TEXT, pos:6, hr_size="3]
+    Text[TEXT, pos:5, hr_size="3]
   body: empty
   block tags: 1
-    Author[AUTHOR, pos:18
+    Author[AUTHOR, pos:16
       name: 1
-        Text[TEXT, pos:26, jjg]
+        Text[TEXT, pos:24, jjg]
     ]
 ]
 */
@@ -312,30 +312,30 @@ DocComment[DOC_COMMENT, pos:1
      */
     void multiple_attr() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:a
       attributes: 4
-        Attribute[ATTRIBUTE, pos:4
+        Attribute[ATTRIBUTE, pos:3
           name: name1
           vkind: DOUBLE
           value: 1
-            Text[TEXT, pos:11, val1]
+            Text[TEXT, pos:10, val1]
         ]
-        Attribute[ATTRIBUTE, pos:17
+        Attribute[ATTRIBUTE, pos:16
           name: name2
           vkind: SINGLE
           value: 1
-            Text[TEXT, pos:24, val2]
+            Text[TEXT, pos:23, val2]
         ]
-        Attribute[ATTRIBUTE, pos:30
+        Attribute[ATTRIBUTE, pos:29
           name: name3
           vkind: UNQUOTED
           value: 1
-            Text[TEXT, pos:36, val3]
+            Text[TEXT, pos:35, val3]
         ]
-        Attribute[ATTRIBUTE, pos:41
+        Attribute[ATTRIBUTE, pos:40
           name: name4
           vkind: EMPTY
           value: null
@@ -392,21 +392,21 @@ DocComment[DOC_COMMENT, pos:1
      */
     void unclosed_attr() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 4
-    Erroneous[ERRONEOUS, pos:1
+    Erroneous[ERRONEOUS, pos:0
       code: compiler.err.dc.malformed.html
       body: <
     ]
-    Text[TEXT, pos:2, a_name1="]
-    Literal[LITERAL, pos:11, value]
-    Text[TEXT, pos:27, "_name2='@foo'_name3="abc]
+    Text[TEXT, pos:1, a_name1="]
+    Literal[LITERAL, pos:10, value]
+    Text[TEXT, pos:26, "_name2='@foo'_name3="abc]
   body: empty
   block tags: 1
-    See[SEE, pos:54
+    See[SEE, pos:52
       reference: 2
-        Reference[REFERENCE, pos:59, Ref]
-        Literal[LITERAL, pos:63, xyz]
+        Reference[REFERENCE, pos:57, Ref]
+        Literal[LITERAL, pos:61, xyz]
     ]
 ]
 */

--- a/test/langtools/tools/javac/doctree/AttrTest.java
+++ b/test/langtools/tools/javac/doctree/AttrTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8076026 8273244 8321500
+ * @bug 7021614 8076026 8273244 8321500 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/CodeTest.java
+++ b/test/langtools/tools/javac/doctree/CodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/doctree/CodeTest.java
+++ b/test/langtools/tools/javac/doctree/CodeTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8241780 8273244 8284908
+ * @bug 7021614 8241780 8273244 8284908 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/CodeTest.java
+++ b/test/langtools/tools/javac/doctree/CodeTest.java
@@ -76,9 +76,9 @@ DocComment[DOC_COMMENT, pos:0
      */
     void nested() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Literal[CODE, pos:1, {@code_nested}_]
+    Literal[CODE, pos:0, {@code_nested}_]
   body: empty
   block tags: empty
 ]
@@ -91,9 +91,9 @@ DocComment[DOC_COMMENT, pos:1
      */
     void embedded_newline() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Literal[CODE, pos:1, if_(a_<_b)_{|________}|_]
+    Literal[CODE, pos:0, if_(a_<_b)_{|_______}|]
   body: empty
   block tags: empty
 ]
@@ -106,9 +106,9 @@ DocComment[DOC_COMMENT, pos:1
      */
     void embedded_at() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Literal[CODE, pos:1, |_@tag|_]
+    Literal[CODE, pos:0, |@tag|]
   body: empty
   block tags: empty
 ]
@@ -122,15 +122,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void pre_at_code() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:pre
       attributes: empty
     ]
-    Literal[CODE, pos:6, |_____@Override|_____void_m()_{_}|_]
+    Literal[CODE, pos:5, |____@Override|____void_m()_{_}|]
   body: 1
-    EndElement[END_ELEMENT, pos:48, pre]
+    EndElement[END_ELEMENT, pos:44, pre]
   block tags: empty
 ]
 */
@@ -154,11 +154,11 @@ DocComment[DOC_COMMENT, pos:0
      * @author jjg */
     void unterminated_2() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Erroneous[ERRONEOUS, pos:1, prefPos:34
+    Erroneous[ERRONEOUS, pos:0, prefPos:32
       code: compiler.err.dc.unterminated.inline.tag
-      body: {@code_if_(a_<_b)_{_}|_@author_jjg
+      body: {@code_if_(a_<_b)_{_}|@author_jjg
     ]
   body: empty
   block tags: empty

--- a/test/langtools/tools/javac/doctree/DeprecatedTest.java
+++ b/test/langtools/tools/javac/doctree/DeprecatedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/doctree/DeprecatedTest.java
+++ b/test/langtools/tools/javac/doctree/DeprecatedTest.java
@@ -39,11 +39,11 @@ class DeprecatedTest {
      */
     void deprecated() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Deprecated[DEPRECATED, pos:1
+    Deprecated[DEPRECATED, pos:0
       body: empty
     ]
 ]
@@ -54,13 +54,13 @@ DocComment[DOC_COMMENT, pos:1
      */
     void deprecated_text() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Deprecated[DEPRECATED, pos:1
+    Deprecated[DEPRECATED, pos:0
       body: 1
-        Text[TEXT, pos:13, text]
+        Text[TEXT, pos:12, text]
     ]
 ]
 */

--- a/test/langtools/tools/javac/doctree/DeprecatedTest.java
+++ b/test/langtools/tools/javac/doctree/DeprecatedTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244
+ * @bug 7021614 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/DocCommentTester.java
+++ b/test/langtools/tools/javac/doctree/DocCommentTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/doctree/DocCommentTester.java
+++ b/test/langtools/tools/javac/doctree/DocCommentTester.java
@@ -989,12 +989,11 @@ public class DocCommentTester {
             if (annos.contains("@PrettyCheck(false)")) {
                 return;
             }
-            boolean normalizeTags = !annos.contains("@NormalizeTags(false)");
 
             Elements.DocCommentKind ck = trees.getDocCommentKind(path);
             boolean isLineComment = ck == Elements.DocCommentKind.END_OF_LINE;
             String raw = trees.getDocComment(path).stripTrailing();
-            String normRaw = normalize(raw, isLineComment, normalizeTags);
+            String normRaw = normalize(raw, isLineComment);
 
             StringWriter out = new StringWriter();
             DocPretty dp = new DocPretty(out);
@@ -1014,65 +1013,19 @@ public class DocCommentTester {
 
         /**
          * Normalize whitespace in places where the tree does not preserve it.
-         * Maintain contents of inline tags unless {@code normalizeTags} is
-         * {@code false}. This should normally be {@code true}, but should be
-         * set to {@code false} when there is syntactically invalid content
-         * that might resemble an inline tag, but which is not so.
          *
          * @param s the comment text to be normalized
-         * @param normalizeTags whether to normalize inline tags
          * @return the normalized content
          */
-        String normalize(String s, boolean isLineComment, boolean normalizeTags) {
-            String s2 = (isLineComment ? s : s.stripIndent().trim())
-                    .replaceFirst("\\.\\s*\\n *@(?![@*])", ".\n@"); // Between block tags
-            StringBuilder sb = new StringBuilder();
-            Pattern p = Pattern.compile("(?i)\\{@([a-z][a-z0-9.:-]*)( )?");
-            Matcher m = p.matcher(s2);
-            int start = 0;
-            if (normalizeTags) {
-                while (m.find(start)) {
-                    sb.append(normalizeFragment(s2.substring(start, m.start())));
-                    sb.append(m.group().trim());
-                    start = copyLiteral(s2, m.end(), sb);
-                }
-            }
-            sb.append(normalizeFragment(s2.substring(start)));
-            return sb.toString()
+        String normalize(String s, boolean isLineComment) {
+            // See comment in MarkdownTest for explanation of dummy and Override
+            return (isLineComment ? s : s.stripIndent().trim())
+                    .replaceFirst("\\.\\s*\\n *@(?![@*])", ".\n@")  // Between block tags
+                    .replaceAll("\n[ \t]+@(?!([@*]|(dummy|Override)))", "\n@")
                     .replaceAll("(?i)\\{@([a-z][a-z0-9.:-]*)\\s+}", "{@$1}")
                     .replaceAll("(\\{@value\\s+[^}]+)\\s+(})", "$1$2");
         }
-
-        // See comment in MarkdownTest for explanation of dummy and Override
-        String normalizeFragment(String s) {
-            return s.replaceAll("\n[ \t]+@(?!([@*]|(dummy|Override)))", "\n@");
-        }
-
-        int copyLiteral(String s, int start, StringBuilder sb) {
-            int depth = 0;
-            for (int i = start; i < s.length(); i++) {
-                char ch = s.charAt(i);
-                if (i == start && !Character.isWhitespace(ch) && ch != '}') {
-                    sb.append(' ');
-                }
-                switch (ch) {
-                    case '{' ->
-                        depth++;
-
-                    case '}' -> {
-                        depth--;
-                        if (depth < 0) {
-                            sb.append(ch);
-                            return i + 1;
-                        }
-                    }
-                }
-                sb.append(ch);
-            }
-            return s.length();
-        }
     }
-
 
     /**
      * Verifies the general "left to right" constraints for the positions of

--- a/test/langtools/tools/javac/doctree/DocCommentTester.java
+++ b/test/langtools/tools/javac/doctree/DocCommentTester.java
@@ -1024,7 +1024,7 @@ public class DocCommentTester {
          * @return the normalized content
          */
         String normalize(String s, boolean isLineComment, boolean normalizeTags) {
-            String s2 = (isLineComment ? s : s.trim())
+            String s2 = (isLineComment ? s : s.stripIndent().trim())
                     .replaceFirst("\\.\\s*\\n *@(?![@*])", ".\n@"); // Between block tags
             StringBuilder sb = new StringBuilder();
             Pattern p = Pattern.compile("(?i)\\{@([a-z][a-z0-9.:-]*)( )?");

--- a/test/langtools/tools/javac/doctree/ElementTest.java
+++ b/test/langtools/tools/javac/doctree/ElementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/doctree/ElementTest.java
+++ b/test/langtools/tools/javac/doctree/ElementTest.java
@@ -39,15 +39,15 @@ class ElementTest {
      */
     void simple() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:p
       attributes: empty
     ]
-    Text[TEXT, pos:4, para]
+    Text[TEXT, pos:3, para]
   body: 1
-    EndElement[END_ELEMENT, pos:8, p]
+    EndElement[END_ELEMENT, pos:7, p]
   block tags: empty
 ]
 */
@@ -57,10 +57,10 @@ DocComment[DOC_COMMENT, pos:1
      */
     void self_closing() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    StartElement[START_ELEMENT, pos:5
+    Text[TEXT, pos:0, abc_]
+    StartElement[START_ELEMENT, pos:4
       name:hr
       attributes: empty
     ]
@@ -74,14 +74,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void bad_lt() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4
       code: compiler.err.dc.malformed.html
       body: <
     ]
-    Text[TEXT, pos:6, _def]
+    Text[TEXT, pos:5, _def]
   body: empty
   block tags: empty
 ]
@@ -92,9 +92,9 @@ DocComment[DOC_COMMENT, pos:1
      */
     void bad_gt() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_>_def]
+    Text[TEXT, pos:0, abc_>_def]
   body: empty
   block tags: empty
 ]
@@ -105,14 +105,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void bad_chars_start();
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4
       code: compiler.err.dc.malformed.html
       body: <
     ]
-    Text[TEXT, pos:6, p_123>_def]
+    Text[TEXT, pos:5, p_123>_def]
   body: empty
   block tags: empty
 ]
@@ -123,14 +123,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void bad_chars_end();
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4
       code: compiler.err.dc.malformed.html
       body: <
     ]
-    Text[TEXT, pos:6, /p_123>_def]
+    Text[TEXT, pos:5, /p_123>_def]
   body: empty
   block tags: empty
 ]
@@ -141,14 +141,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void unterminated_eoi() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4
       code: compiler.err.dc.malformed.html
       body: <
     ]
-    Text[TEXT, pos:6, hr]
+    Text[TEXT, pos:5, hr]
   body: empty
   block tags: empty
 ]
@@ -160,19 +160,19 @@ DocComment[DOC_COMMENT, pos:1
      */
     void unterminated_block() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4
       code: compiler.err.dc.malformed.html
       body: <
     ]
-    Text[TEXT, pos:6, hr]
+    Text[TEXT, pos:5, hr]
   body: empty
   block tags: 1
-    Author[AUTHOR, pos:10
+    Author[AUTHOR, pos:8
       name: 1
-        Text[TEXT, pos:18, jjg]
+        Text[TEXT, pos:16, jjg]
     ]
 ]
 */
@@ -183,14 +183,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void unterminated_end_eoi() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4
       code: compiler.err.dc.malformed.html
       body: <
     ]
-    Text[TEXT, pos:6, /p]
+    Text[TEXT, pos:5, /p]
   body: empty
   block tags: empty
 ]
@@ -202,19 +202,19 @@ DocComment[DOC_COMMENT, pos:1
      */
     void unterminated_end_block() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4
       code: compiler.err.dc.malformed.html
       body: <
     ]
-    Text[TEXT, pos:6, /p]
+    Text[TEXT, pos:5, /p]
   body: empty
   block tags: 1
-    Author[AUTHOR, pos:10
+    Author[AUTHOR, pos:8
       name: 1
-        Text[TEXT, pos:18, jjg]
+        Text[TEXT, pos:16, jjg]
     ]
 ]
 */
@@ -226,11 +226,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     void comment() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc|_]
-    Comment[COMMENT, pos:6, <!--_comment_-->]
-    Text[TEXT, pos:22, |_def]
+    Text[TEXT, pos:0, abc|]
+    Comment[COMMENT, pos:4, <!--_comment_-->]
+    Text[TEXT, pos:20, |def]
   body: empty
   block tags: empty
 ]

--- a/test/langtools/tools/javac/doctree/ElementTest.java
+++ b/test/langtools/tools/javac/doctree/ElementTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8078320 8247788 8273244 8298405
+ * @bug 7021614 8078320 8247788 8273244 8298405 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/EntityTest.java
+++ b/test/langtools/tools/javac/doctree/EntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/doctree/EntityTest.java
+++ b/test/langtools/tools/javac/doctree/EntityTest.java
@@ -39,11 +39,11 @@ class EntityTest {
      */
     public void name() { }
 /*
-DocComment[DOC_COMMENT, pos:2
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:2, abc_]
-    Entity[ENTITY, pos:6, lt]
-    Text[TEXT, pos:10, _def]
+    Text[TEXT, pos:0, abc_]
+    Entity[ENTITY, pos:4, lt]
+    Text[TEXT, pos:8, _def]
   body: empty
   block tags: empty
 ]
@@ -54,11 +54,11 @@ DocComment[DOC_COMMENT, pos:2
      */
     public void decimal_value() { }
 /*
-DocComment[DOC_COMMENT, pos:2
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:2, abc_]
-    Entity[ENTITY, pos:6, #160]
-    Text[TEXT, pos:12, _def]
+    Text[TEXT, pos:0, abc_]
+    Entity[ENTITY, pos:4, #160]
+    Text[TEXT, pos:10, _def]
   body: empty
   block tags: empty
 ]
@@ -69,11 +69,11 @@ DocComment[DOC_COMMENT, pos:2
      */
     public void lower_hex_value() { }
 /*
-DocComment[DOC_COMMENT, pos:2
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:2, abc_]
-    Entity[ENTITY, pos:6, #xa0]
-    Text[TEXT, pos:12, _def]
+    Text[TEXT, pos:0, abc_]
+    Entity[ENTITY, pos:4, #xa0]
+    Text[TEXT, pos:10, _def]
   body: empty
   block tags: empty
 ]
@@ -84,11 +84,11 @@ DocComment[DOC_COMMENT, pos:2
      */
     public void upper_hex_value() { }
 /*
-DocComment[DOC_COMMENT, pos:2
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:2, abc_]
-    Entity[ENTITY, pos:6, #XA0]
-    Text[TEXT, pos:12, _def]
+    Text[TEXT, pos:0, abc_]
+    Entity[ENTITY, pos:4, #XA0]
+    Text[TEXT, pos:10, _def]
   body: empty
   block tags: empty
 ]
@@ -99,14 +99,14 @@ DocComment[DOC_COMMENT, pos:2
      */
     public void bad_amp() { }
 /*
-DocComment[DOC_COMMENT, pos:2
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:2, abc_]
-    Erroneous[ERRONEOUS, pos:6
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4
       code: compiler.err.dc.bad.entity
       body: &
     ]
-    Text[TEXT, pos:7, _def]
+    Text[TEXT, pos:5, _def]
   body: empty
   block tags: empty
 ]
@@ -117,14 +117,14 @@ DocComment[DOC_COMMENT, pos:2
      */
     public void bad_entity_name() { }
 /*
-DocComment[DOC_COMMENT, pos:2
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:2, abc_]
-    Erroneous[ERRONEOUS, pos:6
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4
       code: compiler.err.dc.bad.entity
       body: &
     ]
-    Text[TEXT, pos:7, 1_def]
+    Text[TEXT, pos:5, 1_def]
   body: empty
   block tags: empty
 ]
@@ -135,14 +135,14 @@ DocComment[DOC_COMMENT, pos:2
      */
     public void bad_entity_decimal_value() { }
 /*
-DocComment[DOC_COMMENT, pos:2
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:2, abc_]
-    Erroneous[ERRONEOUS, pos:6, prefPos:10
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:8
       code: compiler.err.dc.missing.semicolon
       body: &#012
     ]
-    Text[TEXT, pos:11, .3;_def]
+    Text[TEXT, pos:9, .3;_def]
   body: empty
   block tags: empty
 ]
@@ -153,14 +153,14 @@ DocComment[DOC_COMMENT, pos:2
      */
     public void bad_entity_hex_value() { }
 /*
-DocComment[DOC_COMMENT, pos:2
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:2, abc_]
-    Erroneous[ERRONEOUS, pos:6, prefPos:12
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:10
       code: compiler.err.dc.missing.semicolon
       body: &#x012a
     ]
-    Text[TEXT, pos:13, zc;_def]
+    Text[TEXT, pos:11, zc;_def]
   body: empty
   block tags: empty
 ]

--- a/test/langtools/tools/javac/doctree/EntityTest.java
+++ b/test/langtools/tools/javac/doctree/EntityTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244 8284908 8298405
+ * @bug 7021614 8273244 8284908 8298405 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/ExceptionTest.java
+++ b/test/langtools/tools/javac/doctree/ExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/doctree/ExceptionTest.java
+++ b/test/langtools/tools/javac/doctree/ExceptionTest.java
@@ -39,13 +39,13 @@ class ExceptionTest {
      */
     void exception() throws Exception { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Throws[EXCEPTION, pos:1
+    Throws[EXCEPTION, pos:0
       exceptionName:
-        Reference[REFERENCE, pos:12, Exception]
+        Reference[REFERENCE, pos:11, Exception]
       description: empty
     ]
 ]
@@ -56,15 +56,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void exception_text() throws Exception { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Throws[EXCEPTION, pos:1
+    Throws[EXCEPTION, pos:0
       exceptionName:
-        Reference[REFERENCE, pos:12, Exception]
+        Reference[REFERENCE, pos:11, Exception]
       description: 1
-        Text[TEXT, pos:22, text]
+        Text[TEXT, pos:21, text]
     ]
 ]
 */

--- a/test/langtools/tools/javac/doctree/ExceptionTest.java
+++ b/test/langtools/tools/javac/doctree/ExceptionTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244
+ * @bug 7021614 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/FirstSentenceTest.java
+++ b/test/langtools/tools/javac/doctree/FirstSentenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/doctree/FirstSentenceTest.java
+++ b/test/langtools/tools/javac/doctree/FirstSentenceTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8078320 8132096 8273244
+ * @bug 7021614 8078320 8132096 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file
@@ -140,6 +140,30 @@ DocComment[DOC_COMMENT, pos:0
 ]
 */
     /**
+     * abc def ghi.
+     * Jkl mno pqr
+     */
+    void dot_newline_upper() { }
+/*
+DocComment[DOC_COMMENT, pos:0
+  firstSentence: 1
+    Text[TEXT, pos:0, abc_def_ghi.]
+  body: 1
+    Text[TEXT, pos:13, Jkl_mno_pqr]
+  block tags: empty
+]
+*/
+/*
+BREAK_ITERATOR
+DocComment[DOC_COMMENT, pos:0
+  firstSentence: 1
+    Text[TEXT, pos:0, abc_def_ghi.]
+  body: 1
+    Text[TEXT, pos:13, Jkl_mno_pqr]
+  block tags: empty
+]
+*/
+    /**
      * abc def ghi
      * <p>jkl mno pqr
      */
@@ -200,6 +224,39 @@ DocComment[DOC_COMMENT, pos:1
     ]
     Text[TEXT, pos:4, abc_def_ghi.|jdl_mno_pqf]
   body: empty
+  block tags: empty
+]
+*/
+    /**
+     *
+     * <p>abc def ghi.
+     * Jdl mno pqf
+     */
+    void newline_p_upper() { }
+/*
+DocComment[DOC_COMMENT, pos:1
+  firstSentence: 2
+    StartElement[START_ELEMENT, pos:1
+      name:p
+      attributes: empty
+    ]
+    Text[TEXT, pos:4, abc_def_ghi.]
+  body: 1
+    Text[TEXT, pos:17, Jdl_mno_pqf]
+  block tags: empty
+]
+*/
+/*
+BREAK_ITERATOR
+DocComment[DOC_COMMENT, pos:1
+  firstSentence: 2
+    StartElement[START_ELEMENT, pos:1
+      name:p
+      attributes: empty
+    ]
+    Text[TEXT, pos:4, abc_def_ghi.]
+  body: 1
+    Text[TEXT, pos:17, Jdl_mno_pqf]
   block tags: empty
 ]
 */
@@ -366,6 +423,38 @@ DocComment[DOC_COMMENT, pos:0
     ]
     Text[TEXT, pos:3, _abc_def.|ghi_jkl]
   body: empty
+  block tags: empty
+]
+*/
+    /**
+     * <p> abc def.
+     * Ghi jkl
+     */
+    void p_at_zero_upper() { }
+/*
+DocComment[DOC_COMMENT, pos:0
+  firstSentence: 2
+    StartElement[START_ELEMENT, pos:0
+      name:p
+      attributes: empty
+    ]
+    Text[TEXT, pos:3, _abc_def.]
+  body: 1
+    Text[TEXT, pos:13, Ghi_jkl]
+  block tags: empty
+]
+*/
+/*
+BREAK_ITERATOR
+DocComment[DOC_COMMENT, pos:0
+  firstSentence: 2
+    StartElement[START_ELEMENT, pos:0
+      name:p
+      attributes: empty
+    ]
+    Text[TEXT, pos:3, _abc_def.]
+  body: 1
+    Text[TEXT, pos:13, Ghi_jkl]
   block tags: empty
 ]
 */

--- a/test/langtools/tools/javac/doctree/FirstSentenceTest.java
+++ b/test/langtools/tools/javac/doctree/FirstSentenceTest.java
@@ -78,18 +78,18 @@ DocComment[DOC_COMMENT, pos:0
      */
     void no_body() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi.]
+    Text[TEXT, pos:0, abc_def_ghi.]
   body: empty
   block tags: empty
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi.]
+    Text[TEXT, pos:0, abc_def_ghi.]
   body: empty
   block tags: empty
 ]
@@ -99,19 +99,19 @@ DocComment[DOC_COMMENT, pos:1
      */
     void dot_space() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi.]
+    Text[TEXT, pos:0, abc_def_ghi.]
   body: 1
-    Text[TEXT, pos:14, jkl_mno_pqr.]
+    Text[TEXT, pos:13, jkl_mno_pqr.]
   block tags: empty
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi._jkl_mno_pqr.]
+    Text[TEXT, pos:0, abc_def_ghi._jkl_mno_pqr.]
   body: empty
   block tags: empty
 ]
@@ -122,21 +122,20 @@ DocComment[DOC_COMMENT, pos:1
      */
     void dot_newline() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi.]
+    Text[TEXT, pos:0, abc_def_ghi.]
   body: 1
-    Text[TEXT, pos:15, jkl_mno_pqr]
+    Text[TEXT, pos:13, jkl_mno_pqr]
   block tags: empty
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi.]
-  body: 1
-    Text[TEXT, pos:15, jkl_mno_pqr]
+    Text[TEXT, pos:0, abc_def_ghi.|jkl_mno_pqr]
+  body: empty
   block tags: empty
 ]
 */
@@ -146,29 +145,29 @@ DocComment[DOC_COMMENT, pos:1
      */
     void dot_p() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi]
+    Text[TEXT, pos:0, abc_def_ghi]
   body: 2
-    StartElement[START_ELEMENT, pos:14
+    StartElement[START_ELEMENT, pos:12
       name:p
       attributes: empty
     ]
-    Text[TEXT, pos:17, jkl_mno_pqr]
+    Text[TEXT, pos:15, jkl_mno_pqr]
   block tags: empty
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi]
+    Text[TEXT, pos:0, abc_def_ghi]
   body: 2
-    StartElement[START_ELEMENT, pos:14
+    StartElement[START_ELEMENT, pos:12
       name:p
       attributes: empty
     ]
-    Text[TEXT, pos:17, jkl_mno_pqr]
+    Text[TEXT, pos:15, jkl_mno_pqr]
   block tags: empty
 ]
 */
@@ -179,29 +178,28 @@ DocComment[DOC_COMMENT, pos:1
      */
     void newline_p() { }
 /*
-DocComment[DOC_COMMENT, pos:2
+DocComment[DOC_COMMENT, pos:1
   firstSentence: 2
-    StartElement[START_ELEMENT, pos:2
+    StartElement[START_ELEMENT, pos:1
       name:p
       attributes: empty
     ]
-    Text[TEXT, pos:5, abc_def_ghi.]
+    Text[TEXT, pos:4, abc_def_ghi.]
   body: 1
-    Text[TEXT, pos:19, jdl_mno_pqf]
+    Text[TEXT, pos:17, jdl_mno_pqf]
   block tags: empty
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:2
+DocComment[DOC_COMMENT, pos:1
   firstSentence: 2
-    StartElement[START_ELEMENT, pos:2
+    StartElement[START_ELEMENT, pos:1
       name:p
       attributes: empty
     ]
-    Text[TEXT, pos:5, abc_def_ghi.]
-  body: 1
-    Text[TEXT, pos:19, jdl_mno_pqf]
+    Text[TEXT, pos:4, abc_def_ghi.|jdl_mno_pqf]
+  body: empty
   block tags: empty
 ]
 */
@@ -211,23 +209,23 @@ DocComment[DOC_COMMENT, pos:2
      */
     void dot_end_p() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi]
+    Text[TEXT, pos:0, abc_def_ghi]
   body: 2
-    EndElement[END_ELEMENT, pos:14, p]
-    Text[TEXT, pos:18, jkl_mno_pqr]
+    EndElement[END_ELEMENT, pos:12, p]
+    Text[TEXT, pos:16, jkl_mno_pqr]
   block tags: empty
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi]
+    Text[TEXT, pos:0, abc_def_ghi]
   body: 2
-    EndElement[END_ELEMENT, pos:14, p]
-    Text[TEXT, pos:18, jkl_mno_pqr]
+    EndElement[END_ELEMENT, pos:12, p]
+    Text[TEXT, pos:16, jkl_mno_pqr]
   block tags: empty
 ]
 */
@@ -236,23 +234,23 @@ DocComment[DOC_COMMENT, pos:1
      */
     void entity() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Entity[ENTITY, pos:5, lt]
-    Text[TEXT, pos:9, _ghi.]
+    Text[TEXT, pos:0, abc_]
+    Entity[ENTITY, pos:4, lt]
+    Text[TEXT, pos:8, _ghi.]
   body: 1
-    Text[TEXT, pos:15, jkl_mno_pqr.]
+    Text[TEXT, pos:14, jkl_mno_pqr.]
   block tags: empty
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Entity[ENTITY, pos:5, lt]
-    Text[TEXT, pos:9, _ghi._jkl_mno_pqr.]
+    Text[TEXT, pos:0, abc_]
+    Entity[ENTITY, pos:4, lt]
+    Text[TEXT, pos:8, _ghi._jkl_mno_pqr.]
   body: empty
   block tags: empty
 ]
@@ -262,23 +260,23 @@ DocComment[DOC_COMMENT, pos:1
      */
     void inline_tag() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Literal[CODE, pos:5, code]
-    Text[TEXT, pos:17, _ghi.]
+    Text[TEXT, pos:0, abc_]
+    Literal[CODE, pos:4, code]
+    Text[TEXT, pos:16, _ghi.]
   body: 1
-    Text[TEXT, pos:23, jkl_mno_pqr.]
+    Text[TEXT, pos:22, jkl_mno_pqr.]
   block tags: empty
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Literal[CODE, pos:5, code]
-    Text[TEXT, pos:17, _ghi._jkl_mno_pqr.]
+    Text[TEXT, pos:0, abc_]
+    Literal[CODE, pos:4, code]
+    Text[TEXT, pos:16, _ghi._jkl_mno_pqr.]
   body: empty
   block tags: empty
 ]
@@ -289,27 +287,27 @@ DocComment[DOC_COMMENT, pos:1
      */
     void block_tag() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi]
+    Text[TEXT, pos:0, abc_def_ghi]
   body: empty
   block tags: 1
-    Author[AUTHOR, pos:14
+    Author[AUTHOR, pos:12
       name: 1
-        Text[TEXT, pos:22, jjg]
+        Text[TEXT, pos:20, jjg]
     ]
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc_def_ghi]
+    Text[TEXT, pos:0, abc_def_ghi]
   body: empty
   block tags: 1
-    Author[AUTHOR, pos:14
+    Author[AUTHOR, pos:12
       name: 1
-        Text[TEXT, pos:22, jjg]
+        Text[TEXT, pos:20, jjg]
     ]
 ]
 */
@@ -318,25 +316,25 @@ DocComment[DOC_COMMENT, pos:1
      */
     void just_tag() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Author[AUTHOR, pos:1
+    Author[AUTHOR, pos:0
       name: 1
-        Text[TEXT, pos:9, jjg]
+        Text[TEXT, pos:8, jjg]
     ]
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Author[AUTHOR, pos:1
+    Author[AUTHOR, pos:0
       name: 1
-        Text[TEXT, pos:9, jjg]
+        Text[TEXT, pos:8, jjg]
     ]
 ]
 */
@@ -346,29 +344,28 @@ DocComment[DOC_COMMENT, pos:1
      */
     void p_at_zero() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:p
       attributes: empty
     ]
-    Text[TEXT, pos:4, _abc_def.]
+    Text[TEXT, pos:3, _abc_def.]
   body: 1
-    Text[TEXT, pos:15, ghi_jkl]
+    Text[TEXT, pos:13, ghi_jkl]
   block tags: empty
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:p
       attributes: empty
     ]
-    Text[TEXT, pos:4, _abc_def.]
-  body: 1
-    Text[TEXT, pos:15, ghi_jkl]
+    Text[TEXT, pos:3, _abc_def.|ghi_jkl]
+  body: empty
   block tags: empty
 ]
 */
@@ -378,29 +375,29 @@ DocComment[DOC_COMMENT, pos:1
      */
     void p_at_nonzero() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc]
+    Text[TEXT, pos:0, abc]
   body: 2
-    StartElement[START_ELEMENT, pos:5
+    StartElement[START_ELEMENT, pos:4
       name:p
       attributes: empty
     ]
-    Text[TEXT, pos:8, _def._ghi_jkl]
+    Text[TEXT, pos:7, _def._ghi_jkl]
   block tags: empty
 ]
 */
 /*
 BREAK_ITERATOR
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc]
+    Text[TEXT, pos:0, abc]
   body: 2
-    StartElement[START_ELEMENT, pos:5
+    StartElement[START_ELEMENT, pos:4
       name:p
       attributes: empty
     ]
-    Text[TEXT, pos:8, _def._ghi_jkl]
+    Text[TEXT, pos:7, _def._ghi_jkl]
   block tags: empty
 ]
 */

--- a/test/langtools/tools/javac/doctree/HiddenTest.java
+++ b/test/langtools/tools/javac/doctree/HiddenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,11 +39,11 @@ class HiddenTest {
      */
     void hidden() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Hidden[HIDDEN, pos:1
+    Hidden[HIDDEN, pos:0
       body: empty
     ]
 ]
@@ -54,13 +54,13 @@ DocComment[DOC_COMMENT, pos:1
      */
     void hidden_text() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Hidden[HIDDEN, pos:1
+    Hidden[HIDDEN, pos:0
       body: 1
-        Text[TEXT, pos:9, text]
+        Text[TEXT, pos:8, text]
     ]
 ]
 */

--- a/test/langtools/tools/javac/doctree/HiddenTest.java
+++ b/test/langtools/tools/javac/doctree/HiddenTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8073100 8273244
+ * @bug 8073100 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/InPreTest.java
+++ b/test/langtools/tools/javac/doctree/InPreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,19 +39,19 @@ class InPreTest {
      */
     public void after_pre() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, xyz]
+    Text[TEXT, pos:0, xyz]
   body: 6
-    StartElement[START_ELEMENT, pos:4
+    StartElement[START_ELEMENT, pos:3
       name:pre
       attributes: empty
     ]
-    Text[TEXT, pos:9, _pqr_]
-    EndElement[END_ELEMENT, pos:14, pre]
-    Text[TEXT, pos:20, _abc]
-    Literal[CODE, pos:24, _def__]
-    Text[TEXT, pos:38, ghi]
+    Text[TEXT, pos:8, _pqr_]
+    EndElement[END_ELEMENT, pos:13, pre]
+    Text[TEXT, pos:19, _abc]
+    Literal[CODE, pos:23, _def__]
+    Text[TEXT, pos:37, ghi]
   block tags: empty
 ]
 */
@@ -60,11 +60,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     public void no_pre() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc]
-    Literal[CODE, pos:4, def]
-    Text[TEXT, pos:15, ghi]
+    Text[TEXT, pos:0, abc]
+    Literal[CODE, pos:3, def]
+    Text[TEXT, pos:14, ghi]
   body: empty
   block tags: empty
 ]
@@ -74,18 +74,18 @@ DocComment[DOC_COMMENT, pos:1
      */
     public void pre_after_text() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, xyz]
+    Text[TEXT, pos:0, xyz]
   body: 5
-    StartElement[START_ELEMENT, pos:4
+    StartElement[START_ELEMENT, pos:3
       name:pre
       attributes: empty
     ]
-    Text[TEXT, pos:9, _abc]
-    Literal[CODE, pos:13, _def__]
-    Text[TEXT, pos:27, ghi]
-    EndElement[END_ELEMENT, pos:30, pre]
+    Text[TEXT, pos:8, _abc]
+    Literal[CODE, pos:12, _def__]
+    Text[TEXT, pos:26, ghi]
+    EndElement[END_ELEMENT, pos:29, pre]
   block tags: empty
 ]
 */
@@ -95,11 +95,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     public void no_pre_extra_whitespace() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc]
-    Literal[CODE, pos:4, _def__]
-    Text[TEXT, pos:18, ghi]
+    Text[TEXT, pos:0, abc]
+    Literal[CODE, pos:3, _def__]
+    Text[TEXT, pos:17, ghi]
   body: empty
   block tags: empty
 ]
@@ -109,17 +109,17 @@ DocComment[DOC_COMMENT, pos:1
      */
     public void in_pre() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 4
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:pre
       attributes: empty
     ]
-    Text[TEXT, pos:6, _abc]
-    Literal[CODE, pos:10, _def__]
-    Text[TEXT, pos:24, ghi]
+    Text[TEXT, pos:5, _abc]
+    Literal[CODE, pos:9, _def__]
+    Text[TEXT, pos:23, ghi]
   body: 1
-    EndElement[END_ELEMENT, pos:27, pre]
+    EndElement[END_ELEMENT, pos:26, pre]
   block tags: empty
 ]
 */
@@ -129,17 +129,17 @@ DocComment[DOC_COMMENT, pos:1
      */
     public void in_pre_with_space_nl() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 4
-    StartElement[START_ELEMENT, pos:1
+    StartElement[START_ELEMENT, pos:0
       name:pre
       attributes: empty
     ]
-    Text[TEXT, pos:6, _abc]
-    Literal[CODE, pos:10, |_def__]
-    Text[TEXT, pos:24, ghi]
+    Text[TEXT, pos:5, _abc]
+    Literal[CODE, pos:9, |def__]
+    Text[TEXT, pos:22, ghi]
   body: 1
-    EndElement[END_ELEMENT, pos:27, pre]
+    EndElement[END_ELEMENT, pos:25, pre]
   block tags: empty
 ]
 */
@@ -169,10 +169,10 @@ DocComment[DOC_COMMENT, pos:1
      */
     public void bad_code_no_content() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:10
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:9
       code: compiler.err.dc.unterminated.inline.tag
       body: {@code
     ]
@@ -185,10 +185,10 @@ DocComment[DOC_COMMENT, pos:1
      */
     public void bad_code_content() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:14
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:13
       code: compiler.err.dc.unterminated.inline.tag
       body: {@code_abc
     ]

--- a/test/langtools/tools/javac/doctree/InPreTest.java
+++ b/test/langtools/tools/javac/doctree/InPreTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8078320 8273244 8284908
+ * @bug 8078320 8273244 8284908 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/IndexTest.java
+++ b/test/langtools/tools/javac/doctree/IndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,15 +39,15 @@ class IndexTest {
      */
     void simple_term() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Index[INDEX, pos:5
+    Text[TEXT, pos:0, abc_]
+    Index[INDEX, pos:4
       term:
-        Text[TEXT, pos:13, xyz]
+        Text[TEXT, pos:12, xyz]
       description: empty
     ]
-    Text[TEXT, pos:17, _def]
+    Text[TEXT, pos:16, _def]
   body: empty
   block tags: empty
 ]
@@ -58,16 +58,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void simple_term_with_description() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Index[INDEX, pos:5
+    Text[TEXT, pos:0, abc_]
+    Index[INDEX, pos:4
       term:
-        Text[TEXT, pos:13, lmn]
+        Text[TEXT, pos:12, lmn]
       description: 1
-        Text[TEXT, pos:17, pqr_stu]
+        Text[TEXT, pos:16, pqr_stu]
     ]
-    Text[TEXT, pos:25, _def]
+    Text[TEXT, pos:24, _def]
   body: empty
   block tags: empty
 ]
@@ -78,16 +78,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void phrase_with_curly_description() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Index[INDEX, pos:5
+    Text[TEXT, pos:0, abc_]
+    Index[INDEX, pos:4
       term:
-        Text[TEXT, pos:13, ijk]
+        Text[TEXT, pos:12, ijk]
       description: 1
-        Text[TEXT, pos:17, {lmn_opq}_]
+        Text[TEXT, pos:16, {lmn_opq}_]
     ]
-    Text[TEXT, pos:28, _def]
+    Text[TEXT, pos:27, _def]
   body: empty
   block tags: empty
 ]
@@ -100,16 +100,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void phrase_with_nl_description() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Index[INDEX, pos:5
+    Text[TEXT, pos:0, abc_]
+    Index[INDEX, pos:4
       term:
-        Text[TEXT, pos:13, ijk]
+        Text[TEXT, pos:12, ijk]
       description: 1
-        Text[TEXT, pos:17, lmn|_opq|_rst|_]
+        Text[TEXT, pos:16, lmn|opq|rst|]
     ]
-    Text[TEXT, pos:33, _def]
+    Text[TEXT, pos:29, _def]
   body: empty
   block tags: empty
 ]
@@ -120,15 +120,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void phrase_no_description() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Index[INDEX, pos:5
+    Text[TEXT, pos:0, abc_]
+    Index[INDEX, pos:4
       term:
-        Text[TEXT, pos:13, "lmn_pqr"]
+        Text[TEXT, pos:12, "lmn_pqr"]
       description: empty
     ]
-    Text[TEXT, pos:23, _def]
+    Text[TEXT, pos:22, _def]
   body: empty
   block tags: empty
 ]
@@ -139,16 +139,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void phrase_with_description() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Index[INDEX, pos:5
+    Text[TEXT, pos:0, abc_]
+    Index[INDEX, pos:4
       term:
-        Text[TEXT, pos:13, "ijk_lmn"]
+        Text[TEXT, pos:12, "ijk_lmn"]
       description: 1
-        Text[TEXT, pos:23, pqr_xyz]
+        Text[TEXT, pos:22, pqr_xyz]
     ]
-    Text[TEXT, pos:31, _def]
+    Text[TEXT, pos:30, _def]
   body: empty
   block tags: empty
 ]
@@ -159,22 +159,22 @@ DocComment[DOC_COMMENT, pos:1
      */
     void term_and_description_with_nested_tag() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Index[INDEX, pos:5
+    Text[TEXT, pos:0, abc_]
+    Index[INDEX, pos:4
       term:
-        Text[TEXT, pos:13, {@xyz}]
+        Text[TEXT, pos:12, {@xyz}]
       description: 3
-        Text[TEXT, pos:20, "]
-        UnknownInlineTag[UNKNOWN_INLINE_TAG, pos:21
+        Text[TEXT, pos:19, "]
+        UnknownInlineTag[UNKNOWN_INLINE_TAG, pos:20
           tag:see
           content: 1
-            Text[TEXT, pos:27, xyz]
+            Text[TEXT, pos:26, xyz]
         ]
-        Text[TEXT, pos:31, "]
+        Text[TEXT, pos:30, "]
     ]
-    Text[TEXT, pos:33, _def]
+    Text[TEXT, pos:32, _def]
   body: empty
   block tags: empty
 ]
@@ -184,16 +184,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void term_with_at() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Index[INDEX, pos:5
+    Text[TEXT, pos:0, abc_]
+    Index[INDEX, pos:4
       term:
-        Text[TEXT, pos:13, @def]
+        Text[TEXT, pos:12, @def]
       description: 1
-        Text[TEXT, pos:18, lmn_]
+        Text[TEXT, pos:17, lmn_]
     ]
-    Text[TEXT, pos:23, _xyz]
+    Text[TEXT, pos:22, _xyz]
   body: empty
   block tags: empty
 ]
@@ -204,16 +204,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void term_with_text_at() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Index[INDEX, pos:5
+    Text[TEXT, pos:0, abc_]
+    Index[INDEX, pos:4
       term:
-        Text[TEXT, pos:13, ijk@lmn]
+        Text[TEXT, pos:12, ijk@lmn]
       description: 1
-        Text[TEXT, pos:21, pqr_]
+        Text[TEXT, pos:20, pqr_]
     ]
-    Text[TEXT, pos:26, _xyz]
+    Text[TEXT, pos:25, _xyz]
   body: empty
   block tags: empty
 ]
@@ -224,15 +224,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void empty_index_in_quotes() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Index[INDEX, pos:5
+    Text[TEXT, pos:0, abc_]
+    Index[INDEX, pos:4
       term:
-        Text[TEXT, pos:13, ""]
+        Text[TEXT, pos:12, ""]
       description: empty
     ]
-    Text[TEXT, pos:16, _def]
+    Text[TEXT, pos:15, _def]
   body: empty
   block tags: empty
 ]
@@ -245,18 +245,18 @@ DocComment[DOC_COMMENT, pos:1
     @NormalizeTags(false) // see DocCommentTester.PrettyChecker
     void bad_nl_at_in_term() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:11
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:10
       code: compiler.err.dc.no.content
       body: {@index
     ]
   body: empty
   block tags: 1
-    Return[RETURN, pos:14
+    Return[RETURN, pos:12
       description: 1
-        Text[TEXT, pos:22, def}_xyz]
+        Text[TEXT, pos:20, def}_xyz]
     ]
 ]
 */
@@ -265,10 +265,10 @@ DocComment[DOC_COMMENT, pos:1
      */
     void bad_unbalanced_quote() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:22
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:21
       code: compiler.err.dc.no.content
       body: {@index_"xyz_}_def
     ]
@@ -281,14 +281,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void bad_no_index() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:11
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:10
       code: compiler.err.dc.no.content
       body: {@index
     ]
-    Text[TEXT, pos:12, }_def]
+    Text[TEXT, pos:11, }_def]
   body: empty
   block tags: empty
 ]

--- a/test/langtools/tools/javac/doctree/IndexTest.java
+++ b/test/langtools/tools/javac/doctree/IndexTest.java
@@ -242,7 +242,6 @@ DocComment[DOC_COMMENT, pos:0
      * abc {@index
      * @return def} xyz
      */
-    @NormalizeTags(false) // see DocCommentTester.PrettyChecker
     void bad_nl_at_in_term() {}
 /*
 DocComment[DOC_COMMENT, pos:0

--- a/test/langtools/tools/javac/doctree/IndexTest.java
+++ b/test/langtools/tools/javac/doctree/IndexTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8144287 8273244 8284908 8305620
+ * @bug 8144287 8273244 8284908 8305620 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/LinkPlainTest.java
+++ b/test/langtools/tools/javac/doctree/LinkPlainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,15 +39,15 @@ class LinkPlainTest {
       */
     void simple_name() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK_PLAIN, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK_PLAIN, pos:4
       reference:
-        Reference[REFERENCE, pos:17, String]
+        Reference[REFERENCE, pos:16, String]
       body: empty
     ]
-    Text[TEXT, pos:24, _def]
+    Text[TEXT, pos:23, _def]
   body: empty
   block tags: empty
 ]
@@ -58,16 +58,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void simple_name_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK_PLAIN, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK_PLAIN, pos:4
       reference:
-        Reference[REFERENCE, pos:17, String]
+        Reference[REFERENCE, pos:16, String]
       body: 1
-        Text[TEXT, pos:24, desc]
+        Text[TEXT, pos:23, desc]
     ]
-    Text[TEXT, pos:29, _def]
+    Text[TEXT, pos:28, _def]
   body: empty
   block tags: empty
 ]
@@ -78,16 +78,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void pkg_name_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK_PLAIN, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK_PLAIN, pos:4
       reference:
-        Reference[REFERENCE, pos:17, java.lang.String]
+        Reference[REFERENCE, pos:16, java.lang.String]
       body: 1
-        Text[TEXT, pos:34, desc]
+        Text[TEXT, pos:33, desc]
     ]
-    Text[TEXT, pos:39, _def]
+    Text[TEXT, pos:38, _def]
   body: empty
   block tags: empty
 ]
@@ -98,16 +98,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void method_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK_PLAIN, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK_PLAIN, pos:4
       reference:
-        Reference[REFERENCE, pos:17, java.lang.String#isEmpty]
+        Reference[REFERENCE, pos:16, java.lang.String#isEmpty]
       body: 1
-        Text[TEXT, pos:42, desc]
+        Text[TEXT, pos:41, desc]
     ]
-    Text[TEXT, pos:47, _def]
+    Text[TEXT, pos:46, _def]
   body: empty
   block tags: empty
 ]
@@ -118,16 +118,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void method_0_args_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK_PLAIN, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK_PLAIN, pos:4
       reference:
-        Reference[REFERENCE, pos:17, java.lang.String#isEmpty()]
+        Reference[REFERENCE, pos:16, java.lang.String#isEmpty()]
       body: 1
-        Text[TEXT, pos:44, desc]
+        Text[TEXT, pos:43, desc]
     ]
-    Text[TEXT, pos:49, _def]
+    Text[TEXT, pos:48, _def]
   body: empty
   block tags: empty
 ]
@@ -138,16 +138,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void method_1_args_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK_PLAIN, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK_PLAIN, pos:4
       reference:
-        Reference[REFERENCE, pos:17, java.lang.String#substring(int)]
+        Reference[REFERENCE, pos:16, java.lang.String#substring(int)]
       body: 1
-        Text[TEXT, pos:49, desc]
+        Text[TEXT, pos:48, desc]
     ]
-    Text[TEXT, pos:54, _def]
+    Text[TEXT, pos:53, _def]
   body: empty
   block tags: empty
 ]
@@ -158,16 +158,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void method_2_args_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK_PLAIN, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK_PLAIN, pos:4
       reference:
-        Reference[REFERENCE, pos:17, java.lang.String#substring(int,_int)]
+        Reference[REFERENCE, pos:16, java.lang.String#substring(int,_int)]
       body: 1
-        Text[TEXT, pos:54, desc]
+        Text[TEXT, pos:53, desc]
     ]
-    Text[TEXT, pos:59, _def]
+    Text[TEXT, pos:58, _def]
   body: empty
   block tags: empty
 ]
@@ -178,16 +178,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void pkg_name_typarams_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK_PLAIN, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK_PLAIN, pos:4
       reference:
-        Reference[REFERENCE, pos:17, java.util.List<T>]
+        Reference[REFERENCE, pos:16, java.util.List<T>]
       body: 1
-        Text[TEXT, pos:35, desc]
+        Text[TEXT, pos:34, desc]
     ]
-    Text[TEXT, pos:40, _def]
+    Text[TEXT, pos:39, _def]
   body: empty
   block tags: empty
 ]
@@ -198,16 +198,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void fragment_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK_PLAIN, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK_PLAIN, pos:4
       reference:
-        Reference[REFERENCE, pos:17, java.lang.String##fragment]
+        Reference[REFERENCE, pos:16, java.lang.String##fragment]
       body: 1
-        Text[TEXT, pos:44, desc]
+        Text[TEXT, pos:43, desc]
     ]
-    Text[TEXT, pos:49, _def]
+    Text[TEXT, pos:48, _def]
   body: empty
   block tags: empty
 ]

--- a/test/langtools/tools/javac/doctree/LinkPlainTest.java
+++ b/test/langtools/tools/javac/doctree/LinkPlainTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244 8200337
+ * @bug 7021614 8273244 8200337 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/LinkTest.java
+++ b/test/langtools/tools/javac/doctree/LinkTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244 8200337
+ * @bug 7021614 8273244 8200337 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/LinkTest.java
+++ b/test/langtools/tools/javac/doctree/LinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,15 +39,15 @@ class LinkTest {
       */
     void simple_name() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK, pos:4
       reference:
-        Reference[REFERENCE, pos:12, String]
+        Reference[REFERENCE, pos:11, String]
       body: empty
     ]
-    Text[TEXT, pos:19, _def]
+    Text[TEXT, pos:18, _def]
   body: empty
   block tags: empty
 ]
@@ -58,16 +58,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void simple_name_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK, pos:4
       reference:
-        Reference[REFERENCE, pos:12, String]
+        Reference[REFERENCE, pos:11, String]
       body: 1
-        Text[TEXT, pos:19, desc]
+        Text[TEXT, pos:18, desc]
     ]
-    Text[TEXT, pos:24, _def]
+    Text[TEXT, pos:23, _def]
   body: empty
   block tags: empty
 ]
@@ -78,16 +78,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void pkg_name_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK, pos:4
       reference:
-        Reference[REFERENCE, pos:12, java.lang.String]
+        Reference[REFERENCE, pos:11, java.lang.String]
       body: 1
-        Text[TEXT, pos:29, desc]
+        Text[TEXT, pos:28, desc]
     ]
-    Text[TEXT, pos:34, _def]
+    Text[TEXT, pos:33, _def]
   body: empty
   block tags: empty
 ]
@@ -98,16 +98,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void method_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK, pos:4
       reference:
-        Reference[REFERENCE, pos:12, java.lang.String#isEmpty]
+        Reference[REFERENCE, pos:11, java.lang.String#isEmpty]
       body: 1
-        Text[TEXT, pos:37, desc]
+        Text[TEXT, pos:36, desc]
     ]
-    Text[TEXT, pos:42, _def]
+    Text[TEXT, pos:41, _def]
   body: empty
   block tags: empty
 ]
@@ -118,16 +118,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void method_0_args_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK, pos:4
       reference:
-        Reference[REFERENCE, pos:12, java.lang.String#isEmpty()]
+        Reference[REFERENCE, pos:11, java.lang.String#isEmpty()]
       body: 1
-        Text[TEXT, pos:39, desc]
+        Text[TEXT, pos:38, desc]
     ]
-    Text[TEXT, pos:44, _def]
+    Text[TEXT, pos:43, _def]
   body: empty
   block tags: empty
 ]
@@ -138,16 +138,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void method_1_args_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK, pos:4
       reference:
-        Reference[REFERENCE, pos:12, java.lang.String#substring(int)]
+        Reference[REFERENCE, pos:11, java.lang.String#substring(int)]
       body: 1
-        Text[TEXT, pos:44, desc]
+        Text[TEXT, pos:43, desc]
     ]
-    Text[TEXT, pos:49, _def]
+    Text[TEXT, pos:48, _def]
   body: empty
   block tags: empty
 ]
@@ -158,16 +158,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void method_2_args_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK, pos:4
       reference:
-        Reference[REFERENCE, pos:12, java.lang.String#substring(int,_int)]
+        Reference[REFERENCE, pos:11, java.lang.String#substring(int,_int)]
       body: 1
-        Text[TEXT, pos:49, desc]
+        Text[TEXT, pos:48, desc]
     ]
-    Text[TEXT, pos:54, _def]
+    Text[TEXT, pos:53, _def]
   body: empty
   block tags: empty
 ]
@@ -178,16 +178,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void pkg_name_typarams_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK, pos:4
       reference:
-        Reference[REFERENCE, pos:12, java.util.List<T>]
+        Reference[REFERENCE, pos:11, java.util.List<T>]
       body: 1
-        Text[TEXT, pos:30, desc]
+        Text[TEXT, pos:29, desc]
     ]
-    Text[TEXT, pos:35, _def]
+    Text[TEXT, pos:34, _def]
   body: empty
   block tags: empty
 ]
@@ -198,16 +198,16 @@ DocComment[DOC_COMMENT, pos:1
      */
     void fragment_desc() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Link[LINK, pos:5
+    Text[TEXT, pos:0, abc_]
+    Link[LINK, pos:4
       reference:
-        Reference[REFERENCE, pos:12, java.lang.String##fragment]
+        Reference[REFERENCE, pos:11, java.lang.String##fragment]
       body: 1
-        Text[TEXT, pos:39, desc]
+        Text[TEXT, pos:38, desc]
     ]
-    Text[TEXT, pos:44, _def]
+    Text[TEXT, pos:43, _def]
   body: empty
   block tags: empty
 ]

--- a/test/langtools/tools/javac/doctree/LiteralTest.java
+++ b/test/langtools/tools/javac/doctree/LiteralTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,9 +76,9 @@ DocComment[DOC_COMMENT, pos:0
      */
     void nested() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Literal[LITERAL, pos:1, {@literal_nested}_]
+    Literal[LITERAL, pos:0, {@literal_nested}_]
   body: empty
   block tags: empty
 ]
@@ -91,9 +91,9 @@ DocComment[DOC_COMMENT, pos:1
      */
     void embedded_newline() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Literal[LITERAL, pos:1, if_(a_<_b)_{|________}|_]
+    Literal[LITERAL, pos:0, if_(a_<_b)_{|_______}|]
   body: empty
   block tags: empty
 ]
@@ -106,14 +106,13 @@ DocComment[DOC_COMMENT, pos:1
      */
     void embedded_at() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Literal[LITERAL, pos:1, |_@tag|_]
+    Literal[LITERAL, pos:0, |@tag|]
   body: empty
   block tags: empty
 ]
 */
-
 
     /** {@literal if (a < b) { } */
     void unterminated_1() { }
@@ -134,11 +133,11 @@ DocComment[DOC_COMMENT, pos:0
      * @author jjg */
     void unterminated_2() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Erroneous[ERRONEOUS, pos:1, prefPos:37
+    Erroneous[ERRONEOUS, pos:0, prefPos:35
       code: compiler.err.dc.unterminated.inline.tag
-      body: {@literal_if_(a_<_b)_{_}|_@author_jjg
+      body: {@literal_if_(a_<_b)_{_}|@author_jjg
     ]
   body: empty
   block tags: empty

--- a/test/langtools/tools/javac/doctree/LiteralTest.java
+++ b/test/langtools/tools/javac/doctree/LiteralTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614  8241780 8273244 8284908
+ * @bug 7021614  8241780 8273244 8284908 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/ParamTest.java
+++ b/test/langtools/tools/javac/doctree/ParamTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244 8284908
+ * @bug 7021614 8273244 8284908 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/ParamTest.java
+++ b/test/langtools/tools/javac/doctree/ParamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,13 +39,13 @@ class ParamTest {
      */
     void no_description(int x) { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Param[PARAM, pos:1
+    Param[PARAM, pos:0
       name:
-        Identifier[IDENTIFIER, pos:8, x]
+        Identifier[IDENTIFIER, pos:7, x]
       description: empty
     ]
 ]
@@ -56,15 +56,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void with_description(int x) { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Param[PARAM, pos:1
+    Param[PARAM, pos:0
       name:
-        Identifier[IDENTIFIER, pos:8, x]
+        Identifier[IDENTIFIER, pos:7, x]
       description: 1
-        Text[TEXT, pos:10, description]
+        Text[TEXT, pos:9, description]
     ]
 ]
 */
@@ -73,11 +73,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     <T> void type_param(int x) { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Erroneous[ERRONEOUS, pos:1, prefPos:10
+    Erroneous[ERRONEOUS, pos:0, prefPos:9
       code: compiler.err.dc.gt.expected
       body: @param_<T_type
     ]

--- a/test/langtools/tools/javac/doctree/ProvidesTest.java
+++ b/test/langtools/tools/javac/doctree/ProvidesTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8160196 8273244
+ * @bug 8160196 8273244 8352249
  * @summary Module summary page should display information based on "api" or "detail" mode.
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/ProvidesTest.java
+++ b/test/langtools/tools/javac/doctree/ProvidesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,14 +40,14 @@ class ProvidesTest {
       */
     void simple_provides() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    Provides[PROVIDES, pos:7
+    Provides[PROVIDES, pos:5
       serviceName:
-        Reference[REFERENCE, pos:17, UsesTest]
+        Reference[REFERENCE, pos:15, UsesTest]
       description: empty
     ]
 ]
@@ -59,16 +59,16 @@ DocComment[DOC_COMMENT, pos:1
       */
     void provides_with_description() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    Provides[PROVIDES, pos:7
+    Provides[PROVIDES, pos:5
       serviceName:
-        Reference[REFERENCE, pos:17, UsesTest]
+        Reference[REFERENCE, pos:15, UsesTest]
       description: 1
-        Text[TEXT, pos:26, Test_description_for_provides.]
+        Text[TEXT, pos:24, Test_description_for_provides.]
     ]
 ]
 */

--- a/test/langtools/tools/javac/doctree/ReturnTest.java
+++ b/test/langtools/tools/javac/doctree/ReturnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,13 +39,13 @@ class ReturnTest {
      */
     int an_int() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Return[RETURN, pos:1
+    Return[RETURN, pos:0
       description: 1
-        Text[TEXT, pos:9, something]
+        Text[TEXT, pos:8, something]
     ]
 ]
 */

--- a/test/langtools/tools/javac/doctree/ReturnTest.java
+++ b/test/langtools/tools/javac/doctree/ReturnTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244
+ * @bug 7021614 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/SeeTest.java
+++ b/test/langtools/tools/javac/doctree/SeeTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8031212 8273244 8284908 8200337 8288619
+ * @bug 7021614 8031212 8273244 8284908 8200337 8288619 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/SeeTest.java
+++ b/test/langtools/tools/javac/doctree/SeeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,14 +40,14 @@ class SeeTest {
      */
     void quoted_text() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    See[SEE, pos:7
+    See[SEE, pos:5
       reference: 1
-        Text[TEXT, pos:12, "String"]
+        Text[TEXT, pos:10, "String"]
     ]
 ]
 */
@@ -58,14 +58,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void at_sign_in_quoted_string() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, Test_'@'_in_quoted_string.]
+    Text[TEXT, pos:0, Test_'@'_in_quoted_string.]
   body: empty
   block tags: 1
-    See[SEE, pos:29
+    See[SEE, pos:27
       reference: 1
-        Text[TEXT, pos:34, "{@code}"]
+        Text[TEXT, pos:32, "{@code}"]
     ]
 ]
 */
@@ -78,14 +78,14 @@ DocComment[DOC_COMMENT, pos:1
     @PrettyCheck(false)
     void new_line_before_quoted_string() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, Test_new_line_before_quoted_string.]
+    Text[TEXT, pos:0, Test_new_line_before_quoted_string.]
   body: empty
   block tags: 1
-    See[SEE, pos:38
+    See[SEE, pos:36
       reference: 1
-        Text[TEXT, pos:47, "{@code}"]
+        Text[TEXT, pos:44, "{@code}"]
     ]
 ]
 */
@@ -96,25 +96,25 @@ DocComment[DOC_COMMENT, pos:1
      */
     void url() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    See[SEE, pos:7
+    See[SEE, pos:5
       reference: 3
-        StartElement[START_ELEMENT, pos:12
+        StartElement[START_ELEMENT, pos:10
           name:a
           attributes: 1
-            Attribute[ATTRIBUTE, pos:15
+            Attribute[ATTRIBUTE, pos:13
               name: href
               vkind: DOUBLE
               value: 1
-                Text[TEXT, pos:21, url]
+                Text[TEXT, pos:19, url]
             ]
         ]
-        Text[TEXT, pos:26, url]
-        EndElement[END_ELEMENT, pos:29, a]
+        Text[TEXT, pos:24, url]
+        EndElement[END_ELEMENT, pos:27, a]
     ]
 ]
 */
@@ -125,15 +125,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void string() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    See[SEE, pos:7
+    See[SEE, pos:5
       reference: 2
-        Reference[REFERENCE, pos:12, String]
-        Text[TEXT, pos:19, text]
+        Reference[REFERENCE, pos:10, String]
+        Text[TEXT, pos:17, text]
     ]
 ]
 */
@@ -144,15 +144,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void j_l_string() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    See[SEE, pos:7
+    See[SEE, pos:5
       reference: 2
-        Reference[REFERENCE, pos:12, java.lang.String]
-        Text[TEXT, pos:29, text]
+        Reference[REFERENCE, pos:10, java.lang.String]
+        Text[TEXT, pos:27, text]
     ]
 ]
 */
@@ -163,15 +163,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void j_l_string_length() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    See[SEE, pos:7
+    See[SEE, pos:5
       reference: 2
-        Reference[REFERENCE, pos:12, java.lang.String#length]
-        Text[TEXT, pos:36, text]
+        Reference[REFERENCE, pos:10, java.lang.String#length]
+        Text[TEXT, pos:34, text]
     ]
 ]
 */
@@ -182,15 +182,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void j_l_string_matches() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    See[SEE, pos:7
+    See[SEE, pos:5
       reference: 2
-        Reference[REFERENCE, pos:12, java.lang.String#matches(String_regex)]
-        Text[TEXT, pos:51, text]
+        Reference[REFERENCE, pos:10, java.lang.String#matches(String_regex)]
+        Text[TEXT, pos:49, text]
     ]
 ]
 */
@@ -201,15 +201,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void j_l_string_anchor() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    See[SEE, pos:7
+    See[SEE, pos:5
       reference: 2
-        Reference[REFERENCE, pos:12, java.lang.String##fragment]
-        Text[TEXT, pos:39, text]
+        Reference[REFERENCE, pos:10, java.lang.String##fragment]
+        Text[TEXT, pos:37, text]
     ]
 ]
 */
@@ -220,12 +220,12 @@ DocComment[DOC_COMMENT, pos:1
      */
     void bad_numeric() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    Erroneous[ERRONEOUS, pos:7, prefPos:19
+    Erroneous[ERRONEOUS, pos:5, prefPos:17
       code: compiler.err.dc.unexpected.content
       body: @see_123_text
     ]

--- a/test/langtools/tools/javac/doctree/SerialDataTest.java
+++ b/test/langtools/tools/javac/doctree/SerialDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,13 +39,13 @@ class SerialDataTest {
      */
     void writeObject(ObjectOutputStream stream) { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    SerialData[SERIAL_DATA, pos:1
+    SerialData[SERIAL_DATA, pos:0
       description: 1
-        Text[TEXT, pos:13, description]
+        Text[TEXT, pos:12, description]
     ]
 ]
 */

--- a/test/langtools/tools/javac/doctree/SerialDataTest.java
+++ b/test/langtools/tools/javac/doctree/SerialDataTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244
+ * @bug 7021614 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/SerialFieldTest.java
+++ b/test/langtools/tools/javac/doctree/SerialFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,15 +40,15 @@ class SerialFieldTest {
      */
     String f1;
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    SerialField[SERIAL_FIELD, pos:1
+    SerialField[SERIAL_FIELD, pos:0
       name:
-        Identifier[IDENTIFIER, pos:14, field]
+        Identifier[IDENTIFIER, pos:13, field]
       type:
-        Reference[REFERENCE, pos:20, String]
+        Reference[REFERENCE, pos:19, String]
       description: empty
     ]
 ]
@@ -59,17 +59,17 @@ DocComment[DOC_COMMENT, pos:1
      */
     String f2;
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    SerialField[SERIAL_FIELD, pos:1
+    SerialField[SERIAL_FIELD, pos:0
       name:
-        Identifier[IDENTIFIER, pos:14, field]
+        Identifier[IDENTIFIER, pos:13, field]
       type:
-        Reference[REFERENCE, pos:20, String]
+        Reference[REFERENCE, pos:19, String]
       description: 1
-        Text[TEXT, pos:27, f2_is_a_String]
+        Text[TEXT, pos:26, f2_is_a_String]
     ]
 ]
 */
@@ -79,11 +79,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     String f3;
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Erroneous[ERRONEOUS, pos:1, prefPos:26
+    Erroneous[ERRONEOUS, pos:0, prefPos:25
       code: compiler.err.dc.ref.unexpected.input
       body: @serialField_field_String#member_f3_is_a_String
     ]
@@ -95,11 +95,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     String f4;
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Erroneous[ERRONEOUS, pos:1, prefPos:26
+    Erroneous[ERRONEOUS, pos:0, prefPos:25
       code: compiler.err.dc.ref.unexpected.input
       body: @serialField_field_String##fragment_f4_is_a_String
     ]

--- a/test/langtools/tools/javac/doctree/SerialFieldTest.java
+++ b/test/langtools/tools/javac/doctree/SerialFieldTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244
+ * @bug 7021614 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/SerialTest.java
+++ b/test/langtools/tools/javac/doctree/SerialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,13 +39,13 @@ class SerialTest {
      */
     void include() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Serial[SERIAL, pos:1
+    Serial[SERIAL, pos:0
       description: 1
-        Text[TEXT, pos:9, include]
+        Text[TEXT, pos:8, include]
     ]
 ]
 */
@@ -55,13 +55,13 @@ DocComment[DOC_COMMENT, pos:1
      */
     void exclude() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Serial[SERIAL, pos:1
+    Serial[SERIAL, pos:0
       description: 1
-        Text[TEXT, pos:9, exclude]
+        Text[TEXT, pos:8, exclude]
     ]
 ]
 */
@@ -71,13 +71,13 @@ DocComment[DOC_COMMENT, pos:1
      */
     void description() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Serial[SERIAL, pos:1
+    Serial[SERIAL, pos:0
       description: 1
-        Text[TEXT, pos:9, description]
+        Text[TEXT, pos:8, description]
     ]
 ]
 */
@@ -87,11 +87,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     void empty() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Serial[SERIAL, pos:1
+    Serial[SERIAL, pos:0
       description: empty
     ]
 ]

--- a/test/langtools/tools/javac/doctree/SerialTest.java
+++ b/test/langtools/tools/javac/doctree/SerialTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244
+ * @bug 7021614 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/SinceTest.java
+++ b/test/langtools/tools/javac/doctree/SinceTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244
+ * @bug 7021614 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/SinceTest.java
+++ b/test/langtools/tools/javac/doctree/SinceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,16 +40,16 @@ class SinceTest {
      */
     void standard() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    Since[SINCE, pos:7
+    Since[SINCE, pos:5
       body: 3
-        Text[TEXT, pos:14, then_]
-        Entity[ENTITY, pos:19, amp]
-        Text[TEXT, pos:24, _now.]
+        Text[TEXT, pos:12, then_]
+        Entity[ENTITY, pos:17, amp]
+        Text[TEXT, pos:22, _now.]
     ]
 ]
 */

--- a/test/langtools/tools/javac/doctree/SnippetTest.java
+++ b/test/langtools/tools/javac/doctree/SnippetTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8266666
+ * @bug 8266666 8352249
  * @summary Implementation for snippets
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/SnippetTest.java
+++ b/test/langtools/tools/javac/doctree/SnippetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,18 +41,18 @@ class SnippetTest {
      */
     void inline() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Snippet[SNIPPET, pos:1
+    Snippet[SNIPPET, pos:0
       attributes: 1
-        Attribute[ATTRIBUTE, pos:11
+        Attribute[ATTRIBUTE, pos:10
           name: attr1
           vkind: DOUBLE
           value: 1
-            Text[TEXT, pos:18, val1]
+            Text[TEXT, pos:17, val1]
         ]
       body:
-        Text[TEXT, pos:26, _____Hello,_Snippet!|_]
+        Text[TEXT, pos:25, ____Hello,_Snippet!|]
     ]
   body: empty
   block tags: empty

--- a/test/langtools/tools/javac/doctree/SpecTest.java
+++ b/test/langtools/tools/javac/doctree/SpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,16 +41,16 @@ class SpecTest {
      */
     void block() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    Spec[SPEC, pos:7
+    Spec[SPEC, pos:5
       url:
-        Text[TEXT, pos:13, http://example.com]
+        Text[TEXT, pos:11, http://example.com]
       title: 1
-        Text[TEXT, pos:32, title]
+        Text[TEXT, pos:30, title]
     ]
 ]
 */
@@ -61,12 +61,12 @@ DocComment[DOC_COMMENT, pos:1
      */
     void bad_no_url() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    Erroneous[ERRONEOUS, pos:7, prefPos:11
+    Erroneous[ERRONEOUS, pos:5, prefPos:9
       code: compiler.err.dc.no.url
       body: @spec
     ]
@@ -79,12 +79,12 @@ DocComment[DOC_COMMENT, pos:1
      */
     void bad_no_label() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    Erroneous[ERRONEOUS, pos:7, prefPos:30
+    Erroneous[ERRONEOUS, pos:5, prefPos:28
       code: compiler.err.dc.no.title
       body: @spec_http://example.com
     ]

--- a/test/langtools/tools/javac/doctree/SpecTest.java
+++ b/test/langtools/tools/javac/doctree/SpecTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6251738 8226279
+ * @bug 6251738 8226279 8352249
  * @summary javadoc should support a new at-spec tag
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/SummaryTest.java
+++ b/test/langtools/tools/javac/doctree/SummaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,13 +39,13 @@ class SummaryTest {
      */
     void empty() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Summary[SUMMARY, pos:1
+    Summary[SUMMARY, pos:0
       summary: empty
     ]
   body: 1
-    Text[TEXT, pos:11, _abc.]
+    Text[TEXT, pos:10, _abc.]
   block tags: empty
 ]
 */
@@ -54,14 +54,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void simple() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Summary[SUMMARY, pos:1
+    Summary[SUMMARY, pos:0
       summary: 1
-        Text[TEXT, pos:11, abc]
+        Text[TEXT, pos:10, abc]
     ]
   body: 1
-    Text[TEXT, pos:15, _def.]
+    Text[TEXT, pos:14, _def.]
   block tags: empty
 ]
 */
@@ -71,8 +71,30 @@ DocComment[DOC_COMMENT, pos:1
      */
     void leading_space() { }
 /*
-DocComment[DOC_COMMENT, pos:4
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
+    Summary[SUMMARY, pos:0
+      summary: 1
+        Text[TEXT, pos:10, abc]
+    ]
+  body: 1
+    Text[TEXT, pos:14, _def]
+  block tags: empty
+]
+*/
+
+    /**
+     * <p> {@summary abc} def
+     */
+    void leading_html() { }
+/*
+DocComment[DOC_COMMENT, pos:0
+  firstSentence: 3
+    StartElement[START_ELEMENT, pos:0
+      name:p
+      attributes: empty
+    ]
+    Text[TEXT, pos:3, _]
     Summary[SUMMARY, pos:4
       summary: 1
         Text[TEXT, pos:14, abc]
@@ -84,41 +106,19 @@ DocComment[DOC_COMMENT, pos:4
 */
 
     /**
-     * <p> {@summary abc} def
-     */
-    void leading_html() { }
-/*
-DocComment[DOC_COMMENT, pos:1
-  firstSentence: 3
-    StartElement[START_ELEMENT, pos:1
-      name:p
-      attributes: empty
-    ]
-    Text[TEXT, pos:4, _]
-    Summary[SUMMARY, pos:5
-      summary: 1
-        Text[TEXT, pos:15, abc]
-    ]
-  body: 1
-    Text[TEXT, pos:19, _def]
-  block tags: empty
-]
-*/
-
-    /**
      * abc {@summary def} ghi
      */
     void leading_text() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    Summary[SUMMARY, pos:5
+    Text[TEXT, pos:0, abc_]
+    Summary[SUMMARY, pos:4
       summary: 1
-        Text[TEXT, pos:15, def]
+        Text[TEXT, pos:14, def]
     ]
   body: 1
-    Text[TEXT, pos:19, _ghi]
+    Text[TEXT, pos:18, _ghi]
   block tags: empty
 ]
 */
@@ -128,15 +128,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void leading_text_with_break() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: 2
-    Summary[SUMMARY, pos:6
+    Summary[SUMMARY, pos:5
       summary: 1
-        Text[TEXT, pos:16, def]
+        Text[TEXT, pos:15, def]
     ]
-    Text[TEXT, pos:20, _ghi]
+    Text[TEXT, pos:19, _ghi]
   block tags: empty
 ]
 */
@@ -146,19 +146,19 @@ DocComment[DOC_COMMENT, pos:1
      */
     void trailing_html() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Summary[SUMMARY, pos:1
+    Summary[SUMMARY, pos:0
       summary: 1
-        Text[TEXT, pos:11, def]
+        Text[TEXT, pos:10, def]
     ]
   body: 3
-    Text[TEXT, pos:15, _]
-    StartElement[START_ELEMENT, pos:16
+    Text[TEXT, pos:14, _]
+    StartElement[START_ELEMENT, pos:15
       name:p
       attributes: empty
     ]
-    Text[TEXT, pos:19, _ghi]
+    Text[TEXT, pos:18, _ghi]
   block tags: empty
 ]
 */
@@ -168,18 +168,18 @@ DocComment[DOC_COMMENT, pos:1
      */
     void with_html() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Summary[SUMMARY, pos:1
+    Summary[SUMMARY, pos:0
       summary: 5
-        Text[TEXT, pos:11, abc_]
-        Entity[ENTITY, pos:15, lt]
-        Text[TEXT, pos:19, def]
-        Entity[ENTITY, pos:22, gt]
-        Text[TEXT, pos:26, _ghi]
+        Text[TEXT, pos:10, abc_]
+        Entity[ENTITY, pos:14, lt]
+        Text[TEXT, pos:18, def]
+        Entity[ENTITY, pos:21, gt]
+        Text[TEXT, pos:25, _ghi]
     ]
   body: 1
-    Text[TEXT, pos:31, _jkl]
+    Text[TEXT, pos:30, _jkl]
   block tags: empty
 ]
 */

--- a/test/langtools/tools/javac/doctree/SummaryTest.java
+++ b/test/langtools/tools/javac/doctree/SummaryTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8173425 8273244
+ * @bug 8173425 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/SystemPropertyTest.java
+++ b/test/langtools/tools/javac/doctree/SystemPropertyTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 5076751 8273244 8284908
+ * @bug 5076751 8273244 8284908 8352249
  * @summary System properties documentation needed in javadocs
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/SystemPropertyTest.java
+++ b/test/langtools/tools/javac/doctree/SystemPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,13 +39,13 @@ class SystemPropertyTest {
      */
     void simple_term() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    SystemProperty[SYSTEM_PROPERTY, pos:5
+    Text[TEXT, pos:0, abc_]
+    SystemProperty[SYSTEM_PROPERTY, pos:4
       property name: xyz.qwe
     ]
-    Text[TEXT, pos:30, _def]
+    Text[TEXT, pos:29, _def]
   body: empty
   block tags: empty
 ]
@@ -56,14 +56,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void bad_with_whitespace() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:26
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:25
       code: compiler.err.dc.unexpected.content
       body: {@systemProperty_xyz_q
     ]
-    Text[TEXT, pos:27, we}]
+    Text[TEXT, pos:26, we}]
   body: empty
   block tags: empty
 ]
@@ -74,14 +74,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void bad_no_property() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:20
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:19
       code: compiler.err.dc.no.content
       body: {@systemProperty
     ]
-    Text[TEXT, pos:21, }]
+    Text[TEXT, pos:20, }]
   body: empty
   block tags: empty
 ]

--- a/test/langtools/tools/javac/doctree/TagTest.java
+++ b/test/langtools/tools/javac/doctree/TagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,14 +39,14 @@ class TagTest {
      */
     void custom_tag_with_a_colon() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    UnknownBlockTag[UNKNOWN_BLOCK_TAG, pos:1
+    UnknownBlockTag[UNKNOWN_BLOCK_TAG, pos:0
       tag:tag:colon
       content: 1
-        Text[TEXT, pos:12, abc]
+        Text[TEXT, pos:11, abc]
     ]
 ]
 */
@@ -56,14 +56,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void custom_tag_with_a_hyphen() {}
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    UnknownBlockTag[UNKNOWN_BLOCK_TAG, pos:1
+    UnknownBlockTag[UNKNOWN_BLOCK_TAG, pos:0
       tag:tag-hyphen
       content: 1
-        Text[TEXT, pos:13, abc]
+        Text[TEXT, pos:12, abc]
     ]
 ]
 */
@@ -73,13 +73,13 @@ DocComment[DOC_COMMENT, pos:1
      */
     void simple_standard_block() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Author[AUTHOR, pos:1
+    Author[AUTHOR, pos:0
       name: 1
-        Text[TEXT, pos:9, jjg]
+        Text[TEXT, pos:8, jjg]
     ]
 ]
 */
@@ -89,11 +89,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     void no_name_block() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Erroneous[ERRONEOUS, pos:1, prefPos:2
+    Erroneous[ERRONEOUS, pos:0, prefPos:1
       code: compiler.err.dc.no.tag.name
       body: @_abc
     ]
@@ -105,14 +105,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     void unknown_name_block() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    UnknownBlockTag[UNKNOWN_BLOCK_TAG, pos:1
+    UnknownBlockTag[UNKNOWN_BLOCK_TAG, pos:0
       tag:abc
       content: 1
-        Text[TEXT, pos:6, def_ghi]
+        Text[TEXT, pos:5, def_ghi]
     ]
 ]
 */
@@ -122,11 +122,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     void simple_standard_inline() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Link[LINK, pos:1
+    Link[LINK, pos:0
       reference:
-        Reference[REFERENCE, pos:8, String]
+        Reference[REFERENCE, pos:7, String]
       body: empty
     ]
   body: empty
@@ -139,13 +139,13 @@ DocComment[DOC_COMMENT, pos:1
      */
     void no_name_inline() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Erroneous[ERRONEOUS, pos:1, prefPos:3
+    Erroneous[ERRONEOUS, pos:0, prefPos:2
       code: compiler.err.dc.no.tag.name
       body: {@
     ]
-    Text[TEXT, pos:3, _abc}]
+    Text[TEXT, pos:2, _abc}]
   body: empty
   block tags: empty
 ]
@@ -156,12 +156,12 @@ DocComment[DOC_COMMENT, pos:1
      */
     void unknown_name_inline() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    UnknownInlineTag[UNKNOWN_INLINE_TAG, pos:1
+    UnknownInlineTag[UNKNOWN_INLINE_TAG, pos:0
       tag:abc
       content: 1
-        Text[TEXT, pos:7, def_ghi]
+        Text[TEXT, pos:6, def_ghi]
     ]
   body: empty
   block tags: empty
@@ -173,9 +173,9 @@ DocComment[DOC_COMMENT, pos:1
      */
     void unterminated_standard_inline() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Erroneous[ERRONEOUS, pos:1, prefPos:13
+    Erroneous[ERRONEOUS, pos:0, prefPos:12
       code: compiler.err.dc.unterminated.inline.tag
       body: {@abc_def_ghi
     ]
@@ -193,9 +193,9 @@ DocComment[DOC_COMMENT, pos:1
      */
     void inline_text_at() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Literal[CODE, pos:1, |_abc|_@def|_ghi|_]
+    Literal[CODE, pos:0, |abc|@def|ghi|]
   body: empty
   block tags: empty
 ]
@@ -209,12 +209,12 @@ DocComment[DOC_COMMENT, pos:1
      */
     void inline_content_at() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    UnknownInlineTag[UNKNOWN_INLINE_TAG, pos:1
+    UnknownInlineTag[UNKNOWN_INLINE_TAG, pos:0
       tag:tag
       content: 1
-        Text[TEXT, pos:7, abc|_@def|_ghi|_]
+        Text[TEXT, pos:6, abc|@def|ghi|]
     ]
   body: empty
   block tags: empty

--- a/test/langtools/tools/javac/doctree/TagTest.java
+++ b/test/langtools/tools/javac/doctree/TagTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8078320 8273244 8284908 8301201 8301813
+ * @bug 7021614 8078320 8273244 8284908 8301201 8301813 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/ThrowableTest.java
+++ b/test/langtools/tools/javac/doctree/ThrowableTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244
+ * @bug 7021614 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/ThrowableTest.java
+++ b/test/langtools/tools/javac/doctree/ThrowableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,13 +39,13 @@ class ThrowableTest {
      */
     void exception() throws Exception { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Throws[THROWS, pos:1
+    Throws[THROWS, pos:0
       exceptionName:
-        Reference[REFERENCE, pos:9, Exception]
+        Reference[REFERENCE, pos:8, Exception]
       description: empty
     ]
 ]
@@ -56,15 +56,15 @@ DocComment[DOC_COMMENT, pos:1
      */
     void exception_text() throws Exception { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Throws[THROWS, pos:1
+    Throws[THROWS, pos:0
       exceptionName:
-        Reference[REFERENCE, pos:9, Exception]
+        Reference[REFERENCE, pos:8, Exception]
       description: 1
-        Text[TEXT, pos:19, text]
+        Text[TEXT, pos:18, text]
     ]
 ]
 */
@@ -74,11 +74,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     void exception_member() throws Exception { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Erroneous[ERRONEOUS, pos:1, prefPos:18
+    Erroneous[ERRONEOUS, pos:0, prefPos:17
       code: compiler.err.dc.ref.unexpected.input
       body: @throws_Exception#member_text
     ]
@@ -90,11 +90,11 @@ DocComment[DOC_COMMENT, pos:1
      */
     void exception_fragment() throws Exception { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Erroneous[ERRONEOUS, pos:1, prefPos:18
+    Erroneous[ERRONEOUS, pos:0, prefPos:17
       code: compiler.err.dc.ref.unexpected.input
       body: @throws_Exception##fragment_text
     ]

--- a/test/langtools/tools/javac/doctree/UsesTest.java
+++ b/test/langtools/tools/javac/doctree/UsesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,14 +40,14 @@ class UsesTest {
       */
     void simple_uses() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    Uses[USES, pos:7
+    Uses[USES, pos:5
       serviceName:
-        Reference[REFERENCE, pos:13, ProvidesTest]
+        Reference[REFERENCE, pos:11, ProvidesTest]
       description: empty
     ]
 ]
@@ -59,16 +59,16 @@ DocComment[DOC_COMMENT, pos:1
       */
     void uses_with_description() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 1
-    Text[TEXT, pos:1, abc.]
+    Text[TEXT, pos:0, abc.]
   body: empty
   block tags: 1
-    Uses[USES, pos:7
+    Uses[USES, pos:5
       serviceName:
-        Reference[REFERENCE, pos:13, ProvidesTest]
+        Reference[REFERENCE, pos:11, ProvidesTest]
       description: 1
-        Text[TEXT, pos:26, Test_description_for_uses.]
+        Text[TEXT, pos:24, Test_description_for_uses.]
     ]
 ]
 */

--- a/test/langtools/tools/javac/doctree/UsesTest.java
+++ b/test/langtools/tools/javac/doctree/UsesTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8160196 8273244
+ * @bug 8160196 8273244 8352249
  * @summary Module summary page should display information based on "api" or "detail" mode.
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/ValueTest.java
+++ b/test/langtools/tools/javac/doctree/ValueTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244 8284908
+ * @bug 7021614 8273244 8284908 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/doctree/ValueTest.java
+++ b/test/langtools/tools/javac/doctree/ValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,10 +39,10 @@ class ValueTest {
      */
     int no_ref() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    Value[VALUE, pos:5
+    Text[TEXT, pos:0, abc_]
+    Value[VALUE, pos:4
       format: null
       reference: null
     ]
@@ -56,13 +56,13 @@ DocComment[DOC_COMMENT, pos:1
      */
     int typical() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    Value[VALUE, pos:5
+    Text[TEXT, pos:0, abc_]
+    Value[VALUE, pos:4
       format: null
       reference:
-        Reference[REFERENCE, pos:13, java.awt.Color#RED]
+        Reference[REFERENCE, pos:12, java.awt.Color#RED]
     ]
   body: empty
   block tags: empty
@@ -74,13 +74,13 @@ DocComment[DOC_COMMENT, pos:1
      */
     int trailing_ws() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    Value[VALUE, pos:5
+    Text[TEXT, pos:0, abc_]
+    Value[VALUE, pos:4
       format: null
       reference:
-        Reference[REFERENCE, pos:13, java.awt.Color#RED]
+        Reference[REFERENCE, pos:12, java.awt.Color#RED]
     ]
   body: empty
   block tags: empty
@@ -92,14 +92,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     int trailing_junk() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:32
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:31
       code: compiler.err.dc.unexpected.content
       body: {@value_java.awt.Color#RED_j
     ]
-    Text[TEXT, pos:33, unk}]
+    Text[TEXT, pos:32, unk}]
   body: empty
   block tags: empty
 ]
@@ -110,14 +110,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     int format_plain() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    Value[VALUE, pos:5
+    Text[TEXT, pos:0, abc_]
+    Value[VALUE, pos:4
       format:
-        Text[TEXT, pos:13, %d]
+        Text[TEXT, pos:12, %d]
       reference:
-        Reference[REFERENCE, pos:16, java.awt.Color#RED]
+        Reference[REFERENCE, pos:15, java.awt.Color#RED]
     ]
   body: empty
   block tags: empty
@@ -129,14 +129,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     int format_quoted() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 2
-    Text[TEXT, pos:1, abc_]
-    Value[VALUE, pos:5
+    Text[TEXT, pos:0, abc_]
+    Value[VALUE, pos:4
       format:
-        Text[TEXT, pos:13, "%d"]
+        Text[TEXT, pos:12, "%d"]
       reference:
-        Reference[REFERENCE, pos:18, java.awt.Color#RED]
+        Reference[REFERENCE, pos:17, java.awt.Color#RED]
     ]
   body: empty
   block tags: empty
@@ -148,14 +148,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     int format_invalid() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:13
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:12
       code: compiler.err.dc.ref.unexpected.input
       body: {@value_0x%x4
     ]
-    Text[TEXT, pos:18, _java.awt.Color#RED}]
+    Text[TEXT, pos:17, _java.awt.Color#RED}]
   body: empty
   block tags: empty
 ]
@@ -166,14 +166,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     int format_trailing_junk() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:37
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:36
       code: compiler.err.dc.unexpected.content
       body: {@value_"%d"_java.awt.Color#RED_j
     ]
-    Text[TEXT, pos:38, unk}]
+    Text[TEXT, pos:37, unk}]
   body: empty
   block tags: empty
 ]
@@ -184,14 +184,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     int type_reference() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:17
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:16
       code: compiler.err.dc.ref.unexpected.input
       body: {@value_java.awt.Color
     ]
-    Text[TEXT, pos:27, }]
+    Text[TEXT, pos:26, }]
   body: empty
   block tags: empty
 ]
@@ -202,14 +202,14 @@ DocComment[DOC_COMMENT, pos:1
      */
     int anchor_reference() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: 3
-    Text[TEXT, pos:1, abc_]
-    Erroneous[ERRONEOUS, pos:5, prefPos:28
+    Text[TEXT, pos:0, abc_]
+    Erroneous[ERRONEOUS, pos:4, prefPos:27
       code: compiler.err.dc.ref.unexpected.input
       body: {@value_java.awt.Color##fragment
     ]
-    Text[TEXT, pos:37, }]
+    Text[TEXT, pos:36, }]
   body: empty
   block tags: empty
 ]

--- a/test/langtools/tools/javac/doctree/VersionTest.java
+++ b/test/langtools/tools/javac/doctree/VersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,13 +39,13 @@ class VersionTest {
      */
     void version() { }
 /*
-DocComment[DOC_COMMENT, pos:1
+DocComment[DOC_COMMENT, pos:0
   firstSentence: empty
   body: empty
   block tags: 1
-    Version[VERSION, pos:1
+    Version[VERSION, pos:0
       body: 1
-        Text[TEXT, pos:10, 1.2]
+        Text[TEXT, pos:9, 1.2]
     ]
 ]
 */

--- a/test/langtools/tools/javac/doctree/VersionTest.java
+++ b/test/langtools/tools/javac/doctree/VersionTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8273244
+ * @bug 7021614 8273244 8352249
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file


### PR DESCRIPTION
Please review a patch to remove incidental indentation from traditional doc comments, comparable to doing a `String.stripIndent()` on the comment contents but without special treatment of a last blank line. This adds a `stripIndent()` method to the `Tokens.Comment` interface and a new `JavadocTokenizer.StrippedComment` nested class that implements indentation stripping while maintaining a map of position offsets to the original comment. 

While the patch changes `javadoc` output by removing leading whitespace, the change is generally not visible in the browser except in `<pre>` elements, which is the point of this enhancement. 

The change affects most tree positions in the AST checker tests in javac/doctree, but mostly does not affect the structure of the parsed trees, with the exception of `BreakIterator` tests in `FirstSentenceTest.java`. 

`BreakIterator` does not recognize `.\n` immediately followed by a lower case letter as sentence break, while it recognizes the break if the letter is an upper-case letter *or* if there is a space between the line break and the letter. I find this rule a bit peculiar but AFAICT we can't influence the behavior of `BreakIterator`, so I have added tests that cover both lower and upper-case behavior.

The source position lookup in the stripped comment is implemented by creating a new `OffsetMap` that translates from the stripped to the original comment, then using the original comment's `OffsetMap` to translate the position to the source file. `OffsetMap` is relatively lightweight (usually 2 `int[]` elements per comment paragraph), so the added overhead is not too bad. 

Inspired by [JDK-8305688](https://bugs.openjdk.org/browse/JDK-8305688) I did various test builds with restricted jobs and memory settings, but didn't notice any change in processing or memory overhead to API docs builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352249](https://bugs.openjdk.org/browse/JDK-8352249): Remove incidental whitespace in traditional doc comments (**Enhancement** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24032/head:pull/24032` \
`$ git checkout pull/24032`

Update a local copy of the PR: \
`$ git checkout pull/24032` \
`$ git pull https://git.openjdk.org/jdk.git pull/24032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24032`

View PR using the GUI difftool: \
`$ git pr show -t 24032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24032.diff">https://git.openjdk.org/jdk/pull/24032.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24032#issuecomment-2734054381)
</details>
