### PR TITLE
8352299: GenShen: Young cycles that interrupt old cycles cannot be cancelled

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2140,8 +2140,8 @@ size_t ShenandoahHeap::tlab_used(Thread* thread) const {
 }
 
 bool ShenandoahHeap::try_cancel_gc(GCCause::Cause cause) {
-  jbyte prev = _cancelled_gc.cmpxchg(cause, GCCause::_no_gc);
-  return prev == GCCause::_no_gc;
+  const jbyte prev = _cancelled_gc.xchg(cause);
+  return prev == GCCause::_no_gc || prev == GCCause::_shenandoah_concurrent_gc;
 }
 
 void ShenandoahHeap::cancel_concurrent_mark() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahSharedVariables.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSharedVariables.hpp
@@ -236,6 +236,13 @@ struct ShenandoahSharedEnumFlag {
     return (T)Atomic::cmpxchg(&value, (ShenandoahSharedValue)expected, (ShenandoahSharedValue)new_value);
   }
 
+  T xchg(T new_value) {
+    assert (new_value >= 0, "sanity");
+    assert (new_value < (sizeof(ShenandoahSharedValue) * CHAR_MAX), "sanity");
+    // Hmm, no platform template specialization defined for exchanging one byte... (up cast to intptr is workaround).
+    return (T)Atomic::xchg((intptr_t*)&value, (intptr_t)new_value);
+  }
+
   volatile ShenandoahSharedValue* addr_of() {
     return &value;
   }


### PR DESCRIPTION
The sequence of events that creates this state:
1. An old collection is trying to finish marking by flushing SATB buffers with a Handshake
2. The regulator thread cancels old marking to start a young collection
3. A mutator thread shortly follows and attempts to cancel the nascent young collection
4. Step `3` fails (because of this bug) and cancellation reason does _not_ become `allocation failure`
5. The mutator thread enters a tight loop in which it retries allocations without `waiting`
6. The mutator thread remains in the `thread_in_vm` state and prevents the VM thread from completing step `1`.