### PR TITLE
8352740: Introduce new factory method HtmlTree.IMG

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SearchWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SearchWriter.java
@@ -143,10 +143,9 @@ public class SearchWriter extends HtmlDocletWriter {
                 .add(HtmlTree.SPAN(Text.of("link"))
                         .setId(HtmlId.of("page-search-link")))
                 .add(HtmlTree.BUTTON(HtmlId.of("page-search-copy"))
-                        .add(HtmlTree.of(HtmlTag.IMG)
-                                .put(HtmlAttr.SRC, pathToRoot.resolve(DocPaths.RESOURCE_FILES)
-                                        .resolve(DocPaths.CLIPBOARD_SVG).getPath())
-                                .put(HtmlAttr.ALT, copyUrlText))
+                        .add(HtmlTree.IMG(pathToRoot.resolve(DocPaths.RESOURCE_FILES)
+                                        .resolve(DocPaths.CLIPBOARD_SVG),
+                                copyUrlText))
                         .add(HtmlTree.SPAN(Text.of(copyText))
                                 .put(HtmlAttr.DATA_COPIED, copiedText))
                         .addStyle(HtmlStyles.copy)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TableOfContents.java
@@ -117,17 +117,12 @@ public class TableOfContents {
         content.add(listBuilder);
         content.add(HtmlTree.BUTTON(HtmlStyles.hideSidebar)
                 .add(HtmlTree.SPAN(writer.contents.hideSidebar).add(Entity.NO_BREAK_SPACE))
-                .add(HtmlTree.of(HtmlTag.IMG)
-                        .put(HtmlAttr.SRC, writer.pathToRoot.resolve(DocPaths.RESOURCE_FILES)
-                                .resolve(DocPaths.LEFT_SVG).getPath())
-                        .put(HtmlAttr.ALT, writer.contents.hideSidebar.toString())));
+                .add(HtmlTree.IMG(writer.pathToRoot.resolve(DocPaths.RESOURCE_FILES).resolve(DocPaths.LEFT_SVG),
+                        writer.contents.hideSidebar.toString())));
         content.add(HtmlTree.BUTTON(HtmlStyles.showSidebar)
-                .add(HtmlTree.of(HtmlTag.IMG)
-                        .put(HtmlAttr.SRC, writer.pathToRoot.resolve(DocPaths.RESOURCE_FILES)
-                                .resolve(DocPaths.RIGHT_SVG).getPath())
-                        .put(HtmlAttr.ALT, writer.contents.showSidebar.toString()))
+                .add(HtmlTree.IMG(writer.pathToRoot.resolve(DocPaths.RESOURCE_FILES)
+                        .resolve(DocPaths.RIGHT_SVG), writer.contents.showSidebar.toString()))
                 .add(HtmlTree.SPAN(Entity.NO_BREAK_SPACE).add(writer.contents.showSidebar)));
         return content;
     }
-
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
@@ -194,10 +194,9 @@ public class SnippetTaglet extends BaseTaglet {
                 HtmlTree.of(HtmlTag.BUTTON)
                         .add(HtmlTree.SPAN(Text.of(copyText))
                                 .put(HtmlAttr.DATA_COPIED, copiedText))
-                        .add(HtmlTree.of(HtmlTag.IMG)
-                                .put(HtmlAttr.SRC, pathToRoot.resolve(DocPaths.RESOURCE_FILES)
-                                                             .resolve(DocPaths.CLIPBOARD_SVG).getPath())
-                                .put(HtmlAttr.ALT, copySnippetText))
+                        .add(HtmlTree.IMG(pathToRoot.resolve(DocPaths.RESOURCE_FILES)
+                                        .resolve(DocPaths.CLIPBOARD_SVG),
+                                copySnippetText))
                         .addStyle(HtmlStyles.copy)
                         .addStyle(HtmlStyles.snippetCopy)
                         .put(HtmlAttr.ARIA_LABEL, copySnippetText)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
@@ -1159,6 +1159,9 @@ public class HtmlTree extends Content {
 
     /**
      * {@return an HTML {@code IMG} element}
+     *
+     * @param src the path of the image
+     * @param alt alternate text for the image
      */
     public static HtmlTree IMG(DocPath src, String alt) {
         return new HtmlTree(HtmlTag.IMG)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
@@ -1160,7 +1160,6 @@ public class HtmlTree extends Content {
     /**
      * {@return an HTML {@code IMG} element}
      */
-
     public static HtmlTree IMG(DocPath src, String alt) {
         return new HtmlTree(HtmlTag.IMG)
                 .put(HtmlAttr.SRC, src.getPath())

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/html/HtmlTree.java
@@ -38,6 +38,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
+import jdk.javadoc.internal.doclets.toolkit.util.DocPath;
+
 /**
  * A tree node representing an HTML element, containing the name of the element,
  * a collection of attributes, and content.
@@ -1153,6 +1155,16 @@ public class HtmlTree extends Content {
      */
     public static HtmlTree WBR() {
         return WBR_INSTANCE;
+    }
+
+    /**
+     * {@return an HTML {@code IMG} element}
+     */
+
+    public static HtmlTree IMG(DocPath src, String alt) {
+        return new HtmlTree(HtmlTag.IMG)
+                .put(HtmlAttr.SRC, src.getPath())
+                .put(HtmlAttr.ALT, alt);
     }
 
     @Override


### PR DESCRIPTION
Please review this small patch to add a new factory method `HtmlTree IMG(DocPath src, String alt)`, to provide a convenient way to reliably create valid tree nodes.

Previously, all uses of `HtmlTag.IMG` followed a similar pattern :
```
HtmlTree.of(HtmlTag.IMG)
                        .put(HtmlAttr.SRC, docpath)
                        .put(HtmlAttr.ALT, alt)
```

However, it was easy to forget to add the required "alt" attribute. Those have been replaced by the new factory method.

No tests are required as part of this change.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352740](https://bugs.openjdk.org/browse/JDK-8352740): Introduce new factory method HtmlTree.IMG (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24204/head:pull/24204` \
`$ git checkout pull/24204`

Update a local copy of the PR: \
`$ git checkout pull/24204` \
`$ git pull https://git.openjdk.org/jdk.git pull/24204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24204`

View PR using the GUI difftool: \
`$ git pr show -t 24204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24204.diff">https://git.openjdk.org/jdk/pull/24204.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24204#issuecomment-2748859616)
</details>
