### PR TITLE
8352642: Set zipinfo-time=false when constructing zipfs FileSystem in com.sun.tools.javac.file.JavacFileManager$ArchiveContainer for better performance

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -562,7 +562,10 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
         public ArchiveContainer(Path archivePath) throws IOException, ProviderNotFoundException {
             this.archivePath = archivePath;
             if (multiReleaseValue != null && archivePath.toString().endsWith(".jar")) {
-                Map<String,String> env = Collections.singletonMap("multi-release", multiReleaseValue);
+                Map<String,String> env = Map.of(
+                    "multi-release", multiReleaseValue,
+                    "zipinfo-time", "false" // ignores timestamps not stored in ZIP central directory, reducing I/O
+                );
                 FileSystemProvider jarFSProvider = fsInfo.getJarFSProvider();
                 Assert.checkNonNull(jarFSProvider, "should have been caught before!");
                 try {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -577,8 +577,7 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
                 }
             } else {
                 // Less common case is possible if the file manager was not initialized in JavacTask,
-                // or if non "*.jar" files are on the classpath. At the time of writing, both `javac -cp a.zip`
-                // and `javac -cp x.JAR` file would hit this branch which may warrant investigation.
+                // or if non "*.jar" files are on the classpath.
                 this.fileSystem = FileSystems.newFileSystem(archivePath, env, (ClassLoader)null);
             }
             packages = new HashMap<>();


### PR DESCRIPTION
zipfs has a (undocumented) property "zipinfo-time" which was introduced in https://bugs.openjdk.org/browse/JDK-8150496 to help improve performance of the ZipFileSystem. When a ZipFileSystem is created with this property's value set to "false", then the implementation in ZipFileSystem, while constructing the entries from the ZIP file will skip reading the access time and the creation time of each ZIP entry from the entry's LOC header. This improves the performance of zipfs, since when reading the CEN, it no longer has to traverse to individual LOC headers to find the access time and creation time values of each entry.

Setting "zipinfo-time" = false, thus implies that the ZipFileAttributes.creationTime() and ZipFileAttributes.lastAccessTime() APIs may not return the right values when used against Path(s) corresponding to the ZIP entries in that FileSystem. Not all usages of zipfs require or use the creationTime()/lastAccessTime() APIs. Such usages can set "zipinfo-time" = false and benefit from improved performance.

com.sun.tools.javac.file.JavacFileManager$ArchiveContainer is one such place where when constructing the FileSystem, it could pass this property. This is especially useful since this part of the code in practice can be dealing with large number of jar files in the classpath and creating one zipfs FileSystem for each such JAR file.

It has been reported in the compiler-dev mailing list, that an experiment to set "zipinfo-time" = false in this part of the code has shown very noticeable performance improvements, especially on Windows, when dealing with large classpath. Details in the thread here https://mail.openjdk.org/pipermail/compiler-dev/2025-March/029529.html.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8352642](https://bugs.openjdk.org/browse/JDK-8352642): Set zipinfo-time=false when constructing zipfs FileSystem in com.sun.tools.javac.file.JavacFileManager$ArchiveContainer for better performance (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) Review applies to [eee2f613](https://git.openjdk.org/jdk/pull/24176/files/eee2f61395bae7ec0a13031ec41cf62c42757d8f)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24176/head:pull/24176` \
`$ git checkout pull/24176`

Update a local copy of the PR: \
`$ git checkout pull/24176` \
`$ git pull https://git.openjdk.org/jdk.git pull/24176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24176`

View PR using the GUI difftool: \
`$ git pr show -t 24176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24176.diff">https://git.openjdk.org/jdk/pull/24176.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24176#issuecomment-2746191818)
</details>
