### PR TITLE
8352585: Add special case handling for Float16.max/min x86 backend

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -13755,6 +13755,7 @@ void Assembler::evcmpsh(KRegister kdst, KRegister mask, XMMRegister nds, XMMRegi
   InstructionAttr attributes(Assembler::AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
   attributes.set_is_evex_instruction();
   attributes.set_embedded_opmask_register_specifier(mask);
+  attributes.reset_is_clear_context();
   int encode = vex_prefix_and_encode(kdst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F_3A, &attributes);
   emit_int24((unsigned char)0xC2, (0xC0 | encode), comparison);
 }

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -13755,7 +13755,6 @@ void Assembler::evcmpsh(KRegister kdst, KRegister mask, XMMRegister nds, XMMRegi
   InstructionAttr attributes(Assembler::AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
   attributes.set_is_evex_instruction();
   attributes.set_embedded_opmask_register_specifier(mask);
-  attributes.reset_is_clear_context();
   int encode = vex_prefix_and_encode(kdst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F_3A, &attributes);
   emit_int24((unsigned char)0xC2, (0xC0 | encode), comparison);
 }

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -13750,6 +13750,16 @@ void Assembler::vcmpps(XMMRegister dst, XMMRegister nds, XMMRegister src, int co
   emit_int24((unsigned char)0xC2, (0xC0 | encode), (unsigned char)comparison);
 }
 
+void Assembler::evcmpsh(KRegister kdst, KRegister mask, XMMRegister nds, XMMRegister src, ComparisonPredicateFP comparison) {
+  assert(VM_Version::supports_avx512_fp16(), "");
+  InstructionAttr attributes(Assembler::AVX_128bit, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  attributes.reset_is_clear_context();
+  int encode = vex_prefix_and_encode(kdst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F_3A, &attributes);
+  emit_int24((unsigned char)0xC2, (0xC0 | encode), comparison);
+}
+
 void Assembler::evcmpps(KRegister kdst, KRegister mask, XMMRegister nds, XMMRegister src,
                         ComparisonPredicateFP comparison, int vector_len) {
   assert(VM_Version::supports_evex(), "");

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -3186,6 +3186,9 @@ private:
   void evcmpps(KRegister kdst, KRegister mask, XMMRegister nds, XMMRegister src,
                ComparisonPredicateFP comparison, int vector_len);
 
+  void evcmpsh(KRegister kdst, KRegister mask, XMMRegister nds, XMMRegister src,
+               ComparisonPredicateFP comparison);
+
   // Vector integer compares
   void vpcmpgtd(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void evpcmpd(KRegister kdst, KRegister mask, XMMRegister nds, XMMRegister src,

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -7105,7 +7105,7 @@ void C2_MacroAssembler::scalar_max_min_fp16(int opcode, XMMRegister dst, XMMRegi
     // the second source operand, either a NaN or a valid floating-point value, is returned
     // dst = max(xtmp1, xtmp2)
     vmaxsh(dst, xtmp1, xtmp2);
-    // isNaN = is_unordered_quite(xtmp1)
+    // isNaN = is_unordered_quiet(xtmp1)
     evcmpsh(ktmp, k0, xtmp1, xtmp1, Assembler::UNORD_Q);
     // Final result is same as first source if its a NaN value,
     // in case second operand holds a NaN value then as per above semantics
@@ -7126,7 +7126,7 @@ void C2_MacroAssembler::scalar_max_min_fp16(int opcode, XMMRegister dst, XMMRegi
     // or a valid floating-point value, is written to the result.
     // dst = min(xtmp1, xtmp2)
     vminsh(dst, xtmp1, xtmp2);
-    // isNaN = is_unordered_quite(xtmp1)
+    // isNaN = is_unordered_quiet(xtmp1)
     evcmpsh(ktmp, k0, xtmp1, xtmp1, Assembler::UNORD_Q);
     // Final result is same as first source if its a NaN value,
     // in case second operand holds a NaN value then as per above semantics

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -6680,8 +6680,6 @@ void C2_MacroAssembler::efp16sh(int opcode, XMMRegister dst, XMMRegister src1, X
     case Op_SubHF: vsubsh(dst, src1, src2); break;
     case Op_MulHF: vmulsh(dst, src1, src2); break;
     case Op_DivHF: vdivsh(dst, src1, src2); break;
-    case Op_MaxHF: vmaxsh(dst, src1, src2); break;
-    case Op_MinHF: vminsh(dst, src1, src2); break;
     default: assert(false, "%s", NodeClassNames[opcode]); break;
   }
 }
@@ -7089,5 +7087,50 @@ void C2_MacroAssembler::vector_saturating_op(int ideal_opc, BasicType elem_bt, X
     vector_saturating_unsigned_op(ideal_opc, elem_bt, dst, src1, src2, vlen_enc);
   } else {
     vector_saturating_op(ideal_opc, elem_bt, dst, src1, src2, vlen_enc);
+  }
+}
+
+void C2_MacroAssembler::scalar_max_min_fp16(int opcode, XMMRegister dst, XMMRegister src1, XMMRegister src2,
+                                          KRegister ktmp, XMMRegister xtmp1, XMMRegister xtmp2, int vlen_enc) {
+  if (opcode == Op_MaxHF) {
+    // Move sign bits of src2 to mask register.
+    evpmovw2m(ktmp, src2, vlen_enc);
+    // xtmp1 = src2 < 0 ? src2 : src1
+    evpblendmw(xtmp1, ktmp, src1, src2, true, vlen_enc);
+    // xtmp2 = src2 < 0 ? ? src1 : src2
+    evpblendmw(xtmp2, ktmp, src2, src1, true, vlen_enc);
+    // Idea behind above swapping is to make seconds source operand a +ve value.
+    // As per instruction semantic, if the values being compared are both 0.0s (of either sign), the value in
+    // the second source operand is returned. If only one value is a NaN (SNaN or QNaN) for this instruction,
+    // the second source operand, either a NaN or a valid floating-point value, is returned
+    // dst = max(xtmp1, xtmp2)
+    vmaxsh(dst, xtmp1, xtmp2);
+    // isNaN = is_unordered_quite(xtmp1)
+    evcmpsh(ktmp, k0, xtmp1, xtmp1, Assembler::UNORD_Q);
+    // Final result is same as first source if its a NaN value,
+    // in case second operand holds a NaN value then as per above semantics
+    // result is same as second operand.
+    Assembler::evmovdquw(dst, ktmp, xtmp1, true, vlen_enc);
+  } else {
+    assert(opcode == Op_MinHF, "");
+    // Move sign bits of src1 to mask register.
+    evpmovw2m(ktmp, src1, vlen_enc);
+    // xtmp1 = src1 < 0 ? src2 : src1
+    evpblendmw(xtmp1, ktmp, src1, src2, true, vlen_enc);
+    // xtmp2 = src1 < 0 ? src1 : src2
+    evpblendmw(xtmp2, ktmp, src2, src1, true, vlen_enc);
+    // Idea behind above swapping is to make seconds source operand a -ve value.
+    // As per instruction semantics, if the values being compared are both 0.0s (of either sign), the value in
+    // the second source operand is returned.
+    // If only one value is a NaN (SNaN or QNaN) for this instruction, the second source operand, either a NaN
+    // or a valid floating-point value, is written to the result.
+    // dst = min(xtmp1, xtmp2)
+    vminsh(dst, xtmp1, xtmp2);
+    // isNaN = is_unordered_quite(xtmp1)
+    evcmpsh(ktmp, k0, xtmp1, xtmp1, Assembler::UNORD_Q);
+    // Final result is same as first source if its a NaN value,
+    // in case second operand holds a NaN value then as per above semantics
+    // result is same as second operand.
+    Assembler::evmovdquw(dst, ktmp, xtmp1, true, vlen_enc);
   }
 }

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -584,4 +584,6 @@ public:
 
   void select_from_two_vectors_evex(BasicType elem_bt, XMMRegister dst, XMMRegister src1, XMMRegister src2, int vlen_enc);
 
+  void scalar_max_min_fp16(int opcode, XMMRegister dst, XMMRegister src1, XMMRegister src2,
+                           KRegister ktmp, XMMRegister xtmp1, XMMRegister xtmp2, int vlen_enc);
 #endif // CPU_X86_C2_MACROASSEMBLER_X86_HPP

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -10956,7 +10956,7 @@ instruct scalar_minmax_HF_reg(regF dst, regF src1, regF src2, kReg ktmp, regF xt
   format %{ "scalar_min_max_fp16 $dst, $src1, $src2\t using $ktmp, $xtmp1 and $xtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    __ scalar_max_min_fp16(opcode, $dst$$XMMRegister, $src2$$XMMRegister, $src1$$XMMRegister, $ktmp$$KRegister,
+    __ scalar_max_min_fp16(opcode, $dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, $ktmp$$KRegister,
                            $xtmp1$$XMMRegister, $xtmp2$$XMMRegister, Assembler::AVX_128bit);
   %}
   ins_pipe( pipe_slow );

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1463,9 +1463,9 @@ bool Matcher::match_rule_supported(int opcode) {
       break;
     case Op_MaxHF:
     case Op_MinHF:
-      if (!VM_Version::supports_avx512bw()) {
+      if (!VM_Version::supports_avx512vlbw()) {
         return false;
-      }
+      }  // fallthrough
     case Op_AddHF:
     case Op_DivHF:
     case Op_FmaHF:

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1461,11 +1461,14 @@ bool Matcher::match_rule_supported(int opcode) {
         return false;
       }
       break;
+    case Op_MaxHF:
+    case Op_MinHF:
+      if (!VM_Version::supports_avx512bw()) {
+        return false;
+      }
     case Op_AddHF:
     case Op_DivHF:
     case Op_FmaHF:
-    case Op_MaxHF:
-    case Op_MinHF:
     case Op_MulHF:
     case Op_ReinterpretS2HF:
     case Op_ReinterpretHF2S:
@@ -10935,8 +10938,6 @@ instruct scalar_binOps_HF_reg(regF dst, regF src1, regF src2)
 %{
   match(Set dst (AddHF src1 src2));
   match(Set dst (DivHF src1 src2));
-  match(Set dst (MaxHF src1 src2));
-  match(Set dst (MinHF src1 src2));
   match(Set dst (MulHF src1 src2));
   match(Set dst (SubHF src1 src2));
   format %{ "scalar_binop_fp16 $dst, $src1, $src2" %}
@@ -10945,6 +10946,20 @@ instruct scalar_binOps_HF_reg(regF dst, regF src1, regF src2)
     __ efp16sh(opcode, $dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister);
   %}
   ins_pipe(pipe_slow);
+%}
+
+instruct scalar_minmax_HF_reg(regF dst, regF src1, regF src2, kReg ktmp, regF xtmp1, regF xtmp2)
+%{
+  match(Set dst (MaxHF src1 src2));
+  match(Set dst (MinHF src1 src2));
+  effect(TEMP_DEF dst, TEMP ktmp, TEMP xtmp1, TEMP xtmp2);
+  format %{ "scalar_min_max_fp16 $dst, $src1, $src2\t using $ktmp, $xtmp1 and $xtmp2 as TEMP" %}
+  ins_encode %{
+    int opcode = this->ideal_Opcode();
+    __ scalar_max_min_fp16(opcode, $dst$$XMMRegister, $src2$$XMMRegister, $src1$$XMMRegister, $ktmp$$KRegister,
+                           $xtmp1$$XMMRegister, $xtmp2$$XMMRegister, Assembler::AVX_128bit);
+  %}
+  ins_pipe( pipe_slow );
 %}
 
 instruct scalar_fma_HF_reg(regF dst, regF src1, regF src2)

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
@@ -53,9 +53,6 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     public static boolean assertionCheck(Float16 actual, Float16 expected) {
-        if (Float16.isNaN(actual) && Float16.isNaN(expected)) {
-            return false;
-        }
         return !actual.equals(expected);
     }
 

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
@@ -30,7 +30,7 @@ import jdk.incubator.vector.*;
  * @bug 8352585
  * @library /test/lib /
  * @summary Add special case handling for Float16.max/min x86 backend
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx512_fp16.*" & vm.cpu.features ~= ".*avx512bw.*")
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx512_fp16.*" & vm.cpu.features ~= ".*avx512bw.*" & vm.cpu.features ~= ".*avx512vl.*")
  * @modules jdk.incubator.vector
  *
  * @run driver compiler.intrinsics.float16.TestFloat16MaxMinSpecialValues
@@ -40,6 +40,7 @@ import jdk.incubator.vector.*;
 public class TestFloat16MaxMinSpecialValues {
     public static Float16 POS_ZERO = Float16.valueOf(0.0f);
     public static Float16 NEG_ZERO = Float16.valueOf(-0.0f);
+    public static Float16 SRC = Float16.valueOf(Float.MAX_VALUE);
 
     public Float16 RES;
 
@@ -54,27 +55,18 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Run(test = "testMaxNaNOperands")
-    @Warmup(1000)
     public void launchMaxNaNOperands() {
-        for (int i = 0; i < 10000; i++) {
-            Float16 SRC = Float16.valueOf(i);
-            RES = testMaxNaNOperands(SRC, Float16.NaN);
-            if (!RES.equals(Float16.NaN)) {
-                throw new AssertionError("input1 = NaN, input2 = " + SRC.floatValue() + ", expected = NaN, actual = " + RES.floatValue());
-            }
+        RES = testMaxNaNOperands(SRC, Float16.NaN);
+        if (!RES.equals(Float16.NaN)) {
+            throw new AssertionError("input1 = " + SRC.floatValue() + " input2 = NaN , expected = NaN, actual = " + RES.floatValue());
         }
-        for (int i = 0; i < 10000; i++) {
-            Float16 SRC = Float16.valueOf(i);
-            RES = testMaxNaNOperands(Float16.NaN, SRC);
-            if (!RES.equals(Float16.NaN)) {
-                throw new AssertionError("input1 = NaN, input2 = " + SRC.floatValue() + ", expected = NaN, actual = " + RES.floatValue());
-            }
+        RES = testMaxNaNOperands(Float16.NaN, SRC);
+        if (!RES.equals(Float16.NaN)) {
+            throw new AssertionError("input1 = NaN, input2 = " + SRC.floatValue() + ", expected = NaN, actual = " + RES.floatValue());
         }
-        for (int i = 0; i < 10000; i++) {
-            RES = testMaxNaNOperands(Float16.NaN, Float16.NaN);
-            if (!RES.equals(Float16.NaN)) {
-                throw new AssertionError("input1 = NaN, input2 = NaN, expected = NaN, actual = " + RES.floatValue());
-            }
+        RES = testMaxNaNOperands(Float16.NaN, Float16.NaN);
+        if (!RES.equals(Float16.NaN)) {
+            throw new AssertionError("input1 = NaN, input2 = NaN, expected = NaN, actual = " + RES.floatValue());
         }
     }
 
@@ -85,27 +77,18 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Run(test = "testMinNaNOperands")
-    @Warmup(1000)
     public void launchMinNaNOperands() {
-        for (int i = 0; i < 10000; i++) {
-            Float16 SRC = Float16.valueOf(i);
-            RES = testMinNaNOperands(SRC, Float16.NaN);
-            if (!RES.equals(Float16.NaN)) {
-                throw new AssertionError("input1 = NaN, input2 = " + SRC.floatValue() + ", expected = NaN, actual = " + RES.floatValue());
-            }
+        RES = testMinNaNOperands(SRC, Float16.NaN);
+        if (!RES.equals(Float16.NaN)) {
+            throw new AssertionError("input1 = " + SRC.floatValue() + " input2 = NaN, expected = NaN, actual = " + RES.floatValue());
         }
-        for (int i = 0; i < 10000; i++) {
-            Float16 SRC = Float16.valueOf(i);
-            RES = testMinNaNOperands(Float16.NaN, SRC);
-            if (!RES.equals(Float16.NaN)) {
-                throw new AssertionError("input1 = NaN, input2 = " + SRC.floatValue() + ", expected = NaN, actual = " + RES.floatValue());
-            }
+        RES = testMinNaNOperands(Float16.NaN, SRC);
+        if (!RES.equals(Float16.NaN)) {
+            throw new AssertionError("input1 = NaN, input2 = " + SRC.floatValue() + ", expected = NaN, actual = " + RES.floatValue());
         }
-        for (int i = 0; i < 10000; i++) {
-            RES = testMinNaNOperands(Float16.NaN, Float16.NaN);
-            if (!RES.equals(Float16.NaN)) {
-                throw new AssertionError("input1 = NaN, input2 = NaN, expected = NaN, actual = " + RES.floatValue());
-            }
+        RES = testMinNaNOperands(Float16.NaN, Float16.NaN);
+        if (!RES.equals(Float16.NaN)) {
+            throw new AssertionError("input1 = NaN, input2 = NaN, expected = NaN, actual = " + RES.floatValue());
         }
     }
 
@@ -116,34 +99,22 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Run(test = "testMaxZeroOperands")
-    @Warmup(1000)
     public void launchMaxZeroOperands() {
-        for (int i = 0; i < 10000; i++) {
-            RES = testMaxZeroOperands(POS_ZERO, NEG_ZERO);
-            if (!RES.equals(POS_ZERO)) {
-                throw new AssertionError("input1 = +0.0, input2 = -0.0, expected = +0.0, actual = " + RES.floatValue());
-            }
+        RES = testMaxZeroOperands(POS_ZERO, NEG_ZERO);
+        if (!RES.equals(POS_ZERO)) {
+            throw new AssertionError("input1 = +0.0, input2 = -0.0, expected = +0.0, actual = " + RES.floatValue());
         }
-        for (int i = 0; i < 10000; i++) {
-            Float16 SRC = Float16.valueOf(i);
-            RES = testMaxZeroOperands(NEG_ZERO, POS_ZERO);
-            if (!RES.equals(POS_ZERO)) {
-                throw new AssertionError("input1 = -0.0, input2 = +0.0, expected = +0.0, actual = " + RES.floatValue());
-            }
+        RES = testMaxZeroOperands(NEG_ZERO, POS_ZERO);
+        if (!RES.equals(POS_ZERO)) {
+            throw new AssertionError("input1 = -0.0, input2 = +0.0, expected = +0.0, actual = " + RES.floatValue());
         }
-        for (int i = 0; i < 10000; i++) {
-            Float16 SRC = Float16.valueOf(i);
-            RES = testMaxZeroOperands(POS_ZERO, POS_ZERO);
-            if (!RES.equals(POS_ZERO)) {
-                throw new AssertionError("input1 = +0.0, input2 = +0.0, expected = +0.0, actual = " + RES.floatValue());
-            }
+        RES = testMaxZeroOperands(POS_ZERO, POS_ZERO);
+        if (!RES.equals(POS_ZERO)) {
+            throw new AssertionError("input1 = +0.0, input2 = +0.0, expected = +0.0, actual = " + RES.floatValue());
         }
-        for (int i = 0; i < 10000; i++) {
-            Float16 SRC = Float16.valueOf(i);
-            RES = testMaxZeroOperands(NEG_ZERO, NEG_ZERO);
-            if (!RES.equals(NEG_ZERO)) {
-                throw new AssertionError("input1 = -0.0, input2 = -0.0, expected = -0.0, actual = " + RES.floatValue());
-            }
+        RES = testMaxZeroOperands(NEG_ZERO, NEG_ZERO);
+        if (!RES.equals(NEG_ZERO)) {
+            throw new AssertionError("input1 = -0.0, input2 = -0.0, expected = -0.0, actual = " + RES.floatValue());
         }
     }
 
@@ -154,34 +125,25 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Run(test = "testMinZeroOperands")
-    @Warmup(1000)
     public void launchMinZeroOperands() {
-        for (int i = 0; i < 10000; i++) {
-            RES = testMinZeroOperands(POS_ZERO, NEG_ZERO);
-            if (!RES.equals(NEG_ZERO)) {
-                throw new AssertionError("input1 = +0.0, input2 = -0.0, expected = -0.0, actual = " + RES.floatValue());
-            }
+        RES = testMinZeroOperands(POS_ZERO, NEG_ZERO);
+        if (!RES.equals(NEG_ZERO)) {
+            throw new AssertionError("input1 = +0.0, input2 = -0.0, expected = -0.0, actual = " + RES.floatValue());
         }
-        for (int i = 0; i < 10000; i++) {
-            Float16 SRC = Float16.valueOf(i);
-            RES = testMinZeroOperands(NEG_ZERO, POS_ZERO);
-            if (!RES.equals(NEG_ZERO)) {
-                throw new AssertionError("input1 = -0.0, input2 = +0.0, expected = -0.0, actual = " + RES.floatValue());
-            }
+
+        RES = testMinZeroOperands(NEG_ZERO, POS_ZERO);
+        if (!RES.equals(NEG_ZERO)) {
+            throw new AssertionError("input1 = -0.0, input2 = +0.0, expected = -0.0, actual = " + RES.floatValue());
         }
-        for (int i = 0; i < 10000; i++) {
-            Float16 SRC = Float16.valueOf(i);
-            RES = testMinZeroOperands(POS_ZERO, POS_ZERO);
-            if (!RES.equals(POS_ZERO)) {
-                throw new AssertionError("input1 = +0.0, input2 = +0.0, expected = +0.0, actual = " + RES.floatValue());
-            }
+
+        RES = testMinZeroOperands(POS_ZERO, POS_ZERO);
+        if (!RES.equals(POS_ZERO)) {
+            throw new AssertionError("input1 = +0.0, input2 = +0.0, expected = +0.0, actual = " + RES.floatValue());
         }
-        for (int i = 0; i < 10000; i++) {
-            Float16 SRC = Float16.valueOf(i);
-            RES = testMinZeroOperands(NEG_ZERO, NEG_ZERO);
-            if (!RES.equals(NEG_ZERO)) {
-                throw new AssertionError("input1 = -0.0, input2 = -0.0, expected = -0.0, actual = " + RES.floatValue());
-            }
+
+        RES = testMinZeroOperands(NEG_ZERO, NEG_ZERO);
+        if (!RES.equals(NEG_ZERO)) {
+            throw new AssertionError("input1 = -0.0, input2 = -0.0, expected = -0.0, actual = " + RES.floatValue());
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.intrinsics.float16;
+
+import compiler.lib.ir_framework.*;
+import jdk.incubator.vector.*;
+
+/**
+ * @test
+ * @bug 8352585
+ * @library /test/lib /
+ * @summary Add special case handling for Float16.max/min x86 backend
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx512_fp16.*" & vm.cpu.features ~= ".*avx512bw.*")
+ * @modules jdk.incubator.vector
+ *
+ * @run driver compiler.intrinsics.float16.TestFloat16MaxMinSpecialValues
+ */
+
+
+public class TestFloat16MaxMinSpecialValues {
+    public static Float16 POS_ZERO = Float16.valueOf(0.0f);
+    public static Float16 NEG_ZERO = Float16.valueOf(-0.0f);
+
+    public Float16 RES;
+
+    public static void main(String [] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+
+    @Test
+    @IR(counts = {IRNode.MAX_HF, " >0 "})
+    public Float16 testMaxNaNOperands(Float16 src1, Float16 src2) {
+        return Float16.max(src1, src2);
+    }
+
+    @Run(test = "testMaxNaNOperands")
+    @Warmup(1000)
+    public void launchMaxNaNOperands() {
+        for (int i = 0; i < 10000; i++) {
+            Float16 SRC = Float16.valueOf(i);
+            RES = testMaxNaNOperands(SRC, Float16.NaN);
+            if (!RES.equals(Float16.NaN)) {
+                throw new AssertionError("input1 = NaN, input2 = " + SRC.floatValue() + ", expected = NaN, actual = " + RES.floatValue());
+            }
+        }
+        for (int i = 0; i < 10000; i++) {
+            Float16 SRC = Float16.valueOf(i);
+            RES = testMaxNaNOperands(Float16.NaN, SRC);
+            if (!RES.equals(Float16.NaN)) {
+                throw new AssertionError("input1 = NaN, input2 = " + SRC.floatValue() + ", expected = NaN, actual = " + RES.floatValue());
+            }
+        }
+        for (int i = 0; i < 10000; i++) {
+            RES = testMaxNaNOperands(Float16.NaN, Float16.NaN);
+            if (!RES.equals(Float16.NaN)) {
+                throw new AssertionError("input1 = NaN, input2 = NaN, expected = NaN, actual = " + RES.floatValue());
+            }
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.MIN_HF, " >0 "})
+    public Float16 testMinNaNOperands(Float16 src1, Float16 src2) {
+        return Float16.min(src1, src2);
+    }
+
+    @Run(test = "testMinNaNOperands")
+    @Warmup(1000)
+    public void launchMinNaNOperands() {
+        for (int i = 0; i < 10000; i++) {
+            Float16 SRC = Float16.valueOf(i);
+            RES = testMinNaNOperands(SRC, Float16.NaN);
+            if (!RES.equals(Float16.NaN)) {
+                throw new AssertionError("input1 = NaN, input2 = " + SRC.floatValue() + ", expected = NaN, actual = " + RES.floatValue());
+            }
+        }
+        for (int i = 0; i < 10000; i++) {
+            Float16 SRC = Float16.valueOf(i);
+            RES = testMinNaNOperands(Float16.NaN, SRC);
+            if (!RES.equals(Float16.NaN)) {
+                throw new AssertionError("input1 = NaN, input2 = " + SRC.floatValue() + ", expected = NaN, actual = " + RES.floatValue());
+            }
+        }
+        for (int i = 0; i < 10000; i++) {
+            RES = testMinNaNOperands(Float16.NaN, Float16.NaN);
+            if (!RES.equals(Float16.NaN)) {
+                throw new AssertionError("input1 = NaN, input2 = NaN, expected = NaN, actual = " + RES.floatValue());
+            }
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.MAX_HF, " >0 "})
+    public Float16 testMaxZeroOperands(Float16 src1, Float16 src2) {
+        return Float16.max(src1, src2);
+    }
+
+    @Run(test = "testMaxZeroOperands")
+    @Warmup(1000)
+    public void launchMaxZeroOperands() {
+        for (int i = 0; i < 10000; i++) {
+            RES = testMaxZeroOperands(POS_ZERO, NEG_ZERO);
+            if (!RES.equals(POS_ZERO)) {
+                throw new AssertionError("input1 = +0.0, input2 = -0.0, expected = +0.0, actual = " + RES.floatValue());
+            }
+        }
+        for (int i = 0; i < 10000; i++) {
+            Float16 SRC = Float16.valueOf(i);
+            RES = testMaxZeroOperands(NEG_ZERO, POS_ZERO);
+            if (!RES.equals(POS_ZERO)) {
+                throw new AssertionError("input1 = -0.0, input2 = +0.0, expected = +0.0, actual = " + RES.floatValue());
+            }
+        }
+        for (int i = 0; i < 10000; i++) {
+            Float16 SRC = Float16.valueOf(i);
+            RES = testMaxZeroOperands(POS_ZERO, POS_ZERO);
+            if (!RES.equals(POS_ZERO)) {
+                throw new AssertionError("input1 = +0.0, input2 = +0.0, expected = +0.0, actual = " + RES.floatValue());
+            }
+        }
+        for (int i = 0; i < 10000; i++) {
+            Float16 SRC = Float16.valueOf(i);
+            RES = testMaxZeroOperands(NEG_ZERO, NEG_ZERO);
+            if (!RES.equals(NEG_ZERO)) {
+                throw new AssertionError("input1 = -0.0, input2 = -0.0, expected = -0.0, actual = " + RES.floatValue());
+            }
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.MIN_HF, " >0 "})
+    public Float16 testMinZeroOperands(Float16 src1, Float16 src2) {
+        return Float16.min(src1, src2);
+    }
+
+    @Run(test = "testMinZeroOperands")
+    @Warmup(1000)
+    public void launchMinZeroOperands() {
+        for (int i = 0; i < 10000; i++) {
+            RES = testMinZeroOperands(POS_ZERO, NEG_ZERO);
+            if (!RES.equals(NEG_ZERO)) {
+                throw new AssertionError("input1 = +0.0, input2 = -0.0, expected = -0.0, actual = " + RES.floatValue());
+            }
+        }
+        for (int i = 0; i < 10000; i++) {
+            Float16 SRC = Float16.valueOf(i);
+            RES = testMinZeroOperands(NEG_ZERO, POS_ZERO);
+            if (!RES.equals(NEG_ZERO)) {
+                throw new AssertionError("input1 = -0.0, input2 = +0.0, expected = -0.0, actual = " + RES.floatValue());
+            }
+        }
+        for (int i = 0; i < 10000; i++) {
+            Float16 SRC = Float16.valueOf(i);
+            RES = testMinZeroOperands(POS_ZERO, POS_ZERO);
+            if (!RES.equals(POS_ZERO)) {
+                throw new AssertionError("input1 = +0.0, input2 = +0.0, expected = +0.0, actual = " + RES.floatValue());
+            }
+        }
+        for (int i = 0; i < 10000; i++) {
+            Float16 SRC = Float16.valueOf(i);
+            RES = testMinZeroOperands(NEG_ZERO, NEG_ZERO);
+            if (!RES.equals(NEG_ZERO)) {
+                throw new AssertionError("input1 = -0.0, input2 = -0.0, expected = -0.0, actual = " + RES.floatValue());
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
@@ -47,8 +47,7 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Test
-    @IR(counts = {IRNode.MAX_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true"})
-    @IR(counts = {IRNode.MAX_HF, " >0 "}, applyIfCPUFeatureOr = {"zvfh", "true", "asimd", "true", "sve", "true"})
+    @IR(counts = {IRNode.MAX_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true", "avx512vl", "true"})
     public Float16 testMaxNaNOperands(Float16 src1, Float16 src2) {
         return Float16.max(src1, src2);
     }
@@ -70,8 +69,7 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Test
-    @IR(counts = {IRNode.MIN_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true"})
-    @IR(counts = {IRNode.MIN_HF, " >0 "}, applyIfCPUFeatureOr = {"zvfh", "true", "asimd", "true", "sve", "true"})
+    @IR(counts = {IRNode.MIN_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true", "avx512vl", "true"})
     public Float16 testMinNaNOperands(Float16 src1, Float16 src2) {
         return Float16.min(src1, src2);
     }
@@ -93,8 +91,7 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Test
-    @IR(counts = {IRNode.MAX_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true"})
-    @IR(counts = {IRNode.MAX_HF, " >0 "}, applyIfCPUFeatureOr = {"zvfh", "true", "asimd", "true", "sve", "true"})
+    @IR(counts = {IRNode.MAX_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true", "avx512vl", "true"})
     public Float16 testMaxZeroOperands(Float16 src1, Float16 src2) {
         return Float16.max(src1, src2);
     }
@@ -120,8 +117,7 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Test
-    @IR(counts = {IRNode.MIN_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true"})
-    @IR(counts = {IRNode.MIN_HF, " >0 "}, applyIfCPUFeatureOr = {"zvfh", "true", "asimd", "true", "sve", "true"})
+    @IR(counts = {IRNode.MIN_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true", "avx512vl", "true"})
     public Float16 testMinZeroOperands(Float16 src1, Float16 src2) {
         return Float16.min(src1, src2);
     }

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
@@ -30,9 +30,7 @@ import jdk.incubator.vector.*;
  * @bug 8352585
  * @library /test/lib /
  * @summary Add special case handling for Float16.max/min x86 backend
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx512_fp16.*" & vm.cpu.features ~= ".*avx512bw.*" & vm.cpu.features ~= ".*avx512vl.*")
  * @modules jdk.incubator.vector
- *
  * @run driver compiler.intrinsics.float16.TestFloat16MaxMinSpecialValues
  */
 
@@ -49,7 +47,8 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Test
-    @IR(counts = {IRNode.MAX_HF, " >0 "})
+    @IR(counts = {IRNode.MAX_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true"})
+    @IR(counts = {IRNode.MAX_HF, " >0 "}, applyIfCPUFeatureOr = {"zvfh", "true", "asimd", "true", "sve", "true"})
     public Float16 testMaxNaNOperands(Float16 src1, Float16 src2) {
         return Float16.max(src1, src2);
     }
@@ -71,7 +70,8 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Test
-    @IR(counts = {IRNode.MIN_HF, " >0 "})
+    @IR(counts = {IRNode.MIN_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true"})
+    @IR(counts = {IRNode.MIN_HF, " >0 "}, applyIfCPUFeatureOr = {"zvfh", "true", "asimd", "true", "sve", "true"})
     public Float16 testMinNaNOperands(Float16 src1, Float16 src2) {
         return Float16.min(src1, src2);
     }
@@ -93,7 +93,8 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Test
-    @IR(counts = {IRNode.MAX_HF, " >0 "})
+    @IR(counts = {IRNode.MAX_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true"})
+    @IR(counts = {IRNode.MAX_HF, " >0 "}, applyIfCPUFeatureOr = {"zvfh", "true", "asimd", "true", "sve", "true"})
     public Float16 testMaxZeroOperands(Float16 src1, Float16 src2) {
         return Float16.max(src1, src2);
     }
@@ -119,7 +120,8 @@ public class TestFloat16MaxMinSpecialValues {
     }
 
     @Test
-    @IR(counts = {IRNode.MIN_HF, " >0 "})
+    @IR(counts = {IRNode.MIN_HF, " >0 "}, applyIfCPUFeatureAnd = {"avx512_fp16", "true", "avx512bw", "true"})
+    @IR(counts = {IRNode.MIN_HF, " >0 "}, applyIfCPUFeatureOr = {"zvfh", "true", "asimd", "true", "sve", "true"})
     public Float16 testMinZeroOperands(Float16 src1, Float16 src2) {
         return Float16.min(src1, src2);
     }


### PR DESCRIPTION
This bugfix patch adds the special handling as per x86 AVX512-FP16 ISA specification[1][2] to compute max/min operations with +/-0.0 or NaN operands.

Special handling leverage the instruction semantic, central idea is to shuffle the operands such that smaller input gets assigned to second operand for min operation or a larger input gets assigned to second operand for max operation, in addition result equals NaN if an unordered comparison detects first input as a NaN value else we return the result of min/max operation. 

Kindly review and share your feedback.

Best Regards,
Jatin

[1] https://www.felixcloutier.com/x86/vminsh
[2] https://www.felixcloutier.com/x86/vmaxsh

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352585](https://bugs.openjdk.org/browse/JDK-8352585): Add special case handling for Float16.max/min x86 backend (**Bug** - P3)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**) Review applies to [1713057d](https://git.openjdk.org/jdk/pull/24169/files/1713057d4d94caff14c51b83de223f6cbde8db2b)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24169/head:pull/24169` \
`$ git checkout pull/24169`

Update a local copy of the PR: \
`$ git checkout pull/24169` \
`$ git pull https://git.openjdk.org/jdk.git pull/24169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24169`

View PR using the GUI difftool: \
`$ git pr show -t 24169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24169.diff">https://git.openjdk.org/jdk/pull/24169.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24169#issuecomment-2744378698)
</details>
