### PR TITLE
8352890: Remove unnecessary Windows version check in FileFontStrike

### DIFF
--- a/src/java.desktop/share/classes/sun/font/FileFontStrike.java
+++ b/src/java.desktop/share/classes/sun/font/FileFontStrike.java
@@ -113,15 +113,6 @@ public class FileFontStrike extends PhysicalStrike {
     /* Used only for communication to native layer */
     private int intPtSize;
 
-    /* Perform global initialisation needed for Windows native rasterizer */
-    private static native void initNative();
-    static {
-        if (FontUtilities.isWindows && !FontUtilities.useJDKScaler &&
-            !GraphicsEnvironment.isHeadless()) {
-            initNative();
-        }
-    }
-
     FileFontStrike(FileFont fileFont, FontStrikeDesc desc) {
         super(fileFont, desc);
         this.fileFont = fileFont;

--- a/src/java.desktop/share/classes/sun/font/FileFontStrike.java
+++ b/src/java.desktop/share/classes/sun/font/FileFontStrike.java
@@ -116,7 +116,8 @@ public class FileFontStrike extends PhysicalStrike {
     /* Perform global initialisation needed for Windows native rasterizer */
     private static native void initNative();
     static {
-        if (FontUtilities.isWindows && !FontUtilities.useJDKScaler && !GraphicsEnvironment.isHeadless()) {
+        if (FontUtilities.isWindows && !FontUtilities.useJDKScaler &&
+            !GraphicsEnvironment.isHeadless()) {
             initNative();
         }
     }

--- a/src/java.desktop/share/classes/sun/font/FileFontStrike.java
+++ b/src/java.desktop/share/classes/sun/font/FileFontStrike.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,16 +109,15 @@ public class FileFontStrike extends PhysicalStrike {
     NativeStrike[] nativeStrikes;
 
     static final int MAX_IMAGE_SIZE = OutlineTextRenderer.THRESHHOLD;
+
     /* Used only for communication to native layer */
     private int intPtSize;
 
     /* Perform global initialisation needed for Windows native rasterizer */
-    private static native boolean initNative();
-    private static boolean isXPorLater = false;
+    private static native void initNative();
     static {
-        if (FontUtilities.isWindows && !FontUtilities.useJDKScaler &&
-            !GraphicsEnvironment.isHeadless()) {
-            isXPorLater = initNative();
+        if (FontUtilities.isWindows && !FontUtilities.useJDKScaler && !GraphicsEnvironment.isHeadless()) {
+            initNative();
         }
     }
 
@@ -212,7 +211,7 @@ public class FileFontStrike extends PhysicalStrike {
          * except that the advance returned by GDI is always overwritten by
          * the JDK rasteriser supplied one (see getGlyphImageFromWindows()).
          */
-        if (FontUtilities.isWindows && isXPorLater &&
+        if (FontUtilities.isWindows &&
             !FontUtilities.useJDKScaler &&
             !GraphicsEnvironment.isHeadless() &&
             !fileFont.useJavaRasterizer &&

--- a/src/java.desktop/windows/native/libfontmanager/lcdglyph.c
+++ b/src/java.desktop/windows/native/libfontmanager/lcdglyph.c
@@ -89,7 +89,7 @@
 #define MAX_GAMMA 220
 #define LCDLUTCOUNT (MAX_GAMMA-MIN_GAMMA+1)
 
-static unsigned char* igLUTable[LCDLUTCOUNT];
+static unsigned char* igLUTable[LCDLUTCOUNT] = { 0 };
 
 static unsigned char* getIGTable(int gamma) {
     int i, index;
@@ -120,10 +120,6 @@ static unsigned char* getIGTable(int gamma) {
     }
     igLUTable[index] = igTable;
     return igTable;
-}
-
-JNIEXPORT void JNICALL Java_sun_font_FileFontStrike_initNative(JNIEnv *env, jclass unused) {
-    memset(igLUTable, 0, sizeof igLUTable);
 }
 
 #ifndef CLEARTYPE_QUALITY

--- a/src/java.desktop/windows/native/libfontmanager/lcdglyph.c
+++ b/src/java.desktop/windows/native/libfontmanager/lcdglyph.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,13 +122,8 @@ static unsigned char* getIGTable(int gamma) {
     return igTable;
 }
 
-
-JNIEXPORT jboolean JNICALL
-    Java_sun_font_FileFontStrike_initNative(JNIEnv *env, jclass unused) {
-
+JNIEXPORT void JNICALL Java_sun_font_FileFontStrike_initNative(JNIEnv *env, jclass unused) {
     memset(igLUTable, 0, sizeof igLUTable);
-
-    return JNI_TRUE;
 }
 
 #ifndef CLEARTYPE_QUALITY


### PR DESCRIPTION
FileFontStrike contains a check as to whether the current Windows version is Windows XP or later. The current minimum supported version is Windows 10, so this is no longer needed.

When the code in question was added 17 years ago, a test was included (test/jdk/java/awt/Graphics2D/DrawString/ScaledLCDTextMetrics.java), so this can be used to verify that there are no regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352890](https://bugs.openjdk.org/browse/JDK-8352890): Remove unnecessary Windows version check in FileFontStrike (**Bug** - P5)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [79e1b2ea](https://git.openjdk.org/jdk/pull/24230/files/79e1b2ea0564b31414cb312d1bcb73c4a463f60f)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24230/head:pull/24230` \
`$ git checkout pull/24230`

Update a local copy of the PR: \
`$ git checkout pull/24230` \
`$ git pull https://git.openjdk.org/jdk.git pull/24230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24230`

View PR using the GUI difftool: \
`$ git pr show -t 24230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24230.diff">https://git.openjdk.org/jdk/pull/24230.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24230#issuecomment-2751453888)
</details>
