### PR TITLE
8352020: [CompileFramework] enable compilation for VectorAPI

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/compile_framework/CompileFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/compile_framework/CompileFramework.java
@@ -71,8 +71,11 @@ public class CompileFramework {
      * Compile all sources: store the sources to the {@link sourceDir} directory, compile
      * Java and Jasm sources and store the generated class-files in the {@link classesDir}
      * directory.
+     *
+     * @param javacFlags: optional, list of additional flags for javac, e.g. to make modules
+     *                    visible.
      */
-    public void compile() {
+    public void compile(String... javacFlags) {
         if (classLoader != null) {
             throw new CompileFrameworkException("Cannot compile twice!");
         }
@@ -86,7 +89,7 @@ public class CompileFramework {
         System.out.println("Classes directory: " + classesDir);
 
         Compile.compileJasmSources(jasmSources, sourceDir, classesDir);
-        Compile.compileJavaSources(javaSources, sourceDir, classesDir);
+        Compile.compileJavaSources(javaSources, sourceDir, classesDir, javacFlags);
         classLoader = ClassLoaderBuilder.build(classesDir);
     }
 

--- a/test/hotspot/jtreg/testlibrary_tests/compile_framework/examples/IRFrameworkWithVectorAPIExample.java
+++ b/test/hotspot/jtreg/testlibrary_tests/compile_framework/examples/IRFrameworkWithVectorAPIExample.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Example test to use the Compile Framework together with the IR Framework (i.e. TestFramework),
+ *          and the VectorAPI.
+ * @modules java.base/jdk.internal.misc
+ * @modules jdk.incubator.vector
+ * @library /test/lib /
+ * @compile ../../../compiler/lib/ir_framework/TestFramework.java
+ * @run driver compile_framework.examples.IRFrameworkWithVectorAPIExample
+ */
+
+package compile_framework.examples;
+
+import compiler.lib.compile_framework.*;
+import jdk.test.lib.Utils;
+import jdk.incubator.vector.IntVector;
+import jdk.test.lib.Platform;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * This test shows that the IR verification can be done on code compiled by the Compile Framework.
+ * The "@compile" command for JTREG is required so that the IRFramework is compiled, other javac
+ * might not compile it because it is not present in the class, only in the dynamically compiled
+ * code.
+ * <p>
+ * Additionally, we must set the classpath for the Test-VM, so that it has access to all compiled
+ * classes (see {@link CompileFramework#getEscapedClassPathOfCompiledClasses}).
+ */
+public class IRFrameworkWithVectorAPIExample {
+
+    public static void main(String[] args) {
+        // Create a new CompileFramework instance.
+        CompileFramework comp = new CompileFramework();
+
+        // Add a java source file.
+        comp.addJavaSourceCode("InnerTest", generateInnerTest(comp));
+
+        // Compile the source file. "javac" needs to know that it is ok to compile with the
+        // VectorAPI module.
+        comp.compile("--add-modules=jdk.incubator.vector");
+
+        // InnerTest.main();
+        comp.invoke("InnerTest", "main", new Object[] {null});
+    }
+
+    // Generate a source java file as String
+    public static String generateInnerTest(CompileFramework comp) {
+        return String.format("""
+               import compiler.lib.ir_framework.*;
+               import jdk.incubator.vector.*;
+
+               public class InnerTest {
+                   public static void main(String args[]) {
+                       TestFramework framework = new TestFramework(X1.class);
+                       // Also the TestFramework must allow the test VM to see the VectorAPI module.
+                       framework.addFlags("-classpath", "%s", "--add-modules=jdk.incubator.vector");
+                       framework.start();
+                   }
+
+                   @Test
+                   static Object test() {
+                       return IntVector.broadcast(IntVector.SPECIES_64, 42);
+                   }
+               }
+               """, comp.getEscapedClassPathOfCompiledClasses());
+    }
+}
+
+ 

--- a/test/hotspot/jtreg/testlibrary_tests/compile_framework/examples/IRFrameworkWithVectorAPIExample.java
+++ b/test/hotspot/jtreg/testlibrary_tests/compile_framework/examples/IRFrameworkWithVectorAPIExample.java
@@ -74,7 +74,7 @@ public class IRFrameworkWithVectorAPIExample {
 
                public class InnerTest {
                    public static void main(String args[]) {
-                       TestFramework framework = new TestFramework(X1.class);
+                       TestFramework framework = new TestFramework(InnerTest.class);
                        // Also the TestFramework must allow the test VM to see the VectorAPI module.
                        framework.addFlags("-classpath", "%s", "--add-modules=jdk.incubator.vector");
                        framework.start();

--- a/test/hotspot/jtreg/testlibrary_tests/compile_framework/examples/IRFrameworkWithVectorAPIExample.java
+++ b/test/hotspot/jtreg/testlibrary_tests/compile_framework/examples/IRFrameworkWithVectorAPIExample.java
@@ -88,5 +88,3 @@ public class IRFrameworkWithVectorAPIExample {
                """, comp.getEscapedClassPathOfCompiledClasses());
     }
 }
-
- 


### PR DESCRIPTION
During work on [JDK-8344942](https://bugs.openjdk.org/browse/JDK-8344942) I discovered that it is currently not possible to compile VectorAPI code because it is still in incubator mode and needs flag "--add-modules=jdk.incubator.vector" for "javac".

Also: "javac" can produce warnings, and that leads to issues like this: [JDK-8351998](https://bugs.openjdk.org/browse/JDK-8351998). We should allow such warnings, they are not compile failures.

Example:
```
javac --add-modules=jdk.incubator.vector Test.java
warning: [incubating] using incubating module(s): jdk.incubator.vector
1 warning
```

I added an example test as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352020](https://bugs.openjdk.org/browse/JDK-8352020): [CompileFramework] enable compilation for VectorAPI (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [3b9eb4ce](https://git.openjdk.org/jdk/pull/24082/files/3b9eb4ce68f7bcb6a0ba8d53be82a4a1a814248e)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24082/head:pull/24082` \
`$ git checkout pull/24082`

Update a local copy of the PR: \
`$ git checkout pull/24082` \
`$ git pull https://git.openjdk.org/jdk.git pull/24082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24082`

View PR using the GUI difftool: \
`$ git pr show -t 24082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24082.diff">https://git.openjdk.org/jdk/pull/24082.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24082#issuecomment-2730065670)
</details>
