### PR TITLE
8351290: Clarify integral only for vector operators

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorOperators.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorOperators.java
@@ -452,23 +452,23 @@ public abstract class VectorOperators {
     public static final Unary ABS = unary("ABS", "abs", VectorSupport.VECTOR_OP_ABS, VO_ALL);
     /** Produce {@code -a}. */
     public static final Unary NEG = unary("NEG", "-a", VectorSupport.VECTOR_OP_NEG, VO_ALL|VO_SPECIAL);
-    /** Produce {@code bitCount(a)}
+    /** Produce {@code bitCount(a)} Integral only.
      * @since 19
      */
     public static final Unary BIT_COUNT = unary("BIT_COUNT", "bitCount", VectorSupport.VECTOR_OP_BIT_COUNT, VO_NOFP);
-    /** Produce {@code numberOfTrailingZeros(a)}
+    /** Produce {@code numberOfTrailingZeros(a)}. Integral only.
      * @since 19
      */
     public static final Unary TRAILING_ZEROS_COUNT = unary("TRAILING_ZEROS_COUNT", "numberOfTrailingZeros", VectorSupport.VECTOR_OP_TZ_COUNT, VO_NOFP);
-    /** Produce {@code numberOfLeadingZeros(a)}
+    /** Produce {@code numberOfLeadingZeros(a)}. Integral only.
      * @since 19
      */
     public static final Unary LEADING_ZEROS_COUNT = unary("LEADING_ZEROS_COUNT", "numberOfLeadingZeros", VectorSupport.VECTOR_OP_LZ_COUNT, VO_NOFP);
-    /** Produce {@code reverse(a)}
+    /** Produce {@code reverse(a)}. Integral only.
      * @since 19
      */
     public static final Unary REVERSE = unary("REVERSE", "reverse", VectorSupport.VECTOR_OP_REVERSE, VO_NOFP);
-    /** Produce {@code reverseBytes(a)}
+    /** Produce {@code reverseBytes(a)}. Integral only.
      * @since 19
      */
     public static final Unary REVERSE_BYTES = unary("REVERSE_BYTES", "reverseBytes", VectorSupport.VECTOR_OP_REVERSE_BYTES, VO_NOFP);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorOperators.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorOperators.java
@@ -452,7 +452,7 @@ public abstract class VectorOperators {
     public static final Unary ABS = unary("ABS", "abs", VectorSupport.VECTOR_OP_ABS, VO_ALL);
     /** Produce {@code -a}. */
     public static final Unary NEG = unary("NEG", "-a", VectorSupport.VECTOR_OP_NEG, VO_ALL|VO_SPECIAL);
-    /** Produce {@code bitCount(a)} Integral only.
+    /** Produce {@code bitCount(a)}. Integral only.
      * @since 19
      */
     public static final Unary BIT_COUNT = unary("BIT_COUNT", "bitCount", VectorSupport.VECTOR_OP_BIT_COUNT, VO_NOFP);


### PR DESCRIPTION
Updating Javadoc for vector operators with VO_NOFP flags, but no corresponding "Integral only." note in docs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351290](https://bugs.openjdk.org/browse/JDK-8351290): Clarify integral only for vector operators (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24237/head:pull/24237` \
`$ git checkout pull/24237`

Update a local copy of the PR: \
`$ git checkout pull/24237` \
`$ git pull https://git.openjdk.org/jdk.git pull/24237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24237`

View PR using the GUI difftool: \
`$ git pr show -t 24237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24237.diff">https://git.openjdk.org/jdk/pull/24237.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24237#issuecomment-2752516589)
</details>
