### PR TITLE
8352393: AIX: Problem list serviceability/attach/AttachAPIv2/StreamingOutputTest.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -130,6 +130,8 @@ containers/docker/TestJcmdWithSideCar.java 8341518 linux-x64
 
 # :hotspot_serviceability
 
+serviceability/attach/AttachAPIv2/StreamingOutputTest.java 8352392 aix-ppc64
+
 serviceability/sa/sadebugd/DebugdConnectTest.java 8239062,8270326 macosx-x64,macosx-aarch64
 serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 


### PR DESCRIPTION
Excluding the test serviceability/attach/AttachAPIv2/StreamingOutputTest.java

JBS Issue : [JDK-8352393](https://bugs.openjdk.org/browse/JDK-8352393)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352393](https://bugs.openjdk.org/browse/JDK-8352393): AIX: Problem list serviceability/attach/AttachAPIv2/StreamingOutputTest.java (**Sub-task** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24116/head:pull/24116` \
`$ git checkout pull/24116`

Update a local copy of the PR: \
`$ git checkout pull/24116` \
`$ git pull https://git.openjdk.org/jdk.git pull/24116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24116`

View PR using the GUI difftool: \
`$ git pr show -t 24116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24116.diff">https://git.openjdk.org/jdk/pull/24116.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24116#issuecomment-2737613598)
</details>
