### PR TITLE
8352706: httpclient HeadTest does not run on HTTP2

### DIFF
--- a/test/jdk/java/net/httpclient/HeadTest.java
+++ b/test/jdk/java/net/httpclient/HeadTest.java
@@ -86,22 +86,21 @@ public class HeadTest implements HttpServerAdapters {
     @DataProvider(name = "positive")
     public Object[][] positive() {
         return new Object[][] {
+                // HTTP/1.1
                 { httpURI, "GET", HTTP_NOT_MODIFIED, HTTP_1_1  },
                 { httpsURI, "GET", HTTP_NOT_MODIFIED, HTTP_1_1  },
-                { httpURI, "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_2  },
-                { httpsURI, "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_2  },
                 { httpURI, "HEAD", HTTP_OK, HTTP_1_1  },
                 { httpsURI, "HEAD", HTTP_OK, HTTP_1_1  },
-                { httpURI, "HEAD", HTTP_OK, HttpClient.Version.HTTP_2  },
-                { httpsURI, "HEAD", HTTP_OK, HttpClient.Version.HTTP_2  },
                 { httpURI + "transfer/", "GET", HTTP_NOT_MODIFIED, HTTP_1_1  },
                 { httpsURI + "transfer/", "GET", HTTP_NOT_MODIFIED, HTTP_1_1  },
-                { httpURI + "transfer/", "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_2  },
-                { httpsURI + "transfer/", "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_2  },
                 { httpURI + "transfer/", "HEAD", HTTP_OK, HTTP_1_1  },
                 { httpsURI + "transfer/", "HEAD", HTTP_OK, HTTP_1_1  },
-                { httpURI + "transfer/", "HEAD", HTTP_OK, HttpClient.Version.HTTP_2  },
-                { httpsURI + "transfer/", "HEAD", HTTP_OK, HttpClient.Version.HTTP_2  }
+                // HTTP/2
+                { http2URI, "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_2  },
+                { https2URI, "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_2  },
+                { http2URI, "HEAD", HTTP_OK, HttpClient.Version.HTTP_2  },
+                { https2URI, "HEAD", HTTP_OK, HttpClient.Version.HTTP_2  },
+                // HTTP2 forbids transfer-encoding
         };
     }
 
@@ -112,17 +111,13 @@ public class HeadTest implements HttpServerAdapters {
         URI uri = URI.create(uriString);
         HttpRequest.Builder requestBuilder = HttpRequest
                 .newBuilder(uri)
+                .version(version)
                 .method(method, HttpRequest.BodyPublishers.noBody());
-        if (version != null) {
-            requestBuilder.version(version);
-        }
         doTest(requestBuilder.build(), expResp);
         // repeat the test this time by building the request using convenience
         // GET and HEAD methods
-        requestBuilder = HttpRequest.newBuilder(uri);
-        if (version != null) {
-            requestBuilder.version(version);
-        }
+        requestBuilder = HttpRequest.newBuilder(uri)
+                .version(version);
         switch (method) {
             case "GET" -> requestBuilder.GET();
             case "HEAD" -> requestBuilder.HEAD();
@@ -146,6 +141,7 @@ public class HeadTest implements HttpServerAdapters {
         assertEquals(response.statusCode(), expResp);
         assertEquals(response.body(), "");
         assertEquals(response.headers().firstValue("Content-length").get(), CONTENT_LEN);
+        assertEquals(response.version(), request.version().get());
     }
 
     // -- Infrastructure
@@ -168,7 +164,7 @@ public class HeadTest implements HttpServerAdapters {
         http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new HeadHandler(), "/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/";
-        https2TestServer = HttpTestServer.create(HTTP_2, SSLContext.getDefault());
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new HeadHandler(), "/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/";
 


### PR DESCRIPTION
The test was using incorrect URIs for testing, and as a result, the test was never run on HTTP2. Additionally, the HTTP2 test server was using an unconfigured SSLContext, and HTTPS was not usable. Both issues are fixed.

The test continues to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8352706: httpclient HeadTest does not run on HTTP2`

### Issue
 * [JDK-8352706](https://bugs.openjdk.org/browse/JDK-8352706): httpclient HeadTest does not run on HTTP2 (**Bug** - P4)


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Contributors
 * Daniel Fuchs `<dfuchs@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24191/head:pull/24191` \
`$ git checkout pull/24191`

Update a local copy of the PR: \
`$ git checkout pull/24191` \
`$ git pull https://git.openjdk.org/jdk.git pull/24191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24191`

View PR using the GUI difftool: \
`$ git pr show -t 24191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24191.diff">https://git.openjdk.org/jdk/pull/24191.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24191#issuecomment-2747829743)
</details>
