### PR TITLE
8352489: Relax jspawnhelper version checks to informative

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/JspawnhelperWarnings.java
+++ b/test/jdk/java/lang/ProcessBuilder/JspawnhelperWarnings.java
@@ -48,7 +48,7 @@ public class JspawnhelperWarnings {
         if (nArgs != 2) {
             oa.shouldContain("Incorrect number of arguments");
         } else {
-            oa.shouldContain("Incorrect Java version");
+            oa.shouldContain("Java version 1");
         }
     }
 
@@ -56,12 +56,12 @@ public class JspawnhelperWarnings {
         String[] args = new String[3];
         args[0] = Paths.get(System.getProperty("java.home"), "lib", "jspawnhelper").toString();
         args[1] = "wrongVersion";
-        args[2] = "1:1:1";
+        args[2] = "-1:-1:-1"; // Avoid passing accidentally correct FD numbers.
         Process p = ProcessTools.startProcess("jspawnhelper", new ProcessBuilder(args));
         OutputAnalyzer oa = new OutputAnalyzer(p);
         oa.shouldHaveExitValue(1);
         oa.shouldContain("This command is not for general use");
-        oa.shouldContain("Incorrect Java version: wrongVersion");
+        oa.shouldContain("Java version wrongVersion");
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
See the bug for rationale. 

This goal for this improvement is to be easily backportable, so we can catch up with update releases. As such, it does a few borderline-trivial changes, and _does not_ change the jspawnhelper protocol. So the overwrite of `jspawnhelper` with this new version would be "compatible" in a very weak sense of the word.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `java/lang/ProcessBuilder`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352489](https://bugs.openjdk.org/browse/JDK-8352489): Relax jspawnhelper version checks to informative (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24127/head:pull/24127` \
`$ git checkout pull/24127`

Update a local copy of the PR: \
`$ git checkout pull/24127` \
`$ git pull https://git.openjdk.org/jdk.git pull/24127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24127`

View PR using the GUI difftool: \
`$ git pr show -t 24127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24127.diff">https://git.openjdk.org/jdk/pull/24127.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24127#issuecomment-2739796271)
</details>
