### PR TITLE
8352317: Assertion failure during size estimation of BoxLockNode with -XX:+UseAPX

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1547,7 +1547,11 @@ void BoxLockNode::emit(C2_MacroAssembler* masm, PhaseRegAlloc* ra_) const
 uint BoxLockNode::size(PhaseRegAlloc *ra_) const
 {
   int offset = ra_->reg2offset(in_RegMask(0).find_first_elem());
-  return (offset < 0x80) ? 5 : 8; // REX
+  if (ra_->get_encode(this) > 15) {
+    return (offset < 0x80) ? 6 : 9; // REX2
+  } else {
+    return (offset < 0x80) ? 5 : 8; // REX
+  }
 }
 
 //=============================================================================


### PR DESCRIPTION
This patch fixes a crash during PhaseOutput while estimating the size of BoxLockNode.
LEA instruction used to load the stack location holding a thread-specific lock in fast locking mode did not account for an additional byte of REX2 prefix if the destination register is an EGPR.

          LEA GPR/EGPR OFFSET(RSP).

This fixed multiple issues seen in SPECjvm2008 worklets.

The issue can be reproduced after changing the static allocation ordering in x86_64.ad giving preference to the EGPR register.
[JDK-8343294](https://bugs.openjdk.org/browse/JDK-8343294) tracks the requirement to randomize the allocation sequence.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352317](https://bugs.openjdk.org/browse/JDK-8352317): Assertion failure during size estimation of BoxLockNode with -XX:+UseAPX (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24109/head:pull/24109` \
`$ git checkout pull/24109`

Update a local copy of the PR: \
`$ git checkout pull/24109` \
`$ git pull https://git.openjdk.org/jdk.git pull/24109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24109`

View PR using the GUI difftool: \
`$ git pr show -t 24109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24109.diff">https://git.openjdk.org/jdk/pull/24109.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24109#issuecomment-2735531635)
</details>
