### PR TITLE
8352044: Add --with-import-jvms to configure

### DIFF
--- a/make/autoconf/configure.ac
+++ b/make/autoconf/configure.ac
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -95,6 +95,7 @@ JDKOPT_SETUP_OPEN_OR_CUSTOM
 # These are needed to be able to create a configuration name (and thus the output directory)
 JDKOPT_SETUP_DEBUG_LEVEL
 HOTSPOT_SETUP_JVM_VARIANTS
+HOTSPOT_SETUP_IMPORT_JVMS
 
 # With basic setup done, call the custom early hook.
 CUSTOM_EARLY_HOOK

--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -100,6 +100,49 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_VARIANTS],
   AC_SUBST(JVM_VARIANTS)
   AC_SUBST(VALID_JVM_VARIANTS)
   AC_SUBST(JVM_VARIANT_MAIN)
+])
+
+################################################################################
+# Setup an optional list of additional JVMs that should be included during
+# build.
+#
+AC_DEFUN_ONCE([HOTSPOT_SETUP_IMPORT_JVMS],
+[
+  UTIL_ARG_WITH(NAME: import-jvms, TYPE: string,
+      DEFAULT: [],
+      DESC: [Additional JVMs to import, on the format <name>:<path to jvm lib>, separated by commas],
+      OPTIONAL: true)
+
+  IMPORT_JVMS=
+  IMPORT_JVM_NAMES=
+  AC_MSG_CHECKING([for import JVMs])
+  # Create a nicely formatted list of import JVM names
+  [ import_jvm_names="`$ECHO $with_import_jvms | $SED -E -e 's/([^:,]+):[^,]+/\1/g; s/,/, /g'`" ]
+  if test "x$import_jvm_names" = x; then
+    AC_MSG_RESULT([none])
+  else
+    AC_MSG_RESULT([$import_jvm_names])
+
+    import_jvms="`$ECHO $with_import_jvms | $SED -e 's/,/ /g'`"
+
+    for import_jvm in $import_jvms; do
+      import_jvm_name=`$ECHO $import_jvm | $CUT -d: -f1`
+      import_jvm_lib=`$ECHO $import_jvm | $CUT -d: -f2`
+      if test "x$import_jvm_name" = "x$JVM_VARIANT_MAIN"; then
+        AC_MSG_ERROR([JVM name '$JVM_VARIANT_MAIN' is not allowed for an import JVM])
+      fi
+      if ! test -e $import_jvm_lib; then
+        AC_MSG_ERROR([Import JVM '$import_jvm_name' not found at $import_jvm_lib])
+      fi
+
+      UTIL_FIXUP_PATH(import_jvm_lib)
+      AC_MSG_NOTICE([Importing JVM '$import_jvm_name' from $import_jvm_lib])
+      IMPORT_JVM_NAMES="$IMPORT_JVM_NAMES $import_jvm_name"
+      IMPORT_JVMS="$IMPORT_JVMS $import_jvm_name:$import_jvm_lib"
+    done
+  fi
+  AC_SUBST(IMPORT_JVMS)
+  AC_SUBST(IMPORT_JVM_NAMES)
 ])
 
 ################################################################################

--- a/make/autoconf/spec.gmk.template
+++ b/make/autoconf/spec.gmk.template
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -322,6 +322,9 @@ JVM_FEATURES_custom := @JVM_FEATURES_custom@
 # Used for make-time verifications
 VALID_JVM_FEATURES := @VALID_JVM_FEATURES@
 VALID_JVM_VARIANTS := @VALID_JVM_VARIANTS@
+
+IMPORT_JVMS := @IMPORT_JVMS@
+IMPORT_JVM_NAMES := @IMPORT_JVM_NAMES@
 
 # Allow overriding the default hotspot library path
 HOTSPOT_OVERRIDE_LIBPATH := @HOTSPOT_OVERRIDE_LIBPATH@

--- a/make/modules/java.base/Copy.gmk
+++ b/make/modules/java.base/Copy.gmk
@@ -83,17 +83,16 @@ ifeq ($(call isTargetOs, windows)+$(CREATING_BUILDJDK), true+false)
 endif
 
 ################################################################################
-# In jvm.cfg, the first listed KNOWN variant is the default. On most build
-# configurations, that is the server variant.
-ifeq ($(call And, $(call isTargetOs, windows) $(call isTargetCpu, x86)), true)
-  DEFAULT_CFG_VARIANT ?= client
-endif
-DEFAULT_CFG_VARIANT ?= server
+# In jvm.cfg, the first listed KNOWN variant is the default.
+DEFAULT_CFG_VARIANT := $(JVM_VARIANT_MAIN)
 
 # Change the order to put the default variant first if present.
 ORDERED_CFG_VARIANTS := \
     $(if $(filter $(DEFAULT_CFG_VARIANT), $(JVM_VARIANTS)), $(DEFAULT_CFG_VARIANT)) \
     $(filter-out $(DEFAULT_CFG_VARIANT), $(JVM_VARIANTS))
+
+# Append imported JVMs
+ORDERED_CFG_VARIANTS += $(IMPORT_JVM_NAMES)
 
 JVMCFG := $(LIB_DST_DIR)/jvm.cfg
 
@@ -117,6 +116,26 @@ $(JVMCFG): $(call DependOnVariable, ORDERED_CFG_VARIANTS)
 	)
 
 TARGETS += $(JVMCFG)
+
+################################################################################
+# Copy import JVMs into place, if any
+#
+ifneq ($(IMPORT_JVM_NAMES),)
+  rename_to_libjvm = $(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
+
+  $(foreach import_jvm, $(IMPORT_JVM_NAMES), \
+    $(eval $(import_jvm)_path := $(patsubst $(import_jvm):%,%,$(filter $(import_jvm):%, $(IMPORT_JVMS)))) \
+    $(eval $(call MakeDir, $(LIB_DST_DIR)/$(import_jvm))) \
+    $(eval $(call SetupCopyFiles, IMPORT_JVM_$(import_jvm), \
+        FILES := $($(import_jvm)_path), \
+        DEST := $(LIB_DST_DIR)/$(import_jvm), \
+        FLATTEN := true, \
+        NAME_MACRO := rename_to_libjvm, \
+        LOG_ACTION := Copying import JVM '$(import_jvm)', \
+    )) \
+    $(eval TARGETS += $(IMPORT_JVM_$(import_jvm))) \
+  )
+endif
 
 ################################################################################
 


### PR DESCRIPTION
We should allow pre-built JVMs to be included in a build, so they are just copied into place, and the jvm.cfg file properly updated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352044](https://bugs.openjdk.org/browse/JDK-8352044): Add --with-import-jvms to configure (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24063/head:pull/24063` \
`$ git checkout pull/24063`

Update a local copy of the PR: \
`$ git checkout pull/24063` \
`$ git pull https://git.openjdk.org/jdk.git pull/24063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24063`

View PR using the GUI difftool: \
`$ git pr show -t 24063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24063.diff">https://git.openjdk.org/jdk/pull/24063.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24063#issuecomment-2725137540)
</details>
