### PR TITLE
8352597: [IR Framework] test bug: TestNotCompilable.java fails on product build

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestNotCompilable.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestNotCompilable.java
@@ -30,7 +30,7 @@ import compiler.lib.ir_framework.driver.irmatching.IRViolationException;
 
 /*
  * @test
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled & vm.flagless & vm.debug == true
  * @summary Test the functionality of allowNotCompilable.
  * @library /test/lib /
  * @run driver ir_framework.tests.TestNotCompilable


### PR DESCRIPTION
This was a test failure.

```
   57 // Note: @Run does not fail, but the @IR detects that there is no compilation, and fails.
   58 runWithExcludeExpectFailure(TestClassE.class, noWarmup);
   59 runOptoNoExecuteExpectFailure(TestClassA.class, noWarmup);
   60 runOptoNoExecuteExpectFailure(TestClassB.class, noWarmup);
```

These tests expect the failure to come from executed @IR rules, because they cannot find the IR, since the methods were not compiled.

But we only execute @IR rules in debug mode, not product. So then we do not get the expected `IRViolationException`.

So it seems reasonable to just add `vm.debug == true`, as @RealFYang suggested in https://github.com/openjdk/jdk/pull/24049

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352597](https://bugs.openjdk.org/browse/JDK-8352597): [IR Framework] test bug: TestNotCompilable.java fails on product build (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24161/head:pull/24161` \
`$ git checkout pull/24161`

Update a local copy of the PR: \
`$ git checkout pull/24161` \
`$ git pull https://git.openjdk.org/jdk.git pull/24161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24161`

View PR using the GUI difftool: \
`$ git pr show -t 24161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24161.diff">https://git.openjdk.org/jdk/pull/24161.diff</a>

</details>
