### PR TITLE
8348732: SunJCE and SunPKCS11 have different PBE key encodings

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,17 +67,7 @@ final class PBEKey implements SecretKey {
             // Should allow an empty password.
             passwd = new char[0];
         }
-        // Accept "\0" to signify "zero-length password with no terminator".
-        if (!(passwd.length == 1 && passwd[0] == 0)) {
-            for (int i=0; i<passwd.length; i++) {
-                if ((passwd[i] < '\u0020') || (passwd[i] > '\u007E')) {
-                    throw new InvalidKeySpecException("Password is not ASCII");
-                }
-            }
-        }
-        this.key = new byte[passwd.length];
-        for (int i=0; i<passwd.length; i++)
-            this.key[i] = (byte) (passwd[i] & 0x7f);
+        this.key = PBKDF2KeyImpl.getPasswordBytes(passwd);
         Arrays.fill(passwd, '\0');
         type = keytype;
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Locale;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.PBEKeySpec;
+import sun.security.util.PBEUtil;
 
 import jdk.internal.ref.CleanerFactory;
 
@@ -67,7 +68,7 @@ final class PBEKey implements SecretKey {
             // Should allow an empty password.
             passwd = new char[0];
         }
-        this.key = PBKDF2KeyImpl.getPasswordBytes(passwd);
+        this.key = PBEUtil.encodePassword(passwd);
         Arrays.fill(passwd, '\0');
         type = keytype;
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -72,7 +72,8 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
     private final transient Mac prf;
     private final transient Cleaner.Cleanable cleaner;
 
-    private static byte[] getPasswordBytes(char[] passwd) {
+    // also used by com.sun.crypto.provider.PBEKey constructor
+    static byte[] getPasswordBytes(char[] passwd) {
         CharBuffer cb = CharBuffer.wrap(passwd);
         ByteBuffer bb = UTF_8.encode(cb);
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -31,8 +31,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
 import java.lang.ref.Cleaner;
 import java.lang.ref.Reference;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
 import java.security.GeneralSecurityException;
 import java.security.KeyRep;
 import java.security.MessageDigest;
@@ -45,8 +43,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.PBEKeySpec;
 
 import jdk.internal.ref.CleanerFactory;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import sun.security.util.PBEUtil;
 
 /**
  * This class represents a PBE key derived using PBKDF2 defined
@@ -72,19 +69,6 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
     private final transient Mac prf;
     private final transient Cleaner.Cleanable cleaner;
 
-    // also used by com.sun.crypto.provider.PBEKey constructor
-    static byte[] getPasswordBytes(char[] passwd) {
-        CharBuffer cb = CharBuffer.wrap(passwd);
-        ByteBuffer bb = UTF_8.encode(cb);
-
-        int len = bb.limit();
-        byte[] passwdBytes = new byte[len];
-        bb.get(passwdBytes, 0, len);
-        bb.clear().put(new byte[len]);
-
-        return passwdBytes;
-    }
-
     /**
      * Creates a PBE key from a given PBE key specification.
      *
@@ -94,8 +78,8 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
     PBKDF2KeyImpl(PBEKeySpec keySpec, String prfAlgo)
         throws InvalidKeySpecException {
         this.passwd = keySpec.getPassword();
-        // Convert the password from char[] to byte[]
-        byte[] passwdBytes = getPasswordBytes(this.passwd);
+        // Convert the password from char[] to byte[] in UTF-8
+        byte[] passwdBytes = PBEUtil.encodePassword(this.passwd);
 
         byte[] key = null;
         try {

--- a/src/java.base/share/classes/sun/security/util/PBEUtil.java
+++ b/src/java.base/share/classes/sun/security/util/PBEUtil.java
@@ -327,7 +327,10 @@ public final class PBEUtil {
         }
     }
 
-    // converts the password char[] to the UTF-8 encoded byte[]
+    /*
+     * Converts the password char[] to the UTF-8 encoded byte[]. Used by PBEKey
+     * and PBKDF2KeyImpl (SunJCE).
+     */
     public static byte[] encodePassword(char[] passwd) {
         ByteBuffer bb = StandardCharsets.UTF_8.encode(CharBuffer.wrap(passwd));
         int len = bb.limit();

--- a/src/java.base/share/classes/sun/security/util/PBEUtil.java
+++ b/src/java.base/share/classes/sun/security/util/PBEUtil.java
@@ -327,31 +327,6 @@ public final class PBEUtil {
         }
     }
 
-    /*
-     * Check that the key implements the PBEKey interface. If params is an
-     * instance of PBEParameterSpec, validate consistency with the key's
-     * derivation data. Used by P11Mac and P11PBECipher (SunPKCS11).
-     */
-    public static void checkKeyAndParams(Key key,
-            AlgorithmParameterSpec params, String algorithm)
-            throws InvalidKeyException, InvalidAlgorithmParameterException {
-        if (key instanceof javax.crypto.interfaces.PBEKey pbeKey) {
-            if (params instanceof PBEParameterSpec pbeParams) {
-                if (pbeParams.getIterationCount() !=
-                        pbeKey.getIterationCount() ||
-                        !Arrays.equals(pbeParams.getSalt(), pbeKey.getSalt())) {
-                    throw new InvalidAlgorithmParameterException(
-                            "Salt or iteration count parameters are " +
-                            "not consistent with PBE key");
-                }
-            }
-        } else {
-            throw new InvalidKeyException(
-                    "Cannot use a " + algorithm + " service with a key that " +
-                    "does not implement javax.crypto.interfaces.PBEKey");
-        }
-    }
-
     // converts the password char[] to the UTF-8 encoded byte[]
     public static byte[] encodePassword(char[] passwd) {
         ByteBuffer bb = StandardCharsets.UTF_8.encode(CharBuffer.wrap(passwd));

--- a/src/java.base/share/classes/sun/security/util/PBEUtil.java
+++ b/src/java.base/share/classes/sun/security/util/PBEUtil.java
@@ -283,11 +283,7 @@ public final class PBEUtil {
                             "PBEParameterSpec required for salt " +
                             "and iteration count");
                 }
-            } else if (!(params instanceof PBEParameterSpec)) {
-                throw new InvalidAlgorithmParameterException(
-                        "PBEParameterSpec type required");
-            } else {
-                PBEParameterSpec pbeParams = (PBEParameterSpec) params;
+            } else if (params instanceof PBEParameterSpec pbeParams) {
                 // make sure the parameter values are consistent
                 if (salt != null) {
                     if (!Arrays.equals(salt, pbeParams.getSalt())) {
@@ -307,7 +303,11 @@ public final class PBEUtil {
                 } else {
                     iCount = pbeParams.getIterationCount();
                 }
+            } else {
+                throw new InvalidAlgorithmParameterException(
+                        "PBEParameterSpec type required");
             }
+
             // For security purpose, we need to enforce a minimum length
             // for salt; just require the minimum salt length to be 8-byte
             // which is what PKCS#5 recommends and openssl does.

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -356,7 +356,9 @@ abstract class P11Key implements Key, Length {
         return new P11SecretKey(session, keyID, algorithm, keyLength, attrs);
     }
 
-    static SecretKey pbeKey(Session session, long keyID, String algorithm,
+    // for PBKDF2 and the deprecated PBE-based key derivation method defined
+    // in RFC 7292 PKCS#12 B.2
+    static SecretKey pbkdfKey(Session session, long keyID, String algorithm,
             int keyLength, CK_ATTRIBUTE[] attrs, char[] password, byte[] salt,
             int iterationCount) {
         attrs = getAttributes(session, keyID, attrs, new CK_ATTRIBUTE[] {
@@ -364,7 +366,7 @@ abstract class P11Key implements Key, Length {
             new CK_ATTRIBUTE(CKA_SENSITIVE),
             new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        return new P11PBEKey(session, keyID, algorithm, keyLength,
+        return new P11PBKDFKey(session, keyID, algorithm, keyLength,
                 attrs, password, salt, iterationCount);
     }
 
@@ -502,16 +504,16 @@ abstract class P11Key implements Key, Length {
         }
     }
 
-    static final class P11PBEKey extends P11SecretKey
+    static final class P11PBKDFKey extends P11SecretKey
             implements PBEKey {
         private static final long serialVersionUID = 6847576994253634876L;
         private char[] password;
         private final byte[] salt;
         private final int iterationCount;
-        P11PBEKey(Session session, long keyID, String algorithm,
+        P11PBKDFKey(Session session, long keyID, String keyAlgo,
                 int keyLength, CK_ATTRIBUTE[] attributes,
                 char[] password, byte[] salt, int iterationCount) {
-            super(session, keyID, algorithm, keyLength, attributes);
+            super(session, keyID, keyAlgo, keyLength, attributes);
             this.password = password.clone();
             this.salt = salt.clone();
             this.iterationCount = iterationCount;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -196,33 +196,23 @@ final class P11Mac extends MacSpi {
         reset(true);
         p11Key = null;
         if (svcPbeKi != null) {
-            if (key instanceof P11Key) {
-                // If the key is a P11Key, it must come from a PBE derivation
-                // because this is a PBE Mac service. In addition to checking
-                // the key, check that params (if passed) are consistent.
-                PBEUtil.checkKeyAndParams(key, params, algorithm);
-            } else {
-                // If the key is not a P11Key, a derivation is needed. Data for
-                // derivation has to be carried either as part of the key or
-                // params. Use SunPKCS11 PBE key derivation to obtain a P11Key.
-                // Assign the derived key to p11Key because conversion is never
-                // needed for this case.
-                PBEKeySpec pbeKeySpec = PBEUtil.getPBAKeySpec(key, params);
-                try {
-                    P11Key.P11PBEKey p11PBEKey =
-                            P11SecretKeyFactory.derivePBEKey(token,
-                            pbeKeySpec, svcPbeKi);
-                    // This Mac service uses the token where the derived key
-                    // lives so there won't be any need to re-derive and use
-                    // the password. The p11Key cannot be accessed out of this
-                    // class.
-                    p11PBEKey.clearPassword();
-                    p11Key = p11PBEKey;
-                } catch (InvalidKeySpecException e) {
-                    throw new InvalidKeyException(e);
-                } finally {
-                    pbeKeySpec.clearPassword();
-                }
+            // Do key derivation using P11SecretKeyFactory, then store the
+            // derived key to p11Key
+            PBEKeySpec pbeKeySpec = PBEUtil.getPBAKeySpec(key, params);
+            try {
+                P11Key.P11PBKDFKey derivedKey =
+                        P11SecretKeyFactory.derivePBEKey(token,
+                        pbeKeySpec, svcPbeKi);
+                // This Mac service uses the token where the derived key
+                // lives so there won't be any need to re-derive and use
+                // the password. The p11Key cannot be accessed out of this
+                // class.
+                derivedKey.clearPassword();
+                p11Key = derivedKey;
+            } catch (InvalidKeySpecException e) {
+                throw new InvalidKeyException(e);
+            } finally {
+                pbeKeySpec.clearPassword();
             }
             if (params instanceof PBEParameterSpec pbeParams) {
                 // For PBE services, reassign params to the underlying
@@ -230,15 +220,12 @@ final class P11Mac extends MacSpi {
                 // value to be null.
                 params = pbeParams.getParameterSpec();
             }
+        } else { // for the non-PBE case
+            p11Key = P11SecretKeyFactory.convertKey(token, key, algorithm);
         }
         if (params != null) {
             throw new InvalidAlgorithmParameterException(
                     "Parameters not supported");
-        }
-        // In non-PBE cases and PBE cases where we didn't derive,
-        // a key conversion might be needed.
-        if (p11Key == null) {
-            p11Key = P11SecretKeyFactory.convertKey(token, key, algorithm);
         }
         try {
             initialize();

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PBECipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PBECipher.java
@@ -38,7 +38,6 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.PBEKeySpec;
-import javax.crypto.spec.PBEParameterSpec;
 
 import sun.security.jca.JCAUtil;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PBECipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PBECipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2023, 2025, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -335,23 +335,30 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         if (keyAlgo == null) {
             throw new InvalidKeyException("Key must specify its algorithm");
         }
+        KeyInfo ki = getKeyInfo(keyAlgo);
+        if (ki == null) {
+            throw new InvalidKeyException("Unknown algorithm " + keyAlgo);
+        }
+
+        KeyInfo si;
         if (svcAlgo == null) {
             svcAlgo = keyAlgo;
-        }
-        KeyInfo ki = null;
-        KeyInfo si = getKeyInfo(svcAlgo);
-        if (si == null) {
-            throw new InvalidKeyException("Unknown algorithm " + svcAlgo);
-        }
-        // Check if the key can be used for the service.
-        // Any key can be used for a MAC service.
-        if (svcAlgo != keyAlgo && !(si instanceof HMACKeyInfo)) {
-            ki = getKeyInfo(keyAlgo);
-            if (ki == null || !KeyInfo.checkUse(ki, si)) {
-                throw new InvalidKeyException("Cannot use a " + keyAlgo +
-                        " key for a " + svcAlgo + " service");
+            si = ki;
+        } else {
+            si = getKeyInfo(svcAlgo);
+            if (si == null) {
+                throw new InvalidKeyException("Unknown algorithm " + svcAlgo);
             }
         }
+
+        // Check if the key can be used for the service.
+        // Any key can be used for a MAC service.
+        if (svcAlgo != keyAlgo && !(si instanceof HMACKeyInfo) &&
+                !KeyInfo.checkUse(ki, si)) {
+            throw new InvalidKeyException("Cannot use a " + keyAlgo +
+                        " key for a " + svcAlgo + " service");
+        }
+
         if (key instanceof P11Key p11Key) {
             if (p11Key.token == token) {
                 if (extraAttrs != null) {
@@ -382,7 +389,6 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
             return p11Key;
         }
         if (key instanceof PBEKey pbeKey) {
-            ki = ki == null ? getKeyInfo(keyAlgo) : ki;
             if (ki instanceof PBEKeyInfo pbeKi) {
                 PBEKeySpec keySpec = getPbeKeySpec(pbeKey);
                 try {
@@ -414,7 +420,9 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         return p11Key;
     }
 
-    static P11Key.P11PBEKey derivePBEKey(Token token, PBEKeySpec keySpec,
+    // utility method for deriving secret keys using PBKDF2 or the legacy
+    // PKCS#12 B.2 method.
+    static P11Key.P11PBKDFKey derivePBEKey(Token token, PBEKeySpec keySpec,
             PBEKeyInfo pbeKi) throws InvalidKeySpecException {
         token.ensureValid();
         if (keySpec == null) {
@@ -429,7 +437,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
             password = keySpec.getPassword();
             byte[] salt = keySpec.getSalt();
             int itCount = keySpec.getIterationCount();
-            int keySize = keySpec.getKeyLength();
+            int keySize = keySpec.getKeyLength(); // in bits
             assert password != null :
                     "PBEKeySpec does not allow a null password";
             if (salt == null) {
@@ -495,7 +503,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
             CK_ATTRIBUTE[] attr = token.getAttributes(
                     O_GENERATE, CKO_SECRET_KEY, pbeKi.keyType, attrs);
             long keyID = token.p11.C_GenerateKey(session.id(), ckMech, attr);
-            return (P11Key.P11PBEKey) P11Key.pbeKey(session, keyID, pbeKi.algo,
+            return (P11Key.P11PBKDFKey) P11Key.pbkdfKey(session, keyID, pbeKi.algo,
                     keySize, attr, password, salt, itCount);
         } catch (PKCS11Exception e) {
             throw new InvalidKeySpecException("Could not create key", e);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -737,46 +737,6 @@ public final class SunPKCS11 extends AuthProvider {
                 m(CKM_GENERIC_SECRET_KEY_GEN));
 
         /*
-         * PBE Secret Key Factories
-         *
-         * KeyDerivationPrf must be supported for these services
-         * to be available.
-         *
-        */
-        d(SKF, "PBEWithHmacSHA1AndAES_128",
-                P11SecretKeyFactory, m(CKM_PKCS5_PBKD2), m(CKM_SHA_1_HMAC));
-        d(SKF, "PBEWithHmacSHA224AndAES_128",
-                P11SecretKeyFactory, m(CKM_PKCS5_PBKD2), m(CKM_SHA224_HMAC));
-        d(SKF, "PBEWithHmacSHA256AndAES_128",
-                P11SecretKeyFactory, m(CKM_PKCS5_PBKD2), m(CKM_SHA256_HMAC));
-        d(SKF, "PBEWithHmacSHA384AndAES_128",
-                P11SecretKeyFactory, m(CKM_PKCS5_PBKD2), m(CKM_SHA384_HMAC));
-        d(SKF, "PBEWithHmacSHA512AndAES_128",
-                P11SecretKeyFactory, m(CKM_PKCS5_PBKD2), m(CKM_SHA512_HMAC));
-        d(SKF, "PBEWithHmacSHA1AndAES_256",
-                P11SecretKeyFactory, m(CKM_PKCS5_PBKD2), m(CKM_SHA_1_HMAC));
-        d(SKF, "PBEWithHmacSHA224AndAES_256",
-                P11SecretKeyFactory, m(CKM_PKCS5_PBKD2), m(CKM_SHA224_HMAC));
-        d(SKF, "PBEWithHmacSHA256AndAES_256",
-                P11SecretKeyFactory, m(CKM_PKCS5_PBKD2), m(CKM_SHA256_HMAC));
-        d(SKF, "PBEWithHmacSHA384AndAES_256",
-                P11SecretKeyFactory, m(CKM_PKCS5_PBKD2), m(CKM_SHA384_HMAC));
-        d(SKF, "PBEWithHmacSHA512AndAES_256",
-                P11SecretKeyFactory, m(CKM_PKCS5_PBKD2), m(CKM_SHA512_HMAC));
-        /*
-         * PBA Secret Key Factories
-         */
-        d(SKF, "HmacPBESHA1",       P11SecretKeyFactory,
-                m(CKM_PBA_SHA1_WITH_SHA1_HMAC));
-        d(SKF, "HmacPBESHA224",     P11SecretKeyFactory,
-                m(CKM_NSS_PKCS12_PBE_SHA224_HMAC_KEY_GEN));
-        d(SKF, "HmacPBESHA256",     P11SecretKeyFactory,
-                m(CKM_NSS_PKCS12_PBE_SHA256_HMAC_KEY_GEN));
-        d(SKF, "HmacPBESHA384",     P11SecretKeyFactory,
-                m(CKM_NSS_PKCS12_PBE_SHA384_HMAC_KEY_GEN));
-        d(SKF, "HmacPBESHA512",     P11SecretKeyFactory,
-                m(CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN));
-        /*
          * PBKDF2 Secret Key Factories
          */
         dA(SKF, "PBKDF2WithHmacSHA1",  P11SecretKeyFactory,

--- a/test/jdk/sun/security/pkcs11/Cipher/PBECipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/PBECipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2023, 2025, Red Hat, Inc.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -47,7 +47,7 @@ import javax.crypto.spec.PBEParameterSpec;
  */
 
 public final class PBECipher extends PKCS11Test {
-    private static final char[] password = "123456".toCharArray();
+    private static final char[] password = "123456\uA4F7".toCharArray();
     private static final byte[] salt = "abcdefgh".getBytes(
             StandardCharsets.UTF_8);
     private static final int iterations = 1000;
@@ -112,35 +112,35 @@ public final class PBECipher extends PKCS11Test {
     // Generated with SunJCE.
     private static final AssertionData[] assertionData = new AssertionData[]{
             cipherAssertionData("PBEWithHmacSHA1AndAES_128",
-                    "AES/CBC/PKCS5Padding", "ba1c9614d550912925d99e0bc8969032" +
-                    "7ac6258b72117dcf750c19ee6ca73dd4"),
+                    "AES/CBC/PKCS5Padding", "9e097796e8d8224f2a7f5c950677d879" +
+                    "c0c578340147c7ae357550e2f4d4c6ce"),
             cipherAssertionData("PBEWithHmacSHA224AndAES_128",
-                    "AES/CBC/PKCS5Padding", "41960c43ca99cf2184511aaf2f0508a9" +
-                    "7da3762ee6c2b7e2027c8076811f2e52"),
+                    "AES/CBC/PKCS5Padding", "7b915941d8e3a87c00e2fbd8ad67a578" +
+                    "9a25648933b737706de4e4d48bdb61b6"),
             cipherAssertionData("PBEWithHmacSHA256AndAES_128",
-                    "AES/CBC/PKCS5Padding", "6bb6a3dc3834e81e5ca6b5e70073ff46" +
-                    "903b188940a269ed26db2ffe622b8e16"),
+                    "AES/CBC/PKCS5Padding", "c23912d15599908f47cc32c9da56b37f" +
+                    "e41e958e9c3a6c6e4e631a2a9e6cd20f"),
             cipherAssertionData("PBEWithHmacSHA384AndAES_128",
-                    "AES/CBC/PKCS5Padding", "22aabf7a6a059415dc4ca7d985f3de06" +
-                    "8f8300ca48d8de585d802670f4c1d9bd"),
+                    "AES/CBC/PKCS5Padding", "f05c6b2dea545d59f2a6fde845170dd6" +
+                    "7aebd6b1cc28904699d7dcff1a0a238c"),
             cipherAssertionData("PBEWithHmacSHA512AndAES_128",
-                    "AES/CBC/PKCS5Padding", "b523e7c462a0b7fd74e492b3a6550464" +
-                    "ceebe81f08649ae163673afc242ad8a2"),
+                    "AES/CBC/PKCS5Padding", "949c0c01a29375b9d421f6e2bf6ed0d7" +
+                    "15a118e0980494797d3a3b799b67daf6"),
             cipherAssertionData("PBEWithHmacSHA1AndAES_256",
-                    "AES/CBC/PKCS5Padding", "1e7c25e166afae069cec68ef9affca61" +
-                    "aea02ab1c3dc7471cb767ed7d6e37af0"),
+                    "AES/CBC/PKCS5Padding", "7bd686b15bc09e5fb5aa1f881c92aa5a" +
+                    "e72bdcd864c74e62395b9aaea7443bcd"),
             cipherAssertionData("PBEWithHmacSHA224AndAES_256",
-                    "AES/CBC/PKCS5Padding", "6701f1cc75b6494ec4bd27158aa2c15d" +
-                    "7d10bc2f1fbb7d92d8277c7edfd1dd57"),
+                    "AES/CBC/PKCS5Padding", "df58a1b26cca7e9e297da61ada03ddc4" +
+                    "39d2a5699753433f19891de33f8741a2"),
             cipherAssertionData("PBEWithHmacSHA256AndAES_256",
-                    "AES/CBC/PKCS5Padding", "f82eb2fc016505baeb23ecdf85163933" +
-                    "5e8d6d48b48631185641febb75898a1d"),
+                    "AES/CBC/PKCS5Padding", "f6ae5a15ec2c18eaa25927858f1da990" +
+                    "6df58a3b4830dbaaaa4c4317e53d717d"),
             cipherAssertionData("PBEWithHmacSHA384AndAES_256",
-                    "AES/CBC/PKCS5Padding", "ee9528022e58cdd9be80cd88443e03b3" +
-                    "de13376cf97c53d946d5c5dfc88097be"),
+                    "AES/CBC/PKCS5Padding", "5795625f51ec701594506944e5ed79f0" +
+                    "c9d8e82319762f00f8ff06a8b6195ac4"),
             cipherAssertionData("PBEWithHmacSHA512AndAES_256",
-                    "AES/CBC/PKCS5Padding", "18f472912ffaa31824e20a5486324e14" +
-                    "0225e20cb158762e8647b1216fe0ab7e"),
+                    "AES/CBC/PKCS5Padding", "ddf55933f80f42f2a8d4e8726290766e" +
+                    "024f225b76b594e8005c00227d553d05"),
     };
 
     private static final class NoRandom extends SecureRandom {
@@ -214,23 +214,16 @@ public final class PBECipher extends PKCS11Test {
     }
 
     private static SecretKey getAnonymousPBEKey(String algorithm,
-            boolean isPbeCipherSvc) {
+            boolean isPbeCipherSvc) throws GeneralSecurityException {
+        byte[] enc = (isPbeCipherSvc ?
+                    getPasswordOnlyPBEKey().getEncoded() : null);
         return new PBEKey() {
             public byte[] getSalt() { return salt.clone(); }
             public int getIterationCount() { return iterations; }
             public String getAlgorithm() { return algorithm; }
             public String getFormat() { return "RAW"; }
             public char[] getPassword() { return password.clone(); }
-            public byte[] getEncoded() {
-                byte[] encodedKey = null;
-                if (isPbeCipherSvc) {
-                    encodedKey = new byte[password.length];
-                    for (int i = 0; i < password.length; i++) {
-                        encodedKey[i] = (byte) (password[i] & 0x7f);
-                    }
-                }
-                return encodedKey;
-            }
+            public byte[] getEncoded() { return enc; }
         };
     }
 

--- a/test/jdk/sun/security/pkcs11/Cipher/PBECipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/PBECipher.java
@@ -40,7 +40,7 @@ import javax.crypto.spec.PBEParameterSpec;
 
 /*
  * @test
- * @bug 8301553
+ * @bug 8301553 8348732
  * @summary test password based encryption on SunPKCS11's Cipher service
  * @library /test/lib ..
  * @run main/othervm/timeout=30 PBECipher
@@ -61,10 +61,6 @@ public final class PBECipher extends PKCS11Test {
     private enum Configuration {
         // Pass salt and iterations to a Cipher through a PBEParameterSpec.
         PBEParameterSpec,
-
-        // Derive a key using SunPKCS11's SecretKeyFactory (wrapping password,
-        // salt and iterations in a PBEKeySpec), and pass it to a Cipher.
-        SecretKeyFactoryDerivedKey,
 
         // Pass salt and iterations to a Cipher through an AlgorithmParameters.
         AlgorithmParameters,
@@ -201,11 +197,6 @@ public final class PBECipher extends PKCS11Test {
                     }
                 }
             }
-            case SecretKeyFactoryDerivedKey -> {
-                SecretKey key = getDerivedSecretKey(p, keyAlgo);
-                cipher.init(Cipher.ENCRYPT_MODE, key,
-                        pbeSpec.getParameterSpec());
-            }
             case AnonymousPBEKey -> {
                 SecretKey key = getAnonymousPBEKey(keyAlgo,
                         svcAlgo.equals(keyAlgo));
@@ -220,12 +211,6 @@ public final class PBECipher extends PKCS11Test {
             throws GeneralSecurityException {
         return SecretKeyFactory.getInstance("PBE")
                 .generateSecret(new PBEKeySpec(password));
-    }
-
-    private static SecretKey getDerivedSecretKey(Provider sunPKCS11,
-            String algorithm) throws GeneralSecurityException {
-        return SecretKeyFactory.getInstance(algorithm, sunPKCS11)
-                .generateSecret(new PBEKeySpec(password, salt, iterations));
     }
 
     private static SecretKey getAnonymousPBEKey(String algorithm,

--- a/test/jdk/sun/security/pkcs11/Mac/PBAMac.java
+++ b/test/jdk/sun/security/pkcs11/Mac/PBAMac.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2023, 2025, Red Hat, Inc.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -44,7 +44,7 @@ import javax.crypto.spec.PBEParameterSpec;
  */
 
 public final class PBAMac extends PKCS11Test {
-    private static final char[] password = "123456".toCharArray();
+    private static final char[] password = "123456\uA4F7".toCharArray();
     private static final byte[] salt = "abcdefgh".getBytes(
             StandardCharsets.UTF_8);
     private static final int iterations = 1000;
@@ -101,20 +101,20 @@ public final class PBAMac extends PKCS11Test {
 
     // Generated with SunJCE.
     private static final AssertionData[] assertionData = new AssertionData[]{
-            macAssertionData("HmacPBESHA1", "HmacSHA1",
-                    "707606929395e4297adc63d520ac7d22f3f5fa66"),
-            macAssertionData("HmacPBESHA224", "HmacSHA224",
-                    "4ffb5ad4974a7a9fca5a36ebe3e34dd443c07fb68c392f8b611657e6"),
-            macAssertionData("HmacPBESHA256", "HmacSHA256",
-                    "9e8c102c212d2fd1334dc497acb4e002b04e84713b7eda5a63807af2" +
-                    "989d3e50"),
-            macAssertionData("HmacPBESHA384", "HmacSHA384",
-                    "77f31a785d4f2220251143a4ba80f5610d9d0aeaebb4a278b8a7535c" +
-                    "8cea8e8211809ba450458e351c5b66d691839c23"),
-            macAssertionData("HmacPBESHA512", "HmacSHA512",
-                    "a53f942a844b234a69c1f92cba20ef272c4394a3cf4024dc16d9dbac" +
-                    "1969870b1c2b28b897149a1a3b9ad80a7ca8c547dfabf3ed5f144c6b" +
-                    "593900b62e120c45"),
+             macAssertionData("HmacPBESHA1", "HmacSHA1",
+                    "8611414ddb1875d9f576282199ab492a802b7d49"),
+             macAssertionData("HmacPBESHA224", "HmacSHA224",
+                    "cebb12b48eb90c07336c695f771d1d0ef4ccf5b9524fc0ab6fb9813a"),
+             macAssertionData("HmacPBESHA256", "HmacSHA256",
+                    "d83a6a4e8b0e1ec939d05790f385dd774bd2b7c17cfa2dd004efc894" +
+                    "e5d53f51"),
+             macAssertionData("HmacPBESHA384", "HmacSHA384",
+                    "ae6b69cf9edfd9cd8c3b51cdf2b0243502f35a3e6007f33b1ab73568" +
+                    "2ea81ea562f4383bb9512ff70752367b7259b16f"),
+             macAssertionData("HmacPBESHA512", "HmacSHA512",
+                    "46f6d09b0e7e50a66fa559ea4c4e9737a9d9e258b94f0075230d0acb" +
+                    "40f2c926f96a152c4f6b03b631efc7f99c84f052f1c78d79e07f2a9e" +
+                    "4a96164f5b46e70b"),
     };
 
     public void main(Provider sunPKCS11) throws Exception {

--- a/test/jdk/sun/security/pkcs11/Mac/PBAMac.java
+++ b/test/jdk/sun/security/pkcs11/Mac/PBAMac.java
@@ -101,17 +101,17 @@ public final class PBAMac extends PKCS11Test {
 
     // Generated with SunJCE.
     private static final AssertionData[] assertionData = new AssertionData[]{
-             macAssertionData("HmacPBESHA1", "HmacSHA1",
+            macAssertionData("HmacPBESHA1", "HmacSHA1",
                     "8611414ddb1875d9f576282199ab492a802b7d49"),
-             macAssertionData("HmacPBESHA224", "HmacSHA224",
+            macAssertionData("HmacPBESHA224", "HmacSHA224",
                     "cebb12b48eb90c07336c695f771d1d0ef4ccf5b9524fc0ab6fb9813a"),
-             macAssertionData("HmacPBESHA256", "HmacSHA256",
+            macAssertionData("HmacPBESHA256", "HmacSHA256",
                     "d83a6a4e8b0e1ec939d05790f385dd774bd2b7c17cfa2dd004efc894" +
                     "e5d53f51"),
-             macAssertionData("HmacPBESHA384", "HmacSHA384",
+            macAssertionData("HmacPBESHA384", "HmacSHA384",
                     "ae6b69cf9edfd9cd8c3b51cdf2b0243502f35a3e6007f33b1ab73568" +
                     "2ea81ea562f4383bb9512ff70752367b7259b16f"),
-             macAssertionData("HmacPBESHA512", "HmacSHA512",
+            macAssertionData("HmacPBESHA512", "HmacSHA512",
                     "46f6d09b0e7e50a66fa559ea4c4e9737a9d9e258b94f0075230d0acb" +
                     "40f2c926f96a152c4f6b03b631efc7f99c84f052f1c78d79e07f2a9e" +
                     "4a96164f5b46e70b"),

--- a/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.java
+++ b/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8335288
+ * @bug 8335288 8348732
  * @library /test/lib ..
  * @modules jdk.crypto.cryptoki
  * @summary check that if any required mech is unavailable, then the
@@ -53,11 +53,11 @@ public class RequiredMechCheck extends PKCS11Test {
         new TestData("MAC", "HmacPBESHA256", true),
         new TestData("MAC", "HmacPBESHA384", false),
         new TestData("MAC", "HmacPBESHA512", false),
-        new TestData("SKF", "PBEWithHmacSHA1AndAES_128", false),
-        new TestData("SKF", "PBEWithHmacSHA224AndAES_128", true),
-        new TestData("SKF", "PBEWithHmacSHA256AndAES_128", true),
-        new TestData("SKF", "PBEWithHmacSHA384AndAES_128", false),
-        new TestData("SKF", "PBEWithHmacSHA512AndAES_128", false),
+        new TestData("SKF", "PBKDF2WithHmacSHA1", false),
+        new TestData("SKF", "PBKDF2WithHmacSHA224", true),
+        new TestData("SKF", "PBKDF2WithHmacSHA256", true),
+        new TestData("SKF", "PBKDF2WithHmacSHA384", false),
+        new TestData("SKF", "PBKDF2WithHmacSHA512", false),
         new TestData("CIP", "PBEWithHmacSHA1AndAES_128", false),
         new TestData("CIP", "PBEWithHmacSHA224AndAES_128", true),
         new TestData("CIP", "PBEWithHmacSHA256AndAES_128", true),

--- a/test/jdk/sun/security/pkcs11/SecretKeyFactory/TestPBKD.java
+++ b/test/jdk/sun/security/pkcs11/SecretKeyFactory/TestPBKD.java
@@ -43,7 +43,6 @@ import javax.crypto.spec.SecretKeySpec;
  * @bug 8301553 8348732
  * @summary test key derivation on a SunPKCS11 SecretKeyFactory service
  * @library /test/lib ..
- * @modules java.base/com.sun.crypto.provider:open
  * @run main/othervm/timeout=30 TestPBKD
  */
 

--- a/test/jdk/sun/security/pkcs11/SecretKeyFactory/TestPBKD.java
+++ b/test/jdk/sun/security/pkcs11/SecretKeyFactory/TestPBKD.java
@@ -43,7 +43,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 /*
  * @test
- * @bug 8301553
+ * @bug 8301553 8348732
  * @summary test key derivation on a SunPKCS11 SecretKeyFactory service
  * @library /test/lib ..
  * @modules java.base/com.sun.crypto.provider:open
@@ -73,38 +73,6 @@ public final class TestPBKD extends PKCS11Test {
 
     private record AssertionData(String algo, PBEKeySpec keySpec,
             BigInteger expectedKey) {}
-
-    private static AssertionData p12PBKDAssertionData(String algo,
-            char[] password, int keyLen, String hashAlgo, int blockLen,
-            String staticExpectedKeyString) {
-        PBEKeySpec keySpec = new PBEKeySpec(password, salt, iterations, keyLen);
-        BigInteger staticExpectedKey = new BigInteger(staticExpectedKeyString,
-                16);
-        BigInteger expectedKey;
-        try {
-            // Since we need to access an internal
-            // SunJCE API, we use reflection.
-            Class<?> PKCS12PBECipherCore = Class.forName(
-                    "com.sun.crypto.provider.PKCS12PBECipherCore");
-
-            Field macKeyField = PKCS12PBECipherCore.getDeclaredField("MAC_KEY");
-            macKeyField.setAccessible(true);
-            int MAC_KEY = (int) macKeyField.get(null);
-
-            Method deriveMethod = PKCS12PBECipherCore.getDeclaredMethod(
-                    "derive", char[].class, byte[].class, int.class,
-                    int.class, int.class, String.class, int.class);
-            deriveMethod.setAccessible(true);
-            expectedKey = i((byte[]) deriveMethod.invoke(null,
-                    keySpec.getPassword(), keySpec.getSalt(),
-                    keySpec.getIterationCount(), keySpec.getKeyLength() / 8,
-                    MAC_KEY, hashAlgo, blockLen));
-            checkAssertionValues(expectedKey, staticExpectedKey);
-        } catch (ReflectiveOperationException ignored) {
-            expectedKey = staticExpectedKey;
-        }
-        return new AssertionData(algo, keySpec, expectedKey);
-    }
 
     private static AssertionData pbkd2AssertionData(String algo,
             char[] password, int keyLen, String kdfAlgo,
@@ -147,78 +115,52 @@ public final class TestPBKD extends PKCS11Test {
 
     // Generated with SunJCE. Keep a reference to some
     // entries for tests executing invalid conditions.
-    private static final AssertionData hmacPBESHA1Data =
-            p12PBKDAssertionData("HmacPBESHA1", pwd, 160, "SHA-1", 64,
-                    "13156c6bee8e13ef568231e0174651afa5a358b0");
-    private static final AssertionData hmacPBESHA224Data =
-            p12PBKDAssertionData("HmacPBESHA224", pwd, 224, "SHA-224", 64,
-                    "d93acf4b3bea8a89d098e290928840c0b693a30cad0117f70ace50c2");
-    private static final AssertionData pbeWithHmacSHA512AndAES256Data =
-            pbkd2AssertionData("PBEWithHmacSHA512AndAES_256", pwd, 256,
-                    "PBKDF2WithHmacSHA512", "845560159e2f3f51dad8d6e0feccc898" +
-                    "7e3077595f90b60ab96d4f29203927b0");
     private static final AssertionData pbkdf2WithHmacSHA256Data =
             pbkd2AssertionData("PBKDF2WithHmacSHA256", pwd, 384,
                     "PBKDF2WithHmacSHA256", "6851e387278dd5a3a0d05e4d742f59d8" +
                     "44984e3e9b619488a42b93dd6453f630ae3e2ad7ed809fa9e98a7921" +
                     "87d62e84");
     private static final AssertionData[] assertionData = new AssertionData[]{
-            hmacPBESHA1Data,
-            hmacPBESHA224Data,
-            p12PBKDAssertionData("HmacPBESHA256", pwd, 256, "SHA-256", 64,
-                    "1bb3ed1ffb784ed32f59b4d7515971699af99cf67a2e574000964c8e" +
-                    "1eba1c45"),
-            p12PBKDAssertionData("HmacPBESHA384", pwd, 384, "SHA-384", 128,
-                    "d4ce121d3cec88a8c8b0c6225f7f996b72d76017c2d91bc51fd47985" +
-                    "86d1012d1ad03a39fdcd0fdc438d164ab50259fc"),
-            p12PBKDAssertionData("HmacPBESHA512", pwd, 512, "SHA-512", 128,
-                    "5f80b350986e5156669193eaa42a107e7d6636d82fb550f67af5b2c2" +
-                    "f546d977b70e52bbbcb6bb8976f9d3f0eaf9bfef5306c50ee5ccda3e" +
-                    "e4c4c7c8421fe4d"),
-            pbkd2AssertionData("PBEWithHmacSHA1AndAES_128", pwd, 128,
+            pbkd2AssertionData("PBKDF2WithHmacSHA1", pwd, 128,
                     "PBKDF2WithHmacSHA1", "29958f3f1c942e50903189eb7f1ba09d"),
-            pbkd2AssertionData("PBEWithHmacSHA224AndAES_128", pwd, 128,
-                    "PBKDF2WithHmacSHA224", "e328140e31f4ffb15af806986c23ee4e"),
-            pbkd2AssertionData("PBEWithHmacSHA256AndAES_128", pwd, 128,
-                    "PBKDF2WithHmacSHA256", "6851e387278dd5a3a0d05e4d742f59d8"),
-            pbkd2AssertionData("PBEWithHmacSHA384AndAES_128", pwd, 128,
-                    "PBKDF2WithHmacSHA384", "5570e2fb1a664910f055b71643b52351"),
-            pbkd2AssertionData("PBEWithHmacSHA512AndAES_128", pwd, 128,
-                    "PBKDF2WithHmacSHA512", "845560159e2f3f51dad8d6e0feccc898"),
-            pbkd2AssertionData("PBEWithHmacSHA1AndAES_256", pwd, 256,
-                    "PBKDF2WithHmacSHA1", "29958f3f1c942e50903189eb7f1ba09d40" +
-                    "b5552da5e645dad4b5911ce0f2f06b"),
-            pbkd2AssertionData("PBEWithHmacSHA224AndAES_256", pwd, 256,
-                    "PBKDF2WithHmacSHA224", "e328140e31f4ffb15af806986c23ee4e" +
-                    "7daa2119fee8c64aef7c1f4c1871724e"),
-            pbkd2AssertionData("PBEWithHmacSHA256AndAES_256", pwd, 256,
-                    "PBKDF2WithHmacSHA256", "6851e387278dd5a3a0d05e4d742f59d8" +
-                    "44984e3e9b619488a42b93dd6453f630"),
-            pbkd2AssertionData("PBEWithHmacSHA384AndAES_256", pwd, 256,
-                    "PBKDF2WithHmacSHA384", "5570e2fb1a664910f055b71643b52351" +
-                    "d7d0ad3a18912086f80d974f2acc2efb"),
-            pbeWithHmacSHA512AndAES256Data,
             pbkd2AssertionData("PBKDF2WithHmacSHA1", pwd, 240,
                     "PBKDF2WithHmacSHA1", "29958f3f1c942e50903189eb7f1ba09d40" +
                     "b5552da5e645dad4b5911ce0f2"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA1", pwd, 256,
+                    "PBKDF2WithHmacSHA1", "29958f3f1c942e50903189eb7f1ba09d40" +
+                    "b5552da5e645dad4b5911ce0f2f06b"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA224", pwd, 128,
+                    "PBKDF2WithHmacSHA224", "e328140e31f4ffb15af806986c23ee4e"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA224", pwd, 256,
+                    "PBKDF2WithHmacSHA224", "e328140e31f4ffb15af806986c23ee4e" +
+                    "7daa2119fee8c64aef7c1f4c1871724e"),
             pbkd2AssertionData("PBKDF2WithHmacSHA224", pwd, 336,
                     "PBKDF2WithHmacSHA224", "e328140e31f4ffb15af806986c23ee4e" +
                     "7daa2119fee8c64aef7c1f4c1871724e0ea628577e0ab54fa7c6"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA256", pwd, 128,
+                    "PBKDF2WithHmacSHA256", "6851e387278dd5a3a0d05e4d742f59d8"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA256", pwd, 256,
+                    "PBKDF2WithHmacSHA256", "6851e387278dd5a3a0d05e4d742f59d8" +
+                    "44984e3e9b619488a42b93dd6453f630"),
             pbkdf2WithHmacSHA256Data,
+            pbkd2AssertionData("PBKDF2WithHmacSHA384", pwd, 128,
+                    "PBKDF2WithHmacSHA384", "5570e2fb1a664910f055b71643b52351"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA384", pwd, 256,
+                    "PBKDF2WithHmacSHA384", "5570e2fb1a664910f055b71643b52351" +
+                    "d7d0ad3a18912086f80d974f2acc2efb"),
             pbkd2AssertionData("PBKDF2WithHmacSHA384", pwd, 576,
                     "PBKDF2WithHmacSHA384", "5570e2fb1a664910f055b71643b52351" +
                     "d7d0ad3a18912086f80d974f2acc2efba52650d4bf872455820f24c8" +
                     "46742161da84a1b4c3f197f4347308e8841a8971cf686aef29107396"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA512", pwd, 256,
+                    "PBKDF2WithHmacSHA512", "845560159e2f3f51dad8d6e0feccc898" +
+                    "7e3077595f90b60ab96d4f29203927b0"),
             pbkd2AssertionData("PBKDF2WithHmacSHA512", pwd, 768,
                     "PBKDF2WithHmacSHA512", "845560159e2f3f51dad8d6e0feccc898" +
                     "7e3077595f90b60ab96d4f29203927b00aa1a11e4d19d4f275a7f453" +
                     "14be500dacc3c1de9f704827b396463ccaa8957344d41bd64d9d09ff" +
                     "474e776469d326b1ee6ee5a5d854b86d3d7a25084afd6d6f"),
-            p12PBKDAssertionData("HmacPBESHA512", emptyPwd, 512, "SHA-512",
-                    128, "90b6e088490c6c5e6b6e81209bd769d27df3868cae79591577a" +
-                    "c35b46e4c6ebcc4b90f4943e3cb165f9d1789d938235f4b35ba74df9" +
-                    "e509fbbb7aa329a432445"),
-            pbkd2AssertionData("PBEWithHmacSHA512AndAES_256", emptyPwd, 256,
+            pbkd2AssertionData("PBKDF2WithHmacSHA512", emptyPwd, 256,
                     "PBKDF2WithHmacSHA512", "3a5c5fd11e4d381b32e11baa93d7b128" +
                     "09e016e48e0542c5d3453fc240a0fa76"),
     };
@@ -391,41 +333,18 @@ public final class TestPBKD extends PKCS11Test {
         System.out.println(sep + System.lineSeparator()
                 + "Invalid SecretKeyFactory::translateKey tests");
 
-        SecretKeyFactory skf1 = SecretKeyFactory.getInstance(
-                hmacPBESHA1Data.algo, sunPKCS11);
         SecretKeyFactory skf2 = SecretKeyFactory.getInstance("AES", sunPKCS11);
         SecretKeyFactory skf3 = SecretKeyFactory.getInstance(
                 pbkdf2WithHmacSHA256Data.algo, sunPKCS11);
-        PBEKey p11PbeKey = (PBEKey) skf1.translateKey(getAnonymousPBEKey(
-                skf1.getAlgorithm(), hmacPBESHA1Data.keySpec));
+        PBEKey p11PbeKey = (PBEKey) skf3.translateKey(getAnonymousPBEKey(
+                skf3.getAlgorithm(), pbkdf2WithHmacSHA256Data.keySpec));
+
         Class<?> e = InvalidKeyException.class;
 
         System.out.println(" * Non-PBEKey key to PBE SecretKeyFactory");
-        assertThrows(e, "PBE service requires a PBE key",
-                () -> skf1.translateKey(new SecretKeySpec(
-                        new byte[10], hmacPBESHA1Data.algo)));
-
-        System.out.println(" * PBEKey key to PBE SecretKeyFactory of a " +
-                "different algorithm");
-        assertThrows(e, "Cannot use a " + hmacPBESHA1Data.algo + " key for a " +
-                hmacPBESHA224Data.algo + " service",
-                () -> SecretKeyFactory.getInstance(hmacPBESHA224Data.algo,
-                        sunPKCS11).translateKey(p11PbeKey));
-
-        System.out.println(" * Non-AES PBEKey key to AES SecretKeyFactory");
-        assertThrows(e, "Cannot use a " + hmacPBESHA1Data.algo + " key for a " +
-                skf2.getAlgorithm() + " service",
-                () -> skf2.translateKey(p11PbeKey));
-
-        System.out.println(" * Inconsistent key length between key and " +
-                "algorithm");
-        PBEKeySpec kSpec1 = new PBEKeySpec(pwd, salt, 1, 16);
-        assertThrows(e, InvalidKeySpecException.class.getName() + ": Key " +
-                "length is invalid for " + skf1.getAlgorithm() + " (expecting" +
-                " " + hmacPBESHA1Data.keySpec.getKeyLength() + " but was " +
-                kSpec1.getKeyLength() + ")",
-                () -> skf1.translateKey(getAnonymousPBEKey(
-                        skf1.getAlgorithm(), kSpec1)));
+        assertThrows(e, "Cannot use a AES key for a " +
+                pbkdf2WithHmacSHA256Data.algo + " service",
+                () -> skf3.translateKey(new SecretKeySpec(new byte[10], "AES")));
 
         System.out.println(" * Invalid key length in bits");
         PBEKeySpec kSpec2 = new PBEKeySpec(pwd, salt, 1);
@@ -442,30 +361,10 @@ public final class TestPBKD extends PKCS11Test {
         System.out.println(sep + System.lineSeparator()
                 + "Invalid SecretKeyFactory::generateSecret tests");
 
-        SecretKeyFactory skf1 = SecretKeyFactory.getInstance(
-                hmacPBESHA1Data.algo, sunPKCS11);
-        SecretKeyFactory skf2 = SecretKeyFactory.getInstance(
-                pbeWithHmacSHA512AndAES256Data.algo, sunPKCS11);
         SecretKeyFactory skf3 = SecretKeyFactory.getInstance(
                 "PBKDF2WithHmacSHA512", sunPKCS11);
         SecretKeyFactory skf4 = SecretKeyFactory.getInstance("AES", sunPKCS11);
         Class<?> e = InvalidKeySpecException.class;
-
-        System.out.println(" * Missing salt and iteration count");
-        assertThrows(e, "Salt not found",
-                () -> skf1.generateSecret(new PBEKeySpec(pwd)));
-
-        System.out.println(" * Inconsistent key length between spec and " +
-                "algorithm");
-        PBEKeySpec kSpec = new PBEKeySpec(pwd, salt, 1, 16);
-        assertThrows(e, "Key length is invalid for " + skf1.getAlgorithm() +
-                " (expecting " + hmacPBESHA1Data.keySpec.getKeyLength() +
-                " but was " + kSpec.getKeyLength() + ")",
-                () -> skf1.generateSecret(kSpec));
-        assertThrows(e, "Key length is invalid for " + skf2.getAlgorithm() +
-                " (expecting " + pbeWithHmacSHA512AndAES256Data.keySpec
-                .getKeyLength() + " but was " + kSpec.getKeyLength() + ")",
-                () -> skf2.generateSecret(kSpec));
 
         System.out.println(" * Invalid key length in bits");
         String msg = "Key length must be multiple of 8 and greater than zero";
@@ -475,6 +374,7 @@ public final class TestPBKD extends PKCS11Test {
                 () -> skf3.generateSecret(new PBEKeySpec(pwd, salt, 1, 3)));
 
         System.out.println(" * PBEKeySpec to non-PBE SecretKeyFactory");
+        PBEKeySpec kSpec = new PBEKeySpec(pwd, salt, 1, 16);
         assertThrows(e, "Unsupported spec: javax.crypto.spec.PBEKeySpec",
                 () -> skf4.generateSecret(kSpec));
 
@@ -487,11 +387,11 @@ public final class TestPBKD extends PKCS11Test {
                 + "Invalid SecretKeyFactory::getKeySpec tests");
 
         SecretKeyFactory skf1 = SecretKeyFactory.getInstance(
-                hmacPBESHA1Data.algo, sunPKCS11);
+                pbkdf2WithHmacSHA256Data.algo, sunPKCS11);
         SecretKeyFactory skf2 = SecretKeyFactory.getInstance(
                 "AES", sunPKCS11);
         PBEKey p11PbeKey = (PBEKey) skf1.translateKey(getAnonymousPBEKey(
-                skf1.getAlgorithm(), hmacPBESHA1Data.keySpec));
+                skf1.getAlgorithm(), pbkdf2WithHmacSHA256Data.keySpec));
         Class<?> e = InvalidKeySpecException.class;
 
         System.out.println(" * null KeySpec class");

--- a/test/jdk/sun/security/pkcs11/SecretKeyFactory/TestPBKD.java
+++ b/test/jdk/sun/security/pkcs11/SecretKeyFactory/TestPBKD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2023, 2025, Red Hat, Inc.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -22,9 +22,6 @@
  * questions.
  */
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.ReflectiveOperationException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
@@ -75,15 +72,14 @@ public final class TestPBKD extends PKCS11Test {
             BigInteger expectedKey) {}
 
     private static AssertionData pbkd2AssertionData(String algo,
-            char[] password, int keyLen, String kdfAlgo,
-            String staticExpectedKeyString) {
+            char[] password, int keyLen, String staticExpectedKeyString) {
         PBEKeySpec keySpec = new PBEKeySpec(password, salt, iterations, keyLen);
         BigInteger staticExpectedKey = new BigInteger(staticExpectedKeyString,
                 16);
         BigInteger expectedKey = null;
         if (sunJCE != null) {
             try {
-                expectedKey = i(SecretKeyFactory.getInstance(kdfAlgo, sunJCE)
+                expectedKey = i(SecretKeyFactory.getInstance(algo, sunJCE)
                         .generateSecret(keySpec).getEncoded());
                 checkAssertionValues(expectedKey, staticExpectedKey);
             } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
@@ -115,54 +111,57 @@ public final class TestPBKD extends PKCS11Test {
 
     // Generated with SunJCE. Keep a reference to some
     // entries for tests executing invalid conditions.
+    private static final AssertionData pbkdf2WithHmacSHA512Data =
+            pbkd2AssertionData("PBKDF2WithHmacSHA512", pwd, 256,
+                    "845560159e2f3f51dad8d6e0feccc8987e3077595f90b60ab96d4f29" +
+                    "203927b0");
     private static final AssertionData pbkdf2WithHmacSHA256Data =
             pbkd2AssertionData("PBKDF2WithHmacSHA256", pwd, 384,
-                    "PBKDF2WithHmacSHA256", "6851e387278dd5a3a0d05e4d742f59d8" +
-                    "44984e3e9b619488a42b93dd6453f630ae3e2ad7ed809fa9e98a7921" +
-                    "87d62e84");
+                    "6851e387278dd5a3a0d05e4d742f59d844984e3e9b619488a42b93dd" +
+                    "6453f630ae3e2ad7ed809fa9e98a792187d62e84");
     private static final AssertionData[] assertionData = new AssertionData[]{
             pbkd2AssertionData("PBKDF2WithHmacSHA1", pwd, 128,
-                    "PBKDF2WithHmacSHA1", "29958f3f1c942e50903189eb7f1ba09d"),
-            pbkd2AssertionData("PBKDF2WithHmacSHA1", pwd, 240,
-                    "PBKDF2WithHmacSHA1", "29958f3f1c942e50903189eb7f1ba09d40" +
-                    "b5552da5e645dad4b5911ce0f2"),
-            pbkd2AssertionData("PBKDF2WithHmacSHA1", pwd, 256,
-                    "PBKDF2WithHmacSHA1", "29958f3f1c942e50903189eb7f1ba09d40" +
-                    "b5552da5e645dad4b5911ce0f2f06b"),
+                    "29958f3f1c942e50903189eb7f1ba09d"),
             pbkd2AssertionData("PBKDF2WithHmacSHA224", pwd, 128,
-                    "PBKDF2WithHmacSHA224", "e328140e31f4ffb15af806986c23ee4e"),
-            pbkd2AssertionData("PBKDF2WithHmacSHA224", pwd, 256,
-                    "PBKDF2WithHmacSHA224", "e328140e31f4ffb15af806986c23ee4e" +
-                    "7daa2119fee8c64aef7c1f4c1871724e"),
-            pbkd2AssertionData("PBKDF2WithHmacSHA224", pwd, 336,
-                    "PBKDF2WithHmacSHA224", "e328140e31f4ffb15af806986c23ee4e" +
-                    "7daa2119fee8c64aef7c1f4c1871724e0ea628577e0ab54fa7c6"),
+                    "e328140e31f4ffb15af806986c23ee4e"),
             pbkd2AssertionData("PBKDF2WithHmacSHA256", pwd, 128,
-                    "PBKDF2WithHmacSHA256", "6851e387278dd5a3a0d05e4d742f59d8"),
-            pbkd2AssertionData("PBKDF2WithHmacSHA256", pwd, 256,
-                    "PBKDF2WithHmacSHA256", "6851e387278dd5a3a0d05e4d742f59d8" +
-                    "44984e3e9b619488a42b93dd6453f630"),
-            pbkdf2WithHmacSHA256Data,
+                    "6851e387278dd5a3a0d05e4d742f59d8"),
             pbkd2AssertionData("PBKDF2WithHmacSHA384", pwd, 128,
-                    "PBKDF2WithHmacSHA384", "5570e2fb1a664910f055b71643b52351"),
+                    "5570e2fb1a664910f055b71643b52351"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA512", pwd, 128,
+                    "845560159e2f3f51dad8d6e0feccc898"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA1", pwd, 256,
+                    "29958f3f1c942e50903189eb7f1ba09d40" +
+                    "b5552da5e645dad4b5911ce0f2f06b"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA224", pwd, 256,
+                    "e328140e31f4ffb15af806986c23ee4e" +
+                    "7daa2119fee8c64aef7c1f4c1871724e"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA256", pwd, 256,
+                    "6851e387278dd5a3a0d05e4d742f59d8" +
+                    "44984e3e9b619488a42b93dd6453f630"),
             pbkd2AssertionData("PBKDF2WithHmacSHA384", pwd, 256,
-                    "PBKDF2WithHmacSHA384", "5570e2fb1a664910f055b71643b52351" +
+                    "5570e2fb1a664910f055b71643b52351" +
                     "d7d0ad3a18912086f80d974f2acc2efb"),
+            pbkdf2WithHmacSHA512Data,
+            pbkd2AssertionData("PBKDF2WithHmacSHA1", pwd, 240,
+                    "29958f3f1c942e50903189eb7f1ba09d40b5552da5e645dad4b5911c" +
+                    "e0f2"),
+            pbkd2AssertionData("PBKDF2WithHmacSHA224", pwd, 336,
+                    "e328140e31f4ffb15af806986c23ee4e7daa2119fee8c64aef7c1f4c" +
+                    "1871724e0ea628577e0ab54fa7c6"),
+            pbkdf2WithHmacSHA256Data,
             pbkd2AssertionData("PBKDF2WithHmacSHA384", pwd, 576,
-                    "PBKDF2WithHmacSHA384", "5570e2fb1a664910f055b71643b52351" +
-                    "d7d0ad3a18912086f80d974f2acc2efba52650d4bf872455820f24c8" +
-                    "46742161da84a1b4c3f197f4347308e8841a8971cf686aef29107396"),
-            pbkd2AssertionData("PBKDF2WithHmacSHA512", pwd, 256,
-                    "PBKDF2WithHmacSHA512", "845560159e2f3f51dad8d6e0feccc898" +
-                    "7e3077595f90b60ab96d4f29203927b0"),
+                    "5570e2fb1a664910f055b71643b52351d7d0ad3a18912086f80d974f" +
+                    "2acc2efba52650d4bf872455820f24c846742161da84a1b4c3f197f4" +
+                    "347308e8841a8971cf686aef29107396"),
             pbkd2AssertionData("PBKDF2WithHmacSHA512", pwd, 768,
-                    "PBKDF2WithHmacSHA512", "845560159e2f3f51dad8d6e0feccc898" +
-                    "7e3077595f90b60ab96d4f29203927b00aa1a11e4d19d4f275a7f453" +
-                    "14be500dacc3c1de9f704827b396463ccaa8957344d41bd64d9d09ff" +
-                    "474e776469d326b1ee6ee5a5d854b86d3d7a25084afd6d6f"),
+                    "845560159e2f3f51dad8d6e0feccc8987e3077595f90b60ab96d4f29" +
+                    "203927b00aa1a11e4d19d4f275a7f45314be500dacc3c1de9f704827" +
+                    "b396463ccaa8957344d41bd64d9d09ff474e776469d326b1ee6ee5a5" +
+                    "d854b86d3d7a25084afd6d6f"),
             pbkd2AssertionData("PBKDF2WithHmacSHA512", emptyPwd, 256,
-                    "PBKDF2WithHmacSHA512", "3a5c5fd11e4d381b32e11baa93d7b128" +
-                    "09e016e48e0542c5d3453fc240a0fa76"),
+                    "3a5c5fd11e4d381b32e11baa93d7b12809e016e48e0542c5d3453fc2" +
+                    "40a0fa76"),
     };
 
     public void main(Provider sunPKCS11) throws Exception {
@@ -333,18 +332,41 @@ public final class TestPBKD extends PKCS11Test {
         System.out.println(sep + System.lineSeparator()
                 + "Invalid SecretKeyFactory::translateKey tests");
 
+        SecretKeyFactory skf1 = SecretKeyFactory.getInstance(
+                pbkdf2WithHmacSHA512Data.algo, sunPKCS11);
         SecretKeyFactory skf2 = SecretKeyFactory.getInstance("AES", sunPKCS11);
         SecretKeyFactory skf3 = SecretKeyFactory.getInstance(
                 pbkdf2WithHmacSHA256Data.algo, sunPKCS11);
-        PBEKey p11PbeKey = (PBEKey) skf3.translateKey(getAnonymousPBEKey(
+        PBEKey p11PbkdfKey = (PBEKey) skf3.translateKey(getAnonymousPBEKey(
                 skf3.getAlgorithm(), pbkdf2WithHmacSHA256Data.keySpec));
 
         Class<?> e = InvalidKeyException.class;
 
         System.out.println(" * Non-PBEKey key to PBE SecretKeyFactory");
-        assertThrows(e, "Cannot use a AES key for a " +
-                pbkdf2WithHmacSHA256Data.algo + " service",
-                () -> skf3.translateKey(new SecretKeySpec(new byte[10], "AES")));
+        assertThrows(e, "PBE service requires a PBE key",
+                () -> skf3.translateKey(new SecretKeySpec(
+                        new byte[10], skf3.getAlgorithm())));
+
+        System.out.println(" * PBEKey key to PBE SecretKeyFactory of a " +
+                "different algorithm");
+        assertThrows(e, "Cannot use a " + pbkdf2WithHmacSHA256Data.algo +
+                " key for a " + pbkdf2WithHmacSHA512Data.algo + " service",
+                () -> skf1.translateKey(p11PbkdfKey));
+
+        System.out.println(" * Non-AES PBEKey key to AES SecretKeyFactory");
+        String keyAlg1 = "HmacPBESHA1";
+        PBEKeySpec kSpec1 = new PBEKeySpec(pwd, salt, 1, 16);
+        assertThrows(e, "Cannot use a " + keyAlg1 + " key for a " +
+                skf2.getAlgorithm() + " service", () ->
+                skf2.translateKey(getAnonymousPBEKey(keyAlg1, kSpec1)));
+
+        System.out.println(" * Inconsistent key length between key and its " +
+                "algorithm");
+        String keyAlg2 = "PBEWithHmacSHA1AndAES_128";
+        assertThrows(e, InvalidKeySpecException.class.getName() + ": Key " +
+                "length is invalid for " + keyAlg2 + " (expecting 128 but " +
+                "was " + kSpec1.getKeyLength() + ")", () ->
+                skf2.translateKey(getAnonymousPBEKey(keyAlg2, kSpec1)));
 
         System.out.println(" * Invalid key length in bits");
         PBEKeySpec kSpec2 = new PBEKeySpec(pwd, salt, 1);
@@ -361,22 +383,26 @@ public final class TestPBKD extends PKCS11Test {
         System.out.println(sep + System.lineSeparator()
                 + "Invalid SecretKeyFactory::generateSecret tests");
 
-        SecretKeyFactory skf3 = SecretKeyFactory.getInstance(
-                "PBKDF2WithHmacSHA512", sunPKCS11);
-        SecretKeyFactory skf4 = SecretKeyFactory.getInstance("AES", sunPKCS11);
+        SecretKeyFactory skf1 = SecretKeyFactory.getInstance(
+                pbkdf2WithHmacSHA512Data.algo, sunPKCS11);
+        SecretKeyFactory skf2 = SecretKeyFactory.getInstance("AES", sunPKCS11);
         Class<?> e = InvalidKeySpecException.class;
+
+        System.out.println(" * Missing salt and iteration count");
+        assertThrows(e, "Salt not found",
+                () -> skf1.generateSecret(new PBEKeySpec(pwd)));
 
         System.out.println(" * Invalid key length in bits");
         String msg = "Key length must be multiple of 8 and greater than zero";
         assertThrows(e, msg,
-                () -> skf3.generateSecret(new PBEKeySpec(pwd, salt, 1)));
+                () -> skf1.generateSecret(new PBEKeySpec(pwd, salt, 1)));
         assertThrows(e, msg,
-                () -> skf3.generateSecret(new PBEKeySpec(pwd, salt, 1, 3)));
+                () -> skf1.generateSecret(new PBEKeySpec(pwd, salt, 1, 3)));
 
         System.out.println(" * PBEKeySpec to non-PBE SecretKeyFactory");
         PBEKeySpec kSpec = new PBEKeySpec(pwd, salt, 1, 16);
         assertThrows(e, "Unsupported spec: javax.crypto.spec.PBEKeySpec",
-                () -> skf4.generateSecret(kSpec));
+                () -> skf2.generateSecret(kSpec));
 
         System.out.println();
     }
@@ -390,13 +416,13 @@ public final class TestPBKD extends PKCS11Test {
                 pbkdf2WithHmacSHA256Data.algo, sunPKCS11);
         SecretKeyFactory skf2 = SecretKeyFactory.getInstance(
                 "AES", sunPKCS11);
-        PBEKey p11PbeKey = (PBEKey) skf1.translateKey(getAnonymousPBEKey(
+        PBEKey p11PbkdfKey = (PBEKey) skf1.translateKey(getAnonymousPBEKey(
                 skf1.getAlgorithm(), pbkdf2WithHmacSHA256Data.keySpec));
         Class<?> e = InvalidKeySpecException.class;
 
         System.out.println(" * null KeySpec class");
         assertThrows(e, "key and keySpec must not be null",
-                () -> skf1.getKeySpec(p11PbeKey, null));
+                () -> skf1.getKeySpec(p11PbkdfKey, null));
 
         System.out.println(" * Invalid key type for PBEKeySpec");
         assertThrows(e, "Unsupported spec: " + PBEKeySpec.class.getName(),
@@ -406,7 +432,7 @@ public final class TestPBKD extends PKCS11Test {
         System.out.println(" * Invalid PBE key and PBEKeySpec for " +
                 skf2.getAlgorithm() + " SecretKeyFactory");
         assertThrows(e, "Unsupported spec: " + PBEKeySpec.class.getName(),
-                () -> skf2.getKeySpec(p11PbeKey, PBEKeySpec.class));
+                () -> skf2.getKeySpec(p11PbkdfKey, PBEKeySpec.class));
 
         System.out.println();
     }


### PR DESCRIPTION
As part of [https://bugs.openjdk.org/browse/JDK-8301553](JDK-8301553), SunPKCS11 provider added support for PBE SecretKeyFactories for `HmacPBESHAxxx` and `PBEWithHmacSHAxxxAndAES_yyy`. These impls produce keys whose encoding contains the PBKDF2 derived bytes. Given that SunJCE provider have supported `PBEWithHmacSHAxxxAndAES_yyy` SecretKeyFactories whose key encoding is the password bytes for long time. Such difference may be very confusing, e.g. using the same KeySpec and same-name SecretKeyFactory (from different providers), the resulting keys have same algorithm and format but different encodings.

Given that the `P11Mac` and `P11PBECipher` classes already do key derivation internally, these PKCS11 SecretKeyFactories aren't a must-have and are proposed to be removed. I've also aligned the com.sun.crypto.provider.PBEKey class with com.sun.crypto.provider.PPBKDF2KeyImpl class to switch to "UTF-8" when converting the char[] to byte[]. This is to accomodate unicode passwords and given that "UTF-8" encoding is same for ASCII characters, this change should not affect backward compatibility.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8352294](https://bugs.openjdk.org/browse/JDK-8352294) to be approved

### Issues
 * [JDK-8348732](https://bugs.openjdk.org/browse/JDK-8348732): SunJCE and SunPKCS11 have different PBE key encodings (**Bug** - P3)
 * [JDK-8352294](https://bugs.openjdk.org/browse/JDK-8352294): SunJCE and SunPKCS11 have different PBE key encodings (**CSR**)


### Reviewers
 * [Francisco Ferrari Bihurriet](https://openjdk.org/census#fferrari) (@franferrax - Committer) Review applies to [e42e4402](https://git.openjdk.org/jdk/pull/24068/files/e42e4402304cf2b438e7823adaadc1cff41a868b)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24068/head:pull/24068` \
`$ git checkout pull/24068`

Update a local copy of the PR: \
`$ git checkout pull/24068` \
`$ git pull https://git.openjdk.org/jdk.git pull/24068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24068`

View PR using the GUI difftool: \
`$ git pr show -t 24068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24068.diff">https://git.openjdk.org/jdk/pull/24068.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24068#issuecomment-2725859279)
</details>
