### PR TITLE
8317976: Optimize SIMD sort for AMD Zen 4

### DIFF
--- a/src/hotspot/cpu/x86/matcher_x86.hpp
+++ b/src/hotspot/cpu/x86/matcher_x86.hpp
@@ -263,8 +263,7 @@
 
   // Is SIMD sort supported for this CPU?
   static bool supports_simd_sort(BasicType bt) {
-    if ((VM_Version::is_intel() || (VM_Version::is_amd() && (VM_Version::cpu_family() > 0x19)))
-        && VM_Version::supports_avx512dq()) {
+    if (VM_Version::supports_avx512_simd_sort()) {
       return true;
     }
     else if (VM_Version::supports_avx2() && !is_double_word_type(bt)) {

--- a/src/hotspot/cpu/x86/matcher_x86.hpp
+++ b/src/hotspot/cpu/x86/matcher_x86.hpp
@@ -263,7 +263,8 @@
 
   // Is SIMD sort supported for this CPU?
   static bool supports_simd_sort(BasicType bt) {
-    if (VM_Version::supports_avx512dq()) {
+    if ((VM_Version::is_intel() || (VM_Version::is_amd() && (VM_Version::cpu_family() > 0x19)))
+        && VM_Version::supports_avx512dq()) {
       return true;
     }
     else if (VM_Version::supports_avx2() && !is_double_word_type(bt)) {

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4326,14 +4326,10 @@ void StubGenerator::generate_compiler_stubs() {
     if (libsimdsort != nullptr) {
       log_info(library)("Loaded library %s, handle " INTPTR_FORMAT, JNI_LIB_PREFIX "simdsort" JNI_LIB_SUFFIX, p2i(libsimdsort));
 
-      snprintf(ebuf_, sizeof(ebuf_),
-               ((VM_Version::is_intel() || (VM_Version::is_amd() && (VM_Version::cpu_family() > 0x19)))
-                && VM_Version::supports_avx512dq()) ? "avx512_sort" : "avx2_sort");
+      snprintf(ebuf_, sizeof(ebuf_), VM_Version::supports_avx512_simd_sort() ? "avx512_sort" : "avx2_sort");
       StubRoutines::_array_sort = (address)os::dll_lookup(libsimdsort, ebuf_);
 
-      snprintf(ebuf_, sizeof(ebuf_),
-               ((VM_Version::is_intel() || (VM_Version::is_amd() && (VM_Version::cpu_family() > 0x19)))
-                && VM_Version::supports_avx512dq()) ? "avx512_partition" : "avx2_partition");
+      snprintf(ebuf_, sizeof(ebuf_), VM_Version::supports_avx512_simd_sort() ? "avx512_partition" : "avx2_partition");
       StubRoutines::_array_partition = (address)os::dll_lookup(libsimdsort, ebuf_);
     }
   }

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4315,7 +4315,7 @@ void StubGenerator::generate_compiler_stubs() {
 
   // Load x86_64_sort library on supported hardware to enable SIMD sort and partition intrinsics
 
-  if (VM_Version::is_intel() && (VM_Version::supports_avx512dq() || VM_Version::supports_avx2())) {
+  if (VM_Version::supports_avx512dq() || VM_Version::supports_avx2()) {
     void *libsimdsort = nullptr;
     char ebuf_[1024];
     char dll_name_simd_sort[JVM_MAXPATHLEN];
@@ -4326,10 +4326,14 @@ void StubGenerator::generate_compiler_stubs() {
     if (libsimdsort != nullptr) {
       log_info(library)("Loaded library %s, handle " INTPTR_FORMAT, JNI_LIB_PREFIX "simdsort" JNI_LIB_SUFFIX, p2i(libsimdsort));
 
-      snprintf(ebuf_, sizeof(ebuf_), VM_Version::supports_avx512dq() ? "avx512_sort" : "avx2_sort");
+      snprintf(ebuf_, sizeof(ebuf_),
+               ((VM_Version::is_intel() || (VM_Version::is_amd() && (VM_Version::cpu_family() > 0x19)))
+                && VM_Version::supports_avx512dq()) ? "avx512_sort" : "avx2_sort");
       StubRoutines::_array_sort = (address)os::dll_lookup(libsimdsort, ebuf_);
 
-      snprintf(ebuf_, sizeof(ebuf_), VM_Version::supports_avx512dq() ? "avx512_partition" : "avx2_partition");
+      snprintf(ebuf_, sizeof(ebuf_),
+               ((VM_Version::is_intel() || (VM_Version::is_amd() && (VM_Version::cpu_family() > 0x19)))
+                && VM_Version::supports_avx512dq()) ? "avx512_partition" : "avx2_partition");
       StubRoutines::_array_partition = (address)os::dll_lookup(libsimdsort, ebuf_);
     }
   }

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -774,8 +774,15 @@ public:
   static bool cpu_supports_evex()     { return (_cpu_features & CPU_AVX512F) != 0; }
 
   static bool supports_avx512_simd_sort() {
-    //  Disable AVX512 version of SIMD Sort on AMD Zen4 Processors
-    return ((is_intel() || (is_amd() && (cpu_family() > CPU_FAMILY_AMD_19H))) && supports_avx512dq()); }
+    if (supports_avx512dq()) {
+      // Disable AVX512 version of SIMD Sort on AMD Zen4 Processors.
+      if (is_amd() && cpu_family() == CPU_FAMILY_AMD_19H) {
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }
 
   // Intel features
   static bool is_intel_family_core() { return is_intel() &&

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -432,6 +432,8 @@ protected:
   enum Extended_Family {
     // AMD
     CPU_FAMILY_AMD_11H       = 0x11,
+    CPU_FAMILY_AMD_17H       = 0x17, /* Zen1 & Zen2 */
+    CPU_FAMILY_AMD_19H       = 0x19, /* Zen3 & Zen4 */
     // ZX
     CPU_FAMILY_ZX_CORE_F6    = 6,
     CPU_FAMILY_ZX_CORE_F7    = 7,
@@ -770,6 +772,10 @@ public:
   // Feature identification not affected by VM flags
   //
   static bool cpu_supports_evex()     { return (_cpu_features & CPU_AVX512F) != 0; }
+
+  static bool supports_avx512_simd_sort() {
+    //  Disable AVX512 version of SIMD Sort on AMD Zen4 Processors
+    return ((is_intel() || (is_amd() && (cpu_family() > CPU_FAMILY_AMD_19H))) && supports_avx512dq()); }
 
   // Intel features
   static bool is_intel_family_core() { return is_intel() &&


### PR DESCRIPTION
In JDK-8309130, Array sort was optimized using  AVX512 SIMD instructions for x86_64. Currently, this optimization has been disabled for AMD Zen 4 [JDK-8317763] due to bad performance of compressstoreu. 
Ref: https://www.reddit.com/r/java/comments/171t5sj/heads_up_openjdk_implementation_of_avx512_based/.

This patch enables Zen 4 to pick optimized AVX2 version of SIMD sort and Zen 5 picks the AVX512 version.

JTREG Tests: Completed Tier1 & Tier2 tests on Zen4 & Zen5 - No Regressions.

Attaching ArraySort performance data for Zen4 & Zen5.
[Zen4-ArraySort-Data.txt](https://github.com/user-attachments/files/19245831/Zen4-ArraySort-Data.txt)
[Zen5-ArraySort-Data.txt](https://github.com/user-attachments/files/19245833/Zen5-ArraySort-Data.txt)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8317976](https://bugs.openjdk.org/browse/JDK-8317976): Optimize SIMD sort for AMD Zen 4 (**Enhancement** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24053/head:pull/24053` \
`$ git checkout pull/24053`

Update a local copy of the PR: \
`$ git checkout pull/24053` \
`$ git pull https://git.openjdk.org/jdk.git pull/24053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24053`

View PR using the GUI difftool: \
`$ git pr show -t 24053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24053.diff">https://git.openjdk.org/jdk/pull/24053.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24053#issuecomment-2724319091)
</details>
