### PR TITLE
8352316: More MergeStoreBench

### DIFF
--- a/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
@@ -58,6 +58,10 @@ public class MergeStoreBench {
             ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN ? StandardCharsets.UTF_16BE : StandardCharsets.UTF_16LE);
     private static final int STR_4_BYTES_LATIN1_INT = UNSAFE.getInt(STR_4_BYTES_LATIN1, Unsafe.ARRAY_BYTE_BASE_OFFSET);
     private static final long STR_4_BYTES_UTF16_LONG = UNSAFE.getLong(STR_4_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET);
+    private static final byte STR_4_BYTES_LATIN1_BYTE_0 = STR_4_BYTES_LATIN1[0];
+    private static final byte STR_4_BYTES_LATIN1_BYTE_1 = STR_4_BYTES_LATIN1[1];
+    private static final byte STR_4_BYTES_LATIN1_BYTE_2 = STR_4_BYTES_LATIN1[2];
+    private static final byte STR_4_BYTES_LATIN1_BYTE_3 = STR_4_BYTES_LATIN1[3];
 
     private static final String STR_5 = "false";
     private static final byte[] STR_5_BYTES_LATIN1 = STR_5.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1);
@@ -67,6 +71,11 @@ public class MergeStoreBench {
     private static final byte STR_5_BYTES_LATIN1_BYTE = STR_5_BYTES_LATIN1[4];
     private static final long STR_5_BYTES_UTF16_LONG = UNSAFE.getLong(STR_5_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET);
     private static final short STR_5_BYTES_UTF16_SHORT = UNSAFE.getShort(STR_5_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET + 8);
+    private static final byte STR_5_BYTES_LATIN1_BYTE_0 = STR_5_BYTES_LATIN1[0];
+    private static final byte STR_5_BYTES_LATIN1_BYTE_1 = STR_5_BYTES_LATIN1[1];
+    private static final byte STR_5_BYTES_LATIN1_BYTE_2 = STR_5_BYTES_LATIN1[2];
+    private static final byte STR_5_BYTES_LATIN1_BYTE_3 = STR_5_BYTES_LATIN1[3];
+    private static final byte STR_5_BYTES_LATIN1_BYTE_4 = STR_5_BYTES_LATIN1[4];
 
     private static final String STR_7 = "truefalse";
     private static final byte[] STR_7_BYTES_LATIN1 = STR_7.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1);
@@ -78,6 +87,14 @@ public class MergeStoreBench {
     private static final long STR_7_BYTES_UTF16_LONG = UNSAFE.getLong(STR_7_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET);
     private static final int STR_7_BYTES_UTF16_INT = UNSAFE.getInt(STR_7_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET + 8);
     private static final short STR_7_BYTES_UTF16_SHORT = UNSAFE.getShort(STR_7_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET + 12);
+    private static final byte STR_7_BYTES_LATIN1_BYTE_0 = STR_7_BYTES_LATIN1[0];
+    private static final byte STR_7_BYTES_LATIN1_BYTE_1 = STR_7_BYTES_LATIN1[1];
+    private static final byte STR_7_BYTES_LATIN1_BYTE_2 = STR_7_BYTES_LATIN1[2];
+    private static final byte STR_7_BYTES_LATIN1_BYTE_3 = STR_7_BYTES_LATIN1[3];
+    private static final byte STR_7_BYTES_LATIN1_BYTE_4 = STR_7_BYTES_LATIN1[4];
+    private static final byte STR_7_BYTES_LATIN1_BYTE_5 = STR_7_BYTES_LATIN1[5];
+    private static final byte STR_7_BYTES_LATIN1_BYTE_6 = STR_7_BYTES_LATIN1[6];
+
 
     final static int NUMBERS = 8192;
 
@@ -85,12 +102,12 @@ public class MergeStoreBench {
     final byte[] bytes5 = new byte[NUMBERS * 5];
     final byte[] bytes8 = new byte[NUMBERS * 8];
     final byte[] bytes10 = new byte[NUMBERS * 10];
-    final byte[] bytes14 = new byte[NUMBERS * 14];
+    final byte[] bytes16 = new byte[NUMBERS * 16];
     final int [] ints   = new int [NUMBERS    ];
     final long[] longs  = new long[NUMBERS    ];
     final char[] chars  = new char[NUMBERS    ];
     final char[] chars5 = new char[NUMBERS * 5];
-    final char[] chars7 = new char[NUMBERS * 7];
+    final char[] chars10 = new char[NUMBERS * 10];
     final StringBuilder sb = new StringBuilder(NUMBERS * 7);
     final StringBuilder sb_utf16 = new StringBuilder(NUMBERS * 14).append('\u4e2d');
 
@@ -541,6 +558,22 @@ public class MergeStoreBench {
     }
 
     /**
+     * Test the performance of array set 4 constant byte, used as a benchmark for comparison with other str4 Benchmarks
+     */
+    @Benchmark
+    public void str4ArraySetConst(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            bytes5[off    ] = STR_4_BYTES_LATIN1_BYTE_0;
+            bytes5[off + 1] = STR_4_BYTES_LATIN1_BYTE_1;
+            bytes5[off + 2] = STR_4_BYTES_LATIN1_BYTE_2;
+            bytes5[off + 3] = STR_4_BYTES_LATIN1_BYTE_3;
+            off += 5; // disable auto vector
+        }
+        BH.consume(off);
+    }
+
+    /**
      * Test whether a constant byte[] with a length of 4 is MergeStored when arraycopy is called
      */
     @Benchmark
@@ -593,14 +626,30 @@ public class MergeStoreBench {
     }
 
     /**
+     * Test the performance of array set 4 constant byte, used as a benchmark for comparison with other str4 Benchmarks
+     */
+    @Benchmark
+    public void str4Utf16ArraySetConst(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            chars5[off    ] = (char) STR_4_BYTES_LATIN1_BYTE_0;
+            chars5[off + 1] = (char) STR_4_BYTES_LATIN1_BYTE_1;
+            chars5[off + 2] = (char) STR_4_BYTES_LATIN1_BYTE_2;
+            chars5[off + 3] = (char) STR_4_BYTES_LATIN1_BYTE_3;
+            off += 5; // disable auto vector
+        }
+        BH.consume(off);
+    }
+
+    /**
      * Test the performance of putLong for comparison with other str4Utf16 benchmarks
      */
     @Benchmark
     public void str4Utf16UnsafePut(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            UNSAFE.putLong(bytes10, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_4_BYTES_UTF16_LONG);
-            off += 10; // disable auto vector
+            UNSAFE.putLong(bytes16, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_4_BYTES_UTF16_LONG);
+            off += 9; // disable auto vector
         }
         BH.consume(off);
     }
@@ -612,8 +661,8 @@ public class MergeStoreBench {
     public void str4Utf16ArrayCopy(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            System.arraycopy(STR_4_BYTES_UTF16, 0, bytes10, off, 8);
-            off += 10;
+            System.arraycopy(STR_4_BYTES_UTF16, 0, bytes16, off, 8);
+            off += 9; // disable auto vector
         }
         BH.consume(off);
     }
@@ -639,8 +688,25 @@ public class MergeStoreBench {
     public void str5GetBytes(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            STR_5.getBytes(0, 4, bytes5, off);
-            off += 5;
+            STR_5.getBytes(0, 4, bytes8, off);
+            off += 6; // disable auto vector
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test the performance of array set 5 constant byte, used as a benchmark for comparison with other str5 Benchmarks
+     */
+    @Benchmark
+    public void str5ArraySetConst(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            bytes8[off    ] = STR_7_BYTES_LATIN1_BYTE_0;
+            bytes8[off + 1] = STR_7_BYTES_LATIN1_BYTE_1;
+            bytes8[off + 2] = STR_7_BYTES_LATIN1_BYTE_2;
+            bytes8[off + 3] = STR_7_BYTES_LATIN1_BYTE_3;
+            bytes8[off + 4] = STR_7_BYTES_LATIN1_BYTE_4;
+            off += 6; // disable auto vector
         }
         BH.consume(off);
     }
@@ -652,8 +718,8 @@ public class MergeStoreBench {
     public void str5Arraycopy(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            System.arraycopy(STR_5_BYTES_LATIN1, 0, bytes5, off, 5);
-            off += 5;
+            System.arraycopy(STR_5_BYTES_LATIN1, 0, bytes8, off, 5);
+            off += 6; // disable auto vector
         }
         BH.consume(off);
     }
@@ -667,7 +733,7 @@ public class MergeStoreBench {
         for (int i = 0; i < NUMBERS; i++) {
             UNSAFE.putInt(bytes5, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_5_BYTES_LATIN1_INT);
             UNSAFE.putByte(bytes5, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 4, STR_5_BYTES_LATIN1_BYTE);
-            off += 5;
+            off += 6; // disable auto vector
         }
         BH.consume(off);
     }
@@ -692,8 +758,8 @@ public class MergeStoreBench {
     public void str5GetChars(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            STR_5.getChars(0, 5, chars5, off);
-            off += 5;
+            STR_5.getChars(0, 5, chars10, off);
+            off += 6; // disable auto vector
         }
         BH.consume(off);
     }
@@ -705,9 +771,26 @@ public class MergeStoreBench {
     public void str5Utf16UnsafePut(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            UNSAFE.putLong(bytes10, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_5_BYTES_UTF16_LONG);
-            UNSAFE.putShort(bytes10, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 8, STR_5_BYTES_UTF16_SHORT);
-            off += 10;
+            UNSAFE.putLong(bytes16, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_5_BYTES_UTF16_LONG);
+            UNSAFE.putShort(bytes16, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 8, STR_5_BYTES_UTF16_SHORT);
+            off += 11; // disable auto vector
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test the performance of array set 5 constant char, used as a benchmark for comparison with other str5 Benchmarks
+     */
+    @Benchmark
+    public void str5Utf16ArraySetConst(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            chars10[off    ] = (char) STR_5_BYTES_LATIN1_BYTE_0;
+            chars10[off + 1] = (char) STR_5_BYTES_LATIN1_BYTE_1;
+            chars10[off + 2] = (char) STR_5_BYTES_LATIN1_BYTE_2;
+            chars10[off + 3] = (char) STR_5_BYTES_LATIN1_BYTE_3;
+            chars10[off + 4] = (char) STR_5_BYTES_LATIN1_BYTE_4;
+            off += 6; // disable auto vector
         }
         BH.consume(off);
     }
@@ -719,8 +802,8 @@ public class MergeStoreBench {
     public void str5Utf16ArrayCopy(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            System.arraycopy(STR_5_BYTES_UTF16, 0, bytes10, off, 10);
-            off += 10;
+            System.arraycopy(STR_5_BYTES_UTF16, 0, bytes16, off, 10);
+            off += 11; // disable auto vector
         }
         BH.consume(off);
     }
@@ -746,8 +829,27 @@ public class MergeStoreBench {
     public void str7GetBytes(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            STR_7.getBytes(0, 7, bytes8, off);
-            off += 7;
+            STR_7.getBytes(0, 7, bytes10, off);
+            off += 9; // disable auto vector
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test the performance of array set 7 constant byte, used as a benchmark for comparison with other str7 Benchmarks
+     */
+    @Benchmark
+    public void str7ArraySetConst(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            bytes10[off    ] = STR_7_BYTES_LATIN1_BYTE_0;
+            bytes10[off + 1] = STR_7_BYTES_LATIN1_BYTE_1;
+            bytes10[off + 2] = STR_7_BYTES_LATIN1_BYTE_2;
+            bytes10[off + 3] = STR_7_BYTES_LATIN1_BYTE_3;
+            bytes10[off + 4] = STR_7_BYTES_LATIN1_BYTE_4;
+            bytes10[off + 5] = STR_7_BYTES_LATIN1_BYTE_5;
+            bytes10[off + 6] = STR_7_BYTES_LATIN1_BYTE_6;
+            off += 9; // disable auto vector
         }
         BH.consume(off);
     }
@@ -759,8 +861,8 @@ public class MergeStoreBench {
     public void str7Arraycopy(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            System.arraycopy(STR_7_BYTES_LATIN1, 0, bytes8, off, 7);
-            off += 7;
+            System.arraycopy(STR_7_BYTES_LATIN1, 0, bytes10, off, 7);
+            off += 9; // disable auto vector
         }
         BH.consume(off);
     }
@@ -772,10 +874,10 @@ public class MergeStoreBench {
     public void str7UnsafePut(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            UNSAFE.putInt(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_7_BYTES_LATIN1_INT);
-            UNSAFE.putShort(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 4, STR_7_BYTES_LATIN1_SHORT);
-            UNSAFE.putByte(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 6, STR_7_BYTES_LATIN1_BYTE);
-            off += 7;
+            UNSAFE.putInt(bytes10, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_7_BYTES_LATIN1_INT);
+            UNSAFE.putShort(bytes10, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 4, STR_7_BYTES_LATIN1_SHORT);
+            UNSAFE.putByte(bytes10, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 6, STR_7_BYTES_LATIN1_BYTE);
+            off += 9; // disable auto vector
         }
         BH.consume(off);
     }
@@ -800,8 +902,27 @@ public class MergeStoreBench {
     public void str7GetChars(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            STR_7.getChars(0, 7, chars7, off);
-            off += 7;
+            STR_7.getChars(0, 7, chars10, off);
+            off += 9; // disable auto vector
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test the performance of array set 7 constant char, used as a benchmark for comparison with other str7 Benchmarks
+     */
+    @Benchmark
+    public void str7Utf16ArraySetConst(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            chars10[off    ] = (char) STR_7_BYTES_LATIN1_BYTE_0;
+            chars10[off + 1] = (char) STR_7_BYTES_LATIN1_BYTE_1;
+            chars10[off + 2] = (char) STR_7_BYTES_LATIN1_BYTE_2;
+            chars10[off + 3] = (char) STR_7_BYTES_LATIN1_BYTE_3;
+            chars10[off + 4] = (char) STR_7_BYTES_LATIN1_BYTE_4;
+            chars10[off + 5] = (char) STR_7_BYTES_LATIN1_BYTE_5;
+            chars10[off + 6] = (char) STR_7_BYTES_LATIN1_BYTE_6;
+            off += 9; // disable auto vector
         }
         BH.consume(off);
     }
@@ -813,10 +934,10 @@ public class MergeStoreBench {
     public void str7Utf16UnsafePut(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            UNSAFE.putLong(bytes14, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_7_BYTES_UTF16_LONG);
-            UNSAFE.putInt(bytes14, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 8, STR_7_BYTES_UTF16_INT);
-            UNSAFE.putShort(bytes14, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 12, STR_7_BYTES_UTF16_SHORT);
-            off += 14;
+            UNSAFE.putLong(bytes16, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_7_BYTES_UTF16_LONG);
+            UNSAFE.putInt(bytes16, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 8, STR_7_BYTES_UTF16_INT);
+            UNSAFE.putShort(bytes16, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 12, STR_7_BYTES_UTF16_SHORT);
+            off += 15; // disable auto vector
         }
         BH.consume(off);
     }
@@ -828,8 +949,8 @@ public class MergeStoreBench {
     public void str7Utf16ArrayCopy(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            System.arraycopy(STR_7_BYTES_UTF16, 0, bytes14, off, 14);
-            off += 14;
+            System.arraycopy(STR_7_BYTES_UTF16, 0, bytes16, off, 14);
+            off += 15; // disable auto vector
         }
         BH.consume(off);
     }

--- a/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
@@ -613,6 +613,22 @@ public class MergeStoreBench {
     }
 
     /**
+     * Test whether StringBuilder is MergeStored when appending 4 constant characters
+     */
+    @Benchmark
+    public void str4StringBuilderAppendChar(Blackhole BH) {
+        sb.setLength(0);
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            sb.append((char) STR_4_BYTES_LATIN1_BYTE_0);
+            sb.append((char) STR_4_BYTES_LATIN1_BYTE_1);
+            sb.append((char) STR_4_BYTES_LATIN1_BYTE_2);
+            sb.append((char) STR_4_BYTES_LATIN1_BYTE_3);
+        }
+        BH.consume(sb.length());
+    }
+
+    /**
      * Test whether the constant String with a length of 4 calls the getChars method to mergestore
      */
     @Benchmark
@@ -676,6 +692,22 @@ public class MergeStoreBench {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
             sb_utf16.append(STR_4);
+        }
+        BH.consume(sb_utf16.length());
+    }
+
+    /**
+     * Test whether the UTF16 StringBuilder is MergeStored when appending 4 constant characters
+     */
+    @Benchmark
+    public void str4Utf16StringBuilderAppendChar(Blackhole BH) {
+        sb_utf16.setLength(0);
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            sb_utf16.append((char) STR_4_BYTES_LATIN1_BYTE_0);
+            sb_utf16.append((char) STR_4_BYTES_LATIN1_BYTE_1);
+            sb_utf16.append((char) STR_4_BYTES_LATIN1_BYTE_2);
+            sb_utf16.append((char) STR_4_BYTES_LATIN1_BYTE_3);
         }
         BH.consume(sb_utf16.length());
     }
@@ -752,6 +784,23 @@ public class MergeStoreBench {
     }
 
     /**
+     * Test whether StringBuilder is MergeStored when appending 5 constant characters
+     */
+    @Benchmark
+    public void str5StringBuilderAppendChar(Blackhole BH) {
+        sb.setLength(0);
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            sb.append((char) STR_5_BYTES_LATIN1_BYTE_0);
+            sb.append((char) STR_5_BYTES_LATIN1_BYTE_1);
+            sb.append((char) STR_5_BYTES_LATIN1_BYTE_2);
+            sb.append((char) STR_5_BYTES_LATIN1_BYTE_3);
+            sb.append((char) STR_5_BYTES_LATIN1_BYTE_4);
+        }
+        BH.consume(sb.length());
+    }
+
+    /**
      * Test whether the constant String with a length of 5 calls the getChars method to mergestore
      */
     @Benchmark
@@ -817,6 +866,23 @@ public class MergeStoreBench {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
             sb_utf16.append(STR_5);
+        }
+        BH.consume(sb_utf16.length());
+    }
+
+    /**
+     * Test whether the UTF16 StringBuilder is MergeStored when appending 5 constant characters
+     */
+    @Benchmark
+    public void str5Utf16StringBuilderAppendChar(Blackhole BH) {
+        sb_utf16.setLength(0);
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            sb_utf16.append((char) STR_5_BYTES_LATIN1_BYTE_0);
+            sb_utf16.append((char) STR_5_BYTES_LATIN1_BYTE_1);
+            sb_utf16.append((char) STR_5_BYTES_LATIN1_BYTE_2);
+            sb_utf16.append((char) STR_5_BYTES_LATIN1_BYTE_3);
+            sb_utf16.append((char) STR_5_BYTES_LATIN1_BYTE_4);
         }
         BH.consume(sb_utf16.length());
     }
@@ -896,6 +962,25 @@ public class MergeStoreBench {
     }
 
     /**
+     * Test whether StringBuilder is MergeStored when appending 7 constant characters
+     */
+    @Benchmark
+    public void str7StringBuilderAppendChar(Blackhole BH) {
+        sb.setLength(0);
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            sb.append((char) STR_7_BYTES_LATIN1_BYTE_0);
+            sb.append((char) STR_7_BYTES_LATIN1_BYTE_1);
+            sb.append((char) STR_7_BYTES_LATIN1_BYTE_2);
+            sb.append((char) STR_7_BYTES_LATIN1_BYTE_3);
+            sb.append((char) STR_7_BYTES_LATIN1_BYTE_4);
+            sb.append((char) STR_7_BYTES_LATIN1_BYTE_5);
+            sb.append((char) STR_7_BYTES_LATIN1_BYTE_6);
+        }
+        BH.consume(sb.length());
+    }
+
+    /**
      * Test whether the constant String with a length of 7 calls the getChars method to mergestore
      */
     @Benchmark
@@ -964,6 +1049,25 @@ public class MergeStoreBench {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
             sb_utf16.append(STR_7);
+        }
+        BH.consume(sb_utf16.length());
+    }
+
+    /**
+     * Test whether the UTF16 StringBuilder is MergeStored when appending 7 constant characters
+     */
+    @Benchmark
+    public void str7Utf16StringBuilderAppendChar(Blackhole BH) {
+        sb_utf16.setLength(0);
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            sb_utf16.append((char) STR_7_BYTES_LATIN1_BYTE_0);
+            sb_utf16.append((char) STR_7_BYTES_LATIN1_BYTE_1);
+            sb_utf16.append((char) STR_7_BYTES_LATIN1_BYTE_2);
+            sb_utf16.append((char) STR_7_BYTES_LATIN1_BYTE_3);
+            sb_utf16.append((char) STR_7_BYTES_LATIN1_BYTE_4);
+            sb_utf16.append((char) STR_7_BYTES_LATIN1_BYTE_5);
+            sb_utf16.append((char) STR_7_BYTES_LATIN1_BYTE_6);
         }
         BH.consume(sb_utf16.length());
     }

--- a/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
@@ -59,16 +59,28 @@ public class MergeStoreBench {
     private static final int STR_4_BYTES_LATIN1_INT = UNSAFE.getInt(STR_4_BYTES_LATIN1, Unsafe.ARRAY_BYTE_BASE_OFFSET);
     private static final long STR_4_BYTES_UTF16_LONG = UNSAFE.getLong(STR_4_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET);
 
+    private static final String STR_5 = "false";
+    private static final byte[] STR_5_BYTES_LATIN1 = STR_5.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1);
+    private static final byte[] STR_5_BYTES_UTF16 = STR_5.getBytes(
+            ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN ? StandardCharsets.UTF_16BE : StandardCharsets.UTF_16LE);
+    private static final int STR_5_BYTES_LATIN1_INT = UNSAFE.getInt(STR_5_BYTES_LATIN1, Unsafe.ARRAY_BYTE_BASE_OFFSET);
+    private static final byte STR_5_BYTES_LATIN1_BYTE = STR_5_BYTES_LATIN1[4];
+    private static final long STR_5_BYTES_UTF16_LONG = UNSAFE.getLong(STR_5_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET);
+    private static final short STR_5_BYTES_UTF16_SHORT = UNSAFE.getShort(STR_5_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET + 8);
+
     final static int NUMBERS = 8192;
 
     final byte[] bytes4 = new byte[NUMBERS * 4];
+    final byte[] bytes5 = new byte[NUMBERS * 5];
     final byte[] bytes8 = new byte[NUMBERS * 8];
+    final byte[] bytes10 = new byte[NUMBERS * 10];
     final int [] ints   = new int [NUMBERS    ];
     final long[] longs  = new long[NUMBERS    ];
     final char[] chars  = new char[NUMBERS    ];
     final char[] chars4 = new char[NUMBERS * 4];
-    final StringBuilder sb = new StringBuilder(NUMBERS * 4);
-    final StringBuilder sb_utf16 = new StringBuilder(NUMBERS * 8).append('\u4e2d');
+    final char[] chars5 = new char[NUMBERS * 5];
+    final StringBuilder sb = new StringBuilder(NUMBERS * 5);
+    final StringBuilder sb_utf16 = new StringBuilder(NUMBERS * 10).append('\u4e2d');
 
     @Setup
     public void setup() {
@@ -530,7 +542,7 @@ public class MergeStoreBench {
     }
 
     /**
-     * Test the performance of Unsafe.putInt, used as a benchmark for comparison with other putNull Benchmarks
+     * Test the performance of Unsafe.putInt, used as a benchmark for comparison with other str4 Benchmarks
      */
     @Benchmark
     public void str4UnsafePutInt(Blackhole BH) {
@@ -552,7 +564,7 @@ public class MergeStoreBench {
         for (int i = 0; i < NUMBERS; i++) {
             sb.append(STR_4);
         }
-        BH.consume(sb_utf16.length());
+        BH.consume(sb.length());
     }
 
     /**
@@ -569,7 +581,7 @@ public class MergeStoreBench {
     }
 
     /**
-     * Test the performance of putLong for comparison with other putNull_utf16 benchmarks
+     * Test the performance of putLong for comparison with other str4Utf16 benchmarks
      */
     @Benchmark
     public void str4Utf16UnsafePutLong(Blackhole BH) {
@@ -603,6 +615,99 @@ public class MergeStoreBench {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
             sb_utf16.append(STR_4);
+        }
+        BH.consume(sb_utf16.length());
+    }
+
+    /**
+     * Test whether a constant byte[] with a length of 5 is MergeStored when arraycopy is called
+     */
+    @Benchmark
+    public void str5Arraycopy(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            System.arraycopy(STR_5_BYTES_LATIN1, 0, bytes5, off, 5);
+            off += 5;
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test the performance of Unsafe.putInt, used as a benchmark for comparison with other str5 Benchmarks
+     */
+    @Benchmark
+    public void str5UnsafePutInt(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            UNSAFE.putInt(bytes5, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_5_BYTES_LATIN1_INT);
+            UNSAFE.putByte(bytes5, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 4, STR_5_BYTES_LATIN1_BYTE);
+            off += 5;
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test whether StringBuilder is MergeStored when appending a constant String of length 5
+     */
+    @Benchmark
+    public void str5StringBuilder(Blackhole BH) {
+        sb.setLength(0);
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            sb.append(STR_5);
+        }
+        BH.consume(sb.length());
+    }
+
+    /**
+     * Test whether the constant String with a length of 5 calls the getChars method to mergestore
+     */
+    @Benchmark
+    public void str5GetChars(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            STR_5.getChars(0, 5, chars5, off);
+            off += 5;
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test the performance of putLong for comparison with other str5Utf16 benchmarks
+     */
+    @Benchmark
+    public void str5Utf16UnsafePutLong(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            UNSAFE.putLong(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_5_BYTES_UTF16_LONG);
+            UNSAFE.putShort(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 8, STR_5_BYTES_UTF16_SHORT);
+            off += 10;
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test whether the byte[] arraycopy with a length of 10 is MergeStore
+     */
+    @Benchmark
+    public void str5Utf16ArrayCopy(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            System.arraycopy(STR_5_BYTES_UTF16, 0, bytes8, off, 10);
+            off += 10;
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test whether the UTF16 StringBuilder appends a constant String of length 5 to MergeStore
+     */
+    @Benchmark
+    public void str5Utf16StringBuilder(Blackhole BH) {
+        sb_utf16.setLength(0);
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            sb_utf16.append(STR_5);
         }
         BH.consume(sb_utf16.length());
     }

--- a/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
@@ -701,11 +701,11 @@ public class MergeStoreBench {
     public void str5ArraySetConst(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            bytes8[off    ] = STR_7_BYTES_LATIN1_BYTE_0;
-            bytes8[off + 1] = STR_7_BYTES_LATIN1_BYTE_1;
-            bytes8[off + 2] = STR_7_BYTES_LATIN1_BYTE_2;
-            bytes8[off + 3] = STR_7_BYTES_LATIN1_BYTE_3;
-            bytes8[off + 4] = STR_7_BYTES_LATIN1_BYTE_4;
+            bytes8[off    ] = STR_5_BYTES_LATIN1_BYTE_0;
+            bytes8[off + 1] = STR_5_BYTES_LATIN1_BYTE_1;
+            bytes8[off + 2] = STR_5_BYTES_LATIN1_BYTE_2;
+            bytes8[off + 3] = STR_5_BYTES_LATIN1_BYTE_3;
+            bytes8[off + 4] = STR_5_BYTES_LATIN1_BYTE_4;
             off += 6; // disable auto vector
         }
         BH.consume(off);

--- a/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
@@ -68,19 +68,31 @@ public class MergeStoreBench {
     private static final long STR_5_BYTES_UTF16_LONG = UNSAFE.getLong(STR_5_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET);
     private static final short STR_5_BYTES_UTF16_SHORT = UNSAFE.getShort(STR_5_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET + 8);
 
+    private static final String STR_7 = "truefalse";
+    private static final byte[] STR_7_BYTES_LATIN1 = STR_7.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1);
+    private static final byte[] STR_7_BYTES_UTF16 = STR_7.getBytes(
+            ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN ? StandardCharsets.UTF_16BE : StandardCharsets.UTF_16LE);
+    private static final int STR_7_BYTES_LATIN1_INT = UNSAFE.getInt(STR_7_BYTES_LATIN1, Unsafe.ARRAY_BYTE_BASE_OFFSET);
+    private static final short STR_7_BYTES_LATIN1_SHORT = UNSAFE.getShort(STR_7_BYTES_LATIN1, Unsafe.ARRAY_BYTE_BASE_OFFSET + 4);
+    private static final byte STR_7_BYTES_LATIN1_BYTE = STR_7_BYTES_LATIN1[6];
+    private static final long STR_7_BYTES_UTF16_LONG = UNSAFE.getLong(STR_7_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET);
+    private static final int STR_7_BYTES_UTF16_INT = UNSAFE.getInt(STR_7_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET + 8);
+    private static final short STR_7_BYTES_UTF16_SHORT = UNSAFE.getShort(STR_7_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET + 12);
+
     final static int NUMBERS = 8192;
 
     final byte[] bytes4 = new byte[NUMBERS * 4];
     final byte[] bytes5 = new byte[NUMBERS * 5];
     final byte[] bytes8 = new byte[NUMBERS * 8];
     final byte[] bytes10 = new byte[NUMBERS * 10];
+    final byte[] bytes14 = new byte[NUMBERS * 14];
     final int [] ints   = new int [NUMBERS    ];
     final long[] longs  = new long[NUMBERS    ];
     final char[] chars  = new char[NUMBERS    ];
-    final char[] chars4 = new char[NUMBERS * 4];
     final char[] chars5 = new char[NUMBERS * 5];
-    final StringBuilder sb = new StringBuilder(NUMBERS * 5);
-    final StringBuilder sb_utf16 = new StringBuilder(NUMBERS * 10).append('\u4e2d');
+    final char[] chars7 = new char[NUMBERS * 7];
+    final StringBuilder sb = new StringBuilder(NUMBERS * 7);
+    final StringBuilder sb_utf16 = new StringBuilder(NUMBERS * 14).append('\u4e2d');
 
     @Setup
     public void setup() {
@@ -519,11 +531,11 @@ public class MergeStoreBench {
      */
     @Benchmark
     @SuppressWarnings("deprecation")
-    public void putNull_getBytes(Blackhole BH) {
+    public void str4GetBytes(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            STR_4.getBytes(0, 4, bytes4, off);
-            off += 4;
+            STR_4.getBytes(0, 4, bytes5, off);
+            off += 5; // disable auto vector
         }
         BH.consume(off);
     }
@@ -535,8 +547,8 @@ public class MergeStoreBench {
     public void str4Arraycopy(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            System.arraycopy(STR_4_BYTES_LATIN1, 0, bytes4, off, 4);
-            off += 4;
+            System.arraycopy(STR_4_BYTES_LATIN1, 0, bytes5, off, 4);
+            off += 5; // disable auto vector
         }
         BH.consume(off);
     }
@@ -545,11 +557,11 @@ public class MergeStoreBench {
      * Test the performance of Unsafe.putInt, used as a benchmark for comparison with other str4 Benchmarks
      */
     @Benchmark
-    public void str4UnsafePutInt(Blackhole BH) {
+    public void str4UnsafePut(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            UNSAFE.putInt(bytes4, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_4_BYTES_LATIN1_INT);
-            off += 4;
+            UNSAFE.putInt(bytes5, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_4_BYTES_LATIN1_INT);
+            off += 5; // disable auto vector
         }
         BH.consume(off);
     }
@@ -574,8 +586,8 @@ public class MergeStoreBench {
     public void str4GetChars(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            STR_4.getChars(0, 4, chars4, off);
-            off += 4;
+            STR_4.getChars(0, 4, chars5, off);
+            off += 5; // disable auto vector
         }
         BH.consume(off);
     }
@@ -584,11 +596,11 @@ public class MergeStoreBench {
      * Test the performance of putLong for comparison with other str4Utf16 benchmarks
      */
     @Benchmark
-    public void str4Utf16UnsafePutLong(Blackhole BH) {
+    public void str4Utf16UnsafePut(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            UNSAFE.putLong(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_4_BYTES_UTF16_LONG);
-            off += 8;
+            UNSAFE.putLong(bytes10, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_4_BYTES_UTF16_LONG);
+            off += 10; // disable auto vector
         }
         BH.consume(off);
     }
@@ -600,8 +612,8 @@ public class MergeStoreBench {
     public void str4Utf16ArrayCopy(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            System.arraycopy(STR_4_BYTES_UTF16, 0, bytes8, off, 8);
-            off += 8;
+            System.arraycopy(STR_4_BYTES_UTF16, 0, bytes10, off, 8);
+            off += 10;
         }
         BH.consume(off);
     }
@@ -617,6 +629,20 @@ public class MergeStoreBench {
             sb_utf16.append(STR_4);
         }
         BH.consume(sb_utf16.length());
+    }
+
+    /**
+     * Test whether a constant String of length 5 is MergeStored when calling getBytes
+     */
+    @Benchmark
+    @SuppressWarnings("deprecation")
+    public void str5GetBytes(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            STR_5.getBytes(0, 4, bytes5, off);
+            off += 5;
+        }
+        BH.consume(off);
     }
 
     /**
@@ -636,7 +662,7 @@ public class MergeStoreBench {
      * Test the performance of Unsafe.putInt, used as a benchmark for comparison with other str5 Benchmarks
      */
     @Benchmark
-    public void str5UnsafePutInt(Blackhole BH) {
+    public void str5UnsafePut(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
             UNSAFE.putInt(bytes5, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_5_BYTES_LATIN1_INT);
@@ -676,11 +702,11 @@ public class MergeStoreBench {
      * Test the performance of putLong for comparison with other str5Utf16 benchmarks
      */
     @Benchmark
-    public void str5Utf16UnsafePutLong(Blackhole BH) {
+    public void str5Utf16UnsafePut(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            UNSAFE.putLong(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_5_BYTES_UTF16_LONG);
-            UNSAFE.putShort(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 8, STR_5_BYTES_UTF16_SHORT);
+            UNSAFE.putLong(bytes10, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_5_BYTES_UTF16_LONG);
+            UNSAFE.putShort(bytes10, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 8, STR_5_BYTES_UTF16_SHORT);
             off += 10;
         }
         BH.consume(off);
@@ -708,6 +734,115 @@ public class MergeStoreBench {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
             sb_utf16.append(STR_5);
+        }
+        BH.consume(sb_utf16.length());
+    }
+
+    /**
+     * Test whether a constant String of length 5 is MergeStored when calling getBytes
+     */
+    @Benchmark
+    @SuppressWarnings("deprecation")
+    public void str7GetBytes(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            STR_7.getBytes(0, 7, bytes8, off);
+            off += 7;
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test whether a constant byte[] with a length of 7 is MergeStored when arraycopy is called
+     */
+    @Benchmark
+    public void str7Arraycopy(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            System.arraycopy(STR_7_BYTES_LATIN1, 0, bytes8, off, 7);
+            off += 7;
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test the performance of Unsafe.putInt, used as a benchmark for comparison with other str7 Benchmarks
+     */
+    @Benchmark
+    public void str7UnsafePut(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            UNSAFE.putInt(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_7_BYTES_LATIN1_INT);
+            UNSAFE.putShort(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 4, STR_7_BYTES_LATIN1_SHORT);
+            UNSAFE.putByte(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 6, STR_7_BYTES_LATIN1_BYTE);
+            off += 7;
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test whether StringBuilder is MergeStored when appending a constant String of length 7
+     */
+    @Benchmark
+    public void str7StringBuilder(Blackhole BH) {
+        sb.setLength(0);
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            sb.append(STR_7);
+        }
+        BH.consume(sb.length());
+    }
+
+    /**
+     * Test whether the constant String with a length of 7 calls the getChars method to mergestore
+     */
+    @Benchmark
+    public void str7GetChars(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            STR_7.getChars(0, 7, chars7, off);
+            off += 7;
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test the performance of putLong for comparison with other str7Utf16 benchmarks
+     */
+    @Benchmark
+    public void str7Utf16UnsafePut(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            UNSAFE.putLong(bytes14, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_7_BYTES_UTF16_LONG);
+            UNSAFE.putInt(bytes14, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 8, STR_7_BYTES_UTF16_INT);
+            UNSAFE.putShort(bytes14, Unsafe.ARRAY_BYTE_BASE_OFFSET + off + 12, STR_7_BYTES_UTF16_SHORT);
+            off += 14;
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test whether the byte[] arraycopy with a length of 14 is MergeStore
+     */
+    @Benchmark
+    public void str7Utf16ArrayCopy(Blackhole BH) {
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            System.arraycopy(STR_7_BYTES_UTF16, 0, bytes14, off, 14);
+            off += 14;
+        }
+        BH.consume(off);
+    }
+
+    /**
+     * Test whether the UTF16 StringBuilder appends a constant String of length 7 to MergeStore
+     */
+    @Benchmark
+    public void str7Utf16StringBuilder(Blackhole BH) {
+        sb_utf16.setLength(0);
+        int off = 0;
+        for (int i = 0; i < NUMBERS; i++) {
+            sb_utf16.append(STR_7);
         }
         BH.consume(sb_utf16.length());
     }

--- a/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
@@ -52,12 +52,12 @@ public class MergeStoreBench {
             CHAR_L = MethodHandles.byteArrayViewVarHandle(char[].class, ByteOrder.LITTLE_ENDIAN),
             CHAR_B = MethodHandles.byteArrayViewVarHandle(char[].class, ByteOrder.BIG_ENDIAN);
 
-    private static final String NULL_STR = "null";
-    private static final byte[] NULL_BYTES_LATIN1 = NULL_STR.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1);
-    private static final byte[] NULL_BYTES_UTF16 = NULL_STR.getBytes(
+    private static final String STR_4 = "null";
+    private static final byte[] STR_4_BYTES_LATIN1 = STR_4.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1);
+    private static final byte[] STR_4_BYTES_UTF16 = STR_4.getBytes(
             ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN ? StandardCharsets.UTF_16BE : StandardCharsets.UTF_16LE);
-    private static final int NULL_INT = UNSAFE.getInt(NULL_BYTES_LATIN1, Unsafe.ARRAY_BYTE_BASE_OFFSET);
-    private static final long NULL_LONG = UNSAFE.getLong(NULL_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET);
+    private static final int STR_4_BYTES_LATIN1_INT = UNSAFE.getInt(STR_4_BYTES_LATIN1, Unsafe.ARRAY_BYTE_BASE_OFFSET);
+    private static final long STR_4_BYTES_UTF16_LONG = UNSAFE.getLong(STR_4_BYTES_UTF16, Unsafe.ARRAY_BYTE_BASE_OFFSET);
 
     final static int NUMBERS = 8192;
 
@@ -510,7 +510,7 @@ public class MergeStoreBench {
     public void putNull_getBytes(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            NULL_STR.getBytes(0, 4, bytes4, off);
+            STR_4.getBytes(0, 4, bytes4, off);
             off += 4;
         }
         BH.consume(off);
@@ -520,10 +520,10 @@ public class MergeStoreBench {
      * Test whether a constant byte[] with a length of 4 is MergeStored when arraycopy is called
      */
     @Benchmark
-    public void putNull_arraycopy(Blackhole BH) {
+    public void str4Arraycopy(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            System.arraycopy(NULL_BYTES_LATIN1, 0, bytes4, off, 4);
+            System.arraycopy(STR_4_BYTES_LATIN1, 0, bytes4, off, 4);
             off += 4;
         }
         BH.consume(off);
@@ -533,10 +533,10 @@ public class MergeStoreBench {
      * Test the performance of Unsafe.putInt, used as a benchmark for comparison with other putNull Benchmarks
      */
     @Benchmark
-    public void putNull_unsafePutInt(Blackhole BH) {
+    public void str4UnsafePutInt(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            UNSAFE.putInt(bytes4, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, NULL_INT);
+            UNSAFE.putInt(bytes4, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_4_BYTES_LATIN1_INT);
             off += 4;
         }
         BH.consume(off);
@@ -546,11 +546,11 @@ public class MergeStoreBench {
      * Test whether StringBuilder is MergeStored when appending a constant String of length 4
      */
     @Benchmark
-    public void putNull_string_builder(Blackhole BH) {
+    public void str4StringBuilder(Blackhole BH) {
         sb.setLength(0);
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            sb.append(NULL_STR);
+            sb.append(STR_4);
         }
         BH.consume(sb_utf16.length());
     }
@@ -559,10 +559,10 @@ public class MergeStoreBench {
      * Test whether the constant String with a length of 4 calls the getChars method to mergestore
      */
     @Benchmark
-    public void putNull_getChars(Blackhole BH) {
+    public void str4GetChars(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            NULL_STR.getChars(0, 4, chars4, off);
+            STR_4.getChars(0, 4, chars4, off);
             off += 4;
         }
         BH.consume(off);
@@ -572,10 +572,10 @@ public class MergeStoreBench {
      * Test the performance of putLong for comparison with other putNull_utf16 benchmarks
      */
     @Benchmark
-    public void putNull_utf16_unsafePutLong(Blackhole BH) {
+    public void str4Utf16UnsafePutLong(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            UNSAFE.putLong(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, NULL_LONG);
+            UNSAFE.putLong(bytes8, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, STR_4_BYTES_UTF16_LONG);
             off += 8;
         }
         BH.consume(off);
@@ -585,10 +585,10 @@ public class MergeStoreBench {
      * Test whether the byte[] arraycopy with a length of 8 is MergeStore
      */
     @Benchmark
-    public void putNull_utf16_arrayCopy(Blackhole BH) {
+    public void str4Utf16ArrayCopy(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            System.arraycopy(NULL_BYTES_UTF16, 0, bytes8, off, 8);
+            System.arraycopy(STR_4_BYTES_UTF16, 0, bytes8, off, 8);
             off += 8;
         }
         BH.consume(off);
@@ -598,11 +598,11 @@ public class MergeStoreBench {
      * Test whether the UTF16 StringBuilder appends a constant String of length 4 to MergeStore
      */
     @Benchmark
-    public void putNull_utf16_string_builder(Blackhole BH) {
+    public void str4Utf16StringBuilder(Blackhole BH) {
         sb_utf16.setLength(0);
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            sb_utf16.append(NULL_STR);
+            sb_utf16.append(STR_4);
         }
         BH.consume(sb_utf16.length());
     }

--- a/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
@@ -693,7 +693,7 @@ public class MergeStoreBench {
     public void str5Utf16ArrayCopy(Blackhole BH) {
         int off = 0;
         for (int i = 0; i < NUMBERS; i++) {
-            System.arraycopy(STR_5_BYTES_UTF16, 0, bytes8, off, 10);
+            System.arraycopy(STR_5_BYTES_UTF16, 0, bytes10, off, 10);
             off += 10;
         }
         BH.consume(off);


### PR DESCRIPTION
Added performance tests related to String.getBytes/String.getChars/StringBuilder.append/System.arraycopy in constant scenarios to verify whether MergeStore works

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352316](https://bugs.openjdk.org/browse/JDK-8352316): More MergeStoreBench (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24108/head:pull/24108` \
`$ git checkout pull/24108`

Update a local copy of the PR: \
`$ git checkout pull/24108` \
`$ git pull https://git.openjdk.org/jdk.git pull/24108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24108`

View PR using the GUI difftool: \
`$ git pr show -t 24108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24108.diff">https://git.openjdk.org/jdk/pull/24108.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24108#issuecomment-2735449736)
</details>
