### PR TITLE
8351375: nsk/jvmti/ tests should fail when  nsk_jvmti_setFailStatus() is called

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass029/redefclass029.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass029/redefclass029.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,6 +97,16 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
         const void* compile_info) {
     char *name;
     char *sig;
+    jvmtiPhase phase;
+
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
+        nsk_jvmti_setFailStatus();
+        return;
+    }
+    if (phase == JVMTI_PHASE_DEAD) {
+      NSK_DISPLAY0("CompiledMethodLoad event recieved in dead phase");
+      return;
+    }
 
     NSK_DISPLAY0("CompiledMethodLoad event received for:\n");
     if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sig, nullptr))) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
@@ -198,7 +198,6 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
     jvmti->RawMonitorExit(syncLock);
 
     NSK_DISPLAY0("Let debuggee to finish\n");
-
     if (!nsk_jvmti_resumeSync())
         return;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -185,7 +185,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
     jvmti->RawMonitorExit(syncLock);
 
     NSK_DISPLAY0("Let debuggee to finish\n");
-    if (!nsk_jvmti_resumeSync())
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock))) {
+        nsk_jvmti_setFailStatus();
+    }
+
+   if (!nsk_jvmti_resumeSync())
         return;
 
 }
@@ -253,12 +257,9 @@ Agent_OnUnload(JavaVM *jvm)
 {
 
     if (!NSK_VERIFY(nsk_list_destroy(plist))) {
-        nsk_jvmti_setFailStatus();
+        exit(97);
     }
 
-    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock))) {
-        nsk_jvmti_setFailStatus();
-    }
 }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t006/ma10t006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t006/ma10t006.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,18 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method,
         const jvmtiAddrLocationMap* map, const void* compile_info) {
     char *name = nullptr;
     char *signature = nullptr;
+    jvmtiPhase phase;
 
     CompiledMethodLoadEventsCount++;
 
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
+        nsk_jvmti_setFailStatus();
+        return;
+    }
+    if (phase == JVMTI_PHASE_DEAD) {
+      NSK_DISPLAY0("CompiledMethodLoad event recieved in dead phase");
+      return;
+    }
     if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, nullptr))) {
         nsk_jvmti_setFailStatus();
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/agent_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/agent_tools.cpp
@@ -21,6 +21,7 @@
  * questions.
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -62,7 +63,8 @@ static volatile int currentAgentStatus = NSK_STATUS_PASSED;
 
 void nsk_jvmti_setFailStatus() {
     currentAgentStatus = NSK_STATUS_FAILED;
-    LOG("Test failed by setFailStatus(true). See log.");
+    printf("Test failed by setFailStatus(). See log.");
+    fflush(stdout);
     exit(97);
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/agent_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/agent_tools.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,8 @@ static volatile int currentAgentStatus = NSK_STATUS_PASSED;
 
 void nsk_jvmti_setFailStatus() {
     currentAgentStatus = NSK_STATUS_FAILED;
+    LOG("Test failed by setFailStatus(true). See log.");
+    exit(97);
 }
 
 int nsk_jvmti_isFailStatus() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/hotswap/HotSwap.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/hotswap/HotSwap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,9 +141,20 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method,
         const jvmtiAddrLocationMap* map, const void* compile_info) {
     char *name = nullptr;
     char *signature = nullptr;
+    jvmtiPhase phase;
 
     CompiledMethodLoadEventsCount++;
 
+    // GetMethodNamme is work only in live phasem so just exit
+    // if event is generated too late
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
+        nsk_jvmti_setFailStatus();
+        return;
+    }
+    if (phase == JVMTI_PHASE_DEAD) {
+      NSK_DISPLAY0("CompiledMethodLoad event recieved in dead phase");
+      return;
+    }
     if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, nullptr))) {
         nsk_jvmti_setFailStatus();
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/hotswap/HotSwap.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/hotswap/HotSwap.cpp
@@ -145,8 +145,7 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method,
 
     CompiledMethodLoadEventsCount++;
 
-    // GetMethodNamme is work only in live phasem so just exit
-    // if event is generated too late
+    // GetMethodName works in live phase only so just exit if the event is generated too late
     if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
         return;


### PR DESCRIPTION
The nsk_jvmti_setFailStatus() sometimes is called after test check results. In these cases the warning logs are generated and hide the real failure reasons. Also, I think it is a error-prone way to set and check error, since check might be just forgotten. Also, the test execution after failure might be incorrect and also make failure analysis harder.
So I think it makes sense to always fail when nsk_jvmti_setFailStatus() is called.

If this is going to work I'll rename it later and add add optional message to be more informative.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351375](https://bugs.openjdk.org/browse/JDK-8351375): nsk/jvmti/ tests should fail when  nsk_jvmti_setFailStatus() is called (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24040/head:pull/24040` \
`$ git checkout pull/24040`

Update a local copy of the PR: \
`$ git checkout pull/24040` \
`$ git pull https://git.openjdk.org/jdk.git pull/24040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24040`

View PR using the GUI difftool: \
`$ git pr show -t 24040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24040.diff">https://git.openjdk.org/jdk/pull/24040.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24040#issuecomment-2722420633)
</details>
