### PR TITLE
8352407: PixelInterleavedSampleModel with unused components throws RasterFormatException: Incorrect pixel stride

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
@@ -237,7 +237,22 @@ public class ComponentSampleModel extends SampleModel
     }
 
     private void verify() {
-        int requiredSize = getBufferSize();
+        // Some parts of the code do account for negative strides, but some do not.
+        // We consider them unsupported for the time being.
+
+        if (scanlineStride < 0 || scanlineStride > (Integer.MAX_VALUE / height)) {
+            throw new IllegalArgumentException("Invalid scanline stride");
+        }
+
+        if (pixelStride < 0 || pixelStride > (scanlineStride / width)) {
+            throw new IllegalArgumentException("Invalid pixel stride");
+        }
+
+        for (int i = 0; i < bandOffsets.length; i++) {
+            if (bandOffsets[i] < 0 || bandOffsets[i] >= pixelStride) {
+                throw new IllegalArgumentException("Invalid band offset: " + i);
+            }
+        }
     }
 
     /**
@@ -245,42 +260,7 @@ public class ComponentSampleModel extends SampleModel
      * for a data buffer that matches this ComponentSampleModel.
      */
      private int getBufferSize() {
-         int maxBandOff=bandOffsets[0];
-         for (int i=1; i<bandOffsets.length; i++) {
-             maxBandOff = Math.max(maxBandOff,bandOffsets[i]);
-         }
-
-         if (maxBandOff < 0 || maxBandOff > (Integer.MAX_VALUE - 1)) {
-             throw new IllegalArgumentException("Invalid band offset");
-         }
-
-         if (pixelStride < 0 || pixelStride > (Integer.MAX_VALUE / width)) {
-             throw new IllegalArgumentException("Invalid pixel stride");
-         }
-
-         if (scanlineStride < 0 || scanlineStride > (Integer.MAX_VALUE / height)) {
-             throw new IllegalArgumentException("Invalid scanline stride");
-         }
-
-         int size = maxBandOff + 1;
-
-         int val = pixelStride * (width - 1);
-
-         if (val > (Integer.MAX_VALUE - size)) {
-             throw new IllegalArgumentException("Invalid pixel stride");
-         }
-
-         size += val;
-
-         val = scanlineStride * (height - 1);
-
-         if (val > (Integer.MAX_VALUE - size)) {
-             throw new IllegalArgumentException("Invalid scan stride");
-         }
-
-         size += val;
-
-         return size;
+         return scanlineStride * height;
      }
 
      /**

--- a/test/jdk/java/awt/image/RasterCreationTest.java
+++ b/test/jdk/java/awt/image/RasterCreationTest.java
@@ -54,6 +54,8 @@ public class RasterCreationTest {
 
         SampleModel[] inputSampleModels = {
             new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE,
+                    1, 1, 4, 4, bandOffsets),
+            new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE,
                     1, 1, 1, 1, bandOffsets),
             new PixelInterleavedSampleModel(DataBuffer.TYPE_USHORT,
                     1, 1, 1, 1, bandOffsets),


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ The pull request body must not be empty.

### Issue
 * [JDK-8352407](https://bugs.openjdk.org/browse/JDK-8352407): PixelInterleavedSampleModel with unused components throws RasterFormatException: Incorrect pixel stride (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24111/head:pull/24111` \
`$ git checkout pull/24111`

Update a local copy of the PR: \
`$ git checkout pull/24111` \
`$ git pull https://git.openjdk.org/jdk.git pull/24111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24111`

View PR using the GUI difftool: \
`$ git pr show -t 24111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24111.diff">https://git.openjdk.org/jdk/pull/24111.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24111#issuecomment-2736297504)
</details>
