### PR TITLE
8352812: remove useless class and function parameter in SuspendThread impl

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -940,14 +940,14 @@ JvmtiEnv::SuspendThread(jthread thread) {
 
     // Do not use JvmtiVTMSTransitionDisabler in context of self suspend to avoid deadlocks.
     if (java_thread != current) {
-      err = suspend_thread(thread_oop, java_thread, /* single_suspend */ true, nullptr);
+      err = suspend_thread(thread_oop, java_thread, /* single_suspend */ true);
       return err;
     }
     // protect thread_oop as a safepoint can be reached in disabler destructor
     self_tobj = Handle(current, thread_oop);
   }
   // Do self suspend for current JavaThread.
-  err = suspend_thread(self_tobj(), current, /* single_suspend */ true, nullptr);
+  err = suspend_thread(self_tobj(), current, /* single_suspend */ true);
   return err;
 } /* end SuspendThread */
 
@@ -988,14 +988,14 @@ JvmtiEnv::SuspendThreadList(jint request_count, const jthread* request_list, jvm
         self_tobj = Handle(current, thread_oop);
         continue; // self suspend after all other suspends
       }
-      results[i] = suspend_thread(thread_oop, java_thread, /* single_suspend */ true, nullptr);
+      results[i] = suspend_thread(thread_oop, java_thread, /* single_suspend */ true);
     }
   }
   // Self suspend after all other suspends if necessary.
   // Do not use JvmtiVTMSTransitionDisabler in context of self suspend to avoid deadlocks.
   if (self_tobj() != nullptr) {
     // there should not be any error for current java_thread
-    results[self_idx] = suspend_thread(self_tobj(), current, /* single_suspend */ true, nullptr);
+    results[self_idx] = suspend_thread(self_tobj(), current, /* single_suspend */ true);
   }
   // per-thread suspend results returned via results parameter
   return JVMTI_ERROR_NONE;
@@ -1048,7 +1048,7 @@ JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list
           self_tobj = Handle(current, vt_oop);
           continue; // self suspend after all other suspends
         }
-        suspend_thread(vt_oop, java_thread, /* single_suspend */ false, nullptr);
+        suspend_thread(vt_oop, java_thread, /* single_suspend */ false);
       }
     }
     JvmtiVTSuspender::register_all_vthreads_suspend();
@@ -1065,7 +1065,7 @@ JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list
   // Self suspend after all other suspends if necessary.
   // Do not use JvmtiVTMSTransitionDisabler in context of self suspend to avoid deadlocks.
   if (self_tobj() != nullptr) {
-    suspend_thread(self_tobj(), current, /* single_suspend */ false, nullptr);
+    suspend_thread(self_tobj(), current, /* single_suspend */ false);
   }
   return JVMTI_ERROR_NONE;
 } /* end SuspendAllVirtualThreads */

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1750,8 +1750,7 @@ JvmtiEnvBase::disable_virtual_threads_notify_jvmti() {
 
 // java_thread - protected by ThreadsListHandle
 jvmtiError
-JvmtiEnvBase::suspend_thread(oop thread_oop, JavaThread* java_thread, bool single_suspend,
-                             int* need_safepoint_p) {
+JvmtiEnvBase::suspend_thread(oop thread_oop, JavaThread* java_thread, bool single_suspend);
   JavaThread* current = JavaThread::current();
   HandleMark hm(current);
   Handle thread_h(current, thread_oop);
@@ -1807,7 +1806,7 @@ JvmtiEnvBase::suspend_thread(oop thread_oop, JavaThread* java_thread, bool singl
     assert(single_suspend || thread_h()->is_a(vmClasses::BaseVirtualThread_klass()),
            "SuspendAllVirtualThreads should never suspend non-virtual threads");
     // Case of mounted virtual or attached carrier thread.
-    if (!JvmtiSuspendControl::suspend(java_thread)) {
+    if (!java_thread->java_suspend()) {
       // Thread is already suspended or in process of exiting.
       if (java_thread->is_exiting()) {
         // The thread was in the process of exiting.
@@ -1869,7 +1868,7 @@ JvmtiEnvBase::resume_thread(oop thread_oop, JavaThread* java_thread, bool single
     assert(single_resume || thread_h()->is_a(vmClasses::BaseVirtualThread_klass()),
            "ResumeAllVirtualThreads should never resume non-virtual threads");
     if (java_thread->is_suspended()) {
-      if (!JvmtiSuspendControl::resume(java_thread)) {
+      if (!java_thread->java_resume()) {
         return JVMTI_ERROR_THREAD_NOT_SUSPENDED;
       }
     }

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1750,7 +1750,7 @@ JvmtiEnvBase::disable_virtual_threads_notify_jvmti() {
 
 // java_thread - protected by ThreadsListHandle
 jvmtiError
-JvmtiEnvBase::suspend_thread(oop thread_oop, JavaThread* java_thread, bool single_suspend);
+JvmtiEnvBase::suspend_thread(oop thread_oop, JavaThread* java_thread, bool single_suspend) {
   JavaThread* current = JavaThread::current();
   HandleMark hm(current);
   Handle thread_h(current, thread_oop);

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -90,8 +90,7 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
   // It is unsafe to use this function when virtual threads are executed.
   static bool disable_virtual_threads_notify_jvmti();
 
-  static jvmtiError suspend_thread(oop thread_oop, JavaThread* java_thread, bool single_suspend,
-                                   int* need_safepoint_p);
+  static jvmtiError suspend_thread(oop thread_oop, JavaThread* java_thread, bool single_suspend);
   static jvmtiError resume_thread(oop thread_oop, JavaThread* java_thread, bool single_resume);
   static jvmtiError check_thread_list(jint count, const jthread* list);
   static bool is_in_thread_list(jint count, const jthread* list, oop jt_oop);

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -745,40 +745,6 @@ VM_VirtualThreadGetReceiver::VM_VirtualThreadGetReceiver(
     : VM_VirtualThreadGetOrSetLocal(env, vthread_h, caller_thread, depth, 0, self) {}
 
 
-/////////////////////////////////////////////////////////////////////////////////////////
-//
-// class JvmtiSuspendControl - see comments in jvmtiImpl.hpp
-//
-
-bool JvmtiSuspendControl::suspend(JavaThread *java_thread) {
-  return java_thread->java_suspend();
-}
-
-bool JvmtiSuspendControl::resume(JavaThread *java_thread) {
-  return java_thread->java_resume();
-}
-
-void JvmtiSuspendControl::print() {
-#ifndef PRODUCT
-  ResourceMark rm;
-  LogStreamHandle(Trace, jvmti) log_stream;
-  log_stream.print("Suspended Threads: [");
-  for (JavaThreadIteratorWithHandle jtiwh; JavaThread *thread = jtiwh.next(); ) {
-#ifdef JVMTI_TRACE
-    const char *name   = JvmtiTrace::safe_get_thread_name(thread);
-#else
-    const char *name   = "";
-#endif /*JVMTI_TRACE */
-    log_stream.print("%s(%c ", name, thread->is_suspended() ? 'S' : '_');
-    if (!thread->has_last_Java_frame()) {
-      log_stream.print("no stack");
-    }
-    log_stream.print(") ");
-  }
-  log_stream.print_cr("]");
-#endif
-}
-
 JvmtiDeferredEvent JvmtiDeferredEvent::compiled_method_load_event(
     nmethod* nm) {
   JvmtiDeferredEvent event = JvmtiDeferredEvent(TYPE_COMPILED_METHOD_LOAD);

--- a/src/hotspot/share/prims/jvmtiImpl.hpp
+++ b/src/hotspot/share/prims/jvmtiImpl.hpp
@@ -278,28 +278,6 @@ class VM_VirtualThreadGetReceiver : public VM_VirtualThreadGetOrSetLocal {
 };
 
 
-///////////////////////////////////////////////////////////////
-//
-// class JvmtiSuspendControl
-//
-// Convenience routines for suspending and resuming threads.
-//
-// All attempts by JVMTI to suspend and resume threads must go through the
-// JvmtiSuspendControl interface.
-//
-// methods return true if successful
-//
-class JvmtiSuspendControl : public AllStatic {
-public:
-  // suspend the thread, taking it to a safepoint
-  static bool suspend(JavaThread *java_thread);
-  // resume the thread
-  static bool resume(JavaThread *java_thread);
-
-  static void print();
-};
-
-
 /**
  * When a thread (such as the compiler thread or VM thread) cannot post a
  * JVMTI event itself because the event needs to be posted from a Java


### PR DESCRIPTION
The internal class JvmtiSuspendControl is transitively used in the SuspendThread implementation is not really needed and is being removed. Also, the suspend_thread function has unused need_safepoint_p parameter which is being removed as well.

Testing:
 - TBD: Run mach5 tiers 1-3 to be safe

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8352812: remove useless class and function parameter in SuspendThread impl`

### Issue
 * [JDK-8352812](https://bugs.openjdk.org/browse/JDK-8352812): remove useless class and function parameter in SuspendThread impl (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) Review applies to [8513e69f](https://git.openjdk.org/jdk/pull/24219/files/8513e69f68beab4cf6473d80abeae4b19f2c6d24)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24219/head:pull/24219` \
`$ git checkout pull/24219`

Update a local copy of the PR: \
`$ git checkout pull/24219` \
`$ git pull https://git.openjdk.org/jdk.git pull/24219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24219`

View PR using the GUI difftool: \
`$ git pr show -t 24219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24219.diff">https://git.openjdk.org/jdk/pull/24219.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24219#issuecomment-2750558447)
</details>
