### PR TITLE
8255849: Make ThreadSafepointState::_at_poll_safepoint DEBUG_ONLY

### DIFF
--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -174,9 +174,11 @@ void JavaThread::set_safepoint_state(ThreadSafepointState *state) {
   _safepoint_state = state;
 }
 
+#ifdef ASSERT
 bool JavaThread::is_at_poll_safepoint() {
   return _safepoint_state->is_at_poll_safepoint();
 }
+#endif
 
 bool JavaThread::is_vthread_mounted() const {
   return vthread_continuation() != nullptr;

--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,7 +182,9 @@ public:
 class ThreadSafepointState: public CHeapObj<mtThread> {
  private:
   // At polling page safepoint (NOT a poll return safepoint):
+#ifdef ASSERT
   volatile bool                   _at_poll_safepoint;
+#endif
   JavaThread*                     _thread;
   bool                            _safepoint_safe;
   volatile uint64_t               _safepoint_id;
@@ -212,8 +214,10 @@ class ThreadSafepointState: public CHeapObj<mtThread> {
   void     set_safepoint_id(uint64_t sid);
 
   // Support for safepoint timeout (debugging)
+#ifdef ASSERT
   bool is_at_poll_safepoint()           { return _at_poll_safepoint; }
   void set_at_poll_safepoint(bool val)  { _at_poll_safepoint = val; }
+#endif
 
   void handle_polling_page_exception();
 


### PR DESCRIPTION
Since `ThreadSafepointState::_at_poll_safepoint` if is only used in `assert` code it's now only declared if `ASSERT` / `NO_DEBUG` is defined.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255849](https://bugs.openjdk.org/browse/JDK-8255849): Make ThreadSafepointState::_at_poll_safepoint DEBUG_ONLY (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24226/head:pull/24226` \
`$ git checkout pull/24226`

Update a local copy of the PR: \
`$ git checkout pull/24226` \
`$ git pull https://git.openjdk.org/jdk.git pull/24226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24226`

View PR using the GUI difftool: \
`$ git pr show -t 24226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24226.diff">https://git.openjdk.org/jdk/pull/24226.diff</a>

</details>
