### PR TITLE
8351992: JFR: Improve robustness of the SettingControl examples

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/SettingControl.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/SettingControl.java
@@ -30,7 +30,7 @@ import java.util.Set;
 /**
  * Base class to extend to create setting controls.
  * <p>
- * The following example shows a naive implementation of a setting control for
+ * The following example shows an implementation of a setting control for
  * regular expressions:
  *
  * {@snippet class="Snippets" region="SettingControlOverview1"}

--- a/src/jdk.jfr/share/classes/jdk/jfr/snippet-files/Snippets.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/snippet-files/Snippets.java
@@ -535,6 +535,9 @@ public class Snippets {
          if (valid.isEmpty()) {
              return DEFAULT_VALUE;
          }
+         if (valid.size() == 1) {
+             return valid.getFirst();
+         }
          return "(" + String.join(")|(", valid) + ")";
      }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/snippet-files/Snippets.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/snippet-files/Snippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,6 +65,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -97,16 +98,26 @@ public class Snippets {
     @Label("Rollback")
     @Description("Include transactions that are rollbacked")
     public static class RollbackSetting extends SettingControl {
+        private static final String DEFAULT_VALUE = "true";
         private boolean value = true;
 
         @Override
         public String combine(Set<String> values) {
-            return values.contains("true") ? "true" : "false";
+            if (values.contains("true")) {
+                return "true";
+            }
+            if (values.contains("false")) {
+                return "false";
+            }
+            return DEFAULT_VALUE;
         }
 
         @Override
-        public void setValue(String settingValue) {
-            value = "true".equals(settingValue);
+        public void setValue(String value) {
+            // Ignore invalid values
+            if ("true".equals(value) || "false".equals(value)) {
+                this.value = "true".equals(value);
+            }
         }
 
         @Override
@@ -507,21 +518,38 @@ public class Snippets {
 
  // @start region="SettingControlOverview1"
  final class RegExpControl extends SettingControl {
-     private Pattern pattern = Pattern.compile(".*");
-
-     @Override
-     public void setValue(String value) {
-         this.pattern = Pattern.compile(value);
-     }
+     private static final String DEFAULT_VALUE = ".*";
+     private Pattern pattern = Pattern.compile(DEFAULT_VALUE);
 
      @Override
      public String combine(Set<String> values) {
-         return String.join("|", values);
+         List<String> valid = new ArrayList<>();
+         for (String value : values) {
+             try {
+                 Pattern.compile(value);
+                 valid.add(value);
+             } catch (PatternSyntaxException pse) {
+                 // Ignore invalid patterns
+             }
+         }
+         if (valid.isEmpty()) {
+             return DEFAULT_VALUE;
+         }
+         return "(" + String.join(")|(", valid) + ")";
+     }
+
+     @Override
+     public void setValue(String value) {
+         try {
+             this.pattern = Pattern.compile(value);
+         } catch (PatternSyntaxException pse) {
+             // Ignore invalid patterns
+         }
      }
 
      @Override
      public String getValue() {
-         return pattern.toString();
+         return pattern.pattern();
      }
 
      public boolean matches(String s) {


### PR DESCRIPTION
Could I have a review of PR that improves the robustness of the SettingControl examples.

Testing: jdk/jdk/jfr + tier1

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351992](https://bugs.openjdk.org/browse/JDK-8351992): JFR: Improve robustness of the SettingControl examples (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24056/head:pull/24056` \
`$ git checkout pull/24056`

Update a local copy of the PR: \
`$ git checkout pull/24056` \
`$ git pull https://git.openjdk.org/jdk.git pull/24056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24056`

View PR using the GUI difftool: \
`$ git pr show -t 24056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24056.diff">https://git.openjdk.org/jdk/pull/24056.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24056#issuecomment-2725171646)
</details>
