### PR TITLE
Strip newline at the beginning of pre / code

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -1248,7 +1248,7 @@ public class DocCommentParser {
                 } else if (cx.state == State.CODE && text.getBody().startsWith("\n")) {
                     // <pre><code>\n...
                     cx.state = State.DONE;
-                    return m.at(((DCText) text).pos).newTextTree(text.getBody().substring(1));
+                    return m.at(((DCText) text).pos + 1).newTextTree(text.getBody().substring(1));
                 }
                 cx.doneOrNone();
                 return (DCTree) text;
@@ -1260,7 +1260,7 @@ public class DocCommentParser {
                     // <pre>{@code\n...
                     cx.state = State.DONE;
                     DCText oldBody = (DCText) literal.getBody();
-                    DCText newBody = m.at(oldBody.pos).newTextTree(oldBody.getBody().substring(1));
+                    DCText newBody = m.at(oldBody.pos + 1).newTextTree(oldBody.getBody().substring(1));
                     m.at(((DCTree) literal).pos);
                     return literal.getKind() == DocTree.Kind.CODE
                             ? m.newCodeTree(newBody)


### PR DESCRIPTION
Patch to strip newline character at the beginning of `<pre><code>`. Work in progress / proof of concept.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24038/head:pull/24038` \
`$ git checkout pull/24038`

Update a local copy of the PR: \
`$ git checkout pull/24038` \
`$ git pull https://git.openjdk.org/jdk.git pull/24038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24038`

View PR using the GUI difftool: \
`$ git pr show -t 24038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24038.diff">https://git.openjdk.org/jdk/pull/24038.diff</a>

</details>
