### PR TITLE
8347449: C2: UseLoopPredicate off should also turn UseProfiledLoopPredicate off

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -785,7 +785,8 @@
           range(0, max_juint)                                               \
                                                                             \
   product(bool, UseProfiledLoopPredicate, true,                             \
-          "Move predicates out of loops based on profiling data")           \
+          "Move predicates out of loops based on profiling data. "          \
+          "Requires UseLoopPredicate to be turned on (default).")           \
                                                                             \
   develop(uintx, StressLongCountedLoop, 0,                                  \
           "if > 0, convert int counted loops to long counted loops"         \

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4082,9 +4082,9 @@ void GraphKit::add_parse_predicate(Deoptimization::DeoptReason reason, const int
 void GraphKit::add_parse_predicates(int nargs) {
   if (UseLoopPredicate) {
     add_parse_predicate(Deoptimization::Reason_predicate, nargs);
-  }
-  if (UseProfiledLoopPredicate) {
-    add_parse_predicate(Deoptimization::Reason_profile_predicate, nargs);
+    if (UseProfiledLoopPredicate) {
+      add_parse_predicate(Deoptimization::Reason_profile_predicate, nargs);
+    }
   }
   add_parse_predicate(Deoptimization::Reason_auto_vectorization_check, nargs);
   // Loop Limit Check Predicate should be near the loop.

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1087,9 +1087,9 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
 
     if (UseLoopPredicate) {
       add_parse_predicate(Deoptimization::Reason_predicate, inner_head, outer_ilt, cloned_sfpt);
-    }
-    if (UseProfiledLoopPredicate) {
-      add_parse_predicate(Deoptimization::Reason_profile_predicate, inner_head, outer_ilt, cloned_sfpt);
+      if (UseProfiledLoopPredicate) {
+        add_parse_predicate(Deoptimization::Reason_profile_predicate, inner_head, outer_ilt, cloned_sfpt);
+      }
     }
 
     // We only want to use the auto-vectorization check as a trap once per bci. And
@@ -4298,7 +4298,7 @@ void IdealLoopTree::dump_head() {
   if (predicates.loop_limit_check_predicate_block()->is_non_empty()) {
     tty->print(" limit_check");
   }
-  if (UseProfiledLoopPredicate && predicates.profiled_loop_predicate_block()->is_non_empty()) {
+  if (UseLoopPredicate && UseProfiledLoopPredicate && predicates.profiled_loop_predicate_block()->is_non_empty()) {
     tty->print(" profile_predicated");
   }
   if (UseLoopPredicate && predicates.loop_predicate_block()->is_non_empty()) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3797,6 +3797,13 @@ jint Arguments::apply_ergo() {
   }
 #endif // COMPILER2_OR_JVMCI
 
+#ifdef COMPILER2
+  if (!FLAG_IS_DEFAULT(UseLoopPredicate) && !UseLoopPredicate && UseProfiledLoopPredicate) {
+    warning("Disabling UseProfiledLoopPredicate since UseLoopPredicate is turned off.");
+    FLAG_SET_ERGO(UseProfiledLoopPredicate, false);
+  }
+#endif // COMPILER2
+
   if (log_is_enabled(Info, perf, class, link)) {
     if (!UsePerfData) {
       warning("Disabling -Xlog:perf+class+link since UsePerfData is turned off.");

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1519,6 +1519,21 @@ public class IRNode {
                                                                        CompilePhase.BEFORE_MATCHING));
     }
 
+    public static final String PARSE_PRED_LOOP = PREFIX + "PARSE_PRED_LOOP" + POSTFIX;
+    static {
+        parsePredicateNodes(PARSE_PRED_LOOP, "Loop");
+    }
+
+    public static final String PARSE_PRED_LOOP_LIMIT_CHK = PREFIX + "PARSE_PRED_LOOP_LIMIT_CHK" + POSTFIX;
+    static {
+        parsePredicateNodes(PARSE_PRED_LOOP_LIMIT_CHK, "Loop Limit Check");
+    }
+
+    public static final String PARSE_PRED_PROFILED_LOOP = PREFIX + "PARSE_PROFILED_PRED_LOOP" + POSTFIX;
+    static {
+        parsePredicateNodes(PARSE_PRED_PROFILED_LOOP, "Profiled Loop");
+    }
+
     public static final String PREDICATE_TRAP = PREFIX + "PREDICATE_TRAP" + POSTFIX;
     static {
         trapNodes(PREDICATE_TRAP, "predicate");
@@ -2739,6 +2754,13 @@ public class IRNode {
     private static void trapNodes(String irNodePlaceholder, String trapReason) {
         String regex = START + "CallStaticJava" + MID + "uncommon_trap.*" + trapReason + END;
         beforeMatching(irNodePlaceholder, regex);
+    }
+
+    private static void parsePredicateNodes(String irNodePlaceholder, String label) {
+        String regex = START + "ParsePredicate" + MID + "#" + label + "[ ]*!jvms:" + END;
+        IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.AFTER_PARSING, regex,
+                                                                          CompilePhase.AFTER_PARSING,
+                                                                          CompilePhase.INCREMENTAL_BOXING_INLINE));
     }
 
     private static void loadOfNodes(String irNodePlaceholder, String irNodeRegex) {

--- a/test/hotspot/jtreg/compiler/predicates/TestDisabledLoopPredicates.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestDisabledLoopPredicates.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package compiler.predicates;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @bug 8347449
+ * @summary Test that profiled loop predicates are turned off if loop predicates are turned off
+ * @library /test/lib /
+ * @run driver compiler.predicates.TestDisabledLoopPredicates
+ */
+
+public class TestDisabledLoopPredicates {
+    static final int WARMUP = 10_000;
+    static final int SIZE = 100;
+    static final int min = 3;
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:+UseLoopPredicate",
+                                   "-XX:+UseProfiledLoopPredicate");
+        TestFramework.runWithFlags("-XX:-UseLoopPredicate");
+    }
+
+    @Run(test = { "test" })
+    private static void check() {
+        for (int i = 0; i < WARMUP; i++) {
+            int res = test(true);
+            Asserts.assertEQ(res, ((SIZE - 1)*SIZE-min*(min+1))/ 2);
+        }
+    }
+
+    @DontInline
+    private static void blackhole(int i) {
+    }
+
+    @DontInline
+    private static int[] getArr() {
+        int[] arr = new int[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            arr[i] = i;
+        }
+
+        return arr;
+    }
+
+    @Test
+    @IR(counts = { IRNode.PARSE_PRED_LOOP, "=1",
+                   IRNode.PARSE_PRED_PROFILED_LOOP, "1" },
+        phase = CompilePhase.AFTER_PARSING,
+        applyIfAnd = { "UseLoopPredicate", "true",
+                       "UseProfiledLoopPredicate", "true" })
+    @IR(failOn = { IRNode.PARSE_PRED_LOOP,
+                   IRNode.PARSE_PRED_PROFILED_LOOP },
+        phase = CompilePhase.AFTER_PARSING,
+        applyIf = { "UseLoopPredicate", "false" })
+    public static int test(boolean cond) {
+        int[] arr = getArr();
+        int sum = 0;
+        for (int i = 0; i < arr.length; i++) {
+            if (cond) {
+                if (arr[i] > min) {
+                    sum += arr[i];
+                }
+            }
+            blackhole(arr[i]);
+        }
+
+        return sum;
+    }
+}


### PR DESCRIPTION
# Issue Summary

When running with `-XX:-UseLoopPredicate` C2 still inserts profiled loop parse predicates, despite those being a form of loop parse predicate. Further, the loop predicate code is not always consistent when to insert/expect profiled parse predicates.

# Change Summary

Following the rationale, that profiled predicates are a subset of loop predicates, this PR disables profiled predicates whenever loop predicates are disabled. They are disabled on the level of arguments. Further, before any checks for whether profiled predicates are enabled, this PR inserts a check that loop predicates are enabled such that the code is consistent in its intention.

Concretel, this PR
 - adds parse predicate nodes to the IR testing framework,
 - turns off `UseProfiledLoopPredicate` if `UseLoopPredicate` is turned off,
 - predicates all checks for `UseProfiledLoopPredicate`on `UseLoopPredicate` first for consistency,
 - adds a regression test.


# Testing
 
The changes passed the following testing:
 - [Github Actions](https://github.com/mhaessig/jdk/actions/runs/14078750038)
 - tier1 through tier3 and Oracle internal testing