### PR TITLE
8351310: Deprecate com.sun.jdi.JDIPermission for removal

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/jdi/JDIPermission.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/JDIPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ package com.sun.jdi;
  * @apiNote
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
+ * Consequently this class is deprecated for removal in a future release.
  *
  * @author  Tim Bell
  * @since   1.5
@@ -44,8 +45,11 @@ package com.sun.jdi;
  * @see java.security.PermissionCollection
  * @see java.lang.SecurityManager
  *
+ * @deprecated This class was only useful in conjunction with the Security Manager,
+ * which is no longer supported. There is no replacement for this class.
  */
 
+@Deprecated(since="25", forRemoval=true)
 public final class JDIPermission extends java.security.BasicPermission {
 
     private static final long serialVersionUID = -6988461416938786271L;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineManagerImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.ServiceLoader;
 
-import com.sun.jdi.JDIPermission;
 import com.sun.jdi.VMDisconnectedException;
 import com.sun.jdi.VirtualMachine;
 import com.sun.jdi.VirtualMachineManager;


### PR DESCRIPTION
Following on from JEP 486 (Permanently Disable the Security Manager), there are Permission classes which are unused. These should be deprecated, for removal in future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8352390](https://bugs.openjdk.org/browse/JDK-8352390) to be approved

### Issues
 * [JDK-8351310](https://bugs.openjdk.org/browse/JDK-8351310): Deprecate com.sun.jdi.JDIPermission for removal (**Enhancement** - P4)
 * [JDK-8352390](https://bugs.openjdk.org/browse/JDK-8352390): Deprecate com.sun.jdi.JDIPermission for removal (**CSR**)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24132/head:pull/24132` \
`$ git checkout pull/24132`

Update a local copy of the PR: \
`$ git checkout pull/24132` \
`$ git pull https://git.openjdk.org/jdk.git pull/24132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24132`

View PR using the GUI difftool: \
`$ git pr show -t 24132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24132.diff">https://git.openjdk.org/jdk/pull/24132.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24132#issuecomment-2740726949)
</details>
