### PR TITLE
8211759: C2: Graph after optimizations should not have dead nodes

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2529,8 +2529,6 @@ void Compile::Optimize() {
   }
  } // (End scope of igvn; run destructor if necessary for asserts.)
 
- check_no_dead_use();
-
  // We will never use the NodeHash table any more. Clear it so that final_graph_reshaping does not have
  // to remove hashes to unlock nodes for modifications.
  C->node_hash()->clear();
@@ -2543,6 +2541,8 @@ void Compile::Optimize() {
      return;
    }
  }
+
+ check_no_dead_use();
 
  print_method(PHASE_OPTIMIZE_FINISHED, 2);
  DEBUG_ONLY(set_phase_optimize_finished();)


### PR DESCRIPTION
Move the check_no_dead_use() call after the final_graph_reshaping() call to catch dead nodes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211759](https://bugs.openjdk.org/browse/JDK-8211759): C2: Graph after optimizations should not have dead nodes (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24175/head:pull/24175` \
`$ git checkout pull/24175`

Update a local copy of the PR: \
`$ git checkout pull/24175` \
`$ git pull https://git.openjdk.org/jdk.git pull/24175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24175`

View PR using the GUI difftool: \
`$ git pr show -t 24175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24175.diff">https://git.openjdk.org/jdk/pull/24175.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24175#issuecomment-2746089126)
</details>
