### PR TITLE
8352648: JFR: 'jfr query' should not be available in product builds

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -429,3 +429,11 @@ JVM_END
 NO_TRANSITION(jlong, jfr_nanos_now(JNIEnv* env, jclass jvm))
   return JfrChunk::nanos_now();
 NO_TRANSITION_END
+
+NO_TRANSITION(jboolean, jfr_is_product(JNIEnv* env, jclass jvm))
+#ifdef PRODUCT
+  return true;
+#else
+  return false;
+#endif
+NO_TRANSITION_END

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -167,6 +167,8 @@ void JNICALL jfr_unregister_stack_filter(JNIEnv* env, jclass jvm, jlong id);
 
 jlong JNICALL jfr_nanos_now(JNIEnv* env, jclass jvm);
 
+jboolean JNICALL jfr_is_product(JNIEnv* env, jclass jvm);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
@@ -100,7 +100,8 @@ JfrJniMethodRegistration::JfrJniMethodRegistration(JNIEnv* env) {
       (char*)"emitDataLoss", (char*)"(J)V", (void*)jfr_emit_data_loss,
       (char*)"registerStackFilter", (char*)"([Ljava/lang/String;[Ljava/lang/String;)J", (void*)jfr_register_stack_filter,
       (char*)"unregisterStackFilter", (char*)"(J)V", (void*)jfr_unregister_stack_filter,
-      (char*)"nanosNow", (char*)"()J", (void*)jfr_nanos_now
+      (char*)"nanosNow", (char*)"()J", (void*)jfr_nanos_now,
+      (char*)"isProduct", (char*)"()Z", (void*)jfr_is_product
     };
 
     const size_t method_array_length = sizeof(method) / sizeof(JNINativeMethod);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -675,4 +675,11 @@ public final class JVM {
      * @param value
      */
     public static native void setMiscellaneous(long eventTypeId, long value);
+
+    /**
+     * Returns whether the current build is a product build.
+     *
+     * @return {@code true} if this is a product build, {@code false} otherwise.
+     */
+    public static native boolean isProduct();
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Command.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Command.java
@@ -42,6 +42,7 @@ import java.util.List;
 
 import jdk.jfr.internal.util.UserDataException;
 import jdk.jfr.internal.util.UserSyntaxException;
+import jdk.jfr.internal.JVM;
 
 abstract class Command {
     public static final String title = "Tool for working with Flight Recorder files";
@@ -51,8 +52,9 @@ abstract class Command {
     private static List<Command> createCommands() {
         List<Command> commands = new ArrayList<>();
         commands.add(new Print());
-        // Uncomment when developing new queries for the view command
-        commands.add(new Query());
+        if (!JVM.isProduct()) {
+            commands.add(new Query());
+        }
         commands.add(new View());
         commands.add(new Configure());
         commands.add(new Metadata());

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Query.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Query.java
@@ -94,12 +94,18 @@ final class Query extends Command {
         p.println("                        WHERE B.when = 'Before GC' AND A.when = 'After GC'");
         p.println("                        GROUP BY gcId");
         p.println("                        ORDER BY G.startTime\" recording.jfr");
+        p.println();
+        p.println("************************************ WARNING ******************************************");
+        p.println("The query command is only available in debug builds and is targeted towards OpenJDK");
+        p.println("developers. The tool may be removed or its syntax changed at any time.");
+        p.println("***************************************************************************************");
+        p.println();
    }
 
     @Override
     public List<String> getOptionSyntax() {
         List<String> list = new ArrayList<>();
-        list.add("[--verbose] [--width <integer>] <query> <file>");
+        list.add("[--verbose] [--width <integer>] <query> <file> (in debug builds)");
         return list;
     }
 


### PR DESCRIPTION
Could I have a review of a PR that removes the 'jfr query' command in product builds.

Testing: tier1 + test/jdk/jdk/jfr

Thanks
Erik