### PR TITLE
8352709: Remove bad timing annotations from WhileOpTest.java

### DIFF
--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,6 @@ import java.util.stream.TestData;
 /*
  * @test
  * @bug 8071597 8193856
- * @run main/timeout=240
  */
 @Test
 public class WhileOpTest extends OpTestCase {


### PR DESCRIPTION
WhileOpTest.java is a TestNG test (`TestNG.dirs` is set in Find file: `test/jdk/java/util/stream/test/TEST.properties`)

As such, the `@run main/timeout=240` annotation is ignored. If that was not the case, it would complain about not specifying a main class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352709](https://bugs.openjdk.org/browse/JDK-8352709): Remove bad timing annotations from WhileOpTest.java (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24193/head:pull/24193` \
`$ git checkout pull/24193`

Update a local copy of the PR: \
`$ git checkout pull/24193` \
`$ git pull https://git.openjdk.org/jdk.git pull/24193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24193`

View PR using the GUI difftool: \
`$ git pr show -t 24193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24193.diff">https://git.openjdk.org/jdk/pull/24193.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24193#issuecomment-2747948837)
</details>
