### PR TITLE
8352064: AIX: now also able to build static-jdk image with a statically linked launcher

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1321,10 +1321,7 @@ endif
 ################################################################################
 
 # all-images builds all our deliverables as images.
-all-images: product-images test-image all-docs-images
-ifeq ($(call isTargetOs, linux macosx windows), true)
-  all-images: static-jdk-image
-endif
+all-images: product-images static-jdk-image test-image all-docs-images
 
 # all-bundles packages all our deliverables as tar.gz bundles.
 all-bundles: product-bundles test-bundles docs-bundles static-libs-bundles

--- a/make/StaticLibs.gmk
+++ b/make/StaticLibs.gmk
@@ -31,6 +31,7 @@ include CopyFiles.gmk
 include DebugInfoUtils.gmk
 include Modules.gmk
 include modules/LauncherCommon.gmk
+include Execute.gmk
 
 ################################################################################
 #
@@ -107,11 +108,9 @@ else ifeq ($(call isTargetOs, aix), true)
   # on AIX we have to generate export files for all static libs, because we have no whole-archive linker flag
   STATIC_LIB_EXPORT_FILES := $(foreach lib, $(STATIC_LIB_FILES), $(lib).exp)
   STATIC_LIBS := -Wl,-bexpfull $(STATIC_LIB_FILES) $(addprefix -Wl$(COMMA)-bE:, $(STATIC_LIB_EXPORT_FILES))
-#  $(STATIC_LIB_EXPORT_FILES): $(STATIC_LIB_FILES)
-#	$(AR) $(ARFLAGS) -w $(patsubst %.exp, %, $@) | $(GREP) -v '^\.' | $(AWK) '{print $$1}' | $(SORT) -u >$@
   $(foreach lib, $(STATIC_LIB_FILES), \
-    $(eval $(call SetupExecute, generate_export_list_$(lib), \
-      INFO := Generating export list for $(lib), \
+    $(eval $(call SetupExecute, generate_export_list_$(notdir $(lib)), \
+      INFO := Generating export list for $(notdir $(lib)), \
       DEPS :=  $(lib), \
       OUTPUT_FILE := $(lib).exp, \
       COMMAND := ( $(AR) $(ARFLAGS) -w $(lib) | $(GREP) -v '^\.' | $(AWK) '{print $$1}' | $(SORT) -u > $(lib).exp ), \

--- a/make/StaticLibs.gmk
+++ b/make/StaticLibs.gmk
@@ -107,14 +107,16 @@ else ifeq ($(call isTargetOs, aix), true)
   # on AIX we have to generate export files for all static libs, because we have no whole-archive linker flag
   STATIC_LIB_EXPORT_FILES := $(foreach lib, $(STATIC_LIB_FILES), $(lib).exp)
   STATIC_LIBS := -Wl,-bexpfull $(STATIC_LIB_FILES) $(addprefix -Wl$(COMMA)-bE:, $(STATIC_LIB_EXPORT_FILES))
-$(STATIC_LIB_EXPORT_FILES): $(STATIC_LIB_FILES)
-	$(AR) $(ARFLAGS) -w $(patsubst %.exp, %, $@) | $(GREP) -v '^\.' | $(AWK) '{print $$1}' | sort -u >$@
-#$(eval $(call SetupExecute, generate_export_list, \
-#    INFO := Generating export list for static libs, \
-#    DEPS :=  $(STATIC_LIB_FILE), \
-#    OUTPUT_FILE := $(STATIC_LIB_EXPORT_FILES), \
-#    COMMAND := $(AR) $(ARFLAGS) -w $(patsubst %.exp, %, $@) | $(GREP) -v '^\.' | $(AWK) '{print $$1}' | sort -u >$@, \
-#))
+#  $(STATIC_LIB_EXPORT_FILES): $(STATIC_LIB_FILES)
+#	$(AR) $(ARFLAGS) -w $(patsubst %.exp, %, $@) | $(GREP) -v '^\.' | $(AWK) '{print $$1}' | $(SORT) -u >$@
+  $(foreach lib, $(STATIC_LIB_FILES), \
+    $(eval $(call SetupExecute, generate_export_list_$(lib), \
+      INFO := Generating export list for $(lib), \
+      DEPS :=  $(lib), \
+      OUTPUT_FILE := $(lib).exp, \
+      COMMAND := ( $(AR) $(ARFLAGS) -w $(lib) | $(GREP) -v '^\.' | $(AWK) '{print $$1}' | $(SORT) -u > $(lib).exp ), \
+    )) \
+  )
 else
   $(error Unsupported platform)
 endif
@@ -133,8 +135,10 @@ $(eval $(call SetupBuildLauncher, java, \
     OBJECT_DIR := $(STATIC_LAUNCHER_OUTPUT_DIR), \
 ))
 
-$(java): $(STATIC_LIB_FILES) $(if $(call isTargetOs, aix), $(STATIC_LIB_EXPORT_FILES))
-#$(java): $(STATIC_LIB_FILES) $(if $(call isTargetOs, aix), $(generate_export_list))
+$(java): $(STATIC_LIB_FILES)
+ifeq ($(call isTargetOs, aix), true)
+  $(java): $(STATIC_LIB_EXPORT_FILES)
+endif
 
 TARGETS += $(java)
 

--- a/make/StaticLibs.gmk
+++ b/make/StaticLibs.gmk
@@ -68,6 +68,10 @@ else ifeq ($(call isTargetOs, windows), true)
   BROKEN_STATIC_LIBS += sspi_bridge
   # dt_shmem define jdwpTransport_OnLoad which conflict with dt_socket
   BROKEN_STATIC_LIBS += dt_shmem
+else ifeq ($(call isTargetOs, aix), true)
+  # libsplashscreen has a name conflict with libawt in the function
+  # BitmapToYXBandedRectangles, so we exclude it for now.
+  BROKEN_STATIC_LIBS += splashscreen
 endif
 
 $(foreach module, $(STATIC_LIB_MODULES), \
@@ -99,6 +103,18 @@ else ifeq ($(call isTargetOs, linux), true)
   STATIC_LIBS := -Wl,--export-dynamic -Wl,--whole-archive $(STATIC_LIB_FILES) -Wl,--no-whole-archive
 else ifeq ($(call isTargetOs, windows), true)
   STATIC_LIBS := $(addprefix -wholearchive:, $(STATIC_LIB_FILES))
+else ifeq ($(call isTargetOs, aix), true)
+  # on AIX we have to generate export files for all static libs, because we have no whole-archive linker flag
+  STATIC_LIB_EXPORT_FILES := $(foreach lib, $(STATIC_LIB_FILES), $(lib).exp)
+  STATIC_LIBS := -Wl,-bexpfull $(STATIC_LIB_FILES) $(addprefix -Wl$(COMMA)-bE:, $(STATIC_LIB_EXPORT_FILES))
+$(STATIC_LIB_EXPORT_FILES): $(STATIC_LIB_FILES)
+	$(AR) $(ARFLAGS) -w $(patsubst %.exp, %, $@) | $(GREP) -v '^\.' | $(AWK) '{print $$1}' | sort -u >$@
+#$(eval $(call SetupExecute, generate_export_list, \
+#    INFO := Generating export list for static libs, \
+#    DEPS :=  $(STATIC_LIB_FILE), \
+#    OUTPUT_FILE := $(STATIC_LIB_EXPORT_FILES), \
+#    COMMAND := $(AR) $(ARFLAGS) -w $(patsubst %.exp, %, $@) | $(GREP) -v '^\.' | $(AWK) '{print $$1}' | sort -u >$@, \
+#))
 else
   $(error Unsupported platform)
 endif
@@ -117,7 +133,8 @@ $(eval $(call SetupBuildLauncher, java, \
     OBJECT_DIR := $(STATIC_LAUNCHER_OUTPUT_DIR), \
 ))
 
-$(java): $(STATIC_LIB_FILES)
+$(java): $(STATIC_LIB_FILES) $(if $(call isTargetOs, aix), $(STATIC_LIB_EXPORT_FILES))
+#$(java): $(STATIC_LIB_FILES) $(if $(call isTargetOs, aix), $(generate_export_list))
 
 TARGETS += $(java)
 

--- a/make/StaticLibs.gmk
+++ b/make/StaticLibs.gmk
@@ -106,8 +106,6 @@ else ifeq ($(call isTargetOs, windows), true)
   STATIC_LIBS := $(addprefix -wholearchive:, $(STATIC_LIB_FILES))
 else ifeq ($(call isTargetOs, aix), true)
   # on AIX we have to generate export files for all static libs, because we have no whole-archive linker flag
-  STATIC_LIB_EXPORT_FILES := $(foreach lib, $(STATIC_LIB_FILES), $(lib).exp)
-  STATIC_LIBS := -Wl,-bexpfull $(STATIC_LIB_FILES) $(addprefix -Wl$(COMMA)-bE:, $(STATIC_LIB_EXPORT_FILES))
   $(foreach lib, $(STATIC_LIB_FILES), \
     $(eval $(call SetupExecute, generate_export_list_$(notdir $(lib)), \
       INFO := Generating export list for $(notdir $(lib)), \
@@ -115,7 +113,9 @@ else ifeq ($(call isTargetOs, aix), true)
       OUTPUT_FILE := $(lib).exp, \
       COMMAND := ( $(AR) $(ARFLAGS) -w $(lib) | $(GREP) -v '^\.' | $(AWK) '{print $$1}' | $(SORT) -u > $(lib).exp ), \
     )) \
+    $(eval STATIC_LIB_EXPORT_FILES += $(lib).exp) \
   )
+  STATIC_LIBS := -Wl,-bexpfull $(STATIC_LIB_FILES) $(addprefix -Wl$(COMMA)-bE:, $(STATIC_LIB_EXPORT_FILES))
 else
   $(error Unsupported platform)
 endif

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -172,6 +172,14 @@ endif
 ifeq ($(call isTargetOs, aix), true)
   # AIX requires a static libjli because the compiler doesn't support '-rpath'
   BUILD_LIBJLI_TYPE := STATIC_LIBRARY
+
+  # This is the object file to provide the dladdr API, which is not
+  # part of AIX. It occurs several times in the jdk code base.
+  # Do not include it. When statically linking the java
+  # launcher with all JDK and VM static libraries, we use the
+  # --whole-archive linker option. The duplicate objects in different
+  # static libraries cause linking errors due to duplicate symbols.
+  LIBJLI_STATIC_EXCLUDE_OBJS += java_md_aix.o
 endif
 
 $(eval $(call SetupJdkLibrary, BUILD_LIBJLI, \

--- a/make/modules/java.desktop/lib/AwtLibraries.gmk
+++ b/make/modules/java.desktop/lib/AwtLibraries.gmk
@@ -95,6 +95,16 @@ ifeq ($(call isTargetOs, windows), true)
       $(TOPDIR)/src/$(MODULE)/windows/native/libawt/windows/awt.rc
 endif
 
+# This is the object file to provide the dladdr API, which is not
+# part of AIX. It occurs several times in the jdk code base.
+# Do not include it. When statically linking the java
+# launcher with all JDK and VM static libraries, we use the
+# --whole-archive linker option. The duplicate objects in different
+# static libraries cause linking errors due to duplicate symbols.
+ifeq ($(call isTargetOs, aix), true)
+  LIBAWT_STATIC_EXCLUDE_OBJS := porting_aix.o
+endif
+
 # -fgcse-after-reload improves performance of MaskFill in Java2D by 20% for
 # some gcc
 $(eval $(call SetupJdkLibrary, BUILD_LIBAWT, \
@@ -140,6 +150,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBAWT, \
         user32.lib uuid.lib winmm.lib winspool.lib, \
     VERSIONINFO_RESOURCE := $(LIBAWT_VERSIONINFO_RESOURCE), \
     EXTRA_RCFLAGS := $(LIBAWT_RCFLAGS), \
+    STATIC_LIB_EXCLUDE_OBJS := $(LIBAWT_STATIC_EXCLUDE_OBJS), \
 ))
 
 TARGETS += $(BUILD_LIBAWT)

--- a/src/hotspot/os/aix/loadlib_aix.cpp
+++ b/src/hotspot/os/aix/loadlib_aix.cpp
@@ -215,11 +215,11 @@ static bool reload_table() {
   if (pgmpath[0] == 0) {
     procentry64 PInfo;
     PInfo.pi_pid = ::getpid();
-    if ( 0 == ::getargs(&PInfo, sizeof(PInfo), (char*)pgmpath,PATH_MAX) && *pgmpath ) {
+    if (0 == ::getargs(&PInfo, sizeof(PInfo), (char*)pgmpath, PATH_MAX) && *pgmpath) {
       pgmpath[PATH_MAX] = '\0';
       pgmbase = strrchr(pgmpath, '/');
-      if (pgmbase) {
-        pgmbase +=1;
+      if (pgmbase != nullptr) {
+        pgmbase += 1;
       }
     }
   }
@@ -242,7 +242,7 @@ static bool reload_table() {
     lm->data     = ldi->ldinfo_dataorg;
     lm->data_len = ldi->ldinfo_datasize;
 
-    if (pgmbase && 0 == strcmp(pgmbase, ldi->ldinfo_filename)) {
+    if (pgmbase != nullptr && 0 == strcmp(pgmbase, ldi->ldinfo_filename)) {
       lm->path = g_stringlist.add(pgmpath);
     } else {
       lm->path = g_stringlist.add(ldi->ldinfo_filename);

--- a/src/hotspot/os/aix/loadlib_aix.cpp
+++ b/src/hotspot/os/aix/loadlib_aix.cpp
@@ -42,6 +42,9 @@
 // For loadquery()
 #include <sys/ldr.h>
 
+// For getargs()
+#include <procinfo.h>
+
 // Use raw malloc instead of os::malloc - this code gets used for error reporting.
 
 // A class to "intern" eternal strings.
@@ -205,6 +208,22 @@ static bool reload_table() {
 
   trcVerbose("loadquery buffer size is %zu.", buflen);
 
+  // the entry for the executable itself does not contain a path.
+  // instead we retrieve the path of the executable with the getargs API.
+  static char pgmpath[PATH_MAX+1] = "";
+  static char* pgmbase = nullptr;
+  if (pgmpath[0] == 0) {
+    procentry64 PInfo;
+    PInfo.pi_pid = ::getpid();
+    if ( 0 == ::getargs(&PInfo, sizeof(PInfo), (char*)pgmpath,PATH_MAX) && *pgmpath ) {
+      pgmpath[PATH_MAX] = '\0';
+      pgmbase = strrchr(pgmpath, '/');
+      if (pgmbase) {
+        pgmbase +=1;
+      }
+    }
+  }
+
   // Iterate over the loadquery result. For details see sys/ldr.h on AIX.
   ldi = (struct ld_info*) buffer;
 
@@ -223,7 +242,12 @@ static bool reload_table() {
     lm->data     = ldi->ldinfo_dataorg;
     lm->data_len = ldi->ldinfo_datasize;
 
-    lm->path = g_stringlist.add(ldi->ldinfo_filename);
+    if (pgmbase && 0 == strcmp(pgmbase, ldi->ldinfo_filename)) {
+      lm->path = g_stringlist.add(pgmpath);
+    } else {
+      lm->path = g_stringlist.add(ldi->ldinfo_filename);
+    }
+
     if (!lm->path) {
       log_warning(os)("OOM.");
       free(lm);


### PR DESCRIPTION
After "JDK-8339480: Build static-jdk image with a statically linked launcher" AIX was not able to build the new target. Therefore with "JDK-8345590 AIX 'make all' fails after JDK-8339480" the new target was disabled again.

Now with this change we can enable the statically linked launcher target again.
There are 3 things to do.
1.	Modify `dladdr()`. Because this API does not exist on AIX it is implemented based on the `loadquery()` API. Unfortunately, this API does only return the name of the executable, but not its path. Beforehand this was no problem, because we asked for a loaded library, for which the API provides the path. But now we are asking for the executable itself.
2.	`dladdr()` is differently implemented three times in the openjdk code. In the static case I supressed now the usage of the additional modules containing version two and three. I know this shouldn't be the final version. Magnus mentioned that they have discussed from time to time to have a "basic JDK utility lib" that can be shared between hotspot and the JDK libraries. I think this is a good idea for the future, but far beyond the scope of this PR. The second best thing Magnus proposed is to only have the `dladdr()` functionality in Hotspot and then export it. Let's see how the community decides.
3.	Because we lack a linker flag like `whole-archive`, I had to force the export of all symbols by creating export files containing all symbols of the static libs. I introduced the new rule for the export file generation as "raw" make recipes. Magnus claimed to use the `SetupExecute`. Unfortunately I was not able to make it function. So I still have my "raw" solution in place, but my last try with `SetupExecute` as comment beneath. Help is welcome.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352064](https://bugs.openjdk.org/browse/JDK-8352064): AIX: now also able to build static-jdk image with a statically linked launcher (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) Review applies to [9b92eea7](https://git.openjdk.org/jdk/pull/24062/files/9b92eea7e4012cff4c8a69ad81bd952cee65f4d2)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24062/head:pull/24062` \
`$ git checkout pull/24062`

Update a local copy of the PR: \
`$ git checkout pull/24062` \
`$ git pull https://git.openjdk.org/jdk.git pull/24062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24062`

View PR using the GUI difftool: \
`$ git pr show -t 24062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24062.diff">https://git.openjdk.org/jdk/pull/24062.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24062#issuecomment-2725081635)
</details>
