### PR TITLE
6734168: BasicButtonUI uses wrong FontMetrics to Layout JButtons text

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsButtonUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsButtonUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,6 +170,10 @@ public class WindowsButtonUI extends BasicButtonUI
     public void paint(Graphics g, JComponent c) {
         if (XPStyle.getXP() != null) {
             WindowsButtonUI.paintXPButtonBackground(g, c);
+        }
+        AbstractButton b = (AbstractButton) c;
+        if (!(b.getFont().equals(g.getFont()))) {
+            b.setFont(g.getFont());
         }
         super.paint(g, c);
     }

--- a/test/jdk/javax/swing/JButton/TestButtonFontMetrics.java
+++ b/test/jdk/javax/swing/JButton/TestButtonFontMetrics.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6734168
+ * @requires (os.family == "windows")
+ * @summary Verifies if BasicButtonUI uses wrong FontMetrics to Layout JButtons text
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestButtonFontMetrics 
+ */
+
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.image.BufferedImage;
+import java.awt.image.ConvolveOp;
+import java.awt.image.Kernel;
+
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.WindowConstants;
+
+public class TestButtonFontMetrics extends JButton {
+
+    private static final String INSTRUCTIONS = """
+        A frame will be shown with a button with text "Test";
+        Click on the button.
+        If the text on the button truncates,
+        then test fails else test passes.""";
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        PassFailJFrame.builder()
+                .title("TestButtonFontMetrics Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(TestButtonFontMetrics::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public TestButtonFontMetrics(String text) {
+        super(text);
+    }
+
+    @Override
+    public void paintComponent(Graphics g) {
+        if (isEnabled()) {
+            super.paintComponent(g);
+            return;
+        }
+        Graphics2D g2 = (Graphics2D) g.create();
+        BufferedImage image = new BufferedImage(getWidth(), getHeight(),
+                                BufferedImage.TYPE_INT_RGB);
+        Graphics imgGraphics = image.getGraphics();
+
+        super.paintComponent(imgGraphics);
+        float[] kernel = { 0.1f, 0.1f, 0.1f, 0.1f, 0.2f, 0.1f, 0.1f, 0.1f, 0.1f };
+        ConvolveOp op = new ConvolveOp(new Kernel(3, 3, kernel),
+                                       ConvolveOp.EDGE_NO_OP, null);
+        image = op.filter(image, null);
+        g2.drawImage(image, 0, 0, null);
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("TestButtonFontMetrics");
+        frame.setLayout(new GridBagLayout());
+        frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        TestButtonFontMetrics button = new TestButtonFontMetrics("Test");
+        button.addActionListener(new DisableListener());
+        frame.add(button, new GridBagConstraints(0, 0, 1, 1, 0, 0,
+             GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(
+                  10, 10, 0, 10), 0, 0));
+        frame.pack();
+        return frame;
+    }
+
+    static class DisableListener implements ActionListener {
+        public void actionPerformed(ActionEvent e) {
+            ((JComponent) e.getSource()).setEnabled(false);
+        }
+    }
+}

--- a/test/jdk/javax/swing/JButton/TestButtonFontMetrics.java
+++ b/test/jdk/javax/swing/JButton/TestButtonFontMetrics.java
@@ -28,7 +28,7 @@
  * @summary Verifies if BasicButtonUI uses wrong FontMetrics to Layout JButtons text
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
- * @run main/manual TestButtonFontMetrics 
+ * @run main/manual TestButtonFontMetrics
  */
 
 import java.awt.Graphics;


### PR DESCRIPTION
javax.swing.plaf.basic.BasicButtonUI uses wrong FontMetrics object to layout the text on a JButton. 
The paint(Graphics, JComponent) method of BasicButtonUI calculates the [FontMetrics](https://github.com/openjdk/jdk/blob/6656254c346ef505a48652fdf4dedd6edc020e33/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicButtonUI.java#L331) using the passed Graphics object without setting the buttons font before. If the buttons font varies from the currently set font of the passed graphics object, the font metrics do not fit the metrics of the expected font leading to truncated text on the button.
In WindowsLookAndFeel, the font in passed graphics object differs from currently set font as in 
```
button font javax.swing.plaf.FontUIResource[family=Tahoma,name=Tahoma,style=plain,size=10] 
graphics font java.awt.Font[family=Dialog,name=Dialog,style=plain,size=12]
```
whereas in Metal and other L&F it is 
`font javax.swing.plaf.FontUIResource[family=Dialog,name=Dialog,style=bold,size=12]`

so the fix is made in Windows L&F to ensure to set the font of the button to the passed graphics object font before calculating the current FontMetrics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6734168](https://bugs.openjdk.org/browse/JDK-6734168): BasicButtonUI uses wrong FontMetrics to Layout JButtons text (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24152/head:pull/24152` \
`$ git checkout pull/24152`

Update a local copy of the PR: \
`$ git checkout pull/24152` \
`$ git pull https://git.openjdk.org/jdk.git pull/24152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24152`

View PR using the GUI difftool: \
`$ git pr show -t 24152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24152.diff">https://git.openjdk.org/jdk/pull/24152.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24152#issuecomment-2743111570)
</details>
