### PR TITLE
8352096: Test jdk/jfr/event/profiling/TestFullStackTrace.java shouldn't be executed with -XX:+DeoptimizeALot

### DIFF
--- a/test/jdk/jdk/jfr/event/profiling/TestFullStackTrace.java
+++ b/test/jdk/jdk/jfr/event/profiling/TestFullStackTrace.java
@@ -39,6 +39,7 @@ import jdk.test.lib.jfr.RecurseThread;
 /**
  * @test
  * @requires vm.hasJFR
+ * @requires vm.opt.DeoptimizeALot != true
  * @library /test/lib
  * @run main/othervm jdk.jfr.event.profiling.TestFullStackTrace
  */


### PR DESCRIPTION
The test create a lot of threads long stacks and overhead of often deoptimization with DeoptimizeALot causes timeouts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352096](https://bugs.openjdk.org/browse/JDK-8352096): Test jdk/jfr/event/profiling/TestFullStackTrace.java shouldn't be executed with -XX:+DeoptimizeALot (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24070/head:pull/24070` \
`$ git checkout pull/24070`

Update a local copy of the PR: \
`$ git checkout pull/24070` \
`$ git pull https://git.openjdk.org/jdk.git pull/24070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24070`

View PR using the GUI difftool: \
`$ git pr show -t 24070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24070.diff">https://git.openjdk.org/jdk/pull/24070.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24070#issuecomment-2726035402)
</details>
