### PR TITLE
8352178: Add precondition in VMThread::execute to prevent deadlock

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -353,7 +353,7 @@ void Handshake::execute(HandshakeClosure* hs_cl) {
 
   // The current thread must not belong to the SuspendibleThreadSet, because an
   // on-the-fly safepoint can be waiting for the current thread, and the
-  // current thread will be blocked in VMThread::execute, resulting into
+  // current thread will be blocked in VMThread::execute, resulting in
   // deadlock.
   assert(!current_thread->is_suspendible_thread(), "precondition");
   assert(!current_thread->is_indirectly_suspendible_thread(), "precondition");

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -349,16 +349,7 @@ void HandshakeOperation::do_handshake(JavaThread* thread) {
 }
 
 void Handshake::execute(HandshakeClosure* hs_cl) {
-  Thread* current_thread = Thread::current();
-
-  // The current thread must not belong to the SuspendibleThreadSet, because an
-  // on-the-fly safepoint can be waiting for the current thread, and the
-  // current thread will be blocked in VMThread::execute, resulting in
-  // deadlock.
-  assert(!current_thread->is_suspendible_thread(), "precondition");
-  assert(!current_thread->is_indirectly_suspendible_thread(), "precondition");
-
-  HandshakeOperation cto(hs_cl, nullptr, current_thread);
+  HandshakeOperation cto(hs_cl, nullptr, Thread::current());
   VM_HandshakeAllThreads handshake(&cto);
   VMThread::execute(&handshake);
 }

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -527,6 +527,13 @@ void VMThread::execute(VM_Operation* op) {
     return;
   }
 
+  // The current thread must not belong to the SuspendibleThreadSet, because an
+  // on-the-fly safepoint can be waiting for the current thread, and the
+  // current thread will be blocked in wait_until_executed, resulting in
+  // deadlock.
+  assert(!t->is_suspendible_thread(), "precondition");
+  assert(!t->is_indirectly_suspendible_thread(), "precondition");
+
   // Avoid re-entrant attempts to gc-a-lot
   SkipGCALot sgcalot(t);
 


### PR DESCRIPTION
Simple patch of adding `SuspendibleThreadSet` related precondition to `Handshake::execute` in order to prevent deadlock.
All existing callsites satisfy this precondition already.

Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352178](https://bugs.openjdk.org/browse/JDK-8352178): Add precondition in VMThread::execute to prevent deadlock (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [e9b48b70](https://git.openjdk.org/jdk/pull/24088/files/e9b48b7028683fa3a31ad21ee61e9530ca276fd1)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [7480c141](https://git.openjdk.org/jdk/pull/24088/files/7480c141f3a89f0c1b7aa4dbc7fba4360d93f155)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24088/head:pull/24088` \
`$ git checkout pull/24088`

Update a local copy of the PR: \
`$ git checkout pull/24088` \
`$ git pull https://git.openjdk.org/jdk.git pull/24088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24088`

View PR using the GUI difftool: \
`$ git pr show -t 24088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24088.diff">https://git.openjdk.org/jdk/pull/24088.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24088#issuecomment-2730708462)
</details>
