### PR TITLE
8347734: Turning off PerfData logging doesn't work

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -336,11 +336,9 @@ void LogConfiguration::disable_logging() {
   notify_update_listeners();
 }
 
-void LogConfiguration::configure_stdout(LogLevelType level, int exact_match, ...) {
+LogSelectionList LogConfiguration::create_selection_list(LogLevelType level, int exact_match, va_list ap) {
   size_t i;
-  va_list ap;
   LogTagType tags[LogTag::MaxTags];
-  va_start(ap, exact_match);
   for (i = 0; i < LogTag::MaxTags; i++) {
     LogTagType tag = static_cast<LogTagType>(va_arg(ap, int));
     tags[i] = tag;
@@ -351,12 +349,32 @@ void LogConfiguration::configure_stdout(LogLevelType level, int exact_match, ...
   }
   assert(i < LogTag::MaxTags || static_cast<LogTagType>(va_arg(ap, int)) == LogTag::__NO_TAG,
          "Too many tags specified! Can only have up to %zu tags in a tag set.", LogTag::MaxTags);
-  va_end(ap);
 
   LogSelection selection(tags, !exact_match, level);
   assert(selection.tag_sets_selected() > 0,
-         "configure_stdout() called with invalid/non-existing log selection");
-  LogSelectionList list(selection);
+         "create_selection_list() called with invalid/non-existing log selection");
+  return LogSelectionList(selection);
+}
+
+void LogConfiguration::disable_tags(int exact_match, ...) {
+  va_list ap;
+  va_start(ap, exact_match);
+  LogSelectionList list = create_selection_list(LogLevel::Off, exact_match, ap);
+  va_end(ap);
+
+  // Apply configuration to all outputs, with the same decorators as before.
+  ConfigurationLock cl;
+  for (size_t i = 0; i < _n_outputs; i++) {
+    configure_output(i, list, _outputs[i]->decorators());
+  }
+  notify_update_listeners();
+}
+
+void LogConfiguration::configure_stdout(LogLevelType level, int exact_match, ...) {
+  va_list ap;
+  va_start(ap, exact_match);
+  LogSelectionList list = create_selection_list(level, exact_match, ap);
+  va_end(ap);
 
   // Apply configuration to stdout (output #0), with the same decorators as before.
   ConfigurationLock cl;

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -97,6 +97,8 @@ private:
   static void describe_available(outputStream* out);
   static void describe_current_configuration(outputStream* out);
 
+  // Create a LogSelectionList given a level and a set of tags
+  static LogSelectionList create_selection_list(LogLevelType level, int exact_match, va_list ap);
 
  public:
   // Initialization and finalization of log configuration, to be run at vm startup and shutdown respectively.
@@ -108,6 +110,13 @@ private:
 
   // Disable all logging, equivalent to -Xlog:disable.
   static void disable_logging();
+
+  // Disables logging on all outputs for the given tags.
+  // If exact_match is true, only tagsets with precisely the specified tags will be disabled
+  // (exact_match=false is the same as "-Xlog:<tags>*=off", and exact_match=true is "-Xlog:<tags>=off").
+  // Tags should be specified using the LOG_TAGS macro, e.g.
+  // LogConfiguration::disable_tags(<true/false>, LOG_TAGS(<tags>));
+  static void disable_tags(int exact_match, ...);
 
   // Configures logging on stdout for the given tags and level combination.
   // Intended for mappings between -XX: flags and Unified Logging configuration.

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3800,7 +3800,8 @@ jint Arguments::apply_ergo() {
   if (log_is_enabled(Info, perf, class, link)) {
     if (!UsePerfData) {
       warning("Disabling -Xlog:perf+class+link since UsePerfData is turned off.");
-      LogConfiguration::configure_stdout(LogLevel::Off, false, LOG_TAGS(perf, class, link));
+      LogConfiguration::disable_tags(false, LOG_TAGS(perf, class, link));
+      assert(!log_is_enabled(Info, perf, class, link), "sanity");
     }
   }
 

--- a/test/hotspot/gtest/logging/test_logConfiguration.cpp
+++ b/test/hotspot/gtest/logging/test_logConfiguration.cpp
@@ -216,6 +216,32 @@ TEST_VM_F(LogConfigurationTest, disable_output) {
   }
 }
 
+TEST_VM_F(LogConfigurationTest, disable_tags) {
+  set_log_config("stdout", "logging*=info");
+  set_log_config(TestLogFileName, "logging*=info");
+
+  EXPECT_TRUE(log_is_enabled(Info, logging, gc));
+  LogConfiguration::disable_tags(true, LOG_TAGS(logging, gc));
+  EXPECT_FALSE(log_is_enabled(Info, logging, gc));
+  EXPECT_TRUE(log_is_enabled(Info, logging));
+
+  set_log_config("stdout", "logging*=info");
+  set_log_config(TestLogFileName, "logging*=info");
+
+  EXPECT_TRUE(log_is_enabled(Info, logging));
+  LogConfiguration::disable_tags(true, LOG_TAGS(logging));
+  EXPECT_TRUE(log_is_enabled(Info, logging, gc));
+  EXPECT_FALSE(log_is_enabled(Info, logging));
+
+  set_log_config("stdout", "logging*=info");
+  set_log_config(TestLogFileName, "logging*=info");
+
+  EXPECT_TRUE(log_is_enabled(Info, logging));
+  LogConfiguration::disable_tags(false, LOG_TAGS(logging));
+  EXPECT_FALSE(log_is_enabled(Info, logging, gc));
+  EXPECT_FALSE(log_is_enabled(Info, logging));
+}
+
 // Test reconfiguration of the selected decorators for an output
 TEST_VM_F(LogConfigurationTest, reconfigure_decorators) {
   // Configure stderr with all decorators


### PR DESCRIPTION
Hi everyone,

When PerfData is disabled, the corresponding perfdata variables remain uninitialized. However, under certain conditions, logging may attempt to access these variables, leading to a crash. The existing code turns off the relevant tags using `LogConfiguration::configure_stdout`, but this doesn't modify other outputs. For example, the test `runtime/logging/RedefineClasses.java` crashes with `-XX:-UsePerfData` because it uses an output that isn't stdout.

To fix this, I've added a new method `LogConfiguration::disable_tags`. Unlike `configure_stdout`, this function iterates over all outputs and disables the specified tags on each. This way, we correctly disable tags across all outputs and longer try and access the uninitialized perfdata variables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347734](https://bugs.openjdk.org/browse/JDK-8347734): Turning off PerfData logging doesn't work (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24036/head:pull/24036` \
`$ git checkout pull/24036`

Update a local copy of the PR: \
`$ git checkout pull/24036` \
`$ git pull https://git.openjdk.org/jdk.git pull/24036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24036`

View PR using the GUI difftool: \
`$ git pr show -t 24036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24036.diff">https://git.openjdk.org/jdk/pull/24036.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24036#issuecomment-2721619041)
</details>
