### PR TITLE
8352131: [REDO] C2: Print compilation bailouts with PrintCompilation compile command

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2340,7 +2340,6 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
       }
     }
 
-    DirectivesStack::release(directive);
 
     if (!ci_env.failing() && !task->is_success()) {
       assert(ci_env.failure_reason() != nullptr, "expect failure reason");
@@ -2374,13 +2373,15 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
     if (CompilationLog::log() != nullptr) {
       CompilationLog::log()->log_failure(thread, task, failure_reason, retry_message);
     }
-    if (PrintCompilation) {
+    if (PrintCompilation || directive->PrintCompilationOption) {
       FormatBufferResource msg = retry_message != nullptr ?
         FormatBufferResource("COMPILE SKIPPED: %s (%s)", failure_reason, retry_message) :
         FormatBufferResource("COMPILE SKIPPED: %s",      failure_reason);
       task->print(tty, msg);
     }
   }
+
+  DirectivesStack::release(directive);
 
   methodHandle method(thread, task->method());
 


### PR DESCRIPTION
We currently only print a compilation bailout with `-XX:+PrintCompilation`:
```
7782 90 b 4 Test::main (19 bytes)
7792 90 b 4 Test::main (19 bytes) COMPILE SKIPPED: StressBailout
```
But not when using `-XX:CompileCommand=printcompilation,*::*`. This patch enables this.

The original fix with https://github.com/openjdk/jdk/pull/24031 missed the following: We release the memory for the directives here:
https://github.com/openjdk/jdk/blob/fed34e46b89bc9b0462d9b5f5e5ab5516fe18c6e/src/hotspot/share/compiler/compileBroker.cpp#L2343

and then wrongly accessed the memory again to fetch `PrintCompilationOption` on this line:
https://github.com/openjdk/jdk/blob/fed34e46b89bc9b0462d9b5f5e5ab5516fe18c6e/src/hotspot/share/compiler/compileBroker.cpp#L2377

This worked most of the time because the memory was not overridden, yet, but of course is a wrong use after free case. We only noticed this in some intermittent test failures where we suddenly dumped `COMPILE SKIPPED` where it was unexpected for tests.

I now moved the memory release down after we access it for `PrintCompilationOption`.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352131](https://bugs.openjdk.org/browse/JDK-8352131): [REDO] C2: Print compilation bailouts with PrintCompilation compile command (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24117/head:pull/24117` \
`$ git checkout pull/24117`

Update a local copy of the PR: \
`$ git checkout pull/24117` \
`$ git pull https://git.openjdk.org/jdk.git pull/24117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24117`

View PR using the GUI difftool: \
`$ git pr show -t 24117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24117.diff">https://git.openjdk.org/jdk/pull/24117.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24117#issuecomment-2737018450)
</details>
