### PR TITLE
8352011: RISC-V: Two IR tests fail after JDK-8351662

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVecCountingDownLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVecCountingDownLoop.java
@@ -29,7 +29,8 @@ import compiler.lib.ir_framework.*;
  * @test
  * @bug 8284981
  * @summary Auto-vectorization enhancement for special counting down loops
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="riscv64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" |
+             (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestAutoVecCountingDownLoop
  */

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
@@ -32,7 +32,8 @@ import jdk.test.lib.Utils;
  * @test
  * @bug 8283091
  * @summary Auto-vectorization enhancement for type conversion between different data sizes.
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch=="aarch64" | os.arch=="riscv64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch=="aarch64" |
+             (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestVectorizeTypeConversion
  */


### PR DESCRIPTION
Hi, please review this small change fixing two IR tests.

These two tests were enabled for riscv64 by JDK-8351662. But they fail on riscv64 platforms where there is no support for RVV. Since they are expecting vector operations thus requires RVV support on this platform, we should add that as a requirement.

Testing: same tests will be skipped on riscv64 platforms without RVV after this change. Tagging @Hamlin-Li

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352011](https://bugs.openjdk.org/browse/JDK-8352011): RISC-V: Two IR tests fail after JDK-8351662 (**Bug** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24048/head:pull/24048` \
`$ git checkout pull/24048`

Update a local copy of the PR: \
`$ git checkout pull/24048` \
`$ git pull https://git.openjdk.org/jdk.git pull/24048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24048`

View PR using the GUI difftool: \
`$ git pr show -t 24048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24048.diff">https://git.openjdk.org/jdk/pull/24048.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24048#issuecomment-2723901127)
</details>
