### PR TITLE
8329173: LCMS_CFLAGS from configure are lost

### DIFF
--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -67,8 +67,6 @@ ifeq ($(USE_EXTERNAL_LCMS), true)
   # If we're using an external library, we can't include our own SRC path
   # as includes, instead the system headers should be used.
   LIBLCMS_HEADERS_FROM_SRC := false
-  # FIXME: Keep old behavior and reset LCMS_CFLAGS. This is likely a bug.
-  LCMS_CFLAGS :=
 endif
 
 ifeq ($(TOOLCHAIN_TYPE)+$(TOOLCHAIN_VERSION), clang+10.1)


### PR DESCRIPTION
In [JDK-8329086](https://bugs.openjdk.org/browse/JDK-8329086), when cleaning up the native build for java.desktop, what was likely a bug with LCMS_CFLAGS was found. See the discussion at https://github.com/openjdk/jdk/pull/18486#discussion_r1539179250.

The old behavior was kept to not introduce any changes in that refactoring PR, but now the time has come to clean this up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329173](https://bugs.openjdk.org/browse/JDK-8329173): LCMS_CFLAGS from configure are lost (**Bug** - P5)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24131/head:pull/24131` \
`$ git checkout pull/24131`

Update a local copy of the PR: \
`$ git checkout pull/24131` \
`$ git pull https://git.openjdk.org/jdk.git pull/24131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24131`

View PR using the GUI difftool: \
`$ git pr show -t 24131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24131.diff">https://git.openjdk.org/jdk/pull/24131.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24131#issuecomment-2740439899)
</details>
