### PR TITLE
8339114: DaCapo xalan performance with -XX:+UseObjectMonitorTable

### DIFF
--- a/src/hotspot/share/runtime/basicLock.cpp
+++ b/src/hotspot/share/runtime/basicLock.cpp
@@ -27,7 +27,7 @@
 #include "runtime/objectMonitor.hpp"
 #include "runtime/synchronizer.hpp"
 
-void BasicLock::print_on(outputStream* st, oop owner) const {
+void BasicLock::print_on(outputStream* st, oop owner) {
   st->print("monitor");
   if (UseObjectMonitorTable) {
     ObjectMonitor* mon = object_monitor_cache();

--- a/src/hotspot/share/runtime/basicLock.hpp
+++ b/src/hotspot/share/runtime/basicLock.hpp
@@ -61,12 +61,12 @@ class BasicLock {
   static int displaced_header_offset_in_bytes() { return metadata_offset_in_bytes(); }
 
   // LM_LIGHTWEIGHT
-  inline ObjectMonitor* object_monitor_cache() const;
+  inline ObjectMonitor* object_monitor_cache();
   inline void clear_object_monitor_cache();
   inline void set_object_monitor_cache(ObjectMonitor* mon);
   static int object_monitor_cache_offset_in_bytes() { return metadata_offset_in_bytes(); }
 
-  void print_on(outputStream* st, oop owner) const;
+  void print_on(outputStream* st, oop owner);
 
   // move a basic lock (used during deoptimization)
   void move_to(oop obj, BasicLock* dest);

--- a/src/hotspot/share/runtime/basicLock.hpp
+++ b/src/hotspot/share/runtime/basicLock.hpp
@@ -50,6 +50,8 @@ class BasicLock {
   static int metadata_offset_in_bytes() { return (int)offset_of(BasicLock, _metadata); }
 
  public:
+  BasicLock() : _metadata(0) {}
+
   // LM_MONITOR
   void set_bad_metadata_deopt() { set_metadata(badDispHeaderDeopt); }
 

--- a/src/hotspot/share/runtime/basicLock.inline.hpp
+++ b/src/hotspot/share/runtime/basicLock.inline.hpp
@@ -26,6 +26,7 @@
 #define SHARE_RUNTIME_BASICLOCK_INLINE_HPP
 
 #include "runtime/basicLock.hpp"
+#include "runtime/objectMonitor.hpp"
 
 inline markWord BasicLock::displaced_header() const {
   assert(LockingMode == LM_LEGACY, "must be");
@@ -37,10 +38,15 @@ inline void BasicLock::set_displaced_header(markWord header) {
   Atomic::store(&_metadata, header.value());
 }
 
-inline ObjectMonitor* BasicLock::object_monitor_cache() const {
+inline ObjectMonitor* BasicLock::object_monitor_cache() {
   assert(UseObjectMonitorTable, "must be");
 #if !defined(ZERO) && (defined(X86) || defined(AARCH64) || defined(RISCV64) || defined(PPC64) || defined(S390))
-  return reinterpret_cast<ObjectMonitor*>(get_metadata());
+  ObjectMonitor* monitor = reinterpret_cast<ObjectMonitor*>(get_metadata());
+  if (monitor != nullptr && monitor->is_being_async_deflated()) {
+    clear_object_monitor_cache();
+    return nullptr;
+  }
+  return monitor;
 #else
   // Other platforms do not make use of the cache yet,
   // and are not as careful with maintaining the invariant

--- a/src/hotspot/share/runtime/basicLock.inline.hpp
+++ b/src/hotspot/share/runtime/basicLock.inline.hpp
@@ -26,7 +26,7 @@
 #define SHARE_RUNTIME_BASICLOCK_INLINE_HPP
 
 #include "runtime/basicLock.hpp"
-#include "runtime/objectMonitor.hpp"
+#include "runtime/objectMonitor.inline.hpp"
 
 inline markWord BasicLock::displaced_header() const {
   assert(LockingMode == LM_LEGACY, "must be");

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -509,7 +509,6 @@ class LightweightSynchronizer::CacheSetter : StackObj {
   JavaThread* const _thread;
   BasicLock* const _lock;
   ObjectMonitor* _monitor;
-  bool _hit;
 
   NONCOPYABLE(CacheSetter);
 
@@ -517,15 +516,13 @@ class LightweightSynchronizer::CacheSetter : StackObj {
   CacheSetter(JavaThread* thread, BasicLock* lock) :
     _thread(thread),
     _lock(lock),
-    _monitor(nullptr), _hit(false) {}
+    _monitor(nullptr) {}
 
   ~CacheSetter() {
     // Only use the cache if using the table.
     if (UseObjectMonitorTable) {
       if (_monitor != nullptr) {
-        if (!_hit) {
-          _thread->om_set_monitor_cache(_monitor);
-        }
+        _thread->om_set_monitor_cache(_monitor);
         _lock->set_object_monitor_cache(_monitor);
       } else {
         _lock->clear_object_monitor_cache();
@@ -533,9 +530,8 @@ class LightweightSynchronizer::CacheSetter : StackObj {
     }
   }
 
-  void set_monitor(ObjectMonitor* monitor, bool hit = false) {
+  void set_monitor(ObjectMonitor* monitor) {
     assert(_monitor == nullptr, "only set once");
-    _hit = hit;
     _monitor = monitor;
   }
 

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -752,7 +752,7 @@ void LightweightSynchronizer::exit(oop object, BasicLock* lock, JavaThread* curr
       }
     }
   } else {
-    monitor = ObjectSynchronizer::read_monitor(current, object, mark);
+    monitor = ObjectSynchronizer::read_monitor(mark);
   }
   if (monitor->has_anonymous_owner()) {
     assert(current->lock_stack().contains(object), "current must have object on its lock stack");

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -746,7 +746,7 @@ void LightweightSynchronizer::exit(oop object, BasicLock* lock, JavaThread* curr
   if (UseObjectMonitorTable) {
     monitor = lock->object_monitor_cache();
     if (monitor == nullptr) {
-      monitor = JavaThread::cast(current)->om_get_from_monitor_cache(object);
+      monitor = current->om_get_from_monitor_cache(object);
       if (monitor == nullptr) {
         monitor = get_monitor_from_table(current, object);
       }

--- a/src/hotspot/share/runtime/lightweightSynchronizer.hpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.hpp
@@ -61,12 +61,12 @@ class LightweightSynchronizer : AllStatic {
  public:
   static void enter_for(Handle obj, BasicLock* lock, JavaThread* locking_thread);
   static void enter(Handle obj, BasicLock* lock, JavaThread* current);
-  static void exit(oop object, JavaThread* current);
+  static void exit(oop object, BasicLock* lock, JavaThread* current);
 
   static ObjectMonitor* inflate_into_object_header(oop object, ObjectSynchronizer::InflateCause cause, JavaThread* locking_thread, Thread* current);
   static ObjectMonitor* inflate_locked_or_imse(oop object, ObjectSynchronizer::InflateCause cause, TRAPS);
   static ObjectMonitor* inflate_fast_locked_object(oop object, ObjectSynchronizer::InflateCause cause, JavaThread* locking_thread, JavaThread* current);
-  static ObjectMonitor* inflate_and_enter(oop object, ObjectSynchronizer::InflateCause cause, JavaThread* locking_thread, JavaThread* current);
+  static ObjectMonitor* inflate_and_enter(oop object, BasicLock* lock, ObjectSynchronizer::InflateCause cause, JavaThread* locking_thread, JavaThread* current);
 
   static void deflate_monitor(Thread* current, oop obj, ObjectMonitor* monitor);
 

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -149,6 +149,7 @@ class ObjectWaiter : public CHeapObj<mtThread> {
 #define OM_CACHE_LINE_SIZE DEFAULT_CACHE_LINE_SIZE
 
 class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
+  friend class LightweightSynchronizer;
   friend class ObjectSynchronizer;
   friend class ObjectWaiter;
   friend class VMStructs;

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -682,7 +682,8 @@ void ObjectSynchronizer::jni_enter(Handle obj, JavaThread* current) {
     ObjectMonitor* monitor;
     bool entered;
     if (LockingMode == LM_LIGHTWEIGHT) {
-      entered = LightweightSynchronizer::inflate_and_enter(obj(), inflate_cause_jni_enter, current, current) != nullptr;
+      BasicLock lock;
+      entered = LightweightSynchronizer::inflate_and_enter(obj(), &lock, inflate_cause_jni_enter, current, current) != nullptr;
     } else {
       monitor = inflate(current, obj(), inflate_cause_jni_enter);
       entered = monitor->enter(current);

--- a/src/hotspot/share/runtime/synchronizer.inline.hpp
+++ b/src/hotspot/share/runtime/synchronizer.inline.hpp
@@ -72,7 +72,7 @@ inline void ObjectSynchronizer::exit(oop object, BasicLock* lock, JavaThread* cu
   current->dec_held_monitor_count();
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    LightweightSynchronizer::exit(object, current);
+    LightweightSynchronizer::exit(object, lock, current);
   } else {
     exit_legacy(object, lock, current);
   }


### PR DESCRIPTION
- When successfully looked up an OM in the OMCache, then make it avaiable in the BasicLock cache. Use that cache whenever possible.
- When successfully looked up an OM in the OMCache, then don't push-back the OM on that cache to avoid shuffling the cache on each monitor enter.
- In the runtime path of monitorexit, attempt to use the BasicLock cache, then the OMCache, and only look up in the table when the caches failed.
- Some small code shufflings.

I did 50 runs of xalan, each of which do 10 warmup iterations before doing one measurement. The following results are the averages of the measurement iterations across the 50 runs:
without-OMT: 773.3 ms
with-OMT: 797.28 ms

That is still a regression of ~3%

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339114](https://bugs.openjdk.org/browse/JDK-8339114): DaCapo xalan performance with -XX:+UseObjectMonitorTable (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24098/head:pull/24098` \
`$ git checkout pull/24098`

Update a local copy of the PR: \
`$ git checkout pull/24098` \
`$ git pull https://git.openjdk.org/jdk.git pull/24098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24098`

View PR using the GUI difftool: \
`$ git pr show -t 24098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24098.diff">https://git.openjdk.org/jdk/pull/24098.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24098#issuecomment-2747778307)
</details>
