### PR TITLE
8352641: [TESTBUG] VerifyGraphEdgesWithDeadCodeCheckFromSafepoints.java fails due to missing UnlockDiagnosticVMOptions

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/VerifyGraphEdgesWithDeadCodeCheckFromSafepoints.java
+++ b/test/hotspot/jtreg/compiler/loopopts/VerifyGraphEdgesWithDeadCodeCheckFromSafepoints.java
@@ -29,6 +29,7 @@
  *
  * @run driver compiler.loopopts.VerifyGraphEdgesWithDeadCodeCheckFromSafepoints
  * @run main/othervm
+ *       -XX:+UnlockDiagnosticVMOptions
  *       -XX:+IgnoreUnrecognizedVMOptions
  *       -XX:-TieredCompilation -XX:+VerifyGraphEdges
  *       -XX:+StressIGVN -Xcomp


### PR DESCRIPTION
Hi, please review this trivial change fixing a test bug.

The test reports following error message when running with release build.
`Error: VM option 'StressIGVN' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.`
This adds the needed UnlockDiagnosticVMOptions option for this test. Same test passes with this extra option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352641](https://bugs.openjdk.org/browse/JDK-8352641): [TESTBUG] VerifyGraphEdgesWithDeadCodeCheckFromSafepoints.java fails due to missing UnlockDiagnosticVMOptions (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24173/head:pull/24173` \
`$ git checkout pull/24173`

Update a local copy of the PR: \
`$ git checkout pull/24173` \
`$ git pull https://git.openjdk.org/jdk.git pull/24173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24173`

View PR using the GUI difftool: \
`$ git pr show -t 24173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24173.diff">https://git.openjdk.org/jdk/pull/24173.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24173#issuecomment-2745120481)
</details>
