### PR TITLE
8352800: [PPC] OpenJDK fails to build on PPC after JDK-8350106

### DIFF
--- a/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "memory/metaspace.hpp"
+#include "os_linux_ppc.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/javaThread.hpp"
 

--- a/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
@@ -24,7 +24,7 @@
  */
 
 #include "memory/metaspace.hpp"
-#include "os_linux_ppc.inline.hpp"
+#include "os_linux.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/javaThread.hpp"
 


### PR DESCRIPTION
Add missing header to resolve the compilation failure.

Testing:
 - built openjdk in PPC qemu vm.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352800](https://bugs.openjdk.org/browse/JDK-8352800): [PPC] OpenJDK fails to build on PPC after JDK-8350106 (**Bug** - P4)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24216/head:pull/24216` \
`$ git checkout pull/24216`

Update a local copy of the PR: \
`$ git checkout pull/24216` \
`$ git pull https://git.openjdk.org/jdk.git pull/24216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24216`

View PR using the GUI difftool: \
`$ git pr show -t 24216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24216.diff">https://git.openjdk.org/jdk/pull/24216.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24216#issuecomment-2752262804)
</details>
