### PR TITLE
8352092: -XX:AOTMode=record crashes with InstanceKlass in allocated state

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -758,8 +758,10 @@ void MetaspaceShared::link_shared_classes(bool jcmd_request, TRAPS) {
       ClassLoaderData* cld = collect_cld.cld_at(i);
       for (Klass* klass = cld->klasses(); klass != nullptr; klass = klass->next_link()) {
         if (klass->is_instance_klass()) {
+          // Skip classes that are not yet loaded: these are classes that have failed
+          // to load after they were inserted into the ClassLoaderData by the ClassFileParser.
           InstanceKlass* ik = InstanceKlass::cast(klass);
-          if (may_be_eagerly_linked(ik)) {
+          if (ik->is_loaded() && may_be_eagerly_linked(ik)) {
             has_linked |= link_class_for_cds(ik, CHECK);
           }
         }

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -683,25 +683,28 @@ void VM_PopulateDumpSharedSpace::doit() {
   _map_info->header()->set_class_location_config(cl_config);
 }
 
-class CollectCLDClosure : public CLDClosure {
-  GrowableArray<ClassLoaderData*> _loaded_cld;
-  GrowableArray<OopHandle> _loaded_cld_handles; // keep the CLDs alive
-  Thread* _current_thread;
+class CollectClassesForLinking : public KlassClosure {
+  GrowableArray<OopHandle> _mirrors;
+
 public:
-  CollectCLDClosure(Thread* thread) : _current_thread(thread) {}
-  ~CollectCLDClosure() {
-    for (int i = 0; i < _loaded_cld_handles.length(); i++) {
-      _loaded_cld_handles.at(i).release(Universe::vm_global());
+  CollectClassesForLinking() {}
+  ~CollectClassesForLinking() {
+    for (int i = 0; i < _mirrors.length(); i++) {
+      _mirrors.at(i).release(Universe::vm_global());
     }
   }
+
   void do_cld(ClassLoaderData* cld) {
     assert(cld->is_alive(), "must be");
-    _loaded_cld.append(cld);
-    _loaded_cld_handles.append(OopHandle(Universe::vm_global(), cld->holder()));
   }
 
-  int nof_cld() const                { return _loaded_cld.length(); }
-  ClassLoaderData* cld_at(int index) { return _loaded_cld.at(index); }
+  void do_klass(Klass* k) {
+    if (k->is_instance_klass()) {
+      _mirrors.append(OopHandle(Universe::vm_global(), k->java_mirror()));
+    }
+  }
+
+  const GrowableArray<OopHandle>* mirrors() const { return &_mirrors; }
 };
 
 // Check if we can eagerly link this class at dump time, so we can avoid the
@@ -741,30 +744,25 @@ void MetaspaceShared::link_shared_classes(bool jcmd_request, TRAPS) {
     LambdaFormInvokers::regenerate_holder_classes(CHECK);
   }
 
-  // Collect all loaded ClassLoaderData.
-  CollectCLDClosure collect_cld(THREAD);
+  CollectClassesForLinking collect_classes;
   {
-    // ClassLoaderDataGraph::loaded_cld_do requires ClassLoaderDataGraph_lock.
+    // ClassLoaderDataGraph::loaded_classes_do_keepalive() requires ClassLoaderDataGraph_lock.
     // We cannot link the classes while holding this lock (or else we may run into deadlock).
-    // Therefore, we need to first collect all the CLDs, and then link their classes after
+    // Therefore, we need to first collect all the classes, keeping them alive by
+    // holding onto their java_mirrors in global OopHandles. We then link the classes after
     // releasing the lock.
     MutexLocker lock(ClassLoaderDataGraph_lock);
-    ClassLoaderDataGraph::loaded_cld_do(&collect_cld);
+    ClassLoaderDataGraph::loaded_classes_do_keepalive(&collect_classes);
   }
 
   while (true) {
     bool has_linked = false;
-    for (int i = 0; i < collect_cld.nof_cld(); i++) {
-      ClassLoaderData* cld = collect_cld.cld_at(i);
-      for (Klass* klass = cld->klasses(); klass != nullptr; klass = klass->next_link()) {
-        if (klass->is_instance_klass()) {
-          // Skip classes that are not yet loaded: these are classes that have failed
-          // to load after they were inserted into the ClassLoaderData by the ClassFileParser.
-          InstanceKlass* ik = InstanceKlass::cast(klass);
-          if (ik->is_loaded() && may_be_eagerly_linked(ik)) {
-            has_linked |= link_class_for_cds(ik, CHECK);
-          }
-        }
+    const GrowableArray<OopHandle>* mirrors = collect_classes.mirrors();
+    for (int i = 0; i < mirrors->length(); i++) {
+      OopHandle mirror = mirrors->at(i);
+      InstanceKlass* ik = InstanceKlass::cast(java_lang_Class::as_Klass(mirror.resolve()));
+      if (may_be_eagerly_linked(ik)) {
+        has_linked |= link_class_for_cds(ik, CHECK);
       }
     }
 

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -687,7 +687,6 @@ class CollectClassesForLinking : public KlassClosure {
   GrowableArray<OopHandle> _mirrors;
 
 public:
-  CollectClassesForLinking() {}
   ~CollectClassesForLinking() {
     for (int i = 0; i < _mirrors.length(); i++) {
       _mirrors.at(i).release(Universe::vm_global());

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -744,18 +744,19 @@ void MetaspaceShared::link_shared_classes(bool jcmd_request, TRAPS) {
     LambdaFormInvokers::regenerate_holder_classes(CHECK);
   }
 
-  CollectClassesForLinking collect_classes;
-  {
-    // ClassLoaderDataGraph::loaded_classes_do_keepalive() requires ClassLoaderDataGraph_lock.
-    // We cannot link the classes while holding this lock (or else we may run into deadlock).
-    // Therefore, we need to first collect all the classes, keeping them alive by
-    // holding onto their java_mirrors in global OopHandles. We then link the classes after
-    // releasing the lock.
-    MutexLocker lock(ClassLoaderDataGraph_lock);
-    ClassLoaderDataGraph::loaded_classes_do_keepalive(&collect_classes);
-  }
 
   while (true) {
+    CollectClassesForLinking collect_classes;
+    {
+      // ClassLoaderDataGraph::loaded_classes_do_keepalive() requires ClassLoaderDataGraph_lock.
+      // We cannot link the classes while holding this lock (or else we may run into deadlock).
+      // Therefore, we need to first collect all the classes, keeping them alive by
+      // holding onto their java_mirrors in global OopHandles. We then link the classes after
+      // releasing the lock.
+      MutexLocker lock(ClassLoaderDataGraph_lock);
+      ClassLoaderDataGraph::loaded_classes_do_keepalive(&collect_classes);
+    }
+
     bool has_linked = false;
     const GrowableArray<OopHandle>* mirrors = collect_classes.mirrors();
     for (int i = 0; i < mirrors->length(); i++) {


### PR DESCRIPTION
Please review this small fix for a crash that can be caused only with JNI `DefineClass()` calls, which can leave a class in the `allocated` state inside a `ClassLoaderData` when the class is in a prohibited package such as `java/foo`.

The bug was found when running the JCK with an AOT cache. I tried to write a jtreg regression test but it's not possible to use pure Java code to reproduce this condition -- attempts by Java code to define classes in a prohibited package will be blocked from entering the ClassFileParser.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352092](https://bugs.openjdk.org/browse/JDK-8352092): -XX:AOTMode=record crashes with InstanceKlass in allocated state (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) Review applies to [ae23a56d](https://git.openjdk.org/jdk/pull/24172/files/ae23a56df9bffd313cf384acb45ff5653df2faee)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24172/head:pull/24172` \
`$ git checkout pull/24172`

Update a local copy of the PR: \
`$ git checkout pull/24172` \
`$ git pull https://git.openjdk.org/jdk.git pull/24172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24172`

View PR using the GUI difftool: \
`$ git pr show -t 24172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24172.diff">https://git.openjdk.org/jdk/pull/24172.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24172#issuecomment-2745010301)
</details>
