### PR TITLE
8352618: Remove old deprecated functionality in the build system

### DIFF
--- a/make/PreInit.gmk
+++ b/make/PreInit.gmk
@@ -75,7 +75,6 @@ ifneq ($(SKIP_SPEC), true)
 
   # Basic checks on environment and command line.
   $(eval $(call CheckControlVariables))
-  $(eval $(call CheckDeprecatedEnvironment))
   $(eval $(call CheckInvalidMakeFlags))
 
   # Check that CONF_CHECK is valid.

--- a/make/PreInitSupport.gmk
+++ b/make/PreInitSupport.gmk
@@ -94,18 +94,6 @@ define CheckControlVariables
   endif
 endef
 
-# Check for deprecated ALT_ variables
-define CheckDeprecatedEnvironment
-  defined_alt_variables := $$(filter ALT_%, $$(.VARIABLES))
-  ifneq ($$(defined_alt_variables), )
-    $$(info Warning: You have the following ALT_ variables set:)
-    $$(foreach var, $$(defined_alt_variables), $$(info * $$(var)=$$($$(var))))
-    $$(info ALT_ variables are deprecated, and may result in a failed build.)
-    $$(info Please clean your environment.)
-    $$(info )
-  endif
-endef
-
 # Check for invalid make flags like -j
 define CheckInvalidMakeFlags
   # This is a trick to get this rule to execute before any other rules

--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -140,7 +140,6 @@ $(eval $(call SetupVariable,JIB_JAR,OPTIONAL))
 include $(TOPDIR)/make/PreInitSupport.gmk
 include $(TOPDIR)/make/common/LogUtils.gmk
 
-$(eval $(call CheckDeprecatedEnvironment))
 $(eval $(call CheckInvalidMakeFlags))
 $(eval $(call ParseLogLevel))
 

--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -549,9 +549,6 @@ AC_DEFUN_ONCE([BASIC_TEST_USABILITY_ISSUES],
 
   BASIC_CHECK_SRC_PERMS
 
-  # Check if the user has any old-style ALT_ variables set.
-  FOUND_ALT_VARIABLES=`env | grep ^ALT_`
-
   # Before generating output files, test if they exist. If they do, this is a reconfigure.
   # Since we can't properly handle the dependencies for this, warn the user about the situation
   if test -e $OUTPUTDIR/spec.gmk; then

--- a/make/autoconf/configure.ac
+++ b/make/autoconf/configure.ac
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -174,9 +174,6 @@ SRCDIRS_SETUP_IMPORT_MODULES
 #
 ################################################################################
 
-# See if we are doing a complete static build or not
-JDKOPT_SETUP_STATIC_BUILD
-
 # First determine the toolchain type (compiler family)
 TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE
 
@@ -259,7 +256,6 @@ LIB_TESTS_ENABLE_DISABLE_JTREG_TEST_THREAD_FACTORY
 
 JDKOPT_ENABLE_DISABLE_GENERATE_CLASSLIST
 JDKOPT_EXCLUDE_TRANSLATIONS
-JDKOPT_ENABLE_DISABLE_MANPAGES
 JDKOPT_ENABLE_DISABLE_CDS_ARCHIVE
 JDKOPT_ENABLE_DISABLE_CDS_ARCHIVE_COH
 JDKOPT_ENABLE_DISABLE_COMPATIBLE_CDS_ALIGNMENT

--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -338,14 +338,6 @@ AC_DEFUN_ONCE([HELP_PRINT_SUMMARY_AND_WARNINGS],
   if test "x$BUILDING_MULTIPLE_JVM_VARIANTS" = "xtrue"; then
     printf "NOTE: You have requested to build more than one version of the JVM, which\n"
     printf "will result in longer build times.\n"
-    printf "\n"
-  fi
-
-  if test "x$FOUND_ALT_VARIABLES" != "x"; then
-    printf "WARNING: You have old-style ALT_ environment variables set.\n"
-    printf "These are not respected, and will be ignored. It is recommended\n"
-    printf "that you clean your environment. The following variables are set:\n"
-    printf "$FOUND_ALT_VARIABLES\n"
     printf "\n"
   fi
 

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -556,16 +556,6 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
 
 ################################################################################
 #
-# Static build support.  When enabled will generate static
-# libraries instead of shared libraries for all JDK libs.
-#
-AC_DEFUN_ONCE([JDKOPT_SETUP_STATIC_BUILD],
-[
-  UTIL_DEPRECATED_ARG_ENABLE(static-build)
-])
-
-################################################################################
-#
 # jmod options.
 #
 AC_DEFUN_ONCE([JDKOPT_SETUP_JMOD_OPTIONS],
@@ -669,15 +659,6 @@ AC_DEFUN([JDKOPT_EXCLUDE_TRANSLATIONS],
   fi
 
   AC_SUBST(EXCLUDE_TRANSLATIONS)
-])
-
-################################################################################
-#
-# Optionally disable man pages (deprecated)
-#
-AC_DEFUN([JDKOPT_ENABLE_DISABLE_MANPAGES],
-[
-  UTIL_DEPRECATED_ARG_ENABLE(manpages)
 ])
 
 ################################################################################
@@ -866,8 +847,6 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_REPRODUCIBLE_BUILD],
   AC_SUBST(SOURCE_DATE)
   AC_SUBST(ISO_8601_FORMAT_STRING)
   AC_SUBST(SOURCE_DATE_ISO_8601)
-
-  UTIL_DEPRECATED_ARG_ENABLE(reproducible-build)
 ])
 
 ################################################################################

--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -50,9 +50,8 @@ m4_define(jvm_features_valid, m4_normalize( \
 ))
 
 # Deprecated JVM features (these are ignored, but with a warning)
-m4_define(jvm_features_deprecated, m4_normalize(
-    cmsgc trace \
-))
+# This list is empty at the moment.
+m4_define(jvm_features_deprecated, m4_normalize( ))
 
 # Feature descriptions
 m4_define(jvm_feature_desc_cds, [enable class data sharing (CDS)])

--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/common/LogUtils.gmk
+++ b/make/common/LogUtils.gmk
@@ -64,12 +64,6 @@ define ParseLogValue
 endef
 
 define ParseLogLevel
-  # Catch old-style VERBOSE= command lines.
-  ifneq ($$(origin VERBOSE), undefined)
-    $$(info Error: VERBOSE is deprecated. Use LOG=<warn|info|debug|trace> instead.)
-    $$(error Cannot continue)
-  endif
-
   # Setup logging according to LOG
 
   # If "nofile" is present, do not log to a file


### PR DESCRIPTION
It's time for some spring cleaning in the build system. These checks are for functionality that has long been deprecated, and should not be in use anymore. We should remove it to keep the code base simpler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352618](https://bugs.openjdk.org/browse/JDK-8352618): Remove old deprecated functionality in the build system (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24159/head:pull/24159` \
`$ git checkout pull/24159`

Update a local copy of the PR: \
`$ git checkout pull/24159` \
`$ git pull https://git.openjdk.org/jdk.git pull/24159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24159`

View PR using the GUI difftool: \
`$ git pr show -t 24159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24159.diff">https://git.openjdk.org/jdk/pull/24159.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24159#issuecomment-2743745546)
</details>
