### PR TITLE
8351976: assert(vthread_epoch == current_epoch) failed: invariant

### DIFF
--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -298,7 +298,9 @@ void JfrThreadLocal::exclude_vthread(const JavaThread* jt) {
 }
 
 void JfrThreadLocal::include_vthread(const JavaThread* jt) {
-  set(&jt->jfr_thread_local()->_vthread_excluded, false);
+  JfrThreadLocal* const tl = jt->jfr_thread_local();
+  Atomic::store(&tl->_vthread_epoch, static_cast<u2>(0));
+  set(&tl->_vthread_excluded, false);
   JfrJavaEventWriter::include(vthread_id(jt), jt);
 }
 


### PR DESCRIPTION
Greetings,

This fix adjusts for an epoch mismatch for excluded virtual threads that become included after being mounted. The JIRA issue has more details.

Testing: jdk_jfr, stress testing

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351976](https://bugs.openjdk.org/browse/JDK-8351976): assert(vthread_epoch == current_epoch) failed: invariant (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24041/head:pull/24041` \
`$ git checkout pull/24041`

Update a local copy of the PR: \
`$ git checkout pull/24041` \
`$ git pull https://git.openjdk.org/jdk.git pull/24041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24041`

View PR using the GUI difftool: \
`$ git pr show -t 24041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24041.diff">https://git.openjdk.org/jdk/pull/24041.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24041#issuecomment-2722687299)
</details>
