### PR TITLE
8350429: runtime/NMT/CheckForProperDetailStackTrace.java should only run for debug JVM

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/CheckForProperDetailStackTrace.java
+++ b/test/hotspot/jtreg/runtime/NMT/CheckForProperDetailStackTrace.java
@@ -28,6 +28,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @requires vm.debug
  * @compile ../modules/CompilerUtils.java
  * @run driver CheckForProperDetailStackTrace
  */


### PR DESCRIPTION
runtime/NMT/CheckForProperDetailStackTrace.java should only run for debug JVM

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350429](https://bugs.openjdk.org/browse/JDK-8350429): runtime/NMT/CheckForProperDetailStackTrace.java should only run for debug JVM (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24198/head:pull/24198` \
`$ git checkout pull/24198`

Update a local copy of the PR: \
`$ git checkout pull/24198` \
`$ git pull https://git.openjdk.org/jdk.git pull/24198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24198`

View PR using the GUI difftool: \
`$ git pr show -t 24198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24198.diff">https://git.openjdk.org/jdk/pull/24198.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24198#issuecomment-2748283211)
</details>
