### PR TITLE
8152293: Incomplete fraction reduction in getValueAsString() for TIFFTag.TIFF_RATIONAL, TIFFTag.TIFF_SRATIONAL

### DIFF
--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/TIFFField.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/TIFFField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1298,30 +1298,10 @@ public final class TIFFField implements Cloneable {
             return Double.toString(((double[])data)[index]);
         case TIFFTag.TIFF_SRATIONAL:
             int[] ivalue = getAsSRational(index);
-            String srationalString;
-            if(ivalue[1] != 0 && ivalue[0] % ivalue[1] == 0) {
-                // If the denominator is a non-zero integral divisor
-                // of the numerator then convert the fraction to be
-                // with respect to a unity denominator.
-                srationalString = (ivalue[0] / ivalue[1]) + "/1";
-            } else {
-                // Use the values directly.
-                srationalString = ivalue[0] + "/" + ivalue[1];
-            }
-            return srationalString;
+            return ivalue[0] + "/" + ivalue[1];
         case TIFFTag.TIFF_RATIONAL:
             long[] lvalue = getAsRational(index);
-            String rationalString;
-            if(lvalue[1] != 0L && lvalue[0] % lvalue[1] == 0) {
-                // If the denominator is a non-zero integral divisor
-                // of the numerator then convert the fraction to be
-                // with respect to a unity denominator.
-                rationalString = (lvalue[0] / lvalue[1]) + "/1";
-            } else {
-                // Use the values directly.
-                rationalString = lvalue[0] + "/" + lvalue[1];
-            }
-            return rationalString;
+            return lvalue[0] + "/" + lvalue[1];
         default:
             throw new ClassCastException(); // should never happen
         }

--- a/test/jdk/javax/imageio/plugins/tiff/TIFFRationalTest.java
+++ b/test/jdk/javax/imageio/plugins/tiff/TIFFRationalTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug     8152293
+ * @summary Verify bounds check and no terms reduction for TIFF_[S]RATIONAL
+ * @run     junit TIFFRationalTest
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.imageio.plugins.tiff.TIFFField;
+import javax.imageio.plugins.tiff.TIFFTag;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TIFFRationalTest {
+    // largest unsigned 32-bit integer
+    private static final long MAX_UINT32 = 0xffffffffL;
+
+    // bogus TIFF tag number
+    private static final int TAG_NUMBER = 12345;
+
+    private static Stream<Arguments> paramsSignedRational() {
+
+        int signedRationals[][] = {
+            { -1,   0},
+            { 11,  22},
+            { 22,  11},
+            {-11,  22},
+            {-22,  11},
+            { 11, -22},
+            { 22, -11},
+            {-11, -22},
+            {-22, -11},
+            {  0,  11},
+            {  0, -11},
+            { 11,  13},
+            {-11,  13},
+            { 11, -13},
+            {105,  30},
+            { 30, 105}
+        };
+
+        final int n = signedRationals.length;
+
+        int type = TIFFTag.TIFF_SRATIONAL;
+        TIFFTag tag = new TIFFTag("tag", TAG_NUMBER, 1 << type);
+        TIFFField f = new TIFFField(tag, type, n, signedRationals);
+
+        List<Arguments> list = new ArrayList<Arguments>();
+        for (int i = 0; i < n; i++) {
+            list.add(Arguments.of(f, i, signedRationals[i]));
+        }
+
+        return list.stream();
+    }
+
+    private static Stream<Arguments> paramsUnsignedRational() {
+
+        long unsignedRationals[][] = {
+            {  1,  0},
+            { 11, 22},
+            { 22, 11},
+            {  0, 11},
+            { 11, 13},
+            {105, 30},
+            { 30, 105}
+        };
+
+        final int n = unsignedRationals.length;
+
+        int type = TIFFTag.TIFF_RATIONAL;
+        TIFFTag tag = new TIFFTag("tag", TAG_NUMBER, 1 << type);
+        TIFFField f = new TIFFField(tag, type, n, unsignedRationals);
+
+        List<Arguments> list = new ArrayList<Arguments>();
+        for (int i = 0; i < n; i++) {
+            list.add(Arguments.of(f, i, unsignedRationals[i]));
+        }
+
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("paramsSignedRational")
+    void signedRational(TIFFField f, int i, int[] expected) {
+        int fraction[] = f.getAsSRational(i);
+        assertEquals(expected[0], fraction[0],
+                     "numerator reduction failure: " +
+                     fraction[0] + " != " + expected[0]);
+        assertEquals(expected[1], fraction[1],
+                     "denominator reduction failure: " +
+                     fraction[1] + " != " + expected[1]);
+
+        String s =
+            Integer.toString(expected[0]) + "/" +
+            Integer.toString(expected[1]);
+        assertEquals(s, f.getValueAsString(i),
+                     "invalid string representation");
+    }
+
+    @ParameterizedTest
+    @MethodSource("paramsUnsignedRational")
+    void unsignedRational(TIFFField f, int i, long[] expected) {
+        long[] fraction = f.getAsRational(i);
+        assertEquals(expected[0], fraction[0],
+                     "numerator reduction failure: " +
+                     fraction[0] + " != " + expected[0]);
+        assertEquals(expected[1], fraction[1],
+                     "denominator reduction failure: " +
+                     fraction[1] + " != " + expected[1]);
+
+        String s =
+            Long.toString(expected[0]) + "/" +
+            Long.toString(expected[1]);
+        assertEquals(s, f.getValueAsString(i),
+                     "invalid string representation");
+    }
+
+    private static Stream<Arguments> aberrantRationals() {
+        List<Arguments> list = new ArrayList<Arguments>();
+
+        list.add(Arguments.of(new long[] {-1,  1}));
+        list.add(Arguments.of(new long[] { 1, -1}));
+        list.add(Arguments.of(new long[] {-1, -1}));
+        list.add(Arguments.of(new long[] {MAX_UINT32 + 1, 1}));
+        list.add(Arguments.of(new long[] {1, MAX_UINT32 + 1}));
+        list.add(Arguments.of(new long[] {MAX_UINT32 + 1, MAX_UINT32 + 1}));
+
+        return list.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("aberrantRationals")
+    void rationalOverflow(long[] frac) {
+        int type = TIFFTag.TIFF_RATIONAL;
+        TIFFTag tag = new TIFFTag("tag", TAG_NUMBER, 1 << type);
+        assertThrows(IllegalArgumentException.class,
+                     () -> new TIFFField(tag, type, 1, new long[][]{frac}));
+    }
+}


### PR DESCRIPTION
Remove from `TIFFField.getValueAsString` the rudimentary reduction in terms in the conversion of `RATIONAL` and `SRATIONAL` field values to a string. Also, add a test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8152293](https://bugs.openjdk.org/browse/JDK-8152293): Incomplete fraction reduction in getValueAsString() for TIFFTag.TIFF_RATIONAL, TIFFTag.TIFF_SRATIONAL (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24141/head:pull/24141` \
`$ git checkout pull/24141`

Update a local copy of the PR: \
`$ git checkout pull/24141` \
`$ git pull https://git.openjdk.org/jdk.git pull/24141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24141`

View PR using the GUI difftool: \
`$ git pr show -t 24141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24141.diff">https://git.openjdk.org/jdk/pull/24141.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24141#issuecomment-2741612094)
</details>
