### PR TITLE
8352529: RISC-V: enable loopopts tests

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVector.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVector.java
@@ -412,7 +412,7 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"MaxVectorSize", ">=8"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test0(byte[] a, byte[] b, byte mask) {
         for (int i = 0; i < RANGE; i+=8) {
             // Safe to vectorize with AlignVector
@@ -432,7 +432,7 @@ public class TestAlignVector {
         // UNSAFE.ARRAY_BYTE_BASE_OFFSET = 16, but with compact object headers UNSAFE.ARRAY_BYTE_BASE_OFFSET=12.
         // If AlignVector=true, we need the offset to be 8-byte aligned, else the vectors are filtered out.
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static Object[] test1a(byte[] a, byte[] b, byte mask) {
         for (int i = 0; i < RANGE; i+=8) {
             b[i+0] = (byte)(a[i+0] & mask); // adr = base + UNSAFE.ARRAY_BYTE_BASE_OFFSET + 0 + iter*8
@@ -455,7 +455,7 @@ public class TestAlignVector {
         // UNSAFE.ARRAY_BYTE_BASE_OFFSET = 16, but with compact object headers UNSAFE.ARRAY_BYTE_BASE_OFFSET=12.
         // If AlignVector=true, we need the offset to be 8-byte aligned, else the vectors are filtered out.
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static Object[] test1b(byte[] a, byte[] b, byte mask) {
         for (int i = 4; i < RANGE-8; i+=8) {
             b[i+0] = (byte)(a[i+0] & mask); // adr = base + UNSAFE.ARRAY_BYTE_BASE_OFFSET + 4 + iter*8
@@ -476,11 +476,11 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=8"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.AND_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test2(byte[] a, byte[] b, byte mask) {
@@ -500,11 +500,11 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=8"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.AND_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test3(byte[] a, byte[] b, byte mask) {
@@ -528,7 +528,7 @@ public class TestAlignVector {
                   IRNode.AND_VB,        IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.AND_VB,        IRNode.VECTOR_SIZE_8, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=16"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, IRNode.VECTOR_SIZE_4, "> 0",
@@ -536,7 +536,7 @@ public class TestAlignVector {
                   IRNode.AND_VB,        IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.AND_VB,        IRNode.VECTOR_SIZE_8, "= 0",// unaligned
                   IRNode.STORE_VECTOR, "> 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">=16"})
     static Object[] test4(byte[] a, byte[] b, byte mask) {
@@ -565,11 +565,11 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=8"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.AND_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test5(byte[] a, byte[] b, byte mask, int inv) {
@@ -591,11 +591,11 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=8"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.AND_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test6(byte[] a, byte[] b, byte mask) {
@@ -617,11 +617,11 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=16"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_S, "= 0",
                   IRNode.AND_VS, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test7(short[] a, short[] b, short mask) {
@@ -643,11 +643,11 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=8"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.AND_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test8(byte[] a, byte[] b, byte mask, int init) {
@@ -669,7 +669,7 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"MaxVectorSize", ">=8"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test9(byte[] a, byte[] b, byte mask) {
         // known non-zero init value does not affect offset, but has implicit effect on iv
         for (int i = 13; i < RANGE-8; i+=8) {
@@ -687,13 +687,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_B, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.AND_VB,        IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=8"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.AND_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test10a(byte[] a, byte[] b, byte mask) {
@@ -711,13 +711,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_B, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.AND_VB,        IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=8"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.AND_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test10b(byte[] a, byte[] b, byte mask) {
@@ -736,13 +736,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_S, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.AND_VS,        IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=16"})
     @IR(counts = {IRNode.LOAD_VECTOR_S, "= 0",
                   IRNode.AND_VS, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test10c(short[] a, short[] b, short mask) {
@@ -765,7 +765,7 @@ public class TestAlignVector {
         // UNSAFE.ARRAY_BYTE_BASE_OFFSET = 16, but with compact object headers UNSAFE.ARRAY_BYTE_BASE_OFFSET=12.
         // If AlignVector=true, we need the offset to be 8-byte aligned, else the vectors are filtered out.
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static Object[] test10d(short[] a, short[] b, short mask) {
         for (int i = 13; i < RANGE-16; i+=8) {
             // adr = base + UNSAFE.ARRAY_SHORT_BASE_OFFSET + 2*(3 + 13) + iter*16
@@ -785,7 +785,7 @@ public class TestAlignVector {
         // UNSAFE.ARRAY_BYTE_BASE_OFFSET = 16, but with compact object headers UNSAFE.ARRAY_BYTE_BASE_OFFSET=12.
         // If AlignVector=true, we need the offset to be 8-byte aligned, else the vectors are filtered out.
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static Object[] test10e(short[] a, short[] b, short mask) {
         for (int i = 11; i < RANGE-16; i+=8) {
             // adr = base + UNSAFE.ARRAY_SHORT_BASE_OFFSET + 2*(3 + 11) + iter*16
@@ -802,7 +802,7 @@ public class TestAlignVector {
                   IRNode.AND_VB, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11aB(byte[] a, byte[] b, byte mask) {
         for (int i = 0; i < RANGE; i++) {
             // always alignable
@@ -816,7 +816,7 @@ public class TestAlignVector {
                   IRNode.AND_VS, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11aS(short[] a, short[] b, short mask) {
         for (int i = 0; i < RANGE; i++) {
             // always alignable
@@ -830,7 +830,7 @@ public class TestAlignVector {
                   IRNode.AND_VI, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11aI(int[] a, int[] b, int mask) {
         for (int i = 0; i < RANGE; i++) {
             // always alignable
@@ -844,7 +844,7 @@ public class TestAlignVector {
                   IRNode.AND_VL, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11aL(long[] a, long[] b, long mask) {
         for (int i = 0; i < RANGE; i++) {
             // always alignable
@@ -858,7 +858,7 @@ public class TestAlignVector {
                   IRNode.AND_VB, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11bB(byte[] a, byte[] b, byte mask) {
         for (int i = 1; i < RANGE; i++) {
             // always alignable
@@ -872,7 +872,7 @@ public class TestAlignVector {
                   IRNode.AND_VS, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11bS(short[] a, short[] b, short mask) {
         for (int i = 1; i < RANGE; i++) {
             // always alignable
@@ -886,7 +886,7 @@ public class TestAlignVector {
                   IRNode.AND_VI, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11bI(int[] a, int[] b, int mask) {
         for (int i = 1; i < RANGE; i++) {
             // always alignable
@@ -900,7 +900,7 @@ public class TestAlignVector {
                   IRNode.AND_VL, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11bL(long[] a, long[] b, long mask) {
         for (int i = 1; i < RANGE; i++) {
             // always alignable
@@ -913,13 +913,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0",
                   IRNode.AND_VB, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.AND_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test11cB(byte[] a, byte[] b, byte mask) {
@@ -934,13 +934,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0",
                   IRNode.AND_VS, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"})
     @IR(counts = {IRNode.LOAD_VECTOR_S, "= 0",
                   IRNode.AND_VS, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test11cS(short[] a, short[] b, short mask) {
@@ -955,13 +955,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0",
                   IRNode.AND_VI, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, "= 0",
                   IRNode.AND_VI, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test11cI(int[] a, int[] b, int mask) {
@@ -977,7 +977,7 @@ public class TestAlignVector {
                   IRNode.AND_VL, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11cL(long[] a, long[] b, long mask) {
         for (int i = 1; i < RANGE-1; i++) {
             // always alignable (8 byte offset)
@@ -991,7 +991,7 @@ public class TestAlignVector {
                   IRNode.AND_VB, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11dB(byte[] a, byte[] b, byte mask, int invar) {
         for (int i = 0; i < RANGE; i++) {
             b[i+0+invar] = (byte)(a[i+0+invar] & mask);
@@ -1004,7 +1004,7 @@ public class TestAlignVector {
                   IRNode.AND_VS, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11dS(short[] a, short[] b, short mask, int invar) {
         for (int i = 0; i < RANGE; i++) {
             b[i+0+invar] = (short)(a[i+0+invar] & mask);
@@ -1017,7 +1017,7 @@ public class TestAlignVector {
                   IRNode.AND_VI, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11dI(int[] a, int[] b, int mask, int invar) {
         for (int i = 0; i < RANGE; i++) {
             b[i+0+invar] = (int)(a[i+0+invar] & mask);
@@ -1030,7 +1030,7 @@ public class TestAlignVector {
                   IRNode.AND_VL, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test11dL(long[] a, long[] b, long mask, int invar) {
         for (int i = 0; i < RANGE; i++) {
             b[i+0+invar] = (long)(a[i+0+invar] & mask);
@@ -1044,7 +1044,7 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR,                                           "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test12(byte[] a, byte[] b, byte mask) {
         for (int i = 0; i < RANGE/16; i++) {
             // Non-power-of-2 stride. Vectorization of 4 bytes, then 2-bytes gap.
@@ -1063,7 +1063,7 @@ public class TestAlignVector {
                   IRNode.ADD_VL, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"})
     // require avx to ensure vectors are larger than what unrolling produces
     static Object[] test13aIL(int[] a, long[] b) {
         for (int i = 0; i < RANGE; i++) {
@@ -1081,7 +1081,7 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static Object[] test13aIB(int[] a, byte[] b) {
         for (int i = 0; i < RANGE; i++) {
             // adr = base + UNSAFE.ARRAY_BYTE_BASE_OFFSET + 1*iter
@@ -1111,7 +1111,7 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static Object[] test13aIS(int[] a, short[] b) {
         for (int i = 0; i < RANGE; i++) {
             // adr = base + UNSAFE.ARRAY_BYTE_BASE_OFFSET + 4*iter
@@ -1145,7 +1145,7 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static Object[] test13aBSIL(byte[] a, short[] b, int[] c, long[] d) {
         for (int i = 0; i < RANGE; i++) {
             // adr = base + UNSAFE.ARRAY_BYTE_BASE_OFFSET + 1*iter
@@ -1175,7 +1175,7 @@ public class TestAlignVector {
                   IRNode.ADD_VL, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"})
     // require avx to ensure vectors are larger than what unrolling produces
     static Object[] test13bIL(int[] a, long[] b) {
         for (int i = 1; i < RANGE; i++) {
@@ -1193,7 +1193,7 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static Object[] test13bIB(int[] a, byte[] b) {
         for (int i = 1; i < RANGE; i++) {
             // adr = base + UNSAFE.ARRAY_INT_BASE_OFFSET + 4 + 4*iter
@@ -1218,7 +1218,7 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static Object[] test13bIS(int[] a, short[] b) {
         for (int i = 1; i < RANGE; i++) {
             // adr = base + UNSAFE.ARRAY_INT_BASE_OFFSET + 4 + 4*iter
@@ -1247,7 +1247,7 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static Object[] test13bBSIL(byte[] a, short[] b, int[] c, long[] d) {
         for (int i = 1; i < RANGE; i++) {
             // adr = base + UNSAFE.ARRAY_BYTE_BASE_OFFSET + 1 + 1*iter
@@ -1274,13 +1274,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.ADD_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.ADD_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test14aB(byte[] a) {
@@ -1313,13 +1313,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.ADD_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.ADD_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test14bB(byte[] a) {
@@ -1352,13 +1352,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.ADD_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.ADD_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test14cB(byte[] a) {
@@ -1391,13 +1391,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_B, IRNode.VECTOR_SIZE + "min(max_byte, 8)", "> 0",
                   IRNode.ADD_VB,        IRNode.VECTOR_SIZE + "min(max_byte, 8)", "> 0",
                   IRNode.STORE_VECTOR,                                           "> 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.ADD_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test14dB(byte[] a) {
@@ -1419,13 +1419,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_B, IRNode.VECTOR_SIZE + "min(max_byte, 8)", "> 0",
                   IRNode.ADD_VB,        IRNode.VECTOR_SIZE + "min(max_byte, 8)", "> 0",
                   IRNode.STORE_VECTOR,                                           "> 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.ADD_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test14eB(byte[] a) {
@@ -1447,13 +1447,13 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_B, IRNode.VECTOR_SIZE + "min(max_byte, 8)", "> 0",
                   IRNode.ADD_VB,        IRNode.VECTOR_SIZE + "min(max_byte, 8)", "> 0",
                   IRNode.STORE_VECTOR,                                           "> 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"})
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.ADD_VB, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test14fB(byte[] a) {
@@ -1602,7 +1602,7 @@ public class TestAlignVector {
                   IRNode.ADD_VL, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test17a(long[] a) {
         // Unsafe: vectorizes with profiling (not xcomp)
         for (int i = 0; i < RANGE; i++) {
@@ -1631,7 +1631,7 @@ public class TestAlignVector {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"MaxVectorSize", ">=32"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] test17c(long[] a) {
         // Unsafe: aligned vectorizes
         for (int i = 0; i < RANGE-1; i+=4) {
@@ -1648,7 +1648,7 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_L, IRNode.VECTOR_SIZE_2, "> 0",
                   IRNode.ADD_VL,        IRNode.VECTOR_SIZE_2, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
-        applyIfCPUFeatureOr = {"avx512", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"avx512", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=64"})
     // Ensure vector width is large enough to fit 64 byte for longs:
@@ -1659,7 +1659,7 @@ public class TestAlignVector {
     @IR(counts = {IRNode.LOAD_VECTOR_L, "= 0",
                   IRNode.ADD_VL, "= 0",
                   IRNode.STORE_VECTOR, "= 0"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"})
     static Object[] test17d(long[] a) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestCompatibleUseDefTypeSize.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestCompatibleUseDefTypeSize.java
@@ -315,7 +315,7 @@ public class TestCompatibleUseDefTypeSize {
     @Test
     @IR(counts = {IRNode.STORE_VECTOR, "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // "inflate"  method: 1 byte -> 2 byte.
     // Java scalar code has no explicit conversion.
     // Vector code would need a conversion. We may add this in the future.
@@ -329,7 +329,7 @@ public class TestCompatibleUseDefTypeSize {
     @Test
     @IR(counts = {IRNode.STORE_VECTOR, "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // "inflate"  method: 1 byte -> 2 byte.
     // Java scalar code has no explicit conversion.
     // Vector code would need a conversion. We may add this in the future.
@@ -343,7 +343,7 @@ public class TestCompatibleUseDefTypeSize {
     @Test
     @IR(counts = {IRNode.STORE_VECTOR, "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // "deflate"  method: 2 byte -> 1 byte.
     // Java scalar code has no explicit conversion.
     // Vector code would need a conversion. We may add this in the future.
@@ -360,7 +360,7 @@ public class TestCompatibleUseDefTypeSize {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"}, // a[i] and a[i+1] cannot both be aligned.
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Used to not vectorize because of "alignment boundaries".
     // Assume 64 byte vector width:
     // a[i+0:i+15] and a[i+1:i+16], each are 4 * 16 = 64 byte.
@@ -378,7 +378,7 @@ public class TestCompatibleUseDefTypeSize {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"}, // a[i] and a[i+1] cannot both be aligned.
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // same as test3, but hand-unrolled
     static Object[] test4(int[] a, int[] b) {
         for (int i = 0; i < a.length-2; i+=2) {
@@ -391,7 +391,7 @@ public class TestCompatibleUseDefTypeSize {
     @Test
     @IR(counts = {IRNode.STORE_VECTOR, "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // In theory, one would expect this to be a simple 4byte -> 4byte conversion.
     // But there is a CmpF and CMove here because we check for isNaN. Plus a MoveF2I.
     //
@@ -406,7 +406,7 @@ public class TestCompatibleUseDefTypeSize {
     @Test
     @IR(counts = {IRNode.STORE_VECTOR, "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Missing support for MoveF2I
     static Object[] test6(int[] a, float[] b) {
         for (int i = 0; i < a.length; i++) {
@@ -418,7 +418,7 @@ public class TestCompatibleUseDefTypeSize {
     @Test
     @IR(counts = {IRNode.STORE_VECTOR, "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Missing support for MoveI2F
     static Object[] test7(int[] a, float[] b) {
         for (int i = 0; i < a.length; i++) {
@@ -430,7 +430,7 @@ public class TestCompatibleUseDefTypeSize {
     @Test
     @IR(counts = {IRNode.STORE_VECTOR, "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Missing support for Needs CmpD, CMove and MoveD2L
     static Object[] test8(long[] a, double[] b) {
         for (int i = 0; i < a.length; i++) {
@@ -442,7 +442,7 @@ public class TestCompatibleUseDefTypeSize {
     @Test
     @IR(counts = {IRNode.STORE_VECTOR, "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Missing support for MoveD2L
     static Object[] test9(long[] a, double[] b) {
         for (int i = 0; i < a.length; i++) {
@@ -454,7 +454,7 @@ public class TestCompatibleUseDefTypeSize {
     @Test
     @IR(counts = {IRNode.STORE_VECTOR, "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Missing support for MoveL2D
     static Object[] test10(long[] a, double[] b) {
         for (int i = 0; i < a.length; i++) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestEquivalentInvariants.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestEquivalentInvariants.java
@@ -383,7 +383,7 @@ public class TestEquivalentInvariants {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testArrayBB(byte[] a, byte[] b) {
         for (int i = 0; i < a.length; i++) {
             b[i+0] = (byte)(a[i] + 1);
@@ -396,7 +396,7 @@ public class TestEquivalentInvariants {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Same int invariant summands, but added in a different order.
     static Object[] testArrayBBInvar3(byte[] a, byte[] b, int invar1, int invar2, int invar3) {
         int i1 = invar1 + invar2 + invar3;
@@ -412,7 +412,7 @@ public class TestEquivalentInvariants {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Just a simple pattern, without any (explicit) invariant.
     static Object[] testMemorySegmentB(MemorySegment m) {
         for (int i = 0; i < (int)m.byteSize(); i++) {
@@ -426,7 +426,7 @@ public class TestEquivalentInvariants {
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Does not vectorize: RangeChecks are not eliminated.
     // Filed RFE: JDK-8327209
     static Object[] testMemorySegmentBInvarI(MemorySegment m, int invar, int size) {
@@ -442,7 +442,7 @@ public class TestEquivalentInvariants {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Has different invariants, before sorting:
     //
     //   3125 AddL = ((CastLL(Param 11) + ConvI2L(1460  Phi)) + 530  LoadL)
@@ -460,7 +460,7 @@ public class TestEquivalentInvariants {
     @IR(counts = {IRNode.LOAD_VECTOR_B, "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Does not vectorize: RangeChecks are not eliminated.
     // Filed RFE: JDK-8327209
     static Object[] testMemorySegmentBInvarIAdr(MemorySegment m, int invar, int size) {
@@ -477,7 +477,7 @@ public class TestEquivalentInvariants {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Since we add "i + invar", the invariant is already equivalent without sorting.
     static Object[] testMemorySegmentBInvarLAdr(MemorySegment m, long invar, int size) {
         for (int i = 0; i < size; i++) {
@@ -493,7 +493,7 @@ public class TestEquivalentInvariants {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentBInvarI3a(MemorySegment m, int invar1, int invar2, int invar3, int size) {
         long i1 = (long)(invar1 + invar2 + invar3);
         long i2 = (long)(invar2 + invar3 + invar1); // equivalent
@@ -510,7 +510,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentBInvarI3b(MemorySegment m, int invar1, int invar2, int invar3, int size) {
         long i1 = (long)(invar1 + invar2 + invar3);
         long i2 = (long)(invar2 + invar3 + invar1); // equivalent
@@ -541,7 +541,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentBInvarI3d(MemorySegment m, int invar1, int invar2, int invar3, int size) {
         long i1 = (long)(invar1 + invar2 + invar3);
         long i2 = (long)(invar2 + invar3) + (long)(invar1);
@@ -559,7 +559,7 @@ public class TestEquivalentInvariants {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentBInvarI3e(MemorySegment m, int invar1, int invar2, int invar3, int size) {
         long i1 = (long)(invar1 + invar2 - invar3);
         long i2 = (long)(invar2 - invar3 + invar1); // equivalent
@@ -575,7 +575,7 @@ public class TestEquivalentInvariants {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentBInvarI3f(MemorySegment m, int invar1, int invar2, int invar3, int size) {
         long i1 = (long)(invar1 - (invar2 - invar3));
         long i2 = (long)(-invar2 + invar3 + invar1); // equivalent
@@ -591,7 +591,7 @@ public class TestEquivalentInvariants {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentBInvarL3g(MemorySegment m, long invar1, long invar2, long invar3, int size) {
         long i1 = invar1 - (invar2 - invar3);
         long i2 = -invar2 + invar3 + invar1; // equivalent
@@ -607,7 +607,7 @@ public class TestEquivalentInvariants {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentBInvarL3h(MemorySegment m, long invar1, long invar2, long invar3, int size) {
         long i1 = -invar1 - invar2 - invar3;
         long i2 = -invar2 - invar3 - invar1; // equivalent
@@ -623,7 +623,7 @@ public class TestEquivalentInvariants {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentBInvarL3k(MemorySegment m, long invar1, long invar2, long invar3, int size) {
         long i1 = -invar1 + invar2 + invar3;
         long i2 = invar2 + invar3 - invar1; // equivalent
@@ -640,7 +640,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentIInvarL3a(MemorySegment m, long invar1, long invar2, long invar3, int size) {
         long i1 = invar1 + invar2 + invar3;
         long i2 = invar2 + invar3 + invar1; // equivalent
@@ -657,7 +657,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentIInvarL3b(MemorySegment m, long invar1, long invar2, long invar3, int size) {
         long i1 = -invar1 - invar2 - invar3;
         long i2 = -invar2 - invar3 - invar1; // equivalent
@@ -674,7 +674,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentIInvarL3c(MemorySegment m, long invar1, long invar2, long invar3, int size) {
         long i1 = -invar1 + invar2 + invar3;
         long i2 = invar2 + invar3 - invar1; // equivalent
@@ -690,12 +690,12 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // With AlignVector (strict alignment requirements): we cannot prove that the invariants are alignable -> no vectorization.
     static Object[] testMemorySegmentIInvarL3d(MemorySegment m, int invar1, int invar2, int invar3, int size) {
         long i1 = (long)(-invar1 + invar2 + invar3);
@@ -714,12 +714,12 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // With AlignVector (strict alignment requirements): we cannot prove that the invariants are alignable -> no vectorization.
     static Object[] testMemorySegmentIInvarL3d2(MemorySegment m, int invar1, int invar2, int invar3, int size) {
         long i1 = (long)(-invar1 + invar2 + invar3);
@@ -738,7 +738,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // But here the "offsetPlain" is folded away
     static Object[] testMemorySegmentIInvarL3d3(MemorySegment m, int size) {
         for (int i = 0; i < size; i+=2) {
@@ -755,12 +755,12 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // With AlignVector (strict alignment requirements): we cannot prove that the invariants are alignable -> no vectorization.
     static Object[] testMemorySegmentIInvarL3e(MemorySegment m, int invar1, int invar2, int invar3, int size) {
         long i1 = (long)(-invar1 + invar2 + invar3);
@@ -779,7 +779,7 @@ public class TestEquivalentInvariants {
     @IR(counts = {IRNode.LOAD_VECTOR_I, "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Should never vectorize, since i1 and i2 are not guaranteed to be adjacent
     // invar2 + invar3 could overflow, and the address be valid with and without overflow.
     // So both addresses are valid, and not adjacent.
@@ -801,7 +801,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentIInvarL3g(MemorySegment m, long invar1, long invar2, long invar3, int size) {
         long i1 = -invar1 + invar2 + invar3;
         long i2 = invar2 + invar3 - invar1; // equivalent
@@ -819,7 +819,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentLInvarL3a(MemorySegment m, long invar1, long invar2, long invar3, int size) {
         long i1 = invar1 + invar2 + invar3;
         long i2 = invar2 + invar3 + invar1; // equivalent
@@ -836,7 +836,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentLInvarL3b(MemorySegment m, long invar1, long invar2, long invar3, int size) {
         long i1 = -invar1 - invar2 - invar3;
         long i2 = -invar2 - invar3 - invar1; // equivalent
@@ -853,7 +853,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentLInvarL3c(MemorySegment m, long invar1, long invar2, long invar3, int size) {
         long i1 = -invar1 + invar2 + invar3;
         long i2 = invar2 + invar3 - invar1; // equivalent
@@ -869,12 +869,12 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_L, "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // With AlignVector (strict alignment requirements): we cannot prove that the invariants are alignable -> no vectorization.
     static Object[] testMemorySegmentLInvarL3d(MemorySegment m, int invar1, int invar2, int invar3, int size) {
         long i1 = (long)(-invar1 + invar2 + invar3);
@@ -893,12 +893,12 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_L, "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // With AlignVector (strict alignment requirements): we cannot prove that the invariants are alignable -> no vectorization.
     static Object[] testMemorySegmentLInvarL3d2(MemorySegment m, int invar1, int invar2, int invar3, int size) {
         long i1 = (long)(-invar1 + invar2 + invar3);
@@ -917,7 +917,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // But here the "offsetPlain" is folded away
     static Object[] testMemorySegmentLInvarL3d3(MemorySegment m, int size) {
         for (int i = 0; i < size; i+=2) {
@@ -934,12 +934,12 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_L, "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // With AlignVector (strict alignment requirements): we cannot prove that the invariants are alignable -> no vectorization.
     static Object[] testMemorySegmentLInvarL3e(MemorySegment m, int invar1, int invar2, int invar3, int size) {
         long i1 = (long)(-invar1 + invar2 + invar3);
@@ -959,7 +959,7 @@ public class TestEquivalentInvariants {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testMemorySegmentLInvarL3f(MemorySegment m, long invar1, long invar2, long invar3, int size) {
         long i1 = -invar1 + invar2 + invar3;
         long i2 = invar2 + invar3 - invar1; // equivalent

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
@@ -81,7 +81,7 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeature = {"avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
         applyIf = {"SuperWordReductions", "true"},
         applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
@@ -94,7 +94,7 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeature = {"avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
         applyIf = {"SuperWordReductions", "true"},
         applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
@@ -108,7 +108,7 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeature = {"avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
         applyIf = {"SuperWordReductions", "true"},
         applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
@@ -133,7 +133,7 @@ public class TestGeneralizedReductions {
     // If this limitation is overcome in the future, the test case should be
     // turned into a positive one.
     @Test
-    @IR(applyIfCPUFeature = {"avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
         applyIf = {"SuperWordReductions", "true"},
         applyIfPlatform = {"64-bit", "true"},
         failOn = {IRNode.ADD_REDUCTION_VI})
@@ -147,13 +147,13 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeature = {"avx2", "true"},
+    @IR(applyIfCPUFeatureOr = {"avx2", "true"},
         applyIfAnd = {"SuperWordReductions", "true","UsePopCountInstruction", "true"},
         applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1",
                   IRNode.POPCOUNT_VL, ">= 1"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"zvbb", "true"},
+        applyIfCPUFeatureOr = {"zvbb", "true"},
         applyIfAnd = {"SuperWordReductions", "true","UsePopCountInstruction", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1",
                   IRNode.POPCOUNT_VL, ">= 1"})

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency.java
@@ -132,7 +132,7 @@ public class TestIndependentPacksWithCyclicDependency {
     @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VF, "> 0"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test0(int[] dataIa, int[] dataIb, float[] dataFa, float[] dataFb) {
         for (int i = 0; i < RANGE; i+=2) {
             // Hand-unrolled 2x. Int and Float slice are completely separate.
@@ -162,7 +162,7 @@ public class TestIndependentPacksWithCyclicDependency {
     @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VF, "> 0", IRNode.VECTOR_CAST_F2I, "> 0", IRNode.VECTOR_CAST_I2F, "> 0"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     static void test1(int[] dataIa, int[] dataIb, float[] dataFa, float[] dataFb) {
         for (int i = 0; i < RANGE; i+=2) {
             // Hand-unrolled 2x. Converst to and from. StoreF -> LoadF dependency.
@@ -191,7 +191,7 @@ public class TestIndependentPacksWithCyclicDependency {
     @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VI, "> 0"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test2(int[] dataIa, int[] dataIb, float[] dataFa, float[] dataFb) {
         for (int i = 0; i < RANGE; i+=2) {
             // int and float arrays are two slices. But we pretend both are of type int.
@@ -221,7 +221,7 @@ public class TestIndependentPacksWithCyclicDependency {
     @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VF, "> 0"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test3(int[] dataIa, int[] dataIb, float[] dataFa, float[] dataFb) {
         for (int i = 0; i < RANGE; i+=2) {
             // Inversion of orders. But because we operate on separate slices, this should
@@ -303,7 +303,7 @@ public class TestIndependentPacksWithCyclicDependency {
     @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VI, "> 0", IRNode.ADD_VF, "> 0"},
         applyIfOr = {"UseCompactObjectHeaders", "false", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static void test6(int[] dataIa, int[] dataIb, float[] dataFa, float[] dataFb,
                       long[] dataLa, long[] dataLb) {
         for (int i = 0; i < RANGE; i+=2) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegment.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegment.java
@@ -431,7 +431,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VB,        "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // FAILS
     // Exit check: iv < long_limit      ->     (long)iv < long_limit
     // Thus, we have an int-iv, but a long-exit-check.
@@ -450,7 +450,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testIntLoop_iv_byte(MemorySegment a) {
         for (int i = 0; i < (int)a.byteSize(); i++) {
             long adr = i;
@@ -465,7 +465,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testIntLoop_longIndex_intInvar_sameAdr_byte(MemorySegment a, int invar) {
         for (int i = 0; i < (int)a.byteSize(); i++) {
             long adr = (long)(i) + (long)(invar);
@@ -480,7 +480,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testIntLoop_longIndex_longInvar_sameAdr_byte(MemorySegment a, long invar) {
         for (int i = 0; i < (int)a.byteSize(); i++) {
             long adr = (long)(i) + (long)(invar);
@@ -495,7 +495,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testIntLoop_longIndex_intInvar_byte(MemorySegment a, int invar) {
         for (int i = 0; i < (int)a.byteSize(); i++) {
             long adr1 = (long)(i) + (long)(invar);
@@ -511,7 +511,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testIntLoop_longIndex_longInvar_byte(MemorySegment a, long invar) {
         for (int i = 0; i < (int)a.byteSize(); i++) {
             long adr1 = (long)(i) + (long)(invar);
@@ -527,7 +527,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VB,        "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // FAILS: RangeCheck cannot be eliminated because of int_index
     static Object[] testIntLoop_intIndex_intInvar_byte(MemorySegment a, int invar) {
         for (int i = 0; i < (int)a.byteSize(); i++) {
@@ -544,7 +544,7 @@ class TestMemorySegmentImpl {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testIntLoop_iv_int(MemorySegment a) {
         for (int i = 0; i < (int)a.byteSize()/4; i++ ) {
             long adr = 4L * i;
@@ -560,7 +560,7 @@ class TestMemorySegmentImpl {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testIntLoop_longIndex_intInvar_sameAdr_int(MemorySegment a, int invar) {
         for (int i = 0; i < (int)a.byteSize()/4; i++) {
             long adr = 4L * (long)(i) + 4L * (long)(invar);
@@ -576,7 +576,7 @@ class TestMemorySegmentImpl {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testIntLoop_longIndex_longInvar_sameAdr_int(MemorySegment a, long invar) {
         for (int i = 0; i < (int)a.byteSize()/4; i++) {
             long adr = 4L * (long)(i) + 4L * (long)(invar);
@@ -592,7 +592,7 @@ class TestMemorySegmentImpl {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testIntLoop_longIndex_intInvar_int(MemorySegment a, int invar) {
         for (int i = 0; i < (int)a.byteSize()/4; i++) {
             long adr1 = 4L * (long)(i) + 4L * (long)(invar);
@@ -609,7 +609,7 @@ class TestMemorySegmentImpl {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testIntLoop_longIndex_longInvar_int(MemorySegment a, long invar) {
         for (int i = 0; i < (int)a.byteSize()/4; i++) {
             long adr1 = 4L * (long)(i) + 4L * (long)(invar);
@@ -625,7 +625,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VI,        "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // FAILS: RangeCheck cannot be eliminated because of int_index
     static Object[] testIntLoop_intIndex_intInvar_int(MemorySegment a, int invar) {
         for (int i = 0; i < (int)a.byteSize()/4; i++) {
@@ -641,7 +641,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testLongLoop_iv_byte(MemorySegment a) {
         for (long i = 0; i < a.byteSize(); i++) {
             long adr = i;
@@ -656,7 +656,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testLongLoop_longIndex_intInvar_sameAdr_byte(MemorySegment a, int invar) {
         for (long i = 0; i < a.byteSize(); i++) {
             long adr = (long)(i) + (long)(invar);
@@ -671,7 +671,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VB,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testLongLoop_longIndex_longInvar_sameAdr_byte(MemorySegment a, long invar) {
         for (long i = 0; i < a.byteSize(); i++) {
             long adr = (long)(i) + (long)(invar);
@@ -714,7 +714,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VB,        "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // FAILS: RangeCheck cannot be eliminated because of int_index
     static Object[] testLongLoop_intIndex_intInvar_byte(MemorySegment a, int invar) {
         for (long i = 0; i < a.byteSize(); i++) {
@@ -731,7 +731,7 @@ class TestMemorySegmentImpl {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testLongLoop_iv_int(MemorySegment a) {
         for (long i = 0; i < a.byteSize()/4; i++ ) {
             long adr = 4L * i;
@@ -747,7 +747,7 @@ class TestMemorySegmentImpl {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testLongLoop_longIndex_intInvar_sameAdr_int(MemorySegment a, int invar) {
         for (long i = 0; i < a.byteSize()/4; i++) {
             long adr = 4L * (long)(i) + 4L * (long)(invar);
@@ -763,7 +763,7 @@ class TestMemorySegmentImpl {
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
         applyIf = {"AlignVector", "false"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     static Object[] testLongLoop_longIndex_longInvar_sameAdr_int(MemorySegment a, long invar) {
         for (long i = 0; i < a.byteSize()/4; i++) {
             long adr = 4L * (long)(i) + 4L * (long)(invar);
@@ -778,7 +778,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VI,        "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // FAILS: invariants are sorted differently, because of differently inserted Cast.
     // See: JDK-8331659
     static Object[] testLongLoop_longIndex_intInvar_int(MemorySegment a, int invar) {
@@ -796,7 +796,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VI,        "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // FAILS: invariants are sorted differently, because of differently inserted Cast.
     // See: JDK-8331659
     static Object[] testLongLoop_longIndex_longInvar_int(MemorySegment a, long invar) {
@@ -814,7 +814,7 @@ class TestMemorySegmentImpl {
                   IRNode.ADD_VI,        "= 0",
                   IRNode.STORE_VECTOR,  "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // FAILS: RangeCheck cannot be eliminated because of int_index
     static Object[] testLongLoop_intIndex_intInvar_int(MemorySegment a, int invar) {
         for (long i = 0; i < a.byteSize()/4; i++) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentUnalignedAddress.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentUnalignedAddress.java
@@ -227,7 +227,7 @@ class TestMemorySegmentUnalignedAddressImpl {
                   IRNode.STORE_VECTOR,  "> 0",
                   "multiversion",       "= 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         phase = CompilePhase.PRINT_IDEAL)
     // We never fail the alignment check in the auto vectorization Predicate,
     // hence we never even create the multiversioned loops.
@@ -247,7 +247,7 @@ class TestMemorySegmentUnalignedAddressImpl {
                   "multiversion_slow",  "= 2"}, // main, post
         applyIf = {"AlignVector", "true"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         phase = CompilePhase.PRINT_IDEAL)
     // We add alignment checks to the auto vectorization Predicate. It fails
     // at runtime, deopts, and recompiles with multiversioning.
@@ -258,7 +258,7 @@ class TestMemorySegmentUnalignedAddressImpl {
                   "multiversion_slow",  "= 0"},
         applyIf = {"AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         phase = CompilePhase.PRINT_IDEAL)
     // We never add any conditions to the auto vectorization Predicate, so
     // we also never deopt and never end up multiversioning.
@@ -278,7 +278,7 @@ class TestMemorySegmentUnalignedAddressImpl {
                   "multiversion_slow",  "= 2"}, // main, post
         applyIf = {"AlignVector", "true"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         phase = CompilePhase.PRINT_IDEAL)
     // We add alignment checks to the auto vectorization Predicate. It fails
     // at runtime, deopts, and recompiles with multiversioning.
@@ -289,7 +289,7 @@ class TestMemorySegmentUnalignedAddressImpl {
                   "multiversion_slow",  "= 0"},
         applyIf = {"AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         phase = CompilePhase.PRINT_IDEAL)
     // We never add any conditions to the auto vectorization Predicate, so
     // we also never deopt and never end up multiversioning.

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMultiversionRemoveUselessSlowLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMultiversionRemoveUselessSlowLoop.java
@@ -60,7 +60,7 @@ public class TestMultiversionRemoveUselessSlowLoop {
                   "multiversion",              "= 8", // nothing unexpected
                   IRNode.OPAQUE_MULTIVERSIONING, "= 2"}, // Both multiversion_if are still here
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         phase = CompilePhase.PHASEIDEALLOOP1)
     @IR(counts = {"pre .* multiversion_fast",  "= 2",
                   "main .* multiversion_fast", "= 1", // The first main loop is fully unrolled
@@ -69,7 +69,7 @@ public class TestMultiversionRemoveUselessSlowLoop {
                   "multiversion",              "= 7", // nothing unexpected
                   IRNode.OPAQUE_MULTIVERSIONING, "= 1"}, // The multiversion_if of the first loop was constant folded, because the main loop disappeared.
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         phase = CompilePhase.PHASEIDEALLOOP_ITERATIONS)
     @IR(counts = {"pre .* multiversion_fast.*", ">= 1", // In some cases, the pre loop of the first loop also disappears because it only has a single iteration
                   "pre .* multiversion_fast.*", "<= 2", // but not in other cases the pre loop of the first loop remains.
@@ -80,7 +80,7 @@ public class TestMultiversionRemoveUselessSlowLoop {
                   "multiversion",              "<= 6", // nothing unexpected
                   IRNode.OPAQUE_MULTIVERSIONING, "= 0"}, // After loop-opts, we also constant fold the multiversion_if of the second loop, as it is unused.
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"},
         phase = CompilePhase.PRINT_IDEAL)
     public static void testIR() {
         // This loop is short, and the multiversion_fast main loop eventuall is fully unrolled.

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestSplitPacks.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestSplitPacks.java
@@ -280,7 +280,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_2, "> 0",
                   IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.AND_VI,        IRNode.VECTOR_SIZE_2, "> 0",
@@ -288,7 +288,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Load and store are already split
     //
     //  0 1 - - 4 5 6 7
@@ -327,7 +327,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_2, "> 0",
                   IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.ADD_VI,        IRNode.VECTOR_SIZE_4, "> 0",
@@ -335,7 +335,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Adjacent Load and Store, but split by Add/Mul
     static Object[] test1a(int[] a, int[] b, int mask) {
         for (int i = 0; i < RANGE; i+=8) {
@@ -362,7 +362,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_2, "> 0",
                   IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.ADD_VI,        IRNode.VECTOR_SIZE_2, "> 0",
@@ -370,7 +370,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Adjacent Load and Store, but split by Add/Mul
     static Object[] test1b(int[] a, int[] b, int mask) {
         for (int i = 0; i < RANGE; i+=8) {
@@ -397,7 +397,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_2, "> 0",
                   IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.ADD_VI,        IRNode.VECTOR_SIZE_2, "> 0",
@@ -405,7 +405,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     // Adjacent Load and Store, but split by Add/Mul
     static Object[] test1c(int[] a, int[] b, int mask) {
         for (int i = 0; i < RANGE; i+=8) {
@@ -432,7 +432,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_2, "> 0",
                   IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.ADD_VI,        IRNode.VECTOR_SIZE_4, "> 0",
@@ -440,7 +440,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true", "rvv", "true"})
     // Adjacent Load and Store, but split by Add/Mul
     static Object[] test1d(int[] a, int[] b, int mask) {
         for (int i = 0; i < RANGE; i+=8) {
@@ -467,7 +467,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_2, "> 0",
                   IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.AND_VI,        IRNode.VECTOR_SIZE_2, "> 0",
@@ -475,7 +475,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Split the load
     //
     //  0 1 2 3 4 5 - -
@@ -516,7 +516,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_2, "> 0",
                   IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.AND_VI,        IRNode.VECTOR_SIZE_2, "> 0",
@@ -524,7 +524,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Split the load
     //
     //  0 1 2 3 4 5 - -
@@ -565,7 +565,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_2, "> 0",
                   IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.AND_VI,        IRNode.VECTOR_SIZE_2, "> 0",
@@ -573,7 +573,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Split the load
     //
     //  0 1 - - 4 5 6 7
@@ -614,7 +614,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_2, "> 0",
                   IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.AND_VI,        IRNode.VECTOR_SIZE_2, "> 0",
@@ -622,7 +622,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Split the load
     //
     //  0 1 2 3 - - 6 7
@@ -660,12 +660,12 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_S, IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // 0 1 2 3 4 5 6 7 -
     // | | | | | | | |
     // | + + + | | | |
@@ -741,7 +741,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"MaxVectorSize", ">=8"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Cyclic dependency with distance 4 -> split into 4-packs
     static Object[] test4c(short[] a, short[] b) {
         for (int i = 0; i < RANGE-64; i++) {
@@ -755,7 +755,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=8", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Cyclic dependency with distance 5 -> split into 4-packs
     static Object[] test4d(short[] a, short[] b) {
         for (int i = 0; i < RANGE-64; i++) {
@@ -769,7 +769,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=8", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Cyclic dependency with distance 6 -> split into 4-packs
     static Object[] test4e(short[] a, short[] b) {
         for (int i = 0; i < RANGE-64; i++) {
@@ -783,7 +783,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=8", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Cyclic dependency with distance 7 -> split into 4-packs
     static Object[] test4f(short[] a, short[] b) {
         for (int i = 0; i < RANGE-64; i++) {
@@ -797,7 +797,7 @@ public class TestSplitPacks {
                   IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"MaxVectorSize", ">=32"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Cyclic dependency with distance 8 -> split into 8-packs
     static Object[] test4g(short[] a, short[] b) {
         for (int i = 0; i < RANGE-64; i++) {
@@ -860,7 +860,7 @@ public class TestSplitPacks {
                   IRNode.ADD_REDUCTION_V,                       "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "AlignVector", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.MUL_VI,          IRNode.VECTOR_SIZE_4, "> 0",
                   IRNode.AND_VI,          IRNode.VECTOR_SIZE_4, "> 0",
@@ -868,7 +868,7 @@ public class TestSplitPacks {
                   IRNode.ADD_REDUCTION_V,                       "> 0"},
         applyIfAnd = {"MaxVectorSize", ">=32", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true", "rvv", "true"})
     // Split packs including reductions
     static Object[] test6a(int[] a, int[] b) {
         int s = 0;
@@ -895,7 +895,7 @@ public class TestSplitPacks {
                   IRNode.MUL_VI,         "> 0",
                   IRNode.POPULATE_INDEX, "> 0"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "sve", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "sve", "true", "rvv", "true"})
     // Index Populate:
     // There can be an issue when all the (iv + 1), (iv + 2), ...
     // get packed, but not (iv). Then we have a pack that is one element

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -66,7 +66,7 @@ public class TestUnorderedReductionPartialVectorization {
                   IRNode.OR_REDUCTION_V,                                                 "> 0",},
         applyIfOr = {"AlignVector", "false", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"})
     static long test1(int[] data, long sum) {
         for (int i = 0; i < data.length; i+=2) {
             // Mixing int and long ops means we only end up allowing half of the int


### PR DESCRIPTION
Hi,
Can you help to review this patch? This is also a follow-up of https://github.com/openjdk/jdk/pull/23985.
There're bunch of test under `test/hotspot/jtreg/compiler/loopopts/` could be enabled for riscv.

There are some failures for some tests after enabling them, I'll investigate further and send out separate pr after fixing them.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352529](https://bugs.openjdk.org/browse/JDK-8352529): RISC-V: enable loopopts tests (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24138/head:pull/24138` \
`$ git checkout pull/24138`

Update a local copy of the PR: \
`$ git checkout pull/24138` \
`$ git pull https://git.openjdk.org/jdk.git pull/24138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24138`

View PR using the GUI difftool: \
`$ git pr show -t 24138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24138.diff">https://git.openjdk.org/jdk/pull/24138.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24138#issuecomment-2741218850)
</details>
