### PR TITLE
8352615 [Test] RISC-V: TestVectorizationMultiInvar.java fails on riscv64 without rvv support

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMultiInvar.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMultiInvar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMultiInvar.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMultiInvar.java
@@ -33,7 +33,8 @@ import java.util.Random;
 /*
  * @test
  * @bug 8300257
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "riscv64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") |
+ *           (os.simpleArch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @summary C2: vectorization fails on some simple Memory Segment loops
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /


### PR DESCRIPTION
Hi,
Can you help to review this trivial patch?
TestVectorizationMultiInvar.java fails on riscv if rvv is not support, as it will verify the `MaxVectorSize > 0` in test framework.

Thanks!