### PR TITLE
8352435: Refactor CDS test library for execution and module packaging

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,282 +22,23 @@
  *
  */
 
-/*
- * @summary Simple jar builder
- *   Input: jarName className1 className2 ...
- *     do not specify extensions, just the names
- *     E.g. prot_domain ProtDomainA ProtDomainB
- *   Output: A jar containing compiled classes, placed in a test classes folder
- * @library /open/test/lib
- */
+import jdk.test.lib.cds.CDSJarUtils;
 
-import jdk.test.lib.JDKToolFinder;
-import jdk.test.lib.cds.CDSTestUtils;
-import jdk.test.lib.compiler.CompilerUtils;
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.helpers.ClassFileInstaller;
-import java.io.File;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.spi.ToolProvider;
-
-public class JarBuilder {
-    // to turn DEBUG on via command line: -DJarBuilder.DEBUG=[true, TRUE]
-    private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("JarBuilder.DEBUG", "false"));
-    private static final String classDir = System.getProperty("test.classes");
-    private static final ToolProvider JAR = ToolProvider.findFirst("jar")
-        .orElseThrow(() -> new RuntimeException("ToolProvider for jar not found"));
-
-    public static String getJarFilePath(String jarName) {
-        return CDSTestUtils.getOutputDir() +  File.separator + jarName + ".jar";
-    }
-
-    // jar all files under dir, with manifest file man, with an optional versionArgs
-    // for generating a multi-release jar.
-    // The jar command is as follows:
-    // jar cmf \
-    //  <path to output jar> <path to the manifest file>\
-    //   -C <path to the base classes> .\
-    //    --release 9 -C <path to the versioned classes> .
-    // the last line begins with "--release" corresponds to the optional versionArgs.
-    public static String build(String jarName, File dir, String man, String ...versionArgs)
-        throws Exception {
-        ArrayList<String> args = new ArrayList<String>();
-        if (man != null) {
-            args.add("cfm");
-        } else {
-            args.add("cf");
-        }
-        String jarFile = getJarFilePath(jarName);
-        args.add(jarFile);
-        if (man != null) {
-            args.add(man);
-        }
-        args.add("-C");
-        args.add(dir.getAbsolutePath());
-        args.add(".");
-        for (String verArg : versionArgs) {
-            args.add(verArg);
-        }
-        createJar(args);
-        return jarFile;
-    }
-
-    public static String build(String jarName, String ...classNames)
-        throws Exception {
-
-        return createSimpleJar(classDir, getJarFilePath(jarName), classNames);
-    }
-
-    public static String build(boolean classesInWorkDir, String jarName, String ...classNames)
-        throws Exception {
-        if (classesInWorkDir) {
-            return createSimpleJar(".", getJarFilePath(jarName), classNames);
-        } else {
-            return build(jarName, classNames);
-        }
-    }
-
-
-    public static String buildWithManifest(String jarName, String manifest,
-        String jarClassesDir, String ...classNames) throws Exception {
-        String jarPath = getJarFilePath(jarName);
-        ArrayList<String> args = new ArrayList<String>();
-        args.add("cvfm");
-        args.add(jarPath);
-        args.add(System.getProperty("test.src") + File.separator + "test-classes"
-            + File.separator + manifest);
-        addClassArgs(args, jarClassesDir, classNames);
-        createJar(args);
-
-        return jarPath;
-    }
-
-
-    // Execute: jar uvf $jarFile -C $dir .
-    static void update(String jarFile, String dir) throws Exception {
-        String jarExe = JDKToolFinder.getJDKTool("jar");
-
-        ArrayList<String> args = new ArrayList<>();
-        args.add(jarExe);
-        args.add("uvf");
-        args.add(jarFile);
-        args.add("-C");
-        args.add(dir);
-        args.add(".");
-
-        executeProcess(args.toArray(new String[1]));
-    }
-
-    private static String createSimpleJar(String jarclassDir, String jarName,
-        String[] classNames) throws Exception {
-
-        ArrayList<String> args = new ArrayList<String>();
-        args.add("cf");
-        args.add(jarName);
-        addClassArgs(args, jarclassDir, classNames);
-        createJar(args);
-
-        return jarName;
-    }
-
-    private static void addClassArgs(ArrayList<String> args, String jarclassDir,
-        String[] classNames) {
-
-        for (String name : classNames) {
-            args.add("-C");
-            args.add(jarclassDir);
-            args.add(name + ".class");
-        }
-    }
+public class JarBuilder extends CDSJarUtils {
 
     public static void createModularJar(String jarPath,
-                                      String classesDir,
-                                      String mainClass) throws Exception {
-        ArrayList<String> argList = new ArrayList<String>();
-        argList.add("--create");
-        argList.add("--file=" + jarPath);
-        if (mainClass != null) {
-            argList.add("--main-class=" + mainClass);
-        }
-        argList.add("-C");
-        argList.add(classesDir);
-        argList.add(".");
-        createJar(argList);
+                                        String classesDir,
+                                        String mainClass) throws Exception {
+        createModularJarWithManifest(jarPath, classesDir, mainClass, null);
     }
 
     public static void createModularJarWithManifest(String jarPath,
                                                     String classesDir,
                                                     String mainClass,
                                                     String manifest) throws Exception {
-        ArrayList<String> argList = new ArrayList<String>();
-        argList.add("--create");
-        argList.add("--file=" + jarPath);
-        if (mainClass != null) {
-            argList.add("--main-class=" + mainClass);
-        }
-        argList.add("--manifest=" + manifest);
-        argList.add("-C");
-        argList.add(classesDir);
-        argList.add(".");
-        createJar(argList);
-    }
-
-    private static void createJar(ArrayList<String> args) {
-        if (DEBUG) printIterable("createJar args: ", args);
-
-        if (JAR.run(System.out, System.err, args.toArray(new String[1])) != 0) {
-            throw new RuntimeException("jar operation failed");
-        }
-    }
-
-    // Many AppCDS tests use the same simple "hello.jar" which contains
-    // simple Hello.class and does not specify additional attributes.
-    // For this common use case, use this method to get the jar path.
-    // The method will check if the jar already exists
-    // (created by another test or test run), and will create the jar
-    // if it does not exist
-    public static String getOrCreateHelloJar() throws Exception {
-        String jarPath = getJarFilePath("hello");
-
-        File jarFile = new File(jarPath);
-        if (jarFile.exists()) {
-            return jarPath;
-        } else {
-            return build("hello", "Hello");
-        }
-    }
-
-    public static void compile(String dstPath, String source, String... extraArgs) throws Exception {
-        ArrayList<String> args = new ArrayList<String>();
-        args.add(JDKToolFinder.getCompileJDKTool("javac"));
-        args.add("-d");
-        args.add(dstPath);
-        if (extraArgs != null) {
-            for (String s : extraArgs) {
-                args.add(s);
-            }
-        }
-        args.add(source);
-
-        if (DEBUG) printIterable("compile args: ", args);
-
-        ProcessBuilder pb = new ProcessBuilder(args);
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldHaveExitValue(0);
-    }
-
-    public static void compileModule(Path src,
-                                     Path dest,
-                                     String modulePathArg // arg to --module-path
-                                     ) throws Exception {
-        boolean compiled = false;
-        if (modulePathArg == null) {
-            compiled = CompilerUtils.compile(src, dest);
-        } else {
-            compiled = CompilerUtils.compile(src, dest,
-                                           "--module-path", modulePathArg);
-        }
-        if (!compiled) {
-            throw new RuntimeException("module did not compile");
-        }
-    }
-
-    static final String keyTool = JDKToolFinder.getJDKTool("keytool");
-    static final String jarSigner = JDKToolFinder.getJDKTool("jarsigner");
-
-    public static void signJarWithDisabledAlgorithm(String jarName) throws Exception {
-        String keyName = "key_with_disabled_alg";
-        executeProcess(keyTool,
-            "-genkey", "-keystore", "./keystore", "-alias", keyName,
-            "-storepass", "abc123", "-keypass", "abc123", "-keyalg", "dsa",
-            "-sigalg", "SHA1withDSA", "-keysize", "512", "-dname", "CN=jvmtest2")
-            .shouldHaveExitValue(0);
-
-        doSigning(jarName, keyName);
-    }
-
-    public static void signJar(String jarName) throws Exception {
-        String keyName = "mykey";
-        executeProcess(keyTool,
-            "-genkey", "-keystore", "./keystore", "-alias", keyName,
-            "-storepass", "abc123", "-keypass", "abc123", "-keyalg", "dsa",
-            "-dname", "CN=jvmtest")
-            .shouldHaveExitValue(0);
-
-        doSigning(jarName, keyName);
-    }
-
-    private static void doSigning(String jarName, String keyName) throws Exception {
-        executeProcess(jarSigner,
-           "-keystore", "./keystore", "-storepass", "abc123", "-keypass",
-           "abc123", "-signedjar", getJarFilePath("signed_" + jarName),
-           getJarFilePath(jarName), keyName)
-           .shouldHaveExitValue(0);
-    }
-
-    private static OutputAnalyzer executeProcess(String... cmds)
-        throws Exception {
-
-        JarBuilder.printArray("executeProcess: ", cmds);
-        return ProcessTools.executeProcess(new ProcessBuilder(cmds));
-    }
-
-    // diagnostic
-    public static void printIterable(String msg, Iterable<String> l) {
-        StringBuilder sum = new StringBuilder();
-        for (String s : l) {
-            sum.append(s).append(' ');
-        }
-        System.out.println(msg + sum.toString());
-    }
-
-    public static void printArray(String msg, String[] l) {
-        StringBuilder sum = new StringBuilder();
-        for (String s : l) {
-            sum.append(s).append(' ');
-        }
-        System.out.println(msg + sum.toString());
+        CDSJarUtils.buildFromDirectory(jarPath, classesDir,
+                                       JarOptions.of()
+                                           .setMainClass(mainClass)
+                                           .setManifest(manifest));
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/AOTClassLinkingVMOptions.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/AOTClassLinkingVMOptions.java
@@ -40,6 +40,7 @@
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import jdk.test.lib.cds.CDSModulePackager;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -101,92 +102,50 @@ public class AOTClassLinkingVMOptions {
     }
 
     static void modulePathTests() throws Exception {
-        CDSModulePathUtils.init();
+        String TEST_ROOT = System.getProperty("test.root");
+        Path SRC_DIR = Paths.get(TEST_ROOT, "runtime/cds/appcds/jigsaw/modulepath/src");
+
+        String MAIN_MODULE = "com.foos";
+        String MAIN_CLASS = "com.foos.Test";
+
+        String appClasses[] = {MAIN_CLASS};
+
+        CDSModulePackager modulePackager = new CDSModulePackager(SRC_DIR);
+        modulePackager.createModularJarWithMainClass(MAIN_MODULE, MAIN_CLASS);
+
+        String modulePath = modulePackager.getOutputDir().toString();
 
         testCase("Cannot use mis-matched module path");
-        String goodModulePath = CDSModulePathUtils.getModulesDir().toString();
-        TestCommon.testDump(null, CDSModulePathUtils.getAppClasses(),
-                            "--module-path", goodModulePath,
+        TestCommon.testDump(null, appClasses,
+                            "--module-path", modulePath,
                             "-XX:+AOTClassLinking",
-                            "-m", CDSModulePathUtils.MAIN_MODULE);
+                            "-m", MAIN_MODULE);
         TestCommon.run("-Xlog:cds",
-                       "--module-path", goodModulePath,
-                       "-m", CDSModulePathUtils.MAIN_MODULE)
+                       "--module-path", modulePath,
+                       "-m", MAIN_MODULE)
             .assertNormalExit("Using AOT-linked classes: true");
 
         TestCommon.run("-Xlog:cds",
-                       "--module-path", goodModulePath + "/bad",
-                       "-m", CDSModulePathUtils.MAIN_MODULE)
+                       "--module-path", modulePath + "/bad",
+                       "-m", MAIN_MODULE)
             .assertAbnormalExit("CDS archive has aot-linked classes. It cannot be used when archived full module graph is not used.");
 
         testCase("Cannot use mis-matched --add-modules");
-        TestCommon.testDump(null, CDSModulePathUtils.getAppClasses(),
-                            "--module-path", goodModulePath,
+        TestCommon.testDump(null, appClasses,
+                            "--module-path", modulePath,
                             "-XX:+AOTClassLinking",
-                            "--add-modules", CDSModulePathUtils.MAIN_MODULE);
+                            "--add-modules", MAIN_MODULE);
         TestCommon.run("-Xlog:cds",
-                       "--module-path", goodModulePath,
-                       "--add-modules", CDSModulePathUtils.MAIN_MODULE,
-                       CDSModulePathUtils.MAIN_CLASS)
+                       "--module-path", modulePath,
+                       "--add-modules", MAIN_MODULE,
+                       MAIN_CLASS)
             .assertNormalExit("Using AOT-linked classes: true");
 
         TestCommon.run("-Xlog:cds",
-                       "--module-path", goodModulePath + "/bad",
-                       "--add-modules", CDSModulePathUtils.TEST_MODULE,
-                       CDSModulePathUtils.MAIN_CLASS)
+                       "--module-path", modulePath,
+                       "--add-modules", "java.base",
+                       MAIN_CLASS)
             .assertAbnormalExit("Mismatched values for property jdk.module.addmods",
                                 "CDS archive has aot-linked classes. It cannot be used when archived full module graph is not used.");
-    }
-}
-
-// TODO: enhance and move this class to jdk.test.lib.cds.CDSModulePathUtils
-
-class CDSModulePathUtils {
-    private static String TEST_SRC = System.getProperty("test.root");
-    private static Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
-    private static Path SRC_DIR = Paths.get(TEST_SRC, "runtime/cds/appcds/jigsaw/modulepath/src");
-    private static Path MODS_DIR = Paths.get("mods");
-
-    public static String MAIN_MODULE = "com.bars";
-    public static String TEST_MODULE = "com.foos";
-
-    public static String MAIN_CLASS = "com.bars.Main";
-    public static String TEST_CLASS = "com.foos.Test";
-    private static String appClasses[] = {MAIN_CLASS, TEST_CLASS};
-
-    private static Path modulesDir;
-
-    // This directory contains all the modular jar files
-    //     $USER_DIR/modules/com.bars.jar
-    //     $USER_DIR/modules/com.foos.jar
-    static Path getModulesDir() {
-        return modulesDir;
-    }
-
-    static String[] getAppClasses() {
-        return appClasses;
-    }
-
-    static void init() throws Exception  {
-        JarBuilder.compileModule(SRC_DIR.resolve(TEST_MODULE),
-                                 MODS_DIR.resolve(TEST_MODULE),
-                                 null);
-        JarBuilder.compileModule(SRC_DIR.resolve(MAIN_MODULE),
-                                 MODS_DIR.resolve(MAIN_MODULE),
-                                 MODS_DIR.toString());
-
-        String PATH_LIBS = "modules";
-        modulesDir = Files.createTempDirectory(USER_DIR, PATH_LIBS);
-        Path mainJar = modulesDir.resolve(MAIN_MODULE + ".jar");
-        Path testJar = modulesDir.resolve(TEST_MODULE + ".jar");
-
-        // modylibs contains both modules com.foos.jar, com.bars.jar
-        // build com.foos.jar
-        String classes = MODS_DIR.resolve(TEST_MODULE).toString();
-        JarBuilder.createModularJar(testJar.toString(), classes, TEST_CLASS);
-
-        // build com.bars.jar
-        classes = MODS_DIR.resolve(MAIN_MODULE).toString();
-        JarBuilder.createModularJar(mainJar.toString(), classes, MAIN_CLASS);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ExportModule.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ExportModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,15 +30,13 @@
  * @summary Tests involve exporting a module from the module path to a jar in the -cp.
  */
 
-import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import jdk.test.lib.cds.CDSJarUtils;
+import jdk.test.lib.cds.CDSModulePackager;
 import jdk.test.lib.cds.CDSTestUtils;
-import jdk.test.lib.compiler.CompilerUtils;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.Asserts;
 
 public class ExportModule {
 
@@ -63,59 +61,42 @@ public class ExportModule {
     // unnamed module main class
     private static final String UNNAMED_MAIN = "com.nomodule.Main";
 
-    private static Path moduleDir = null;
+    private static Path moduleDir1 = null;
     private static Path moduleDir2 = null;
-    private static Path appJar = null;
+    private static Path appJar1 = null;
     private static Path appJar2 = null;
 
-    public static void buildTestModule() throws Exception {
+    private static void buildJars() throws Exception {
+        moduleDir2 = Paths.get("module-path2");
+        CDSModulePackager modulePackager2 = new CDSModulePackager(SRC_DIR, moduleDir2);
+        modulePackager2.createModularJar(TEST_MODULE2);
 
-        // javac -d mods/$TESTMODULE src/$TESTMODULE/**
-        JarBuilder.compileModule(SRC_DIR.resolve(TEST_MODULE2),
-                                 MODS_DIR.resolve(TEST_MODULE2),
-                                 null);
-
-        // javac -d mods/$TESTMODULE --module-path MOD_DIR src/$TESTMODULE/**
-        JarBuilder.compileModule(SRC_DIR.resolve(TEST_MODULE1),
-                                 MODS_DIR.resolve(TEST_MODULE1),
-                                 MODS_DIR.toString());
-
-        moduleDir = Files.createTempDirectory(USER_DIR, "mlib");
-        Path jar = moduleDir.resolve(TEST_MODULE2 + ".jar");
-        String classes = MODS_DIR.resolve(TEST_MODULE2).toString();
-        JarBuilder.createModularJar(jar.toString(), classes, null);
-
-        moduleDir2 = Files.createTempDirectory(USER_DIR, "mlib2");
-        appJar = moduleDir2.resolve(TEST_MODULE1 + ".jar");
-        classes = MODS_DIR.resolve(TEST_MODULE1).toString();
-        JarBuilder.createModularJar(appJar.toString(), classes, MAIN_CLASS);
+        moduleDir1 = Paths.get("module-path1");
+        CDSModulePackager modulePackager1 = new CDSModulePackager(SRC_DIR, moduleDir1);
+        modulePackager1.addExtraModulePath("module-path2");
+        appJar1 = modulePackager1.createModularJar(TEST_MODULE1);
 
         // build a non-modular jar containing the main class which
         // requires the org.astro package
-        boolean compiled
-            = CompilerUtils.compile(SRC_DIR.resolve(PKG_NAME),
-                                    MODS_DIR.resolve(PKG_NAME),
-                                    "--module-path", MODS_DIR.toString(),
-                                    "--add-modules", TEST_MODULE2,
-                                    "--add-exports", "org.astro/org.astro=ALL-UNNAMED");
-        Asserts.assertTrue(compiled, "test package did not compile");
+        appJar2 = USER_DIR.resolve("non-modular.jar");
 
-        appJar2 = moduleDir2.resolve(PKG_NAME + ".jar");
-        classes = MODS_DIR.resolve(PKG_NAME).toString();
-        JarBuilder.createModularJar(appJar2.toString(), classes, null);
+        CDSJarUtils.buildFromSourceDirectory(appJar2.toString(), SRC_DIR.resolve(PKG_NAME).toString(),
+                                             "--module-path", moduleDir2.toString(),
+                                             "--add-modules", TEST_MODULE2,
+                                             "--add-exports", "org.astro/org.astro=ALL-UNNAMED");
     }
 
     public static void main(String... args) throws Exception {
-        // compile the modules and create the modular jar files
-        buildTestModule();
+        buildJars();
+
         String appClasses[] = {MAIN_CLASS, APP_CLASS};
         // create an archive with the class in the org.astro module built in the
         // previous step and the main class from the modular jar in the -cp
         // note: the main class is in the modular jar in the -cp which requires
-        // the module in the --module-path
+        // the dependent module, org.astro, in the --module-path
         OutputAnalyzer output = TestCommon.createArchive(
-                                        appJar.toString(), appClasses,
-                                        "--module-path", moduleDir.toString(),
+                                        appJar1.toString(), appClasses,
+                                        "--module-path", moduleDir2.toString(),
                                         "--add-modules", TEST_MODULE2, MAIN_CLASS);
         TestCommon.checkDump(output);
 
@@ -123,8 +104,8 @@ public class ExportModule {
         // both the main class and the class from the org.astro module should
         // be loaded from the archive
         TestCommon.run("-Xlog:class+load=trace",
-                              "-cp", appJar.toString(),
-                              "--module-path", moduleDir.toString(),
+                              "-cp", appJar1.toString(),
+                              "--module-path", moduleDir2.toString(),
                               "--add-modules", TEST_MODULE2, MAIN_CLASS)
             .assertNormalExit(
                 "[class,load] org.astro.World source: shared objects file",
@@ -138,7 +119,7 @@ public class ExportModule {
         // unnmaed.
         output = TestCommon.createArchive(
                                         appJar2.toString(), appClasses2,
-                                        "--module-path", moduleDir.toString(),
+                                        "--module-path", moduleDir2.toString(),
                                         "--add-modules", TEST_MODULE2,
                                         "--add-exports", "org.astro/org.astro=ALL-UNNAMED",
                                         UNNAMED_MAIN);
@@ -148,7 +129,7 @@ public class ExportModule {
         // be loaded from the archive
         TestCommon.run("-Xlog:class+load=trace",
                        "-cp", appJar2.toString(),
-                       "--module-path", moduleDir.toString(),
+                       "--module-path", moduleDir2.toString(),
                        "--add-modules", TEST_MODULE2,
                        "--add-exports", "org.astro/org.astro=ALL-UNNAMED",
                        UNNAMED_MAIN)

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -131,6 +131,11 @@ abstract public class CDSAppTester {
         return null;
     }
 
+    // optional
+    public String modulepath(RunMode runMode) {
+        return null;
+    }
+
     // must override
     // main class, followed by arguments to the main class
     abstract public String[] appCommandLine(RunMode runMode);
@@ -194,16 +199,31 @@ abstract public class CDSAppTester {
         return output;
     }
 
+    private String[] addClassOrModulePath(RunMode runMode, String[] cmdLine) {
+        String cp = classpath(runMode);
+        if (cp == null) {
+            // Override the "-cp ...." added by Jtreg
+            cmdLine = StringArrayUtils.concat(cmdLine, "-Djava.class.path=");
+        } else {
+            cmdLine = StringArrayUtils.concat(cmdLine, "-cp", cp);
+        }
+        String mp = modulepath(runMode);
+        if (mp != null) {
+            cmdLine = StringArrayUtils.concat(cmdLine, "--module-path", mp);
+        }
+        return cmdLine;
+    }
+
     private OutputAnalyzer recordAOTConfiguration() throws Exception {
         RunMode runMode = RunMode.TRAINING;
         String[] cmdLine = StringArrayUtils.concat(vmArgs(runMode),
                                                    "-XX:AOTMode=record",
                                                    "-XX:AOTConfiguration=" + aotConfigurationFile,
-                                                   "-cp", classpath(runMode),
                                                    logToFile(aotConfigurationFileLog,
                                                              "class+load=debug",
                                                              "cds=debug",
                                                              "cds+class=debug"));
+        cmdLine = addClassOrModulePath(runMode, cmdLine);
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, aotConfigurationFile, aotConfigurationFileLog);
     }
@@ -213,9 +233,9 @@ abstract public class CDSAppTester {
         String[] cmdLine = StringArrayUtils.concat(vmArgs(runMode),
                                                    "-Xshare:off",
                                                    "-XX:DumpLoadedClassList=" + classListFile,
-                                                   "-cp", classpath(runMode),
                                                    logToFile(classListFileLog,
                                                              "class+load=debug"));
+        cmdLine = addClassOrModulePath(runMode, cmdLine);
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, classListFile, classListFileLog);
     }
@@ -228,12 +248,13 @@ abstract public class CDSAppTester {
                                                    "-Xshare:dump",
                                                    "-XX:SharedArchiveFile=" + staticArchiveFile,
                                                    "-XX:SharedClassListFile=" + classListFile,
-                                                   "-cp", classpath(runMode),
                                                    logToFile(staticArchiveFileLog,
                                                              "cds=debug",
                                                              "cds+class=debug",
                                                              "cds+heap=warning",
                                                              "cds+resolve=debug"));
+        cmdLine = addClassOrModulePath(runMode, cmdLine);
+        cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, staticArchiveFile, staticArchiveFileLog);
     }
 
@@ -245,12 +266,13 @@ abstract public class CDSAppTester {
                                                    "-XX:AOTMode=create",
                                                    "-XX:AOTConfiguration=" + aotConfigurationFile,
                                                    "-XX:AOTCache=" + aotCacheFile,
-                                                   "-cp", classpath(runMode),
                                                    logToFile(aotCacheFileLog,
                                                              "cds=debug",
                                                              "cds+class=debug",
                                                              "cds+heap=warning",
                                                              "cds+resolve=debug"));
+        cmdLine = addClassOrModulePath(runMode, cmdLine);
+        cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, aotCacheFile, aotCacheFileLog);
     }
 
@@ -290,12 +312,12 @@ abstract public class CDSAppTester {
           cmdLine = StringArrayUtils.concat(vmArgs(runMode),
                                             "-Xlog:cds",
                                             "-XX:ArchiveClassesAtExit=" + dynamicArchiveFile,
-                                            "-cp", classpath(runMode),
                                             logToFile(dynamicArchiveFileLog,
                                                       "cds=debug",
                                                       "cds+class=debug",
                                                       "cds+resolve=debug",
                                                       "class+load=debug"));
+          cmdLine = addClassOrModulePath(runMode, cmdLine);
         }
         if (baseArchive != null) {
             cmdLine = StringArrayUtils.concat(cmdLine, "-XX:SharedArchiveFile=" + baseArchive);
@@ -319,8 +341,8 @@ abstract public class CDSAppTester {
         String[] cmdLine = StringArrayUtils.concat(vmArgs(runMode),
                                                    "-XX:+UnlockDiagnosticVMOptions",
                                                    "-XX:VerifyArchivedFields=2", // make sure archived heap objects are good.
-                                                   "-cp", classpath(runMode),
                                                    logToFile(productionRunLog(), "cds"));
+        cmdLine = addClassOrModulePath(runMode, cmdLine);
 
         if (isStaticWorkflow()) {
             cmdLine = StringArrayUtils.concat(cmdLine, "-Xshare:on", "-XX:SharedArchiveFile=" + staticArchiveFile);
@@ -368,21 +390,21 @@ abstract public class CDSAppTester {
         }
     }
 
-    private void runStaticWorkflow() throws Exception {
+    public void runStaticWorkflow() throws Exception {
         this.workflow = Workflow.STATIC;
         createClassList();
         dumpStaticArchive();
         productionRun();
     }
 
-    private void runDynamicWorkflow() throws Exception {
+    public void runDynamicWorkflow() throws Exception {
         this.workflow = Workflow.DYNAMIC;
         dumpDynamicArchive();
         productionRun();
     }
 
-    // See JEP 485
-    private void runAOTWorkflow() throws Exception {
+    // See JEP 483
+    public void runAOTWorkflow() throws Exception {
         this.workflow = Workflow.AOT;
         recordAOTConfiguration();
         createAOTCache();

--- a/test/lib/jdk/test/lib/cds/CDSJarUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSJarUtils.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package jdk.test.lib.cds;
+
+import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.StringArrayUtils;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.compiler.CompilerUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.util.FileUtils;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.spi.ToolProvider;
+
+public class CDSJarUtils {
+    // to turn DEBUG on via command line: -DCDSJarUtils.DEBUG=[true, TRUE]
+    private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("CDSJarUtils.DEBUG", "false"));
+    private static final String classDir = System.getProperty("test.classes");
+    private static final ToolProvider JAR = ToolProvider.findFirst("jar")
+        .orElseThrow(() -> new RuntimeException("ToolProvider for jar not found"));
+
+    public static String getJarFilePath(String jarName) {
+        return CDSTestUtils.getOutputDir() +  File.separator + jarName + ".jar";
+    }
+
+    // jar all files under dir, with manifest file man, with an optional versionArgs
+    // for generating a multi-release jar.
+    // The jar command is as follows:
+    // jar cmf \
+    //  <path to output jar> <path to the manifest file>\
+    //   -C <path to the base classes> .\
+    //    --release 9 -C <path to the versioned classes> .
+    // the last line begins with "--release" corresponds to the optional versionArgs.
+    public static String build(String jarName, File dir, String man, String ...versionArgs)
+        throws Exception {
+        ArrayList<String> args = new ArrayList<String>();
+        if (man != null) {
+            args.add("cfm");
+        } else {
+            args.add("cf");
+        }
+        String jarFile = getJarFilePath(jarName);
+        args.add(jarFile);
+        if (man != null) {
+            args.add(man);
+        }
+        args.add("-C");
+        args.add(dir.getAbsolutePath());
+        args.add(".");
+        for (String verArg : versionArgs) {
+            args.add(verArg);
+        }
+        createJar(args);
+        return jarFile;
+    }
+
+    public static String build(String jarName, String ...classNames)
+        throws Exception {
+
+        return createSimpleJar(classDir, getJarFilePath(jarName), classNames);
+    }
+
+    public static String build(boolean classesInWorkDir, String jarName, String ...classNames)
+        throws Exception {
+        if (classesInWorkDir) {
+            return createSimpleJar(".", getJarFilePath(jarName), classNames);
+        } else {
+            return build(jarName, classNames);
+        }
+    }
+
+
+    public static String buildWithManifest(String jarName, String manifest,
+        String jarClassesDir, String ...classNames) throws Exception {
+        String jarPath = getJarFilePath(jarName);
+        ArrayList<String> args = new ArrayList<String>();
+        args.add("cvfm");
+        args.add(jarPath);
+        args.add(System.getProperty("test.src") + File.separator + "test-classes"
+            + File.separator + manifest);
+        addClassArgs(args, jarClassesDir, classNames);
+        createJar(args);
+
+        return jarPath;
+    }
+
+
+    // Execute: jar uvf $jarFile -C $dir .
+    public static void update(String jarFile, String dir) throws Exception {
+        String jarExe = JDKToolFinder.getJDKTool("jar");
+
+        ArrayList<String> args = new ArrayList<>();
+        args.add(jarExe);
+        args.add("uvf");
+        args.add(jarFile);
+        args.add("-C");
+        args.add(dir);
+        args.add(".");
+
+        executeProcess(args.toArray(new String[1]));
+    }
+
+    private static String createSimpleJar(String jarclassDir, String jarName,
+        String[] classNames) throws Exception {
+
+        ArrayList<String> args = new ArrayList<String>();
+        args.add("cf");
+        args.add(jarName);
+        addClassArgs(args, jarclassDir, classNames);
+        createJar(args);
+
+        return jarName;
+    }
+
+    private static void addClassArgs(ArrayList<String> args, String jarclassDir,
+        String[] classNames) {
+
+        for (String name : classNames) {
+            args.add("-C");
+            args.add(jarclassDir);
+            args.add(name + ".class");
+        }
+    }
+
+    /*
+     * This class is for passing extra options to the "jar" command-line tool
+     * for buildFromDirectory() and buildFromSourceDirectory().
+     *
+     * E.g.
+     *
+     * buildFromSourceDirectory("out.jar", "src", JarOptions.of().setMainClass("MyMainClass"),
+     *                          "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED");
+     */
+    public static class JarOptions {
+        private String [] options;
+        private JarOptions() {}
+        
+        public static JarOptions of(String... options) {
+            JarOptions jo = new JarOptions();
+            jo.options = options;
+            return jo;
+        }
+
+        public JarOptions setMainClass(String mainClass) {
+            if (mainClass != null) {
+                options = StringArrayUtils.concat(options, "--main-class=" + mainClass);
+            }
+            return this;
+        }
+        public JarOptions setManifest(String manifest) {
+            if (manifest != null) {
+                options = StringArrayUtils.concat(options, "--manifest=" + manifest);
+            }
+            return this;
+        }
+    }
+
+    public static void buildFromDirectory(String jarPath,
+                                          String classesDir) throws Exception {
+        buildFromDirectory(jarPath, classesDir, null);
+    }
+
+    public static void buildFromDirectory(String jarPath,
+                                          String classesDir,
+                                          JarOptions jarOptions) throws Exception {
+        ArrayList<String> argList = new ArrayList<String>();
+        argList.add("--create");
+        argList.add("--file=" + jarPath);
+        if (jarOptions != null) {
+            for (String s : jarOptions.options) {
+                argList.add(s);
+            }
+        }
+        argList.add("-C");
+        argList.add(classesDir);
+        argList.add(".");
+        createJar(argList);
+    }
+
+    public static void buildFromSourceDirectory(String jarName, String srcDir, String... extraJavacArgs) throws Exception  {
+        buildFromSourceDirectory(jarName, srcDir, null, extraJavacArgs);
+    }
+ 
+    /*
+     * Compile all source files under srcDir using javac with extraJavacArgs. Package
+     * all the classes into the specified JAR file
+     */
+    public static void buildFromSourceDirectory(String jarName, String srcDir, JarOptions jarOptions,
+                                                String... extraJavacArgs) throws Exception
+    {
+        System.out.print("Compiling " + srcDir + " into " + jarName);
+        if (extraJavacArgs.length > 0) {
+            System.out.print(" with");
+            for (String s : extraJavacArgs) {
+                System.out.print(" " + s);
+            }
+        }
+        System.out.println();
+
+        Path dst = Files.createTempDirectory(Paths.get(""), "tmp-classes");
+
+        if (!CompilerUtils.compile(Paths.get(srcDir), dst, extraJavacArgs)) {
+            throw new RuntimeException("Compilation of " + srcDir + " failed");
+        }
+
+        CDSJarUtils.buildFromDirectory(jarName, dst.toString(), jarOptions);
+
+        try {
+            // Remove temp files to avoid clutter
+            FileUtils.deleteFileTreeWithRetry(dst);
+        } catch (Exception e) {
+            // Might fail on Windows due to anti-virus. Just ignore
+        }
+    }
+
+    private static void createJar(ArrayList<String> args) {
+        if (DEBUG) printIterable("createJar args: ", args);
+
+        if (JAR.run(System.out, System.err, args.toArray(new String[1])) != 0) {
+            throw new RuntimeException("jar operation failed");
+        }
+    }
+
+    // Many AppCDS tests use the same simple "hello.jar" which contains
+    // simple Hello.class and does not specify additional attributes.
+    // For this common use case, use this method to get the jar path.
+    // The method will check if the jar already exists
+    // (created by another test or test run), and will create the jar
+    // if it does not exist
+    public static String getOrCreateHelloJar() throws Exception {
+        String jarPath = getJarFilePath("hello");
+
+        File jarFile = new File(jarPath);
+        if (jarFile.exists()) {
+            return jarPath;
+        } else {
+            return build("hello", "Hello");
+        }
+    }
+
+    public static void compile(String dstPath, String source, String... extraArgs) throws Exception {
+        ArrayList<String> args = new ArrayList<String>();
+        args.add(JDKToolFinder.getCompileJDKTool("javac"));
+        args.add("-d");
+        args.add(dstPath);
+        if (extraArgs != null) {
+            for (String s : extraArgs) {
+                args.add(s);
+            }
+        }
+        args.add(source);
+
+        if (DEBUG) printIterable("compile args: ", args);
+
+        ProcessBuilder pb = new ProcessBuilder(args);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+    }
+
+    public static void compileModule(Path src,
+                                     Path dest,
+                                     String modulePathArg // arg to --module-path
+                                     ) throws Exception {
+        boolean compiled = false;
+        if (modulePathArg == null) {
+            compiled = CompilerUtils.compile(src, dest);
+        } else {
+            compiled = CompilerUtils.compile(src, dest,
+                                           "--module-path", modulePathArg);
+        }
+        if (!compiled) {
+            throw new RuntimeException("module did not compile");
+        }
+    }
+
+    static final String keyTool = JDKToolFinder.getJDKTool("keytool");
+    static final String jarSigner = JDKToolFinder.getJDKTool("jarsigner");
+
+    public static void signJarWithDisabledAlgorithm(String jarName) throws Exception {
+        String keyName = "key_with_disabled_alg";
+        executeProcess(keyTool,
+            "-genkey", "-keystore", "./keystore", "-alias", keyName,
+            "-storepass", "abc123", "-keypass", "abc123", "-keyalg", "dsa",
+            "-sigalg", "SHA1withDSA", "-keysize", "512", "-dname", "CN=jvmtest2")
+            .shouldHaveExitValue(0);
+
+        doSigning(jarName, keyName);
+    }
+
+    public static void signJar(String jarName) throws Exception {
+        String keyName = "mykey";
+        executeProcess(keyTool,
+            "-genkey", "-keystore", "./keystore", "-alias", keyName,
+            "-storepass", "abc123", "-keypass", "abc123", "-keyalg", "dsa",
+            "-dname", "CN=jvmtest")
+            .shouldHaveExitValue(0);
+
+        doSigning(jarName, keyName);
+    }
+
+    private static void doSigning(String jarName, String keyName) throws Exception {
+        executeProcess(jarSigner,
+           "-keystore", "./keystore", "-storepass", "abc123", "-keypass",
+           "abc123", "-signedjar", getJarFilePath("signed_" + jarName),
+           getJarFilePath(jarName), keyName)
+           .shouldHaveExitValue(0);
+    }
+
+    private static OutputAnalyzer executeProcess(String... cmds)
+        throws Exception {
+
+        printArray("executeProcess: ", cmds);
+        return ProcessTools.executeProcess(new ProcessBuilder(cmds));
+    }
+
+    // diagnostic
+    public static void printIterable(String msg, Iterable<String> l) {
+        StringBuilder sum = new StringBuilder();
+        for (String s : l) {
+            sum.append(s).append(' ');
+        }
+        System.out.println(msg + sum.toString());
+    }
+
+    public static void printArray(String msg, String[] l) {
+        StringBuilder sum = new StringBuilder();
+        for (String s : l) {
+            sum.append(s).append(' ');
+        }
+        System.out.println(msg + sum.toString());
+    }
+}

--- a/test/lib/jdk/test/lib/cds/CDSModulePackager.java
+++ b/test/lib/jdk/test/lib/cds/CDSModulePackager.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package jdk.test.lib.cds;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import jdk.test.lib.StringArrayUtils;
+import jdk.test.lib.compiler.CompilerUtils;
+import jdk.test.lib.util.FileUtils;
+import jdk.test.lib.cds.CDSJarUtils.JarOptions;
+
+public class CDSModulePackager {
+    private Path srcRoot;
+
+    // By default: ./test-modules in the scratch directory of the Jtreg test case.
+    private Path outputDir;
+
+    private String extraModulePaths;
+
+    // Create modules where the source code is located in ${test.src}/${srcRoot},
+    // where test.src is the directory that contains the current Jtreg test case.
+    //
+    // All modules will be packaged under ./${outputDir}/
+    public CDSModulePackager(String srcRoot, String outputDir) {
+        String testSrc = System.getProperty("test.src");
+        this.srcRoot = Paths.get(testSrc, srcRoot);
+        this.outputDir = Paths.get(outputDir);
+    }
+
+    public CDSModulePackager(String srcRoot) {
+        this(srcRoot, "test-modules");
+    }
+
+    public CDSModulePackager(Path srcRoot, Path outputDir) {
+        this.srcRoot = srcRoot;
+        this.outputDir = outputDir;
+    }
+
+    public CDSModulePackager(Path srcRoot) {
+        this(srcRoot, Paths.get("test-modules"));
+    }
+
+    public Path getOutputDir() {
+        return outputDir;
+    }
+
+    public void addExtraModulePath(String... extra) {
+        for (String s : extra) {
+            if (extraModulePaths == null) {
+                extraModulePaths = s;
+            } else {
+                extraModulePaths += File.pathSeparator + s;
+            }
+        }
+    }
+
+     public void addExtraModulePath(Path... extra) {
+        for (Path p : extra) {
+            if (extraModulePaths == null) {
+                extraModulePaths = p.toString();
+            } else {
+                extraModulePaths += File.pathSeparator + p.toString();
+            }
+        }
+    }
+
+    public Path createModularJar(String moduleName) throws Exception {
+       return createModularJarWithMainClass(moduleName, null, (JarOptions)null);
+    }
+
+    public Path createModularJar(String moduleName, String... javacOptions) throws Exception {
+       return createModularJarWithMainClass(moduleName, null, (JarOptions)null, javacOptions);
+    }
+
+    public Path createModularJarWithMainClass(String moduleName, String mainClass, String... javacOptions) throws Exception {
+        return createModularJarWithMainClass(moduleName, mainClass, (JarOptions)null, javacOptions);
+    }
+
+    // Compile all files under ${this.srcRoot}/${moduleName}.
+    public Path createModularJarWithMainClass(String moduleName, String mainClass, JarOptions jarOptions, String... javacOptions) throws Exception {
+        Path src = srcRoot.resolve(moduleName);
+
+        // We always include the outputDir in the --module-path, so that you can compile new modules
+        // that are dependent on modules already inside the outputDir.
+        String modulePath = outputDir.toString();
+        if (extraModulePaths != null) {
+            modulePath += File.pathSeparator + extraModulePaths;
+        }
+        if (javacOptions == null) {            
+            javacOptions = new String[] {"--module-path", modulePath};
+        } else {
+            javacOptions = StringArrayUtils.concat(javacOptions, "--module-path", modulePath);
+        }
+
+        if (mainClass != null) {
+            if (jarOptions == null) {
+                jarOptions = JarOptions.of();
+            }
+            jarOptions.setMainClass(mainClass);
+        }
+
+        Path jarFile = outputDir.resolve(moduleName + ".jar");
+        CDSJarUtils.buildFromSourceDirectory(jarFile.toString(), src.toString(), jarOptions, javacOptions);
+
+        return jarFile;
+    }
+}

--- a/test/lib/jdk/test/lib/cds/SimpleCDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/SimpleCDSAppTester.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.cds;
+
+import java.io.File;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.StringArrayUtils;
+import jdk.test.whitebox.WhiteBox;
+import jtreg.SkippedException;
+
+import java.util.function.Consumer;
+
+/*
+ * A simpler way to use CDSAppTester. Example:
+ *
+ * SimpleCDSAppTester.of("moduleNeedsJdkAddExport")
+ *    .classpath(dummyJar)
+ *    .modulepath(modulePath)
+ *    .addVmArgs("--add-modules", "com.needsjdkaddexport",
+ *               "--add-exports", "java.base/jdk.internal.misc=com.needsjdkaddexport", "-Xlog:cds")
+ *    .appCommandLine("-m", "com.needsjdkaddexport/com.needsjdkaddexport.Main")
+ *    .setAssemblyChecker((OutputAnalyzer out) -> {
+ *           out.shouldContain("Full module graph = enabled");
+ *        })
+ *    .setProductionChecker((OutputAnalyzer out) -> {
+ *            out.shouldContain("use_full_module_graph = true; java.base");
+ *        })
+ *    .runStaticWorkflow()
+ *    .runAOTWorkflow();
+ */
+public class SimpleCDSAppTester {
+    private String name;
+    private Consumer<OutputAnalyzer> assemblyChecker;
+    private Consumer<OutputAnalyzer> productionChecker;
+    private String classpath;
+    private String modulepath;
+    private String[] appCommandLine;
+    private String[] vmArgs = new String[] {};
+
+    private SimpleCDSAppTester(String name) {
+        this.name = name;
+    }
+
+    public static SimpleCDSAppTester of(String name) {
+        return new SimpleCDSAppTester(name);
+    }
+
+    public SimpleCDSAppTester classpath(String... paths) {
+        this.classpath = null;
+        for (String p : paths) {
+            if (this.classpath == null) {
+                this.classpath = p;
+            } else {
+                this.classpath += File.pathSeparator + p;
+            }
+        }
+        return this;
+    }
+
+    public SimpleCDSAppTester modulepath(String... paths) {
+        this.modulepath = null;
+        for (String p : paths) {
+            if (this.modulepath == null) {
+                this.modulepath = p;
+            } else {
+                this.modulepath += File.pathSeparator + p;
+            }
+        }
+        return this;
+    }
+
+    public SimpleCDSAppTester addVmArgs(String... args) {
+        vmArgs = StringArrayUtils.concat(vmArgs, args);
+        return this;
+    }
+
+    public SimpleCDSAppTester appCommandLine(String... args) {
+        this.appCommandLine = args;
+        return this;
+    }
+
+    public SimpleCDSAppTester setAssemblyChecker(Consumer<OutputAnalyzer> checker) {
+        this.assemblyChecker = checker;
+        return this;
+    }
+
+    public SimpleCDSAppTester setProductionChecker(Consumer<OutputAnalyzer> checker) {
+        this.productionChecker = checker;
+        return this;
+    }
+
+    class Tester extends CDSAppTester {
+        public Tester(String name) {
+            super(name);
+        }
+
+        @Override
+        public String classpath(RunMode runMode) {
+            return SimpleCDSAppTester.this.classpath;
+        }
+
+        @Override
+        public String modulepath(RunMode runMode) {
+            return SimpleCDSAppTester.this.modulepath;
+        }
+
+        @Override
+        public String[] vmArgs(RunMode runMode) {
+            return SimpleCDSAppTester.this.vmArgs;
+        }
+
+        @Override
+        public String[] appCommandLine(RunMode runMode) {
+            return SimpleCDSAppTester.this.appCommandLine;
+        }
+
+        @Override
+        public void checkExecution(OutputAnalyzer out, RunMode runMode) throws Exception {
+            if (isDumping(runMode) && runMode != RunMode.TRAINING) {
+                if (assemblyChecker != null) {
+                    assemblyChecker.accept(out);
+                }
+            } else if (runMode.isProductionRun()) {
+                if (productionChecker != null) {
+                    productionChecker.accept(out);
+                }
+            }
+        }
+    }
+
+    public SimpleCDSAppTester runStaticWorkflow() throws Exception {
+        (new Tester(name)).runStaticWorkflow();
+        return this;
+    }
+
+    public SimpleCDSAppTester runAOTWorkflow() throws Exception {
+        (new Tester(name)).runAOTWorkflow();
+        return this;
+    }
+}


### PR DESCRIPTION
In CDS/AOT testing, we have a lot of code that deal with compiling/packaging modules, as well as running various child processes for the training/assembly/production phases.

Currently, these operations are done in many low-level steps, so it's difficult to understand and maintain:

https://github.com/openjdk/jdk/blob/fcc2a24291d499f7149debad1250903ddc369d91/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ExportModule.java

This PR adds a few new classes to simplify the test cases:

Example: build two modular JAR files into `modulePath`

```
CDSModulePackager modulePackager = new CDSModulePackager(SRC);
modulePath = modulePackager.getOutputDir().toString();

modulePackager.createModularJar("com.foos");
modulePackager.createModularJar("com.needsfoosaddexport",
                                "--add-exports",
                                "com.foos/com.foos.internal=com.needsfoosaddexport");
```

Example: use modules in training/assembly/production phases

```
SimpleCDSAppTester.of("moduleNeedsJdkAddExport")
   .classpath(dummyJar)
   .modulepath(modulePath)
   .addVmArgs("--add-modules", "com.needsjdkaddexport",
              "--add-exports", "java.base/jdk.internal.misc=com.needsjdkaddexport", "-Xlog:cds")
   .appCommandLine("-m", "com.needsjdkaddexport/com.needsjdkaddexport.Main")
   .setAssemblyChecker((OutputAnalyzer out) -> {
           out.shouldContain("Full module graph = enabled");
        })
    .setProductionChecker((OutputAnalyzer out) -> {
            out.shouldContain("use_full_module_graph = true; java.base");
        })
    .runStaticWorkflow()
    .runAOTWorkflow();
```