### PR TITLE
8351601: [JMH] test UnixSocketChannelReadWrite failed for 2 threads config

### DIFF
--- a/test/micro/org/openjdk/bench/java/net/UnixSocketChannelReadWrite.java
+++ b/test/micro/org/openjdk/bench/java/net/UnixSocketChannelReadWrite.java
@@ -92,8 +92,8 @@ public class UnixSocketChannelReadWrite {
         s1.close();
         s2.close();
         ssc.close();
-        Files.delete(socket);
-        Files.delete(Path.of(tempDir));
+        Files.deleteIfExists(socket);
+        Files.deleteIfExists(Path.of(tempDir));
         rt.join();
     }
 


### PR DESCRIPTION
Guards against multi-deletes in `UnixSocketChannelReadWrite`.