### PR TITLE
8350749: Upgrade JLine to 3.29.0

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/LineReader.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/LineReader.java
@@ -10,6 +10,7 @@ package jdk.internal.org.jline.reader;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.IntConsumer;
@@ -766,7 +767,11 @@ public interface LineReader {
 
     void addCommandsInBuffer(Collection<String> commands);
 
-    void editAndAddInBuffer(File file) throws Exception;
+    default void editAndAddInBuffer(File file) throws Exception {
+        editAndAddInBuffer(file != null ? file.toPath() : null);
+    }
+
+    void editAndAddInBuffer(Path file) throws Exception;
 
     String getLastBinding();
 

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/UserInterruptException.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/UserInterruptException.java
@@ -19,6 +19,11 @@ public class UserInterruptException extends RuntimeException {
 
     private final String partialLine;
 
+    public UserInterruptException(Throwable cause) {
+        super(cause);
+        this.partialLine = null;
+    }
+
     public UserInterruptException(String partialLine) {
         this.partialLine = partialLine;
     }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/DefaultHighlighter.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/DefaultHighlighter.java
@@ -38,6 +38,7 @@ public class DefaultHighlighter implements Highlighter {
         int underlineEnd = -1;
         int negativeStart = -1;
         int negativeEnd = -1;
+        boolean first = true;
         String search = reader.getSearchTerm();
         if (search != null && search.length() > 0) {
             underlineStart = buffer.indexOf(search);
@@ -65,6 +66,7 @@ public class DefaultHighlighter implements Highlighter {
         }
 
         AttributedStringBuilder sb = new AttributedStringBuilder();
+        commandStyle(reader, sb, true);
         for (int i = 0; i < buffer.length(); i++) {
             if (i == underlineStart) {
                 sb.style(AttributedStyle::underline);
@@ -77,6 +79,10 @@ public class DefaultHighlighter implements Highlighter {
             }
 
             char c = buffer.charAt(i);
+            if (first && Character.isSpaceChar(c)) {
+                first = false;
+                commandStyle(reader, sb, false);
+            }
             if (c == '\t' || c == '\n') {
                 sb.append(c);
             } else if (c < 32) {
@@ -105,4 +111,6 @@ public class DefaultHighlighter implements Highlighter {
         }
         return sb.toAttributedString();
     }
+
+    protected void commandStyle(LineReader reader, AttributedStringBuilder sb, boolean enable) {}
 }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/LineReaderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/LineReaderImpl.java
@@ -10,7 +10,6 @@ package jdk.internal.org.jline.reader.impl;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.Flushable;
 import java.io.IOError;
@@ -1131,16 +1130,16 @@ public class LineReaderImpl implements LineReader, Flushable {
     }
 
     @Override
-    public void editAndAddInBuffer(File file) throws Exception {
+    public void editAndAddInBuffer(Path file) throws Exception {
         if (isSet(Option.BRACKETED_PASTE)) {
             terminal.writer().write(BRACKETED_PASTE_OFF);
         }
-        Constructor<?> ctor = Class.forName("org.jline.builtins.Nano").getConstructor(Terminal.class, File.class);
-        Editor editor = (Editor) ctor.newInstance(terminal, new File(file.getParent()));
+        Constructor<?> ctor = Class.forName("org.jline.builtins.Nano").getConstructor(Terminal.class, Path.class);
+        Editor editor = (Editor) ctor.newInstance(terminal, file.getParent());
         editor.setRestricted(true);
-        editor.open(Collections.singletonList(file.getName()));
+        editor.open(Collections.singletonList(file.getFileName().toString()));
         editor.run();
-        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+        try (BufferedReader br = Files.newBufferedReader(file)) {
             String line;
             commandsBuffer.clear();
             while ((line = br.readLine()) != null) {
@@ -3529,7 +3528,7 @@ public class LineReaderImpl implements LineReader, Flushable {
             buf.move(1);
             putString(yankBuffer);
             buf.move(-yankBuffer.length());
-        } else if (yankBuffer.length() != 0) {
+        } else if (!yankBuffer.isEmpty()) {
             if (buf.cursor() < buf.length()) {
                 buf.move(1);
             }
@@ -3547,7 +3546,7 @@ public class LineReaderImpl implements LineReader, Flushable {
                 ;
             putString(yankBuffer);
             buf.move(-yankBuffer.length());
-        } else if (yankBuffer.length() != 0) {
+        } else if (!yankBuffer.isEmpty()) {
             if (buf.cursor() > 0) {
                 buf.move(-1);
             }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/completer/SystemCompleter.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/completer/SystemCompleter.java
@@ -9,6 +9,8 @@
 package jdk.internal.org.jline.reader.impl.completer;
 
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import jdk.internal.org.jline.reader.Candidate;
 import jdk.internal.org.jline.reader.Completer;
@@ -24,6 +26,7 @@ import jdk.internal.org.jline.utils.AttributedString;
 public class SystemCompleter implements Completer {
     private Map<String, List<Completer>> completers = new HashMap<>();
     private Map<String, String> aliasCommand = new HashMap<>();
+    private Map<String, String> descriptions = new HashMap<>();
     private StringsCompleter commands;
     private boolean compiled = false;
 
@@ -124,6 +127,10 @@ public class SystemCompleter implements Completer {
     }
 
     public void compile() {
+        compile(s -> new Candidate(AttributedString.stripAnsi(s), s, null, null, null, null, true));
+    }
+
+    public void compile(Function<String, Candidate> candidateBuilder) {
         if (compiled) {
             return;
         }
@@ -139,7 +146,7 @@ public class SystemCompleter implements Completer {
         completers = compiledCompleters;
         Set<String> cmds = new HashSet<>(completers.keySet());
         cmds.addAll(aliasCommand.keySet());
-        commands = new StringsCompleter(cmds);
+        commands = new StringsCompleter(cmds.stream().map(candidateBuilder).collect(Collectors.toList()));
         compiled = true;
     }
 

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/history/DefaultHistory.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/history/DefaultHistory.java
@@ -200,7 +200,7 @@ public class DefaultHistory implements History {
     public void write(Path file, boolean incremental) throws IOException {
         Path path = file != null ? file : getPath();
         if (path != null && Files.exists(path)) {
-            path.toFile().delete();
+            Files.deleteIfExists(path);
         }
         internalWrite(path, incremental ? getLastLoaded(path) : 0);
     }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/TerminalBuilder.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/TerminalBuilder.java
@@ -209,41 +209,85 @@ public final class TerminalBuilder {
         return this;
     }
 
+    /**
+     * Forces the usage of the give terminal provider.
+     *
+     * @param provider The {@link TerminalProvider}'s name to use when creating the Terminal.
+     * @return The builder.
+     */
     public TerminalBuilder provider(String provider) {
         this.provider = provider;
         return this;
     }
 
+    /**
+     * Sets the list of providers to try when creating the terminal.
+     * If not specified, the system property {@link #PROP_PROVIDERS} will be used if set.
+     * Else, the value {@link #PROP_PROVIDERS_DEFAULT} will be used.
+     *
+     * @param providers The list of {@link TerminalProvider}'s names to check when creating the Terminal.
+     * @return The builder.
+     */
     public TerminalBuilder providers(String providers) {
         this.providers = providers;
         return this;
     }
 
+    /**
+     * Enables or disables the {@link #PROP_PROVIDER_JNA}/{@code jna} terminal provider.
+     * If not specified, the system property {@link #PROP_JNA} will be used if set.
+     * If not specified, the provider will be checked.
+     */
     public TerminalBuilder jna(boolean jna) {
         this.jna = jna;
         return this;
     }
 
+    /**
+     * Enables or disables the {@link #PROP_PROVIDER_JANSI}/{@code jansi} terminal provider.
+     * If not specified, the system property {@link #PROP_JANSI} will be used if set.
+     * If not specified, the provider will be checked.
+     */
     public TerminalBuilder jansi(boolean jansi) {
         this.jansi = jansi;
         return this;
     }
 
+    /**
+     * Enables or disables the {@link #PROP_PROVIDER_JNI}/{@code jni} terminal provider.
+     * If not specified, the system property {@link #PROP_JNI} will be used if set.
+     * If not specified, the provider will be checked.
+     */
     public TerminalBuilder jni(boolean jni) {
         this.jni = jni;
         return this;
     }
 
+    /**
+     * Enables or disables the {@link #PROP_PROVIDER_EXEC}/{@code exec} terminal provider.
+     * If not specified, the system property {@link #PROP_EXEC} will be used if set.
+     * If not specified, the provider will be checked.
+     */
     public TerminalBuilder exec(boolean exec) {
         this.exec = exec;
         return this;
     }
 
+    /**
+     * Enables or disables the {@link #PROP_PROVIDER_FFM}/{@code ffm} terminal provider.
+     * If not specified, the system property {@link #PROP_FFM} will be used if set.
+     * If not specified, the provider will be checked.
+     */
     public TerminalBuilder ffm(boolean ffm) {
         this.ffm = ffm;
         return this;
     }
 
+    /**
+     * Enables or disables the {@link #PROP_PROVIDER_DUMB}/{@code dumb} terminal provider.
+     * If not specified, the system property {@link #PROP_DUMB} will be used if set.
+     * If not specified, the provider will be checked.
+     */
     public TerminalBuilder dumb(boolean dumb) {
         this.dumb = dumb;
         return this;

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/AbstractPosixTerminal.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/AbstractPosixTerminal.java
@@ -94,4 +94,13 @@ public abstract class AbstractPosixTerminal extends AbstractTerminal {
     public SystemStream getSystemStream() {
         return getPty().getSystemStream();
     }
+
+    @Override
+    public String toString() {
+        return getKind() + "[" + "name='"
+                + name + '\'' + ", pty='"
+                + pty + '\'' + ", type='"
+                + type + '\'' + ", size='"
+                + getSize() + '\'' + ']';
+    }
 }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/AbstractTerminal.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/AbstractTerminal.java
@@ -287,4 +287,12 @@ public abstract class AbstractTerminal implements TerminalExt {
     public ColorPalette getPalette() {
         return palette;
     }
+
+    @Override
+    public String toString() {
+        return getKind() + "[" + "name='"
+                + name + '\'' + ", type='"
+                + type + '\'' + ", size='"
+                + getSize() + '\'' + ']';
+    }
 }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/exec/ExecPty.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/exec/ExecPty.java
@@ -278,7 +278,7 @@ public class ExecPty extends AbstractPty implements Pty {
                 return Integer.parseInt(matcher.group(1));
             }
         }
-        throw new IOException("Unable to parse " + name);
+        return 0;
     }
 
     @Override

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/exec/ExecTerminalProvider.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/exec/ExecTerminalProvider.java
@@ -46,6 +46,9 @@ public class ExecTerminalProvider implements TerminalProvider {
     }
 
     public Pty current(SystemStream systemStream) throws IOException {
+        if (!isSystemStream(systemStream)) {
+            throw new IOException("Not a system stream: " + systemStream);
+        }
         return ExecPty.current(this, systemStream);
     }
 

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/ffm/Kernel32.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/ffm/Kernel32.java
@@ -19,7 +19,7 @@ final class Kernel32 {
 
     public static final int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
 
-    public static final int INVALID_HANDLE_VALUE = -1;
+    public static final long INVALID_HANDLE_VALUE = -1;
     public static final int STD_INPUT_HANDLE = -10;
     public static final int STD_OUTPUT_HANDLE = -11;
     public static final int STD_ERROR_HANDLE = -12;
@@ -235,8 +235,8 @@ final class Kernel32 {
             CHAR_INFO lpFill) {
         MethodHandle mh$ = requireNonNull(ScrollConsoleScreenBufferW$MH, "ScrollConsoleScreenBuffer");
         try {
-            return (int)
-                    mh$.invokeExact(hConsoleOutput, lpScrollRectangle.seg, lpClipRectangle.seg, dwDestinationOrigin.seg, lpFill.seg);
+            return (int) mh$.invokeExact(
+                    hConsoleOutput, lpScrollRectangle.seg, lpClipRectangle.seg, dwDestinationOrigin.seg, lpFill.seg);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/ffm/NativeWinSysTerminal.java
@@ -83,7 +83,7 @@ public class NativeWinSysTerminal extends AbstractWindowsTerminal<java.lang.fore
                 type = type != null ? type : OSUtils.IS_CONEMU ? TYPE_WINDOWS_CONEMU : TYPE_WINDOWS;
                 writer = new NativeWinConsoleWriter();
             } else {
-                int m = inMode.get(java.lang.foreign.ValueLayout.JAVA_INT, 0);
+                int m = outMode.get(java.lang.foreign.ValueLayout.JAVA_INT, 0);
                 if (enableVtp(console, m)) {
                     type = type != null ? type : TYPE_WINDOWS_VTP;
                     writer = new NativeWinConsoleWriter();

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/Display.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/Display.java
@@ -219,7 +219,8 @@ public class Display {
                 cursorPos++;
                 if (newLength == 0 || newLine.isHidden(0)) {
                     // go to next line column zero
-                    rawPrint(new AttributedString(" \b"));
+                    rawPrint(' ');
+                    terminal.puts(Capability.key_backspace);
                 } else {
                     AttributedString firstChar = newLine.substring(0, 1);
                     // go to next line column one
@@ -319,7 +320,8 @@ public class Display {
             } else if (atRight) {
                 if (this.wrapAtEol) {
                     if (!fullScreen || (fullScreen && lineIndex < numLines)) {
-                        terminal.writer().write(" \b");
+                        rawPrint(' ');
+                        terminal.puts(Capability.key_backspace);
                         cursorPos++;
                     }
                 } else {

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/InputStreamReader.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/InputStreamReader.java
@@ -22,8 +22,7 @@ import java.nio.charset.CodingErrorAction;
 import java.nio.charset.MalformedInputException;
 import java.nio.charset.UnmappableCharacterException;
 
-/**
- *
+/*
  * NOTE for JLine: the default InputStreamReader that comes from the JRE
  * usually read more bytes than needed from the input stream, which
  * is not usable in a character per character model used in the terminal.

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/Status.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/Status.java
@@ -48,13 +48,18 @@ public class Status {
         this.supported = terminal.getStringCapability(Capability.change_scroll_region) != null
                 && terminal.getStringCapability(Capability.save_cursor) != null
                 && terminal.getStringCapability(Capability.restore_cursor) != null
-                && terminal.getStringCapability(Capability.cursor_address) != null;
+                && terminal.getStringCapability(Capability.cursor_address) != null
+                && isValid(terminal.getSize());
         if (supported) {
             display = new MovingCursorDisplay(terminal);
             resize();
             display.reset();
             scrollRegion = display.rows - 1;
         }
+    }
+
+    private boolean isValid(Size size) {
+        return size.getRows() > 0 && size.getRows() < 1000 && size.getColumns() > 0 && size.getColumns() < 1000;
     }
 
     public void close() {
@@ -147,6 +152,7 @@ public class Status {
         if (newScrollRegion < scrollRegion) {
             // We need to scroll up to grow the status bar
             terminal.puts(Capability.save_cursor);
+            terminal.puts(Capability.cursor_address, scrollRegion, 0);
             for (int i = newScrollRegion; i < scrollRegion; i++) {
                 terminal.puts(Capability.cursor_down);
             }

--- a/src/jdk.internal.le/share/legal/jline.md
+++ b/src/jdk.internal.le/share/legal/jline.md
@@ -1,4 +1,4 @@
-## JLine v3.26.1
+## JLine v3.29.0
 
 ### JLine License
 <pre>


### PR DESCRIPTION
This is an upgrade of JLine to JLine 3.29.0. It is basically applying a patch with changes between JLine 3.26.1 and JLine 3.29.0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350749](https://bugs.openjdk.org/browse/JDK-8350749): Upgrade JLine to 3.29.0 (**Task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24080/head:pull/24080` \
`$ git checkout pull/24080`

Update a local copy of the PR: \
`$ git checkout pull/24080` \
`$ git pull https://git.openjdk.org/jdk.git pull/24080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24080`

View PR using the GUI difftool: \
`$ git pr show -t 24080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24080.diff">https://git.openjdk.org/jdk/pull/24080.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24080#issuecomment-2729606803)
</details>
