### PR TITLE
8352141: UBSAN: fix the left shift of negative value in relocInfo.cpp, internal_word_Relocation::pack_data_to()

### DIFF
--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -508,7 +508,7 @@ void internal_word_Relocation::pack_data_to(CodeSection* dest) {
     jint offset = scaled_offset(_target, base);
     assert((uint)sindex < (uint)CodeBuffer::SECT_LIMIT, "sanity");
     assert(CodeBuffer::SECT_LIMIT <= (1 << section_width), "section_width++");
-    p = pack_1_int_to(p, (offset << section_width) | sindex);
+    p = pack_1_int_to(p, (java_shift_left(offset, section_width)) | sindex);
   }
 
   dest->set_locs_end((relocInfo*) p);


### PR DESCRIPTION
The `offset` variable used in left-shift op can be a large number with its sign-bit set. This makes a negative value which is UB for left-shift and is reported as 
`runtime error: left shift of negative value -25 at relocInfo.cpp:...`
 
Using `java_left_shif()` function is the workaround to avoid UB. This function uses reinterpret_cast to cast from signed to unsigned and back.

Tests:
linux-x64-debug tier1 on a UBSAN enabled build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352141](https://bugs.openjdk.org/browse/JDK-8352141): UBSAN: fix the left shift of negative value in relocInfo.cpp, internal_word_Relocation::pack_data_to() (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24196/head:pull/24196` \
`$ git checkout pull/24196`

Update a local copy of the PR: \
`$ git checkout pull/24196` \
`$ git pull https://git.openjdk.org/jdk.git pull/24196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24196`

View PR using the GUI difftool: \
`$ git pr show -t 24196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24196.diff">https://git.openjdk.org/jdk/pull/24196.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24196#issuecomment-2748153989)
</details>
