### PR TITLE
8352110: [BACKOUT] C2: Print compilation bailouts with PrintCompilation compile command

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2374,7 +2374,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
     if (CompilationLog::log() != nullptr) {
       CompilationLog::log()->log_failure(thread, task, failure_reason, retry_message);
     }
-    if (PrintCompilation || task->directive()->PrintCompilationOption) {
+    if (PrintCompilation) {
       FormatBufferResource msg = retry_message != nullptr ?
         FormatBufferResource("COMPILE SKIPPED: %s (%s)", failure_reason, retry_message) :
         FormatBufferResource("COMPILE SKIPPED: %s",      failure_reason);


### PR DESCRIPTION
Due to some failures, I think it's best to backout this and address the problems properly in a REDO.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352110](https://bugs.openjdk.org/browse/JDK-8352110): [BACKOUT] C2: Print compilation bailouts with PrintCompilation compile command (**Sub-task** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24074/head:pull/24074` \
`$ git checkout pull/24074`

Update a local copy of the PR: \
`$ git checkout pull/24074` \
`$ git pull https://git.openjdk.org/jdk.git pull/24074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24074`

View PR using the GUI difftool: \
`$ git pr show -t 24074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24074.diff">https://git.openjdk.org/jdk/pull/24074.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24074#issuecomment-2728378760)
</details>
