### PR TITLE
8351655: Optimize ObjectMonitor::unlink_after_acquire()

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1257,7 +1257,7 @@ void ObjectMonitor::vthread_epilog(JavaThread* current, ObjectWaiter* node) {
 //   1. Empty.
 //   2. Only singly linked.
 //   3. Only doubly linked.
-//   4. Starting as sigly linked (from the head), but ending as doubly
+//   4. Starting as singly linked (from the head), but ending as doubly
 //      linked (at the tail).
 // Number four is because new threads has pushed themself to the
 // entry_list head after the entry_list was last converted into a
@@ -1290,7 +1290,7 @@ void ObjectMonitor::entry_list_build_dll(JavaThread* current) {
     // node that had its prev pointer set. I.e. we converted the first
     // part of the entry_list from a singly linked list into a doubly
     // linked list. Now we just want to make sure the rest of the list
-    // is doubly liked. But first we check that we have a tail
+    // is doubly linked. But first we check that we have a tail
     // pointer, because if the end of the entry_list is doubly linked
     // and we don't have the tail pointer, something is broken.
     assert(_entry_list_tail != nullptr, "should be");
@@ -1301,9 +1301,9 @@ void ObjectMonitor::entry_list_build_dll(JavaThread* current) {
       prev = w;
       w = w->next();
     }
+    assert(_entry_list_tail == prev, "should be");
 #endif
   }
-  assert(_entry_list_tail == prev, "should be");
 }
 
 // Return the tail of the _entry_list. If the tail is currently not

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -441,6 +441,7 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   void      dequeue_specific_waiter(ObjectWaiter* waiter);
   void      enter_internal(JavaThread* current);
   void      reenter_internal(JavaThread* current, ObjectWaiter* current_node);
+  void      entry_list_build_dll(JavaThread* current);
   void      unlink_after_acquire(JavaThread* current, ObjectWaiter* current_node);
   ObjectWaiter* entry_list_tail(JavaThread* current);
 


### PR DESCRIPTION
This PR implements an optimization of `ObjectMonitor::unlink_after_acquire()`. If it's possible it only converts the first part (the singly linked part) of the `entry_list` into a doubly linked list and leave the _entry_list_tail pointer untouched. 

It has passed tier1-tier8 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351655](https://bugs.openjdk.org/browse/JDK-8351655): Optimize ObjectMonitor::unlink_after_acquire() (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) Review applies to [12581560](https://git.openjdk.org/jdk/pull/24078/files/125815606128732a2aa8de161f8c94e955bb8ec2)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24078/head:pull/24078` \
`$ git checkout pull/24078`

Update a local copy of the PR: \
`$ git checkout pull/24078` \
`$ git pull https://git.openjdk.org/jdk.git pull/24078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24078`

View PR using the GUI difftool: \
`$ git pr show -t 24078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24078.diff">https://git.openjdk.org/jdk/pull/24078.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24078#issuecomment-2733274923)
</details>
