### PR TITLE
8352098: -Xrunjdwp fails on static JDK

### DIFF
--- a/src/hotspot/share/prims/jvmtiAgent.cpp
+++ b/src/hotspot/share/prims/jvmtiAgent.cpp
@@ -360,8 +360,7 @@ void JvmtiAgent::convert_xrun_agent() {
   // If there is an JVM_OnLoad function it will get called later,
   // otherwise see if there is an Agent_OnLoad.
   if (on_load_entry == nullptr) {
-    on_load_entry = lookup_Agent_OnLoad_entry_point(
-      this, /* vm exit on error */ true);
+    on_load_entry = lookup_Agent_OnLoad_entry_point(this, /* vm exit on error */ true);
     assert(on_load_entry != nullptr, "invariant");
     _xrun = false; // converted
   }


### PR DESCRIPTION
Please review this fix that avoids `JvmtiAgent::convert_xrun_agent` from prematurely exiting VM if `lookup_On_Load_entry_point` cannot load the agent using `JVM_OnLoad` symbol. Thanks

`lookup_On_Load_entry_point` first tries to load the builtin agent from the executable by checking the requested symbol (`JVM_OnLoad`). If no builtin agent is found, it then tries to load the agent shared library (e.g. `libjdwp.so`) by calling `load_library`. The issue is that `load_library` is called with `vm_exit_on_error` set to `true`, which causes the VM to exit immediately if the agent shared library is not loaded. Therefore, `JvmtiAgent::convert_xrun_agent` has no chance to try loading the agent using `Agent_OnLoad` symbol (https://github.com/openjdk/jdk/blob/19154f7af34bf6f13d61d7a9f05d6277964845d8/src/hotspot/share/prims/jvmtiAgent.cpp#L352). This is a hidden issue on regular JDK, since the `load_library` can successfully find the agent shared library when `JvmtiAgent::convert_xrun_agent` first tries to load the agent using `JVM_OnLoad` symbol. The issue is noticed on static JDK as there is no `libjdwp.so` in static JDK. It can be reproduced with jtreg `runtime/6294277/SourceDebugExtension.java` test.

As part of the fix, I cleaned up following in `invoke_JVM_OnLoad` and `invoke_Agent_OnLoad`. If there's an error, the VM should already have exited during `lookup_<JVM|Agent>_OnLoad_entry_point` in those cases.

```
  if (on_load_entry == nullptr) {
    vm_exit_during_initialization("Could not find ... function in -Xrun library", agent->name());
  }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352098](https://bugs.openjdk.org/browse/JDK-8352098): -Xrunjdwp fails on static JDK (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [b165b86f](https://git.openjdk.org/jdk/pull/24086/files/b165b86fd2c9c5b3ffaf508b2d4f49d529869120)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24086/head:pull/24086` \
`$ git checkout pull/24086`

Update a local copy of the PR: \
`$ git checkout pull/24086` \
`$ git pull https://git.openjdk.org/jdk.git pull/24086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24086`

View PR using the GUI difftool: \
`$ git pr show -t 24086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24086.diff">https://git.openjdk.org/jdk/pull/24086.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24086#issuecomment-2730653298)
</details>
