### PR TITLE
8352486: [ubsan] compilationMemoryStatistic.cpp:659:21: runtime error: index 64 out of bounds for type const struct unnamed struct

### DIFF
--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -656,7 +656,7 @@ class MemStatStore : public CHeapObj<mtCompiler> {
     assert_lock_strong(NMTCompilationCostHistory_lock);
     const unsigned stop_after = max_num_printed == -1 ? UINT_MAX : (unsigned)max_num_printed;
     result.num = result.num_c1 = result.num_c2 = result.num_filtered_out = 0;
-    for (int i = 0; _entries[i].e != nullptr && i < max_entries && result.num < stop_after; i++) {
+    for (int i = 0; i < max_entries && _entries[i].e != nullptr && result.num < stop_after; i++) {
       if (_entries[i].s >= minsize) {
         f(_entries[i].e);
         result.num++;


### PR DESCRIPTION
When running ubsan enabled binaries on macOS aarch, the test serviceability/dcmd/compiler/CompilerMemoryStatisticTest triggers the following warning :

```
/priv/jenkins/client-home/workspace/openjdk-jdk-weekly-macos_aarch64-opt/jdk/src/hotspot/share/compiler/compilationMemoryStatistic.cpp:659:21: runtime error: index 64 out of bounds for type 'const struct (unnamed struct at /priv/jenkins/client-home/workspace/openjdk-jdk-weekly-macos_aarch64-opt/jdk/src/hotspot/share/compiler/compilationMemoryStatistic.cpp:649:3)[64]'
    #0 0x108d99cf0 in void MemStatStore::iterate_sorted_filtered<MemStatStore::print_table(outputStream*, bool, unsigned long, int) const::'lambda'(MemStatEntry const*)>(MemStatStore::print_table(outputStream*, bool, unsigned long, int) const::'lambda'(MemStatEntry const*), unsigned long, int, MemStatStore::iteration_result&) const compilationMemoryStatistic.cpp:659
    #1 0x108d97c68 in MemStatStore::print_table(outputStream*, bool, unsigned long, int) const compilationMemoryStatistic.cpp:734
    #2 0x108d9789c in CompilationMemoryStatistic::print_all_by_size(outputStream*, bool, bool, unsigned long, int) compilationMemoryStatistic.cpp:1044
    #3 0x108d97b74 in CompilationMemoryStatistic::print_jcmd_report(outputStream*, bool, bool, unsigned long) compilationMemoryStatistic.cpp:1036
    #4 0x1090cc72c in DCmd::Executor::execute(DCmd*, JavaThread*) diagnosticFramework.cpp:421
    #5 0x108ab6a0c in jcmd(AttachOperation*, attachStream*)::Executor::execute(DCmd*, JavaThread*) attachListener.cpp:391
    #6 0x1090cbf64 in DCmd::Executor::parse_and_execute(char const*, char, JavaThread*) diagnosticFramework.cpp:414
    #7 0x108ab5f98 in jcmd(AttachOperation*, attachStream*) attachListener.cpp:395
    #8 0x108ab2db0 in AttachListenerThread::thread_entry(JavaThread*, JavaThread*) attachListener.cpp:636
    #9 0x1093cc254 in JavaThread::thread_main_inner() javaThread.cpp:776
    #10 0x109c08d68 in Thread::call_run() thread.cpp:231
    #11 0x10992dc44 in thread_native_entry(Thread*) os_bsd.cpp:601
    #12 0x1936fef90 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6f90)
    #13 0x1936f9d30 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1d30)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352486](https://bugs.openjdk.org/browse/JDK-8352486): [ubsan] compilationMemoryStatistic.cpp:659:21: runtime error: index 64 out of bounds for type const struct unnamed struct (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24156/head:pull/24156` \
`$ git checkout pull/24156`

Update a local copy of the PR: \
`$ git checkout pull/24156` \
`$ git pull https://git.openjdk.org/jdk.git pull/24156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24156`

View PR using the GUI difftool: \
`$ git pr show -t 24156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24156.diff">https://git.openjdk.org/jdk/pull/24156.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24156#issuecomment-2743529426)
</details>
