### PR TITLE
8352696: JFR: assert(false): EA: missing memory path

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3173,11 +3173,7 @@ bool LibraryCallKit::inline_native_jvm_commit() {
   Node* next_pos_X = _gvn.transform(ConvL2X(arg));
 
   // Store the next_position to the underlying jfr java buffer.
-#ifdef _LP64
-  store_to_memory(control(), java_buffer_pos_offset, next_pos_X, T_LONG, MemNode::release);
-#else
-  store_to_memory(control(), java_buffer_pos_offset, next_pos_X, T_INT, MemNode::release);
-#endif
+  store_to_memory(control(), java_buffer_pos_offset, next_pos_X, LP64_ONLY(T_LONG) NOT_LP64(T_INT), MemNode::release);
 
   Node* commit_memory = reset_memory();
   set_all_memory(commit_memory);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3154,7 +3154,8 @@ bool LibraryCallKit::inline_native_jvm_commit() {
   set_control(is_notified);
 
   // Reset notified state.
-  Node* notified_reset_memory = store_to_memory(control(), notified_offset, _gvn.intcon(0), T_BOOLEAN, MemNode::unordered);
+  store_to_memory(control(), notified_offset, _gvn.intcon(0), T_BOOLEAN, MemNode::unordered);
+  Node* notified_reset_memory = reset_memory();
 
   // Iff notified, the return address of the commit method is the current position of the backing java buffer. This is used to reset the event writer.
   Node* current_pos_X = _gvn.transform(new LoadXNode(control(), input_memory_state, java_buffer_pos_offset, TypeRawPtr::NOTNULL, TypeX_X, MemNode::unordered));
@@ -3172,12 +3173,14 @@ bool LibraryCallKit::inline_native_jvm_commit() {
   Node* next_pos_X = _gvn.transform(ConvL2X(arg));
 
   // Store the next_position to the underlying jfr java buffer.
-  Node* commit_memory;
 #ifdef _LP64
-  commit_memory = store_to_memory(control(), java_buffer_pos_offset, next_pos_X, T_LONG, MemNode::release);
+  store_to_memory(control(), java_buffer_pos_offset, next_pos_X, T_LONG, MemNode::release);
 #else
-  commit_memory = store_to_memory(control(), java_buffer_pos_offset, next_pos_X, T_INT, MemNode::release);
+  store_to_memory(control(), java_buffer_pos_offset, next_pos_X, T_INT, MemNode::release);
 #endif
+
+  Node* commit_memory = reset_memory();
+  set_all_memory(commit_memory);
 
   // Now load the flags from off the java buffer and decide if the buffer is a lease. If so, it needs to be returned post-commit.
   Node* java_buffer_flags_offset = _gvn.transform(new AddPNode(top(), java_buffer, _gvn.transform(MakeConX(in_bytes(JFR_BUFFER_FLAGS_OFFSET)))));

--- a/test/jdk/jdk/jfr/jvm/TestJvmCommitIntrinsicAndEA.java
+++ b/test/jdk/jdk/jfr/jvm/TestJvmCommitIntrinsicAndEA.java
@@ -75,8 +75,7 @@ import jdk.test.lib.jfr.Events;
 /**
  * @test
  * @bug 8352696
- * @requires vm.flagless
- * @requires vm.hasJFR & vm.debug
+ * @requires vm.flagless & vm.hasJFR & vm.debug
  * @library /test/lib /test/jdk
  * @run main/othervm jdk.jfr.jvm.TestJvmCommitIntrinsicAndEA
  */

--- a/test/jdk/jdk/jfr/jvm/TestJvmCommitIntrinsicAndEA.java
+++ b/test/jdk/jdk/jfr/jvm/TestJvmCommitIntrinsicAndEA.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jvm;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import jdk.jfr.EventType;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.jfr.Events;
+
+/**
+ *
+ * A successful execution is when the JTREG test executes successfully,
+ * i.e., with no exceptions or JVM asserts.
+ *
+ * In JVM debug builds, C2 will assert as part of EscapeAnalysis and dump an hs_err<pid>.log:
+ *
+ * #
+ * # A fatal error has been detected by the Java Runtime Environment:
+ * #
+ * # Internal Error (..\open\src\hotspot\share\opto\escape.cpp:4788)
+ * # assert(false) failed: EA: missing memory path
+ *
+ * Current thread JavaThread "C2 CompilerThread2"
+ * Current CompileTask:
+ * C2:27036 1966 ! 4   java.lang.VirtualThread::run (173 bytes)
+ *
+ * ConnectionGraph::split_unique_types+0x2409 (escape.cpp:4788)
+ * ConnectionGraph::compute_escape+0x11e6 (escape.cpp:397)
+ * ConnectionGraph::do_analysis+0xf2 (escape.cpp:118)
+ * Compile::Optimize+0x85d (compile.cpp:2381)
+ * ...
+ *
+ * The error is because C2's Escape Analysis does not recognize a pattern
+ * where one input of memory Phi node is MergeMem node, and another is RAW store.
+ * This pattern is created by the jdk.jfr.internal.JVM.commit() intrinsic,
+ * which is inlined because of inlining the JFR event jdk.VirtualThreadStart.
+ *
+ * As a result, EA complains about a strange memory graph.
+ */
+
+/**
+ * @test
+ * @bug 8352696
+ * @requires vm.flagless
+ * @requires vm.hasJFR & vm.debug
+ * @library /test/lib /test/jdk
+ * @run main/othervm jdk.jfr.jvm.TestJvmCommitIntrinsicAndEA
+ */
+public final class TestJvmCommitIntrinsicAndEA {
+
+     public static void main(String[] args) throws Throwable {
+         try (Recording recording = new Recording()) {
+            recording.enable(EventNames.VirtualThreadStart).withoutStackTrace();
+            recording.enable(EventNames.VirtualThreadEnd).withoutStackTrace();
+            recording.start();
+            // execute 10_000 tasks, each in their own virtual thread
+            ThreadFactory factory = Thread.ofVirtual().factory();
+            try (var executor = Executors.newThreadPerTaskExecutor(factory)) {
+                for (int i = 0; i < 10_000; i++) {
+                    executor.submit(() -> { });
+                }
+            } finally {
+                recording.stop();
+            }
+
+            Map<String, Integer> events = sumEvents(recording);
+            System.err.println(events);
+
+            int startCount = events.getOrDefault(EventNames.VirtualThreadStart, 0);
+            int endCount = events.getOrDefault(EventNames.VirtualThreadEnd, 0);
+            Asserts.assertEquals(10_000, startCount, "Expected 10000, got " + startCount);
+            Asserts.assertEquals(10_000, endCount, "Expected 10000, got " + endCount);
+        }
+    }
+
+    private static Map<String, Integer> sumEvents(Recording recording) throws Exception {
+        List<RecordedEvent> events = Events.fromRecording(recording);
+        return events.stream()
+                    .map(RecordedEvent::getEventType)
+                    .collect(Collectors.groupingBy(EventType::getName,
+                                                   Collectors.summingInt(x -> 1)));
+    }
+}

--- a/test/jdk/jdk/jfr/jvm/TestJvmCommitIntrinsicAndEA.java
+++ b/test/jdk/jdk/jfr/jvm/TestJvmCommitIntrinsicAndEA.java
@@ -77,7 +77,7 @@ import jdk.test.lib.jfr.Events;
  * @bug 8352696
  * @requires vm.flagless & vm.hasJFR & vm.debug
  * @library /test/lib /test/jdk
- * @run main/othervm jdk.jfr.jvm.TestJvmCommitIntrinsicAndEA
+ * @run main/othervm -Xbatch jdk.jfr.jvm.TestJvmCommitIntrinsicAndEA
  */
 public final class TestJvmCommitIntrinsicAndEA {
 

--- a/test/jdk/jdk/jfr/jvm/TestJvmCommitIntrinsicAndEA.java
+++ b/test/jdk/jdk/jfr/jvm/TestJvmCommitIntrinsicAndEA.java
@@ -82,8 +82,8 @@ import jdk.test.lib.jfr.Events;
  */
 public final class TestJvmCommitIntrinsicAndEA {
 
-     public static void main(String[] args) throws Throwable {
-         try (Recording recording = new Recording()) {
+    public static void main(String[] args) throws Throwable {
+        try (Recording recording = new Recording()) {
             recording.enable(EventNames.VirtualThreadStart).withoutStackTrace();
             recording.enable(EventNames.VirtualThreadEnd).withoutStackTrace();
             recording.start();
@@ -109,9 +109,7 @@ public final class TestJvmCommitIntrinsicAndEA {
 
     private static Map<String, Integer> sumEvents(Recording recording) throws Exception {
         List<RecordedEvent> events = Events.fromRecording(recording);
-        return events.stream()
-                    .map(RecordedEvent::getEventType)
-                    .collect(Collectors.groupingBy(EventType::getName,
-                                                   Collectors.summingInt(x -> 1)));
+        return events.stream().map(RecordedEvent::getEventType)
+                               .collect(Collectors.groupingBy(EventType::getName, Collectors.summingInt(x -> 1)));
     }
 }


### PR DESCRIPTION
Greetings,

In debug builds, we can sometimes assert because C2's Escape Analysis does not recognize a pattern where one input of memory Phi node is a MergeMem node, and another is a RAW store.

This pattern is created by the jdk.jfr.internal.JVM.commit() intrinsic, which is inlined because of inlining JFR events, for example jdk.VirtualThreadStart.

As a result, EA complains about a strange memory graph. 

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352696](https://bugs.openjdk.org/browse/JDK-8352696): JFR: assert(false): EA: missing memory path (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [c63fb608](https://git.openjdk.org/jdk/pull/24192/files/c63fb60891bce8f787df63a31f19bc0d8a89d210)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24192/head:pull/24192` \
`$ git checkout pull/24192`

Update a local copy of the PR: \
`$ git checkout pull/24192` \
`$ git pull https://git.openjdk.org/jdk.git pull/24192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24192`

View PR using the GUI difftool: \
`$ git pr show -t 24192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24192.diff">https://git.openjdk.org/jdk/pull/24192.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24192#issuecomment-2747842683)
</details>
