### PR TITLE
8351933: Inaccurate masking of TC subfield decrement in ForkJoinPool

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -2077,7 +2077,8 @@ public class ForkJoinPool extends AbstractExecutorService {
         else if (deadline - System.currentTimeMillis() >= TIMEOUT_SLOP)
             stat = 0;                       // spurious wakeup
         else if (!compareAndSetCtl(
-                     c, nc = (w.stackPred & LMASK) | (c & RC_MASK) | ((c - TC_UNIT) & TC_MASK)))
+                     c, nc = ((w.stackPred & LMASK) | (RC_MASK & c) |
+                               (TC_MASK & (c - TC_UNIT)))))
             stat = -1;                      // lost race to signaller
         else {
             stat = 1;

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -2077,7 +2077,7 @@ public class ForkJoinPool extends AbstractExecutorService {
         else if (deadline - System.currentTimeMillis() >= TIMEOUT_SLOP)
             stat = 0;                       // spurious wakeup
         else if (!compareAndSetCtl(
-                     c, nc = (w.stackPred & LMASK) | (UMASK & (c - TC_UNIT))))
+                     c, nc = (w.stackPred & LMASK) | (c & RC_MASK) | ((c - TC_UNIT) & TC_MASK)))
             stat = -1;                      // lost race to signaller
         else {
             stat = 1;


### PR DESCRIPTION
Please review a tiny fix in the ForkJoinPool. Since JDK 9 (JDK-8134852 [1]) in one case when TC subfield in ctl field is decremented, the applied masking (UMASK, upper bits) may not preserve neighbor RC subfield sometimes. In JDKs prior to 19 FJP may stop executing tasks, which requires a long running application restart [2]. Since 19 it is even harder to reproduce because of the separate parallelism field.

The fix is to replace 'UMASK & (c - TC_UNIT)'  with '(c & RC_MASK) | ((c - TC_UNIT)  & TC_MASK)' which preserves the RC part of the compareAndSetCtl() candidate argument. On 17u and 11u that repairs known tests and applications. This PR is for the mainline, and I intend to backport it to 21u, 17u and 11u.

[1] https://bugs.openjdk.org/browse/JDK-8134852
[2] https://bugs.openjdk.org/browse/JDK-8330017

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8351933](https://bugs.openjdk.org/browse/JDK-8351933): Inaccurate masking of TC subfield decrement in ForkJoinPool (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [e5517c7d](https://git.openjdk.org/jdk/pull/24034/files/e5517c7d14cdfe6571aa8170fffd2fcaf15550bc)
 * [Doug Lea](https://openjdk.org/census#dl) (@DougLea - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @Lujie1996 (no known openjdk.org user name / role) Review applies to [e5517c7d](https://git.openjdk.org/jdk/pull/24034/files/e5517c7d14cdfe6571aa8170fffd2fcaf15550bc)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24034/head:pull/24034` \
`$ git checkout pull/24034`

Update a local copy of the PR: \
`$ git checkout pull/24034` \
`$ git pull https://git.openjdk.org/jdk.git pull/24034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24034`

View PR using the GUI difftool: \
`$ git pr show -t 24034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24034.diff">https://git.openjdk.org/jdk/pull/24034.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24034#issuecomment-2721301438)
</details>
