### PR TITLE
8343891: Test javax/swing/JTabbedPane/TestJTabbedPaneBackgroundColor.java failed

### DIFF
--- a/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneBackgroundColor.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneBackgroundColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneBackgroundColor.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneBackgroundColor.java
@@ -48,6 +48,9 @@ public class TestJTabbedPaneBackgroundColor {
     private static Robot robot;
     private static volatile Dimension dim;
     private static volatile Point loc;
+    private static volatile boolean isOpaque;
+    private static volatile Color c1 = null;
+    private static volatile Color c2 = null;
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
@@ -55,10 +58,12 @@ public class TestJTabbedPaneBackgroundColor {
         for (UIManager.LookAndFeelInfo laf :
                 UIManager.getInstalledLookAndFeels()) {
             System.out.println("Testing: " + laf.getName());
-            setLookAndFeel(laf);
 
             try {
-                SwingUtilities.invokeAndWait(TestJTabbedPaneBackgroundColor::createAndShowUI);
+                SwingUtilities.invokeAndWait(() -> {
+                    setLookAndFeel(laf);
+                    createAndShowUI();
+                });
                 robot.waitForIdle();
                 robot.delay(500);
 
@@ -70,10 +75,12 @@ public class TestJTabbedPaneBackgroundColor {
                 loc = new Point(loc.x + dim.width - 2, loc.y + 2);
                 doTesting(loc, laf);
 
-                if (!pane.isOpaque()) {
-                    pane.setOpaque(true);
-                    pane.repaint();
-                }
+                SwingUtilities.invokeAndWait(() -> {
+                    if (!pane.isOpaque()) {
+                        pane.setOpaque(true);
+                        pane.repaint();
+                    }
+                });
                 robot.waitForIdle();
                 robot.delay(500);
 
@@ -119,12 +126,14 @@ public class TestJTabbedPaneBackgroundColor {
         frame.setVisible(true);
     }
 
-    private static void doTesting(Point p, UIManager.LookAndFeelInfo laf) {
-        boolean isOpaque = pane.isOpaque();
+    private static void doTesting(Point p, UIManager.LookAndFeelInfo laf) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            isOpaque = pane.isOpaque();
+            c1 = pane.getBackground();
+            c2 = frame.getContentPane().getBackground();
+        });
         Color actual = robot.getPixelColor(p.x, p.y);
-        Color expected = isOpaque
-                ? pane.getBackground()
-                : frame.getContentPane().getBackground();
+        Color expected = isOpaque ? c1 : c2;
 
         if (!expected.equals(actual)) {
             addOpaqueError(laf.getName(), isOpaque);

--- a/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneBackgroundColor.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneBackgroundColor.java
@@ -136,6 +136,8 @@ public class TestJTabbedPaneBackgroundColor {
         Color expected = isOpaque ? c1 : c2;
 
         if (!expected.equals(actual)) {
+            System.out.println("Expected Color : " + expected);
+            System.out.println("Actual Color : " + actual);
             addOpaqueError(laf.getName(), isOpaque);
         }
     }


### PR DESCRIPTION
TestJTabbedPaneBackgroundColor.java test was failing intermittently in CI jobs. Test is modified to access UI components on EDT for stabilizations. CI testing seems fine after test change. Link attached in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343891](https://bugs.openjdk.org/browse/JDK-8343891): Test javax/swing/JTabbedPane/TestJTabbedPaneBackgroundColor.java failed (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24148/head:pull/24148` \
`$ git checkout pull/24148`

Update a local copy of the PR: \
`$ git checkout pull/24148` \
`$ git pull https://git.openjdk.org/jdk.git pull/24148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24148`

View PR using the GUI difftool: \
`$ git pr show -t 24148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24148.diff">https://git.openjdk.org/jdk/pull/24148.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24148#issuecomment-2742676730)
</details>
