### PR TITLE
8352689: Allow for hash sum overrides when linking from the run-time image

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JRTArchive.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JRTArchive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Red Hat, Inc.
+ * Copyright (c) 2024, 2025, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Jlink.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Jlink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Jlink.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Jlink.java
@@ -148,7 +148,7 @@ public final class Jlink {
         private final Set<String> modules;
         private final ModuleFinder finder;
         private final boolean linkFromRuntimeImage;
-        private final boolean ignoreModifiedRuntime;
+        private final LinkableRuntimeImage.Config runtimeImageConfig;
         private final boolean generateRuntimeImage;
 
         /**
@@ -162,13 +162,13 @@ public final class Jlink {
                                   Set<String> modules,
                                   ModuleFinder finder,
                                   boolean linkFromRuntimeImage,
-                                  boolean ignoreModifiedRuntime,
+                                  LinkableRuntimeImage.Config runtimeImageConfig,
                                   boolean generateRuntimeImage) {
             this.output = output;
             this.modules = Objects.requireNonNull(modules);
             this.finder = finder;
             this.linkFromRuntimeImage = linkFromRuntimeImage;
-            this.ignoreModifiedRuntime = ignoreModifiedRuntime;
+            this.runtimeImageConfig = runtimeImageConfig;
             this.generateRuntimeImage = generateRuntimeImage;
         }
 
@@ -198,8 +198,8 @@ public final class Jlink {
             return linkFromRuntimeImage;
         }
 
-        public boolean ignoreModifiedRuntime() {
-            return ignoreModifiedRuntime;
+        public LinkableRuntimeImage.Config runtimeImageConfig() {
+            return runtimeImageConfig;
         }
 
         public boolean isGenerateRuntimeImage() {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
@@ -199,12 +199,20 @@ public class JlinkTask {
                     // Only allow a single @file value
                     throw taskHelper.newBadArgs("err.sha.overrides.multiple");
                 }
-                Path file = Paths.get(arg.substring(1));
                 // Ignore non-existing sha overrides file.
                 //
                 // This is to allow for custom builds needing to optionally
                 // support run-time image links on (possibly) modified
                 // binaries/debuginfo files done after the JDK build
+                //
+                // Allow for JAVA_HOME relative paths for the file, by replacing
+                // the ${java.home} token in the file name
+                String fileName = arg.substring(1);
+                if (fileName.startsWith("${java.home}")) {
+                    String javaHome = System.getProperty("java.home");
+                    fileName = javaHome + fileName.substring(12 /* ${java.home}.length() */);
+                }
+                Path file = Paths.get(fileName);
                 if (Files.exists(file)) {
                     try {
                         Files.readAllLines(file).stream()

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/LinkableRuntimeImage.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/LinkableRuntimeImage.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import jdk.tools.jlink.internal.runtimelink.ResourceDiff;
 
@@ -67,7 +69,7 @@ public class LinkableRuntimeImage {
 
     public static Archive newArchive(String module,
                                      Path path,
-                                     boolean ignoreModifiedRuntime,
+                                     Config config,
                                      TaskHelper taskHelper) {
         assert isLinkableRuntime();
         // Here we retrieve the per module difference file, which is
@@ -81,8 +83,15 @@ public class LinkableRuntimeImage {
             throw new AssertionError("Failure to retrieve resource diff for " +
                                      "module " + module, e);
         }
-        return new JRTArchive(module, path, !ignoreModifiedRuntime, perModuleDiff, taskHelper);
+        return new JRTArchive(module,
+                              path,
+                              !config.ignoreModifiedRuntime,
+                              perModuleDiff,
+                              // Empty map if no alternative sha sums
+                              config.altHashSums.computeIfAbsent(module, k -> Map.of()),
+                              taskHelper);
     }
 
-
+    static record Config(boolean ignoreModifiedRuntime,
+                         Map<String, Map<String, Set<String>>> altHashSums) {}
 }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/LinkableRuntimeImage.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/LinkableRuntimeImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Red Hat, Inc.
+ * Copyright (c) 2024, 2025, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
@@ -127,6 +127,12 @@ err.runtime.link.packaged.mods=This JDK has no packaged modules.\
 err.runtime.link.modified.file={0} has been modified
 err.runtime.link.patched.module=jlink does not support linking from the run-time image\
 \ when running on a patched runtime with --patch-module
+
+# Linking from the run-time image, SHA sum handling
+err.sha.overrides.multiple=option --sha-overrides does not allow @file and non-file combinations
+err.sha.overrides.freaderr=Error reading file ''{0}'' passed with option --sha-overrides
+err.sha.overrides.bad.format=Bad format in --sha-overrides. Token was {0}. Expected <module-name>|<file-path>|<sha-sum>
+
 err.no.module.path=--module-path option must be specified with --add-modules ALL-MODULE-PATH
 err.empty.module.path=No module found in module path ''{0}'' with --add-modules ALL-MODULE-PATH
 err.limit.modules=--limit-modules not allowed with --add-modules ALL-MODULE-PATH

--- a/test/jdk/tools/jlink/IntegrationTest.java
+++ b/test/jdk/tools/jlink/IntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jlink/IntegrationTest.java
+++ b/test/jdk/tools/jlink/IntegrationTest.java
@@ -159,7 +159,7 @@ public class IntegrationTest {
                 mods,
                 JlinkTask.limitFinder(JlinkTask.newModuleFinder(modulePaths), limits, mods),
                 linkFromRuntime,
-                false /* ignore modified runtime */,
+                null /* run-time image link config */,
                 false /* generate run-time image */);
 
         List<Plugin> lst = new ArrayList<>();

--- a/test/jdk/tools/jlink/runtimeImage/AddOptionsTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/AddOptionsTest.java
@@ -33,7 +33,6 @@ import tests.Helper;
  * @summary Test --add-options jlink plugin when linking from the run-time image
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/BasicJlinkMissingJavaBase.java
+++ b/test/jdk/tools/jlink/runtimeImage/BasicJlinkMissingJavaBase.java
@@ -34,7 +34,6 @@ import tests.Helper;
  *          but java.xml.jmod present. It should link from the run-time image without errors.
  * @requires (jlink.packagedModules & vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/BasicJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/BasicJlinkTest.java
@@ -32,7 +32,6 @@ import tests.Helper;
  * @summary Test basic linking from the run-time image
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/CustomModuleJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/CustomModuleJlinkTest.java
@@ -32,7 +32,6 @@ import tests.Helper;
  * @summary Test jmod-less jlink with a custom module
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/GenerateJLIClassesTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/GenerateJLIClassesTest.java
@@ -32,7 +32,6 @@ import tests.Helper;
  * @summary Verify JLI class generation in run-time image link mode
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/JavaSEReproducibleTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/JavaSEReproducibleTest.java
@@ -33,7 +33,6 @@ import tests.Helper;
  *          image.
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/KeepPackagedModulesFailTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/KeepPackagedModulesFailTest.java
@@ -34,7 +34,6 @@ import tests.Helper;
  *          --keep-packaged-modules fails as expected.
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesExitTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesExitTest.java
@@ -33,7 +33,6 @@ import tests.Helper;
  *          and files have been modified
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWarningTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWarningTest.java
@@ -32,7 +32,6 @@ import tests.Helper;
  *          image and files have been modified
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWithShaOverrideBase.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWithShaOverrideBase.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
+import tests.Helper;
+
+/*
+ * Base class for sha overrides tests
+ */
+public abstract class ModifiedFilesWithShaOverrideBase extends ModifiedFilesTest {
+
+    protected static final String SHA_OVERRIDE_FLAG = "--sha-overrides";
+
+    @Override
+    protected Path modifyFileInImage(Path jmodLessImg) {
+        try {
+            Path libJVM = jmodLessImg.resolve("lib").resolve("server").resolve(System.mapLibraryName("jvm"));
+            String shaBefore = buildSHA512(libJVM);
+            List<String> objcopy = new ArrayList<>();
+            objcopy.add("objcopy");
+            // The OpenJDK build doesn't strip all symbols by default. In order
+            // to get a different libjvm.so file, we strip everything. The
+            // expectation is for the sha to be different before and after the
+            // stripping of the file.
+            objcopy.add("--strip-all");
+            objcopy.add(libJVM.toString());
+            ProcessBuilder builder = new ProcessBuilder(objcopy);
+            Process p = builder.start();
+            int returnVal = p.waitFor();
+            if (returnVal != 0) {
+                throw new SkippedException("Stripping of libjvm failed. Is objcopy installed?");
+            }
+            String shaAfter = buildSHA512(libJVM);
+            if (shaBefore.equals(shaAfter)) {
+                throw new SkippedException("Binary file would be the same before after - test skipped");
+            }
+            return libJVM;
+        } catch (IOException | InterruptedException e) {
+            throw new SkippedException("Stripping of libjvm failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    void testAndAssert(Path modifiedFile, Helper helper, Path initialImage) throws Exception {
+        String extraJlinkOption = getShaOverrideOption(modifiedFile, initialImage);
+        CapturingHandler handler = new CapturingHandler();
+        jlinkUsingImage(new JlinkSpecBuilder()
+                                .helper(helper)
+                                .imagePath(initialImage)
+                                .name(getTargetName())
+                                .addModule("java.base")
+                                .validatingModule("java.base")
+                                .extraJlinkOpt(extraJlinkOption) // allow for the modified sha
+                                .build(), handler);
+        OutputAnalyzer out = handler.analyzer();
+        // verify we don't get a warning message for the modified file
+        out.stdoutShouldNotMatch(".* has been modified");
+        out.stdoutShouldNotContain("java.lang.IllegalArgumentException");
+        out.stdoutShouldNotContain("IOException");
+    }
+
+    public abstract String getTargetName();
+    public abstract String getShaOverrideOption(Path modifiedFile, Path initialImage);
+
+    protected String buildSHA512(Path modifiedFile) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-512");
+            try (InputStream is = Files.newInputStream(modifiedFile)) {
+                byte[] buf = new byte[1024];
+                int readBytes = -1;
+                while ((readBytes = is.read(buf)) != -1) {
+                    digest.update(buf, 0, readBytes);
+                }
+            }
+            byte[] actual = digest.digest();
+            return HexFormat.of().formatHex(actual);
+        } catch (Exception e) {
+            throw new AssertionError("SHA-512 sum generation failed");
+        }
+    }
+}

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWithShaOverrideFileTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWithShaOverrideFileTest.java
@@ -33,7 +33,6 @@ import java.nio.file.Path;
  *          gets the SHA override from a file
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g & os.family == "linux")
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWithShaOverrideTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWithShaOverrideTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
+import tests.Helper;
+
+/*
+ * @test
+ * @summary Verify no warnings are being produced on a modified file which
+ *          gets the SHA override from CLI/file
+ * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g & os.family == "linux")
+ * @library ../../lib /test/lib
+ * @enablePreview
+ * @modules java.base/jdk.internal.jimage
+ *          jdk.jlink/jdk.tools.jlink.internal
+ *          jdk.jlink/jdk.tools.jlink.plugin
+ *          jdk.jlink/jdk.tools.jimage
+ * @build tests.* jdk.test.lib.process.OutputAnalyzer
+ *        jdk.test.lib.process.ProcessTools
+ * @run main/othervm -Xmx1g ModifiedFilesWithShaOverrideTest
+ */
+public class ModifiedFilesWithShaOverrideTest extends ModifiedFilesTest {
+
+    private static final String SHA_OVERRIDE_FLAG = "--sha-overrides";
+
+    public static void main(String[] args) throws Exception {
+        ModifiedFilesWithShaOverrideTest test = new ModifiedFilesWithShaOverrideTest();
+        test.run();
+    }
+
+    @Override
+    String initialImageName() {
+        return "java-base-jlink-with-sha-override";
+    }
+
+    @Override
+    protected Path modifyFileInImage(Path jmodLessImg) {
+        try {
+            Path libJVM = jmodLessImg.resolve("lib").resolve("server").resolve(System.mapLibraryName("jvm"));
+            String shaBefore = buildSHA512(libJVM);
+            List<String> objcopy = new ArrayList<>();
+            objcopy.add("objcopy");
+            // The OpenJDK build doesn't strip all symbols by default. In order
+            // to get a different libjvm.so file, we strip everything. The
+            // expectation is for the sha to be different before and after the
+            // stripping of the file.
+            objcopy.add("--strip-all");
+            objcopy.add(libJVM.toString());
+            ProcessBuilder builder = new ProcessBuilder(objcopy);
+            Process p = builder.start();
+            int returnVal = p.waitFor();
+            if (returnVal != 0) {
+                throw new SkippedException("Stripping of libjvm failed. Is objcopy installed?");
+            }
+            String shaAfter = buildSHA512(libJVM);
+            if (shaBefore.equals(shaAfter)) {
+                throw new SkippedException("Binary file would be the same before after - test skipped");
+            }
+            return libJVM;
+        } catch (IOException | InterruptedException e) {
+            throw new SkippedException("Stripping of libjvm failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    void testAndAssert(Path modifiedFile, Helper helper, Path initialImage) throws Exception {
+        String strippedSha = buildSHA512(modifiedFile);
+        Path relativePath = initialImage.relativize(modifiedFile);
+        String overrideVal = String.format("%s|%s|%s", "java.base", relativePath.toString(), strippedSha);
+        String extraJlinkOpt = SHA_OVERRIDE_FLAG + "=" + overrideVal;
+        CapturingHandler handler = new CapturingHandler();
+        jlinkUsingImage(new JlinkSpecBuilder()
+                                .helper(helper)
+                                .imagePath(initialImage)
+                                .name("java-base-jlink-with-sha-override-target")
+                                .addModule("java.base")
+                                .validatingModule("java.base")
+                                .extraJlinkOpt(extraJlinkOpt) // allow for the modified sha
+                                .build(), handler);
+        OutputAnalyzer out = handler.analyzer();
+        // verify we don't get a warning message for the modified file
+        out.stdoutShouldNotMatch(".* has been modified");
+        out.stdoutShouldNotContain("java.lang.IllegalArgumentException");
+        out.stdoutShouldNotContain("IOException");
+    }
+
+    private String buildSHA512(Path modifiedFile) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-512");
+            try (InputStream is = Files.newInputStream(modifiedFile)) {
+                byte[] buf = new byte[1024];
+                int readBytes = -1;
+                while ((readBytes = is.read(buf)) != -1) {
+                    digest.update(buf, 0, readBytes);
+                }
+            }
+            byte[] actual = digest.digest();
+            return HexFormat.of().formatHex(actual);
+        } catch (Exception e) {
+            throw new AssertionError("SHA-512 sum generation failed");
+        }
+    }
+}

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWithShaOverrideTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWithShaOverrideTest.java
@@ -29,7 +29,6 @@ import java.nio.file.Path;
  *          gets the SHA override from command line
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g & os.family == "linux")
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/MultiHopTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/MultiHopTest.java
@@ -33,7 +33,6 @@ import tests.Helper;
  * @summary Verify that a jlink using the run-time image cannot include jdk.jlink
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java
@@ -42,7 +42,6 @@ import tests.JImageGenerator;
  *          produce the same result
  * @requires (jlink.packagedModules & vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/PatchedJDKModuleJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/PatchedJDKModuleJlinkTest.java
@@ -35,7 +35,6 @@ import tests.Helper;
  * @summary Test run-time link with --patch-module. Expect failure.
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/SystemModulesTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/SystemModulesTest.java
@@ -34,7 +34,6 @@ import tests.JImageValidator;
  * @summary Test appropriate handling of generated SystemModules* classes in run-time image link mode
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/runtimeImage/SystemModulesTest2.java
+++ b/test/jdk/tools/jlink/runtimeImage/SystemModulesTest2.java
@@ -35,7 +35,6 @@ import tests.JImageValidator;
  *          generated classes to not be there.
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib /test/lib
- * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin


### PR DESCRIPTION
Please review this enhancement which adds a hidden `jlink` option `--sha-overrides` that can be used to provide alternative hash sums for files in an image. Please see the bug for use-cases as to why this is needed. This patch allows for the `--sha-overrides` option to be either specified multiple times or separated by a comma to list multiple hash sum overrides. Alternatively when starting with the `@` character the override options come from a file. The format is the same: `<module>|<file-path>|<sha>` triplets, either on the command line or in a file (one per line).

The added, linux only, test uses `objcopy` to fully strip `libjvm.so` of its symbols with the assumption that this would change the hash sum of the resulting file. Then, a link from the run-time image is being attempted with the added option `--sha-overrides=java.base|lib/server/libjvm.so|<new-sha-sum>` and verifies the link succeeds.

Having something like that is useful when it gets combined with e.g. `--save-jlink-arg-files` to produce a `jlink` which works out of the box on say JDK builds that modify binaries due to some debug symbols handling outside the JDK builds' control. 

While using `--ignore-modified-runtime` is an option that is sub-optimal as that would spit out many warnings in the RPM build case, where the user wouldn't control that RPM build to begin with.

Testing:
- [x] GHA
- [x] Some manual tests together with [JDK-8352692](https://bugs.openjdk.org/browse/JDK-8352692) on some JEP 493 enabled builds.
- [x] `jlink` jtreg tests.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8352689](https://bugs.openjdk.org/browse/JDK-8352689): Allow for hash sum overrides when linking from the run-time image (**Enhancement** - P3) ⚠️ Issue is not open.


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) 🔄 Re-review required (review applies to [e387bd64](https://git.openjdk.org/jdk/pull/24190/files/e387bd6481be9edd4d2003679d175005aab123ea))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24190/head:pull/24190` \
`$ git checkout pull/24190`

Update a local copy of the PR: \
`$ git checkout pull/24190` \
`$ git pull https://git.openjdk.org/jdk.git pull/24190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24190`

View PR using the GUI difftool: \
`$ git pr show -t 24190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24190.diff">https://git.openjdk.org/jdk/pull/24190.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24190#issuecomment-2747749005)
</details>
