### PR TITLE
8351821: VMManagementImpl.c avoid switching off warnings

### DIFF
--- a/make/modules/java.management/Lib.gmk
+++ b/make/modules/java.management/Lib.gmk
@@ -34,8 +34,6 @@ include LibCommon.gmk
 $(eval $(call SetupJdkLibrary, BUILD_LIBMANAGEMENT, \
     NAME := management, \
     OPTIMIZATION := HIGH, \
-    DISABLED_WARNINGS_gcc_VMManagementImpl.c := unused-variable, \
-    DISABLED_WARNINGS_clang_VMManagementImpl.c := unused-variable, \
     JDK_LIBS := java.base:libjava java.base:libjvm, \
     LIBS_aix := -lperfstat, \
     LIBS_windows := advapi32.lib psapi.lib, \

--- a/src/java.management/share/native/libmanagement/VMManagementImpl.c
+++ b/src/java.management/share/native/libmanagement/VMManagementImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,12 +37,8 @@ Java_sun_management_VMManagementImpl_getVersion0
 {
     char buf[MAX_VERSION_LEN];
     jstring version_string = NULL;
-
     unsigned int major = ((unsigned int) jmm_version & 0x0FFF0000) >> 16;
     unsigned int minor = ((unsigned int) jmm_version & 0xFF00) >> 8;
-
-    // for internal use
-    unsigned int micro = (unsigned int) jmm_version & 0xFF;
 
     snprintf(buf, sizeof(buf), "%d.%d", major, minor);
     version_string = (*env)->NewStringUTF(env, buf);
@@ -64,7 +60,7 @@ Java_sun_management_VMManagementImpl_initOptionalSupportFields
   (JNIEnv *env, jclass cls)
 {
     jmmOptionalSupport mos;
-    jint ret = jmm_interface->GetOptionalSupport(env, &mos);
+    jmm_interface->GetOptionalSupport(env, &mos);
 
     jboolean value;
 


### PR DESCRIPTION
We switched off unused-variable warnings for the file VMManagementImpl.c, this should be avoided.
This came up in [JDK-8351542](https://bugs.openjdk.org/browse/JDK-8351542) ,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8351821](https://bugs.openjdk.org/browse/JDK-8351821): VMManagementImpl.c avoid switching off warnings (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24052/head:pull/24052` \
`$ git checkout pull/24052`

Update a local copy of the PR: \
`$ git checkout pull/24052` \
`$ git pull https://git.openjdk.org/jdk.git pull/24052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24052`

View PR using the GUI difftool: \
`$ git pr show -t 24052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24052.diff">https://git.openjdk.org/jdk/pull/24052.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24052#issuecomment-2724234117)
</details>
