### PR TITLE
8236073: G1: Use SoftMaxHeapSize to guide GC heuristics

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2061,6 +2061,11 @@ size_t G1CollectedHeap::max_capacity() const {
   return max_regions() * G1HeapRegion::GrainBytes;
 }
 
+size_t G1CollectedHeap::soft_max_capacity() const {
+  return clamp(align_up(SoftMaxHeapSize, HeapAlignment), MinHeapSize,
+               max_capacity());
+}
+
 void G1CollectedHeap::prepare_for_verify() {
   _verifier->prepare_for_verify();
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1200,6 +1200,9 @@ public:
   // Print the maximum heap capacity.
   size_t max_capacity() const override;
 
+  // Print the soft maximum heap capacity.
+  size_t soft_max_capacity() const;
+
   Tickspan time_since_last_collection() const { return Ticks::now() - _collection_pause_end; }
 
   // Convenience function to be used in situations where the heap type can be

--- a/src/hotspot/share/gc/g1/g1IHOPControl.hpp
+++ b/src/hotspot/share/gc/g1/g1IHOPControl.hpp
@@ -55,6 +55,10 @@ class G1IHOPControl : public CHeapObj<mtGC> {
   // Most recent time from the end of the concurrent start to the start of the first
   // mixed gc.
   virtual double last_marking_length_s() const = 0;
+
+  // Default non-young occupancy at which concurrent marking should start.
+  size_t default_conc_mark_start_threshold();
+
  public:
   virtual ~G1IHOPControl() { }
 
@@ -92,8 +96,7 @@ class G1StaticIHOPControl : public G1IHOPControl {
   G1StaticIHOPControl(double ihop_percent, G1OldGenAllocationTracker const* old_gen_alloc_tracker);
 
   size_t get_conc_mark_start_threshold() {
-    guarantee(_target_occupancy > 0, "Target occupancy must have been initialized.");
-    return (size_t) (_initial_ihop_percent * _target_occupancy / 100.0);
+    return default_conc_mark_start_threshold();
   }
 
   virtual void update_marking_length(double marking_length_s) {


### PR DESCRIPTION
Hi all,

I have implemented SoftMaxHeapSize for G1 as attached. It is completely reworked compared to [previous PR](https://github.com/openjdk/jdk/pull/20783), and excludes code for `CurrentMaxHeapSize`. I believe I have addressed all direct concerns from [previous email thread](https://mail.openjdk.org/pipermail/hotspot-gc-dev/2024-November/050214.html), such as:

- does not respect `MinHeapSize`;
- being too "blunt" and does not respect other G1 heuristics and flags for resizing, such as `MinHeapFreeRatio`, `MaxHeapFreeRatio`;
- does not affect heuristcs to trigger a concurrent cycle;

[This recent thread](https://mail.openjdk.org/pipermail/hotspot-gc-dev/2025-March/051619.html) also has some context.
