### PR TITLE
8352248: Check if CMoveX is supported

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -843,7 +843,7 @@ Node *PhaseIdealLoop::conditional_move( Node *region ) {
         break;
       }
     }
-    if (phi == nullptr || _igvn.type(phi) == Type::TOP) {
+    if (phi == nullptr || _igvn.type(phi) == Type::TOP || !CMoveNode::supported(_igvn.type(phi))) {
       break;
     }
     // Move speculative ops

--- a/src/hotspot/share/opto/movenode.cpp
+++ b/src/hotspot/share/opto/movenode.cpp
@@ -200,6 +200,21 @@ CMoveNode* CMoveNode::make(Node* bol, Node* left, Node* right, const Type* t) {
   }
 }
 
+bool CMoveNode::supported(const Type* t) {
+  switch( t->basic_type() ) {
+    case T_INT:     return Matcher::match_rule_supported(Op_CMoveI);
+    case T_FLOAT:   return Matcher::match_rule_supported(Op_CMoveF);
+    case T_DOUBLE:  return Matcher::match_rule_supported(Op_CMoveD);
+    case T_LONG:    return Matcher::match_rule_supported(Op_CMoveL);
+    case T_OBJECT:  return Matcher::match_rule_supported(Op_CMoveP);
+    case T_ADDRESS: return Matcher::match_rule_supported(Op_CMoveP);
+    case T_NARROWOOP: return Matcher::match_rule_supported(Op_CMoveN);
+    default:
+    ShouldNotReachHere();
+    return false;
+  }
+}
+
 // Try to identify min/max patterns in CMoves
 Node* CMoveNode::Ideal_minmax(PhaseGVN* phase, CMoveNode* cmove) {
   // Only create MinL/MaxL if we are allowed to create macro nodes.

--- a/src/hotspot/share/opto/movenode.cpp
+++ b/src/hotspot/share/opto/movenode.cpp
@@ -186,7 +186,7 @@ const Type* CMoveNode::Value(PhaseGVN* phase) const {
 // Make a correctly-flavored CMove.  Since _type is directly determined
 // from the inputs we do not need to specify it here.
 CMoveNode* CMoveNode::make(Node* bol, Node* left, Node* right, const Type* t) {
-  switch( t->basic_type() ) {
+  switch (t->basic_type()) {
     case T_INT:     return new CMoveINode(bol, left, right, t->is_int());
     case T_FLOAT:   return new CMoveFNode(bol, left, right, t);
     case T_DOUBLE:  return new CMoveDNode(bol, left, right, t);
@@ -195,13 +195,13 @@ CMoveNode* CMoveNode::make(Node* bol, Node* left, Node* right, const Type* t) {
     case T_ADDRESS: return new CMovePNode(bol, left, right, t->is_ptr());
     case T_NARROWOOP: return new CMoveNNode(bol, left, right, t);
     default:
-    ShouldNotReachHere();
-    return nullptr;
+      ShouldNotReachHere();
+      return nullptr;
   }
 }
 
 bool CMoveNode::supported(const Type* t) {
-  switch( t->basic_type() ) {
+  switch (t->basic_type()) {
     case T_INT:     return Matcher::match_rule_supported(Op_CMoveI);
     case T_FLOAT:   return Matcher::match_rule_supported(Op_CMoveF);
     case T_DOUBLE:  return Matcher::match_rule_supported(Op_CMoveD);
@@ -210,8 +210,8 @@ bool CMoveNode::supported(const Type* t) {
     case T_ADDRESS: return Matcher::match_rule_supported(Op_CMoveP);
     case T_NARROWOOP: return Matcher::match_rule_supported(Op_CMoveN);
     default:
-    ShouldNotReachHere();
-    return false;
+      ShouldNotReachHere();
+      return false;
   }
 }
 

--- a/src/hotspot/share/opto/movenode.hpp
+++ b/src/hotspot/share/opto/movenode.hpp
@@ -48,6 +48,7 @@ class CMoveNode : public TypeNode {
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
   static CMoveNode* make(Node* bol, Node* left, Node* right, const Type* t);
+  static bool supported(const Type* t);
   // Helper function to spot cmove graph shapes
   static Node* is_cmove_id(PhaseTransform* phase, Node* cmp, Node* t, Node* f, BoolNode* b);
   static Node* Ideal_minmax(PhaseGVN* phase, CMoveNode* cmov);


### PR DESCRIPTION
Hi,
Can you help to review this patch?

Currenlty, seems CMoveX are fully supported on most platforms, except of riscv64.
On riscv64, there is no efficient way to implement CMoveF/D as other CMoveX (e.g. CMoveI), but it will still bring benefit by just supporting CMoveX without CMoveF/D. This patch is to supply such option.

As other platforms already supported CMoveX, this patch should not impact them, as `!CMoveNode::supported(_igvn.type(phi))` should always be false.

BTW, in a subsequent pr for riscv, I'll implement CMoveX except of CMoveF/D, and also return false for CMoveF/D in Matcher::match_rule_supported.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352248](https://bugs.openjdk.org/browse/JDK-8352248): Check if CMoveX is supported (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24095/head:pull/24095` \
`$ git checkout pull/24095`

Update a local copy of the PR: \
`$ git checkout pull/24095` \
`$ git pull https://git.openjdk.org/jdk.git pull/24095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24095`

View PR using the GUI difftool: \
`$ git pr show -t 24095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24095.diff">https://git.openjdk.org/jdk/pull/24095.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24095#issuecomment-2733067136)
</details>
