### PR TITLE
8350705: [JMH] test security.SSLHandshake failed for 2 threads configuration

### DIFF
--- a/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
+++ b/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,6 @@ public class SSLHandshake {
                     KeyManagerFactory.getDefaultAlgorithm());
             kmf.init(ks, new char[0]);
 
-            // server context will be set by every thread; last one wins
             SSLContext sslCtx = SSLContext.getInstance("TLS");
             sslCtx.init(kmf.getKeyManagers(), null, null);
             return sslCtx;
@@ -103,7 +102,6 @@ public class SSLHandshake {
                 TrustManagerFactory.getDefaultAlgorithm());
         tmf.init(ts);
 
-        // server context will be set by every thread; last one wins
         SSLContext sslCtx = SSLContext.getInstance(tlsVersion);
         sslCtx.init(null, tmf.getTrustManagers(), null);
         sslClientCtx = sslCtx;


### PR DESCRIPTION
Update the SSLHandshake benchmark to enable running in multiple threads.

This PR changes the scope of the state from per-benchmark to per-thread. The server SSLContext is still shared across all threads to simulate the scenario where multiple clients try to connect to the same server at the same time.

Before the change, running this benchmark with `make test TEST=micro:SSLHandshake MICRO=OPTIONS="-t 3"` failed with an exception. After this change the benchmark completes successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350705](https://bugs.openjdk.org/browse/JDK-8350705): [JMH] test security.SSLHandshake failed for 2 threads configuration (**Enhancement** - P4)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24195/head:pull/24195` \
`$ git checkout pull/24195`

Update a local copy of the PR: \
`$ git checkout pull/24195` \
`$ git pull https://git.openjdk.org/jdk.git pull/24195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24195`

View PR using the GUI difftool: \
`$ git pr show -t 24195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24195.diff">https://git.openjdk.org/jdk/pull/24195.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24195#issuecomment-2748052969)
</details>
