### PR TITLE
8352022: RISC-V: Support Zfa fminm_h/fmaxm_h for float16

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1450,6 +1450,16 @@ enum operand_size { int8, int16, int32, uint32, int64 };
     fp_base<D_64_dp, 0b11110>(Rd, Rs1, 0b00001, 0b000);
   }
 
+  void fminm_h(FloatRegister Rd, FloatRegister Rs1, FloatRegister Rs2) {
+    assert_cond(UseZfa);
+    fp_base<H_16_hp, 0b00101>(Rd, Rs1, Rs2, 0b010);
+  }
+
+  void fmaxm_h(FloatRegister Rd, FloatRegister Rs1, FloatRegister Rs2) {
+    assert_cond(UseZfa);
+    fp_base<H_16_hp, 0b00101>(Rd, Rs1, Rs2, 0b011);
+  }
+
   void fminm_s(FloatRegister Rd, FloatRegister Rs1, FloatRegister Rs2) {
     assert_cond(UseZfa);
     fp_base<S_32_sp, 0b00101>(Rd, Rs1, Rs2, 0b010);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8382,6 +8382,7 @@ instruct binOps_HF_reg(fRegF dst, fRegF src1, fRegF src2)
 
 instruct min_max_HF_reg(fRegF dst, fRegF src1, fRegF src2)
 %{
+  predicate(!UseZfa);
   match(Set dst (MinHF src1 src2));
   match(Set dst (MaxHF src1 src2));
   format %{ "min_max_hf $dst, $src1, $src2" %}
@@ -8397,6 +8398,37 @@ instruct min_max_HF_reg(fRegF dst, fRegF src1, fRegF src2)
       default: assert(false, "%s is not supported here", NodeClassNames[opcode]); break;
     }
   %}
+  ins_pipe(pipe_class_default);
+%}
+
+instruct minHF_reg_reg_zfa(fRegF dst, fRegF src1, fRegF src2)
+%{
+  predicate(UseZfa);
+
+  match(Set dst (MinHF src1 src2));
+
+  format %{ "minHF $dst, $src1, $src2" %}
+
+  ins_encode %{
+    __ fminm_h(as_FloatRegister($dst$$reg),
+               as_FloatRegister($src1$$reg), as_FloatRegister($src2$$reg));
+  %}
+
+  ins_pipe(pipe_class_default);
+%}
+
+instruct maxHF_reg_reg_zfa(fRegF dst, fRegF src1, fRegF src2)
+%{
+  predicate(UseZfa);
+  match(Set dst (MaxHF src1 src2));
+
+  format %{ "maxHF $dst, $src1, $src2" %}
+
+  ins_encode %{
+    __ fmaxm_h(as_FloatRegister($dst$$reg),
+               as_FloatRegister($src1$$reg), as_FloatRegister($src2$$reg));
+  %}
+
   ins_pipe(pipe_class_default);
 %}
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8401,13 +8401,12 @@ instruct min_max_HF_reg(fRegF dst, fRegF src1, fRegF src2)
   ins_pipe(pipe_class_default);
 %}
 
-instruct minHF_reg_reg_zfa(fRegF dst, fRegF src1, fRegF src2)
+instruct minHF_reg_zfa(fRegF dst, fRegF src1, fRegF src2)
 %{
   predicate(UseZfa);
-
   match(Set dst (MinHF src1 src2));
 
-  format %{ "minHF $dst, $src1, $src2" %}
+  format %{ "min_hf $dst, $src1, $src2" %}
 
   ins_encode %{
     __ fminm_h(as_FloatRegister($dst$$reg),
@@ -8417,12 +8416,12 @@ instruct minHF_reg_reg_zfa(fRegF dst, fRegF src1, fRegF src2)
   ins_pipe(pipe_class_default);
 %}
 
-instruct maxHF_reg_reg_zfa(fRegF dst, fRegF src1, fRegF src2)
+instruct maxHF_reg_zfa(fRegF dst, fRegF src1, fRegF src2)
 %{
   predicate(UseZfa);
   match(Set dst (MaxHF src1 src2));
 
-  format %{ "maxHF $dst, $src1, $src2" %}
+  format %{ "max_hf $dst, $src1, $src2" %}
 
   ins_encode %{
     __ fmaxm_h(as_FloatRegister($dst$$reg),


### PR DESCRIPTION
For the support of float16, add the Zfa fminm/fmaxm with the type of float16
this related to https://bugs.openjdk.org/browse/JDK-8345298

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352022](https://bugs.openjdk.org/browse/JDK-8352022): RISC-V: Support Zfa fminm_h/fmaxm_h for float16 (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24047/head:pull/24047` \
`$ git checkout pull/24047`

Update a local copy of the PR: \
`$ git checkout pull/24047` \
`$ git pull https://git.openjdk.org/jdk.git pull/24047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24047`

View PR using the GUI difftool: \
`$ git pr show -t 24047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24047.diff">https://git.openjdk.org/jdk/pull/24047.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24047#issuecomment-2724422415)
</details>
