### PR TITLE
8351002: com/sun/management/OperatingSystemMXBean cpuLoad tests fail intermittently

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -536,9 +536,8 @@ java/io/IO/IO.java                                              8337935 linux-pp
 
 # jdk_management
 
-# First bug for AIX, second for Windows
-com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad.java 8030957,8351002 aix-all,windows-all
-com/sun/management/OperatingSystemMXBean/GetSystemCpuLoad.java  8030957,8351002 aix-all,windows-all
+com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad.java 8030957 aix-all
+com/sun/management/OperatingSystemMXBean/GetSystemCpuLoad.java  8030957 aix-all
 
 java/lang/management/MemoryMXBean/Pending.java                  8158837 generic-all
 java/lang/management/MemoryMXBean/PendingAllGC.sh               8158837 generic-all

--- a/test/jdk/com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad.java
+++ b/test/jdk/com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad.java
@@ -36,18 +36,33 @@ public class GetProcessCpuLoad {
     public static void main(String[] argv) throws Exception {
         OperatingSystemMXBean mbean = (com.sun.management.OperatingSystemMXBean)
             ManagementFactory.getOperatingSystemMXBean();
+
+        Exception ex = null;
         double load;
-        for(int i=0; i<10; i++) {
+
+        for(int i = 0; i < 10; i++) {
             load = mbean.getProcessCpuLoad();
-            if(load<0.0 || load>1.0) {
+            if (load == -1.0) {
+				// Some Windows 2019 systems can return -1 for the first few reads.
+                // Remember a -1 in case it never gets better.
+                ex = new RuntimeException("getProcessCpuLoad() returns " + load
+                     + " which is not in the [0.0,1.0] interval");
+            } else if (load < 0.0 || load > 1.0) {
                 throw new RuntimeException("getProcessCpuLoad() returns " + load
-                       +   " which is not in the [0.0,1.0] interval");
+                          + " which is not in the [0.0,1.0] interval");
+            } else {
+                // A good reading: forget any previous -1.
+                ex = null;
             }
             try {
                 Thread.sleep(200);
             } catch(InterruptedException e) {
                 e.printStackTrace();
             }
+        }
+
+        if (ex != null) {
+            throw ex;
         }
     }
 }

--- a/test/jdk/com/sun/management/OperatingSystemMXBean/GetProcessCpuTime.java
+++ b/test/jdk/com/sun/management/OperatingSystemMXBean/GetProcessCpuTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class GetProcessCpuTime {
 
     // Careful with these values.
     private static final long MIN_TIME_FOR_PASS = 1;
-    private static final long MAX_TIME_FOR_PASS = Long.MAX_VALUE;
+    private static final long MAX_TIME_FOR_PASS = Long.MAX_VALUE / 1000;
 
     // No max time.
 
@@ -73,10 +73,22 @@ public class GetProcessCpuTime {
           sum /= i;
         }
 
-        long ns = mbean.getProcessCpuTime();
+        long ns = 0;
+		// Do not skip test if first read is -1:
+		// Some Windows 2019 systems can return -1 for the first few reads.
+        for (int i = 0; i < 10; i++) {
+            ns = mbean.getProcessCpuTime();
+            if (ns != -1) {
+                break;
+            }
+            try {
+                Thread.sleep(200);
+            } catch(InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
         if (ns == -1) {
-            System.out.println("getProcessCpuTime() is not supported");
-            return;
+            throw new RuntimeException("getProcessCpuTime() is not supported");
         }
 
         if (trace) {

--- a/test/jdk/com/sun/management/OperatingSystemMXBean/GetSystemCpuLoad.java
+++ b/test/jdk/com/sun/management/OperatingSystemMXBean/GetSystemCpuLoad.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug     7028071
- * @summary Basic unit test of OperatingSystemMXBean.getSystemCpuLoad()
+ * @summary Basic unit test of OperatingSystemMXBean.getProcessCpuLoad()
  *
  * @run main GetSystemCpuLoad
  */
@@ -36,18 +36,34 @@ public class GetSystemCpuLoad {
     public static void main(String[] argv) throws Exception {
         OperatingSystemMXBean mbean = (com.sun.management.OperatingSystemMXBean)
             ManagementFactory.getOperatingSystemMXBean();
+
+        Exception ex = null;
         double load;
-        for(int i=0; i<10; i++) {
+
+        for(int i = 0; i < 10; i++) {
             load = mbean.getSystemCpuLoad();
-            if(load<0.0 || load>1.0) {
+            if (load == -1.0) {
+				// Some Windows 2019 systems can return -1 for the first few reads.
+                // Remember a -1 in case it never gets better.
+                ex = new RuntimeException("getSystemCpuLoad() returns " + load
+                         +  " which is not in the [0.0,1.0] interval");
+
+            } else if (load < 0.0 || load > 1.0) {
                 throw new RuntimeException("getSystemCpuLoad() returns " + load
-                       +  " which is not in the [0.0,1.0] interval");
+                           +  " which is not in the [0.0,1.0] interval");
+            } else {
+                // A good reading: forget any previous -1.
+                ex = null;
             }
             try {
                 Thread.sleep(200);
             } catch(InterruptedException e) {
                 e.printStackTrace();
             }
+        }
+
+        if (ex != null) {
+            throw ex;
         }
     }
 }


### PR DESCRIPTION
These tests have always silently permitted a -1 return value from OperatingSystemMXBean CPU time methods.

They need to be stricter, but occasionally Windows 2019 returns a -1 for the first few calls of these methods.  This seems to be a Windows 2019 bug or peculiarity.  Other Windows versions are not affected.

GetProcessCpuLoad.java and GetSystemCpuLoad.java need to fail only if the CPU time calls continually return -1.  They should permit -1 values, as long as subsequently a value in the valid range is read.

GetProcessCpuTime also needs to retry enough times to expect no -1 values.  While here, that test has a maximum expcted value of Long.MAX_VALUE, which it may as well reduce to something that does not look like a binary "all ones except for the high bit" value.
