### PR TITLE
8352588: GenShen: Enabling JFR asserts when getting GCId

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -132,8 +132,9 @@ void ShenandoahControlThread::run_service() {
       // Cannot uncommit bitmap slices during concurrent reset
       ShenandoahNoUncommitMark forbid_region_uncommit(heap);
 
-      // GC is starting, bump the internal ID
+      // GC is starting, bump the internal ID and set GCIdMark
       update_gc_id();
+      GCIdMark gc_id_mark(get_gc_id());
 
       heuristics->cancel_trigger_request();
 
@@ -299,7 +300,6 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle)) return;
 
-  GCIdMark gc_id_mark;
   ShenandoahGCSession session(cause, heap->global_generation());
 
   TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
@@ -343,7 +343,6 @@ void ShenandoahControlThread::stop_service() {
 
 void ShenandoahControlThread::service_stw_full_cycle(GCCause::Cause cause) {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  GCIdMark gc_id_mark;
   ShenandoahGCSession session(cause, heap->global_generation());
 
   ShenandoahFullGC gc;
@@ -353,7 +352,6 @@ void ShenandoahControlThread::service_stw_full_cycle(GCCause::Cause cause) {
 void ShenandoahControlThread::service_stw_degenerated_cycle(GCCause::Cause cause, ShenandoahGC::ShenandoahDegenPoint point) {
   assert (point != ShenandoahGC::_degenerated_unset, "Degenerated point should be set");
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  GCIdMark gc_id_mark;
   ShenandoahGCSession session(cause, heap->global_generation());
 
   ShenandoahDegenGC gc(point, heap->global_generation());

--- a/src/hotspot/share/gc/shenandoah/shenandoahController.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahController.hpp
@@ -39,7 +39,7 @@ private:
   shenandoah_padding(0);
   volatile size_t _allocs_seen;
   shenandoah_padding(1);
-  // A monotonically increasing GC count.
+  // A monotonically increasing GC id.
   volatile size_t _gc_id;
   shenandoah_padding(2);
 
@@ -50,13 +50,14 @@ protected:
   Monitor _alloc_failure_waiters_lock;
   Monitor _gc_waiters_lock;
 
-  // Increments the internal GC count.
+  // Increments the internal GC id for next GC cycle,
+  // it is called by control thread when it starts fulfill a GC reqeust.
   void update_gc_id();
 
 public:
   ShenandoahController():
     _allocs_seen(0),
-    _gc_id(0),
+    _gc_id(-1),
     _alloc_failure_waiters_lock(Mutex::safepoint-2, "ShenandoahAllocFailureGC_lock", true),
     _gc_waiters_lock(Mutex::safepoint-2, "ShenandoahRequestedGC_lock", true)
   { }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -230,8 +230,9 @@ void ShenandoahGenerationalControlThread::run_gc_cycle(const ShenandoahGCRequest
     _heap->soft_ref_policy()->set_should_clear_all_soft_refs(true);
   }
 
-  // GC is starting, bump the internal ID
+  // GC is starting, bump the internal ID and set GCIdMark
   update_gc_id();
+  GCIdMark gc_id_mark(get_gc_id());
 
   _heap->reset_bytes_allocated_since_gc_start();
 
@@ -263,7 +264,6 @@ void ShenandoahGenerationalControlThread::run_gc_cycle(const ShenandoahGCRequest
       }
       case servicing_old: {
         assert(request.generation->is_old(), "Expected old generation here");
-        GCIdMark gc_id_mark;
         service_concurrent_old_cycle(request);
         break;
       }
@@ -386,7 +386,6 @@ void ShenandoahGenerationalControlThread::process_phase_timings() const {
 //      +--->  Global Degen +--------------------> Full <----+
 //
 void ShenandoahGenerationalControlThread::service_concurrent_normal_cycle(const ShenandoahGCRequest& request) {
-  GCIdMark gc_id_mark;
   log_info(gc, ergo)("Start GC cycle (%s)", request.generation->name());
   if (request.generation->is_old()) {
     service_concurrent_old_cycle(request);
@@ -621,7 +620,6 @@ bool ShenandoahGenerationalControlThread::check_cancellation_or_degen(Shenandoah
 }
 
 void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause cause) {
-  GCIdMark gc_id_mark;
   ShenandoahGCSession session(cause, _heap->global_generation());
   maybe_set_aging_cycle();
   ShenandoahFullGC gc;
@@ -632,7 +630,6 @@ void ShenandoahGenerationalControlThread::service_stw_full_cycle(GCCause::Cause 
 void ShenandoahGenerationalControlThread::service_stw_degenerated_cycle(const ShenandoahGCRequest& request) {
   assert(_degen_point != ShenandoahGC::_degenerated_unset, "Degenerated point should be set");
 
-  GCIdMark gc_id_mark;
   ShenandoahGCSession session(request.cause, request.generation);
 
   ShenandoahDegenGC gc(_degen_point, request.generation);


### PR DESCRIPTION
### Root cause
Shenandoah has it's way to generate its own gc id([link](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp#L234), [link](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shenandoah/shenandoahController.hpp#L43)), but it run a specific GC cycle, it still use the default GCIdMark([link](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp#L389)) to generate a gc id and set it to NamedThread::_gc_id. Once the specific GC cycle finishes, the NamedThread::_gc_id is restored to the original value which is `undefined`, which causes the asserts when Enabling JFR, in release build it should causes invalid GC id in JFR.

### Solution
it is confusing that Shenandoah generates its own gc id but not use it for GC logging and JFR, the solution is fairly simple, the control thread just need inject gc id with GCIdMark(gc_id) it generates in `ShenandoahControlThread::run_service` and `ShenandoahGenerationalControlThread::run_gc_cycle`

### Test
