### PR TITLE
8352107: Allow jtreg test cases to query test VM properties

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
@@ -46,11 +46,10 @@
  * @requires !vm.jvmci.enabled
  * @library /test/jdk/lib/testlibrary /test/lib
  * @build InitiatingLoaderTester BadOldClassA BadOldClassB
- * @build jdk.test.whitebox.WhiteBox BulkLoaderTest
+ * @build BulkLoaderTest
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar BulkLoaderTestApp.jar BulkLoaderTestApp MyUtil InitiatingLoaderTester
  *                 BadOldClassA BadOldClassB
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. BulkLoaderTest DYNAMIC
+ * @run driver BulkLoaderTest DYNAMIC
  */
 
 /*

--- a/test/hotspot/jtreg/runtime/cds/appcds/applications/JavacBench.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/applications/JavacBench.java
@@ -35,9 +35,7 @@
  * @summary Run JavacBenchApp with the classic dynamic archive workflow
  * @requires vm.cds
  * @library /test/lib
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. JavacBench DYNAMIC
+ * @run driver JavacBench DYNAMIC
  */
 
 /*

--- a/test/lib-test/TEST.ROOT
+++ b/test/lib-test/TEST.ROOT
@@ -36,3 +36,26 @@ requiredVersion=7.5.1+1
 external.lib.roots = ../../
 
 groups=TEST.groups
+
+# Allow querying of various System properties in @requires clauses
+#
+# Source files for classes that will be used at the beginning of each test suite run,
+# to determine additional characteristics of the system for use with the @requires tag.
+# Note: compiled bootlibs classes will be added to BCP.
+requires.extraPropDefns = ../jtreg-ext/requires/VMProps.java
+requires.extraPropDefns.bootlibs = ../lib/jdk/test/whitebox
+requires.extraPropDefns.libs = \
+    ../lib/jdk/test/lib/Platform.java \
+    ../lib/jdk/test/lib/Container.java
+requires.extraPropDefns.javacOpts = \
+    --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED \
+    --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+requires.extraPropDefns.vmOpts = \
+    -XX:+UnlockDiagnosticVMOptions \
+    -XX:+LogVMOutput -XX:-DisplayVMOutput -XX:LogFile=vmprops.flags.final.vm.log \
+    -XX:+PrintFlagsFinal \
+    -XX:+WhiteBoxAPI \
+    --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED \
+    --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+requires.properties= \
+    vm.flagless

--- a/test/lib-test/jdk/test/lib/VMPropsGetterTest.java
+++ b/test/lib-test/jdk/test/lib/VMPropsGetterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @summary Unit Test for jdk.test.lib.VMPropsGetter.
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run driver VMPropsGetterTest
+ * @run main VMPropsGetterTest
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.VMPropsGetter;
+
+public class VMPropsGetterTest {
+    public static void main(String[] args) throws Exception {
+        // Sanity test: we should be able to read the vm.flagless property using VMPropsGetter.
+        String key = "vm.flagless";
+        String value = VMPropsGetter.get(key);
+        Asserts.assertEQ(value, "true");
+    }
+}

--- a/test/lib/jdk/test/lib/VMPropsGetter.java
+++ b/test/lib/jdk/test/lib/VMPropsGetter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+public class VMPropsGetter {
+    private static final Properties vmProps = init();
+
+    /**
+     * @return the directory specified with 'jtreg -workDir:<dir>'
+     */
+    private static Path getJtregWorkDir() {
+        Path pwd = Paths.get("").toAbsolutePath();
+        Path dir = pwd;
+        if (dir.getFileName().toString().matches("^[0-9]+$")) {
+            dir = dir.getParent();
+        }
+
+        if (dir.getFileName().toString().equals("scratch")) {
+            return dir.getParent();
+        }
+        throw new RuntimeException("The current directory '" + pwd +
+                                   "' does not end with /scratch((/[0-9]+)|)");
+    }
+
+    static Properties init() {
+        Path workDir = getJtregWorkDir();
+        Path input = workDir.resolve("vm.properties");
+        Properties props = new Properties();
+
+        try (FileInputStream in = new FileInputStream(input.toFile())) {
+            props.load(in);
+            System.out.println("Loaded " + props.size() + " propertis from '" +
+                               input + "'");
+        } catch (IOException e) {
+            e.printStackTrace(System.err);
+            throw new RuntimeException("Failed to load properties from '"
+                                       + input + "'", e);
+        }
+
+        return props;
+    }
+
+    public static String get(String key) {
+        return vmProps.getProperty(key);
+    }
+}

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -28,7 +28,7 @@ import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.StringArrayUtils;
-import jdk.test.whitebox.WhiteBox;
+import jdk.test.lib.VMPropsGetter;
 import jtreg.SkippedException;
 
 /*
@@ -257,10 +257,9 @@ abstract public class CDSAppTester {
     // Creating a dynamic CDS archive (with -XX:ArchiveClassesAtExit=<foo>.jsa) requires that the current
     // JVM process is using a static archive (which is usually the default CDS archive included in the JDK).
     // However, if the JDK doesn't include a default CDS archive that's compatible with the set of
-    // VM options used by this test, we need to create a temporary static archive to be used with -XX:ArchiveClassesAtExit.
+    // VM options used by this test, we need to create a temporary static archive.
     private String getBaseArchiveForDynamicArchive() throws Exception {
-        WhiteBox wb = WhiteBox.getWhiteBox();
-        if (wb.isSharingEnabled()) {
+        if ("true".equals(VMPropsGetter.get("vm.cds.sharing.enabled"))) {
             // This current JVM is able to use a default CDS archive included by the JDK, so
             // if we launch a JVM child process (with the same set of options as the current JVM),
             // that process is also able to use the same default CDS archive for creating


### PR DESCRIPTION
This PR tries to cut down the use of `WhiteBox` in the HotSpot test cases. It modifies `VMProps` to save the set of VM properties into a file called "vm.properties" under Jtreg's work directory. The new API `jdk.test.lib.VMPropsGetter` loads the properties from this file to pass onto individual test cases.

See `getJtregWorkDir()` for the code that figures out the work directory. It assumes that `VMProps` and all test cases are always executed under

- `workDir/scratch/` ; or
- `workDir/scratch/[0-9]+/` 

This is probably not the right thing to do. I would be better for Jtreg to pass the location of the work directory to the test cases, with a command-line options like `-Djtreg.work.dir=<dir>`.

To show the benefit of this PR, I modified a few test cases to remove their use of WhiteBox.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352107](https://bugs.openjdk.org/browse/JDK-8352107): Allow jtreg test cases to query test VM properties (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24071/head:pull/24071` \
`$ git checkout pull/24071`

Update a local copy of the PR: \
`$ git checkout pull/24071` \
`$ git pull https://git.openjdk.org/jdk.git pull/24071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24071`

View PR using the GUI difftool: \
`$ git pr show -t 24071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24071.diff">https://git.openjdk.org/jdk/pull/24071.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24071#issuecomment-2727153267)
</details>
