### PR TITLE
8315447: Invalid Type Annotation attached to a method instead of a lambda

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -462,6 +462,10 @@ public class LambdaToMethod extends TreeTranslator {
         ListBuffer<Attribute.TypeCompound> lambdaTypeAnnos = new ListBuffer<>();
 
         for (Attribute.TypeCompound tc : source.get()) {
+            if (tc.hasUnknownPosition()) {
+                // Handle container annotations
+                tc.tryFixPosition();
+            }
             if (tc.position.onLambda == tree) {
                 lambdaTypeAnnos.append(tc);
             } else {

--- a/test/langtools/tools/javac/annotations/typeAnnotations/classfile/RepeatableInLambdaTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/classfile/RepeatableInLambdaTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8315447
+ * @summary Container annotations for type annotations in lambdas should be
+ *          placed on the lambda method
+ * @library /test/lib
+ * @run junit RepeatableInLambdaTest
+ */
+
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
+import java.lang.constant.ClassDesc;
+import java.lang.reflect.AccessFlag;
+import java.util.Map;
+
+import jdk.test.lib.compiler.InMemoryJavaCompiler;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RepeatableInLambdaTest {
+    static final String src = """
+            import java.lang.annotation.Repeatable;
+            import java.lang.annotation.Target;
+            import static java.lang.annotation.ElementType.TYPE_USE;
+            import java.util.function.Supplier;
+
+            @Target(TYPE_USE)
+            @Repeatable(AC.class)
+            @interface A {
+            }
+
+            @Target(TYPE_USE)
+            @interface AC {
+                A[] value();
+            }
+
+            @Target(TYPE_USE)
+            @interface B {}
+
+            class Test {
+                void test() {
+                    Supplier<Integer> s = () -> (@A @A @B Integer) 1;
+                }
+            }
+            """;
+
+    @Test
+    void test() {
+        var codes = InMemoryJavaCompiler.compile(Map.of("Test", src));
+        var bytes = codes.get("Test");
+        var cf = ClassFile.of().parse(bytes);
+        var lambdaMethod = cf.methods().stream().filter(mm -> mm.flags().has(AccessFlag.SYNTHETIC))
+                .findFirst().orElseThrow();
+        System.err.println(lambdaMethod);
+        var ritva = lambdaMethod.code().orElseThrow().findAttribute(Attributes.runtimeInvisibleTypeAnnotations()).orElseThrow();
+        var annoList = ritva.annotations();
+        assertEquals(2, annoList.size());
+        assertEquals(ClassDesc.of("AC"), annoList.getFirst().annotation().classSymbol());
+        assertEquals(ClassDesc.of("B"), annoList.get(1).annotation().classSymbol());
+    }
+}


### PR DESCRIPTION
In `LambdaToMethod`, when a type annotation is attributed to a lambda's synthetic method or the original method, the annotation's position is queried. However, for container annotations, their positions may not yet be up-to-date, and they are wrongly attributed to the outer method.

This bug was discovered because this wrong attribution can bring in an invalid BCI value referring to a lambda method code array that may be out-of-bounds for the outer method. CombinationTargetTest3 had to stay on the old internal proprietary classfile API due to this reason, as the ClassFile API throws an IAE for such a malformed type annotation attribute.

Please review this patch; this is a blocker for the removal of com.sun.tools.classfile from the JDK, which I wish to accomplish when the boot JDK is 24.

Testing: langtools/tools/javac and javap.