### PR TITLE
8351999: JFR: Incorrect scaling of throttled values

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
@@ -94,7 +94,7 @@ public final class ThrottleSetting extends SettingControl {
             // if unit is less than 1 s, scale samples
             if (unit.nanos < SECONDS.nanos) {
                 long perSecond = SECONDS.nanos / unit.nanos;
-                samples *= Utils.multiplyOverflow(samples, perSecond, Long.MAX_VALUE);
+                samples = Utils.multiplyOverflow(samples, perSecond, Long.MAX_VALUE);
             }
             eventType.setThrottle(samples, millis);
             this.value = value;


### PR DESCRIPTION
Could I have a review of a PR that fixes an incorrect scaling of samples for the ThrottleSetting.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351999](https://bugs.openjdk.org/browse/JDK-8351999): JFR: Incorrect scaling of throttled values (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24045/head:pull/24045` \
`$ git checkout pull/24045`

Update a local copy of the PR: \
`$ git checkout pull/24045` \
`$ git pull https://git.openjdk.org/jdk.git pull/24045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24045`

View PR using the GUI difftool: \
`$ git pr show -t 24045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24045.diff">https://git.openjdk.org/jdk/pull/24045.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24045#issuecomment-2724310389)
</details>
