### PR TITLE
8334322: Misleading values of keys in jpackage resource bundle

### DIFF
--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
@@ -83,11 +83,15 @@ public class LinuxDebBundler extends LinuxPackageBundler {
             },
             (s, p) -> {
                 if (!DEB_PACKAGE_NAME_PATTERN.matcher(s).matches()) {
-                    throw new IllegalArgumentException(new ConfigException(
+                    try {
+                        throw new ConfigException(
                             MessageFormat.format(I18N.getString(
-                            "error.invalid-value-for-package-name"), s),
+                            "error.deb-invalid-value-for-package-name"), s),
                             I18N.getString(
-                            "error.invalid-value-for-package-name.advice")));
+                            "error.deb-invalid-value-for-package-name.advice"));
+                    } catch (ConfigException ex) {
+                        throw new IllegalArgumentException(ex);
+                    }
                 }
 
                 return s;

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxRpmBundler.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxRpmBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxRpmBundler.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxRpmBundler.java
@@ -87,11 +87,15 @@ public class LinuxRpmBundler extends LinuxPackageBundler {
             },
             (s, p) -> {
                 if (!RPM_PACKAGE_NAME_PATTERN.matcher(s).matches()) {
-                    String msgKey = "error.invalid-value-for-package-name";
-                    throw new IllegalArgumentException(
-                            new ConfigException(MessageFormat.format(
-                                    I18N.getString(msgKey), s),
-                                    I18N.getString(msgKey + ".advice")));
+                    try {
+                        throw new ConfigException(
+                            MessageFormat.format(I18N.getString(
+                            "error.rpm-invalid-value-for-package-name"), s),
+                            I18N.getString(
+                            "error.rpm-invalid-value-for-package-name.advice"));
+                    } catch (ConfigException ex) {
+                        throw new IllegalArgumentException(ex);
+                    }
                 }
 
                 return s;

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/LinuxResources.properties
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/LinuxResources.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/LinuxResources.properties
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/LinuxResources.properties
@@ -46,8 +46,11 @@ error.tool-old-version.advice=Please install required packages
 
 error.invalid-install-dir=Invalid installation directory "{0}"
 
-error.invalid-value-for-package-name=Invalid value "{0}" for the bundle name.
-error.invalid-value-for-package-name.advice=Set the "linux-bundle-name" option to a valid Debian package name. Note that the package names must consist only of lower case letters (a-z), digits (0-9), plus (+) and minus (-) signs, and periods (.). They must be at least two characters long and must start with an alphanumeric character.
+error.deb-invalid-value-for-package-name=Invalid value "{0}" for the package name.
+error.deb-invalid-value-for-package-name.advice=Set the "--linux-package-name" option to a valid Debian package name. Note that the package names must consist only of lower case letters (a-z), digits (0-9), plus (+) and minus (-) signs, and periods (.). They must be at least two characters long and must start with a letter character.
+
+error.rpm-invalid-value-for-package-name=Invalid value "{0}" for the package name.
+error.rpm-invalid-value-for-package-name.advice=Set the "--linux-package-name" option to a valid RPM package name. Note that the package names must consist only of letters (a-z, A-Z), digits (0-9), plus (+) and minus (-) signs, periods (.) and underscores (_). They must be at least one character long and must start with a letter.
 
 message.icon-not-png=The specified icon "{0}" is not a PNG file and will not be used. The default icon will be used in it's place.
 message.test-for-tool=Test for [{0}]. Result: {1}

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
@@ -700,9 +700,7 @@ public class Arguments {
 
         Map<String, ? super Object> localParams = new HashMap<>(params);
         try {
-            bundler.validate(localParams);
-            Path result = bundler.execute(localParams,
-                    StandardBundlerParam.OUTPUT_DIR.fetchFrom(params));
+            Path result = executeBundler(bundler, params, localParams);
             if (result == null) {
                 throw new PackagerException("MSG_BundlerFailed",
                         bundler.getID(), bundler.getName());
@@ -733,6 +731,24 @@ public class Arguments {
                 // always clean up the temporary directory created
                 // when --temp option not used.
                 bundler.cleanup(localParams);
+            }
+        }
+    }
+
+    private static Path executeBundler(Bundler bundler, Map<String, ? super Object> params,
+            Map<String, ? super Object> localParams) throws ConfigException, PackagerException {
+        try {
+            bundler.validate(localParams);
+            return bundler.execute(localParams, StandardBundlerParam.OUTPUT_DIR.fetchFrom(params));
+        } catch (ConfigException|PackagerException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            if (ex.getCause() instanceof ConfigException cfgEx) {
+                throw cfgEx;
+            } else if (ex.getCause() instanceof PackagerException pkgEx) {
+                throw pkgEx;
+            } else {
+                throw ex;
             }
         }
     }

--- a/test/jdk/tools/jpackage/share/ErrorTest.java
+++ b/test/jdk/tools/jpackage/share/ErrorTest.java
@@ -410,6 +410,7 @@ public final class ErrorTest {
     @ParameterSupplier("basic")
     @ParameterSupplier(value="testWindows", ifOS = WINDOWS)
     @ParameterSupplier(value="testMac", ifOS = MACOS)
+    @ParameterSupplier(value="testLinux", ifOS = LINUX)
     @ParameterSupplier(value="winOption", ifNotOS = WINDOWS)
     @ParameterSupplier(value="linuxOption", ifNotOS = LINUX)
     @ParameterSupplier(value="macOption", ifNotOS = MACOS)
@@ -583,6 +584,23 @@ public final class ErrorTest {
         }
 
         cmd.execute(1);
+    }
+
+    public static Collection<Object[]> testLinux() {
+        final List<TestSpec> testCases = new ArrayList<>();
+
+        testCases.addAll(Stream.of(
+                testSpec().type(PackageType.LINUX_DEB).addArgs("--linux-package-name", "#")
+                        .error("error.deb-invalid-value-for-package-name", "#")
+                        .error("error.deb-invalid-value-for-package-name.advice"),
+                testSpec().type(PackageType.LINUX_RPM).addArgs("--linux-package-name", "#")
+                        .error("error.rpm-invalid-value-for-package-name", "#")
+                        .error("error.rpm-invalid-value-for-package-name.advice")
+        ).map(TestSpec.Builder::create).filter(spec -> {
+            return spec.type().orElseThrow().isSupported();
+        }).toList());
+
+        return toTestArgs(testCases.stream());
     }
 
     private static void duplicate(TestSpec.Builder builder, Consumer<TestSpec> accumulator, Consumer<TestSpec.Builder> mutator) {


### PR DESCRIPTION
Replace `error.invalid-value-for-package-name` and `error.invalid-value-for-package-name.advice` l10n keys with a pair for rpm packaging:
 - `error.rpm-invalid-value-for-package-name`
 - `error.rpm-invalid-value-for-package-name.advice`
and a pair for deb packaging:
 - `error.deb-invalid-value-for-package-name`
 - `error.deb-invalid-value-for-package-name.advice`

Added tests for the new l10n keys.
Altered jdk.jpackage.internal.Arguments class to prevent it from suppressing the advice property of wrapped `jdk.jpackage.internal.ConfigException` exceptions.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334322](https://bugs.openjdk.org/browse/JDK-8334322): Misleading values of keys in jpackage resource bundle (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24215/head:pull/24215` \
`$ git checkout pull/24215`

Update a local copy of the PR: \
`$ git checkout pull/24215` \
`$ git pull https://git.openjdk.org/jdk.git pull/24215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24215`

View PR using the GUI difftool: \
`$ git pr show -t 24215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24215.diff">https://git.openjdk.org/jdk/pull/24215.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24215#issuecomment-2750011887)
</details>
