### PR TITLE
8350471: Unhandled compilation bailout in GraphKit::builtin_throw

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -587,7 +587,7 @@ void GraphKit::builtin_throw(Deoptimization::DeoptReason reason) {
     default:
       break;
     }
-    if (failing()) { stop(); return; }  // exception allocation might fail
+    // If we have a preconstructed exception object, use it.
     if (ex_obj != nullptr) {
       if (env()->jvmti_can_post_on_exceptions()) {
         // check if we must post exception events, take uncommon trap if so


### PR DESCRIPTION
# Issue Summary

When creating a builtin exception node, a stress test decided to bail out as if the allocation of the builtin exception objects had failed. Since these are preallocated at VM creation, the test failure is a false positive. 

# Change Rationale

`GraphKit::builtin_throw()` features a bailout check after getting an appropriate exception object. However, up to that point, the execution in `builtin_throw()` cannot fail. In particular, there can be no failure to allocate the exception because these are all preallocated during `Threads::create_vm()` startup in `universe_post_init()` and `Threads:initialize_java_lang_classes()`. Further, none of the three callers handles a possible bailout in `builtin_throw()`. Hence, this PR removes the bailout check responsible for the test failure

# Testing

 - [Github Actions](https://github.com/mhaessig/jdk/actions/runs/14078715650)
 - tier1 through tier3 and Oracle internal testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350471](https://bugs.openjdk.org/browse/JDK-8350471): Unhandled compilation bailout in GraphKit::builtin_throw (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24243/head:pull/24243` \
`$ git checkout pull/24243`

Update a local copy of the PR: \
`$ git checkout pull/24243` \
`$ git pull https://git.openjdk.org/jdk.git pull/24243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24243`

View PR using the GUI difftool: \
`$ git pr show -t 24243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24243.diff">https://git.openjdk.org/jdk/pull/24243.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24243#issuecomment-2753654734)
</details>
