### PR TITLE
8352109: java/awt/Desktop/MailTest.java fails in platforms where Action.MAIL is not supported

### DIFF
--- a/test/jdk/java/awt/Desktop/MailTest.java
+++ b/test/jdk/java/awt/Desktop/MailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,20 +21,22 @@
  * questions.
  */
 
-/*
- * @test
- * @bug 6255196
- * @summary Verifies the function of methods mail() and mail(java.net.URI uri).
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
- * @run main/manual MailTest
- */
-
 import java.awt.Desktop;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import javax.swing.JPanel;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 6255196
+ * @summary Verifies the function of methods mail() and mail(java.net.URI uri).
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
+ * @run main/manual MailTest
+ */
 
 public class MailTest extends JPanel {
 
@@ -48,20 +50,7 @@ public class MailTest extends JPanel {
             """;
 
     private MailTest() {
-        if (!Desktop.isDesktopSupported()) {
-            PassFailJFrame.log("Class java.awt.Desktop is not supported on " +
-                    "current platform. Farther testing will not be performed");
-            PassFailJFrame.forcePass();
-            return;
-        }
-
         Desktop desktop = Desktop.getDesktop();
-        if (!desktop.isSupported(Desktop.Action.MAIL)) {
-            PassFailJFrame.log("Action.MAIL is not supported.");
-            PassFailJFrame.forcePass();
-            return;
-        }
-
         /*
          * Part 1: launch the mail composing window without a mailto URI.
          */
@@ -105,6 +94,18 @@ public class MailTest extends JPanel {
 
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException {
+        if (!Desktop.isDesktopSupported()) {
+            String errorMessage = "Class java.awt.Desktop is not supported on " +
+                    "current platform. Further testing will not be performed";
+            throw new SkippedException(errorMessage);
+        }
+
+        Desktop desktop = Desktop.getDesktop();
+        if (!desktop.isSupported(Desktop.Action.MAIL)) {
+            String errorMessage = "Action.MAIL is not supported.";
+            throw new SkippedException(errorMessage);
+        }
+
         PassFailJFrame.builder()
                 .title("Mail Test")
                 .splitUI(MailTest::new)

--- a/test/jdk/java/awt/Desktop/MailTest.java
+++ b/test/jdk/java/awt/Desktop/MailTest.java
@@ -52,12 +52,14 @@ public class MailTest extends JPanel {
             PassFailJFrame.log("Class java.awt.Desktop is not supported on " +
                     "current platform. Farther testing will not be performed");
             PassFailJFrame.forcePass();
+            return;
         }
 
         Desktop desktop = Desktop.getDesktop();
         if (!desktop.isSupported(Desktop.Action.MAIL)) {
             PassFailJFrame.log("Action.MAIL is not supported.");
             PassFailJFrame.forcePass();
+            return;
         }
 
         /*

--- a/test/jdk/java/awt/Desktop/MailTest.java
+++ b/test/jdk/java/awt/Desktop/MailTest.java
@@ -95,15 +95,12 @@ public class MailTest extends JPanel {
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException {
         if (!Desktop.isDesktopSupported()) {
-            String errorMessage = "Class java.awt.Desktop is not supported on " +
-                    "current platform. Further testing will not be performed";
-            throw new SkippedException(errorMessage);
+            throw new SkippedException("Class java.awt.Desktop is not supported " +
+                    "on current platform. Further testing will not be performed");
         }
 
-        Desktop desktop = Desktop.getDesktop();
-        if (!desktop.isSupported(Desktop.Action.MAIL)) {
-            String errorMessage = "Action.MAIL is not supported.";
-            throw new SkippedException(errorMessage);
+        if (!Desktop.getDesktop().isSupported(Desktop.Action.MAIL)) {
+            throw new SkippedException("Action.MAIL is not supported.");
         }
 
         PassFailJFrame.builder()


### PR DESCRIPTION
**Issue**
java/awt/Desktop/MailTest.java fails in platforms where Action.MAIL is not supported

**Reason**
In `MailTest.java`, there is a condition check(`if (!desktop.isSupported(Desktop.Action.MAIL))`) which will force pass the test if the corresponding 'Action' is not supported by the platform. But, apparently, this is not working good and the code flow went past this and fails in desktop.mail() method with an UnsupportedOperationException. 

**Fix**
Even though we are calling `PassFailJFrame.forcePass()` if the 'Action.MAIL' is unsupported, the PassFailJFrame just count downs a latch and the actual action will be taken later only(in `awaitAndCheck()`). But at the meantime, the desktop.mail() call gets executed in the constructor of MailTest() and it will result in an UnsupportedOperationException. So, the fix is to return from the constructor immediately if the operation is 'unsupported'.

**Testing**
This is a manual test, so it is tested locally and found to be working fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352109](https://bugs.openjdk.org/browse/JDK-8352109): java/awt/Desktop/MailTest.java fails in platforms where Action.MAIL is not supported (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24072/head:pull/24072` \
`$ git checkout pull/24072`

Update a local copy of the PR: \
`$ git checkout pull/24072` \
`$ git pull https://git.openjdk.org/jdk.git pull/24072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24072`

View PR using the GUI difftool: \
`$ git pr show -t 24072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24072.diff">https://git.openjdk.org/jdk/pull/24072.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24072#issuecomment-2727277567)
</details>
