### PR TITLE
8352276: Skip jtreg tests using native executable with libjvm.so/libjli.so dependencies on static JDK

### DIFF
--- a/test/hotspot/jtreg/runtime/StackGap/TestStackGap.java
+++ b/test/hotspot/jtreg/runtime/StackGap/TestStackGap.java
@@ -27,6 +27,7 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @requires os.family == "linux"
+ * @requires !jdk.static
  * @compile T.java
  * @run main/native TestStackGap
  */

--- a/test/hotspot/jtreg/runtime/StackGuardPages/TestStackGuardPages.java
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/TestStackGuardPages.java
@@ -27,6 +27,7 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @requires os.family == "linux"
+ * @requires !jdk.static
  * @compile DoOverflow.java
  * @run main/native TestStackGuardPages
  */

--- a/test/hotspot/jtreg/runtime/TLS/TestTLS.java
+++ b/test/hotspot/jtreg/runtime/TLS/TestTLS.java
@@ -28,6 +28,7 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @requires os.family == "linux"
+ * @requires !jdk.static
  * @compile T.java
  * @run main/native TestTLS
  */

--- a/test/hotspot/jtreg/runtime/jni/daemonDestroy/TestDaemonDestroy.java
+++ b/test/hotspot/jtreg/runtime/jni/daemonDestroy/TestDaemonDestroy.java
@@ -29,6 +29,7 @@
  *          a daemon and non-daemon thread. The result should be the same in
  *          both cases.
  * @requires vm.flagless
+ * @requires !jdk.static
  * @library /test/lib
  * @build Main
  * @run main/native TestDaemonDestroy

--- a/test/hotspot/jtreg/runtime/jni/getCreatedJavaVMs/TestGetCreatedJavaVMs.java
+++ b/test/hotspot/jtreg/runtime/jni/getCreatedJavaVMs/TestGetCreatedJavaVMs.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib
  * @requires os.family != "Windows"
+ * @requires !jdk.static
  * @run driver TestGetCreatedJavaVMs
  */
 import jdk.test.lib.Utils;

--- a/test/jdk/java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java
+++ b/test/jdk/java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8221530 8221642
  * @library /test/lib
+ * @requires !jdk.static
  * @run main/native CallerAccessTest
  */
 

--- a/test/jdk/jni/nullCaller/NullCallerTest.java
+++ b/test/jdk/jni/nullCaller/NullCallerTest.java
@@ -28,6 +28,7 @@
  * @summary Test uses custom launcher that starts VM using JNI that verifies
  *          various API called with a null caller class function properly.
  * @library /test/lib
+ * @requires !jdk.static
  * @modules java.base/jdk.internal.module
  *          jdk.compiler
  * @build NullCallerTest

--- a/test/jdk/tools/launcher/JniInvocationTest.java
+++ b/test/jdk/tools/launcher/JniInvocationTest.java
@@ -27,6 +27,7 @@
  * @bug 8213362
  * @comment Test uses custom launcher that starts VM using JNI via libjli, only for MacOS
  * @requires os.family == "mac"
+ * @requires !jdk.static
  * @library /test/lib
  * @run main/native JniInvocationTest
  */


### PR DESCRIPTION
Please review this PR that adds `@requires !jdk.static` to tests, thanks.

- runtime/StackGap/TestStackGap.java
- runtime/StackGuardPages/TestStackGuardPages.java
- runtime/TLS/TestTLS.java
- runtime/jni/daemonDestroy/TestDaemonDestroy.java
- runtime/jni/getCreatedJavaVMs/TestGetCreatedJavaVMs.java
- jdk/java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java
- jdk/jni/nullCaller/NullCallerTest.java
- jdk/tools/launcher/JniInvocationTest.java

These tests use native executables that have dependencies on `libjvm.so`, `libjli.so`, etc. Static JDK does not provide the separate JDK/VM shared libraries, hence cannot support the specific testing mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352276](https://bugs.openjdk.org/browse/JDK-8352276): Skip jtreg tests using native executable with libjvm.so/libjli.so dependencies on static JDK (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24103/head:pull/24103` \
`$ git checkout pull/24103`

Update a local copy of the PR: \
`$ git checkout pull/24103` \
`$ git pull https://git.openjdk.org/jdk.git pull/24103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24103`

View PR using the GUI difftool: \
`$ git pr show -t 24103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24103.diff">https://git.openjdk.org/jdk/pull/24103.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24103#issuecomment-2734429056)
</details>
