### PR TITLE
8352184: Jtreg tests using CommandLineOptionTest.getVMTypeOption() and optionsvalidation.JVMOptionsUtils fail on static JDK

### DIFF
--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -163,8 +163,10 @@ const char* Abstract_VM_Version::vm_info_string() {
 
   const char* static_info = ", static";
   const char* sharing_info = ", sharing";
-  size_t len = strlen(mode) + (is_vm_statically_linked() ? strlen(static_info) : 0) +
-               (CDSConfig::is_using_archive() ? strlen(sharing_info) : 0) + 1;
+  size_t len = strlen(mode) +
+               (is_vm_statically_linked() ? strlen(static_info) : 0) +
+               (CDSConfig::is_using_archive() ? strlen(sharing_info) : 0) +
+               1;
   char* vm_info = NEW_C_HEAP_ARRAY(char, len, mtInternal);
   // jio_snprintf places null character in the last character.
   jio_snprintf(vm_info, len, "%s%s%s", mode,

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -160,13 +160,16 @@ const char* Abstract_VM_Version::vm_info_string() {
     default:
       ShouldNotReachHere();
   }
-  size_t len = strlen(mode) + (is_vm_statically_linked() ? 8 : 0) +
-               (CDSConfig::is_using_archive() ? 9 : 0) + 1;
+
+  const char* static_info = ", static";
+  const char* sharing_info = ", sharing";
+  size_t len = strlen(mode) + (is_vm_statically_linked() ? strlen(static_info) : 0) +
+               (CDSConfig::is_using_archive() ? strlen(sharing_info) : 0) + 1;
   char* vm_info = NEW_C_HEAP_ARRAY(char, len, mtInternal);
   // jio_snprintf places null character in the last character.
   jio_snprintf(vm_info, len, "%s%s%s", mode,
-               is_vm_statically_linked() ? ", static" : "",
-               CDSConfig::is_using_archive() ? ", sharing" : "");
+               is_vm_statically_linked() ? static_info : "",
+               CDSConfig::is_using_archive() ? sharing_info : "");
   return vm_info;
 }
 

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -140,26 +140,37 @@ const char* Abstract_VM_Version::vm_vendor() {
 const char* Abstract_VM_Version::vm_info_string() {
   switch (Arguments::mode()) {
     case Arguments::_int:
-      return CDSConfig::is_using_archive() ? "interpreted mode, sharing" : "interpreted mode";
+      if (is_vm_statically_linked()) {
+        return CDSConfig::is_using_archive() ? "interpreted mode, static, sharing" : "interpreted mode, static";
+      } else {
+        return CDSConfig::is_using_archive() ? "interpreted mode, sharing" : "interpreted mode";
+      }
     case Arguments::_mixed:
-      if (CDSConfig::is_using_archive()) {
+      if (is_vm_statically_linked()) {
         if (CompilationModeFlag::quick_only()) {
-          return "mixed mode, emulated-client, sharing";
+          return CDSConfig::is_using_archive() ? "mixed mode, emulated-client, static, sharing" : "mixed mode, emulated-client, static";
         } else {
-          return "mixed mode, sharing";
+          return CDSConfig::is_using_archive() ? "mixed mode, static, sharing" : "mixed mode, static";
          }
       } else {
         if (CompilationModeFlag::quick_only()) {
-          return "mixed mode, emulated-client";
+          return CDSConfig::is_using_archive() ? "mixed mode, emulated-client, sharing" : "mixed mode, emulated-client";
         } else {
-          return "mixed mode";
+          return CDSConfig::is_using_archive() ? "mixed mode, sharing" : "mixed mode";
         }
       }
     case Arguments::_comp:
-      if (CompilationModeFlag::quick_only()) {
-         return CDSConfig::is_using_archive() ? "compiled mode, emulated-client, sharing" : "compiled mode, emulated-client";
+      if (is_vm_statically_linked()) {
+        if (CompilationModeFlag::quick_only()) {
+          return CDSConfig::is_using_archive() ? "compiled mode, emulated-client, static, sharing" : "compiled mode, emulated-client, static";
+        }
+        return CDSConfig::is_using_archive() ? "compiled mode, static, sharing" : "compiled mode, static";
+      } else {
+        if (CompilationModeFlag::quick_only()) {
+          return CDSConfig::is_using_archive() ? "compiled mode, emulated-client, sharing" : "compiled mode, emulated-client";
+        }
+        return CDSConfig::is_using_archive() ? "compiled mode, sharing" : "compiled mode";
       }
-      return CDSConfig::is_using_archive() ? "compiled mode, sharing" : "compiled mode";
   }
   ShouldNotReachHere();
   return "";

--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/JVMOptionsUtils.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/JVMOptionsUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class JVMOptionsUtils {
     private static final StringBuilder finalFailedMessage = new StringBuilder();
 
     /* Used to start the JVM with the same type as current */
-    static String VMType;
+    static String VMType = null;
 
     /* Used to start the JVM with the same GC type as current */
     static String GCType;
@@ -61,14 +61,14 @@ public class JVMOptionsUtils {
     private static Map<String, JVMOption> optionsAsMap;
 
     static {
-        if (Platform.isServer()) {
-            VMType = "-server";
-        } else if (Platform.isClient()) {
-            VMType = "-client";
-        } else if (Platform.isMinimal()) {
-            VMType = "-minimal";
-        } else {
-            VMType = null;
+        if (!Platform.isStatic()) {
+            if (Platform.isServer()) {
+                VMType = "-server";
+            } else if (Platform.isClient()) {
+                VMType = "-client";
+            } else if (Platform.isMinimal()) {
+                VMType = "-minimal";
+            }
         }
 
         List<GarbageCollectorMXBean> gcMxBeans = ManagementFactory.getGarbageCollectorMXBeans();

--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/JVMOptionsUtils.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/JVMOptionsUtils.java
@@ -53,7 +53,7 @@ public class JVMOptionsUtils {
     private static final StringBuilder finalFailedMessage = new StringBuilder();
 
     /* Used to start the JVM with the same type as current */
-    static String VMType = null;
+    static String VMType;
 
     /* Used to start the JVM with the same GC type as current */
     static String GCType;
@@ -61,14 +61,17 @@ public class JVMOptionsUtils {
     private static Map<String, JVMOption> optionsAsMap;
 
     static {
-        if (!Platform.isStatic()) {
-            if (Platform.isServer()) {
-                VMType = "-server";
-            } else if (Platform.isClient()) {
-                VMType = "-client";
-            } else if (Platform.isMinimal()) {
-                VMType = "-minimal";
-            }
+        if (Platform.isStatic()) {
+            // -server|-client|-minimal flags are not supported on static JDK.
+            VMType = null;
+        } else if (Platform.isServer()) {
+            VMType = "-server";
+        } else if (Platform.isClient()) {
+            VMType = "-client";
+        } else if (Platform.isMinimal()) {
+            VMType = "-minimal";
+        } else {
+            VMType = null;
         }
 
         List<GarbageCollectorMXBean> gcMxBeans = ManagementFactory.getGarbageCollectorMXBeans();

--- a/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
+++ b/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
+++ b/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
@@ -51,7 +51,7 @@ public class TestMutuallyExclusivePlatformPredicates {
         VM_TYPE("isClient", "isServer", "isMinimal", "isZero", "isEmbedded"),
         MODE("isInt", "isMixed", "isComp"),
         IGNORED("isEmulatedClient", "isDebugBuild", "isFastDebugBuild", "isMusl",
-                "isSlowDebugBuild", "hasSA", "isRoot", "isTieredSupported",
+                "isStatic", "isSlowDebugBuild", "hasSA", "isRoot", "isTieredSupported",
                 "areCustomLoadersSupportedForCDS", "isDefaultCDSArchiveSupported",
                 "isHardenedOSX", "hasOSXPlistEntries", "isOracleLinux7", "isOnWayland");
 

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,10 @@ public class Platform {
 
     public static boolean isEmbedded() {
         return vmName.contains("Embedded");
+    }
+
+    public static boolean isStatic() {
+        return vmInfo.contains("static");
     }
 
     public static boolean isEmulatedClient() {

--- a/test/lib/jdk/test/lib/cli/CommandLineOptionTest.java
+++ b/test/lib/jdk/test/lib/cli/CommandLineOptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,7 +199,9 @@ public abstract class CommandLineOptionTest {
             String wrongWarningMessage, ExitCode exitCode, String... options)
             throws Throwable {
         List<String> finalOptions = new ArrayList<>();
-        finalOptions.add(CommandLineOptionTest.getVMTypeOption());
+        if (!Platform.isStatic()) {
+            finalOptions.add(CommandLineOptionTest.getVMTypeOption());
+        }
         String extraFlagForEmulated = CommandLineOptionTest.getVMTypeOptionForEmulated();
         if (extraFlagForEmulated != null) {
             finalOptions.add(extraFlagForEmulated);
@@ -394,7 +396,9 @@ public abstract class CommandLineOptionTest {
             String expectedValue, String optionErrorString,
             String... additionalVMOpts) throws Throwable {
         List<String> finalOptions = new ArrayList<>();
-        finalOptions.add(CommandLineOptionTest.getVMTypeOption());
+        if (!Platform.isStatic()) {
+            finalOptions.add(CommandLineOptionTest.getVMTypeOption());
+        }
         String extraFlagForEmulated = CommandLineOptionTest.getVMTypeOptionForEmulated();
         if (extraFlagForEmulated != null) {
             finalOptions.add(extraFlagForEmulated);


### PR DESCRIPTION
Please review following changes, thanks.

- Add `static` to the vm_info for static JDK. The `-version` output now contains `static` on static JDK, e.g.:

```
$ static-jdk/bin/java -version
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (fastdebug build 25-internal-adhoc.jianglizhou.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 25-internal-adhoc.jianglizhou.jdk, mixed mode, static, sharing)

$ jdk/bin/java -version
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (fastdebug build 25-internal-adhoc.jianglizhou.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 25-internal-adhoc.jianglizhou.jdk, mixed mode, sharing)
```

Following changes resolve jtreg test failures on static JDK due to '-server|-client|-minimal|-zero' flag added by `CommandLineOptionTest.getVMTypeOption()` or `optionsvalidation.JVMOptionsUtils`. '-server|-client|-minimal|-zero' flags are unrecognized on static JDK (please see https://bugs.openjdk.org/browse/JDK-8350982).

- Add `jdk.test.lib.Platform.isStatic()`, which checks for `static` in `java.vm.info` system property to determine if current test is running on static JDK. 
- Change `CommandLineOptionTest` to only call `getVMTypeOption()` on regular JDK (`!Platform.isStatic()`).
- Change `optionsvalidation.JVMOptionsUtils` to only set VMType to '-server|-client|-minimal' on regular JDK ( `!Platform.isStatic()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352184](https://bugs.openjdk.org/browse/JDK-8352184): Jtreg tests using CommandLineOptionTest.getVMTypeOption() and optionsvalidation.JVMOptionsUtils fail on static JDK (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24171/head:pull/24171` \
`$ git checkout pull/24171`

Update a local copy of the PR: \
`$ git checkout pull/24171` \
`$ git pull https://git.openjdk.org/jdk.git pull/24171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24171`

View PR using the GUI difftool: \
`$ git pr show -t 24171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24171.diff">https://git.openjdk.org/jdk/pull/24171.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24171#issuecomment-2744963124)
</details>
