### PR TITLE
8196896: Use SYSROOT_CFLAGS in dtrace gensrc

### DIFF
--- a/make/hotspot/gensrc/GensrcDtrace.gmk
+++ b/make/hotspot/gensrc/GensrcDtrace.gmk
@@ -47,7 +47,7 @@ ifeq ($(call check-jvm-feature, dtrace), true)
 	$(call LogInfo, Generating dtrace header file $(@F))
 	$(call MakeDir, $(@D) $(DTRACE_SUPPORT_DIR))
 	$(call ExecuteWithLog, $(DTRACE_SUPPORT_DIR)/$(@F).d, \
-	    ($(CPP) $(DTRACE_CPP_FLAGS) $< > $(DTRACE_SUPPORT_DIR)/$(@F).d))
+	    ($(CPP) $(DTRACE_CPP_FLAGS) $(SYSROOT_CFLAGS) $< > $(DTRACE_SUPPORT_DIR)/$(@F).d))
 	$(call ExecuteWithLog, $@, $(DTRACE) $(DTRACE_FLAGS) -h -o $@ -s $(DTRACE_SUPPORT_DIR)/$(@F).d)
 
   # Process all .d files in DTRACE_SOURCE_DIR. They are:


### PR DESCRIPTION
We are missing `$(SYSROOT_CFLAGS)` when calling `$(CPP)` directly (instead of going via `SetupNativeCompilation`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8196896](https://bugs.openjdk.org/browse/JDK-8196896): Use SYSROOT_CFLAGS in dtrace gensrc (**Bug** - P5)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24160/head:pull/24160` \
`$ git checkout pull/24160`

Update a local copy of the PR: \
`$ git checkout pull/24160` \
`$ git pull https://git.openjdk.org/jdk.git pull/24160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24160`

View PR using the GUI difftool: \
`$ git pr show -t 24160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24160.diff">https://git.openjdk.org/jdk/pull/24160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24160#issuecomment-2743745906)
</details>
