### PR TITLE
8352673: RISC-V: Vector can't be turned on with -XX:+UseRVV

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -194,7 +194,7 @@ void VM_Version::common_initialize() {
   }
 
   if (UseRVV) {
-    if (!ext_V.enabled()) {
+    if (!ext_V.enabled() && FLAG_IS_DEFAULT(UseRVV)) {
       warning("RVV is not supported on this CPU");
       FLAG_SET_DEFAULT(UseRVV, false);
     } else {

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -168,7 +168,7 @@ void RiscvHwprobe::add_features_from_query_result() {
     // Linux signal return bug when using vector with vlen > 128b in pre 6.8.5.
     long major, minor, patch;
     os::Linux::kernel_version(&major, &minor, &patch);
-    if (os::Linux::kernel_version_compare(major, minor, patch, 6, 8, 5) == -1) {
+    if (!UseRVV && (os::Linux::kernel_version_compare(major, minor, patch, 6, 8, 5) == -1)) {
       LogMessage(os) log;
       if (log.is_info()) {
         log.info("Linux kernels before 6.8.5 (current %ld.%ld.%ld) have a known bug when using Vector and signals.", major, minor, patch);

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -168,7 +168,7 @@ void RiscvHwprobe::add_features_from_query_result() {
     // Linux signal return bug when using vector with vlen > 128b in pre 6.8.5.
     long major, minor, patch;
     os::Linux::kernel_version(&major, &minor, &patch);
-    if (!UseRVV && (os::Linux::kernel_version_compare(major, minor, patch, 6, 8, 5) == -1)) {
+    if (os::Linux::kernel_version_compare(major, minor, patch, 6, 8, 5) == -1) {
       LogMessage(os) log;
       if (log.is_info()) {
         log.info("Linux kernels before 6.8.5 (current %ld.%ld.%ld) have a known bug when using Vector and signals.", major, minor, patch);


### PR DESCRIPTION
Hi all,
After [JDK-8348384](https://bugs.openjdk.org/browse/JDK-8348384), Vector can't be turned on with -XX:+UseRVV when Linux kernels before 6.8.5, which does not match the printed log:
```
log.info("Linux kernels before 6.8.5 (current %ld.%ld.%ld) have a known bug when using Vector and signals.", major, minor, patch);
log.info("Vector not enabled automatically via hwprobe, but can be turned on with -XX:+UseRVV.");
```

Testing on QEMU before this PR:
```shell
$ uname -a
Linux ubuntu 6.8.0-52-generic #53.1-Ubuntu SMP PREEMPT_DYNAMIC Sun Jan 26 04:38:25 UTC 2025 riscv64 riscv64 riscv64 GNU/Linux

$ ./java -XX:+PrintFlagsFinal -XX:+UnlockDiagnosticVMOptions -version | grep UseRVV
     bool UseRVV                                   = false                             {ARCH diagnostic} {default}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (build 25-internal-adhoc.zhangdingli.jdk)
OpenJDK 64-Bit Server VM (build 25-internal-adhoc.zhangdingli.jdk, mixed mode)

$ ./java -XX:+PrintFlagsFinal -XX:+UnlockDiagnosticVMOptions -XX:+UseRVV -version | grep UseRVV
OpenJDK 64-Bit Server VM warning: RVV is not supported on this CPU
     bool UseRVV                                   = false                             {ARCH diagnostic} {command line}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (build 25-internal-adhoc.zhangdingli.jdk)
OpenJDK 64-Bit Server VM (build 25-internal-adhoc.zhangdingli.jdk, mixed mode)

$ ./java -XX:+PrintFlagsFinal -XX:+UnlockDiagnosticVMOptions -XX:-UseRVV -version | grep UseRVV
     bool UseRVV                                   = false                             {ARCH diagnostic} {command line}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (build 25-internal-adhoc.zhangdingli.jdk)
OpenJDK 64-Bit Server VM (build 25-internal-adhoc.zhangdingli.jdk, mixed mode)

$ ./java -XX:+UnlockDiagnosticVMOptions -XX:+UseRVV -Xlog:os=info -version
[0.021s][info][os] Use of CLOCK_MONOTONIC is supported
[0.022s][info][os] Use of pthread_condattr_setclock is supported
[0.022s][info][os] Relative timed-wait using pthread_cond_timedwait is associated with CLOCK_MONOTONIC
[0.022s][info][os] HotSpot is running with glibc 2.39, NPTL 2.39
[0.022s][info][os] Glibc stack size guard page adjustment is not needed
[0.024s][info][os] SafePoint Polling address, bad (protected) page:0x00007fff7fe66000, good (unprotected) page:0x00007fff7fe67000
[0.040s][info][os] attempting shared library load of /home/ubuntu/jdk-rvv-before/lib/libjava.so
[0.043s][info][os] shared library load of /home/ubuntu/jdk-rvv-before/lib/libjava.so was successful
[0.047s][info][os] Linux kernels before 6.8.5 (current 6.8.0) have a known bug when using Vector and signals.
[0.047s][info][os] Vector not enabled automatically via hwprobe, but can be turned on with -XX:+UseRVV.
OpenJDK 64-Bit Server VM warning: RVV is not supported on this CPU
[0.763s][info][os] Initialized VM with process ID 33530
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (build 25-internal-adhoc.zhangdingli.jdk)
OpenJDK 64-Bit Server VM (build 25-internal-adhoc.zhangdingli.jdk, mixed mode)
```

Testing on QEMU after this PR:
```shell
$ uname -a
Linux ubuntu 6.8.0-52-generic #53.1-Ubuntu SMP PREEMPT_DYNAMIC Sun Jan 26 04:38:25 UTC 2025 riscv64 riscv64 riscv64 GNU/Linux

$ ./java -XX:+PrintFlagsFinal -XX:+UnlockDiagnosticVMOptions -version | grep UseRVV
     bool UseRVV                                   = false                             {ARCH diagnostic} {default}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (build 25-internal-adhoc.zhangdingli.jdk)
OpenJDK 64-Bit Server VM (build 25-internal-adhoc.zhangdingli.jdk, mixed mode)

$ ./java -XX:+PrintFlagsFinal -XX:+UnlockDiagnosticVMOptions -XX:+UseRVV -version | grep UseRVV
     bool UseRVV                                   = true                              {ARCH diagnostic} {command line}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (build 25-internal-adhoc.zhangdingli.jdk)
OpenJDK 64-Bit Server VM (build 25-internal-adhoc.zhangdingli.jdk, mixed mode)

$ ./java -XX:+PrintFlagsFinal -XX:+UnlockDiagnosticVMOptions -XX:-UseRVV -version | grep UseRVV
     bool UseRVV                                   = false                             {ARCH diagnostic} {command line}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (build 25-internal-adhoc.zhangdingli.jdk)
OpenJDK 64-Bit Server VM (build 25-internal-adhoc.zhangdingli.jdk, mixed mode)

$ ./java -XX:+UnlockDiagnosticVMOptions -XX:+UseRVV -Xlog:os=info -version
[0.021s][info][os] Use of CLOCK_MONOTONIC is supported
[0.021s][info][os] Use of pthread_condattr_setclock is supported
[0.022s][info][os] Relative timed-wait using pthread_cond_timedwait is associated with CLOCK_MONOTONIC
[0.022s][info][os] HotSpot is running with glibc 2.39, NPTL 2.39
[0.022s][info][os] Glibc stack size guard page adjustment is not needed
[0.025s][info][os] SafePoint Polling address, bad (protected) page:0x00007ff6a1315000, good (unprotected) page:0x00007ff6a1316000
[0.040s][info][os] attempting shared library load of /home/ubuntu/jdk-after/lib/libjava.so
[0.043s][info][os] shared library load of /home/ubuntu/jdk-after/lib/libjava.so was successful
[0.753s][info][os] Initialized VM with process ID 33590
[0.795s][info][os] attempting shared library load of /home/ubuntu/jdk-after/lib/libsleef.so
[0.797s][info][os] shared library load of /home/ubuntu/jdk-after/lib/libsleef.so was successful
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (build 25-internal-adhoc.zhangdingli.jdk)
OpenJDK 64-Bit Server VM (build 25-internal-adhoc.zhangdingli.jdk, mixed mode)
```

In addition, manual tested 6.11 as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352673](https://bugs.openjdk.org/browse/JDK-8352673): RISC-V: Vector can't be turned on with -XX:+UseRVV (**Bug** - P5)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24182/head:pull/24182` \
`$ git checkout pull/24182`

Update a local copy of the PR: \
`$ git checkout pull/24182` \
`$ git pull https://git.openjdk.org/jdk.git pull/24182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24182`

View PR using the GUI difftool: \
`$ git pr show -t 24182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24182.diff">https://git.openjdk.org/jdk/pull/24182.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24182#issuecomment-2747176631)
</details>
