### PR TITLE
8352015: LIBVERIFY_OPTIMIZATION remove special optimization settings

### DIFF
--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -32,14 +32,9 @@ ifeq ($(INCLUDE), true)
 ## Build libverify
 ################################################################################
 
-LIBVERIFY_OPTIMIZATION := HIGH
-ifeq ($(call isTargetOs, linux)+$(COMPILE_WITH_DEBUG_SYMBOLS), true+true)
-  LIBVERIFY_OPTIMIZATION := LOW
-endif
-
 $(eval $(call SetupJdkLibrary, BUILD_LIBVERIFY, \
     NAME := verify, \
-    OPTIMIZATION := $(LIBVERIFY_OPTIMIZATION), \
+    OPTIMIZATION := HIGH, \
     DISABLED_WARNINGS_gcc_check_code.c := unused-variable, \
     DISABLED_WARNINGS_clang_check_code.c := unused-variable, \
     EXTRA_HEADER_DIRS := libjava, \


### PR DESCRIPTION
On Linux there are some special settings for LIBVERIFY_OPTIMIZATION that are most likely not needed any more and could be removed.
The removal (on Linux) brings the lib optimization level de facto from LOW to HIGH.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352015](https://bugs.openjdk.org/browse/JDK-8352015): LIBVERIFY_OPTIMIZATION remove special optimization settings (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24054/head:pull/24054` \
`$ git checkout pull/24054`

Update a local copy of the PR: \
`$ git checkout pull/24054` \
`$ git pull https://git.openjdk.org/jdk.git pull/24054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24054`

View PR using the GUI difftool: \
`$ git pr show -t 24054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24054.diff">https://git.openjdk.org/jdk/pull/24054.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24054#issuecomment-2724377921)
</details>
