### PR TITLE
8352922: Refactor client classes javadoc to use @throws instead of @exception

### DIFF
--- a/src/demo/share/jfc/CodePointIM/com/sun/inputmethods/internal/codepointim/CodePointInputMethodDescriptor.java
+++ b/src/demo/share/jfc/CodePointIM/com/sun/inputmethods/internal/codepointim/CodePointInputMethodDescriptor.java
@@ -63,7 +63,7 @@ public class CodePointInputMethodDescriptor implements InputMethodDescriptor {
      * Creates a new instance of the Code Point input method.
      *
      * @return a new instance of the Code Point input method
-     * @exception Exception any exception that may occur while creating the
+     * @throws Exception any exception that may occur while creating the
      * input method instance
      */
     public InputMethod createInputMethod() throws Exception {

--- a/src/java.desktop/aix/classes/sun/awt/X11InputMethod.java
+++ b/src/java.desktop/aix/classes/sun/awt/X11InputMethod.java
@@ -49,7 +49,7 @@ public abstract class X11InputMethod extends X11InputMethodBase {
      * Constructs an X11InputMethod instance. It initializes the XIM
      * environment if it's not done yet.
      *
-     * @exception AWTException if XOpenIM() failed.
+     * @throws AWTException if XOpenIM() failed.
      */
     public X11InputMethod() throws AWTException {
         super();

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneCopyFromBasicUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneCopyFromBasicUI.java
@@ -638,7 +638,7 @@ public class AquaTabbedPaneCopyFromBasicUI extends TabbedPaneUI implements Swing
      * Returns the baseline for the specified tab.
      *
      * @param tab index of tab to get baseline for
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            (index < 0 || index >= tab count)
      * @return baseline or a value &lt; 0 indicating there is no reasonable
      *                  baseline

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CInputMethod.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CInputMethod.java
@@ -101,7 +101,7 @@ public class CInputMethod extends InputMethodAdapter {
      * method.
      *
      * @param context the input method context for this input method
-     * @exception NullPointerException if {@code context} is null
+     * @throws NullPointerException if {@code context} is null
      */
     public void setInputMethodContext(InputMethodContext context) {
         fIMContext = context;
@@ -124,7 +124,7 @@ public class CInputMethod extends InputMethodAdapter {
      *
      * @param lang locale to input
      * @return whether the specified locale is supported
-     * @exception NullPointerException if {@code locale} is null
+     * @throws NullPointerException if {@code locale} is null
      */
     public boolean setLocale(Locale lang) {
         return setLocale(lang, false);
@@ -216,7 +216,7 @@ public class CInputMethod extends InputMethodAdapter {
      * This method is called by {@link java.awt.im.InputContext#dispatchEvent InputContext.dispatchEvent}.
      *
      * @param event the event being dispatched to the input method
-     * @exception NullPointerException if {@code event} is null
+     * @throws NullPointerException if {@code event} is null
      */
     public void dispatchEvent(final AWTEvent event) {
         // No-op for Mac OS X.

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -101,7 +101,7 @@ public final class CPrinterJob extends RasterPrinterJob {
      * selected by the user.
      * @return {@code true} if the user does not cancel the dialog;
      * {@code false} otherwise.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -143,7 +143,7 @@ public final class CPrinterJob extends RasterPrinterJob {
      *            is cancelled; a new {@code PageFormat} object
      *          containing the format indicated by the user if the
      *          dialog is acknowledged.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since     1.2

--- a/src/java.desktop/unix/classes/sun/awt/X11InputMethod.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11InputMethod.java
@@ -45,7 +45,7 @@ public abstract class X11InputMethod extends X11InputMethodBase {
      * Constructs an X11InputMethod instance. It initializes the XIM
      * environment if it's not done yet.
      *
-     * @exception AWTException if XOpenIM() failed.
+     * @throws AWTException if XOpenIM() failed.
      */
     public X11InputMethod() throws AWTException {
         super();

--- a/src/java.desktop/unix/classes/sun/awt/X11InputMethodBase.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11InputMethodBase.java
@@ -162,7 +162,7 @@ public abstract class X11InputMethodBase extends InputMethodAdapter {
      * Constructs an X11InputMethod instance. It initializes the XIM
      * environment if it's not done yet.
      *
-     * @exception AWTException if XOpenIM() failed.
+     * @throws AWTException if XOpenIM() failed.
      */
     public X11InputMethodBase() throws AWTException {
         // supports only the locale in which the VM is started

--- a/src/java.desktop/unix/classes/sun/awt/XSettings.java
+++ b/src/java.desktop/unix/classes/sun/awt/XSettings.java
@@ -232,7 +232,7 @@ public class XSettings {
         /**
          * Parses a particular x setting.
          *
-         * @exception IndexOutOfBoundsException if there isn't enough
+         * @throws IndexOutOfBoundsException if there isn't enough
          *     data for a setting.
          */
         private void updateOne(long currentSerial)

--- a/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
@@ -418,7 +418,7 @@ public final class WPrinterJob extends RasterPrinterJob
      *            is cancelled, or a new PageFormat object containing
      *            the format indicated by the user if the dialog is
      *            acknowledged
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since     1.2
@@ -571,7 +571,7 @@ public final class WPrinterJob extends RasterPrinterJob
      * print job interactively.
      * @return false if the user cancels the dialog and
      *         true otherwise.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */

--- a/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
+++ b/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
@@ -6531,7 +6531,7 @@ public final class AccessBridge {
          *
          * @return This component's locale. If this component does not have
          * a locale, the locale of its parent is returned.
-         * @exception IllegalComponentStateException
+         * @throws IllegalComponentStateException
          * If the Component does not have its own locale and has not yet
          * been added to a containment hierarchy such that the locale can be
          * determined from the containing parent.


### PR DESCRIPTION
Prevailing JDK coding practices use @throws rather than @exception.
Refactored javadoc in client code to follow this convention, similar requests in the past https://github.com/openjdk/jdk/pull/7675 and https://github.com/openjdk/jdk/pull/7644.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352922](https://bugs.openjdk.org/browse/JDK-8352922): Refactor client classes javadoc to use @<!---->throws instead of @<!---->exception (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24239/head:pull/24239` \
`$ git checkout pull/24239`

Update a local copy of the PR: \
`$ git checkout pull/24239` \
`$ git pull https://git.openjdk.org/jdk.git pull/24239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24239`

View PR using the GUI difftool: \
`$ git pr show -t 24239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24239.diff">https://git.openjdk.org/jdk/pull/24239.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24239#issuecomment-2753321937)
</details>
