### PR TITLE
8351096: Typos in Vector API doc

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
@@ -44,7 +44,7 @@ abstract class AbstractVector<E> extends Vector<E> {
     /**
      * The order of vector bytes when stored in natural,
      * array elements of the same lane type.
-     * This is the also the behavior of the
+     * This is also the behavior of the
      * VectorSupport load/store instructions.
      * If these instructions gain the capability to do
      * byte swapping on the fly, add a bit to those
@@ -302,8 +302,9 @@ abstract class AbstractVector<E> extends Vector<E> {
     Vector<F> convert(Conversion<E,F> conv, int part) {
         // Shape invariance is simple to implement.
         // It's part of the API because shape invariance
-        // is the default mode of operation, and shape
-        // shifting operations must advertise themselves.
+        // is the default mode of operation, and
+        // shape-shifting operations must advertise
+        // themselves.
         ConversionImpl<E,F> c = (ConversionImpl<E,F>) conv;
         @SuppressWarnings("unchecked")
         VectorSpecies<F> rsp = (VectorSpecies<F>)

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -84,7 +84,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     //       super.bOp((Byte128Vector) o);
     // The purpose of that is to forcibly inline
     // the generic definition from this file
-    // into a sharply type- and size-specific
+    // into a sharply-typed and size-specific
     // wrapper in the subclass file, so that
     // the JIT can specialize the code.
     // The code is only inlined and expanded
@@ -554,7 +554,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     // Note: A surprising behavior in javadoc
     // sometimes makes a lone /** {@inheritDoc} */
     // comment drop the method altogether,
-    // apparently if the method mentions an
+    // apparently if the method mentions a
     // parameter or return type of Vector<Byte>
     // instead of Vector<E> as originally specified.
     // Adding an empty HTML fragment appears to
@@ -1748,7 +1748,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
      * Computes the bitwise logical conjunction ({@code &})
      * of this vector and a second input vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "and" operation ({@code &})
      * to each pair of corresponding lane values.
      *
@@ -1781,7 +1781,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
      * Computes the bitwise logical conjunction ({@code &})
      * of this vector and a scalar.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "and" operation ({@code &})
      * to each pair of corresponding lane values.
      *
@@ -1805,7 +1805,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
      * Computes the bitwise logical disjunction ({@code |})
      * of this vector and a second input vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "or" operation ({@code |})
      * to each pair of corresponding lane values.
      *
@@ -1838,7 +1838,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
      * Computes the bitwise logical disjunction ({@code |})
      * of this vector and a scalar.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "or" operation ({@code |})
      * to each pair of corresponding lane values.
      *
@@ -1906,7 +1906,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
      * Computes the bitwise logical complement ({@code ~})
      * of this vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "not" operation ({@code ~})
      * to each lane value.
      *
@@ -2950,7 +2950,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
 
     /** {@inheritDoc} <!--workaround-->
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code ByteVector},
      * there will be no loss of precision or range,
      * and so no {@code UnsupportedOperationException} will
@@ -2970,7 +2970,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
 
     /** {@inheritDoc} <!--workaround-->
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code ByteVector},
      * there will be no loss of precision or range,
      * and so no {@code UnsupportedOperationException} will
@@ -2990,7 +2990,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
 
     /** {@inheritDoc} <!--workaround-->
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code ByteVector},
      * there will be no loss of precision.
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -84,7 +84,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     //       super.bOp((Byte128Vector) o);
     // The purpose of that is to forcibly inline
     // the generic definition from this file
-    // into a sharply type- and size-specific
+    // into a sharply-typed and size-specific
     // wrapper in the subclass file, so that
     // the JIT can specialize the code.
     // The code is only inlined and expanded
@@ -543,7 +543,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     // Note: A surprising behavior in javadoc
     // sometimes makes a lone /** {@inheritDoc} */
     // comment drop the method altogether,
-    // apparently if the method mentions an
+    // apparently if the method mentions a
     // parameter or return type of Vector<Double>
     // instead of Vector<E> as originally specified.
     // Adding an empty HTML fragment appears to
@@ -2771,7 +2771,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     /** {@inheritDoc} <!--workaround-->
      * @implNote
      * This is an alias for {@link #toArray()}
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code DoubleVector},
      * there will be no loss of precision.
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
@@ -2262,7 +2262,7 @@ public final class Float16
          * &lt; 10<sup><i>k</i>+1</sup>.
          * <p>
          * The result is correct when |{@code e}| &le; 6_432_162.
-         * Otherwise the result is undefined.
+         * Otherwise, the result is undefined.
          *
          * @param e The exponent of 2, which should meet
          *          |{@code e}| &le; 6_432_162 for safe results.
@@ -2279,7 +2279,7 @@ public final class Float16
          * <p>
          * The result is correct when
          * -3_606_689 &le; {@code e} &le; 3_150_619.
-         * Otherwise the result is undefined.
+         * Otherwise, the result is undefined.
          *
          * @param e The exponent of 2, which should meet
          *          -3_606_689 &le; {@code e} &le; 3_150_619 for safe results.
@@ -2296,7 +2296,7 @@ public final class Float16
          * &lt; 2<sup><i>k</i>+1</sup>.
          * <p>
          * The result is correct when |{@code e}| &le; 1_838_394.
-         * Otherwise the result is undefined.
+         * Otherwise, the result is undefined.
          *
          * @param e The exponent of 10, which should meet
          *          |{@code e}| &le; 1_838_394 for safe results.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -84,7 +84,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     //       super.bOp((Byte128Vector) o);
     // The purpose of that is to forcibly inline
     // the generic definition from this file
-    // into a sharply type- and size-specific
+    // into a sharply-typed and size-specific
     // wrapper in the subclass file, so that
     // the JIT can specialize the code.
     // The code is only inlined and expanded
@@ -543,7 +543,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     // Note: A surprising behavior in javadoc
     // sometimes makes a lone /** {@inheritDoc} */
     // comment drop the method altogether,
-    // apparently if the method mentions an
+    // apparently if the method mentions a
     // parameter or return type of Vector<Float>
     // instead of Vector<E> as originally specified.
     // Adding an empty HTML fragment appears to
@@ -2790,7 +2790,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /** {@inheritDoc} <!--workaround-->
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code FloatVector},
      * there will be no loss of precision.
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -84,7 +84,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     //       super.bOp((Byte128Vector) o);
     // The purpose of that is to forcibly inline
     // the generic definition from this file
-    // into a sharply type- and size-specific
+    // into a sharply-typed and size-specific
     // wrapper in the subclass file, so that
     // the JIT can specialize the code.
     // The code is only inlined and expanded
@@ -554,7 +554,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     // Note: A surprising behavior in javadoc
     // sometimes makes a lone /** {@inheritDoc} */
     // comment drop the method altogether,
-    // apparently if the method mentions an
+    // apparently if the method mentions a
     // parameter or return type of Vector<Integer>
     // instead of Vector<E> as originally specified.
     // Adding an empty HTML fragment appears to
@@ -1751,7 +1751,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
      * Computes the bitwise logical conjunction ({@code &})
      * of this vector and a second input vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "and" operation ({@code &})
      * to each pair of corresponding lane values.
      *
@@ -1784,7 +1784,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
      * Computes the bitwise logical conjunction ({@code &})
      * of this vector and a scalar.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "and" operation ({@code &})
      * to each pair of corresponding lane values.
      *
@@ -1808,7 +1808,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
      * Computes the bitwise logical disjunction ({@code |})
      * of this vector and a second input vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "or" operation ({@code |})
      * to each pair of corresponding lane values.
      *
@@ -1841,7 +1841,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
      * Computes the bitwise logical disjunction ({@code |})
      * of this vector and a scalar.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "or" operation ({@code |})
      * to each pair of corresponding lane values.
      *
@@ -1891,7 +1891,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
      * Computes the bitwise logical complement ({@code ~})
      * of this vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "not" operation ({@code ~})
      * to each lane value.
      *
@@ -2936,7 +2936,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     /**
      * {@inheritDoc} <!--workaround-->
      * This is an alias for {@link #toArray()}
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code IntVector},
      * there will be no loss of range or precision.
      */
@@ -2948,7 +2948,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
 
     /** {@inheritDoc} <!--workaround-->
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code IntVector},
      * there will be no loss of precision or range,
      * and so no {@code UnsupportedOperationException} will
@@ -2968,7 +2968,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
 
     /** {@inheritDoc} <!--workaround-->
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code IntVector},
      * there will be no loss of precision.
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -84,7 +84,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     //       super.bOp((Byte128Vector) o);
     // The purpose of that is to forcibly inline
     // the generic definition from this file
-    // into a sharply type- and size-specific
+    // into a sharply-typed and size-specific
     // wrapper in the subclass file, so that
     // the JIT can specialize the code.
     // The code is only inlined and expanded
@@ -554,7 +554,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     // Note: A surprising behavior in javadoc
     // sometimes makes a lone /** {@inheritDoc} */
     // comment drop the method altogether,
-    // apparently if the method mentions an
+    // apparently if the method mentions a
     // parameter or return type of Vector<Long>
     // instead of Vector<E> as originally specified.
     // Adding an empty HTML fragment appears to
@@ -1664,7 +1664,7 @@ public abstract class LongVector extends AbstractVector<Long> {
      * Computes the bitwise logical conjunction ({@code &})
      * of this vector and a second input vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "and" operation ({@code &})
      * to each pair of corresponding lane values.
      *
@@ -1697,7 +1697,7 @@ public abstract class LongVector extends AbstractVector<Long> {
      * Computes the bitwise logical conjunction ({@code &})
      * of this vector and a scalar.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "and" operation ({@code &})
      * to each pair of corresponding lane values.
      *
@@ -1721,7 +1721,7 @@ public abstract class LongVector extends AbstractVector<Long> {
      * Computes the bitwise logical disjunction ({@code |})
      * of this vector and a second input vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "or" operation ({@code |})
      * to each pair of corresponding lane values.
      *
@@ -1754,7 +1754,7 @@ public abstract class LongVector extends AbstractVector<Long> {
      * Computes the bitwise logical disjunction ({@code |})
      * of this vector and a scalar.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "or" operation ({@code |})
      * to each pair of corresponding lane values.
      *
@@ -1804,7 +1804,7 @@ public abstract class LongVector extends AbstractVector<Long> {
      * Computes the bitwise logical complement ({@code ~})
      * of this vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "not" operation ({@code ~})
      * to each lane value.
      *
@@ -2816,7 +2816,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     /**
      * {@inheritDoc} <!--workaround-->
      * This is an alias for {@link #toArray()}
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code LongVector},
      * there will be no loss of range or precision.
      */
@@ -2828,7 +2828,7 @@ public abstract class LongVector extends AbstractVector<Long> {
 
     /** {@inheritDoc} <!--workaround-->
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code LongVector},
      * up to nine bits of precision may be lost
      * for lane values of large magnitude.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -84,7 +84,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     //       super.bOp((Byte128Vector) o);
     // The purpose of that is to forcibly inline
     // the generic definition from this file
-    // into a sharply type- and size-specific
+    // into a sharply-typed and size-specific
     // wrapper in the subclass file, so that
     // the JIT can specialize the code.
     // The code is only inlined and expanded
@@ -554,7 +554,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     // Note: A surprising behavior in javadoc
     // sometimes makes a lone /** {@inheritDoc} */
     // comment drop the method altogether,
-    // apparently if the method mentions an
+    // apparently if the method mentions a
     // parameter or return type of Vector<Short>
     // instead of Vector<E> as originally specified.
     // Adding an empty HTML fragment appears to
@@ -1748,7 +1748,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
      * Computes the bitwise logical conjunction ({@code &})
      * of this vector and a second input vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "and" operation ({@code &})
      * to each pair of corresponding lane values.
      *
@@ -1781,7 +1781,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
      * Computes the bitwise logical conjunction ({@code &})
      * of this vector and a scalar.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "and" operation ({@code &})
      * to each pair of corresponding lane values.
      *
@@ -1805,7 +1805,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
      * Computes the bitwise logical disjunction ({@code |})
      * of this vector and a second input vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "or" operation ({@code |})
      * to each pair of corresponding lane values.
      *
@@ -1838,7 +1838,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
      * Computes the bitwise logical disjunction ({@code |})
      * of this vector and a scalar.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "or" operation ({@code |})
      * to each pair of corresponding lane values.
      *
@@ -1907,7 +1907,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
      * Computes the bitwise logical complement ({@code ~})
      * of this vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "not" operation ({@code ~})
      * to each lane value.
      *
@@ -2951,7 +2951,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
 
     /** {@inheritDoc} <!--workaround-->
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code ShortVector},
      * there will be no loss of precision or range,
      * and so no {@code UnsupportedOperationException} will
@@ -2971,7 +2971,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
 
     /** {@inheritDoc} <!--workaround-->
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code ShortVector},
      * there will be no loss of precision or range,
      * and so no {@code UnsupportedOperationException} will
@@ -2991,7 +2991,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
 
     /** {@inheritDoc} <!--workaround-->
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code ShortVector},
      * there will be no loss of precision.
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
@@ -146,7 +146,7 @@ import java.util.Arrays;
  * {@code VSHAPE}.  Each possible {@code VSHAPE} is represented by
  * a member of the {@link VectorShape} enumeration, and represents
  * an implementation format shared in common by all vectors of
- * that shape.  Thus, the {@linkplain #bitSize() size in bits} of
+ * that shape.  Thus, the {@linkplain #bitSize() size in bits}
  * of a vector is determined by appealing to its vector shape.
  *
  * <p> Some Java platforms give special support to only one shape,
@@ -195,12 +195,12 @@ import java.util.Arrays;
  * <h2><a id="subtypes"></a>Vector subtypes</h2>
  *
  * Vector declares a set of vector operations (methods) that are common to all
- * element types (such as addition).  Sub-classes of Vector with a concrete
+ * element types (such as addition).  Subclasses of Vector with a concrete
  * element type declare further operations that are specific to that
  * element type (such as access to element values in lanes, logical operations
  * on values of integral elements types, or transcendental operations on values
  * of floating point element types).
- * There are six abstract sub-classes of Vector corresponding to the supported set
+ * There are six abstract subclasses of Vector corresponding to the supported set
  * of element types, {@link ByteVector}, {@link ShortVector},
  * {@link IntVector}, {@link LongVector}, {@link FloatVector}, and
  * {@link DoubleVector}. Along with type-specific operations these classes
@@ -325,7 +325,7 @@ import java.util.Arrays;
  * this API has no support for
  * lane-wise n-ary operations.
  *
- * For each lane of all of the input vectors {@code v[j]},
+ * For each lane of all the input vectors {@code v[j]},
  * the underlying scalar operator is applied to the lane values.
  * The result is placed into the vector result in the same lane.
  * The following pseudocode illustrates the behavior of this operation
@@ -555,7 +555,7 @@ import java.util.Arrays;
  * <p> An operation suppressed by a mask will never cause an exception
  * or side effect of any sort, even if the underlying scalar operator
  * can potentially do so.  For example, an unset lane that seems to
- * access an out of bounds array element or divide an integral value
+ * access an out-of-bounds array element or divide an integral value
  * by zero will simply be ignored.  Values in suppressed lanes never
  * participate or appear in the result of the overall operation.
  *
@@ -578,7 +578,7 @@ import java.util.Arrays;
  * does not exist (because it is out of an array's index range).</li>
  *
  * <li>If the operation is a cross-lane operation with an operand
- * which supplies lane indexes (of type {@code VectorShuffle} or
+ * which supplies lane indexes (of type {@code VectorShuffle}) or
  * {@code Vector}, suppressed lanes are not computed, and are filled
  * with the zero default value.  Normally, invalid lane indexes elicit
  * an {@code IndexOutOfBoundsException}, but if a lane is unset, the
@@ -739,11 +739,11 @@ import java.util.Arrays;
  * byte order is slightly preferable to an equivalent big-endian
  * fiction, because some related formulas are much simpler,
  * specifically those which renumber bytes after lane structure
- * changes.  The earliest byte is invariantly earliest across all lane
- * structure changes, but only if little-endian convention are used.
+ * changes.  The earliest byte is invariantly the earliest across all
+ * lane structure changes, but only if little-endian convention are used.
  * The root cause of this is that bytes in scalars are numbered from
  * the least significant (rightmost) to the most significant
- * (leftmost), and almost never vice-versa.  If we habitually numbered
+ * (leftmost), and almost never vice versa.  If we habitually numbered
  * sign bits as zero (as on some computers) then this API would reach
  * for big-endian fictions to create unified addressing of vector
  * bytes.
@@ -983,7 +983,7 @@ import java.util.Arrays;
  * {@linkplain #bitSize() vector bit-size} of its input is
  * crammed into a smaller (respectively, dropped into a larger)
  * output container by a factor of {@code M}.
- * Otherwise it is an in-place operation.
+ * Otherwise, it is an in-place operation.
  *
  * Since this method is a reinterpretation cast that can erase and
  * redraw lane boundaries as well as modify shape, the input vector's
@@ -1035,7 +1035,7 @@ import java.util.Arrays;
  * methods, which select an arbitrary set of {@code VLENGTH} lanes
  * from one or two input vectors, and assemble them in an arbitrary
  * order.  The selection and order of lanes is controlled by a
- * {@code VectorShuffle} object, which acts as an routing table
+ * {@code VectorShuffle} object, which acts as a routing table
  * mapping source lanes to destination lanes.  A {@code VectorShuffle}
  * can encode a mathematical permutation as well as many other
  * patterns of data movement.
@@ -1111,7 +1111,7 @@ import java.util.Arrays;
  *
  * <li> ARM AArch64 platforms supporting NEON.  Although the API has
  * been designed to ensure ARM SVE instructions can be supported
- * (vector sizes between 128 to 2048 bits) there is currently no
+ * (vector sizes between 128 and 2048 bits) there is currently no
  * implementation of such instructions and the general masking
  * capability.
  *
@@ -1941,14 +1941,14 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      * of the vector's native {@code ETYPE}.
      * (In the case of floating point types, the value
      * {@code NEGATIVE_INFINITY} is used, and will appear
-     * after casting as {@code Long.MIN_VALUE}.
+     * after casting as {@code Long.MIN_VALUE}.)
      * <li>
      * If the operation is {@code MIN},
      * then the identity value is the {@code MAX_VALUE}
      * of the vector's native {@code ETYPE}.
      * (In the case of floating point types, the value
      * {@code POSITIVE_INFINITY} is used, and will appear
-     * after casting as {@code Long.MAX_VALUE}.
+     * after casting as {@code Long.MAX_VALUE}.)
      * </ul>
      * <p>
      * In the case of operations {@code ADD} and {@code MUL},
@@ -2257,7 +2257,7 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      * in lane {@code N} of the current vector.
      *
      * <p> The scale must not be so large, and the element size must
-     * not be so small, that that there would be an overflow when
+     * not be so small, that there would be an overflow when
      * computing any of the {@code N*scale} or {@code VLENGTH*scale},
      * when the result is represented using the vector
      * lane type {@code ETYPE}.
@@ -2339,7 +2339,7 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      *
      * <li>To shift lanes backward to the back of the vector, supply a
      * zero vector for the <em>first</em> operand, and specify the
-     * negative shift count as the origin (modulo {@code VLENGTH}.
+     * negative shift count as the origin (modulo {@code VLENGTH}).
      * For example: {@code v.broadcast(0).slice(v.length()-shift, v)}.
      *
      * <li>To rotate lanes forward toward the front end of the vector,
@@ -2354,7 +2354,7 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      * {@code v.slice(v.length() - rotate, v)}.
      *
      * <li>
-     * Since {@code origin} values less then zero or more than
+     * Since {@code origin} values less than zero or more than
      * {@code VLENGTH} will be rejected, if you need to rotate
      * by an unpredictable multiple of {@code VLENGTH}, be sure
      * to reduce the origin value into the required range.
@@ -2426,7 +2426,7 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      * @see #slice(int,Vector)
      * @see #unslice(int,Vector,int,VectorMask)
      */
-    // This doesn't pull its weight, but its symmetrical with
+    // This doesn't pull its weight, but it's symmetrical with
     // masked unslice, and might cause questions if missing.
     // It could make for clearer code.
     public abstract Vector<E> slice(int origin, Vector<E> v1, VectorMask<E> m);
@@ -2636,7 +2636,7 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      * source index {@code I=s.wrapIndex(s.laneSource(N))} in the shuffle,
      * the output lane {@code N} obtains the value from
      * the input vector at lane {@code I} if the mask is set.
-     * Otherwise the output lane {@code N} is set to zero.
+     * Otherwise, the output lane {@code N} is set to zero.
      *
      * <p> This method returns the value of this pseudocode:
      * <pre>{@code
@@ -2868,7 +2868,7 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      *
      * @apiNote
      * Subtypes improve on this method by sharpening
-     * the method return type and
+     * the method return type
      * and the type of the scalar parameter {@code e}.
      *
      * @param e the value to broadcast
@@ -2934,7 +2934,7 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      * <p>
      * The underlying bits of this vector are copied to the resulting
      * vector without modification, but those bits, before copying,
-     * may be truncated if the this vector's bit-size is greater than
+     * may be truncated if this vector's bit-size is greater than
      * desired vector's bit size, or filled with zero bits if this
      * vector's bit-size is less than desired vector's bit-size.
      *
@@ -3187,7 +3187,7 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      * documented, conversion operations <em>never change vector
      * shape</em>, regardless of how they may change <em>lane sizes</em>.
      *
-     * Therefore an <em>expanding</em> conversion cannot store all of its
+     * Therefore, an <em>expanding</em> conversion cannot store all of its
      * results in its output vector, because the output vector has fewer
      * lanes of larger size, in order to have the same overall bit-size as
      * its input.
@@ -3199,7 +3199,7 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
      * <p> As an example, a conversion from {@code byte} to {@code long}
      * ({@code M=8}) will discard 87.5% of the input values in order to
      * convert the remaining 12.5% into the roomy {@code long} lanes of
-     * the output vector. The inverse conversion will convert back all of
+     * the output vector. The inverse conversion will convert back all
      * the large results, but will waste 87.5% of the lanes in the output
      * vector.
      *

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -342,9 +342,9 @@ public abstract class VectorMask<E> extends jdk.internal.vm.vector.VectorSupport
     public abstract boolean anyTrue();
 
     /**
-     * Returns {@code true} if all of the mask lanes are set.
+     * Returns {@code true} if all the mask lanes are set.
      *
-     * @return {@code true} if all of the mask lanes are set, otherwise
+     * @return {@code true} if all the mask lanes are set, otherwise
      * {@code false}.
      */
     public abstract boolean allTrue();
@@ -528,7 +528,7 @@ public abstract class VectorMask<E> extends jdk.internal.vm.vector.VectorSupport
      * For each mask lane, where {@code N} is the mask lane index, if
      * the mask lane is set at {@code N} then the specific non-default
      * value {@code -1} is placed into the resulting vector at lane
-     * index {@code N}.  Otherwise the default element value {@code 0}
+     * index {@code N}.  Otherwise, the default element value {@code 0}
      * is placed into the resulting vector at lane index {@code N}.
      *
      * Whether the element type ({@code ETYPE}) of this mask is

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMath.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMath.java
@@ -67,7 +67,7 @@ public final class VectorMath {
 
     /**
      * Adds two {@code long} values using saturation
-     * arithemetic. The lower and upper (inclusive) bounds are
+     * arithmetic. The lower and upper (inclusive) bounds are
      * {@code Long.MIN_VALUE} and {@code Long.MAX_VALUE}, respectively.
      * <p>
      * If the result of the addition would otherwise overflow from
@@ -94,7 +94,7 @@ public final class VectorMath {
 
     /**
      * Subtracts two {@code long} values using saturation
-     * arithemetic. The lower and upper (inclusive) bounds are
+     * arithmetic. The lower and upper (inclusive) bounds are
      * {@code Long.MIN_VALUE} and {@code Long.MAX_VALUE}, respectively.
      * <p>
      * If the result of the subtraction would otherwise overflow from
@@ -122,7 +122,7 @@ public final class VectorMath {
 
     /**
      * Adds two {@code long} values using saturation
-     * arithemetic and numerically treating the values
+     * arithmetic and numerically treating the values
      * as unsigned. The lower and upper (inclusive) bounds
      * are {@code 0L} and {@code 0xFFFFFFFF_FFFFFFFFL}, respectively,
      * numerically treating them as unsigned.
@@ -148,7 +148,7 @@ public final class VectorMath {
 
     /**
      * Subtracts two {@code long} values using saturation
-     * arithemetic and numerically treating the values
+     * arithmetic and numerically treating the values
      * as unsigned. The lower and upper (inclusive) bounds
      * are {@code 0L} and {@code 0xFFFFFFFF_FFFFFFFFL}, respectively,
      * numerically treating them as unsigned.
@@ -204,7 +204,7 @@ public final class VectorMath {
 
     /**
      * Adds two {@code int} values using saturation
-     * arithemetic. The lower and upper (inclusive) bounds are
+     * arithmetic. The lower and upper (inclusive) bounds are
      * {@code Integer.MIN_VALUE} and {@code Integer.MAX_VALUE}, respectively.
      * <p>
      * If the result of the addition would otherwise overflow from
@@ -232,7 +232,7 @@ public final class VectorMath {
 
     /**
      * Subtracts two {@code int} values using saturation
-     * arithemetic. The lower and upper (inclusive) bounds are
+     * arithmetic. The lower and upper (inclusive) bounds are
      * {@code Integer.MIN_VALUE} and {@code Integer.MAX_VALUE}, respectively.
      * <p>
      * If the result of the subtraction would otherwise overflow from
@@ -260,7 +260,7 @@ public final class VectorMath {
 
     /**
      * Adds two {@code int} values using saturation
-     * arithemetic and numerically treating the values
+     * arithmetic and numerically treating the values
      * as unsigned. The lower and upper (inclusive) bounds
      * are {@code 0} and {@code 0xFFFFFFFF}, respectively,
      * numerically treating them as unsigned.
@@ -286,7 +286,7 @@ public final class VectorMath {
 
     /**
      * Subtracts two {@code int} values using saturation
-     * arithemetic and numerically treating the values
+     * arithmetic and numerically treating the values
      * as unsigned. The lower and upper (inclusive) bounds
      * are {@code 0} and {@code -0xFFFFFFFF}, respectively,
      * numerically treating them as unsigned.
@@ -342,7 +342,7 @@ public final class VectorMath {
 
     /**
      * Adds two {@code short} values using saturation
-     * arithemetic. The lower and upper (inclusive) bounds are
+     * arithmetic. The lower and upper (inclusive) bounds are
      * {@code Short.MIN_VALUE} and {@code Short.MAX_VALUE}, respectively.
      * <p>
      * If the result of the addition would otherwise overflow from
@@ -370,7 +370,7 @@ public final class VectorMath {
 
     /**
      * Subtracts two {@code short} values using saturation
-     * arithemetic. The lower and upper (inclusive) bounds are
+     * arithmetic. The lower and upper (inclusive) bounds are
      * {@code Short.MIN_VALUE} and {@code Short.MAX_VALUE}, respectively.
      * <p>
      * If the result of the subtraction would otherwise overflow from
@@ -398,7 +398,7 @@ public final class VectorMath {
 
     /**
      * Adds two {@code short} values using saturation
-     * arithemetic and numerically treating the values
+     * arithmetic and numerically treating the values
      * as unsigned. The lower and upper (inclusive) bounds
      * are {@code 0} and {@code 0xFFFF}, respectively,
      * numerically treating them as unsigned.
@@ -424,7 +424,7 @@ public final class VectorMath {
 
     /**
      * Subtracts two {@code short} values using saturation
-     * arithemetic and numerically treating the values
+     * arithmetic and numerically treating the values
      * as unsigned. The lower and upper (inclusive) bounds
      * are {@code 0} and {@code 0xFFFF}, respectively,
      * numerically treating them as unsigned.
@@ -480,7 +480,7 @@ public final class VectorMath {
 
     /**
      * Adds two {@code byte} values using saturation
-     * arithemetic. The lower and upper (inclusive) bounds are
+     * arithmetic. The lower and upper (inclusive) bounds are
      * {@code Byte.MIN_VALUE} and {@code Byte.MAX_VALUE}, respectively.
      * <p>
      * If the result of the addition would otherwise overflow from
@@ -508,7 +508,7 @@ public final class VectorMath {
 
     /**
      * Subtracts two {@code byte} values using saturation
-     * arithemetic. The lower and upper (inclusive) bounds are
+     * arithmetic. The lower and upper (inclusive) bounds are
      * {@code Byte.MIN_VALUE} and {@code Byte.MAX_VALUE}, respectively.
      * <p>
      * If the result of the subtraction would otherwise overflow from
@@ -536,7 +536,7 @@ public final class VectorMath {
 
     /**
      * Adds two {@code byte} values using saturation
-     * arithemetic and numerically treating the values
+     * arithmetic and numerically treating the values
      * as unsigned. The lower and upper (inclusive) bounds
      * are {@code 0} and {@code 0xFF}, respectively,
      * numerically treating them as unsigned.
@@ -562,7 +562,7 @@ public final class VectorMath {
 
     /**
      * Subtracts two {@code byte} values using saturation
-     * arithemetic and numerically treating the values
+     * arithmetic and numerically treating the values
      * as unsigned. The lower and upper (inclusive) bounds
      * are {@code 0} and {@code 0xFF}, respectively,
      * numerically treating them as unsigned.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorSpecies.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorSpecies.java
@@ -272,7 +272,7 @@ public interface VectorSpecies<E> {
      * viewed as measuring the proportion of "dropped input bits"
      * which must be deleted from the input in order for the result to
      * fit in the output vector.  It is also the <em>part limit</em>,
-     * a upper exclusive limit on the {@code part} parameter to a
+     * an upper exclusive limit on the {@code part} parameter to a
      * method that would transform the input species to the output
      * species.
      *
@@ -392,7 +392,7 @@ public interface VectorSpecies<E> {
      * <li>{@linkplain Vector#reinterpretShape(VectorSpecies, int) Reinterpretation casts}
      * between vectors of preferred species will neither truncate
      * lanes nor fill them with default values.
-     * <li>For any particular element type, some platform might possibly
+     * <li>For any particular element type, some platform might
      * provide a {@linkplain #ofLargestShape(Class) larger vector shape}
      * that (as a trade-off) does not support all possible element types.
      * </ul>
@@ -548,7 +548,7 @@ public interface VectorSpecies<E> {
      *
      * <p> This method returns the value of this expression:
      * {@code EVector.broadcast(this, (ETYPE)e)}, where
-     * {@code EVector} is the vector class specific to the
+     * {@code EVector} is the vector class specific to
      * the {@code ETYPE} of this species.
      * The {@code long} value must be accurately representable
      * by {@code ETYPE}, so that {@code e==(long)(ETYPE)e}.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -88,7 +88,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     //       super.bOp((Byte128Vector) o);
     // The purpose of that is to forcibly inline
     // the generic definition from this file
-    // into a sharply type- and size-specific
+    // into a sharply-typed and size-specific
     // wrapper in the subclass file, so that
     // the JIT can specialize the code.
     // The code is only inlined and expanded
@@ -568,7 +568,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     // Note: A surprising behavior in javadoc
     // sometimes makes a lone /** {@inheritDoc} */
     // comment drop the method altogether,
-    // apparently if the method mentions an
+    // apparently if the method mentions a
     // parameter or return type of Vector<$Boxtype$>
     // instead of Vector<E> as originally specified.
     // Adding an empty HTML fragment appears to
@@ -1942,7 +1942,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * Computes the bitwise logical conjunction ({@code &})
      * of this vector and a second input vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "and" operation ({@code &})
      * to each pair of corresponding lane values.
      *
@@ -1975,7 +1975,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * Computes the bitwise logical conjunction ({@code &})
      * of this vector and a scalar.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "and" operation ({@code &})
      * to each pair of corresponding lane values.
      *
@@ -1999,7 +1999,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * Computes the bitwise logical disjunction ({@code |})
      * of this vector and a second input vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "or" operation ({@code |})
      * to each pair of corresponding lane values.
      *
@@ -2032,7 +2032,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * Computes the bitwise logical disjunction ({@code |})
      * of this vector and a scalar.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "or" operation ({@code |})
      * to each pair of corresponding lane values.
      *
@@ -2202,7 +2202,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * Computes the bitwise logical complement ({@code ~})
      * of this vector.
      *
-     * This is a lane-wise binary operation which applies the
+     * This is a lane-wise binary operation which applies
      * the primitive bitwise "not" operation ({@code ~})
      * to each lane value.
      *
@@ -3499,7 +3499,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     /**
      * {@inheritDoc} <!--workaround-->
      * This is an alias for {@link #toArray()}
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code $abstractvectortype$},
      * there will be no loss of range or precision.
      */
@@ -3513,7 +3513,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #if[!FP]
 #if[!long]
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code $abstractvectortype$},
      * there will be no loss of precision or range,
      * and so no {@code UnsupportedOperationException} will
@@ -3538,7 +3538,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     /**
      * {@inheritDoc} <!--workaround-->
      * This is an alias for {@link #toArray()}
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code $abstractvectortype$},
      * there will be no loss of range or precision.
      */
@@ -3551,7 +3551,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     /** {@inheritDoc} <!--workaround-->
 #if[!FP]
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code $abstractvectortype$},
      * there will be no loss of precision or range,
      * and so no {@code UnsupportedOperationException} will
@@ -3575,7 +3575,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     /** {@inheritDoc} <!--workaround-->
      * @implNote
      * This is an alias for {@link #toArray()}
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code $abstractvectortype$},
      * there will be no loss of precision.
      */
@@ -3588,13 +3588,13 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     /** {@inheritDoc} <!--workaround-->
 #if[long]
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code $abstractvectortype$},
      * up to nine bits of precision may be lost
      * for lane values of large magnitude.
 #else[long]
      * @implNote
-     * When this method is used on used on vectors
+     * When this method is used on vectors
      * of type {@code $abstractvectortype$},
      * there will be no loss of precision.
 #end[long]

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/package-info.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/package-info.java
@@ -141,7 +141,7 @@
  * to prevent reading/writing past the array length.
  * The first {@code a.length / SPECIES.length()} iterations will have a mask
  * with all lanes set. Only the final iteration (if {@code a.length}
- * is not a multiple of {@code SPECIES.length()} will have a mask with
+ * is not a multiple of {@code SPECIES.length()}) will have a mask with
  * the first {@code a.length % SPECIES.length()} lanes set.
  *
  * Since a mask is used in all iterations, the above implementation


### PR DESCRIPTION
Improvements and fixes to grammar, spelling, and punctuation issues in the Vector API docs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351096](https://bugs.openjdk.org/browse/JDK-8351096): Typos in Vector API doc (**Enhancement** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24065/head:pull/24065` \
`$ git checkout pull/24065`

Update a local copy of the PR: \
`$ git checkout pull/24065` \
`$ git pull https://git.openjdk.org/jdk.git pull/24065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24065`

View PR using the GUI difftool: \
`$ git pr show -t 24065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24065.diff">https://git.openjdk.org/jdk/pull/24065.diff</a>

</details>
