### PR TITLE
8351970: Retire JavaLangAccess::exit

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2196,11 +2196,6 @@ public final class System {
                 return ClassLoader.nativeLibrariesFor(loader);
             }
 
-            @Override
-            public void exit(int statusCode) {
-                Shutdown.exit(statusCode);
-            }
-
             public Thread[] getAllThreads() {
                 return Thread.getAllThreads();
             }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -478,12 +478,6 @@ public interface JavaLangAccess {
     NativeLibraries nativeLibrariesFor(ClassLoader loader);
 
     /**
-     * Direct access to Shutdown.exit to avoid security manager checks
-     * @param statusCode the status code
-     */
-    void exit(int statusCode);
-
-    /**
      * Returns an array of all platform threads.
      */
     Thread[] getAllThreads();

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -72,7 +72,6 @@ public final class SharedUtils {
     private SharedUtils() {
     }
 
-    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
     private static final JavaLangInvokeAccess JLIA = SharedSecrets.getJavaLangInvokeAccess();
 
     private static final MethodHandle MH_ALLOC_BUFFER;
@@ -310,7 +309,7 @@ public final class SharedUtils {
                 t.printStackTrace();
                 System.err.println("Unrecoverable uncaught exception encountered. The VM will now exit");
             } finally {
-                JLA.exit(1);
+                System.exit(1);
             }
         }
     }


### PR DESCRIPTION
Cleanup the single use of JavaLangAccess.exit() it is no longer necessary; System.exit() can be called directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351970](https://bugs.openjdk.org/browse/JDK-8351970): Retire JavaLangAccess::exit (**Enhancement** - P4)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24066/head:pull/24066` \
`$ git checkout pull/24066`

Update a local copy of the PR: \
`$ git checkout pull/24066` \
`$ git pull https://git.openjdk.org/jdk.git pull/24066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24066`

View PR using the GUI difftool: \
`$ git pr show -t 24066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24066.diff">https://git.openjdk.org/jdk/pull/24066.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24066#issuecomment-2725484055)
</details>
