### PR TITLE
8352163: [AIX] SIGILL in AttachOperation::ReplyWriter::write_fully after 8319055

### DIFF
--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -127,9 +127,11 @@ public:
   // Called after the operation is completed.
   // If reply_writer is provided, writes the results.
   void complete() {
-    JavaThread* thread = JavaThread::current();
-    ThreadBlockInVM tbivm(thread);
-    flush_reply();
+    if (_reply_writer != nullptr) {
+      JavaThread* thread = JavaThread::current();
+      ThreadBlockInVM tbivm(thread);
+      flush_reply();
+    }
   }
 
   virtual void write(const char* str, size_t len) override {


### PR DESCRIPTION
The change fixes crash on AIX after JDK-8319055
Can't test it on AIX, but the reason is obvious from the stack trace.
AIX is the only platform that does not implement `reply_writer` yet

Testing: sanity tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352163](https://bugs.openjdk.org/browse/JDK-8352163): [AIX] SIGILL in AttachOperation::ReplyWriter::write_fully after 8319055 (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24089/head:pull/24089` \
`$ git checkout pull/24089`

Update a local copy of the PR: \
`$ git checkout pull/24089` \
`$ git pull https://git.openjdk.org/jdk.git pull/24089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24089`

View PR using the GUI difftool: \
`$ git pr show -t 24089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24089.diff">https://git.openjdk.org/jdk/pull/24089.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24089#issuecomment-2730869643)
</details>
