### PR TITLE
8351224: Deprecate com.sun.tools.attach.AttachPermission for removal

### DIFF
--- a/src/jdk.attach/share/classes/com/sun/tools/attach/AttachPermission.java
+++ b/src/jdk.attach/share/classes/com/sun/tools/attach/AttachPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,12 +33,17 @@ package com.sun.tools.attach;
  * @apiNote
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
+ * Consequently this class is deprecated for removal in a future release.
  *
  * @see com.sun.tools.attach.VirtualMachine
  * @see com.sun.tools.attach.spi.AttachProvider
  * @since 1.6
+ *
+ * @deprecated This class was only useful in conjunction with the Security Manager,
+ * which is no longer supported. There is no replacement for this class.
  */
 
+@Deprecated(since="25", forRemoval=true)
 public final class AttachPermission extends java.security.BasicPermission {
 
     /** use serialVersionUID for interoperability */


### PR DESCRIPTION
Following on from JEP 486 (Permanently Disable the Security Manager), there are Permission classes which are unused. These should be deprecated, for removal in future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8352391](https://bugs.openjdk.org/browse/JDK-8352391) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8351224](https://bugs.openjdk.org/browse/JDK-8351224): Deprecate com.sun.tools.attach.AttachPermission for removal (**Enhancement** - P4)
 * [JDK-8352391](https://bugs.openjdk.org/browse/JDK-8352391): Deprecate com.sun.tools.attach.AttachPermission for removal (**CSR**)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24133/head:pull/24133` \
`$ git checkout pull/24133`

Update a local copy of the PR: \
`$ git checkout pull/24133` \
`$ git pull https://git.openjdk.org/jdk.git pull/24133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24133`

View PR using the GUI difftool: \
`$ git pr show -t 24133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24133.diff">https://git.openjdk.org/jdk/pull/24133.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24133#issuecomment-2740717996)
</details>
