### PR TITLE
8351366: Remove the java.security.debug=scl option

### DIFF
--- a/src/java.base/share/classes/java/security/SecureClassLoader.java
+++ b/src/java.base/share/classes/java/security/SecureClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/SecureClassLoader.java
+++ b/src/java.base/share/classes/java/security/SecureClassLoader.java
@@ -182,13 +182,6 @@ public class SecureClassLoader extends ClassLoader {
     }
 
     /*
-     * holder class for the static field "debug" to delay its initialization
-     */
-    private static class DebugHolder {
-        private static final Debug debug = Debug.getInstance("scl");
-    }
-
-    /*
      * Returned cached ProtectionDomain for the specified CodeSource.
      */
     private ProtectionDomain getProtectionDomain(CodeSource cs) {
@@ -209,10 +202,6 @@ public class SecureClassLoader extends ClassLoader {
                         = SecureClassLoader.this.getPermissions(key.cs);
                 ProtectionDomain pd = new ProtectionDomain(
                         key.cs, perms, SecureClassLoader.this, null);
-                if (DebugHolder.debug != null) {
-                    DebugHolder.debug.println(" getPermissions " + pd);
-                    DebugHolder.debug.println("");
-                }
                 return pd;
             }
         });

--- a/src/java.base/share/classes/java/security/SecureClassLoader.java
+++ b/src/java.base/share/classes/java/security/SecureClassLoader.java
@@ -25,8 +25,6 @@
 
 package java.security;
 
-import sun.security.util.Debug;
-
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/java.base/share/classes/sun/security/util/Debug.java
+++ b/src/java.base/share/classes/sun/security/util/Debug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/util/Debug.java
+++ b/src/java.base/share/classes/sun/security/util/Debug.java
@@ -104,7 +104,6 @@ public class Debug {
         System.err.println("pkcs12        PKCS12 KeyStore debugging");
         System.err.println("properties    Security property and configuration file debugging");
         System.err.println("sunpkcs11     SunPKCS11 provider debugging");
-        System.err.println("scl           permissions SecureClassLoader assigns");
         System.err.println("securerandom  SecureRandom");
         System.err.println("ts            timestamping");
         System.err.println("x509          X.509 certificate debugging");


### PR DESCRIPTION
This option dumped the permissions that the SecureClassLoader assigns to ProtectionDomains, but with the disabling of the Security Manager in JDK 24, these permissions are always empty and the debugging has no value. So this option should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8352902](https://bugs.openjdk.org/browse/JDK-8352902) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8351366](https://bugs.openjdk.org/browse/JDK-8351366): Remove the java.security.debug=scl option (**Bug** - P4)
 * [JDK-8352902](https://bugs.openjdk.org/browse/JDK-8352902): Remove the java.security.debug=scl option (**CSR**)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24208/head:pull/24208` \
`$ git checkout pull/24208`

Update a local copy of the PR: \
`$ git checkout pull/24208` \
`$ git pull https://git.openjdk.org/jdk.git pull/24208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24208`

View PR using the GUI difftool: \
`$ git pr show -t 24208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24208.diff">https://git.openjdk.org/jdk/pull/24208.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24208#issuecomment-2751993578)
</details>
