### PR TITLE
8343618: Stack smashing in awt_InputMethod.c on Linux s390x

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_InputMethod.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_InputMethod.c
@@ -1618,14 +1618,14 @@ JNIEXPORT jboolean JNICALL Java_sun_awt_X11InputMethodBase_setCompositionEnabled
     if (NULL != pX11IMData->statusWindow) {
         Window focus = 0;
         int revert_to;
-#if defined(_LP64) && !defined(_LITTLE_ENDIAN)
-        // The Window value which is used for XGetICValues must be 32bit on BigEndian XOrg's xlib
-        unsigned int w = 0;
-#else
         Window w = 0;
-#endif
         XGetInputFocus(awt_display, &focus, &revert_to);
         XGetICValues(pX11IMData->current_ic, XNFocusWindow, &w, NULL);
+#if defined(_LP64) && !defined(_LITTLE_ENDIAN)
+        // On 64bit BigEndian,
+        // Window value may be stored on high 32bit by XGetICValues via XIM
+        if (w > 0xffffffffUL) w = w >> 32;
+#endif
         if (RevertToPointerRoot == revert_to
                 && pX11IMData->ic_active != pX11IMData->ic_passive) {
             if (pX11IMData->current_ic == pX11IMData->ic_active) {
@@ -1674,12 +1674,7 @@ JNIEXPORT jboolean JNICALL Java_sun_awt_X11InputMethodBase_isCompositionEnabledN
 {
     X11InputMethodData *pX11IMData = NULL;
     char * ret = NULL;
-#if defined(__linux__) && defined(_LP64) && !defined(_LITTLE_ENDIAN)
-    // XIMPreeditState value which is used for XGetICValues must be 32bit on BigEndian XOrg's xlib
-    unsigned int state = XIMPreeditUnKnown;
-#else
     XIMPreeditState state = XIMPreeditUnKnown;
-#endif
 
     XVaNestedList   pr_atrb;
 
@@ -1695,6 +1690,11 @@ JNIEXPORT jboolean JNICALL Java_sun_awt_X11InputMethodBase_isCompositionEnabledN
     ret = XGetICValues(pX11IMData->current_ic, XNPreeditAttributes, pr_atrb, NULL);
     XFree((void *)pr_atrb);
     AWT_UNLOCK();
+#if defined(__linux__) && defined(_LP64) && !defined(_LITTLE_ENDIAN)
+    // On 64bit BigEndian,
+    // XIMPreeditState value may be stored on high 32bit by XGetICValues via XIM
+    if (state > 0xffffffffUL) state = state >> 32;
+#endif
 
     if ((ret != 0)
             && ((strcmp(ret, XNPreeditAttributes) == 0)


### PR DESCRIPTION
This fixes stack smashing issue in awt library on linux s390x. (jdk compiled with `-fstack-protector-strong`)

Fix is based on patch [submitted](https://mail.openjdk.org/pipermail/awt-dev/2019-July/015337.html) in JDK-8227919 review thread, rebased to master. They decided to go for Solaris only fix there, with [expected follow-up](https://mail.openjdk.org/pipermail/awt-dev/2019-July/015347.html) for linux/s390x. But that never happened.

I was not able to get response from original author for this issue, so I am creating PR myself.

**Testing:**
I tested jdk with and without this fix on linux/s390x (using Xvfb). It fixes the issue (reproducer for this bug no longer crashes the JVM). I have also tried to run `jdk_awt` tests, where lot of tests was also affected by this. With this patch amount of failures dropped by ~100. 

Without fix:
```
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
>> jtreg:test/jdk:jdk_awt                             2171  1063   415     6   687 <<
```

With fix
```
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
>> jtreg:test/jdk:jdk_awt                             2171  1162   316     6   687 <<
```

Many tests are no longer crashing the VM:
```
-java/awt/Choice/ChoiceKeyEventReaction/ChoiceKeyEventReaction.java                                                      Failed. Unexpected exit from test [exit code: 134]
+java/awt/Choice/ChoiceKeyEventReaction/ChoiceKeyEventReaction.java                                                      Passed. Execution successful
```
There seem to be few unstable tests in jdk_awt. (Ones that fail in one or another run, but seem unrelated to this fix)

I have not done any additional manual testing of XIM as did original author (in review thread mentioned higher), as I am not at all familiar with input method for Japanese (or other Asian characters), or how that supposed to work. (So I cannot verify that input of Asian characters works as expected on linux/s390x, but at least JVM no longer crashes.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343618](https://bugs.openjdk.org/browse/JDK-8343618): Stack smashing in awt_InputMethod.c on Linux s390x (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Contributors
 * Ichiroh Takiguchi `<itakiguchi@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24197/head:pull/24197` \
`$ git checkout pull/24197`

Update a local copy of the PR: \
`$ git checkout pull/24197` \
`$ git pull https://git.openjdk.org/jdk.git pull/24197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24197`

View PR using the GUI difftool: \
`$ git pr show -t 24197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24197.diff">https://git.openjdk.org/jdk/pull/24197.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24197#issuecomment-2748189627)
</details>
