### PR TITLE
8352591: Missing UnlockDiagnosticVMOptions in VerifyGraphEdgesWithDeadCodeCheckFromSafepoints test

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/VerifyGraphEdgesWithDeadCodeCheckFromSafepoints.java
+++ b/test/hotspot/jtreg/compiler/loopopts/VerifyGraphEdgesWithDeadCodeCheckFromSafepoints.java
@@ -29,7 +29,7 @@
  *
  * @run driver compiler.loopopts.VerifyGraphEdgesWithDeadCodeCheckFromSafepoints
  * @run main/othervm
- *       -XX:+IgnoreUnrecognizedVMOptions
+ *       -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *       -XX:-TieredCompilation -XX:+VerifyGraphEdges
  *       -XX:+StressIGVN -Xcomp
  *       -XX:CompileCommand=compileonly,compiler.loopopts.VerifyGraphEdgesWithDeadCodeCheckFromSafepoints::mainTest


### PR DESCRIPTION
Using `StressIGVN` in product requires `UnlockDiagnosticVMOptions`. My bad

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352591](https://bugs.openjdk.org/browse/JDK-8352591): Missing UnlockDiagnosticVMOptions in VerifyGraphEdgesWithDeadCodeCheckFromSafepoints test (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24151/head:pull/24151` \
`$ git checkout pull/24151`

Update a local copy of the PR: \
`$ git checkout pull/24151` \
`$ git pull https://git.openjdk.org/jdk.git pull/24151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24151`

View PR using the GUI difftool: \
`$ git pr show -t 24151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24151.diff">https://git.openjdk.org/jdk/pull/24151.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24151#issuecomment-2744187942)
</details>
