### PR TITLE
8352110: [ASAN] heap-use-after-free of task->directive()->PrintCompilationOption

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2374,7 +2374,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
     if (CompilationLog::log() != nullptr) {
       CompilationLog::log()->log_failure(thread, task, failure_reason, retry_message);
     }
-    if (PrintCompilation || (task->directive()->PrintCompilationOption && strcmp(failure_reason, "concurrent class loading") != 0)) {
+    if (PrintCompilation) {
       FormatBufferResource msg = retry_message != nullptr ?
         FormatBufferResource("COMPILE SKIPPED: %s (%s)", failure_reason, retry_message) :
         FormatBufferResource("COMPILE SKIPPED: %s",      failure_reason);

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2374,7 +2374,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
     if (CompilationLog::log() != nullptr) {
       CompilationLog::log()->log_failure(thread, task, failure_reason, retry_message);
     }
-    if (PrintCompilation || task->directive()->PrintCompilationOption) {
+    if (PrintCompilation || (task->directive()->PrintCompilationOption && strcmp(failure_reason, "concurrent class loading") != 0)) {
       FormatBufferResource msg = retry_message != nullptr ?
         FormatBufferResource("COMPILE SKIPPED: %s (%s)", failure_reason, retry_message) :
         FormatBufferResource("COMPILE SKIPPED: %s",      failure_reason);

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -334,6 +334,10 @@ static void register_command(TypedMethodOptionMatcher* matcher,
     return;
   }
 
+  if (option == CompileCommandEnum::PrintCompilation) {
+    PrintCompilation = true;
+  }
+
   matcher->init(option, option_list);
   matcher->set_value<T>(value);
   option_list = matcher;


### PR DESCRIPTION
Hi all,

After [JDK-8351938](https://bugs.openjdk.org/browse/JDK-8351938) several tests intermittent fails, because JVM print additional message "COMPILE SKIPPED: concurrent class loading", and AddressSanitizer report 'heap-use-after-free' error.

I don't  know why `task->directive()->PrintCompilationOption`  set as `true` automatically. This PR remove `task->directive()->PrintCompilationOption` usage, and set PrintCompilation to true when receive CompileCommandEnum::PrintCompilation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8352110](https://bugs.openjdk.org/browse/JDK-8352110)

### Issue
 * [JDK-8352110](https://bugs.openjdk.org/browse/JDK-8352110): [BACKOUT] C2: Print compilation bailouts with PrintCompilation compile command (**Sub-task** - P2) ⚠️ Title mismatch between PR and JBS.


### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24073/head:pull/24073` \
`$ git checkout pull/24073`

Update a local copy of the PR: \
`$ git checkout pull/24073` \
`$ git pull https://git.openjdk.org/jdk.git pull/24073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24073`

View PR using the GUI difftool: \
`$ git pr show -t 24073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24073.diff">https://git.openjdk.org/jdk/pull/24073.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24073#issuecomment-2727278722)
</details>
