### PR TITLE
8314999: IR framework fails to detect allocation

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -713,6 +713,15 @@ void CallNode::dump_spec(outputStream *st) const {
   if (_cnt != COUNT_UNKNOWN)  st->print(" C=%f",_cnt);
   if (jvms() != nullptr)  jvms()->dump_spec(st);
 }
+
+void AllocateNode::dump_spec(outputStream* st) const {
+  const Node* const klass_node = in(KlassNode);
+  if (klass_node != nullptr && klass_node->is_ConP()) {
+    st->print(" ");
+    klass_node->as_ConP()->type()->dump_on(st);
+  }
+  CallNode::dump_spec(st);
+}
 #endif
 
 const Type *CallNode::bottom_type() const { return tf()->range(); }

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -1062,6 +1062,10 @@ public:
   bool is_allocation_MemBar_redundant() { return _is_allocation_MemBar_redundant; }
 
   Node* make_ideal_mark(PhaseGVN *phase, Node* obj, Node* control, Node* mem);
+
+#ifndef PRODUCT
+  virtual void dump_spec(outputStream* st) const;
+#endif
 };
 
 //------------------------------AllocateArray---------------------------------

--- a/src/hotspot/share/opto/connode.hpp
+++ b/src/hotspot/share/opto/connode.hpp
@@ -70,7 +70,9 @@ public:
 // Simple pointer constants
 class ConPNode : public ConNode {
 public:
-  ConPNode(const TypePtr *t) : ConNode(t) {}
+  ConPNode(const TypePtr *t) : ConNode(t) {
+    init_class_id(Class_ConP);
+  }
   virtual int Opcode() const;
 
   // Factory methods:

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -73,6 +73,7 @@ class CodeBuffer;
 class ConstraintCastNode;
 class ConNode;
 class ConINode;
+class ConPNode;
 class ConvertNode;
 class CompareAndSwapNode;
 class CompareAndExchangeNode;
@@ -746,6 +747,7 @@ public:
         DEFINE_CLASS_ID(MulVL, Vector, 10)
       DEFINE_CLASS_ID(Con, Type, 8)
           DEFINE_CLASS_ID(ConI, Con, 0)
+          DEFINE_CLASS_ID(ConP, Con, 1)
       DEFINE_CLASS_ID(SafePointScalarMerge, Type, 9)
       DEFINE_CLASS_ID(Convert, Type, 10)
 
@@ -912,6 +914,7 @@ public:
   DEFINE_CLASS_QUERY(CastLL)
   DEFINE_CLASS_QUERY(CastFF)
   DEFINE_CLASS_QUERY(ConI)
+  DEFINE_CLASS_QUERY(ConP)
   DEFINE_CLASS_QUERY(CastPP)
   DEFINE_CLASS_QUERY(ConstraintCast)
   DEFINE_CLASS_QUERY(ClearArray)

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -342,26 +342,26 @@ public class IRNode {
 
     public static final String ALLOC = PREFIX + "ALLOC" + POSTFIX;
     static {
-        String optoRegex = "(.*precise .*\\R((.*(?i:mov|mv|xorl|nop|spill).*|\\s*)\\R)*.*(?i:call,static).*wrapper for: C2 Runtime new_instance" + END;
-        allocNodes(ALLOC, "Allocate", optoRegex);
+        String regex = START + "Allocate\\b" + MID + END;
+        macroNodes(ALLOC, regex);
     }
 
     public static final String ALLOC_OF = COMPOSITE_PREFIX + "ALLOC_OF" + POSTFIX;
     static {
-        String regex = "(.*precise .*" + IS_REPLACED + ":.*\\R((.*(?i:mov|mv|xorl|nop|spill).*|\\s*)\\R)*.*(?i:call,static).*wrapper for: C2 Runtime new_instance" + END;
-        optoOnly(ALLOC_OF, regex);
+        String regex = START + "Allocate\\b" + MID + "precise .*\\b" + IS_REPLACED + ":.*" + END;
+        macroNodes(ALLOC_OF, regex);
     }
 
     public static final String ALLOC_ARRAY = PREFIX + "ALLOC_ARRAY" + POSTFIX;
     static {
-        String optoRegex = "(.*precise \\[.*\\R((.*(?i:mov|mv|xor|nop|spill).*|\\s*|.*(LGHI|LI).*)\\R)*.*(?i:call,static).*wrapper for: C2 Runtime new_array" + END;
-        allocNodes(ALLOC_ARRAY, "AllocateArray", optoRegex);
+        String regex = START + "AllocateArray\\b" + MID + END;
+        macroNodes(ALLOC_ARRAY,  regex);
     }
 
     public static final String ALLOC_ARRAY_OF = COMPOSITE_PREFIX + "ALLOC_ARRAY_OF" + POSTFIX;
     static {
-        String regex = "(.*precise \\[.*" + IS_REPLACED + ":.*\\R((.*(?i:mov|mv|xorl|nop|spill).*|\\s*|.*(LGHI|LI).*)\\R)*.*(?i:call,static).*wrapper for: C2 Runtime new_array" + END;
-        optoOnly(ALLOC_ARRAY_OF, regex);
+        String regex = START + "AllocateArray\\b" + MID + "precise \\[.*\\b" + IS_REPLACED + ":.*" + END;
+        macroNodes(ALLOC_ARRAY_OF, regex);
     }
 
     public static final String OR = PREFIX + "OR" + POSTFIX;
@@ -2558,12 +2558,14 @@ public class IRNode {
 
     public static final String MOD_F = PREFIX + "MOD_F" + POSTFIX;
     static {
-        macroNodes(MOD_F, "ModF");
+        String regex = START + "ModF" + MID + END;
+        macroNodes(MOD_F, regex);
     }
 
     public static final String MOD_D = PREFIX + "MOD_D" + POSTFIX;
     static {
-        macroNodes(MOD_D, "ModD");
+        String regex = START + "ModD" + MID + END;
+        macroNodes(MOD_D, regex);
     }
 
     /*
@@ -2601,21 +2603,10 @@ public class IRNode {
         VECTOR_NODE_TYPE.put(irNodePlaceholder, typeString);
     }
 
-    private static void allocNodes(String irNode, String irNodeName, String optoRegex) {
-        String idealIndependentRegex = START + irNodeName + "\\b" + MID + END;
-        Map<PhaseInterval, String> intervalToRegexMap = new HashMap<>();
-        intervalToRegexMap.put(new PhaseInterval(CompilePhase.BEFORE_REMOVEUSELESS, CompilePhase.PHASEIDEALLOOP_ITERATIONS),
-                               idealIndependentRegex);
-        intervalToRegexMap.put(new PhaseInterval(CompilePhase.PRINT_OPTO_ASSEMBLY), optoRegex);
-        MultiPhaseRangeEntry entry = new MultiPhaseRangeEntry(CompilePhase.PRINT_OPTO_ASSEMBLY, intervalToRegexMap);
-        IR_NODE_MAPPINGS.put(irNode, entry);
-    }
-
     /**
      * Apply {@code regex} on all ideal graph phases up to and including {@link CompilePhase#BEFORE_MACRO_EXPANSION}.
      */
-    private static void macroNodes(String irNodePlaceholder, String irNodeRegex) {
-        String regex = START + irNodeRegex + MID + END;
+    private static void macroNodes(String irNodePlaceholder, String regex) {
         IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.BEFORE_MACRO_EXPANSION, regex,
                                                                           CompilePhase.BEFORE_STRINGOPTS,
                                                                           CompilePhase.BEFORE_MACRO_EXPANSION));


### PR DESCRIPTION
Bring the `ALLOC(_ARRAY)?(_OF)?` IR framework regex in the modern era!

Rather than matching on the OptoAssembly, we now match before macro expansion.
Ideed, matching on OptoAssembly is fragile: between the register being assigned
the class to allocate and the actual call to `_new_instance_Java`, there might
be register spill, making the match hard, and fragile. Now, these regex are
applied before macro expansion.

To make that work, I needed to adapt the dump_spec of `AllocateNode` to print
the allocated class, in case it is a precise constant. This is also nice to have
as a human reading the output.

The new feature is also slightly more precise in case we want to match the
allocation of a given class (that is `ALLOC(_ARRAY)?_OF`). It used to be along
the lines of:
```
"precise .*" + IS_REPLACED + ":"
```
which is actually too lenient: it only assert the suffix is what is expected.
On the plus side, if we wanted to have `MyClass`, then `some/package/MyClass`
would match, but on the other hand, `ItLooksLikeButIsNotMyClass` would also
match. The new regex use a word boundary:
```
"precise .*\\b" + IS_REPLACED + ":"
```
which make it a bit more specific: the given name cannot be extended with only
letters: there must be a non-letter char. For instance,
`ItLooksLikeButIsNotMyClass` wouldn't work anymore, since there is no word
boundary between `ItLooksLikeButIsNot` and `MyClass`.

It is not quite fool-proof since a package path can still be extended, e.g.
```
@IR(counts = {IRNode.ALLOC_OF, "some/package/MyClass", "1"})
```
will also match allocations of `a/prefix/some/package/MyClass`.

I think it's an acceptable limitation.
