### PR TITLE
8351515: C2 incorrectly removes double negation for double and float

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -57,8 +57,8 @@ Node* SubNode::Identity(PhaseGVN* phase) {
 
   // Remove double negation if it is not a floating point number since negation
   // is not the same as subtraction for floating point numbers
-  // (cf. JLS § 15.15.4). `0-(0-(-0.0))` must equal to positive 0.0 according to
-  // JLS § 15.8.2, but would result in -0.0 this would apply.
+  // (cf. JLS § 15.15.4). `0-(0-(-0.0))` must be equal to positive 0.0 according to
+  // JLS § 15.8.2, but would result in -0.0 if this folding would be applied.
   if (phase->type(in(1))->higher_equal(zero) &&
       in(2)->Opcode() == Opcode() &&
       phase->type(in(2)->in(1))->higher_equal(zero) &&

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -53,8 +53,9 @@ Node* SubNode::Identity(PhaseGVN* phase) {
   assert(in(1) != this, "Must already have called Value");
   assert(in(2) != this, "Must already have called Value");
 
+  const Type* zero = add_id();
+
   // Remove double negation
-  const Type *zero = add_id();
   if( phase->type( in(1) )->higher_equal( zero ) &&
       in(2)->Opcode() == Opcode() &&
       phase->type( in(2)->in(1) )->higher_equal( zero ) ) {

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -55,10 +55,12 @@ Node* SubNode::Identity(PhaseGVN* phase) {
 
   const Type* zero = add_id();
 
-  // Remove double negation
-  if( phase->type( in(1) )->higher_equal( zero ) &&
+  // Remove double negation if it is not a floating point number, as it might be
+  // negative zero (`0.0 - (0.0 - (-0.0)) != -0.0`).
+  if (phase->type(in(1))->higher_equal(zero) &&
       in(2)->Opcode() == Opcode() &&
-      phase->type( in(2)->in(1) )->higher_equal( zero ) ) {
+      phase->type(in(2)->in(1))->higher_equal(zero) &&
+      !phase->type(in(2)->in(2))->is_floatingpoint()) {
     return in(2)->in(2);
   }
 

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -55,8 +55,10 @@ Node* SubNode::Identity(PhaseGVN* phase) {
 
   const Type* zero = add_id();
 
-  // Remove double negation if it is not a floating point number, as it might be
-  // negative zero (`0.0 - (0.0 - (-0.0)) != -0.0`).
+  // Remove double negation if it is not a floating point number since negation
+  // is not the same as subtraction for floating point numbers
+  // (cf. JLS § 15.15.4). `0-(0-(-0.0))` must equal to positive 0.0 according to
+  // JLS § 15.8.2, but would result in -0.0 this would apply.
   if (phase->type(in(1))->higher_equal(zero) &&
       in(2)->Opcode() == Opcode() &&
       phase->type(in(2)->in(1))->higher_equal(zero) &&

--- a/test/hotspot/jtreg/compiler/floatingpoint/TestSubNodeFloatDoubleNegation.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/TestSubNodeFloatDoubleNegation.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8351515
+ * @summary The compiler must not fold `0-(0-x)` for x: float | double
+ * @library /test/lib /
+ * @modules jdk.incubator.vector
+ * @run driver compiler.floatingpoint.TestSubNodeFloatDoubleNegation
+ */
+package compiler.floatingpoint;
+
+import compiler.lib.ir_framework.*;
+import jdk.incubator.vector.Float16;
+import jdk.test.lib.Asserts;
+
+public class TestSubNodeFloatDoubleNegation {
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector", "-XX:CompileCommand=inline,jdk.incubator.vector.Float16::*");
+    }
+
+    @Run(test = { "testHalfFloat", "testFloat", "testDouble" })
+    public static void assertResults() {
+        short halfFloatRes = Float16.float16ToShortBits(testHalfFloat(Float16.valueOf(-0.0f)));
+        int floatRes = Float.floatToIntBits(testFloat(-0.0f));
+        long doubleRes = Double.doubleToLongBits(testDouble(-0.0));
+
+        Asserts.assertEQ((short) 0, halfFloatRes);
+        Asserts.assertEQ((int) 0, floatRes);
+        Asserts.assertEQ((long) 0, doubleRes);
+    }
+
+    @Test
+    // Match a generic SubNode, because scalar Float16 operations are often
+    // performed as float operations.
+    @IR(counts = { IRNode.SUB, "2" })
+    // Checks that the subtractions in 0 - (0 - hf) do not get eliminiated
+    public static Float16 testHalfFloat(Float16 hf) {
+        return Float16.subtract(
+                Float16.shortBitsToFloat16((short) 0),
+                Float16.subtract(Float16.shortBitsToFloat16((short) 0), hf));
+    }
+
+    @Test
+    @IR(counts = { IRNode.SUB_F, "2" })
+    // Checks that the subtractions in 0 - (0 - f) do not get eliminated
+    public static float testFloat(float f) {
+        return 0 - (0 - f);
+    }
+
+    @Test
+    @IR(counts = { IRNode.SUB_D, "2" })
+    // Checks that the subtractions in 0 - (0 - d) do not get eliminated
+    public static double testDouble(double d) {
+        return 0 - (0 - d);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1833,7 +1833,7 @@ public class IRNode {
 
     public static final String SUB = PREFIX + "SUB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(SUB, "Sub(I|L|F|D)");
+        beforeMatchingNameRegex(SUB, "Sub(I|L|F|D|HF)");
     }
 
     public static final String SUB_D = PREFIX + "SUB_D" + POSTFIX;


### PR DESCRIPTION
# Issue Summary

A fuzzer run discovered that code of the form `0 - (0 - x)` yields the wrong result for `x = -0.0`. According to the [Java Language Spec 15.8.2](https://docs.oracle.com/javase/specs/jls/se23/html/jls-15.html#jls-15.18.2) the sum of floating point zeroes of opposite sign is positive zero. Hence, `(0 - (0 - (-0.0))` must result in `+0.0`, but due to the folding of all double negations in `SubNode::Identity` this was optimized to `-0.0`

# Changeset overview

To fix this issue, I excluded floating point numbers from the folding of double negations, which also includes `Float16` values. This might seem excessive at first glance, but we do not track range information for floating point types. Hence, we could still perform the folding of the double negation if a floating point constant is not `-0.0`. However, constant folding already takes care of this.

Changes:
 - IR-Framework: fix `IRNode.SUB`not matching `SubHFNode`
 - Add a regression IR-test
 - Exclude floating point `SubNodes` from folding double negations

# Testing
- [Github Actions](https://github.com/mhaessig/jdk/actions/runs/13989207348)
- `tier1` through `tier5` plus Oracle internal testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351515](https://bugs.openjdk.org/browse/JDK-8351515): C2 incorrectly removes double negation for double and float (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) Review applies to [7805314f](https://git.openjdk.org/jdk/pull/24150/files/7805314fc49c4e0eeb4695763ea0b39171d5570f)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24150/head:pull/24150` \
`$ git checkout pull/24150`

Update a local copy of the PR: \
`$ git checkout pull/24150` \
`$ git pull https://git.openjdk.org/jdk.git pull/24150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24150`

View PR using the GUI difftool: \
`$ git pr show -t 24150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24150.diff">https://git.openjdk.org/jdk/pull/24150.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24150#issuecomment-2742942729)
</details>
