### PR TITLE
8352858: Make java.net.JarURLConnection fields final

### DIFF
--- a/src/java.base/share/classes/java/net/JarURLConnection.java
+++ b/src/java.base/share/classes/java/net/JarURLConnection.java
@@ -172,20 +172,35 @@ public abstract class JarURLConnection extends URLConnection {
             throw new MalformedURLException("no !/ found in url spec:" + spec);
         }
 
-        @SuppressWarnings("deprecation")
-        var _unused = jarFileURL = new URL(spec.substring(0, separator));
+        jarFileURL = parseJarFileURL(spec, separator, url);
+        entryName = parseEntryName(spec, separator);
+    }
 
+    /**
+     * Parse the URL of the JAR file backing this JarURLConnection,
+     * appending any #runtime fragment as neccessary
+     *
+     * @param spec the URL spec of this connection
+     * @param separator the index of the '!/' separator
+     * @param connectionURL the URL passed to the constructor
+     * @return a URL to the JAR file this connection reads from
+     *
+     * @throws MalformedURLException if a malformed URL is found
+     */
+    @SuppressWarnings("deprecation")
+    private static URL parseJarFileURL(String spec, int separator, URL connectionURL) throws MalformedURLException {
+
+        URL url = new URL(spec.substring(0, separator));
         /*
-         * The url argument may have had a runtime fragment appended, so
+         * The url passed to the constructor may have had a runtime fragment appended, so
          * we need to add a runtime fragment to the jarFileURL to enable
          * runtime versioning when the underlying jar file is opened.
          */
-        if ("runtime".equals(url.getRef())) {
-            @SuppressWarnings("deprecation")
-            var _unused2 = jarFileURL = new URL(jarFileURL, "#runtime");
+        if ("runtime".equals(connectionURL.getRef())) {
+            return new URL(url, "#runtime");
+        } else {
+            return url;
         }
-
-        entryName = parseEntryName(spec, separator);
     }
 
     /**

--- a/src/java.base/share/classes/java/net/JarURLConnection.java
+++ b/src/java.base/share/classes/java/net/JarURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,7 +173,7 @@ public abstract class JarURLConnection extends URLConnection {
         }
 
         @SuppressWarnings("deprecation")
-        var _unused = jarFileURL = new URL(spec.substring(0, separator++));
+        var _unused = jarFileURL = new URL(spec.substring(0, separator));
 
         /*
          * The url argument may have had a runtime fragment appended, so
@@ -184,12 +184,14 @@ public abstract class JarURLConnection extends URLConnection {
             @SuppressWarnings("deprecation")
             var _unused2 = jarFileURL = new URL(jarFileURL, "#runtime");
         }
-        entryName = null;
 
-        /* if ! is the last letter of the innerURL, entryName is null */
-        if (++separator != spec.length()) {
-            entryName = spec.substring(separator, spec.length());
-            entryName = ParseUtil.decode (entryName);
+        // If the URL ends with the '!/' separator, entryName is null
+        int nameIdx = separator + 2;
+        if (nameIdx == spec.length()) {
+            entryName = null;
+        } else {
+            String encodedName = spec.substring(nameIdx, spec.length());
+            entryName = ParseUtil.decode(encodedName);
         }
     }
 

--- a/src/java.base/share/classes/java/net/JarURLConnection.java
+++ b/src/java.base/share/classes/java/net/JarURLConnection.java
@@ -185,13 +185,24 @@ public abstract class JarURLConnection extends URLConnection {
             var _unused2 = jarFileURL = new URL(jarFileURL, "#runtime");
         }
 
+        entryName = parseEntryName(spec, separator);
+    }
+
+    /**
+     * Parse the entry name (if any) of this JarURLConnection
+     *
+     * @param spec the URL spec of this connection
+     * @param separator the index of the '!/' separator
+     * @return the decoded entry name, or null if this URL has no entry name
+     */
+    private static String parseEntryName(String spec, int separator) {
         // If the URL ends with the '!/' separator, entryName is null
         int nameIdx = separator + 2;
         if (nameIdx == spec.length()) {
-            entryName = null;
+            return null;
         } else {
             String encodedName = spec.substring(nameIdx, spec.length());
-            entryName = ParseUtil.decode(encodedName);
+            return ParseUtil.decode(encodedName);
         }
     }
 

--- a/src/java.base/share/classes/java/net/JarURLConnection.java
+++ b/src/java.base/share/classes/java/net/JarURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.util.jar.JarFile;
 import java.util.jar.JarEntry;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-import java.security.Permission;
+
 import sun.net.www.ParseUtil;
 
 /**
@@ -136,8 +136,11 @@ import sun.net.www.ParseUtil;
  */
 public abstract class JarURLConnection extends URLConnection {
 
-    private URL jarFileURL;
-    private String entryName;
+    // The URL to the JAR file this connection reads from
+    private final URL jarFileURL;
+
+    // The entry this connection reads from, if any
+    private final String entryName;
 
     /**
      * The connection to the JAR file URL, if the connection has been
@@ -152,22 +155,14 @@ public abstract class JarURLConnection extends URLConnection {
      * could be found in a specification string or the
      * string could not be parsed.
      */
-
     protected JarURLConnection(URL url) throws MalformedURLException {
         super(url);
-        parseSpecs(url);
-    }
 
-    /* get the specs for a given url out of the cache, and compute and
-     * cache them if they're not there.
-     */
-    private void parseSpecs(URL url) throws MalformedURLException {
+        // Extract JAR file URL and entry name components from the URL
         String spec = url.getFile();
-
         int separator = spec.indexOf("!/");
-        /*
-         * REMIND: we don't handle nested JAR URLs
-         */
+
+        // REMIND: we don't handle nested JAR URLs
         if (separator == -1) {
             throw new MalformedURLException("no !/ found in url spec:" + spec);
         }
@@ -198,9 +193,8 @@ public abstract class JarURLConnection extends URLConnection {
          */
         if ("runtime".equals(connectionURL.getRef())) {
             return new URL(url, "#runtime");
-        } else {
-            return url;
         }
+        return url;
     }
 
     /**

--- a/src/java.base/share/classes/java/net/JarURLConnection.java
+++ b/src/java.base/share/classes/java/net/JarURLConnection.java
@@ -160,15 +160,15 @@ public abstract class JarURLConnection extends URLConnection {
 
         // Extract JAR file URL and entry name components from the URL
         String spec = url.getFile();
-        int separator = spec.indexOf("!/");
+        int separatorIndex = spec.indexOf("!/");
 
         // REMIND: we don't handle nested JAR URLs
-        if (separator == -1) {
+        if (separatorIndex == -1) {
             throw new MalformedURLException("no !/ found in url spec:" + spec);
         }
 
-        jarFileURL = parseJarFileURL(spec, separator, url);
-        entryName = parseEntryName(spec, separator);
+        jarFileURL = parseJarFileURL(spec, separatorIndex, url);
+        entryName = parseEntryName(spec, separatorIndex);
     }
 
     /**
@@ -176,16 +176,16 @@ public abstract class JarURLConnection extends URLConnection {
      * appending any #runtime fragment as neccessary
      *
      * @param spec the URL spec of this connection
-     * @param separator the index of the '!/' separator
+     * @param separatorIndex the index of the '!/' separator
      * @param connectionURL the URL passed to the constructor
      * @return a URL to the JAR file this connection reads from
      *
      * @throws MalformedURLException if a malformed URL is found
      */
     @SuppressWarnings("deprecation")
-    private static URL parseJarFileURL(String spec, int separator, URL connectionURL) throws MalformedURLException {
+    private static URL parseJarFileURL(String spec, int separatorIndex, URL connectionURL) throws MalformedURLException {
 
-        URL url = new URL(spec.substring(0, separator));
+        URL url = new URL(spec.substring(0, separatorIndex));
         /*
          * The url passed to the constructor may have had a runtime fragment appended, so
          * we need to add a runtime fragment to the jarFileURL to enable
@@ -201,16 +201,16 @@ public abstract class JarURLConnection extends URLConnection {
      * Parse the entry name (if any) of this JarURLConnection
      *
      * @param spec the URL spec of this connection
-     * @param separator the index of the '!/' separator
+     * @param separatorIndex the index of the '!/' separator
      * @return the decoded entry name, or null if this URL has no entry name
      */
-    private static String parseEntryName(String spec, int separator) {
+    private static String parseEntryName(String spec, int separatorIndex) {
         // If the URL ends with the '!/' separator, entryName is null
-        int nameIdx = separator + 2;
-        if (nameIdx == spec.length()) {
+        int nameIndex = separatorIndex + 2;
+        if (nameIndex == spec.length()) {
             return null;
         } else {
-            String encodedName = spec.substring(nameIdx, spec.length());
+            String encodedName = spec.substring(nameIndex, spec.length());
             return ParseUtil.decode(encodedName);
         }
     }


### PR DESCRIPTION
Please help review this cleanup PR which makes the `java.net.JarURLConnection` fields `jarFileURL` and `entryName` final.

The current `parseSpec` method is somewhat crufty, with some code quality  issues which this PR aims to improve:

* The method-level comment seems stale and misplaced
* The local variable  `separator` is confusingly incremented during parsing (using pre AND post increment operators) 
* Unused local variables introduced for the sole purpose of attaching `@SuppressWarnings` annotations
* The `jarFileURL` and `entryName` fields are both assigned more than once
* Block comments are used where line comments would suffice

The PR addresses the above issues by inlining `parseSpec` into the constructor, then extracting static helper methods for parsing the file URL and the entry name. This allows the fields to be made final.

Since this is purely a refactoring PR, no tests are updated and the `noreg-cleanup` label is added in JBS.

Reviewing individual commits in this PR may aid verification of separate refactorings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352858](https://bugs.openjdk.org/browse/JDK-8352858): Make java.net.JarURLConnection fields final (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24218/head:pull/24218` \
`$ git checkout pull/24218`

Update a local copy of the PR: \
`$ git checkout pull/24218` \
`$ git pull https://git.openjdk.org/jdk.git pull/24218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24218`

View PR using the GUI difftool: \
`$ git pr show -t 24218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24218.diff">https://git.openjdk.org/jdk/pull/24218.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24218#issuecomment-2750570844)
</details>
