### PR TITLE
8352607: RISC-V: use cmove in min/max when Zicond is supported

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -9066,17 +9066,11 @@ instruct minI_reg_reg(iRegINoSp dst, iRegI src)
   match(Set dst (MinI dst src));
 
   ins_cost(BRANCH_COST + ALU_COST);
-  format %{
-    "ble $dst, $src, skip\t#@minI_reg_reg\n\t"
-    "mv  $dst, $src\n\t"
-    "skip:"
-  %}
+  format %{"minI_reg_reg $dst, $dst, $src\t#@minI_reg_reg\n\t"%}
 
   ins_encode %{
-    Label Lskip;
-    __ ble(as_Register($dst$$reg), as_Register($src$$reg), Lskip);
-    __ mv(as_Register($dst$$reg), as_Register($src$$reg));
-    __ bind(Lskip);
+    __ cmov_gt(as_Register($dst$$reg), as_Register($src$$reg),
+               as_Register($dst$$reg), as_Register($src$$reg));
   %}
 
   ins_pipe(pipe_class_compare);
@@ -9087,17 +9081,11 @@ instruct maxI_reg_reg(iRegINoSp dst, iRegI src)
   match(Set dst (MaxI dst src));
 
   ins_cost(BRANCH_COST + ALU_COST);
-  format %{
-    "bge $dst, $src, skip\t#@maxI_reg_reg\n\t"
-    "mv  $dst, $src\n\t"
-    "skip:"
-  %}
+  format %{"maxI_reg_reg $dst, $dst, $src\t#@maxI_reg_reg\n\t"%}
 
   ins_encode %{
-    Label Lskip;
-    __ bge(as_Register($dst$$reg), as_Register($src$$reg), Lskip);
-    __ mv(as_Register($dst$$reg), as_Register($src$$reg));
-    __ bind(Lskip);
+    __ cmov_lt(as_Register($dst$$reg), as_Register($src$$reg),
+               as_Register($dst$$reg), as_Register($src$$reg));
   %}
 
   ins_pipe(pipe_class_compare);
@@ -9113,17 +9101,11 @@ instruct minI_reg_zero(iRegINoSp dst, immI0 zero)
   match(Set dst (MinI zero dst));
 
   ins_cost(BRANCH_COST + ALU_COST);
-  format %{
-    "blez $dst, skip\t#@minI_reg_zero\n\t"
-    "mv   $dst, zr\n\t"
-    "skip:"
-  %}
+  format %{"minI_reg_zero $dst, $dst, zr\t#@minI_reg_zero\n\t"%}
 
   ins_encode %{
-    Label Lskip;
-    __ blez(as_Register($dst$$reg), Lskip);
-    __ mv(as_Register($dst$$reg), zr);
-    __ bind(Lskip);
+    __ cmov_gt(as_Register($dst$$reg), zr,
+               as_Register($dst$$reg), zr);
   %}
 
   ins_pipe(pipe_class_compare);
@@ -9135,17 +9117,11 @@ instruct maxI_reg_zero(iRegINoSp dst, immI0 zero)
   match(Set dst (MaxI zero dst));
 
   ins_cost(BRANCH_COST + ALU_COST);
-  format %{
-    "bgez $dst, skip\t#@maxI_reg_zero\n\t"
-    "mv   $dst, zr\n\t"
-    "skip:"
-  %}
+  format %{"maxI_reg_zero $dst, $dst, zr\t#@maxI_reg_zero\n\t"%}
 
   ins_encode %{
-    Label Lskip;
-    __ bgez(as_Register($dst$$reg), Lskip);
-    __ mv(as_Register($dst$$reg), zr);
-    __ bind(Lskip);
+    __ cmov_lt(as_Register($dst$$reg), zr,
+               as_Register($dst$$reg), zr);
   %}
 
   ins_pipe(pipe_class_compare);
@@ -9158,23 +9134,12 @@ instruct minI_rReg(iRegINoSp dst, iRegI src1, iRegI src2)
   effect(DEF dst, USE src1, USE src2);
 
   ins_cost(BRANCH_COST + ALU_COST * 2);
-  format %{
-    "ble $src1, $src2, Lsrc1\t#@minI_rReg\n\t"
-    "mv $dst, $src2\n\t"
-    "j Ldone\n\t"
-    "Lsrc1:\n\t"
-    "mv $dst, $src1\n\t"
-    "Ldone:"
-  %}
+  format %{"minI_rReg $dst, $src1, $src2\t#@minI_rReg\n\t"%}
 
   ins_encode %{
-    Label Lsrc1, Ldone;
-    __ ble(as_Register($src1$$reg), as_Register($src2$$reg), Lsrc1);
-    __ mv(as_Register($dst$$reg), as_Register($src2$$reg));
-    __ j(Ldone);
-    __ bind(Lsrc1);
     __ mv(as_Register($dst$$reg), as_Register($src1$$reg));
-    __ bind(Ldone);
+    __ cmov_gt(as_Register($src1$$reg), as_Register($src2$$reg),
+               as_Register($dst$$reg), as_Register($src2$$reg));
   %}
 
   ins_pipe(pipe_class_compare);
@@ -9187,24 +9152,12 @@ instruct maxI_rReg(iRegINoSp dst, iRegI src1, iRegI src2)
   effect(DEF dst, USE src1, USE src2);
 
   ins_cost(BRANCH_COST + ALU_COST * 2);
-  format %{
-    "bge $src1, $src2, Lsrc1\t#@maxI_rReg\n\t"
-    "mv $dst, $src2\n\t"
-    "j Ldone\n\t"
-    "Lsrc1:\n\t"
-    "mv $dst, $src1\n\t"
-    "Ldone:"
-  %}
+  format %{"maxI_rReg $dst, $src1, $src2\t#@maxI_rReg\n\t"%}
 
   ins_encode %{
-    Label Lsrc1, Ldone;
-    __ bge(as_Register($src1$$reg), as_Register($src2$$reg), Lsrc1);
-    __ mv(as_Register($dst$$reg), as_Register($src2$$reg));
-    __ j(Ldone);
-    __ bind(Lsrc1);
     __ mv(as_Register($dst$$reg), as_Register($src1$$reg));
-    __ bind(Ldone);
-
+    __ cmov_lt(as_Register($src1$$reg), as_Register($src2$$reg),
+               as_Register($dst$$reg), as_Register($src2$$reg));
   %}
 
   ins_pipe(pipe_class_compare);


### PR DESCRIPTION
Hi,
Can you help to review this patch?
We can let min/max to use cmove if Zicond is supported rather than a branch.
At this same time, this patch also simplify the code of min/max.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352607](https://bugs.openjdk.org/browse/JDK-8352607): RISC-V: use cmove in min/max when Zicond is supported (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24153/head:pull/24153` \
`$ git checkout pull/24153`

Update a local copy of the PR: \
`$ git checkout pull/24153` \
`$ git pull https://git.openjdk.org/jdk.git pull/24153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24153`

View PR using the GUI difftool: \
`$ git pr show -t 24153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24153.diff">https://git.openjdk.org/jdk/pull/24153.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24153#issuecomment-2743311537)
</details>
