### PR TITLE
8352719: Add an equals sign to the modules statement

### DIFF
--- a/test/jdk/sun/security/krb5/auto/TEST.properties
+++ b/test/jdk/sun/security/krb5/auto/TEST.properties
@@ -1,12 +1,12 @@
-modules java.base/jdk.internal.misc \
-        java.base/sun.security.util \
-        java.security.jgss/sun.security.jgss \
-        java.security.jgss/sun.security.jgss.krb5 \
-        java.security.jgss/sun.security.krb5:+open \
-        java.security.jgss/sun.security.krb5.internal:+open \
-        java.security.jgss/sun.security.krb5.internal.ccache \
-        java.security.jgss/sun.security.krb5.internal.rcache \
-        java.security.jgss/sun.security.krb5.internal.crypto \
-        java.security.jgss/sun.security.krb5.internal.ktab \
-        jdk.security.auth \
-        jdk.security.jgss
+modules = java.base/jdk.internal.misc \
+          java.base/sun.security.util \
+          java.security.jgss/sun.security.jgss \
+          java.security.jgss/sun.security.jgss.krb5 \
+          java.security.jgss/sun.security.krb5:+open \
+          java.security.jgss/sun.security.krb5.internal:+open \
+          java.security.jgss/sun.security.krb5.internal.ccache \
+          java.security.jgss/sun.security.krb5.internal.rcache \
+          java.security.jgss/sun.security.krb5.internal.crypto \
+          java.security.jgss/sun.security.krb5.internal.ktab \
+          jdk.security.auth \
+          jdk.security.jgss


### PR DESCRIPTION
krb5/auto/TEST.properties: add an equals sign to the modules statement (this is the only `TEST.properties` file that uses this undocumented feature) .

compare:
```
find -name "TEST.properties" | xargs grep 'modules.*java' 
find -name "TEST.properties" | xargs grep 'modules.*java' | grep -v =
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352719](https://bugs.openjdk.org/browse/JDK-8352719): Add an equals sign to the modules statement (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24194/head:pull/24194` \
`$ git checkout pull/24194`

Update a local copy of the PR: \
`$ git checkout pull/24194` \
`$ git pull https://git.openjdk.org/jdk.git pull/24194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24194`

View PR using the GUI difftool: \
`$ git pr show -t 24194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24194.diff">https://git.openjdk.org/jdk/pull/24194.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24194#issuecomment-2747987338)
</details>
