### PR TITLE
8352536: Add overloads to parse and build class files from/to MemorySegment

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -26,10 +26,7 @@ package java.lang.classfile;
 
 import java.io.IOException;
 import java.lang.classfile.AttributeMapper.AttributeStability;
-import java.lang.classfile.attribute.CharacterRangeInfo;
 import java.lang.classfile.attribute.CodeAttribute;
-import java.lang.classfile.attribute.LocalVariableInfo;
-import java.lang.classfile.attribute.LocalVariableTypeInfo;
 import java.lang.classfile.attribute.ModuleAttribute;
 import java.lang.classfile.attribute.StackMapTableAttribute;
 import java.lang.classfile.attribute.UnknownAttribute;
@@ -44,13 +41,17 @@ import java.lang.classfile.instruction.LineNumber;
 import java.lang.classfile.instruction.LocalVariable;
 import java.lang.classfile.instruction.LocalVariableType;
 import java.lang.constant.ClassDesc;
+import java.lang.foreign.MemorySegment;
 import java.lang.reflect.AccessFlag;
 import java.lang.reflect.ClassFileFormatVersion;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.LongFunction;
 
 import jdk.internal.classfile.impl.ClassFileImpl;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
@@ -524,6 +525,46 @@ public sealed interface ClassFile
     ClassModel parse(byte[] bytes);
 
     /**
+     * Parses a {@code class} file into a {@link ClassModel}.
+     * <p>
+     * Due to the on-demand nature of {@code class} file parsing, an {@link
+     * IllegalArgumentException} may be thrown on any accessor method invocation
+     * on the returned model or any structure returned by the accessors in the
+     * structure hierarchy.
+     * <p>
+     * On return, the byte buffer's position and limit will be unchanged.
+     *
+     * @param bytes a byte buffer containing the bytes of the {@code class} file
+     * @return the class model
+     * @throws IllegalArgumentException if the {@code class} file is malformed
+     *         or of a version {@linkplain #latestMajorVersion() not supported}
+     *         by the current runtime
+     * @implNote The implementation may or may not support parsing directly from
+     *           a given buffer. In the latter case, the implementation may copy
+     *           the buffer's contents to a temporary array before parsing.
+     */
+    ClassModel parse(ByteBuffer bytes);
+
+    /**
+     * Parses a {@code class} file into a {@link ClassModel}.
+     * <p>
+     * Due to the on-demand nature of {@code class} file parsing, an {@link
+     * IllegalArgumentException} may be thrown on any accessor method invocation
+     * on the returned model or any structure returned by the accessors in the
+     * structure hierarchy.
+     *
+     * @param bytes a memory segment containing the bytes of the {@code class} file
+     * @return the class model
+     * @throws IllegalArgumentException if the {@code class} file is malformed
+     *         or of a version {@linkplain #latestMajorVersion() not supported}
+     *         by the current runtime
+     * @implNote The implementation may or may not support parsing directly from
+     *           a given memory segment. In the latter case, the implementation may copy
+     *           the memory segment's contents to a temporary array before parsing.
+     */
+    ClassModel parse(MemorySegment bytes);
+
+    /**
      * Parses a {@code class} into a {@link ClassModel}.
      * <p>
      * Due to the on-demand nature of {@code class} file parsing, an {@link
@@ -571,6 +612,96 @@ public sealed interface ClassFile
     byte[] build(ClassEntry thisClassEntry,
                  ConstantPoolBuilder constantPool,
                  Consumer<? super ClassBuilder> handler);
+
+    /**
+     * Builds a {@code class} file into a byte buffer.
+     * <p>
+     * The allocator function must allocate a buffer with a
+     * {@linkplain ByteBuffer#remaining remaining size}
+     * which is <em>at least</em> as large as the size given to it.
+     * If the allocated buffer has a size which is smaller than the size provided
+     * to the allocator function, an unspecified exception may be thrown.
+     * The class file data will be written to the allocated byte buffer at its
+     * initial position. The returned buffer will have a position corresponding
+     * to the first byte after the class file data.
+     *
+     * @param allocator the buffer allocator function
+     * @param thisClass the name of the class to build
+     * @param handler a handler that receives a {@link ClassBuilder}
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if {@code thisClass} represents a
+     *         primitive type or building encounters a failure
+     */
+    default ByteBuffer buildToByteBuffer(IntFunction<ByteBuffer> allocator,
+                                         ClassDesc thisClass,
+                                         Consumer<? super ClassBuilder> handler) {
+        ConstantPoolBuilder pool = ConstantPoolBuilder.of();
+        return buildToByteBuffer(allocator, pool.classEntry(thisClass), pool, handler);
+    }
+
+    /**
+     * Builds a {@code class} file into a byte buffer using the provided constant
+     * pool builder.
+     * <p>
+     * The allocator function must allocate a buffer with a
+     * {@linkplain ByteBuffer#remaining remaining size}
+     * which is <em>at least</em> as large as the size given to it.
+     * If the allocated buffer has a size which is smaller than the size provided
+     * to the allocator function, an unspecified exception may be thrown.
+     * The class file data will be written to the allocated byte buffer at its
+     * initial position. The returned buffer will have a position corresponding
+     * to the first byte after the class file data.
+     *
+     * @param allocator the buffer allocator function
+     * @param thisClassEntry the name of the class to build
+     * @param constantPool the constant pool builder
+     * @param handler a handler that receives a {@link ClassBuilder}
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if building encounters a failure
+     */
+    ByteBuffer buildToByteBuffer(IntFunction<ByteBuffer> allocator,
+                                 ClassEntry thisClassEntry,
+                                 ConstantPoolBuilder constantPool,
+                                 Consumer<? super ClassBuilder> handler);
+
+    /**
+     * Builds a {@code class} file into a memory segment.
+     * <p>
+     * The allocator function must allocate a memory segment with a
+     * {@linkplain MemorySegment#byteSize() size}
+     * which is <em>at least</em> as large as the size given to it.
+     * If the allocated segment has a size which is smaller than the size provided
+     * to the allocator function, an unspecified exception or error may be thrown.
+     *
+     * @param allocator the segment allocator function
+     * @param thisClass the name of the class to build
+     * @param handler a handler that receives a {@link ClassBuilder}
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if {@code thisClass} represents a
+     *         primitive type or building encounters a failure
+     */
+    default MemorySegment buildToMemorySegment(LongFunction<MemorySegment> allocator,
+                                               ClassDesc thisClass,
+                                               Consumer<? super ClassBuilder> handler) {
+        ConstantPoolBuilder pool = ConstantPoolBuilder.of();
+        return buildToMemorySegment(allocator, pool.classEntry(thisClass), pool, handler);
+    }
+
+    /**
+     * Builds a {@code class} file into a memory segment using the provided constant
+     * pool builder.
+     *
+     * @param allocator the segment allocator function
+     * @param thisClassEntry the name of the class to build
+     * @param constantPool the constant pool builder
+     * @param handler a handler that receives a {@link ClassBuilder}
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if building encounters a failure
+     */
+    MemorySegment buildToMemorySegment(LongFunction<MemorySegment> allocator,
+                                       ClassEntry thisClassEntry,
+                                       ConstantPoolBuilder constantPool,
+                                       Consumer<? super ClassBuilder> handler);
 
     /**
      * Builds a {@code class} file into a file in a file system.
@@ -627,6 +758,88 @@ public sealed interface ClassFile
     default byte[] buildModule(ModuleAttribute moduleAttribute,
                                Consumer<? super ClassBuilder> handler) {
         return build(CD_module_info, clb -> {
+            clb.withFlags(AccessFlag.MODULE);
+            clb.with(moduleAttribute);
+            handler.accept(clb);
+        });
+    }
+
+    /**
+     * Builds a module descriptor into a byte buffer.
+     * <p>
+     * The allocator function must allocate a buffer with a
+     * {@linkplain ByteBuffer#remaining remaining size}
+     * which is <em>at least</em> as large as the size given to it.
+     * If the allocated buffer has a size which is smaller than the size provided
+     * to the allocator function, an unspecified exception may be thrown.
+     * The class file data will be written to the allocated byte buffer at its
+     * initial position. The returned buffer will have a position corresponding
+     * to the first byte after the class file data.
+     *
+     * @param allocator the buffer allocator function
+     * @param moduleAttribute the {@code Module} attribute
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if building encounters a failure
+     */
+    default ByteBuffer buildModuleToByteBuffer(IntFunction<ByteBuffer> allocator,
+                                               ModuleAttribute moduleAttribute) {
+        return buildModuleToByteBuffer(allocator, moduleAttribute, clb -> {});
+    }
+
+    /**
+     * Builds a module descriptor into a byte buffer.
+     * <p>
+     * The allocator function must allocate a buffer with a
+     * {@linkplain ByteBuffer#remaining remaining size}
+     * which is <em>at least</em> as large as the size given to it.
+     * If the allocated buffer has a size which is smaller than the size provided
+     * to the allocator function, an unspecified exception may be thrown.
+     * The class file data will be written to the allocated byte buffer at its
+     * initial position. The returned buffer will have a position corresponding
+     * to the first byte after the class file data.
+     *
+     * @param allocator the buffer allocator function
+     * @param moduleAttribute the {@code Module} attribute
+     * @param handler a handler that receives a {@link ClassBuilder}
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if building encounters a failure
+     */
+    default ByteBuffer buildModuleToByteBuffer(IntFunction<ByteBuffer> allocator,
+                                               ModuleAttribute moduleAttribute,
+                                               Consumer<? super ClassBuilder> handler) {
+        return buildToByteBuffer(allocator, CD_module_info, clb -> {
+            clb.withFlags(AccessFlag.MODULE);
+            clb.with(moduleAttribute);
+            handler.accept(clb);
+        });
+    }
+
+    /**
+     * Builds a module descriptor into a memory segment.
+     *
+     * @param allocator the segment allocator function
+     * @param moduleAttribute the {@code Module} attribute
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if building encounters a failure
+     */
+    default MemorySegment buildModuleToMemorySegment(LongFunction<MemorySegment> allocator,
+                                                     ModuleAttribute moduleAttribute) {
+        return buildModuleToMemorySegment(allocator, moduleAttribute, clb -> {});
+    }
+
+    /**
+     * Builds a module descriptor into a memory segment.
+     *
+     * @param allocator the segment allocator function
+     * @param moduleAttribute the {@code Module} attribute
+     * @param handler a handler that receives a {@link ClassBuilder}
+     * @return the {@code class} file bytes
+     * @throws IllegalArgumentException if building encounters a failure
+     */
+    default MemorySegment buildModuleToMemorySegment(LongFunction<MemorySegment> allocator,
+                                                     ModuleAttribute moduleAttribute,
+                                                     Consumer<? super ClassBuilder> handler) {
+        return buildToMemorySegment(allocator, CD_module_info, clb -> {
             clb.withFlags(AccessFlag.MODULE);
             clb.with(moduleAttribute);
             handler.accept(clb);
@@ -749,6 +962,231 @@ public sealed interface ClassFile
     byte[] transformClass(ClassModel model, ClassEntry newClassName, ClassTransform transform);
 
     /**
+     * Transform one {@code class} file into a new {@code class} file according
+     * to a {@link ClassTransform}.  The transform will receive each element of
+     * this class, as well as a {@link ClassBuilder} for building the new class.
+     * The transform is free to preserve, remove, or replace elements as it
+     * sees fit.
+     * <p>
+     * This method behaves as if:
+     * {@snippet lang=java :
+     * ConstantPoolBuilder cpb = null; // @replace substring=null; replacement=...
+     * this.build(model.thisClass(), cpb,
+     *            clb -> clb.transform(model, transform));
+     * }
+     * where {@code cpb} is determined by {@link ConstantPoolSharingOption}.
+     * <p>
+     * The allocator function must allocate a buffer with a
+     * {@linkplain ByteBuffer#remaining remaining size}
+     * which is <em>at least</em> as large as the size given to it.
+     * If the allocated buffer has a size which is smaller than the size provided
+     * to the allocator function, an unspecified exception may be thrown.
+     * The class file data will be written to the allocated byte buffer at its
+     * initial position. The returned buffer will have a position corresponding
+     * to the first byte after the class file data.
+     *
+     * @apiNote
+     * This is named {@code transformClass} instead of {@code transform} for
+     * consistency with {@link ClassBuilder#transformField}, {@link
+     * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
+     * and to distinguish from {@link ClassFileBuilder#transform}, which is
+     * more generic and powerful.
+     *
+     * @param allocator the buffer allocator function
+     * @param model the class model to transform
+     * @param transform the transform
+     * @return the bytes of the new class
+     * @throws IllegalArgumentException if building encounters a failure
+     * @see ConstantPoolSharingOption
+     */
+    default ByteBuffer transformClassToByteBuffer(IntFunction<ByteBuffer> allocator, ClassModel model, ClassTransform transform) {
+        return transformClassToByteBuffer(allocator, model, model.thisClass(), transform);
+    }
+
+    /**
+     * Transform one {@code class} file into a new {@code class} file according
+     * to a {@link ClassTransform}.  The transform will receive each element of
+     * this class, as well as a {@link ClassBuilder} for building the new class.
+     * The transform is free to preserve, remove, or replace elements as it
+     * sees fit.
+     * <p>
+     * The allocator function must allocate a buffer with a
+     * {@linkplain ByteBuffer#remaining remaining size}
+     * which is <em>at least</em> as large as the size given to it.
+     * If the allocated buffer has a size which is smaller than the size provided
+     * to the allocator function, an unspecified exception may be thrown.
+     * The class file data will be written to the allocated byte buffer at its
+     * initial position. The returned buffer will have a position corresponding
+     * to the first byte after the class file data.
+     *
+     * @apiNote
+     * This is named {@code transformClass} instead of {@code transform} for
+     * consistency with {@link ClassBuilder#transformField}, {@link
+     * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
+     * and to distinguish from {@link ClassFileBuilder#transform}, which is
+     * more generic and powerful.
+     *
+     * @param allocator the buffer allocator function
+     * @param model the class model to transform
+     * @param newClassName new class name
+     * @param transform the transform
+     * @return the bytes of the new class
+     * @throws IllegalArgumentException if building encounters a failure
+     * @see ConstantPoolSharingOption
+     */
+    default ByteBuffer transformClassToByteBuffer(IntFunction<ByteBuffer> allocator, ClassModel model, ClassDesc newClassName, ClassTransform transform) {
+        return transformClassToByteBuffer(allocator, model, TemporaryConstantPool.INSTANCE.classEntry(newClassName), transform);
+    }
+
+    /**
+     * Transform one {@code class} file into a new {@code class} file according
+     * to a {@link ClassTransform}.  The transform will receive each element of
+     * this class, as well as a {@link ClassBuilder} for building the new class.
+     * The transform is free to preserve, remove, or replace elements as it
+     * sees fit.
+     * <p>
+     * This method behaves as if:
+     * {@snippet lang=java :
+     * ConstantPoolBuilder cpb = null; // @replace substring=null; replacement=...
+     * this.build(newClassName, cpb, clb -> clb.transform(model, transform));
+     * }
+     * where {@code cpb} is determined by {@link ConstantPoolSharingOption}.
+     * <p>
+     * The allocator function must allocate a buffer with a
+     * {@linkplain ByteBuffer#remaining remaining size}
+     * which is <em>at least</em> as large as the size given to it.
+     * If the allocated buffer has a size which is smaller than the size provided
+     * to the allocator function, an unspecified exception may be thrown.
+     * The class file data will be written to the allocated byte buffer at its
+     * initial position. The returned buffer will have a position corresponding
+     * to the first byte after the class file data.
+     *
+     * @apiNote
+     * This is named {@code transformClass} instead of {@code transform} for
+     * consistency with {@link ClassBuilder#transformField}, {@link
+     * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
+     * and to distinguish from {@link ClassFileBuilder#transform}, which is
+     * more generic and powerful.
+     *
+     * @param allocator the buffer allocator function
+     * @param model the class model to transform
+     * @param newClassName new class name
+     * @param transform the transform
+     * @return the bytes of the new class
+     * @throws IllegalArgumentException if building encounters a failure
+     * @see ConstantPoolSharingOption
+     */
+    ByteBuffer transformClassToByteBuffer(IntFunction<ByteBuffer> allocator, ClassModel model, ClassEntry newClassName, ClassTransform transform);
+
+    /**
+     * Transform one {@code class} file into a new {@code class} file according
+     * to a {@link ClassTransform}.  The transform will receive each element of
+     * this class, as well as a {@link ClassBuilder} for building the new class.
+     * The transform is free to preserve, remove, or replace elements as it
+     * sees fit.
+     * <p>
+     * This method behaves as if:
+     * {@snippet lang=java :
+     * ConstantPoolBuilder cpb = null; // @replace substring=null; replacement=...
+     * this.build(model.thisClass(), cpb,
+     *            clb -> clb.transform(model, transform));
+     * }
+     * where {@code cpb} is determined by {@link ConstantPoolSharingOption}.
+     * <p>
+     * The allocator function must allocate a memory segment with a
+     * {@linkplain MemorySegment#byteSize() size}
+     * which is <em>at least</em> as large as the size given to it.
+     * If the allocated segment has a size which is smaller than the size provided
+     * to the allocator function, an unspecified exception or error may be thrown.
+     *
+     * @apiNote
+     * This is named {@code transformClass} instead of {@code transform} for
+     * consistency with {@link ClassBuilder#transformField}, {@link
+     * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
+     * and to distinguish from {@link ClassFileBuilder#transform}, which is
+     * more generic and powerful.
+     *
+     * @param allocator the segment allocator function
+     * @param model the class model to transform
+     * @param transform the transform
+     * @return the bytes of the new class
+     * @throws IllegalArgumentException if building encounters a failure
+     * @see ConstantPoolSharingOption
+     */
+    default MemorySegment transformClassToMemorySegment(LongFunction<MemorySegment> allocator, ClassModel model, ClassTransform transform) {
+        return transformClassToMemorySegment(allocator, model, model.thisClass(), transform);
+    }
+
+    /**
+     * Transform one {@code class} file into a new {@code class} file according
+     * to a {@link ClassTransform}.  The transform will receive each element of
+     * this class, as well as a {@link ClassBuilder} for building the new class.
+     * The transform is free to preserve, remove, or replace elements as it
+     * sees fit.
+     * <p>
+     * The allocator function must allocate a memory segment with a
+     * {@linkplain MemorySegment#byteSize() size}
+     * which is <em>at least</em> as large as the size given to it.
+     * If the allocated segment has a size which is smaller than the size provided
+     * to the allocator function, an unspecified exception or error may be thrown.
+     *
+     * @apiNote
+     * This is named {@code transformClass} instead of {@code transform} for
+     * consistency with {@link ClassBuilder#transformField}, {@link
+     * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
+     * and to distinguish from {@link ClassFileBuilder#transform}, which is
+     * more generic and powerful.
+     *
+     * @param allocator the buffer allocator function
+     * @param model the class model to transform
+     * @param newClassName new class name
+     * @param transform the transform
+     * @return the bytes of the new class
+     * @throws IllegalArgumentException if building encounters a failure
+     * @see ConstantPoolSharingOption
+     */
+    default MemorySegment transformClassToMemorySegment(LongFunction<MemorySegment> allocator, ClassModel model, ClassDesc newClassName, ClassTransform transform) {
+        return transformClassToMemorySegment(allocator, model, TemporaryConstantPool.INSTANCE.classEntry(newClassName), transform);
+    }
+
+    /**
+     * Transform one {@code class} file into a new {@code class} file according
+     * to a {@link ClassTransform}.  The transform will receive each element of
+     * this class, as well as a {@link ClassBuilder} for building the new class.
+     * The transform is free to preserve, remove, or replace elements as it
+     * sees fit.
+     * <p>
+     * This method behaves as if:
+     * {@snippet lang=java :
+     * ConstantPoolBuilder cpb = null; // @replace substring=null; replacement=...
+     * this.build(newClassName, cpb, clb -> clb.transform(model, transform));
+     * }
+     * where {@code cpb} is determined by {@link ConstantPoolSharingOption}.
+     * <p>
+     * The allocator function must allocate a memory segment with a
+     * {@linkplain MemorySegment#byteSize() size}
+     * which is <em>at least</em> as large as the size given to it.
+     * If the allocated segment has a size which is smaller than the size provided
+     * to the allocator function, an unspecified exception or error may be thrown.
+     *
+     * @apiNote
+     * This is named {@code transformClass} instead of {@code transform} for
+     * consistency with {@link ClassBuilder#transformField}, {@link
+     * ClassBuilder#transformMethod}, and {@link MethodBuilder#transformCode},
+     * and to distinguish from {@link ClassFileBuilder#transform}, which is
+     * more generic and powerful.
+     *
+     * @param allocator the buffer allocator function
+     * @param model the class model to transform
+     * @param newClassName new class name
+     * @param transform the transform
+     * @return the bytes of the new class
+     * @throws IllegalArgumentException if building encounters a failure
+     * @see ConstantPoolSharingOption
+     */
+    MemorySegment transformClassToMemorySegment(LongFunction<MemorySegment> allocator, ClassModel model, ClassEntry newClassName, ClassTransform transform);
+
+    /**
      * Verify a {@code class} file.  All verification errors found will be returned.
      *
      * @param model the class model to verify
@@ -765,6 +1203,24 @@ public sealed interface ClassFile
      * found
      */
     List<VerifyError> verify(byte[] bytes);
+
+    /**
+     * Verify a {@code class} file.  All verification errors found will be returned.
+     *
+     * @param bytes the {@code class} file bytes to verify
+     * @return a list of verification errors, or an empty list if no error is
+     * found
+     */
+    List<VerifyError> verify(ByteBuffer bytes);
+
+    /**
+     * Verify a {@code class} file.  All verification errors found will be returned.
+     *
+     * @param bytes the {@code class} file bytes to verify
+     * @return a list of verification errors, or an empty list if no error is
+     * found
+     */
+    List<VerifyError> verify(MemorySegment bytes);
 
     /**
      * Verify a {@code class} file.  All verification errors found will be returned.

--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -606,11 +606,11 @@ public sealed interface ClassFile
      * @throws IllegalArgumentException if {@code thisClass} represents a
      *         primitive type or building encounters a failure
      */
-    default MemorySegment buildToMemorySegment(SegmentAllocator allocator,
-                                               ClassDesc thisClass,
-                                               Consumer<? super ClassBuilder> handler) {
+    default MemorySegment build(SegmentAllocator allocator,
+                                ClassDesc thisClass,
+                                Consumer<? super ClassBuilder> handler) {
         ConstantPoolBuilder pool = ConstantPoolBuilder.of();
-        return buildToMemorySegment(allocator, pool.classEntry(thisClass), pool, handler);
+        return build(allocator, pool.classEntry(thisClass), pool, handler);
     }
 
     /**
@@ -624,10 +624,10 @@ public sealed interface ClassFile
      * @return the {@code class} file bytes
      * @throws IllegalArgumentException if building encounters a failure
      */
-    MemorySegment buildToMemorySegment(SegmentAllocator allocator,
-                                       ClassEntry thisClassEntry,
-                                       ConstantPoolBuilder constantPool,
-                                       Consumer<? super ClassBuilder> handler);
+    MemorySegment build(SegmentAllocator allocator,
+                        ClassEntry thisClassEntry,
+                        ConstantPoolBuilder constantPool,
+                        Consumer<? super ClassBuilder> handler);
 
     /**
      * Builds a {@code class} file into a file in a file system.
@@ -698,9 +698,9 @@ public sealed interface ClassFile
      * @return the {@code class} file bytes
      * @throws IllegalArgumentException if building encounters a failure
      */
-    default MemorySegment buildModuleToMemorySegment(SegmentAllocator allocator,
-                                                     ModuleAttribute moduleAttribute) {
-        return buildModuleToMemorySegment(allocator, moduleAttribute, clb -> {});
+    default MemorySegment buildModule(SegmentAllocator allocator,
+                                      ModuleAttribute moduleAttribute) {
+        return buildModule(allocator, moduleAttribute, clb -> {});
     }
 
     /**
@@ -712,10 +712,10 @@ public sealed interface ClassFile
      * @return the {@code class} file bytes
      * @throws IllegalArgumentException if building encounters a failure
      */
-    default MemorySegment buildModuleToMemorySegment(SegmentAllocator allocator,
-                                                     ModuleAttribute moduleAttribute,
-                                                     Consumer<? super ClassBuilder> handler) {
-        return buildToMemorySegment(allocator, CD_module_info, clb -> {
+    default MemorySegment buildModule(SegmentAllocator allocator,
+                                      ModuleAttribute moduleAttribute,
+                                      Consumer<? super ClassBuilder> handler) {
+        return build(allocator, CD_module_info, clb -> {
             clb.withFlags(AccessFlag.MODULE);
             clb.with(moduleAttribute);
             handler.accept(clb);
@@ -872,8 +872,8 @@ public sealed interface ClassFile
      * @throws IllegalArgumentException if building encounters a failure
      * @see ConstantPoolSharingOption
      */
-    default MemorySegment transformClassToMemorySegment(SegmentAllocator allocator, ClassModel model, ClassTransform transform) {
-        return transformClassToMemorySegment(allocator, model, model.thisClass(), transform);
+    default MemorySegment transformClass(SegmentAllocator allocator, ClassModel model, ClassTransform transform) {
+        return transformClass(allocator, model, model.thisClass(), transform);
     }
 
     /**
@@ -904,8 +904,8 @@ public sealed interface ClassFile
      * @throws IllegalArgumentException if building encounters a failure
      * @see ConstantPoolSharingOption
      */
-    default MemorySegment transformClassToMemorySegment(SegmentAllocator allocator, ClassModel model, ClassDesc newClassName, ClassTransform transform) {
-        return transformClassToMemorySegment(allocator, model, TemporaryConstantPool.INSTANCE.classEntry(newClassName), transform);
+    default MemorySegment transformClass(SegmentAllocator allocator, ClassModel model, ClassDesc newClassName, ClassTransform transform) {
+        return transformClass(allocator, model, TemporaryConstantPool.INSTANCE.classEntry(newClassName), transform);
     }
 
     /**
@@ -943,7 +943,7 @@ public sealed interface ClassFile
      * @throws IllegalArgumentException if building encounters a failure
      * @see ConstantPoolSharingOption
      */
-    MemorySegment transformClassToMemorySegment(SegmentAllocator allocator, ClassModel model, ClassEntry newClassName, ClassTransform transform);
+    MemorySegment transformClass(SegmentAllocator allocator, ClassModel model, ClassEntry newClassName, ClassTransform transform);
 
     /**
      * Verify a {@code class} file.  All verification errors found will be returned.

--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -896,7 +896,7 @@ public sealed interface ClassFile
      * and to distinguish from {@link ClassFileBuilder#transform}, which is
      * more generic and powerful.
      *
-     * @param allocator the buffer allocator function
+     * @param allocator the segment allocator function
      * @param model the class model to transform
      * @param newClassName new class name
      * @param transform the transform
@@ -935,7 +935,7 @@ public sealed interface ClassFile
      * and to distinguish from {@link ClassFileBuilder#transform}, which is
      * more generic and powerful.
      *
-     * @param allocator the buffer allocator function
+     * @param allocator the segment allocator function
      * @param model the class model to transform
      * @param newClassName new class name
      * @param transform the transform

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,10 +33,7 @@ import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.ValueLayout;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.function.IntFunction;
-import java.util.function.LongFunction;
 
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
@@ -374,10 +371,6 @@ public final class BufWriterImpl implements BufWriter {
         System.arraycopy(elems, 0, array, bufferOffset, size());
     }
 
-    public void copyTo(ByteBuffer buffer) {
-        buffer.put(elems, 0, size());
-    }
-
     public void copyTo(MemorySegment segment, long offset) {
         MemorySegment.copy(elems, 0, segment, ValueLayout.JAVA_BYTE, offset, size());
     }
@@ -425,16 +418,6 @@ public final class BufWriterImpl implements BufWriter {
         head.copyTo(result, 0);
         tail.copyTo(result, head.size());
         return result;
-    }
-
-    /**
-     * Join head and tail into an exact-size byte buffer
-     */
-    static ByteBuffer joinToBuffer(IntFunction<ByteBuffer> allocator, BufWriterImpl head, BufWriterImpl tail) {
-        ByteBuffer buffer = allocator.apply(head.size() + tail.size());
-        head.copyTo(buffer);
-        tail.copyTo(buffer);
-        return buffer;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
@@ -31,6 +31,7 @@ import java.lang.classfile.constantpool.ConstantPool;
 import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -439,8 +440,8 @@ public final class BufWriterImpl implements BufWriter {
     /**
      * Join head and tail into an exact-size memory segment
      */
-    static MemorySegment joinToMemorySegment(LongFunction<MemorySegment> allocator, BufWriterImpl head, BufWriterImpl tail) {
-        MemorySegment segment = allocator.apply((long)head.size() + tail.size());
+    static MemorySegment joinToMemorySegment(SegmentAllocator allocator, BufWriterImpl head, BufWriterImpl tail) {
+        MemorySegment segment = allocator.allocate((long)head.size() + tail.size());
         head.copyTo(segment, 0);
         tail.copyTo(segment, head.size());
         return segment;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
@@ -162,7 +162,7 @@ public final class ClassFileImpl implements ClassFile {
     }
 
     @Override
-    public MemorySegment buildToMemorySegment(SegmentAllocator allocator,
+    public MemorySegment build(SegmentAllocator allocator,
                                               ClassEntry thisClassEntry,
                                               ConstantPoolBuilder constantPool,
                                               Consumer<? super ClassBuilder> handler) {
@@ -180,10 +180,10 @@ public final class ClassFileImpl implements ClassFile {
     }
 
     @Override
-    public MemorySegment transformClassToMemorySegment(SegmentAllocator allocator, ClassModel model, ClassEntry newClassName, ClassTransform transform) {
+    public MemorySegment transformClass(SegmentAllocator allocator, ClassModel model, ClassEntry newClassName, ClassTransform transform) {
         ConstantPoolBuilder constantPool = sharedConstantPool() ? ConstantPoolBuilder.of(model)
                                                                 : ConstantPoolBuilder.of();
-        return buildToMemorySegment(allocator, newClassName, constantPool, transformationHandler((ClassImpl) model, transform));
+        return build(allocator, newClassName, constantPool, transformationHandler((ClassImpl) model, transform));
     }
 
     private static Consumer<ClassBuilder> transformationHandler(final ClassImpl model, final ClassTransform transform) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
@@ -34,11 +34,17 @@ import java.lang.classfile.ClassTransform;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.Utf8Entry;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.LongFunction;
 
 import jdk.internal.classfile.impl.verifier.VerifierImpl;
+import jdk.internal.foreign.AbstractMemorySegmentImpl;
 
 import static java.util.Objects.requireNonNull;
 
@@ -136,6 +142,35 @@ public final class ClassFileImpl implements ClassFile {
     }
 
     @Override
+    public ClassModel parse(final MemorySegment bytes) {
+        AbstractMemorySegmentImpl amsi = (AbstractMemorySegmentImpl) bytes;
+        if (amsi.unsafeGetBase() instanceof byte[] ba) {
+            if (amsi.unsafeGetOffset() == 0 && amsi.byteSize() == ba.length) {
+                return parse(ba);
+            }
+        }
+        // must copy the bytes
+        return parse(bytes.toArray(ValueLayout.JAVA_BYTE));
+    }
+
+    @Override
+    public ClassModel parse(final ByteBuffer bytes) {
+        // defensive copy
+        ByteBuffer dup = bytes.duplicate();
+        byte[] array;
+        if (dup.hasArray()) {
+            array = dup.array();
+            if (array.length == dup.limit() && dup.arrayOffset() == 0 && dup.position() == 0) {
+                return parse(array);
+            }
+        }
+        // must copy the bytes
+        array = new byte[dup.remaining()];
+        dup.get(array);
+        return parse(array);
+    }
+
+    @Override
     public byte[] build(ClassEntry thisClassEntry,
                          ConstantPoolBuilder constantPool,
                          Consumer<? super ClassBuilder> handler) {
@@ -146,18 +181,57 @@ public final class ClassFileImpl implements ClassFile {
     }
 
     @Override
+    public ByteBuffer buildToByteBuffer(IntFunction<ByteBuffer> allocator,
+                                        ClassEntry thisClassEntry,
+                                        ConstantPoolBuilder constantPool,
+                                        Consumer<? super ClassBuilder> handler) {
+        thisClassEntry = AbstractPoolEntry.maybeClone(constantPool, thisClassEntry);
+        DirectClassBuilder builder = new DirectClassBuilder((SplitConstantPool)constantPool, this, thisClassEntry);
+        handler.accept(builder);
+        return builder.buildToByteBuffer(allocator);
+    }
+
+    @Override
+    public MemorySegment buildToMemorySegment(LongFunction<MemorySegment> allocator,
+                                              ClassEntry thisClassEntry,
+                                              ConstantPoolBuilder constantPool,
+                                              Consumer<? super ClassBuilder> handler) {
+        thisClassEntry = AbstractPoolEntry.maybeClone(constantPool, thisClassEntry);
+        DirectClassBuilder builder = new DirectClassBuilder((SplitConstantPool)constantPool, this, thisClassEntry);
+        handler.accept(builder);
+        return builder.buildToMemorySegment(allocator);
+    }
+
+    @Override
     public byte[] transformClass(ClassModel model, ClassEntry newClassName, ClassTransform transform) {
         ConstantPoolBuilder constantPool = sharedConstantPool() ? ConstantPoolBuilder.of(model)
                                                                 : ConstantPoolBuilder.of();
-        return build(newClassName, constantPool,
-                new Consumer<ClassBuilder>() {
-                    @Override
-                    public void accept(ClassBuilder builder) {
-                        ((DirectClassBuilder) builder).setOriginal((ClassImpl)model);
-                        ((DirectClassBuilder) builder).setSizeHint(((ClassImpl)model).classfileLength());
-                        builder.transform((ClassImpl)model, transform);
-                    }
-                });
+        return build(newClassName, constantPool, transformationHandler((ClassImpl) model, transform));
+    }
+
+    @Override
+    public ByteBuffer transformClassToByteBuffer(IntFunction<ByteBuffer> allocator, ClassModel model, ClassEntry newClassName, ClassTransform transform) {
+        ConstantPoolBuilder constantPool = sharedConstantPool() ? ConstantPoolBuilder.of(model)
+                                                                : ConstantPoolBuilder.of();
+        return buildToByteBuffer(allocator, newClassName, constantPool, transformationHandler((ClassImpl) model, transform));
+    }
+
+    @Override
+    public MemorySegment transformClassToMemorySegment(LongFunction<MemorySegment> allocator, ClassModel model, ClassEntry newClassName, ClassTransform transform) {
+        ConstantPoolBuilder constantPool = sharedConstantPool() ? ConstantPoolBuilder.of(model)
+                                                                : ConstantPoolBuilder.of();
+        return buildToMemorySegment(allocator, newClassName, constantPool, transformationHandler((ClassImpl) model, transform));
+    }
+
+    private static Consumer<ClassBuilder> transformationHandler(final ClassImpl model, final ClassTransform transform) {
+        return new Consumer<ClassBuilder>() {
+            @Override
+            public void accept(ClassBuilder builder) {
+                ((DirectClassBuilder) builder).setOriginal(model);
+                ((DirectClassBuilder) builder).setSizeHint(model.classfileLength());
+                builder.transform(model, transform);
+            }
+        };
     }
 
     public boolean sharedConstantPool() {
@@ -175,6 +249,24 @@ public final class ClassFileImpl implements ClassFile {
 
     @Override
     public List<VerifyError> verify(byte[] bytes) {
+        try {
+            return verify(parse(bytes));
+        } catch (IllegalArgumentException parsingError) {
+            return List.of(new VerifyError(parsingError.getMessage()));
+        }
+    }
+
+    @Override
+    public List<VerifyError> verify(ByteBuffer bytes) {
+        try {
+            return verify(parse(bytes));
+        } catch (IllegalArgumentException parsingError) {
+            return List.of(new VerifyError(parsingError.getMessage()));
+        }
+    }
+
+    @Override
+    public List<VerifyError> verify(MemorySegment bytes) {
         try {
             return verify(parse(bytes));
         } catch (IllegalArgumentException parsingError) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
@@ -31,13 +31,13 @@ import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.Utf8Entry;
 import java.lang.constant.ConstantDescs;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SegmentAllocator;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
-import java.util.function.LongFunction;
 
 import static java.util.Objects.requireNonNull;
 
@@ -229,7 +229,7 @@ public final class DirectClassBuilder
         return BufWriterImpl.joinToBuffer(allocator, head, tail);
     }
 
-    public MemorySegment buildToMemorySegment(LongFunction<MemorySegment> allocator) {
+    public MemorySegment buildToMemorySegment(SegmentAllocator allocator) {
 
         // The logic of this is very carefully ordered.  We want to avoid
         // repeated buffer copyings, so we accumulate lists of writers which

--- a/test/jdk/jdk/classfile/BuildAndParseBuffersAndSegments.java
+++ b/test/jdk/jdk/classfile/BuildAndParseBuffersAndSegments.java
@@ -52,13 +52,7 @@ class BuildAndParseBuffersAndSegments {
         }
 
         testWithModel(classFile, classFile.parse(originalBytes));
-        testWithModel(classFile, classFile.parse(ByteBuffer.wrap(originalBytes)));
         testWithModel(classFile, classFile.parse(MemorySegment.ofArray(originalBytes)));
-
-        ByteBuffer direct = ByteBuffer.allocateDirect(originalBytes.length);
-        direct.put(originalBytes);
-        direct.rewind();
-        testWithModel(classFile, classFile.parse(direct));
 
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment segment = arena.allocate(ValueLayout.JAVA_BYTE, originalBytes.length);
@@ -70,13 +64,10 @@ class BuildAndParseBuffersAndSegments {
     private static void testWithModel(final ClassFile classFile, final ClassModel model) {
         try (Arena arena = Arena.ofConfined()) {
             // transform to an array, buffers, and segments, and compare them all for equality
-            ByteBuffer asDirectBuffer = classFile.transformClassToByteBuffer(ByteBuffer::allocateDirect, model, ClassTransform.ACCEPT_ALL);
-            asDirectBuffer.rewind();
-            MemorySegment asSegment = classFile.transformClassToMemorySegment(arena::allocate, model, ClassTransform.ACCEPT_ALL);
+            MemorySegment asSegment = classFile.transformClassToMemorySegment(arena, model, ClassTransform.ACCEPT_ALL);
             byte[] asArray = classFile.transformClass(model, ClassTransform.ACCEPT_ALL);
 
             Assertions.assertEquals(-1, asSegment.mismatch(MemorySegment.ofArray(asArray)));
-            Assertions.assertEquals(ByteBuffer.wrap(asArray), asDirectBuffer);
         }
     }
 }

--- a/test/jdk/jdk/classfile/BuildAndParseBuffersAndSegments.java
+++ b/test/jdk/jdk/classfile/BuildAndParseBuffersAndSegments.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.ClassTransform;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/*
+ * @test
+ * @bug 8352536
+ * @summary Test parsing and generating non-array class data
+ * @run junit BuildAndParseBuffersAndSegments
+ */
+class BuildAndParseBuffersAndSegments {
+
+    @Test
+    public void testParseAndGenerate() throws IOException {
+        ClassFile classFile = ClassFile.of();
+        // use our own class, why not?
+        byte[] originalBytes;
+        try (InputStream is = BuildAndParseBuffersAndSegments.class.getResourceAsStream("BuildAndParseBuffersAndSegments.class")) {
+            originalBytes = is.readAllBytes();
+        }
+
+        testWithModel(classFile, classFile.parse(originalBytes));
+        testWithModel(classFile, classFile.parse(ByteBuffer.wrap(originalBytes)));
+        testWithModel(classFile, classFile.parse(MemorySegment.ofArray(originalBytes)));
+
+        ByteBuffer direct = ByteBuffer.allocateDirect(originalBytes.length);
+        direct.put(originalBytes);
+        direct.rewind();
+        testWithModel(classFile, classFile.parse(direct));
+
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(ValueLayout.JAVA_BYTE, originalBytes.length);
+            segment.copyFrom(MemorySegment.ofArray(originalBytes));
+            testWithModel(classFile, classFile.parse(segment));
+        }
+    }
+
+    private static void testWithModel(final ClassFile classFile, final ClassModel model) {
+        try (Arena arena = Arena.ofConfined()) {
+            // transform to an array, buffers, and segments, and compare them all for equality
+            ByteBuffer asDirectBuffer = classFile.transformClassToByteBuffer(ByteBuffer::allocateDirect, model, ClassTransform.ACCEPT_ALL);
+            asDirectBuffer.rewind();
+            MemorySegment asSegment = classFile.transformClassToMemorySegment(arena::allocate, model, ClassTransform.ACCEPT_ALL);
+            byte[] asArray = classFile.transformClass(model, ClassTransform.ACCEPT_ALL);
+
+            Assertions.assertEquals(-1, asSegment.mismatch(MemorySegment.ofArray(asArray)));
+            Assertions.assertEquals(ByteBuffer.wrap(asArray), asDirectBuffer);
+        }
+    }
+}

--- a/test/jdk/jdk/classfile/BuildAndParseBuffersAndSegments.java
+++ b/test/jdk/jdk/classfile/BuildAndParseBuffersAndSegments.java
@@ -29,7 +29,6 @@ import java.lang.classfile.ClassTransform;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.nio.ByteBuffer;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -64,7 +63,7 @@ class BuildAndParseBuffersAndSegments {
     private static void testWithModel(final ClassFile classFile, final ClassModel model) {
         try (Arena arena = Arena.ofConfined()) {
             // transform to an array, buffers, and segments, and compare them all for equality
-            MemorySegment asSegment = classFile.transformClassToMemorySegment(arena, model, ClassTransform.ACCEPT_ALL);
+            MemorySegment asSegment = classFile.transformClass(arena, model, ClassTransform.ACCEPT_ALL);
             byte[] asArray = classFile.transformClass(model, ClassTransform.ACCEPT_ALL);
 
             Assertions.assertEquals(-1, asSegment.mismatch(MemorySegment.ofArray(asArray)));

--- a/test/jdk/jdk/classfile/BuildAndParseSegments.java
+++ b/test/jdk/jdk/classfile/BuildAndParseSegments.java
@@ -37,16 +37,16 @@ import org.junit.jupiter.api.Test;
  * @test
  * @bug 8352536
  * @summary Test parsing and generating non-array class data
- * @run junit BuildAndParseBuffersAndSegments
+ * @run junit BuildAndParseSegments
  */
-class BuildAndParseBuffersAndSegments {
+class BuildAndParseSegments {
 
     @Test
     public void testParseAndGenerate() throws IOException {
         ClassFile classFile = ClassFile.of();
         // use our own class, why not?
         byte[] originalBytes;
-        try (InputStream is = BuildAndParseBuffersAndSegments.class.getResourceAsStream("BuildAndParseBuffersAndSegments.class")) {
+        try (InputStream is = BuildAndParseSegments.class.getResourceAsStream("BuildAndParseSegments.class")) {
             originalBytes = is.readAllBytes();
         }
 

--- a/test/micro/org/openjdk/bench/jdk/classfile/MemorySegmentBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/MemorySegmentBenchmark.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.classfile;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.ClassTransform;
+import java.lang.classfile.CompoundElement;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SegmentAllocator;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * MemorySegmentBenchmark
+ */
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class MemorySegmentBenchmark {
+    private ClassFile classFile;
+    private byte[] inputBytes0;
+    private ClassModel model0;
+    private byte[] inputBytes1;
+    private ClassModel model1;
+    private MemorySegment outputSegment;
+    private SegmentAllocator segmentAllocator;
+
+    @Setup
+    public void setup() throws IOException {
+        classFile = ClassFile.of();
+        FileSystem jrtFs = FileSystems.getFileSystem(URI.create("jrt:/"));
+        inputBytes0 = Files.readAllBytes(
+                jrtFs.getPath("modules/java.base/java/util/AbstractMap.class"));
+        inputBytes1 = Files.readAllBytes(
+                jrtFs.getPath("modules/java.base/java/util/TreeMap.class"));
+        // preallocate a big-enough space and zero it
+        outputSegment = Arena.ofAuto().allocate(1 << 20);
+        model0 = classFile.parse(inputBytes0);
+        model1 = classFile.parse(inputBytes1);
+        segmentAllocator = (_, _) -> outputSegment;
+        // expand the models
+        consume(model0);
+        consume(model1);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void emitWithoutCopy0(Blackhole bh) {
+        classFile.transformClass(segmentAllocator, model0, ClassTransform.ACCEPT_ALL);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void emitWithCopy0(Blackhole bh) {
+        outputSegment.copyFrom(MemorySegment.ofArray(classFile.transformClass(model0, ClassTransform.ACCEPT_ALL)));
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void emitWithoutCopy1(Blackhole bh) {
+        classFile.transformClass(segmentAllocator, model1, ClassTransform.ACCEPT_ALL);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void emitWithCopy1(Blackhole bh) {
+        outputSegment.copyFrom(MemorySegment.ofArray(classFile.transformClass(model1, ClassTransform.ACCEPT_ALL)));
+    }
+
+    private static void consume(CompoundElement<?> parent) {
+        parent.forEach(e -> {
+            if (e instanceof CompoundElement<?> ce) consume(ce);
+        });
+    }
+}


### PR DESCRIPTION
Provide method overloads to the ClassFile interface of the java.lang.classfile API which allow parsing of classes found in memory segments, as well as allowing built class files to be output to them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8352562](https://bugs.openjdk.org/browse/JDK-8352562) to be approved

### Issues
 * [JDK-8352536](https://bugs.openjdk.org/browse/JDK-8352536): Add overloads to parse and build class files from/to MemorySegment (**Enhancement** - P4)
 * [JDK-8352562](https://bugs.openjdk.org/browse/JDK-8352562): Add overloads to parse and build class files from/to MemorySegment (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24139/head:pull/24139` \
`$ git checkout pull/24139`

Update a local copy of the PR: \
`$ git checkout pull/24139` \
`$ git pull https://git.openjdk.org/jdk.git pull/24139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24139`

View PR using the GUI difftool: \
`$ git pr show -t 24139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24139.diff">https://git.openjdk.org/jdk/pull/24139.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24139#issuecomment-2741520709)
</details>
