### PR TITLE
8352617: IR framework test TestCompileCommandFileWriter.java runs TestCompilePhaseCollector instead of itself

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/flag/TestCompileCommandFileWriter.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/flag/TestCompileCommandFileWriter.java
@@ -44,7 +44,7 @@ import static compiler.lib.ir_framework.CompilePhase.*;
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run junit/othervm -Xbootclasspath/a:. -DSkipWhiteBoxInstall=true -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
- *                    -XX:+WhiteBoxAPI compiler.lib.ir_framework.flag.TestCompilePhaseCollector
+ *                    -XX:+WhiteBoxAPI compiler.lib.ir_framework.flag.TestCompileCommandFileWriter
  */
 public class TestCompileCommandFileWriter {
 
@@ -81,6 +81,8 @@ public class TestCompileCommandFileWriter {
     }
 
     private void check(Class<?> testClass, boolean findIdeal, boolean findOpto, CompilePhase... compilePhases) throws IOException {
+        var compilerDirectivesFlagBuilder = new CompilerDirectivesFlagBuilder(testClass);
+        compilerDirectivesFlagBuilder.build();
         try (Scanner scanner = new Scanner(Paths.get(FlagVM.TEST_VM_COMPILE_COMMANDS_FILE))) {
             boolean foundIdeal = false;
             boolean foundOpto = false;
@@ -132,14 +134,14 @@ public class TestCompileCommandFileWriter {
 
     static class OptoOnly1 {
         @Test
-        @IR(failOn = IRNode.ALLOC)
+        @IR(failOn = IRNode.FIELD_ACCESS)
         public void test() {
         }
     }
 
     static class OptoOnly2 {
         @Test
-        @IR(failOn = IRNode.ALLOC, phase = PRINT_OPTO_ASSEMBLY)
+        @IR(failOn = IRNode.FIELD_ACCESS, phase = PRINT_OPTO_ASSEMBLY)
         public void test() {
         }
     }
@@ -147,14 +149,14 @@ public class TestCompileCommandFileWriter {
     static class Both1 {
         @Test
         @IR(failOn = IRNode.STORE)
-        @IR(failOn = IRNode.ALLOC)
+        @IR(failOn = IRNode.FIELD_ACCESS)
         public void test() {
         }
     }
 
     static class Both2 {
         @Test
-        @IR(failOn = {IRNode.STORE, IRNode. ALLOC})
+        @IR(failOn = {IRNode.STORE, IRNode. FIELD_ACCESS})
         public void test() {
         }
     }
@@ -183,7 +185,7 @@ public class TestCompileCommandFileWriter {
 
     static class Mix2 {
         @Test
-        @IR(failOn = IRNode.ALLOC, phase = AFTER_PARSING)
+        @IR(failOn = IRNode.FIELD_ACCESS, phase = AFTER_PARSING)
         @IR(failOn = IRNode.STORE, phase = PRINT_OPTO_ASSEMBLY)
         public void test() {
         }
@@ -193,7 +195,7 @@ public class TestCompileCommandFileWriter {
         @Test
         @IR(failOn = IRNode.STORE, phase = AFTER_PARSING)
         @IR(failOn = IRNode.STORE, phase = PRINT_IDEAL)
-        @IR(failOn = IRNode.ALLOC, phase = PRINT_OPTO_ASSEMBLY)
+        @IR(failOn = IRNode.FIELD_ACCESS, phase = PRINT_OPTO_ASSEMBLY)
         public void test() {
         }
     }
@@ -201,7 +203,7 @@ public class TestCompileCommandFileWriter {
     static class Mix4 {
         @Test
         @IR(failOn = IRNode.STORE, phase = {AFTER_PARSING, PRINT_IDEAL})
-        @IR(failOn = IRNode.ALLOC, phase = PRINT_OPTO_ASSEMBLY)
+        @IR(failOn = IRNode.FIELD_ACCESS, phase = PRINT_OPTO_ASSEMBLY)
         public void test() {
         }
     }

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/flag/TestCompileCommandFileWriter.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/flag/TestCompileCommandFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,12 +38,12 @@ import static compiler.lib.ir_framework.CompilePhase.*;
 
 /*
  * @test
- * @requires vm.debug == true & vm.flagless
+ * @requires vm.flagless
  * @summary Test compile command file writer.
  * @library /test/lib /testlibrary_tests /
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run junit/othervm -Xbootclasspath/a:. -DSkipWhiteBoxInstall=true -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ * @run junit/othervm -Xbootclasspath/a:. -DSkipWhiteBoxInstall=true -XX:+UnlockDiagnosticVMOptions
  *                    -XX:+WhiteBoxAPI compiler.lib.ir_framework.flag.TestCompileCommandFileWriter
  */
 public class TestCompileCommandFileWriter {


### PR DESCRIPTION
Simply changing the path in `@run` was not enough (see JBS for details). And actually, the test wasn't doing anything before trying to open an output file to check the result. From various hints, I completed the test: I hope it was the intent!

I think @chhagedorn's eye would be the most relevant.

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352617](https://bugs.openjdk.org/browse/JDK-8352617): IR framework test TestCompileCommandFileWriter.java runs TestCompilePhaseCollector instead of itself (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24240/head:pull/24240` \
`$ git checkout pull/24240`

Update a local copy of the PR: \
`$ git checkout pull/24240` \
`$ git pull https://git.openjdk.org/jdk.git pull/24240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24240`

View PR using the GUI difftool: \
`$ git pr show -t 24240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24240.diff">https://git.openjdk.org/jdk/pull/24240.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24240#issuecomment-2753768648)
</details>
