### PR TITLE
8352676: Opensource JMenu tests - series1

### DIFF
--- a/test/jdk/javax/swing/JMenu/bug4140643.java
+++ b/test/jdk/javax/swing/JMenu/bug4140643.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4140643
+ * @summary Tests that Motif menus open with both Alt-key and Meta-key
+ * @key headful
+ * @run main bug4140643
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+public class bug4140643 {
+    private static JFrame frame;
+    private static JMenu menu;
+    private static volatile boolean isPopMenuVisible;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                try {
+                    UIManager.setLookAndFeel(
+                        "com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+                } catch (ClassNotFoundException | InstantiationException
+                        | UnsupportedLookAndFeelException
+                        | IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+                frame = new JFrame("bug4140643");
+
+                menu = new JMenu("File");
+                menu.setMnemonic(KeyEvent.VK_F);
+                menu.add(new JMenuItem("Open..."));
+                menu.add(new JMenuItem("Save"));
+
+                JMenuBar mbar = new JMenuBar();
+                mbar.add(menu);
+                frame.setJMenuBar(mbar);
+
+                frame.add(new JButton("Click Here"));
+                frame.pack();
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            if (System.getProperty("os.name").contains("OS X")) {
+                robot.keyPress(KeyEvent.VK_CONTROL);
+                robot.keyPress(KeyEvent.VK_ALT);
+                robot.keyPress(KeyEvent.VK_F);
+                robot.keyRelease(KeyEvent.VK_F);
+                robot.keyRelease(KeyEvent.VK_ALT);
+                robot.keyRelease(KeyEvent.VK_CONTROL);
+            } else {
+                robot.keyPress(KeyEvent.VK_ALT);
+                robot.keyPress(KeyEvent.VK_F);
+                robot.keyRelease(KeyEvent.VK_F);
+                robot.keyRelease(KeyEvent.VK_ALT);
+            }
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                isPopMenuVisible = menu.isPopupMenuVisible();
+            });
+            if (!isPopMenuVisible) {
+                throw new RuntimeException("Menu popup is not shown");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug4146588.java
+++ b/test/jdk/javax/swing/JMenu/bug4146588.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4146588
+ * @summary JMenu.setMenuLocation has no effect
+ * @key headful
+ * @run main bug4146588
+ */
+
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.SwingUtilities;
+
+public class bug4146588  {
+
+    private static JFrame fr;
+    private static JMenu menu;
+    private static volatile Point loc;
+    private static volatile Point popupLoc;
+    private static volatile Point menuLoc;
+    private static volatile Rectangle frameBounds;
+    private static volatile Rectangle popupBounds;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                fr = new JFrame("bug4146588 frame");
+
+                JMenuBar menubar = new JMenuBar();
+                menu = new JMenu("Menu");
+                menu.add("Item 1");
+                menu.add("Item 2");
+                menu.add("Item 3");
+                menu.setMenuLocation(150, 150);
+                menubar.add(menu);
+                fr.setJMenuBar(menubar);
+
+                fr.setSize(400, 400);
+                fr.setLocationRelativeTo(null);
+                fr.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                menu.doClick(0);
+            });
+            robot.waitForIdle();
+            robot.delay(200);
+            SwingUtilities.invokeAndWait(() -> {
+                popupLoc = menu.getPopupMenu().getLocationOnScreen();
+                menuLoc = menu.getLocationOnScreen();
+                frameBounds = fr.getBounds();
+                popupBounds = menu.getPopupMenu().getBounds();
+            });
+            System.out.println(popupLoc);
+            System.out.println(popupBounds);
+            System.out.println(frameBounds);
+            System.out.println(menuLoc);
+            if (!(popupLoc.getX()
+                 > ((frameBounds.getX() + frameBounds.getWidth() / 2) - popupBounds.getWidth()))
+                && (popupLoc.getY()
+                 > ((frameBounds.getY() + frameBounds.getHeight() / 2) - popupBounds.getHeight()))) {
+                throw new RuntimeException("popup is not at center of frame");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug4342646.java
+++ b/test/jdk/javax/swing/JMenu/bug4342646.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4342646
+ * @summary Tests that very long menus are properly placed on the screen.
+ * @key headful
+ * @run main bug4342646
+ */
+
+import java.awt.Point;
+import java.awt.Robot;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+
+public class bug4342646 {
+
+    private static JFrame frame;
+    private static JMenu menu;
+    private static volatile Point popupLoc;
+    private static volatile Point menuLoc;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                JMenuBar mbar = new JMenuBar();
+                menu = new JMenu("Menu");
+                menu.add(new JMenuItem(
+                         "AAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                         "AAAAAAAAAAAAAAAAAAAAAAA"));
+                mbar.add(menu);
+
+                frame = new JFrame("4342646");
+                frame.setJMenuBar(mbar);
+                frame.setBounds(10, 10, 200, 100);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                menu.doClick();
+            });
+            robot.waitForIdle();
+            robot.delay(200);
+            SwingUtilities.invokeAndWait(() -> {
+                popupLoc = menu.getPopupMenu().getLocationOnScreen();
+                menuLoc = menu.getLocationOnScreen();
+            });
+            System.out.println(menuLoc);
+            System.out.println(popupLoc);
+            if (popupLoc.getX() < menuLoc.getX()) {
+                throw new RuntimeException("PopupMenu is incorrectly placed at left of menu");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Few JMenu tests are opensourced

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352676](https://bugs.openjdk.org/browse/JDK-8352676): Opensource JMenu tests - series1 (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24220/head:pull/24220` \
`$ git checkout pull/24220`

Update a local copy of the PR: \
`$ git checkout pull/24220` \
`$ git pull https://git.openjdk.org/jdk.git pull/24220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24220`

View PR using the GUI difftool: \
`$ git pr show -t 24220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24220.diff">https://git.openjdk.org/jdk/pull/24220.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24220#issuecomment-2750626514)
</details>
