### PR TITLE
8352088: Call of com.sun.jdi.ThreadReference.threadGroups() can lock up target VM

### DIFF
--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -658,10 +658,16 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
 
     /**
      * Returns a snapshot of the subgroups as an array, used by JVMTI.
+     * WARNING: Make sure this API does not trigger any class loading.
      */
     private ThreadGroup[] subgroupsAsArray() {
         List<ThreadGroup> groups = synchronizedSubgroups();
-        return groups.toArray(new ThreadGroup[groups.size()]);
+        int count = groups.size();
+        var array = new ThreadGroup[count];
+        for (int i = 0; i < count; i++) {
+            array[i] = groups.get(i);
+        }
+        return array;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -659,7 +659,7 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
     /**
      * Returns a snapshot of the subgroups as an array, used by JVMTI.
      * WARNING: Make sure this method does not trigger any class loading,
-     * because a ClassPrepareEvent can deadlock the debugger and debug agent.
+     * because a ClassPrepare event can deadlock the debugger and debug agent.
      */
     private ThreadGroup[] subgroupsAsArray() {
         List<ThreadGroup> groups = synchronizedSubgroups();

--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -661,7 +661,7 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
      */
     private ThreadGroup[] subgroupsAsArray() {
         List<ThreadGroup> groups = synchronizedSubgroups();
-        return groups.toArray(new ThreadGroup[0]);
+        return groups.toArray(new ThreadGroup[groups.size()]);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -658,7 +658,7 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
 
     /**
      * Returns a snapshot of the subgroups as an array, used by JVMTI.
-     * WARNING: Make sure this API does not trigger any class loading.
+     * WARNING: Make sure this method does not trigger any class loading.
      */
     private ThreadGroup[] subgroupsAsArray() {
         List<ThreadGroup> groups = synchronizedSubgroups();

--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -658,7 +658,8 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
 
     /**
      * Returns a snapshot of the subgroups as an array, used by JVMTI.
-     * WARNING: Make sure this method does not trigger any class loading.
+     * WARNING: Make sure this method does not trigger any class loading,
+     * because a ClassPrepareEvent can deadlock the debugger and debug agent.
      */
     private ThreadGroup[] subgroupsAsArray() {
         List<ThreadGroup> groups = synchronizedSubgroups();

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.c
@@ -234,22 +234,6 @@ util_initialize(JNIEnv *env)
         saveGlobalRef(env, localSystemThreadGroup, &(gdata->systemThreadGroup));
         jvmtiDeallocate(groups);
 
-        #if 0
-        // This is a workaround for 8352088. GetThreadGroupChildren does an upcall to 
-        // java which may trigger class loading the first time it is called. Call is now
-        // for the first time when we know it will be safe to trigger the class loading.
-        jint threadCount;
-        jthread *theThreads;
-        jthread *theGroups;
-        error = JVMTI_FUNC_PTR(gdata->jvmti,GetThreadGroupChildren)
-                    (gdata->jvmti, gdata->systemThreadGroup,
-                     &threadCount,&theThreads,
-                     &groupCount, &theGroups);
-        if (error != JVMTI_ERROR_NONE) {
-            EXIT_ERROR(error, "JDWP unable to call GetThreadGroupChildren");
-        }
-        #endif
-
         /* Get some basic Java property values we will need at some point */
         gdata->property_java_version
                         = getPropertyUTF8(env, "java.version");

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.c
@@ -234,6 +234,22 @@ util_initialize(JNIEnv *env)
         saveGlobalRef(env, localSystemThreadGroup, &(gdata->systemThreadGroup));
         jvmtiDeallocate(groups);
 
+        #if 0
+        // This is a workaround for 8352088. GetThreadGroupChildren does an upcall to 
+        // java which may trigger class loading the first time it is called. Call is now
+        // for the first time when we know it will be safe to trigger the class loading.
+        jint threadCount;
+        jthread *theThreads;
+        jthread *theGroups;
+        error = JVMTI_FUNC_PTR(gdata->jvmti,GetThreadGroupChildren)
+                    (gdata->jvmti, gdata->systemThreadGroup,
+                     &threadCount,&theThreads,
+                     &groupCount, &theGroups);
+        if (error != JVMTI_ERROR_NONE) {
+            EXIT_ERROR(error, "JDWP unable to call GetThreadGroupChildren");
+        }
+        #endif
+
         /* Get some basic Java property values we will need at some point */
         gdata->property_java_version
                         = getPropertyUTF8(env, "java.version");

--- a/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
+++ b/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
@@ -64,9 +64,6 @@ public class EarlyThreadGroupChildrenTest extends TestScaffold {
 
     /********** event handlers **********/
 
-    static final int NUM_BREAKPOINTS = 1;
-    int bkptCount;
-    BreakpointRequest bkptRequest;
     ClassPrepareRequest cpRequest;
     ThreadStartRequest tsRequest;
 

--- a/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
+++ b/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
@@ -77,9 +77,8 @@ public class EarlyThreadGroupChildrenTest extends TestScaffold {
         cpRequest.setSuspendPolicy(EventRequest.SUSPEND_ALL);
         cpRequest.enable();
     }
-    
+
     static volatile int classPreparedCount = 0;
-    //static final int MAX_CLASSPREPARED_EVENTS = 50;
 
     @Override
     public void classPrepared(ClassPrepareEvent event) {

--- a/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
+++ b/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
@@ -51,9 +51,6 @@ class EarlyThreadGroupChildrenTestTarg {
     /********** test program **********/
 
 public class EarlyThreadGroupChildrenTest extends TestScaffold {
-    ClassType targetClass;
-    ThreadReference mainThread;
-
     EarlyThreadGroupChildrenTest(String args[]) {
         super(args);
     }

--- a/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
+++ b/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8352088
+ * @summary If ThreadGroupReference.groups() is called very early on from an
+ *          event handler, it can cause a deadlock because the call can result
+ *          in ClassPrepareEvents, which the debug agent will block on until
+ *          the debugger handles them, which it won't because the event handler
+ *          thread is waiting for a reply to ThreadGroupReference.groups(). 
+ *
+ * @run build TestScaffold VMConnection TargetListener TargetAdapter
+ * @run compile -g EarlyThreadGroupChildrenTest.java
+ * @run main/othervm/timeout=20 EarlyThreadGroupChildrenTest
+ */
+
+import com.sun.jdi.*;
+import com.sun.jdi.event.*;
+import com.sun.jdi.request.*;
+
+import java.util.*;
+
+class EarlyThreadGroupChildrenTestTarg {
+    public static void main(String[] args) throws InterruptedException {
+        System.out.println("Start");
+        System.out.println("Finish");
+    }
+}
+
+    /********** test program **********/
+
+public class EarlyThreadGroupChildrenTest extends TestScaffold {
+    ClassType targetClass;
+    ThreadReference mainThread;
+
+    EarlyThreadGroupChildrenTest(String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args)      throws Exception {
+        new EarlyThreadGroupChildrenTest(args).startTests();
+    }
+
+    /********** event handlers **********/
+
+    static final int NUM_BREAKPOINTS = 1;
+    int bkptCount;
+    BreakpointRequest bkptRequest;
+    ClassPrepareRequest cpRequest;
+    ThreadStartRequest tsRequest;
+    
+    @Override
+    public void threadStarted(ThreadStartEvent event) {
+        System.out.println("Got ThreadStartEvent: " + event);
+        cpRequest = eventRequestManager().createClassPrepareRequest();
+        cpRequest.setSuspendPolicy(EventRequest.SUSPEND_ALL);
+        cpRequest.enable();
+    }
+    
+    static volatile int classPreparedCount = 0;
+    //static final int MAX_CLASSPREPARED_EVENTS = 50;
+    
+    @Override
+    public void classPrepared(ClassPrepareEvent event) {
+        try {
+            ++classPreparedCount;
+            System.out.println("ClassPreparedEvent " + classPreparedCount +
+                               " on thread " + event.thread() +
+                               ": " + event.referenceType());
+            List<ThreadGroupReference> groups = vm().topLevelThreadGroups();
+            ThreadGroupReference systemThreadGroup = groups.get(0);
+            groups = systemThreadGroup.threadGroups();
+            System.out.println("system child ThreadGroups: " + groups);
+        } catch (VMDisconnectedException e) {
+            // This usually eventually happens during shutdown.
+            System.out.println("ClassPreparedEvent " + classPreparedCount +
+                               ": Got VMDisconnectedException");
+        }
+    }
+
+    public void vmDisconnected(VMDisconnectEvent event) {
+        System.out.println("Got VMDisconnectEvent");
+    }
+
+    /********** test core **********/
+
+    protected void runTests() throws Exception {
+        connect(new String[]{"EarlyThreadGroupChildrenTestTarg"});
+        System.out.println("Connected: ");
+        addListener(this);
+
+        // Create a ThreadStartRequest for the first ThreadStartEvent. When this event is
+        // received, we will enable ClassPrepareEvents.
+        tsRequest = eventRequestManager().createThreadStartRequest();
+        tsRequest.setSuspendPolicy(EventRequest.SUSPEND_ALL);
+        tsRequest.addCountFilter(1);
+        tsRequest.enable();
+
+        waitForVMStart();
+        System.out.println("VM Started: ");
+
+        resumeToVMDisconnect();
+
+        // Failure mode for this test is deadlocking, so there is no error to check for.
+        System.out.println("EarlyThreadGroupChildrenTest: passed");
+    }
+}

--- a/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
+++ b/test/jdk/com/sun/jdi/EarlyThreadGroupChildrenTest.java
@@ -28,7 +28,7 @@
  *          event handler, it can cause a deadlock because the call can result
  *          in ClassPrepareEvents, which the debug agent will block on until
  *          the debugger handles them, which it won't because the event handler
- *          thread is waiting for a reply to ThreadGroupReference.groups(). 
+ *          thread is waiting for a reply to ThreadGroupReference.groups().
  *
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g EarlyThreadGroupChildrenTest.java
@@ -69,7 +69,7 @@ public class EarlyThreadGroupChildrenTest extends TestScaffold {
     BreakpointRequest bkptRequest;
     ClassPrepareRequest cpRequest;
     ThreadStartRequest tsRequest;
-    
+
     @Override
     public void threadStarted(ThreadStartEvent event) {
         System.out.println("Got ThreadStartEvent: " + event);
@@ -80,7 +80,7 @@ public class EarlyThreadGroupChildrenTest extends TestScaffold {
     
     static volatile int classPreparedCount = 0;
     //static final int MAX_CLASSPREPARED_EVENTS = 50;
-    
+
     @Override
     public void classPrepared(ClassPrepareEvent event) {
         try {


### PR DESCRIPTION
Calling ThreadGroupReference.groups() from an event handler can cause a deadlock. Details in first comment. Tested with :jdk_lang on all supported platforms and tier1, tier2, tier3, and tier5 svc testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352088](https://bugs.openjdk.org/browse/JDK-8352088): Call of com.sun.jdi.ThreadReference.threadGroups() can lock up target VM (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24236/head:pull/24236` \
`$ git checkout pull/24236`

Update a local copy of the PR: \
`$ git checkout pull/24236` \
`$ git pull https://git.openjdk.org/jdk.git pull/24236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24236`

View PR using the GUI difftool: \
`$ git pr show -t 24236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24236.diff">https://git.openjdk.org/jdk/pull/24236.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24236#issuecomment-2752803225)
</details>
