### PR TITLE
8351491: Add info from release file to hserr file

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3661,9 +3661,6 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
     Arguments::print_on(&st);
   }
 
-  // cache the release file of the JDK image
-  os::read_image_release_file();
-
   return JNI_OK;
 }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3661,6 +3661,9 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
     Arguments::print_on(&st);
   }
 
+  // cache the release file of the JDK image
+  os::read_image_release_file();
+
   return JNI_OK;
 }
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1552,7 +1552,7 @@ void os::read_image_release_file() {
       }
       fseek(file, 0, SEEK_SET);
 
-      _image_release_file_content = (char*) os::malloc(sz, mtInternal);
+      _image_release_file_content = (char*) os::malloc(sz + 1, mtInternal);
       if (!_image_release_file_content) {
         fclose(file);
         free(release_file);
@@ -1561,6 +1561,11 @@ void os::read_image_release_file() {
 
       size_t elements_read = fread(_image_release_file_content, 1, sz, file);
       if (elements_read < (size_t)sz) _image_release_file_content[elements_read] = '\0';
+      _image_release_file_content[sz] = '\0';
+      // issues with \r in line endings on Windows, so better replace those
+      for (size_t i=0; i < elements_read; i++) {
+        if (_image_release_file_content[i] == '\r') { _image_release_file_content[i] = ' '; }
+      }
       fclose(file);
     }
     free(release_file);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1570,8 +1570,9 @@ void os::read_image_release_file() {
 }
 
 void os::print_image_release_file(outputStream* st) {
-  if (_image_release_file_content != nullptr) {
-    st->print_cr("%s", _image_release_file_content);
+  char* ifrc = Atomic::load_acquire(&_image_release_file_content);
+  if (ifrc != nullptr) {
+    st->print_cr("%s", ifrc);
   }
 }
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1573,6 +1573,8 @@ void os::print_image_release_file(outputStream* st) {
   char* ifrc = Atomic::load_acquire(&_image_release_file_content);
   if (ifrc != nullptr) {
     st->print_cr("%s", ifrc);
+  } else {
+    st->print_cr("<release file has not been read>");
   }
 }
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1531,7 +1531,7 @@ bool os::set_boot_path(char fileSep, char pathSep) {
 static char* _image_release_file_content = nullptr;
 
 void os::read_image_release_file() {
-  assert(_image_release_file_content == nullptr, "release file content must not be already set")
+  assert(_image_release_file_content == nullptr, "release file content must not be already set");
   const char* home = Arguments::get_java_home();
   stringStream ss;
   ss.print("%s/release", home);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1532,43 +1532,40 @@ static char* _image_release_file_content = nullptr;
 
 void os::read_image_release_file() {
   const char* home = Arguments::get_java_home();
-  int rfile_len = (int)strlen(home) + 10;
+  stringStream ss;
+  ss.print("%s/release", home);
 
-  char* release_file = (char*) os::malloc(rfile_len, mtInternal);
-  if (release_file) {
-    os::snprintf(release_file, rfile_len, "%s/release", home);
-
-    if (_image_release_file_content == nullptr) {
-      FILE *file = fopen(release_file, "rb");
-      if (!file) {
-        free(release_file);
-        return;
-      }
-      fseek(file, 0, SEEK_END);
-      long sz = ftell(file);
-      if (sz == -1) {
-        free(release_file);
-        return;
-      }
-      fseek(file, 0, SEEK_SET);
-
-      _image_release_file_content = (char*) os::malloc(sz + 1, mtInternal);
-      if (!_image_release_file_content) {
-        fclose(file);
-        free(release_file);
-        return;
-      }
-
-      size_t elements_read = fread(_image_release_file_content, 1, sz, file);
-      if (elements_read < (size_t)sz) _image_release_file_content[elements_read] = '\0';
-      _image_release_file_content[sz] = '\0';
-      // issues with \r in line endings on Windows, so better replace those
-      for (size_t i=0; i < elements_read; i++) {
-        if (_image_release_file_content[i] == '\r') { _image_release_file_content[i] = ' '; }
-      }
-      fclose(file);
+  if (_image_release_file_content == nullptr) {
+    FILE* file = fopen(ss.base(), "rb");
+    if (file == nullptr) {
+      return;
     }
-    free(release_file);
+    fseek(file, 0, SEEK_END);
+    long sz = ftell(file);
+    if (sz == -1) {
+      return;
+    }
+    fseek(file, 0, SEEK_SET);
+
+    _image_release_file_content = (char*) os::malloc(sz + 1, mtInternal);
+    if (!_image_release_file_content) {
+      fclose(file);
+      return;
+    }
+
+    size_t elements_read = fread(_image_release_file_content, 1, sz, file);
+    if (elements_read < (size_t)sz) {
+      _image_release_file_content[elements_read] = '\0';
+    } else {
+      _image_release_file_content[sz] = '\0';
+    }
+    // issues with \r in line endings on Windows, so better replace those
+    for (size_t i = 0; i < elements_read; i++) {
+      if (_image_release_file_content[i] == '\r') {
+        _image_release_file_content[i] = ' ';
+      }
+    }
+    fclose(file);
   }
 }
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -670,6 +670,11 @@ class os: AllStatic {
   static FILE* fopen(const char* path, const char* mode);
   static jlong lseek(int fd, jlong offset, int whence);
   static bool file_exists(const char* file);
+
+  // read/store and print the release file of the image
+  static void read_image_release_file();
+  static void print_image_release_file(outputStream* st);
+
   // This function, on Windows, canonicalizes a given path (see os_windows.cpp for details).
   // On Posix, this function is a noop: it does not change anything and just returns
   // the input pointer.

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -425,15 +425,15 @@ void Threads::initialize_jsr292_core_classes(TRAPS) {
   }
 }
 
-// One-shot PeriodicTask subclass for reading release file
+// One-shot PeriodicTask subclass for reading the release file
 class ReadReleaseFileTask : public PeriodicTask {
  public:
-  ReadReleaseFileTask(size_t interval_time) : PeriodicTask(interval_time) {}
+  ReadReleaseFileTask() : PeriodicTask(100) {}
 
   virtual void task() {
     os::read_image_release_file();
 
-    // Reclaim our storage and disenroll ourself
+    // Reclaim our storage and disenroll ourself.
     delete this;
   }
 };
@@ -593,7 +593,8 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
     return status;
   }
 
-  ReadReleaseFileTask* read_task = new ReadReleaseFileTask(100);
+  // Have the WatcherThread read the release file in the background.
+  ReadReleaseFileTask* read_task = new ReadReleaseFileTask();
   read_task->enroll();
 
   // Create WatcherThread as soon as we can since we need it in case

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1250,6 +1250,10 @@ void VMError::report(outputStream* st, bool _verbose) {
     LogConfiguration::describe_current_configuration(st);
     st->cr();
 
+  STEP_IF("printing release file content", _verbose)
+    st->print_cr("Release file:");
+    os::print_image_release_file(st);
+
   STEP_IF("printing all environment variables", _verbose)
     os::print_environment_variables(st, env_list);
     st->cr();
@@ -1428,6 +1432,10 @@ void VMError::print_vm_info(outputStream* st) {
   st->print_cr("Logging:");
   LogConfiguration::describe(st);
   st->cr();
+
+  // printing release file content
+  st->print_cr("Release file:");
+  os::print_image_release_file(st);
 
   // STEP("printing all environment variables")
 

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1433,7 +1433,7 @@ void VMError::print_vm_info(outputStream* st) {
   LogConfiguration::describe(st);
   st->cr();
 
-  // printing release file content
+  // STEP("printing release file content")
   st->print_cr("Release file:");
   os::print_image_release_file(st);
 


### PR DESCRIPTION
The release file of the JDK image contains useful info, for example the SOURCE used to built this image e.g.
SOURCE=".:git:21af8c7e7405"
Also the MODULES list is probably useful to have.
Add this info (or the complete content of the release file) to the hs_err files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351491](https://bugs.openjdk.org/browse/JDK-8351491): Add info from release file to hserr file (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24244/head:pull/24244` \
`$ git checkout pull/24244`

Update a local copy of the PR: \
`$ git checkout pull/24244` \
`$ git pull https://git.openjdk.org/jdk.git pull/24244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24244`

View PR using the GUI difftool: \
`$ git pr show -t 24244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24244.diff">https://git.openjdk.org/jdk/pull/24244.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24244#issuecomment-2753690284)
</details>
