### PR TITLE
8352511: Show additional level of headings in table of contents

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -221,7 +221,8 @@ public abstract class AbstractMemberWriter {
             Content member = getMemberSummaryHeader(target);
             summaryTreeList.forEach(member::add);
             buildSummary(target, member);
-            writer.tableOfContents.addLink(HtmlIds.forMemberSummary(kind), getSummaryLabel());
+            writer.tableOfContents.addLink(HtmlIds.forMemberSummary(kind), getSummaryLabel(),
+                    TableOfContents.Level.FIRST);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriter.java
@@ -91,8 +91,8 @@ public class AnnotationTypeMemberWriter extends AbstractMemberWriter {
             addAnnotationDetailsMarker(target);
             Content annotationDetailsHeader = getAnnotationDetailsHeader();
             Content memberList = getMemberList();
-            writer.tableOfContents.addLink(HtmlIds.ANNOTATION_TYPE_ELEMENT_DETAIL, contents.annotationTypeDetailsLabel);
-            writer.tableOfContents.pushNestedList();
+            writer.tableOfContents.addLink(HtmlIds.ANNOTATION_TYPE_ELEMENT_DETAIL,
+                    contents.annotationTypeDetailsLabel, TableOfContents.Level.FIRST);
 
             for (Element member : members) {
                 currentMember = member;
@@ -102,11 +102,10 @@ public class AnnotationTypeMemberWriter extends AbstractMemberWriter {
                 annotationContent.add(div);
                 memberList.add(writer.getMemberListItem(annotationContent));
                 writer.tableOfContents.addLink(htmlIds.forMember((ExecutableElement) member).getFirst(),
-                        Text.of(name(member)));
+                        Text.of(name(member)), TableOfContents.Level.SECOND);
             }
             Content annotationDetails = getAnnotationDetails(annotationDetailsHeader, memberList);
             target.add(annotationDetails);
-            writer.tableOfContents.popNestedList();
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
@@ -516,13 +516,12 @@ public class ClassWriter extends SubWriterHolderWriter {
 
     protected void addClassDescription(Content classInfo) {
         addPreviewInfo(classInfo);
-        tableOfContents.addLink(HtmlIds.TOP_OF_PAGE, contents.descriptionLabel);
+        tableOfContents.addLink(HtmlIds.TOP_OF_PAGE, contents.descriptionLabel,
+                TableOfContents.Level.FIRST);
         if (!options.noComment()) {
             // generate documentation for the class.
             if (!utils.getFullBody(typeElement).isEmpty()) {
-                tableOfContents.pushNestedList();
                 addInlineComment(typeElement, classInfo);
-                tableOfContents.popNestedList();
             }
         }
     }
@@ -534,9 +533,7 @@ public class ClassWriter extends SubWriterHolderWriter {
     protected void addClassTagInfo(Content classInfo) {
         if (!options.noComment()) {
             // Print Information about all the tags here
-            tableOfContents.pushNestedList();
             addTagsInfo(typeElement, classInfo);
-            tableOfContents.popNestedList();
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriter.java
@@ -144,8 +144,8 @@ public class ConstantsSummaryWriter extends HtmlDocletWriter {
      * Builds the list of contents for the groups of packages appearing in the constants summary page.
      */
     protected void buildContents() {
-        tableOfContents.addLink(HtmlIds.TOP_OF_PAGE, Text.of(resources.getText("doclet.Constants_Summary")))
-                .pushNestedList();
+        tableOfContents.addLink(HtmlIds.TOP_OF_PAGE, Text.of(resources.getText("doclet.Constants_Summary")),
+                TableOfContents.Level.FIRST);
         packageGroupHeadings.clear();
         for (PackageElement pkg : configuration.packages) {
             String abbrevPackageName = getAbbrevPackageName(pkg);
@@ -154,7 +154,6 @@ public class ConstantsSummaryWriter extends HtmlDocletWriter {
                 packageGroupHeadings.add(abbrevPackageName);
             }
         }
-        tableOfContents.popNestedList();
         bodyContents.setSideContent(tableOfContents.toContent(true));
     }
 
@@ -341,9 +340,11 @@ public class ConstantsSummaryWriter extends HtmlDocletWriter {
 
     void addLinkToTableOfContents(String abbrevPackageName) {
         if (abbrevPackageName.isEmpty()) {
-            tableOfContents.addLink(HtmlIds.UNNAMED_PACKAGE_ANCHOR, contents.defaultPackageLabel);
+            tableOfContents.addLink(HtmlIds.UNNAMED_PACKAGE_ANCHOR, contents.defaultPackageLabel,
+                    TableOfContents.Level.SECOND);
         } else {
-            tableOfContents.addLink(HtmlId.of(abbrevPackageName), Text.of(abbrevPackageName + ".*"));
+            tableOfContents.addLink(HtmlId.of(abbrevPackageName), Text.of(abbrevPackageName + ".*"),
+                    TableOfContents.Level.SECOND);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
@@ -106,8 +106,8 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
 
             Content constructorDetailsHeader = getConstructorDetailsHeader(target);
             Content memberList = getMemberList();
-            writer.tableOfContents.addLink(HtmlIds.CONSTRUCTOR_DETAIL, contents.constructorDetailsLabel);
-            writer.tableOfContents.pushNestedList();
+            writer.tableOfContents.addLink(HtmlIds.CONSTRUCTOR_DETAIL, contents.constructorDetailsLabel,
+                    TableOfContents.Level.FIRST);
 
             for (Element constructor : constructors) {
                 currentConstructor = (ExecutableElement)constructor;
@@ -122,11 +122,11 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
                 memberList.add(getMemberListItem(constructorContent));
                 writer.tableOfContents.addLink(htmlIds.forMember(currentConstructor).getFirst(),
                         Text.of(utils.getSimpleName(constructor)
-                                + utils.makeSignature(currentConstructor, typeElement, false, true)));
+                                + utils.makeSignature(currentConstructor, typeElement, false, true)),
+                        TableOfContents.Level.SECOND);
             }
             Content constructorDetails = getConstructorDetails(constructorDetailsHeader, memberList);
             target.add(constructorDetails);
-            writer.tableOfContents.popNestedList();
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandler.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandler.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandler.java
@@ -235,6 +235,11 @@ public class DocFilesHandler {
             printHtmlDocument(List.of(), null, localTagsContent, List.of(), htmlContent);
         }
 
+        @Override
+        protected TableOfContents createTableOfContents() {
+            return null;
+        }
+
         private String getWindowTitle(HtmlDocletWriter docletWriter, DocFileElement element) {
             var t = docletWriter.getFileTitle(element);
             return docletWriter.getWindowTitle(t);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriter.java
@@ -70,8 +70,8 @@ public class EnumConstantWriter extends AbstractMemberWriter {
         if (!enumConstants.isEmpty()) {
             Content enumConstantsDetailsHeader = getEnumConstantsDetailsHeader(target);
             Content memberList = getMemberList();
-            writer.tableOfContents.addLink(HtmlIds.ENUM_CONSTANT_DETAIL, contents.enumConstantDetailLabel);
-            writer.tableOfContents.pushNestedList();
+            writer.tableOfContents.addLink(HtmlIds.ENUM_CONSTANT_DETAIL, contents.enumConstantDetailLabel,
+                    TableOfContents.Level.FIRST);
 
             for (Element enumConstant : enumConstants) {
                 currentElement = (VariableElement)enumConstant;
@@ -84,12 +84,12 @@ public class EnumConstantWriter extends AbstractMemberWriter {
                 buildTagInfo(div);
                 enumConstantContent.add(div);
                 memberList.add(getMemberListItem(enumConstantContent));
-                writer.tableOfContents.addLink(htmlIds.forMember(currentElement), Text.of(name(currentElement)));
+                writer.tableOfContents.addLink(htmlIds.forMember(currentElement), Text.of(name(currentElement)),
+                        TableOfContents.Level.SECOND);
             }
             Content enumConstantDetails = getEnumConstantsDetails(
                     enumConstantsDetailsHeader, memberList);
             target.add(enumConstantDetails);
-            writer.tableOfContents.popNestedList();
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriter.java
@@ -81,8 +81,8 @@ public class FieldWriter extends AbstractMemberWriter {
         if (!fields.isEmpty()) {
             Content fieldDetailsHeader = getFieldDetailsHeader(target);
             Content memberList = getMemberList();
-            writer.tableOfContents.addLink(HtmlIds.FIELD_DETAIL, contents.fieldDetailsLabel);
-            writer.tableOfContents.pushNestedList();
+            writer.tableOfContents.addLink(HtmlIds.FIELD_DETAIL, contents.fieldDetailsLabel,
+                    TableOfContents.Level.FIRST);
 
             for (Element element : fields) {
                 currentElement = (VariableElement)element;
@@ -95,11 +95,11 @@ public class FieldWriter extends AbstractMemberWriter {
                 buildTagInfo(div);
                 fieldContent.add(div);
                 memberList.add(getMemberListItem(fieldContent));
-                writer.tableOfContents.addLink(htmlIds.forMember(currentElement), Text.of(name(element)));
+                writer.tableOfContents.addLink(htmlIds.forMember(currentElement), Text.of(name(element)),
+                        TableOfContents.Level.SECOND);
             }
             Content fieldDetails = getFieldDetails(fieldDetailsHeader, memberList);
             target.add(fieldDetails);
-            writer.tableOfContents.popNestedList();
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
@@ -102,8 +102,7 @@ public class HelpWriter extends HtmlDocletWriter {
      */
     protected void addHelpFileContents(Content content) {
         var mainHeading = getContent("doclet.help.main_heading");
-        tableOfContents.addLink(HtmlIds.TOP_OF_PAGE, mainHeading);
-        tableOfContents.pushNestedList();
+        tableOfContents.addLink(HtmlIds.TOP_OF_PAGE, mainHeading, TableOfContents.Level.FIRST);
         content.add(HtmlTree.HEADING(Headings.PAGE_TITLE_HEADING, HtmlStyles.title, mainHeading))
                 .add(HtmlTree.HR())
                 .add(getNavigationSection())
@@ -116,7 +115,6 @@ public class HelpWriter extends HtmlDocletWriter {
                 .add(HtmlTree.HR())
                 .add(HtmlTree.SPAN(HtmlStyles.helpFootnote,
                         getContent("doclet.help.footnote")));
-        tableOfContents.popNestedList();
     }
 
     /**
@@ -149,8 +147,7 @@ public class HelpWriter extends HtmlDocletWriter {
         }
         content.add(navSection);
 
-        tableOfContents.addLink(HtmlIds.HELP_NAVIGATION, navHeading);
-        tableOfContents.pushNestedList();
+        tableOfContents.addLink(HtmlIds.HELP_NAVIGATION, navHeading, TableOfContents.Level.SECOND);
 
         HtmlTree section;
 
@@ -194,8 +191,6 @@ public class HelpWriter extends HtmlDocletWriter {
                 HtmlTree.KBD(Entity.of("leftarrow")), HtmlTree.KBD(Entity.of("rightarrow")))));
         navSection.add(section.add(keyboardList));
 
-        tableOfContents.popNestedList();
-
         return content;
     }
 
@@ -220,8 +215,7 @@ public class HelpWriter extends HtmlDocletWriter {
                 .add(HtmlTree.HEADING(Headings.CONTENT_HEADING, pageKindsHeading).setId(HtmlIds.HELP_PAGES))
                 .add(contents.getContent("doclet.help.page_kinds.intro"));
 
-        tableOfContents.addLink(HtmlIds.HELP_PAGES, pageKindsHeading);
-        tableOfContents.pushNestedList();
+        tableOfContents.addLink(HtmlIds.HELP_PAGES, pageKindsHeading, TableOfContents.Level.SECOND);
 
         HtmlTree section;
 
@@ -427,7 +421,6 @@ public class HelpWriter extends HtmlDocletWriter {
                     .add(HtmlTree.P(getContent("doclet.help.index.body", indexLink, links)));
             pageKindsSection.add(section);
         }
-        tableOfContents.popNestedList();
 
         return pageKindsSection;
     }
@@ -444,9 +437,7 @@ public class HelpWriter extends HtmlDocletWriter {
             releasesSection.add(HtmlTree.P(contents.getContent("doclet.help.releases.body.refer")));
         }
 
-        tableOfContents.addLink(HtmlIds.HELP_RELEASES, releasesHeading);
-        tableOfContents.pushNestedList();
-        tableOfContents.popNestedList();
+        tableOfContents.addLink(HtmlIds.HELP_RELEASES, releasesHeading, TableOfContents.Level.SECOND);
 
         return releasesSection;
 
@@ -465,7 +456,7 @@ public class HelpWriter extends HtmlDocletWriter {
     }
 
     private HtmlTree newHelpSection(Content headingContent, HtmlId id) {
-        tableOfContents.addLink(id, headingContent);
+        tableOfContents.addLink(id, headingContent, TableOfContents.Level.THIRD);
 
         return HtmlTree.SECTION(HtmlStyles.helpSection,
                 HtmlTree.HEADING(Headings.SUB_HEADING, headingContent))

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -237,7 +237,7 @@ public abstract class HtmlDocletWriter {
         this.pathToRoot = path.parent().invert();
         this.docPaths = configuration.docPaths;
         this.mainBodyScript = new Script();
-        this.tableOfContents = new TableOfContents(this);
+        this.tableOfContents = createTableOfContents();
 
         if (generating) {
             writeGenerating();
@@ -1563,7 +1563,8 @@ public abstract class HtmlDocletWriter {
                             super.visit(text);
                         }
                     }.visit(heading);
-                    tableOfContents.addLink(id, Text.of(headingContent));
+                    tableOfContents.addLink(id, Text.of(headingContent),
+                            TableOfContents.Level.forHeading(htag));
                 }
             }
 
@@ -1833,6 +1834,16 @@ public abstract class HtmlDocletWriter {
                  .findFirst();
     }
 
+    /**
+     * Creates table of contents for this writer. Can be overridden to return {@code null} in
+     * subclasses that don't require a table of contents.
+     *
+     * @return a table of contents
+     */
+    protected TableOfContents createTableOfContents() {
+        return new TableOfContents(this);
+    }
+
     private void createSectionIdAndIndex(StartElementTree node, List<? extends DocTree> trees, Content attrs,
                                          Element element, TagletWriter.Context context) {
         // Use existing id attribute if available
@@ -1886,16 +1897,15 @@ public abstract class HtmlDocletWriter {
                     new DocLink(path, id));
             configuration.indexBuilder.add(item);
         }
-        if (includeHeadingInTableOfContents(node.getName())) {
-            tableOfContents.addLink(HtmlId.of(id), Text.of(headingContent));
+        if (includeHeadingInTableOfContents(tagName)) {
+            tableOfContents.addLink(HtmlId.of(id), Text.of(headingContent),
+                    TableOfContents.Level.forHeading(tagName));
         }
     }
 
-    private boolean includeHeadingInTableOfContents(CharSequence tag) {
-        // Record second-level headings for use in table of contents
-        // TODO: maybe extend this to all headings up to a given level
-        return tableOfContents != null
-                && tag.toString().equalsIgnoreCase("h2");
+    private boolean includeHeadingInTableOfContents(String tag) {
+        // Record second- and third-level headings for use in table of contents
+        return tableOfContents != null &&  ("h2".equals(tag) || "h3".equals(tag));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
@@ -101,8 +101,8 @@ public class MethodWriter extends AbstractExecutableMemberWriter {
         if (!methods.isEmpty()) {
             Content methodDetailsHeader = getMethodDetailsHeader(detailsList);
             Content memberList = writer.getMemberList();
-            writer.tableOfContents.addLink(HtmlIds.METHOD_DETAIL, contents.methodDetailLabel);
-            writer.tableOfContents.pushNestedList();
+            writer.tableOfContents.addLink(HtmlIds.METHOD_DETAIL, contents.methodDetailLabel,
+                    TableOfContents.Level.FIRST);
 
             for (Element method : methods) {
                 currentMethod = (ExecutableElement)method;
@@ -118,11 +118,11 @@ public class MethodWriter extends AbstractExecutableMemberWriter {
                 memberList.add(writer.getMemberListItem(methodContent));
                 writer.tableOfContents.addLink(htmlIds.forMember(currentMethod).getFirst(),
                         Text.of(utils.getSimpleName(method)
-                                + utils.makeSignature(currentMethod, typeElement, false, true)));
+                                + utils.makeSignature(currentMethod, typeElement, false, true)),
+                        TableOfContents.Level.SECOND);
             }
             Content methodDetails = getMethodDetails(methodDetailsHeader, memberList);
             detailsList.add(methodDetails);
-            writer.tableOfContents.popNestedList();
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
@@ -256,11 +256,10 @@ public class ModuleWriter extends HtmlDocletWriter {
      *                      be added
      */
     protected void buildModuleDescription(Content moduleContent) {
-        tableOfContents.addLink(HtmlIds.TOP_OF_PAGE, contents.navDescription);
+        tableOfContents.addLink(HtmlIds.TOP_OF_PAGE, contents.navDescription,
+                TableOfContents.Level.FIRST);
         if (!options.noComment()) {
-            tableOfContents.pushNestedList();
             addModuleDescription(moduleContent);
-            tableOfContents.popNestedList();
         }
     }
 
@@ -529,7 +528,7 @@ public class ModuleWriter extends HtmlDocletWriter {
 
     protected void addModulesSummary(Content summariesList) {
         if (display(requires) || display(indirectModules)) {
-            tableOfContents.addLink(HtmlIds.MODULES, contents.navModules);
+            tableOfContents.addLink(HtmlIds.MODULES, contents.navModules, TableOfContents.Level.FIRST);
             TableHeader requiresTableHeader =
                     new TableHeader(contents.modifierLabel, contents.moduleLabel,
                             contents.descriptionLabel);
@@ -574,7 +573,7 @@ public class ModuleWriter extends HtmlDocletWriter {
     protected void addPackagesSummary(Content summariesList) {
         if (display(packages)
                 || display(indirectPackages) || display(indirectOpenPackages)) {
-            tableOfContents.addLink(HtmlIds.PACKAGES, contents.navPackages);
+            tableOfContents.addLink(HtmlIds.PACKAGES, contents.navPackages, TableOfContents.Level.FIRST);
             var section = HtmlTree.SECTION(HtmlStyles.packagesSummary)
                     .setId(HtmlIds.PACKAGES);
             addSummaryHeader(MarkerComments.START_OF_PACKAGES_SUMMARY, contents.navPackages, section);
@@ -788,7 +787,7 @@ public class ModuleWriter extends HtmlDocletWriter {
         boolean haveProvides = displayServices(provides.keySet(), providesTrees);
 
         if (haveProvides || haveUses) {
-            tableOfContents.addLink(HtmlIds.SERVICES, contents.navServices);
+            tableOfContents.addLink(HtmlIds.SERVICES, contents.navServices, TableOfContents.Level.FIRST);
             var section = HtmlTree.SECTION(HtmlStyles.servicesSummary)
                     .setId(HtmlIds.SERVICES);
             addSummaryHeader(MarkerComments.START_OF_SERVICES_SUMMARY, contents.navServices, section);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
@@ -179,13 +179,12 @@ public class PackageWriter extends HtmlDocletWriter {
      *                       be added
      */
     protected void buildPackageDescription(Content packageContent) {
-        tableOfContents.addLink(HtmlIds.TOP_OF_PAGE, contents.navDescription);
+        tableOfContents.addLink(HtmlIds.TOP_OF_PAGE, contents.navDescription,
+                TableOfContents.Level.FIRST);
         if (options.noComment()) {
             return;
         }
-        tableOfContents.pushNestedList();
         addPackageDescription(packageContent);
-        tableOfContents.popNestedList();
     }
 
     /**
@@ -339,7 +338,8 @@ public class PackageWriter extends HtmlDocletWriter {
             }
         }
         if (!table.isEmpty()) {
-            tableOfContents.addLink(HtmlIds.CLASS_SUMMARY, contents.navClassesAndInterfaces);
+            tableOfContents.addLink(HtmlIds.CLASS_SUMMARY, contents.navClassesAndInterfaces,
+                    TableOfContents.Level.FIRST);
             target.add(HtmlTree.LI(table));
         }
     }
@@ -347,7 +347,8 @@ public class PackageWriter extends HtmlDocletWriter {
     protected void addRelatedPackageSummary(TableHeader tableHeader, Content summaryContent,
                                      boolean showModules) {
         if (!relatedPackages.isEmpty()) {
-            tableOfContents.addLink(HtmlIds.RELATED_PACKAGE_SUMMARY, contents.relatedPackages);
+            tableOfContents.addLink(HtmlIds.RELATED_PACKAGE_SUMMARY, contents.relatedPackages,
+                    TableOfContents.Level.FIRST);
             var table = new Table<Void>(HtmlStyles.summaryTable)
                     .setId(HtmlIds.RELATED_PACKAGE_SUMMARY)
                     .setCaption(contents.relatedPackages)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriter.java
@@ -75,8 +75,8 @@ public class PropertyWriter extends AbstractMemberWriter {
         if (!properties.isEmpty()) {
             Content propertyDetailsHeader = getPropertyDetailsHeader(detailsList);
             Content memberList = getMemberList();
-            writer.tableOfContents.addLink(HtmlIds.PROPERTY_DETAIL, contents.propertyDetailsLabel);
-            writer.tableOfContents.pushNestedList();
+            writer.tableOfContents.addLink(HtmlIds.PROPERTY_DETAIL, contents.propertyDetailsLabel,
+                    TableOfContents.Level.FIRST);
 
             for (Element property : properties) {
                 currentProperty = (ExecutableElement)property;
@@ -90,11 +90,10 @@ public class PropertyWriter extends AbstractMemberWriter {
                 propertyContent.add(div);
                 memberList.add(getMemberListItem(propertyContent));
                 writer.tableOfContents.addLink(htmlIds.forProperty(currentProperty),
-                        Text.of(utils.getPropertyLabel(name(property))));
+                        Text.of(utils.getPropertyLabel(name(property))), TableOfContents.Level.SECOND);
             }
             Content propertyDetails = getPropertyDetails(propertyDetailsHeader, memberList);
             detailsList.add(propertyDetails);
-            writer.tableOfContents.popNestedList();
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
@@ -35,6 +35,8 @@ import jdk.javadoc.internal.html.HtmlTree;
 import jdk.javadoc.internal.html.ListBuilder;
 import jdk.javadoc.internal.html.Text;
 
+import java.util.Locale;
+
 /**
  * A class used by various {@link HtmlDocletWriter} subclasses to build tables of contents.
  */
@@ -43,38 +45,45 @@ public class TableOfContents {
     private final HtmlDocletWriter writer;
 
     /**
+     * Supported hierarchy levels for entries in the table of contents.
+     */
+    public enum Level {
+        FIRST,
+        SECOND,
+        THIRD;
+
+        /**
+         * {@return the appropriate level to represent the given HTML heading}
+         */
+        public static Level forHeading(String tag) {
+            return switch (tag.toLowerCase(Locale.ROOT)) {
+                case "h1" -> FIRST;
+                case "h2" -> SECOND;
+                case "h3" -> THIRD;
+                default -> throw new IllegalArgumentException(tag);
+            };
+        }
+    }
+
+    /**
      * Constructor
      * @param writer the writer
      */
     public TableOfContents(HtmlDocletWriter writer) {
         this.writer = writer;
-        listBuilder = new ListBuilder(HtmlTree.OL(HtmlStyles.tocList)
-                .put(HtmlAttr.TABINDEX, "-1"));
+        listBuilder = new ListBuilder(HtmlTag.OL, HtmlStyles.tocList);
     }
 
     /**
-     * Adds a link to the table of contents.
+     * Adds a link to the table of contents at the given level.
+     *
      * @param id the link fragment
      * @param label the link label
-     * @return this object
+     * @param level the hierarchical level of the link
      */
-    public TableOfContents addLink(HtmlId id, Content label) {
-        listBuilder.add(writer.links.createLink(id, label).put(HtmlAttr.TABINDEX, "0"));
-        return this;
-    }
-
-    /**
-     * Adds a new nested list to add new items to.
-     */
-    public void pushNestedList() {
-        listBuilder.pushNestedList(HtmlTree.OL(HtmlStyles.tocList));
-    }
-
-    /**
-     * Closes the current nested list and go back to the parent list.
-     */
-    public void popNestedList() {
-        listBuilder.popNestedList();
+    public void addLink(HtmlId id, Content label, Level level) {
+        listBuilder.addItem(writer.links.createLink(id, label).put(HtmlAttr.TABINDEX, "0"),
+                level.ordinal());
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
@@ -464,7 +464,6 @@ document.addEventListener("DOMContentLoaded", function(e) {
         });
     var sections;
     var scrollTimeout;
-    var scrollTimeoutNeeded;
     var prevHash;
     function initSectionData() {
         bodyHeight = document.body.offsetHeight;
@@ -479,35 +478,30 @@ document.addEventListener("DOMContentLoaded", function(e) {
             }));
     }
     function setScrollTimeout() {
-        clearTimeout(scrollTimeout);
-        scrollTimeoutNeeded = false;
+        if (scrollTimeout) {
+            clearTimeout(scrollTimeout);
+        }
         scrollTimeout = setTimeout(() => {
             scrollTimeout = null;
-            handleScroll();
         }, 100);
     }
     function handleScroll() {
         if (!sidebar || !sidebar.offsetParent || sidebar.classList.contains("hide-sidebar")) {
             return;
         }
-        if (scrollTimeout || scrollTimeoutNeeded) {
+        if (scrollTimeout) {
             setScrollTimeout();
             return;
         }
         var scrollTop = document.documentElement.scrollTop;
         var scrollHeight = document.documentElement.scrollHeight;
         var currHash = null;
-        if (scrollHeight - scrollTop < window.innerHeight + 10) {
-            // Select last item if at bottom of the page
-            currHash = "#" + encodeURI(sections.at(-1).id);
-        } else {
-            for (var i = 0; i < sections.length; i++) {
-                var top = sections[i].top;
-                var bottom = sections[i + 1] ? sections[i + 1].top : scrollHeight;
-                if (top + ((bottom - top) / 2) > scrollTop || bottom > scrollTop + (window.innerHeight / 3)) {
-                    currHash = "#" + encodeURI(sections[i].id);
-                    break;
-                }
+        for (var i = 0; i < sections.length; i++) {
+            var top = sections[i].top;
+            var bottom = sections[i + 1] ? sections[i + 1].top : scrollHeight;
+            if (top + ((bottom - top) / 2) > scrollTop || bottom > scrollTop + (window.innerHeight / 3)) {
+                currHash = "#" + encodeURI(sections[i].id);
+                break;
             }
         }
         if (currHash !== prevHash) {
@@ -542,29 +536,26 @@ document.addEventListener("DOMContentLoaded", function(e) {
         document.querySelectorAll("a[href^='#']").forEach((link) => {
             link.addEventListener("click", (e) => {
                 link.blur();
-                scrollTimeoutNeeded = true;
+                setScrollTimeout();
                 setSelected(link.getAttribute("href"));
             })
         });
         sidebar.querySelector("button.hide-sidebar").addEventListener("click", hideSidebar);
         sidebar.querySelector("button.show-sidebar").addEventListener("click", showSidebar);
         window.addEventListener("hashchange", (e) => {
-            scrollTimeoutNeeded = true;
+            setScrollTimeout();
+            const hash = e.newURL.indexOf("#");
+            if (hash > -1) {
+                setSelected(e.newURL.substring(hash));
+            }
         });
         if (document.location.hash) {
-            scrollTimeoutNeeded = true;
+            setScrollTimeout();
             setSelected(document.location.hash);
         } else {
             handleScroll();
         }
         window.addEventListener("scroll", handleScroll);
-        window.addEventListener("scrollend", () => {
-            if (scrollTimeout) {
-                clearTimeout(scrollTimeout);
-                scrollTimeout = null;
-                handleScroll();
-            }
-        })
     }
     // Resize handler
     new ResizeObserver((entries) => {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
@@ -467,7 +467,8 @@ document.addEventListener("DOMContentLoaded", function(e) {
     var prevHash;
     function initSectionData() {
         bodyHeight = document.body.offsetHeight;
-        sections = [{ id: "", top: 0 }].concat(Array.from(main.querySelectorAll("section[id], h2[id], h2 a[id], div[id]"))
+        sections = [{ id: "", top: 0 }].concat(Array.from(main.querySelectorAll(
+                "section[id], h2[id], h2 a[id], h3[id], h3 a[id], div[id]"))
             .filter((e) => {
                 return sidebar.querySelector("a[href=\"#" + encodeURI(e.getAttribute("id")) + "\"]") !== null
             }).map((e) => {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -79,9 +79,10 @@
     --search-input-placeholder-color: #909090;
     /* Highlight color for active search tag target */
     --search-tag-highlight-color: #ffff66;
-    /* Adjustments for icon and active background colors of copy-to-clipboard buttons */
-    --copy-icon-brightness: 100%;
-    --copy-button-background-color-active: rgba(168, 168, 176, 0.3);
+    /* Copy button colors and filters */
+    --button-border-color: #b0b8c8;
+    --button-active-filter: brightness(96%);
+    --button-focus-filter: brightness(104%);
     /* Colors for invalid tag notifications */
     --invalid-tag-background-color: #ffe6e6;
     --invalid-tag-text-color: #000000;
@@ -535,6 +536,9 @@ nav.toc a {
 }
 nav.toc ol.toc-list ol.toc-list a {
     padding-left: 24px;
+}
+nav.toc ol.toc-list ol.toc-list ol.toc-list a {
+    padding-left: 40px;
 }
 nav.toc a:hover {
     background-color: var(--toc-hover-color);
@@ -1053,7 +1057,7 @@ input[type="text"] {
 }
 input#page-search-input {
     width: calc(180px + 10vw);
-    margin: 0;
+    margin: 10px 0;
 }
 input#search-input {
     width: 270px;
@@ -1101,7 +1105,7 @@ input:focus::placeholder {
     color: transparent;
 }
 select#search-modules {
-    margin: 0 10px 0 2px;
+    margin: 0 10px 10px 2px;
     font-size: var(--nav-font-size);
     padding: 3px 5px;
     border-radius: 4px;
@@ -1329,49 +1333,48 @@ a.anchor-link > img {
  * Styles for copy-to-clipboard buttons
  */
 button.copy {
-    opacity: 60%;
-    border: none;
+    font-size: var(--nav-font-size);
+    line-height: 1.2;
+    padding:0.3em;
+    background-color: transparent;
+    border: 1px solid transparent;
     border-radius: 3px;
     position: relative;
-    background:none;
-    transition: opacity 0.3s;
+    opacity: 80%;
+    transition: all 0.1s ease;
     cursor: pointer;
-}
-:hover > button.copy {
-    opacity: 70%;
 }
 button.copy:hover,
 button.copy:active,
-button.copy:focus-visible,
+button.copy:focus,
 button.copy.visible {
     opacity: 100%;
+    background-color: inherit;
+    border-color: var(--button-border-color);
+    filter: var(--button-focus-filter);
+}
+button.copy:active {
+    filter: var(--button-active-filter);
 }
 button.copy img {
     position: relative;
-    background: none;
-    filter: brightness(var(--copy-icon-brightness));
-}
-button.copy:active {
-    background-color: var(--copy-button-background-color-active);
 }
 button.copy span {
     color: var(--body-text-color);
     position: relative;
+    padding: 0.2em;
     top: -0.1em;
-    transition: all 0.1s;
-    font-size: 0.76rem;
-    line-height: 1.2;
+    transition: opacity 0.1s ease;
     opacity: 0;
 }
 button.copy:hover span,
-button.copy:focus-visible span,
+button.copy:focus span,
 button.copy.visible span {
     opacity: 100%;
 }
 /* search page copy button */
 button#page-search-copy {
     margin-left: 0.4em;
-    padding:0.3em;
     top:0.13em;
 }
 button#page-search-copy img {
@@ -1381,35 +1384,22 @@ button#page-search-copy img {
     top: 0.15em;
 }
 button#page-search-copy span {
-    color: var(--body-text-color);
-    line-height: 1.2;
-    padding: 0.2em;
     top: -0.18em;
-}
-div.page-search-info:hover button#page-search-copy span {
-    opacity: 100%;
 }
 /* snippet copy button */
 button.snippet-copy {
     position: absolute;
-    top: 6px;
-    right: 6px;
-    height: 1.7em;
-    padding: 2px;
+    top: 2px;
+    right: 2px;
+    height: 32px;
 }
 button.snippet-copy img {
     width: 18px;
     height: 18px;
-    padding: 0.05em 0;
+    padding: 2px 0;
 }
 button.snippet-copy span {
-    line-height: 1.2;
-    padding: 0.2em;
-    position: relative;
-    top: -0.5em;
-}
-div.snippet-container button.snippet-copy:hover span {
-    opacity: 100%;
+    top: -7px;
 }
 /*
  * Styles for user-provided tables.
@@ -1667,15 +1657,8 @@ pre.snippet {
 }
 div.snippet-container {
     position: relative;
-}
-@media screen and (max-width: 800px) {
-    pre.snippet {
-        padding-top: 26px;
-    }
-    button.snippet-copy {
-        top: 4px;
-        right: 4px;
-    }
+    padding-right: 30px;
+    background-color: var(--snippet-background-color);
 }
 pre.snippet .italic {
     font-style: italic;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/ListBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/ListBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,11 +33,9 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /**
- * A utility class for building nested HTML lists. This class is implemented as a
- * stack of nested list/item pairs where list items are added to the inner-most
- * list and nested lists are added to the current list item of the inner-most list.
- * Lists can be added to and removed from the stack using the {@link #pushNestedList}
- * and {@link #popNestedList} methods.
+ * A utility class for building nested HTML lists. The class maintains a
+ * stack of nested list trees which it adapts to obtain the desired nesting
+ * level of added items.
  */
 public class ListBuilder extends Content {
 
@@ -73,8 +71,8 @@ public class ListBuilder extends Content {
      * until the level is reached. If {@code level} is less than the current level, sublists
      * are closed to reach the level.
      *
-     * @param listItemContent the content for the new list item.
-     * @param level the level on which to add the item.
+     * @param listItemContent content for the new list item.
+     * @param level nesting level for the added item
      */
     public void addItem(Content listItemContent, int level) {
         if (level < 0 || level > MAX_LEVEL) {
@@ -91,35 +89,28 @@ public class ListBuilder extends Content {
     }
 
     /**
-     * Adds a new nested list to the current list item and makes it the recipient for new list items.
-     * Note that the nested list is added even if empty; use {@code addNested} to avoid adding empty
-     * lists.
-     *
-     * @return this list builder
+     * Adds a new nested nested list to which new items will be added.
      */
-    public ListBuilder pushNestedList() {
+    private void pushNestedList() {
         if (currentItem == null) {
             currentItem = HtmlTree.LI();
         }
         stack.push(new Pair(currentList, currentItem));
         currentList = createList();
         currentItem = null;
-        return this;
     }
 
     /**
-     * Pops the current list from the stack and returns to adding list items to the parent list.
+     * Closes the current nested list and makes its parent the current list.
      *
-     * @return this list builder
      * @throws NoSuchElementException if the stack is empty
      */
-    public ListBuilder popNestedList() {
+    private void popNestedList() {
         Pair pair = stack.pop();
         // First restore currentItem and add nested list to it before restoring currentList to outer list.
         currentItem = pair.item;
         currentItem.add(currentList);
         currentList = pair.list;
-        return this;
     }
 
     @Override

--- a/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownHeadings.java
+++ b/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownHeadings.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8298405
+ * @bug      8298405 8352511
  * @summary  Markdown support in the standard doclet
  * @library  /tools/lib ../../lib
  * @modules  jdk.javadoc/jdk.javadoc.internal.tool
@@ -287,6 +287,10 @@ public class TestMarkdownHeadings extends JavadocTester {
                     ///
                     /// Lorem ipsum
                     ///
+                    /// ### ATX Level 3 Heading
+                    ///
+                    /// Lorem ipsum
+                    ///
                     /// Setext heading
                     /// ==============
                     ///
@@ -312,13 +316,21 @@ public class TestMarkdownHeadings extends JavadocTester {
         checkExit(Exit.OK);
 
         checkOutput("p/C.html", true,
-                // note only the level 1 headings in the class description
+                // note only the level 1 and 2 headings in the class description
                 """
                     <ol class="toc-list" tabindex="-1">
                     <li><a href="#" tabindex="0">Description</a>
                     <ol class="toc-list">
-                    <li><a href="#atx-heading-code-underline-text-heading" tabindex="0">ATX heading code underline text</a></li>
-                    <li><a href="#setext-heading-heading" tabindex="0">Setext heading</a></li>
+                    <li><a href="#atx-heading-code-underline-text-heading" tabindex="0">ATX heading code underline text</a>
+                    <ol class="toc-list">
+                    <li><a href="#atx-subheading-heading" tabindex="0">ATX Subheading</a></li>
+                    </ol>
+                    </li>
+                    <li><a href="#setext-heading-heading" tabindex="0">Setext heading</a>
+                    <ol class="toc-list">
+                    <li><a href="#setext-subheading-heading" tabindex="0">Setext subheading</a></li>
+                    </ol>
+                    </li>
                     </ol>
                     </li>
                     <li><a href="#constructor-summary" tabindex="0">Constructor Summary</a></li>

--- a/test/langtools/jdk/javadoc/doclet/testTOCHeadings/TestTOCHeadings.java
+++ b/test/langtools/jdk/javadoc/doclet/testTOCHeadings/TestTOCHeadings.java
@@ -54,35 +54,35 @@ public class TestTOCHeadings extends JavadocTester {
                     package p;
                     /**
                      * <h1>First Level Heading</h1>
-                     * 
+                     *
                      * Lorem ipsum
-                     * 
+                     *
                      * <h2>Second Level Heading</h2>
-                     * 
+                     *
                      * Lorem ipsum
-                     * 
+                     *
                      * <h3>Third Level Heading</h3>
-                     * 
+                     *
                      * Lorem ipsum
-                     * 
+                     *
                      * <h2>Other Second Level Heading</h2>
-                     * 
+                     *
                      * Lorem ipsum
-                     * 
+                     *
                      * <h3>Other Third Level Heading</h3>
-                     * 
+                     *
                      * Lorem ipsum
-                     *            
+                     *
                      * <h4>Fourth Level Heading</h4>
-                     * 
+                     *
                      * Lorem ipsum
-                     *         
+                     *
                      * <h5>Fifth Level Heading</h5>
-                     * 
+                     *
                      * Lorem ipsum
-                     * 
+                     *
                      * <h6>Sixth Level Heading</h6>
-                     * 
+                     *
                      * Lorem ipsum
                      */
                     public class C {

--- a/test/langtools/jdk/javadoc/doclet/testTOCHeadings/TestTOCHeadings.java
+++ b/test/langtools/jdk/javadoc/doclet/testTOCHeadings/TestTOCHeadings.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug      8352511
+ * @summary  Show additional level of headings in table of contents
+ * @library  /tools/lib ../../lib
+ * @modules  jdk.javadoc/jdk.javadoc.internal.tool
+ * @build    toolbox.ToolBox javadoc.tester.*
+ * @run main TestTOCHeadings
+ */
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+import java.nio.file.Path;
+
+public class TestTOCHeadings extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        var tester = new TestTOCHeadings();
+        tester.runTests();
+    }
+
+    ToolBox tb = new ToolBox();
+
+    @Test
+    public void testHeadings(Path base) throws Exception {
+        Path src = base.resolve("src");
+
+        tb.writeJavaFiles(src,
+                """
+                    package p;
+                    /**
+                     * <h1>First Level Heading</h1>
+                     * 
+                     * Lorem ipsum
+                     * 
+                     * <h2>Second Level Heading</h2>
+                     * 
+                     * Lorem ipsum
+                     * 
+                     * <h3>Third Level Heading</h3>
+                     * 
+                     * Lorem ipsum
+                     * 
+                     * <h2>Other Second Level Heading</h2>
+                     * 
+                     * Lorem ipsum
+                     * 
+                     * <h3>Other Third Level Heading</h3>
+                     * 
+                     * Lorem ipsum
+                     *            
+                     * <h4>Fourth Level Heading</h4>
+                     * 
+                     * Lorem ipsum
+                     *         
+                     * <h5>Fifth Level Heading</h5>
+                     * 
+                     * Lorem ipsum
+                     * 
+                     * <h6>Sixth Level Heading</h6>
+                     * 
+                     * Lorem ipsum
+                     */
+                    public class C {
+                        /**
+                         * Method m.
+                         *
+                         * <h4>Subheading in m()</h4>
+                         *
+                         * Lorem ipsum
+                         */
+                        public void m() { }
+                    }""");
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-Xdoclint:none",
+                "--no-platform-links",
+                "--source-path", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput("p/C.html", true,
+                // note only the level 2 and 3 headings in the class description
+                """
+                    <ol class="toc-list" tabindex="-1">
+                    <li><a href="#" tabindex="0">Description</a>
+                    <ol class="toc-list">
+                    <li><a href="#second-level-heading-heading" tabindex="0">Second Level Heading</a>
+                    <ol class="toc-list">
+                    <li><a href="#third-level-heading-heading" tabindex="0">Third Level Heading</a></li>
+                    </ol>
+                    </li>
+                    <li><a href="#other-second-level-heading-heading" tabindex="0">Other Second Level Heading</a>
+                    <ol class="toc-list">
+                    <li><a href="#other-third-level-heading-heading" tabindex="0">Other Third Level Heading</a></li>
+                    </ol>
+                    </li>
+                    </ol>
+                    </li>
+                    <li><a href="#constructor-summary" tabindex="0">Constructor Summary</a></li>
+                    <li><a href="#method-summary" tabindex="0">Method Summary</a></li>
+                    <li><a href="#constructor-detail" tabindex="0">Constructor Details</a>
+                    <ol class="toc-list">
+                    <li><a href="#%3Cinit%3E()" tabindex="0">C()</a></li>
+                    </ol>
+                    </li>
+                    <li><a href="#method-detail" tabindex="0">Method Details</a>
+                    <ol class="toc-list">
+                    <li><a href="#m()" tabindex="0">m()</a></li>
+                    </ol>
+                    </li>
+                    </ol>
+                    """);
+    }
+}


### PR DESCRIPTION
Please review a patch to show an additional level of headings in the table of contents for module, package and class descriptions. Previously only `<h2>` headings were shown in the table of contents, now we also show `<h3>` level headings.

The `TableOfContents` class no longer provides `pushNestedList`/`popNestedList` methods that require us to manually manage nesting level. Instead, the method to add a TOC entry gets an additional `level` parameter with an enum type to specify the nesting level (`FIRST`, `SECOND`, `THIRD`). The class will then configure the list to the desired nesting level before adding the entry. Of course this works with both tradidtional and Markdown doc comments and has tests for both.

There are not too many API elements in JDK that use `<h3>` level headings, but those that do benefit a lot from this change. A few examples:

 - [package java.util.stream](https://cr.openjdk.org/~hannesw/8352511/api.00/java.base/java/util/stream/package-summary.html)
 - [package java.lang.classfile](https://cr.openjdk.org/~hannesw/8352511/api.00/java.base/java/lang/classfile/package-summary.html)
 - [package java.lang.invoke](https://cr.openjdk.org/~hannesw/8352511/api.00/java.base/java/lang/invoke/package-summary.html)
 - [package java.lang.module](https://cr.openjdk.org/~hannesw/8352511/api.00/java.base/java/lang/module/package-summary.html)

This PR depends on #24083 not for technical reasons but because that PR fixes the rendering of the third level of TOC entries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352511](https://bugs.openjdk.org/browse/JDK-8352511): Show additional level of headings in table of contents (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24137/head:pull/24137` \
`$ git checkout pull/24137`

Update a local copy of the PR: \
`$ git checkout pull/24137` \
`$ git pull https://git.openjdk.org/jdk.git pull/24137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24137`

View PR using the GUI difftool: \
`$ git pr show -t 24137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24137.diff">https://git.openjdk.org/jdk/pull/24137.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24137#issuecomment-2741212658)
</details>
