### PR TITLE
8352420: [ubsan] codeBuffer.cpp:984:27: runtime error: applying non-zero offset 18446744073709486080 to null pointer

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -980,7 +980,7 @@ void CodeBuffer::take_over_code_from(CodeBuffer* cb) {
 
 void CodeBuffer::verify_section_allocation() {
   address tstart = _total_start;
-  if (tstart == 0)  return;  // ignore not fully initialized buffer
+  if (tstart == nullptr) return;  // ignore not fully initialized buffer
   if (tstart == badAddress)  return;  // smashed by set_blob(nullptr)
   address tend   = tstart + _total_size;
   if (_blob != nullptr) {

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -980,6 +980,7 @@ void CodeBuffer::take_over_code_from(CodeBuffer* cb) {
 
 void CodeBuffer::verify_section_allocation() {
   address tstart = _total_start;
+  if (tstart == 0)  return;  // ignore not fully initialized buffer
   if (tstart == badAddress)  return;  // smashed by set_blob(nullptr)
   address tend   = tstart + _total_size;
   if (_blob != nullptr) {

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -455,7 +455,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
     _name            = name;
     _before_expand   = nullptr;
     _blob            = nullptr;
-    _total_start     = 0;
+    _total_start     = nullptr;
     _total_size      = 0;
     _oop_recorder    = nullptr;
     _overflow_arena  = nullptr;

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -455,6 +455,8 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
     _name            = name;
     _before_expand   = nullptr;
     _blob            = nullptr;
+    _total_start     = 0;
+    _total_size      = 0;
     _oop_recorder    = nullptr;
     _overflow_arena  = nullptr;
     _last_insn       = nullptr;
@@ -546,8 +548,6 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
     DEBUG_ONLY(: Scrubber(this, sizeof(*this)))
   {
     initialize_misc(name);
-    _total_start = 0;
-    _total_size  = 0;
   }
 
   // (4) code buffer allocating codeBlob memory for code & relocation

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -546,6 +546,8 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
     DEBUG_ONLY(: Scrubber(this, sizeof(*this)))
   {
     initialize_misc(name);
+    _total_start = 0;
+    _total_size  = 0;
   }
 
   // (4) code buffer allocating codeBlob memory for code & relocation


### PR DESCRIPTION
This PR addresses undefined behavior in CodeBuffer by making `verify_section_allocation` return early for a partially initialized CodeBuffer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352420](https://bugs.openjdk.org/browse/JDK-8352420): [ubsan] codeBuffer.cpp:984:27: runtime error: applying non-zero offset 18446744073709486080 to null pointer (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) Review applies to [15d90178](https://git.openjdk.org/jdk/pull/24118/files/15d901788dc9539538467e1dd7f027373d7e4a17)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24118/head:pull/24118` \
`$ git checkout pull/24118`

Update a local copy of the PR: \
`$ git checkout pull/24118` \
`$ git pull https://git.openjdk.org/jdk.git pull/24118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24118`

View PR using the GUI difftool: \
`$ git pr show -t 24118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24118.diff">https://git.openjdk.org/jdk/pull/24118.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24118#issuecomment-2739883190)
</details>
