### PR TITLE
8352652: [BACKOUT] nsk/jvmti/ tests should fail when nsk_jvmti_setFailStatus() is called

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass029/redefclass029.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass029/redefclass029.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,16 +97,6 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
         const void* compile_info) {
     char *name;
     char *sig;
-    jvmtiPhase phase;
-
-    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
-        nsk_jvmti_setFailStatus();
-        return;
-    }
-    if (phase == JVMTI_PHASE_DEAD) {
-      NSK_DISPLAY0("CompiledMethodLoad event recieved in dead phase");
-      return;
-    }
 
     NSK_DISPLAY0("CompiledMethodLoad event received for:\n");
     if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sig, nullptr))) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,18 +118,6 @@ cbDynamicCodeGenerated2(jvmtiEnv *jvmti_env, const char *name,
 
 }
 
- void JNICALL
-cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
-    if (!NSK_VERIFY(nsk_list_destroy(plist))) {
-        nsk_jvmti_setFailStatus();
-    }
-
-    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock))) {
-        nsk_jvmti_setFailStatus();
-    }
-
-}
-
 /* ============================================================================= */
 
 static int
@@ -147,7 +135,6 @@ int setCallBacks(int stage) {
     jvmtiEventCallbacks eventCallbacks;
     memset(&eventCallbacks, 0, sizeof(eventCallbacks));
 
-    eventCallbacks.VMDeath = cbVMDeath;
     eventCallbacks.DynamicCodeGenerated = (stage == 1) ?
                             cbDynamicCodeGenerated1 : cbDynamicCodeGenerated2;
 
@@ -253,6 +240,25 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     return JNI_OK;
+}
+
+/* ============================================================================= */
+
+JNIEXPORT void JNICALL
+#ifdef STATIC_BUILD
+Agent_OnUnload_em04t001(JavaVM *jvm)
+#else
+Agent_OnUnload(JavaVM *jvm)
+#endif
+{
+
+    if (!NSK_VERIFY(nsk_list_destroy(plist))) {
+        nsk_jvmti_setFailStatus();
+    }
+
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock))) {
+        nsk_jvmti_setFailStatus();
+    }
 }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t006/ma10t006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t006/ma10t006.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,18 +51,9 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method,
         const jvmtiAddrLocationMap* map, const void* compile_info) {
     char *name = nullptr;
     char *signature = nullptr;
-    jvmtiPhase phase;
 
     CompiledMethodLoadEventsCount++;
 
-    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
-        nsk_jvmti_setFailStatus();
-        return;
-    }
-    if (phase == JVMTI_PHASE_DEAD) {
-      NSK_DISPLAY0("CompiledMethodLoad event recieved in dead phase");
-      return;
-    }
     if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, nullptr))) {
         nsk_jvmti_setFailStatus();
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/agent_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/agent_tools.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,6 @@
  * questions.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -63,9 +62,6 @@ static volatile int currentAgentStatus = NSK_STATUS_PASSED;
 
 void nsk_jvmti_setFailStatus() {
     currentAgentStatus = NSK_STATUS_FAILED;
-    printf("Test failed by setFailStatus(). See log.");
-    fflush(stdout);
-    exit(97);
 }
 
 int nsk_jvmti_isFailStatus() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/hotswap/HotSwap.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/hotswap/HotSwap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,19 +141,9 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method,
         const jvmtiAddrLocationMap* map, const void* compile_info) {
     char *name = nullptr;
     char *signature = nullptr;
-    jvmtiPhase phase;
 
     CompiledMethodLoadEventsCount++;
 
-    // GetMethodName works in live phase only so just exit if the event is generated too late
-    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
-        nsk_jvmti_setFailStatus();
-        return;
-    }
-    if (phase == JVMTI_PHASE_DEAD) {
-      NSK_DISPLAY0("CompiledMethodLoad event recieved in dead phase");
-      return;
-    }
     if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, nullptr))) {
         nsk_jvmti_setFailStatus();
         return;


### PR DESCRIPTION
Revert "8351375: nsk/jvmti/ tests should fail when  nsk_jvmti_setFailStatus() is called"

This reverts commit 334a1eec2375a4f9f3150bdb556c1c2432596b4b.

The original change caused numerous test failures.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352652](https://bugs.openjdk.org/browse/JDK-8352652): [BACKOUT] nsk/jvmti/ tests should fail when nsk_jvmti_setFailStatus() is called (**Sub-task** - P3)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24181/head:pull/24181` \
`$ git checkout pull/24181`

Update a local copy of the PR: \
`$ git checkout pull/24181` \
`$ git pull https://git.openjdk.org/jdk.git pull/24181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24181`

View PR using the GUI difftool: \
`$ git pr show -t 24181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24181.diff">https://git.openjdk.org/jdk/pull/24181.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24181#issuecomment-2746574060)
</details>
