### PR TITLE
8352180: AttachListenerThread causes many tests to timeout on Windows

### DIFF
--- a/src/hotspot/os/windows/attachListener_windows.cpp
+++ b/src/hotspot/os/windows/attachListener_windows.cpp
@@ -92,6 +92,7 @@ public:
 
   void close() {
     if (opened()) {
+      ThreadBlockInVM tbivm(JavaThread::current());
       FlushFileBuffers(_hPipe);
       CloseHandle(_hPipe);
       _hPipe = INVALID_HANDLE_VALUE;


### PR DESCRIPTION
The change fixes regression from JDK-8319055 (see David's evaluation in the CR description)

Testing: sanity tier1;
  tier6, tier7 - in progress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352180](https://bugs.openjdk.org/browse/JDK-8352180): AttachListenerThread causes many tests to timeout on Windows (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24091/head:pull/24091` \
`$ git checkout pull/24091`

Update a local copy of the PR: \
`$ git checkout pull/24091` \
`$ git pull https://git.openjdk.org/jdk.git pull/24091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24091`

View PR using the GUI difftool: \
`$ git pr show -t 24091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24091.diff">https://git.openjdk.org/jdk/pull/24091.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24091#issuecomment-2731255347)
</details>
