### PR TITLE
8352091: GenShen: assert(!(request.generation->is_old() && _heap->old_generation()->is_doing_mixed_evacuations())) failed: Old heuristic should not request cycles while it waits for mixed evacuation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -689,7 +689,8 @@ bool ShenandoahGenerationalControlThread::request_concurrent_gc(ShenandoahGenera
   }
 
   if (gc_mode() == none) {
-    while (gc_mode() == none) {
+    const size_t current_gc_id = get_gc_id();
+    while (gc_mode() == none && current_gc_id == get_gc_id()) {
       if (_requested_gc_cause != GCCause::_no_gc) {
         log_debug(gc, thread)("Reject request for concurrent gc because another gc is pending: %s", GCCause::to_string(_requested_gc_cause));
         return false;


### PR DESCRIPTION
Consider the following:
1. Regulator thread sees that control thread is `idle` and requests an old cycle
2. Regulator thread waits until control thread is not `idle`
3. Control thread starts old cycle and notifies the Regulator thread (as expected)
4. Regulator thread stays off CPU for a _long_ time
5. Control thread _completes_ old marking and returns to `idle` state
6. Regulator thread finally wakes up and sees that Control thread is _still_ idle
7. In fact, the control thread has completed old marking and the regulator thread should not request another cycle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352091](https://bugs.openjdk.org/browse/JDK-8352091): GenShen: assert(!(request.generation-&gt;is_old() &amp;&amp; _heap-&gt;old_generation()-&gt;is_doing_mixed_evacuations())) failed: Old heuristic should not request cycles while it waits for mixed evacuation (**Task** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24069/head:pull/24069` \
`$ git checkout pull/24069`

Update a local copy of the PR: \
`$ git checkout pull/24069` \
`$ git pull https://git.openjdk.org/jdk.git pull/24069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24069`

View PR using the GUI difftool: \
`$ git pr show -t 24069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24069.diff">https://git.openjdk.org/jdk/pull/24069.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24069#issuecomment-2726022467)
</details>
