### PR TITLE
8352151: Fix display issues in javadoc-generated docs

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
@@ -464,7 +464,6 @@ document.addEventListener("DOMContentLoaded", function(e) {
         });
     var sections;
     var scrollTimeout;
-    var scrollTimeoutNeeded;
     var prevHash;
     function initSectionData() {
         bodyHeight = document.body.offsetHeight;
@@ -479,35 +478,30 @@ document.addEventListener("DOMContentLoaded", function(e) {
             }));
     }
     function setScrollTimeout() {
-        clearTimeout(scrollTimeout);
-        scrollTimeoutNeeded = false;
+        if (scrollTimeout) {
+            clearTimeout(scrollTimeout);
+        }
         scrollTimeout = setTimeout(() => {
             scrollTimeout = null;
-            handleScroll();
         }, 100);
     }
     function handleScroll() {
         if (!sidebar || !sidebar.offsetParent || sidebar.classList.contains("hide-sidebar")) {
             return;
         }
-        if (scrollTimeout || scrollTimeoutNeeded) {
+        if (scrollTimeout) {
             setScrollTimeout();
             return;
         }
         var scrollTop = document.documentElement.scrollTop;
         var scrollHeight = document.documentElement.scrollHeight;
         var currHash = null;
-        if (scrollHeight - scrollTop < window.innerHeight + 10) {
-            // Select last item if at bottom of the page
-            currHash = "#" + encodeURI(sections.at(-1).id);
-        } else {
-            for (var i = 0; i < sections.length; i++) {
-                var top = sections[i].top;
-                var bottom = sections[i + 1] ? sections[i + 1].top : scrollHeight;
-                if (top + ((bottom - top) / 2) > scrollTop || bottom > scrollTop + (window.innerHeight / 3)) {
-                    currHash = "#" + encodeURI(sections[i].id);
-                    break;
-                }
+        for (var i = 0; i < sections.length; i++) {
+            var top = sections[i].top;
+            var bottom = sections[i + 1] ? sections[i + 1].top : scrollHeight;
+            if (top + ((bottom - top) / 2) > scrollTop || bottom > scrollTop + (window.innerHeight / 3)) {
+                currHash = "#" + encodeURI(sections[i].id);
+                break;
             }
         }
         if (currHash !== prevHash) {
@@ -542,29 +536,26 @@ document.addEventListener("DOMContentLoaded", function(e) {
         document.querySelectorAll("a[href^='#']").forEach((link) => {
             link.addEventListener("click", (e) => {
                 link.blur();
-                scrollTimeoutNeeded = true;
+                setScrollTimeout();
                 setSelected(link.getAttribute("href"));
             })
         });
         sidebar.querySelector("button.hide-sidebar").addEventListener("click", hideSidebar);
         sidebar.querySelector("button.show-sidebar").addEventListener("click", showSidebar);
         window.addEventListener("hashchange", (e) => {
-            scrollTimeoutNeeded = true;
+            setScrollTimeout();
+            const hash = e.newURL.indexOf("#");
+            if (hash > -1) {
+                setSelected(e.newURL.substring(hash));
+            }
         });
         if (document.location.hash) {
-            scrollTimeoutNeeded = true;
+            setScrollTimeout();
             setSelected(document.location.hash);
         } else {
             handleScroll();
         }
         window.addEventListener("scroll", handleScroll);
-        window.addEventListener("scrollend", () => {
-            if (scrollTimeout) {
-                clearTimeout(scrollTimeout);
-                scrollTimeout = null;
-                handleScroll();
-            }
-        })
     }
     // Resize handler
     new ResizeObserver((entries) => {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -79,9 +79,10 @@
     --search-input-placeholder-color: #909090;
     /* Highlight color for active search tag target */
     --search-tag-highlight-color: #ffff66;
-    /* Adjustments for icon and active background colors of copy-to-clipboard buttons */
-    --copy-icon-brightness: 100%;
-    --copy-button-background-color-active: rgba(168, 168, 176, 0.3);
+    /* Copy button colors and filters */
+    --button-border-color: #b0b8c8;
+    --button-active-filter: brightness(96%);
+    --button-focus-filter: brightness(104%);
     /* Colors for invalid tag notifications */
     --invalid-tag-background-color: #ffe6e6;
     --invalid-tag-text-color: #000000;
@@ -535,6 +536,9 @@ nav.toc a {
 }
 nav.toc ol.toc-list ol.toc-list a {
     padding-left: 24px;
+}
+nav.toc ol.toc-list ol.toc-list ol.toc-list a {
+    padding-left: 40px;
 }
 nav.toc a:hover {
     background-color: var(--toc-hover-color);
@@ -1053,7 +1057,7 @@ input[type="text"] {
 }
 input#page-search-input {
     width: calc(180px + 10vw);
-    margin: 0;
+    margin: 10px 0;
 }
 input#search-input {
     width: 270px;
@@ -1101,7 +1105,7 @@ input:focus::placeholder {
     color: transparent;
 }
 select#search-modules {
-    margin: 0 10px 0 2px;
+    margin: 0 10px 10px 2px;
     font-size: var(--nav-font-size);
     padding: 3px 5px;
     border-radius: 4px;
@@ -1329,49 +1333,48 @@ a.anchor-link > img {
  * Styles for copy-to-clipboard buttons
  */
 button.copy {
-    opacity: 60%;
-    border: none;
+    font-size: var(--nav-font-size);
+    line-height: 1.2;
+    padding:0.3em;
+    background-color: transparent;
+    border: 1px solid transparent;
     border-radius: 3px;
     position: relative;
-    background:none;
-    transition: opacity 0.3s;
+    opacity: 80%;
+    transition: all 0.1s ease;
     cursor: pointer;
-}
-:hover > button.copy {
-    opacity: 70%;
 }
 button.copy:hover,
 button.copy:active,
-button.copy:focus-visible,
+button.copy:focus,
 button.copy.visible {
     opacity: 100%;
+    background-color: inherit;
+    border-color: var(--button-border-color);
+    filter: var(--button-focus-filter);
+}
+button.copy:active {
+    filter: var(--button-active-filter);
 }
 button.copy img {
     position: relative;
-    background: none;
-    filter: brightness(var(--copy-icon-brightness));
-}
-button.copy:active {
-    background-color: var(--copy-button-background-color-active);
 }
 button.copy span {
     color: var(--body-text-color);
     position: relative;
+    padding: 0.2em;
     top: -0.1em;
-    transition: all 0.1s;
-    font-size: 0.76rem;
-    line-height: 1.2;
+    transition: opacity 0.1s ease;
     opacity: 0;
 }
 button.copy:hover span,
-button.copy:focus-visible span,
+button.copy:focus span,
 button.copy.visible span {
     opacity: 100%;
 }
 /* search page copy button */
 button#page-search-copy {
     margin-left: 0.4em;
-    padding:0.3em;
     top:0.13em;
 }
 button#page-search-copy img {
@@ -1381,35 +1384,22 @@ button#page-search-copy img {
     top: 0.15em;
 }
 button#page-search-copy span {
-    color: var(--body-text-color);
-    line-height: 1.2;
-    padding: 0.2em;
     top: -0.18em;
-}
-div.page-search-info:hover button#page-search-copy span {
-    opacity: 100%;
 }
 /* snippet copy button */
 button.snippet-copy {
     position: absolute;
-    top: 6px;
-    right: 6px;
-    height: 1.7em;
-    padding: 2px;
+    top: 2px;
+    right: 2px;
+    height: 32px;
 }
 button.snippet-copy img {
     width: 18px;
     height: 18px;
-    padding: 0.05em 0;
+    padding: 2px 0;
 }
 button.snippet-copy span {
-    line-height: 1.2;
-    padding: 0.2em;
-    position: relative;
-    top: -0.5em;
-}
-div.snippet-container button.snippet-copy:hover span {
-    opacity: 100%;
+    top: -7px;
 }
 /*
  * Styles for user-provided tables.
@@ -1667,15 +1657,8 @@ pre.snippet {
 }
 div.snippet-container {
     position: relative;
-}
-@media screen and (max-width: 800px) {
-    pre.snippet {
-        padding-top: 26px;
-    }
-    button.snippet-copy {
-        top: 4px;
-        right: 4px;
-    }
+    padding-right: 30px;
+    background-color: var(--snippet-background-color);
 }
 pre.snippet .italic {
     font-style: italic;


### PR DESCRIPTION
Please review a patch to fix a number of display bugs in javadoc-generated documentation.

 -  Snippet copy button is transparent and can overlap with snippet content ([before][snippet-before], [after][snippet-after])
 - After clicking on the second-to-last item in the sidebar, the last item is highlighted if the click triggers scrolling to the end of the page ([before][target-before], [after][target-after])
 - No indentation on sidebar entries beyond the first two levels of hierarchy ([before][indent-before], [after][indent-after])
 - (Minor) Add vertical margin to search page inputs so they look better when wrapped

[snippet-before]: https://download.java.net/java/early_access/jdk25/docs/api/java.base/java/lang/invoke/MethodHandle.html#asSpreader(int,java.lang.Class,int)
[snippet-after]: https://cr.openjdk.org/~hannesw/8352151/api.00/java.base/java/lang/invoke/MethodHandle.html#asSpreader(int,java.lang.Class,int)

[target-before]: https://download.java.net/java/early_access/jdk25/docs/api/java.base/java/lang/Thread.Builder.html#start(java.lang.Runnable)
[target-after]: https://cr.openjdk.org/~hannesw/8352151/api.00/java.base/java/lang/Thread.Builder.html#start(java.lang.Runnable)

[indent-before]: https://download.java.net/java/early_access/jdk25/docs/api/help-doc.html
[indent-after]: https://cr.openjdk.org/~hannesw/8352151/api.00/help-doc.html

The sidebar highlighting script actually became simpler, which is great. The snippet copy button change is a bit more involved, because I had to change snippet layout to not overlay snippet content with the copy button, and make the button opaque. But the result is better than what we had before IMO. The other changes are simple one-liners.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352151](https://bugs.openjdk.org/browse/JDK-8352151): Fix display issues in javadoc-generated docs (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24083/head:pull/24083` \
`$ git checkout pull/24083`

Update a local copy of the PR: \
`$ git checkout pull/24083` \
`$ git pull https://git.openjdk.org/jdk.git pull/24083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24083`

View PR using the GUI difftool: \
`$ git pr show -t 24083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24083.diff">https://git.openjdk.org/jdk/pull/24083.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24083#issuecomment-2730220223)
</details>
