### PR TITLE
8352509: Update jdk.test.lib.SecurityTools jar method to accept List<String> parameter

### DIFF
--- a/test/lib/jdk/test/lib/SecurityTools.java
+++ b/test/lib/jdk/test/lib/SecurityTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/SecurityTools.java
+++ b/test/lib/jdk/test/lib/SecurityTools.java
@@ -236,13 +236,36 @@ public class SecurityTools {
     /**
      * Runs jar.
      *
+     * @param args arguments to jar in the list.
+     * @return an {@link OutputAnalyzer} object
+     * @throws Exception if there is an error
+     */
+    public static OutputAnalyzer jar(final List<String> args) throws Exception {
+        return execute(getProcessBuilder("jar", args));
+    }
+
+    /**
+     * Runs jar.
+     *
      * @param args arguments to jar in a single string. The string is
      *             converted to be List with makeList.
      * @return an {@link OutputAnalyzer} object
      * @throws Exception if there is an error
      */
-    public static OutputAnalyzer jar(String args) throws Exception {
-        return execute(getProcessBuilder("jar", makeList(args)));
+    public static OutputAnalyzer jar(final String args) throws Exception {
+        return  jar(makeList(args));
+    }
+
+    /**
+     * Runs jar.
+     *
+     * @param args arguments to jar in multiple strings.
+     *             Converted to be a List with List.of.
+     * @return an {@link OutputAnalyzer} object
+     * @throws Exception if there is an error
+     */
+    public static OutputAnalyzer jar(final String... args) throws Exception {
+        return jar(List.of(args));
     }
 
     /**


### PR DESCRIPTION
Updating `jdk.test.lib.SecurityTools` class to have jar method accept `List<String>` parameter similar to `keytool` methods.
Currently this only accept String parameter, which is error prone with missing space

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352509](https://bugs.openjdk.org/browse/JDK-8352509): Update jdk.test.lib.SecurityTools jar method to accept List&lt;String&gt; parameter (**Enhancement** - P5)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24225/head:pull/24225` \
`$ git checkout pull/24225`

Update a local copy of the PR: \
`$ git checkout pull/24225` \
`$ git pull https://git.openjdk.org/jdk.git pull/24225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24225`

View PR using the GUI difftool: \
`$ git pr show -t 24225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24225.diff">https://git.openjdk.org/jdk/pull/24225.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24225#issuecomment-2751031993)
</details>
