### PR TITLE
8352620: C2: rename MemNode::memory_type() to MemNode::value_basic_type()

### DIFF
--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -126,7 +126,7 @@ Bytecodes::Code ciBytecodeStream::next_wide_or_table(Bytecodes::Code bc) {
   }
 
   default:
-    fatal("unhandled bytecode");
+    fatal("unhandled bytecode : BCI = %d, OPCODE = %s (0x%X)", cur_bci(), Bytecodes::name(bc), bc);
   }
   return bc;
 }

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -2819,14 +2819,13 @@ int ConnectionGraph::find_init_values_null(JavaObjectNode* pta, PhaseValues* pha
         offsets_worklist.append(offset);
         Node* value = nullptr;
         if (ini != nullptr) {
-          // StoreP::memory_type() == T_ADDRESS
           BasicType ft = UseCompressedOops ? T_NARROWOOP : T_ADDRESS;
           Node* store = ini->find_captured_store(offset, type2aelembytes(ft, true), phase);
           // Make sure initializing store has the same type as this AddP.
           // This AddP may reference non existing field because it is on a
           // dead branch of bimorphic call which is not eliminated yet.
           if (store != nullptr && store->is_Store() &&
-              store->as_Store()->memory_type() == ft) {
+              store->as_Store()->value_basic_type() == ft) {
             value = store->in(MemNode::ValueIn);
 #ifdef ASSERT
             if (VerifyConnectionGraph) {

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3589,7 +3589,7 @@ bool PhaseIdealLoop::match_fill_loop(IdealLoopTree* lpt, Node*& store, Node*& st
   }
 
   // Make sure there is an appropriate fill routine
-  BasicType t = store->as_Mem()->memory_type();
+  BasicType t = store->as_Mem()->value_basic_type();
   const char* fill_name;
   if (msg == nullptr &&
       StubRoutines::select_fill_function(t, false, fill_name) == nullptr) {
@@ -3635,7 +3635,7 @@ bool PhaseIdealLoop::match_fill_loop(IdealLoopTree* lpt, Node*& store, Node*& st
       if (value != head->phi()) {
         msg = "unhandled shift in address";
       } else {
-        if (type2aelembytes(store->as_Mem()->memory_type(), true) != (1 << n->in(2)->get_int())) {
+        if (type2aelembytes(store->as_Mem()->value_basic_type(), true) != (1 << n->in(2)->get_int())) {
           msg = "scale doesn't match";
         } else {
           found_index = true;
@@ -3841,7 +3841,7 @@ bool PhaseIdealLoop::intrinsify_fill(IdealLoopTree* lpt) {
 #endif
   }
 
-  BasicType t = store->as_Mem()->memory_type();
+  BasicType t = store->as_Mem()->value_basic_type();
   bool aligned = false;
   if (offset != nullptr && head->init_trip()->is_Con()) {
     int element_size = type2aelembytes(t);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1206,12 +1206,12 @@ Node* MemNode::can_see_stored_value(Node* st, PhaseValues* phase) const {
       // (This is one of the few places where a generic PhaseTransform
       // can create new nodes.  Think of it as lazily manifesting
       // virtually pre-existing constants.)
-      if (memory_type() != T_VOID) {
+      if (value_basic_type() != T_VOID) {
         if (ReduceBulkZeroing || find_array_copy_clone(ld_alloc, in(MemNode::Memory)) == nullptr) {
           // If ReduceBulkZeroing is disabled, we need to check if the allocation does not belong to an
           // ArrayCopyNode clone. If it does, then we cannot assume zero since the initialization is done
           // by the ArrayCopyNode.
-          return phase->zerocon(memory_type());
+          return phase->zerocon(value_basic_type());
         }
       } else {
         // TODO: materialize all-zero vector constant
@@ -2040,7 +2040,7 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
         int stable_dimension = (ary->stable_dimension() > 0 ? ary->stable_dimension() - 1 : 0);
         const Type* con_type = Type::make_constant_from_array_element(aobj->as_array(), off,
                                                                       stable_dimension,
-                                                                      memory_type(), is_unsigned());
+                                                                      value_basic_type(), is_unsigned());
         if (con_type != nullptr) {
           return con_type;
         }
@@ -2108,7 +2108,7 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
     const TypeInstPtr* tinst = tp->is_instptr();
     ciObject* const_oop = tinst->const_oop();
     if (!is_mismatched_access() && off != Type::OffsetBot && const_oop != nullptr && const_oop->is_instance()) {
-      const Type* con_type = Type::make_constant_from_field(const_oop->as_instance(), off, is_unsigned(), memory_type());
+      const Type* con_type = Type::make_constant_from_field(const_oop->as_instance(), off, is_unsigned(), value_basic_type());
       if (con_type != nullptr) {
         return con_type;
       }

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -134,12 +134,12 @@ public:
   virtual int store_Opcode() const { return -1; }
 
   // What is the type of the value in memory?  (T_VOID mean "unspecified".)
-  virtual BasicType memory_type() const = 0;
+  virtual BasicType value_basic_type() const = 0;
   virtual int memory_size() const {
 #ifdef ASSERT
-    return type2aelembytes(memory_type(), true);
+    return type2aelembytes(value_basic_type(), true);
 #else
-    return type2aelembytes(memory_type());
+    return type2aelembytes(value_basic_type());
 #endif
   }
 
@@ -337,7 +337,7 @@ public:
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual int store_Opcode() const { return Op_StoreB; }
-  virtual BasicType memory_type() const { return T_BYTE; }
+  virtual BasicType value_basic_type() const { return T_BYTE; }
 };
 
 //------------------------------LoadUBNode-------------------------------------
@@ -351,7 +351,7 @@ public:
   virtual Node* Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual int store_Opcode() const { return Op_StoreB; }
-  virtual BasicType memory_type() const { return T_BYTE; }
+  virtual BasicType value_basic_type() const { return T_BYTE; }
 };
 
 //------------------------------LoadUSNode-------------------------------------
@@ -365,7 +365,7 @@ public:
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual int store_Opcode() const { return Op_StoreC; }
-  virtual BasicType memory_type() const { return T_CHAR; }
+  virtual BasicType value_basic_type() const { return T_CHAR; }
 };
 
 //------------------------------LoadSNode--------------------------------------
@@ -379,7 +379,7 @@ public:
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual int store_Opcode() const { return Op_StoreC; }
-  virtual BasicType memory_type() const { return T_SHORT; }
+  virtual BasicType value_basic_type() const { return T_SHORT; }
 };
 
 //------------------------------LoadINode--------------------------------------
@@ -391,7 +391,7 @@ public:
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegI; }
   virtual int store_Opcode() const { return Op_StoreI; }
-  virtual BasicType memory_type() const { return T_INT; }
+  virtual BasicType value_basic_type() const { return T_INT; }
 };
 
 //------------------------------LoadRangeNode----------------------------------
@@ -424,7 +424,7 @@ public:
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegL; }
   virtual int store_Opcode() const { return Op_StoreL; }
-  virtual BasicType memory_type() const { return T_LONG; }
+  virtual BasicType value_basic_type() const { return T_LONG; }
   bool require_atomic_access() const { return _require_atomic_access; }
 
 #ifndef PRODUCT
@@ -453,7 +453,7 @@ public:
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegF; }
   virtual int store_Opcode() const { return Op_StoreF; }
-  virtual BasicType memory_type() const { return T_FLOAT; }
+  virtual BasicType value_basic_type() const { return T_FLOAT; }
 };
 
 //------------------------------LoadDNode--------------------------------------
@@ -474,7 +474,7 @@ public:
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegD; }
   virtual int store_Opcode() const { return Op_StoreD; }
-  virtual BasicType memory_type() const { return T_DOUBLE; }
+  virtual BasicType value_basic_type() const { return T_DOUBLE; }
   bool require_atomic_access() const { return _require_atomic_access; }
 
 #ifndef PRODUCT
@@ -503,7 +503,7 @@ public:
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegP; }
   virtual int store_Opcode() const { return Op_StoreP; }
-  virtual BasicType memory_type() const { return T_ADDRESS; }
+  virtual BasicType value_basic_type() const { return T_ADDRESS; }
 };
 
 
@@ -516,7 +516,7 @@ public:
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegN; }
   virtual int store_Opcode() const { return Op_StoreN; }
-  virtual BasicType memory_type() const { return T_NARROWOOP; }
+  virtual BasicType value_basic_type() const { return T_NARROWOOP; }
 };
 
 //------------------------------LoadKlassNode----------------------------------
@@ -555,7 +555,7 @@ public:
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegN; }
   virtual int store_Opcode() const { return Op_StoreNKlass; }
-  virtual BasicType memory_type() const { return T_NARROWKLASS; }
+  virtual BasicType value_basic_type() const { return T_NARROWKLASS; }
 
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
@@ -666,7 +666,7 @@ public:
     : StoreNode(c, mem, adr, at, val, mo) {}
   virtual int Opcode() const;
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
-  virtual BasicType memory_type() const { return T_BYTE; }
+  virtual BasicType value_basic_type() const { return T_BYTE; }
 };
 
 //------------------------------StoreCNode-------------------------------------
@@ -677,7 +677,7 @@ public:
     : StoreNode(c, mem, adr, at, val, mo) {}
   virtual int Opcode() const;
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
-  virtual BasicType memory_type() const { return T_CHAR; }
+  virtual BasicType value_basic_type() const { return T_CHAR; }
 };
 
 //------------------------------StoreINode-------------------------------------
@@ -687,7 +687,7 @@ public:
   StoreINode(Node *c, Node *mem, Node *adr, const TypePtr* at, Node *val, MemOrd mo)
     : StoreNode(c, mem, adr, at, val, mo) {}
   virtual int Opcode() const;
-  virtual BasicType memory_type() const { return T_INT; }
+  virtual BasicType value_basic_type() const { return T_INT; }
 };
 
 //------------------------------StoreLNode-------------------------------------
@@ -705,7 +705,7 @@ public:
   StoreLNode(Node *c, Node *mem, Node *adr, const TypePtr* at, Node *val, MemOrd mo, bool require_atomic_access = false)
     : StoreNode(c, mem, adr, at, val, mo), _require_atomic_access(require_atomic_access) {}
   virtual int Opcode() const;
-  virtual BasicType memory_type() const { return T_LONG; }
+  virtual BasicType value_basic_type() const { return T_LONG; }
   bool require_atomic_access() const { return _require_atomic_access; }
 
 #ifndef PRODUCT
@@ -723,7 +723,7 @@ public:
   StoreFNode(Node *c, Node *mem, Node *adr, const TypePtr* at, Node *val, MemOrd mo)
     : StoreNode(c, mem, adr, at, val, mo) {}
   virtual int Opcode() const;
-  virtual BasicType memory_type() const { return T_FLOAT; }
+  virtual BasicType value_basic_type() const { return T_FLOAT; }
 };
 
 //------------------------------StoreDNode-------------------------------------
@@ -741,7 +741,7 @@ public:
              MemOrd mo, bool require_atomic_access = false)
     : StoreNode(c, mem, adr, at, val, mo), _require_atomic_access(require_atomic_access) {}
   virtual int Opcode() const;
-  virtual BasicType memory_type() const { return T_DOUBLE; }
+  virtual BasicType value_basic_type() const { return T_DOUBLE; }
   bool require_atomic_access() const { return _require_atomic_access; }
 
 #ifndef PRODUCT
@@ -760,7 +760,7 @@ public:
   StorePNode(Node *c, Node *mem, Node *adr, const TypePtr* at, Node *val, MemOrd mo)
     : StoreNode(c, mem, adr, at, val, mo) {}
   virtual int Opcode() const;
-  virtual BasicType memory_type() const { return T_ADDRESS; }
+  virtual BasicType value_basic_type() const { return T_ADDRESS; }
 };
 
 //------------------------------StoreNNode-------------------------------------
@@ -770,7 +770,7 @@ public:
   StoreNNode(Node *c, Node *mem, Node *adr, const TypePtr* at, Node *val, MemOrd mo)
     : StoreNode(c, mem, adr, at, val, mo) {}
   virtual int Opcode() const;
-  virtual BasicType memory_type() const { return T_NARROWOOP; }
+  virtual BasicType value_basic_type() const { return T_NARROWOOP; }
 };
 
 //------------------------------StoreNKlassNode--------------------------------------
@@ -780,7 +780,7 @@ public:
   StoreNKlassNode(Node *c, Node *mem, Node *adr, const TypePtr* at, Node *val, MemOrd mo)
     : StoreNNode(c, mem, adr, at, val, mo) {}
   virtual int Opcode() const;
-  virtual BasicType memory_type() const { return T_NARROWKLASS; }
+  virtual BasicType value_basic_type() const { return T_NARROWKLASS; }
 };
 
 //------------------------------SCMemProjNode---------------------------------------

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -158,7 +158,7 @@ void SuperWord::unrolling_analysis(const VLoop &vloop, int &local_loop_unroll_fa
     // Ignore nodes with non-primitive type.
     BasicType bt;
     if (n->is_Mem()) {
-      bt = n->as_Mem()->memory_type();
+      bt = n->as_Mem()->value_basic_type();
     } else {
       bt = n->bottom_type()->basic_type();
     }
@@ -191,7 +191,7 @@ void SuperWord::unrolling_analysis(const VLoop &vloop, int &local_loop_unroll_fa
       BasicType bt;
       Node* n = lpt->_body.at(i);
       if (n->is_Mem()) {
-        bt = n->as_Mem()->memory_type();
+        bt = n->as_Mem()->value_basic_type();
       } else {
         bt = n->bottom_type()->basic_type();
       }
@@ -564,7 +564,7 @@ void SuperWord::collect_valid_memops(GrowableArray<MemOp>& memops) const {
     const VPointer& p = vpointer(mem);
     if (p.is_valid() &&
         !mem->is_LoadStore() &&
-        is_java_primitive(mem->memory_type())) {
+        is_java_primitive(mem->value_basic_type())) {
       memops.append(MemOp(mem, &p, original_index++));
     }
   });
@@ -764,8 +764,8 @@ bool SuperWord::are_adjacent_refs(Node* s1, Node* s2) const {
   if (!in_bb(s1)    || !in_bb(s2))    return false;
 
   // Do not use superword for non-primitives
-  if (!is_java_primitive(s1->as_Mem()->memory_type()) ||
-      !is_java_primitive(s2->as_Mem()->memory_type())) {
+  if (!is_java_primitive(s1->as_Mem()->value_basic_type()) ||
+      !is_java_primitive(s2->as_Mem()->value_basic_type())) {
     return false;
   }
 
@@ -2592,7 +2592,7 @@ void VLoopTypes::compute_vector_element_type() {
 // Smallest type containing range of values
 const Type* VLoopTypes::container_type(Node* n) const {
   if (n->is_Mem()) {
-    BasicType bt = n->as_Mem()->memory_type();
+    BasicType bt = n->as_Mem()->value_basic_type();
     if (n->is_Store() && (bt == T_CHAR)) {
       // Use T_SHORT type instead of T_CHAR for stored values because any
       // preceding arithmetic operation extends values to signed Int.

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -1017,7 +1017,7 @@ class LoadVectorNode : public LoadNode {
   virtual int Opcode() const;
 
   virtual uint ideal_reg() const  { return Matcher::vector_ideal_reg(memory_size()); }
-  virtual BasicType memory_type() const { return T_VOID; }
+  virtual BasicType value_basic_type() const { return T_VOID; }
   virtual int memory_size() const { return vect_type()->length_in_bytes(); }
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 
@@ -1090,7 +1090,7 @@ class StoreVectorNode : public StoreNode {
   virtual int Opcode() const;
 
   virtual uint ideal_reg() const  { return Matcher::vector_ideal_reg(memory_size()); }
-  virtual BasicType memory_type() const { return T_VOID; }
+  virtual BasicType value_basic_type() const { return T_VOID; }
   virtual int memory_size() const { return vect_type()->length_in_bytes(); }
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 


### PR DESCRIPTION
Description: The current name` MemNode::memory_type()` is misleading because the returned type is a property of the value that is loaded/stored, not the memory that is accessed. Usually, the two of them match, but for mismatched memory accesses (arising e.g. from using Unsafe or memory segments) they might differ, e.g. one might store a value of type 'short' into an array of elements of type 'long'. The proposal was to rename `MemNode::memory_type()` to `MemNode::value_basic_type()` to clarify these cases.

Solution: Replaced all occurrence of `MemNode::memory_type()` with `MemNode::value_basic_type()`