### PR TITLE
8352866: TestLogJIT.java runs wrong test class

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestLogJIT.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestLogJIT.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Test running with log:jit*=debug enabled.
- * @run main/othervm -Xlog:jit*=debug compiler.arguments.TestTraceTypeProfile
+ * @run main/othervm -Xlog:jit*=debug compiler.arguments.TestLogJIT
  */
 
 package compiler.arguments;

--- a/test/hotspot/jtreg/compiler/c2/Test7005594.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7005594.java
@@ -27,8 +27,8 @@
  * @summary Array overflow not handled correctly with loop optimzations
  *
  * @run main/othervm -Xcomp
-                     -XX:CompileOnly=compiler.c2.Test7005594::test
-                     compiler.c2.Test7005594
+ *                   -XX:CompileOnly=compiler.c2.Test7005594::test
+ *                   compiler.c2.Test7005594
  */
 
 package compiler.c2;

--- a/test/hotspot/jtreg/compiler/loopopts/TestMissingSkeletonPredicateForIfNode.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestMissingSkeletonPredicateForIfNode.java
@@ -28,7 +28,7 @@
  *          predicate is created in loop predication.
  * @requires vm.debug == true & vm.compiler2.enabled
  * @run main/othervm -XX:-TieredCompilation -Xbatch -XX:-RangeCheckElimination -XX:+BailoutToInterpreterForThrows
-                     compiler.loopopts.TestMissingSkeletonPredicateForIfNode
+ *                   compiler.loopopts.TestMissingSkeletonPredicateForIfNode
  */
 package compiler.loopopts;
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestSearchAlignment.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestSearchAlignment.java
@@ -27,7 +27,7 @@
  * @summary JVM crash in SWPointer during C2 compilation
  *
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
-        -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestSearchAlignment::vMeth
+ *      -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestSearchAlignment::vMeth
  *      compiler.loopopts.superword.TestSearchAlignment
  */
 


### PR DESCRIPTION
Fixed wrong test class in `@run` statement and fixed comment style in three unrelated tests.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352866](https://bugs.openjdk.org/browse/JDK-8352866): TestLogJIT.java runs wrong test class (**Bug** - P5)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24221/head:pull/24221` \
`$ git checkout pull/24221`

Update a local copy of the PR: \
`$ git checkout pull/24221` \
`$ git pull https://git.openjdk.org/jdk.git pull/24221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24221`

View PR using the GUI difftool: \
`$ git pr show -t 24221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24221.diff">https://git.openjdk.org/jdk/pull/24221.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24221#issuecomment-2750768918)
</details>
