### PR TITLE
8351332: Line breaks in search tag descriptions corrupt JSON search index

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1890,7 +1890,7 @@ public abstract class HtmlDocletWriter {
         }
         // Generate index item
         if (!headingContent.isEmpty() && configuration.indexBuilder != null) {
-            String tagText = headingContent.replaceAll("\\s+", " ");
+            String tagText = utils.normalizeWhitespace(headingContent);
             IndexItem item = IndexItem.of(element, node, tagText,
                     getTagletWriterInstance(context).getHolderName(element),
                     "",

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/IndexTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/IndexTaglet.java
@@ -58,10 +58,10 @@ public class IndexTaglet extends BaseTaglet {
         if (tagText.charAt(0) == '"' && tagText.charAt(tagText.length() - 1) == '"') {
             tagText = tagText.substring(1, tagText.length() - 1);
         }
-        tagText = tagText.replaceAll("\\s+", " ");
+        tagText = utils.normalizeWhitespace(tagText);
 
         Content desc = tagletWriter.htmlWriter.commentTagsToContent(element, indexTree.getDescription(), context.within(indexTree));
-        String descText = extractText(desc);
+        String descText = utils.normalizeWhitespace(extractText(desc));
 
         return tagletWriter.createAnchorAndSearchIndex(element, tagText, descText, tag);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SpecTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SpecTaglet.java
@@ -123,7 +123,7 @@ public class SpecTaglet extends BaseTaglet implements InheritableTaglet {
         List<? extends DocTree> specTreeLabel = specTree.getTitle();
         Content label = htmlWriter.commentTagsToContent(holder, specTreeLabel, tagletWriter.context.isFirstSentence);
         return getExternalSpecContent(holder, specTree, specTreeURL,
-                textOf(label).replaceAll("\\s+", " "), label);
+                utils.normalizeWhitespace(textOf(label)), label);
     }
 
     // this is here, for now, but might be a useful addition elsewhere,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
@@ -641,7 +641,8 @@ public class IndexItem {
                 builder.append("l", escapeQuotes(label))
                        .append("h", holder);
                 if (!description.isEmpty()) {
-                    builder.append("d", escapeQuotes(description));
+                    String normalizedDescription = description.replaceAll("\\s+", " ");
+                    builder.append("d", escapeQuotes(normalizedDescription));
                 }
                 if (kind != null && kind != Kind.SEARCH_ITEM) {
                     builder.append("k", kind.ordinal());

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
@@ -641,8 +641,7 @@ public class IndexItem {
                 builder.append("l", escapeQuotes(label))
                        .append("h", holder);
                 if (!description.isEmpty()) {
-                    String normalizedDescription = description.replaceAll("\\s+", " ");
-                    builder.append("d", escapeQuotes(normalizedDescription));
+                    builder.append("d", escapeQuotes(description));
                 }
                 if (kind != null && kind != Kind.SEARCH_ITEM) {
                     builder.append("k", kind.ordinal());

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1130,6 +1130,10 @@ public class Utils {
         }
         result.append(text, pos, textLength);
         return result.toString();
+    }
+
+    public String normalizeWhitespace(String s) {
+        return s.replaceAll("\\s+", " ");
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -1132,6 +1132,11 @@ public class Utils {
         return result.toString();
     }
 
+    /**
+     * Replaces each group of one or more whitespace characters with a single canonical space
+     * @param s the string to be normalized
+     * @return normalized string
+     */
     public String normalizeWhitespace(String s) {
         return s.replaceAll("\\s+", " ");
     }

--- a/test/langtools/jdk/javadoc/doclet/testIndexLineBreaks/TestIndexLineBreaks.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexLineBreaks/TestIndexLineBreaks.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8351332
+ * @summary Line breaks in the description of `{@index}` tags may corrupt JSON search index
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestIndexLineBreaks
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+public class TestIndexLineBreaks extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        var tester = new TestIndexLineBreaks ();
+        tester.runTests();
+    }
+
+    ToolBox tb = new ToolBox();
+
+    @Test
+    public void test() throws IOException {
+        Path src = Path.of("src");
+        tb.writeJavaFiles(src,
+                """
+                            package p;
+                            public interface I {
+                                /**
+                                 *
+                                 * The {@index "phrase1
+                                 * phrase2" description1
+                                 * description2 }
+                                 */
+                                int a();
+                            }
+                        """);
+
+        javadoc("-d",
+                "out",
+                "-sourcepath",
+                src.toString(),
+                "p");
+
+        checkExit(Exit.OK);
+
+        checkOutput("tag-search-index.js", true,
+                """
+                        {"l":"phrase1 phrase2","h":"p.I.a()","d":"description1 description2 ","u":"p/I.html#phrase1phrase2"},{"l":"Search Tags","h":"","k":"18","u":"search-tags.html"}""");
+
+        checkOutput("tag-search-index.js", false,
+                """
+                        {"l":"phrase1 phrase2","h":"p.I.a()","d":"description1
+                        description2 ","u":"p/I.html#phrase1phrase2"},{"l":"Search Tags","h":"","k":"18","u":"search-tags.html"}""");
+    }
+}


### PR DESCRIPTION
Please review this patch to fix an issue in the `tag-search-index.js` generation.

The problem was in the `toJSON()` method of `IndexItem`. When adding the description, it's using `escapeQuotes(description)` which only escapes backslashes and quotes, but doesn't normalize whitespace.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351332](https://bugs.openjdk.org/browse/JDK-8351332): Line breaks in search tag descriptions corrupt JSON search index (**Bug** - P3)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [3e040204](https://git.openjdk.org/jdk/pull/24202/files/3e040204520084254fbed5d1e4245d13aa24cf42)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24202/head:pull/24202` \
`$ git checkout pull/24202`

Update a local copy of the PR: \
`$ git checkout pull/24202` \
`$ git pull https://git.openjdk.org/jdk.git pull/24202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24202`

View PR using the GUI difftool: \
`$ git pr show -t 24202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24202.diff">https://git.openjdk.org/jdk/pull/24202.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24202#issuecomment-2748415341)
</details>
