### PR TITLE
8352490: Fatal error message for unhandled bytecode needs more detail

### DIFF
--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -126,7 +126,7 @@ Bytecodes::Code ciBytecodeStream::next_wide_or_table(Bytecodes::Code bc) {
   }
 
   default:
-    fatal("unhandled bytecode : BCI = %d, OPCODE = %s (0x%X)", cur_bci(), Bytecodes::name(bc), bc);
+    fatal("unhandled bytecode : Current Method = %s, BCI = %d, OPCODE = %s (0x%X)", _method->name()->as_utf8(), cur_bci(), Bytecodes::name(bc), bc);
   }
   return bc;
 }

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -126,7 +126,7 @@ Bytecodes::Code ciBytecodeStream::next_wide_or_table(Bytecodes::Code bc) {
   }
 
   default:
-    fatal("unhandled bytecode");
+    fatal("unhandled bytecode : BCI = %d, OPCODE = %s (0x%X)", cur_bci(), Bytecodes::name(bc), bc);
   }
   return bc;
 }


### PR DESCRIPTION
Description: Improve the error message for unhandled bytecode in `line#129` of function `Bytecodes::Code ciBytecodeStream::next_wide_or_table` in file ciStream.cpp

Solution: The error message is improved to print OPCODE and bytecode index (BCI)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352490](https://bugs.openjdk.org/browse/JDK-8352490): Fatal error message for unhandled bytecode needs more detail (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24187/head:pull/24187` \
`$ git checkout pull/24187`

Update a local copy of the PR: \
`$ git checkout pull/24187` \
`$ git pull https://git.openjdk.org/jdk.git pull/24187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24187`

View PR using the GUI difftool: \
`$ git pr show -t 24187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24187.diff">https://git.openjdk.org/jdk/pull/24187.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24187#issuecomment-2747619161)
</details>
