### PR TITLE
8351151: Clean up x86 template interpreter after 32-bit x86 removal

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -1401,9 +1401,6 @@ void InterpreterMacroAssembler::_interp_verify_oop(Register reg, TosState state,
   }
 }
 
-void InterpreterMacroAssembler::verify_FPU(int stack_depth, TosState state) { ; }
-
-
 void InterpreterMacroAssembler::notify_method_entry() {
   // Whenever JVMTI is interp_only_mode, method entry/exit events are sent to
   // track stack depth.  If it is possible to enter interp_only_mode we add

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
@@ -303,8 +303,6 @@ class InterpreterMacroAssembler: public MacroAssembler {
   // only if +VerifyOops && state == atos
 #define interp_verify_oop(reg, state) _interp_verify_oop(reg, state, __FILE__, __LINE__);
   void _interp_verify_oop(Register reg, TosState state, const char* file, int line);
-  // only if +VerifyFPU  && (state == ftos || state == dtos)
-  void verify_FPU(int stack_depth, TosState state = ftos);
 
   typedef enum { NotifyJVMTI, SkipNotifyJVMTI } NotifyMethodExitMode;
 

--- a/src/hotspot/cpu/arm/interp_masm_arm.hpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.hpp
@@ -198,10 +198,6 @@ class InterpreterMacroAssembler: public MacroAssembler {
   // Debugging
   void interp_verify_oop(Register reg, TosState state, const char* file, int line);    // only if +VerifyOops && state == atos
 
-  void verify_FPU(int stack_depth, TosState state = ftos) {
-    // No VFP state verification is required for ARM
-  }
-
   // Object locking
   void lock_object  (Register lock_reg);
   void unlock_object(Register lock_reg);

--- a/src/hotspot/cpu/ppc/interp_masm_ppc.hpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc.hpp
@@ -265,7 +265,6 @@ class InterpreterMacroAssembler: public MacroAssembler {
   // Debugging
   void verify_oop(Register reg, TosState state = atos);    // only if +VerifyOops && state == atos
   void verify_oop_or_return_address(Register reg, Register rtmp); // for astore
-  void verify_FPU(int stack_depth, TosState state = ftos);
 
   typedef enum { NotifyJVMTI, SkipNotifyJVMTI } NotifyMethodExitMode;
 

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -2381,12 +2381,6 @@ static bool verify_return_address(Method* m, int bci) {
   return false;
 }
 
-void InterpreterMacroAssembler::verify_FPU(int stack_depth, TosState state) {
-  if (VerifyFPU) {
-    unimplemented("verfiyFPU");
-  }
-}
-
 void InterpreterMacroAssembler::verify_oop_or_return_address(Register reg, Register Rtmp) {
   if (!VerifyOops) return;
 

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -1431,8 +1431,6 @@ void InterpreterMacroAssembler::profile_switch_case(Register index,
   }
 }
 
-void InterpreterMacroAssembler::verify_FPU(int stack_depth, TosState state) { ; }
-
 void InterpreterMacroAssembler::notify_method_entry() {
   // Whenever JVMTI is interp_only_mode, method entry/exit events are sent to
   // track stack depth.  If it is possible to enter interp_only_mode we add

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
@@ -284,10 +284,6 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void profile_return_type(Register mdp, Register ret, Register tmp);
   void profile_parameters_type(Register mdp, Register tmp1, Register tmp2, Register tmp3);
 
-  // Debugging
-  // only if +VerifyFPU  && (state == ftos || state == dtos)
-  void verify_FPU(int stack_depth, TosState state = ftos);
-
   typedef enum { NotifyJVMTI, SkipNotifyJVMTI } NotifyMethodExitMode;
 
   // support for jvmti/dtrace

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -93,8 +93,6 @@ void InterpreterMacroAssembler::dispatch_next(TosState state, int bcp_incr, bool
 // Dispatch value in Lbyte_code and increment Lbcp.
 
 void InterpreterMacroAssembler::dispatch_base(TosState state, address* table, bool generate_poll) {
-  verify_FPU(1, state);
-
 #ifdef ASSERT
   address reentry = nullptr;
   { Label OK;
@@ -2188,10 +2186,4 @@ void InterpreterMacroAssembler::pop_interpreter_frame(Register return_pc, Regist
   load_const_optimized(Z_ARG3, 0xb00b1);
   z_stg(Z_ARG3, _z_parent_ijava_frame_abi(return_pc), Z_SP);
 #endif
-}
-
-void InterpreterMacroAssembler::verify_FPU(int stack_depth, TosState state) {
-  if (VerifyFPU) {
-    unimplemented("verifyFPU");
-  }
 }

--- a/src/hotspot/cpu/s390/interp_masm_s390.hpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.hpp
@@ -313,7 +313,6 @@ class InterpreterMacroAssembler: public MacroAssembler {
   // Debugging
   void verify_oop(Register reg, TosState state = atos);    // Only if +VerifyOops && state == atos.
   void verify_oop_or_return_address(Register reg, Register rtmp); // for astore
-  void verify_FPU(int stack_depth, TosState state = ftos);
 
   // JVMTI helpers
   void skip_if_jvmti_mode(Label &Lskip, Register Rscratch = Z_R0);

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -53,11 +53,7 @@ void InterpreterMacroAssembler::jump_to_entry(address entry) {
 void InterpreterMacroAssembler::profile_obj_type(Register obj, const Address& mdo_addr) {
   Label update, next, none;
 
-#ifdef _LP64
   assert_different_registers(obj, rscratch1, mdo_addr.base(), mdo_addr.index());
-#else
-  assert_different_registers(obj, mdo_addr.base(), mdo_addr.index());
-#endif
 
   interp_verify_oop(obj, atos);
 
@@ -72,9 +68,7 @@ void InterpreterMacroAssembler::profile_obj_type(Register obj, const Address& md
 
   bind(update);
   load_klass(obj, obj, rscratch1);
-#ifdef _LP64
   mov(rscratch1, obj);
-#endif
 
   xorptr(obj, mdo_addr);
   testptr(obj, TypeEntries::type_klass_mask);
@@ -89,7 +83,7 @@ void InterpreterMacroAssembler::profile_obj_type(Register obj, const Address& md
   jccb(Assembler::equal, none);
   cmpptr(mdo_addr, TypeEntries::null_seen);
   jccb(Assembler::equal, none);
-#ifdef _LP64
+
   // There is a chance that the checks above (re-reading profiling
   // data from memory) fail if another thread has just set the
   // profiling to this obj's klass
@@ -97,7 +91,6 @@ void InterpreterMacroAssembler::profile_obj_type(Register obj, const Address& md
   xorptr(obj, mdo_addr);
   testptr(obj, TypeEntries::type_klass_mask);
   jccb(Assembler::zero, next);
-#endif
 
   // different than before. Cannot keep accurate profile.
   orptr(mdo_addr, TypeEntries::type_unknown);
@@ -314,7 +307,6 @@ void InterpreterMacroAssembler::call_VM_base(Register oop_result,
   //       really make a difference for these runtime calls, since they are
   //       slow anyway. Btw., bcp must be saved/restored since it may change
   //       due to GC.
-  NOT_LP64(assert(java_thread == noreg , "not expecting a precomputed java thread");)
   save_bcp();
 #ifdef ASSERT
   {
@@ -335,7 +327,6 @@ void InterpreterMacroAssembler::call_VM_base(Register oop_result,
   restore_locals();
 }
 
-#ifdef _LP64
 void InterpreterMacroAssembler::call_VM_preemptable(Register oop_result,
                                                     address entry_point,
                                                     Register arg_1) {
@@ -387,13 +378,6 @@ void InterpreterMacroAssembler::restore_after_resume(bool is_native) {
     push(ltos);
   }
 }
-#else
-void InterpreterMacroAssembler::call_VM_preemptable(Register oop_result,
-                         address entry_point,
-                         Register arg_1) {
-  MacroAssembler::call_VM(oop_result, entry_point, arg_1);
-}
-#endif  // _LP64
 
 void InterpreterMacroAssembler::check_and_handle_popframe(Register java_thread) {
   if (JvmtiExport::can_pop_frame()) {
@@ -404,8 +388,7 @@ void InterpreterMacroAssembler::check_and_handle_popframe(Register java_thread) 
     // don't want to reenter.
     // This method is only called just after the call into the vm in
     // call_VM_base, so the arg registers are available.
-    Register pop_cond = NOT_LP64(java_thread) // Not clear if any other register is available on 32 bit
-                        LP64_ONLY(c_rarg0);
+    Register pop_cond = c_rarg0;
     movl(pop_cond, Address(java_thread, JavaThread::popframe_condition_offset()));
     testl(pop_cond, JavaThread::popframe_pending_bit);
     jcc(Assembler::zero, L);
@@ -416,18 +399,15 @@ void InterpreterMacroAssembler::check_and_handle_popframe(Register java_thread) 
     call_VM_leaf(CAST_FROM_FN_PTR(address, Interpreter::remove_activation_preserving_args_entry));
     jmp(rax);
     bind(L);
-    NOT_LP64(get_thread(java_thread);)
   }
 }
 
 void InterpreterMacroAssembler::load_earlyret_value(TosState state) {
-  Register thread = LP64_ONLY(r15_thread) NOT_LP64(rcx);
-  NOT_LP64(get_thread(thread);)
-  movptr(rcx, Address(thread, JavaThread::jvmti_thread_state_offset()));
+  movptr(rcx, Address(r15_thread, JavaThread::jvmti_thread_state_offset()));
   const Address tos_addr(rcx, JvmtiThreadState::earlyret_tos_offset());
   const Address oop_addr(rcx, JvmtiThreadState::earlyret_oop_offset());
   const Address val_addr(rcx, JvmtiThreadState::earlyret_value_offset());
-#ifdef _LP64
+
   switch (state) {
     case atos: movptr(rax, oop_addr);
                movptr(oop_addr, NULL_WORD);
@@ -443,41 +423,18 @@ void InterpreterMacroAssembler::load_earlyret_value(TosState state) {
     case vtos: /* nothing to do */                  break;
     default  : ShouldNotReachHere();
   }
-  // Clean up tos value in the thread object
-  movl(tos_addr, ilgl);
-  movl(val_addr, NULL_WORD);
-#else
-  const Address val_addr1(rcx, JvmtiThreadState::earlyret_value_offset()
-                             + in_ByteSize(wordSize));
-  switch (state) {
-    case atos: movptr(rax, oop_addr);
-               movptr(oop_addr, NULL_WORD);
-               interp_verify_oop(rax, state);         break;
-    case ltos:
-               movl(rdx, val_addr1);               // fall through
-    case btos:                                     // fall through
-    case ztos:                                     // fall through
-    case ctos:                                     // fall through
-    case stos:                                     // fall through
-    case itos: movl(rax, val_addr);                   break;
-    case ftos: load_float(val_addr);                  break;
-    case dtos: load_double(val_addr);                 break;
-    case vtos: /* nothing to do */                    break;
-    default  : ShouldNotReachHere();
-  }
-#endif // _LP64
+
   // Clean up tos value in the thread object
   movl(tos_addr, ilgl);
   movptr(val_addr, NULL_WORD);
-  NOT_LP64(movptr(val_addr1, NULL_WORD);)
 }
 
 
 void InterpreterMacroAssembler::check_and_handle_earlyret(Register java_thread) {
   if (JvmtiExport::can_force_early_return()) {
     Label L;
-    Register tmp = LP64_ONLY(c_rarg0) NOT_LP64(java_thread);
-    Register rthread = LP64_ONLY(r15_thread) NOT_LP64(java_thread);
+    Register tmp = c_rarg0;
+    Register rthread = r15_thread;
 
     movptr(tmp, Address(rthread, JavaThread::jvmti_thread_state_offset()));
     testptr(tmp, tmp);
@@ -492,18 +449,11 @@ void InterpreterMacroAssembler::check_and_handle_earlyret(Register java_thread) 
 
     // Call Interpreter::remove_activation_early_entry() to get the address of the
     // same-named entrypoint in the generated interpreter code.
-    NOT_LP64(get_thread(java_thread);)
     movptr(tmp, Address(rthread, JavaThread::jvmti_thread_state_offset()));
-#ifdef _LP64
     movl(tmp, Address(tmp, JvmtiThreadState::earlyret_tos_offset()));
     call_VM_leaf(CAST_FROM_FN_PTR(address, Interpreter::remove_activation_early_entry), tmp);
-#else
-    pushl(Address(tmp, JvmtiThreadState::earlyret_tos_offset()));
-    call_VM_leaf(CAST_FROM_FN_PTR(address, Interpreter::remove_activation_early_entry), 1);
-#endif // _LP64
     jmp(rax);
     bind(L);
-    NOT_LP64(get_thread(java_thread);)
   }
 }
 
@@ -582,23 +532,6 @@ void InterpreterMacroAssembler::gen_subtype_check(Register Rsub_klass,
 }
 
 
-#ifndef _LP64
-void InterpreterMacroAssembler::f2ieee() {
-  if (IEEEPrecision) {
-    fstp_s(Address(rsp, 0));
-    fld_s(Address(rsp, 0));
-  }
-}
-
-
-void InterpreterMacroAssembler::d2ieee() {
-  if (IEEEPrecision) {
-    fstp_d(Address(rsp, 0));
-    fld_d(Address(rsp, 0));
-  }
-}
-#endif // _LP64
-
 // Java Expression Stack
 
 void InterpreterMacroAssembler::pop_ptr(Register r) {
@@ -637,7 +570,6 @@ void InterpreterMacroAssembler::pop_d(XMMRegister r) {
   addptr(rsp, 2 * Interpreter::stackElementSize);
 }
 
-#ifdef _LP64
 void InterpreterMacroAssembler::pop_i(Register r) {
   // XXX can't use pop currently, upper half non clean
   movl(r, Address(rsp, 0));
@@ -688,105 +620,6 @@ void InterpreterMacroAssembler::push(TosState state) {
   default  : ShouldNotReachHere();
   }
 }
-#else
-void InterpreterMacroAssembler::pop_i(Register r) {
-  pop(r);
-}
-
-void InterpreterMacroAssembler::pop_l(Register lo, Register hi) {
-  pop(lo);
-  pop(hi);
-}
-
-void InterpreterMacroAssembler::pop_f() {
-  fld_s(Address(rsp, 0));
-  addptr(rsp, 1 * wordSize);
-}
-
-void InterpreterMacroAssembler::pop_d() {
-  fld_d(Address(rsp, 0));
-  addptr(rsp, 2 * wordSize);
-}
-
-
-void InterpreterMacroAssembler::pop(TosState state) {
-  switch (state) {
-    case atos: pop_ptr(rax);                                 break;
-    case btos:                                               // fall through
-    case ztos:                                               // fall through
-    case ctos:                                               // fall through
-    case stos:                                               // fall through
-    case itos: pop_i(rax);                                   break;
-    case ltos: pop_l(rax, rdx);                              break;
-    case ftos:
-      if (UseSSE >= 1) {
-        pop_f(xmm0);
-      } else {
-        pop_f();
-      }
-      break;
-    case dtos:
-      if (UseSSE >= 2) {
-        pop_d(xmm0);
-      } else {
-        pop_d();
-      }
-      break;
-    case vtos: /* nothing to do */                           break;
-    default  : ShouldNotReachHere();
-  }
-  interp_verify_oop(rax, state);
-}
-
-
-void InterpreterMacroAssembler::push_l(Register lo, Register hi) {
-  push(hi);
-  push(lo);
-}
-
-void InterpreterMacroAssembler::push_f() {
-  // Do not schedule for no AGI! Never write beyond rsp!
-  subptr(rsp, 1 * wordSize);
-  fstp_s(Address(rsp, 0));
-}
-
-void InterpreterMacroAssembler::push_d() {
-  // Do not schedule for no AGI! Never write beyond rsp!
-  subptr(rsp, 2 * wordSize);
-  fstp_d(Address(rsp, 0));
-}
-
-
-void InterpreterMacroAssembler::push(TosState state) {
-  interp_verify_oop(rax, state);
-  switch (state) {
-    case atos: push_ptr(rax); break;
-    case btos:                                               // fall through
-    case ztos:                                               // fall through
-    case ctos:                                               // fall through
-    case stos:                                               // fall through
-    case itos: push_i(rax);                                    break;
-    case ltos: push_l(rax, rdx);                               break;
-    case ftos:
-      if (UseSSE >= 1) {
-        push_f(xmm0);
-      } else {
-        push_f();
-      }
-      break;
-    case dtos:
-      if (UseSSE >= 2) {
-        push_d(xmm0);
-      } else {
-        push_d();
-      }
-      break;
-    case vtos: /* nothing to do */                             break;
-    default  : ShouldNotReachHere();
-  }
-}
-#endif // _LP64
-
 
 // Helpers for swap and dup
 void InterpreterMacroAssembler::load_ptr(int n, Register val) {
@@ -821,9 +654,7 @@ void InterpreterMacroAssembler::jump_from_interpreted(Register method, Register 
     // interp_only_mode if these events CAN be enabled.
     // interp_only is an int, on little endian it is sufficient to test the byte only
     // Is a cmpl faster?
-    LP64_ONLY(temp = r15_thread;)
-    NOT_LP64(get_thread(temp);)
-    cmpb(Address(temp, JavaThread::interp_only_mode_offset()), 0);
+    cmpb(Address(r15_thread, JavaThread::interp_only_mode_offset()), 0);
     jccb(Assembler::zero, run_compiled_code);
     jmp(Address(method, Method::interpreter_entry_offset()));
     bind(run_compiled_code);
@@ -846,7 +677,6 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
                                               address* table,
                                               bool verifyoop,
                                               bool generate_poll) {
-  verify_FPU(1, state);
   if (VerifyActivationFrameSize) {
     Label L;
     mov(rcx, rbp);
@@ -864,7 +694,6 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
   }
 
   address* const safepoint_table = Interpreter::safept_table(state);
-#ifdef _LP64
   Label no_safepoint, dispatch;
   if (table != safepoint_table && generate_poll) {
     NOT_PRODUCT(block_comment("Thread-local Safepoint poll"));
@@ -879,27 +708,6 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
   lea(rscratch1, ExternalAddress((address)table));
   bind(dispatch);
   jmp(Address(rscratch1, rbx, Address::times_8));
-
-#else
-  Address index(noreg, rbx, Address::times_ptr);
-  if (table != safepoint_table && generate_poll) {
-    NOT_PRODUCT(block_comment("Thread-local Safepoint poll"));
-    Label no_safepoint;
-    const Register thread = rcx;
-    get_thread(thread);
-    testb(Address(thread, JavaThread::polling_word_offset()), SafepointMechanism::poll_bit());
-
-    jccb(Assembler::zero, no_safepoint);
-    ArrayAddress dispatch_addr(ExternalAddress((address)safepoint_table), index);
-    jump(dispatch_addr, noreg);
-    bind(no_safepoint);
-  }
-
-  {
-    ArrayAddress dispatch_addr(ExternalAddress((address)table), index);
-    jump(dispatch_addr, noreg);
-  }
-#endif // _LP64
 }
 
 void InterpreterMacroAssembler::dispatch_only(TosState state, bool generate_poll) {
@@ -951,24 +759,19 @@ void InterpreterMacroAssembler::narrow(Register result) {
   bind(notBool);
   cmpl(rcx, T_BYTE);
   jcc(Assembler::notEqual, notByte);
-  LP64_ONLY(movsbl(result, result);)
-  NOT_LP64(shll(result, 24);)      // truncate upper 24 bits
-  NOT_LP64(sarl(result, 24);)      // and sign-extend byte
+  movsbl(result, result);
   jmp(done);
 
   bind(notByte);
   cmpl(rcx, T_CHAR);
   jcc(Assembler::notEqual, notChar);
-  LP64_ONLY(movzwl(result, result);)
-  NOT_LP64(andl(result, 0xFFFF);)  // truncate upper 16 bits
+  movzwl(result, result);
   jmp(done);
 
   bind(notChar);
   // cmpl(rcx, T_SHORT);  // all that's left
   // jcc(Assembler::notEqual, done);
-  LP64_ONLY(movswl(result, result);)
-  NOT_LP64(shll(result, 16);)      // truncate upper 16 bits
-  NOT_LP64(sarl(result, 16);)      // and sign-extend short
+  movswl(result, result);
 
   // Nothing to do for T_INT
   bind(done);
@@ -998,12 +801,9 @@ void InterpreterMacroAssembler::remove_activation(
   // result check if synchronized method
   Label unlocked, unlock, no_unlock;
 
-  const Register rthread = LP64_ONLY(r15_thread) NOT_LP64(rcx);
-  const Register robj    = LP64_ONLY(c_rarg1) NOT_LP64(rdx);
-  const Register rmon    = LP64_ONLY(c_rarg1) NOT_LP64(rcx);
-                              // monitor pointers need different register
-                              // because rdx may have the result in it
-  NOT_LP64(get_thread(rthread);)
+  const Register rthread = r15_thread;
+  const Register robj    = c_rarg1;
+  const Register rmon    = c_rarg1;
 
   // The below poll is for the stack watermark barrier. It allows fixing up frames lazily,
   // that would normally not be safe to use. Such bad returns into unsafe territory of
@@ -1016,7 +816,6 @@ void InterpreterMacroAssembler::remove_activation(
   push(state);
   set_last_Java_frame(rthread, noreg, rbp, (address)pc(), rscratch1);
   super_call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::at_unwind), rthread);
-  NOT_LP64(get_thread(rthread);) // call_VM clobbered it, restore
   reset_last_Java_frame(rthread, true);
   pop(state);
   bind(fast_path);
@@ -1057,7 +856,6 @@ void InterpreterMacroAssembler::remove_activation(
   pop(state);
   if (throw_monitor_exception) {
     // Entry already unlocked, need to throw exception
-    NOT_LP64(empty_FPU_stack();)  // remove possible return value from FPU-stack, otherwise stack could overflow
     call_VM(noreg, CAST_FROM_FN_PTR(address,
                    InterpreterRuntime::throw_illegal_monitor_state_exception));
     should_not_reach_here();
@@ -1066,7 +864,6 @@ void InterpreterMacroAssembler::remove_activation(
     // install an illegal_monitor_state_exception.  Continue with
     // stack unrolling.
     if (install_monitor_exception) {
-      NOT_LP64(empty_FPU_stack();)
       call_VM(noreg, CAST_FROM_FN_PTR(address,
                      InterpreterRuntime::new_illegal_monitor_state_exception));
     }
@@ -1108,7 +905,6 @@ void InterpreterMacroAssembler::remove_activation(
 
     if (throw_monitor_exception) {
       // Throw exception
-      NOT_LP64(empty_FPU_stack();)
       MacroAssembler::call_VM(noreg,
                               CAST_FROM_FN_PTR(address, InterpreterRuntime::
                                    throw_illegal_monitor_state_exception));
@@ -1124,7 +920,6 @@ void InterpreterMacroAssembler::remove_activation(
       pop(state);
 
       if (install_monitor_exception) {
-        NOT_LP64(empty_FPU_stack();)
         call_VM(noreg, CAST_FROM_FN_PTR(address,
                                         InterpreterRuntime::
                                         new_illegal_monitor_state_exception));
@@ -1159,10 +954,8 @@ void InterpreterMacroAssembler::remove_activation(
          Address(rbp, frame::interpreter_frame_sender_sp_offset * wordSize));
   if (StackReservedPages > 0) {
     // testing if reserved zone needs to be re-enabled
-    Register rthread = LP64_ONLY(r15_thread) NOT_LP64(rcx);
+    Register rthread = r15_thread;
     Label no_reserved_zone_enabling;
-
-    NOT_LP64(get_thread(rthread);)
 
     // check if already enabled - if so no re-enabling needed
     assert(sizeof(StackOverflow::StackGuardState) == 4, "unexpected size");
@@ -1209,8 +1002,7 @@ void InterpreterMacroAssembler::get_method_counters(Register method,
 // Kills:
 //      rax, rbx
 void InterpreterMacroAssembler::lock_object(Register lock_reg) {
-  assert(lock_reg == LP64_ONLY(c_rarg1) NOT_LP64(rdx),
-         "The argument is only for looks. It must be c_rarg1");
+  assert(lock_reg == c_rarg1, "The argument is only for looks. It must be c_rarg1");
 
   if (LockingMode == LM_MONITOR) {
     call_VM_preemptable(noreg,
@@ -1221,7 +1013,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
 
     const Register swap_reg = rax; // Must use rax for cmpxchg instruction
     const Register tmp_reg = rbx;
-    const Register obj_reg = LP64_ONLY(c_rarg3) NOT_LP64(rcx); // Will contain the oop
+    const Register obj_reg = c_rarg3; // Will contain the oop
     const Register rklass_decode_tmp = rscratch1;
 
     const int obj_offset = in_bytes(BasicObjectLock::obj_offset());
@@ -1239,13 +1031,8 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
     }
 
     if (LockingMode == LM_LIGHTWEIGHT) {
-#ifdef _LP64
       const Register thread = r15_thread;
       lightweight_lock(lock_reg, obj_reg, swap_reg, thread, tmp_reg, slow_case);
-#else
-      // Lacking registers and thread on x86_32. Always take slow path.
-      jmp(slow_case);
-#endif
     } else if (LockingMode == LM_LEGACY) {
       // Load immediate 1 into swap_reg %rax
       movl(swap_reg, 1);
@@ -1263,7 +1050,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
       cmpxchgptr(lock_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
       jcc(Assembler::zero, count_locking);
 
-      const int zero_bits = LP64_ONLY(7) NOT_LP64(3);
+      const int zero_bits = 7;
 
       // Fast check for recursive lock.
       //
@@ -1328,8 +1115,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
 //      rscratch1 (scratch reg)
 // rax, rbx, rcx, rdx
 void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
-  assert(lock_reg == LP64_ONLY(c_rarg1) NOT_LP64(rdx),
-         "The argument is only for looks. It must be c_rarg1");
+  assert(lock_reg == c_rarg1, "The argument is only for looks. It must be c_rarg1");
 
   if (LockingMode == LM_MONITOR) {
     call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), lock_reg);
@@ -1337,8 +1123,8 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
     Label count_locking, done, slow_case;
 
     const Register swap_reg   = rax;  // Must use rax for cmpxchg instruction
-    const Register header_reg = LP64_ONLY(c_rarg2) NOT_LP64(rbx);  // Will contain the old oopMark
-    const Register obj_reg    = LP64_ONLY(c_rarg3) NOT_LP64(rcx);  // Will contain the oop
+    const Register header_reg = c_rarg2;  // Will contain the old oopMark
+    const Register obj_reg    = c_rarg3;  // Will contain the oop
 
     save_bcp(); // Save in case of exception
 
@@ -1355,12 +1141,7 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
     movptr(Address(lock_reg, BasicObjectLock::obj_offset()), NULL_WORD);
 
     if (LockingMode == LM_LIGHTWEIGHT) {
-#ifdef _LP64
       lightweight_unlock(obj_reg, swap_reg, r15_thread, header_reg, slow_case);
-#else
-      // Lacking registers and thread on x86_32. Always take slow path.
-      jmp(slow_case);
-#endif
     } else if (LockingMode == LM_LEGACY) {
       // Load the old header from BasicLock structure
       movptr(header_reg, Address(swap_reg,
@@ -1436,8 +1217,8 @@ void InterpreterMacroAssembler::verify_method_data_pointer() {
   Label verify_continue;
   push(rax);
   push(rbx);
-  Register arg3_reg = LP64_ONLY(c_rarg3) NOT_LP64(rcx);
-  Register arg2_reg = LP64_ONLY(c_rarg2) NOT_LP64(rdx);
+  Register arg3_reg = c_rarg3;
+  Register arg2_reg = c_rarg2;
   push(arg3_reg);
   push(arg2_reg);
   test_method_data_pointer(arg3_reg, verify_continue); // If mdp is zero, continue
@@ -1895,8 +1676,6 @@ void InterpreterMacroAssembler::profile_typecheck(Register mdp, Register klass, 
 
       // Record the object type.
       record_klass_in_profile(klass, mdp, reg2, false);
-      NOT_LP64(assert(reg2 == rdi, "we know how to fix this blown reg");)
-      NOT_LP64(restore_locals();)         // Restore EDI
     }
     update_mdp_by_constant(mdp, mdp_delta);
 
@@ -1964,14 +1743,6 @@ void InterpreterMacroAssembler::_interp_verify_oop(Register reg, TosState state,
   }
 }
 
-void InterpreterMacroAssembler::verify_FPU(int stack_depth, TosState state) {
-#ifndef _LP64
-  if ((state == ftos && UseSSE < 1) ||
-      (state == dtos && UseSSE < 2)) {
-    MacroAssembler::verify_FPU(stack_depth);
-  }
-#endif
-}
 
 // Jump if ((*counter_addr += increment) & mask) == 0
 void InterpreterMacroAssembler::increment_mask_and_jump(Address counter_addr, Address mask,
@@ -1992,11 +1763,10 @@ void InterpreterMacroAssembler::notify_method_entry() {
   // Whenever JVMTI is interp_only_mode, method entry/exit events are sent to
   // track stack depth.  If it is possible to enter interp_only_mode we add
   // the code to check if the event should be sent.
-  Register rthread = LP64_ONLY(r15_thread) NOT_LP64(rcx);
-  Register rarg = LP64_ONLY(c_rarg1) NOT_LP64(rbx);
+  Register rthread = r15_thread;
+  Register rarg = c_rarg1;
   if (JvmtiExport::can_post_interpreter_events()) {
     Label L;
-    NOT_LP64(get_thread(rthread);)
     movl(rdx, Address(rthread, JavaThread::interp_only_mode_offset()));
     testl(rdx, rdx);
     jcc(Assembler::zero, L);
@@ -2006,7 +1776,6 @@ void InterpreterMacroAssembler::notify_method_entry() {
   }
 
   if (DTraceMethodProbes) {
-    NOT_LP64(get_thread(rthread);)
     get_method(rarg);
     call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_entry),
                  rthread, rarg);
@@ -2014,7 +1783,6 @@ void InterpreterMacroAssembler::notify_method_entry() {
 
   // RedefineClasses() tracing support for obsolete method entry
   if (log_is_enabled(Trace, redefine, class, obsolete)) {
-    NOT_LP64(get_thread(rthread);)
     get_method(rarg);
     call_VM_leaf(
       CAST_FROM_FN_PTR(address, SharedRuntime::rc_trace_method_entry),
@@ -2028,8 +1796,8 @@ void InterpreterMacroAssembler::notify_method_exit(
   // Whenever JVMTI is interp_only_mode, method entry/exit events are sent to
   // track stack depth.  If it is possible to enter interp_only_mode we add
   // the code to check if the event should be sent.
-  Register rthread = LP64_ONLY(r15_thread) NOT_LP64(rcx);
-  Register rarg = LP64_ONLY(c_rarg1) NOT_LP64(rbx);
+  Register rthread = r15_thread;
+  Register rarg = c_rarg1;
   if (mode == NotifyJVMTI && JvmtiExport::can_post_interpreter_events()) {
     Label L;
     // Note: frame::interpreter_frame_result has a dependency on how the
@@ -2039,7 +1807,6 @@ void InterpreterMacroAssembler::notify_method_exit(
 
     // template interpreter will leave the result on the top of the stack.
     push(state);
-    NOT_LP64(get_thread(rthread);)
     movl(rdx, Address(rthread, JavaThread::interp_only_mode_offset()));
     testl(rdx, rdx);
     jcc(Assembler::zero, L);
@@ -2051,7 +1818,6 @@ void InterpreterMacroAssembler::notify_method_exit(
 
   if (DTraceMethodProbes) {
     push(state);
-    NOT_LP64(get_thread(rthread);)
     get_method(rarg);
     call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_exit),
                  rthread, rarg);

--- a/src/hotspot/cpu/x86/interp_masm_x86.hpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.hpp
@@ -53,8 +53,8 @@ class InterpreterMacroAssembler: public MacroAssembler {
 
  public:
   InterpreterMacroAssembler(CodeBuffer* code) : MacroAssembler(code),
-    _locals_register(LP64_ONLY(r14) NOT_LP64(rdi)),
-    _bcp_register(LP64_ONLY(r13) NOT_LP64(rsi)) {}
+    _locals_register(r14),
+    _bcp_register(r13) {}
 
   void jump_to_entry(address entry);
 
@@ -121,9 +121,6 @@ class InterpreterMacroAssembler: public MacroAssembler {
                                     Register cpool,  // the constant pool (corrupted on return)
                                     Register index); // the constant pool index (corrupted on return)
 
-  NOT_LP64(void f2ieee();)        // truncate ftos to 32bits
-  NOT_LP64(void d2ieee();)        // truncate dtos to 64bits
-
   // Expression stack
   void pop_ptr(Register r = rax);
   void pop_i(Register r = rax);
@@ -143,18 +140,8 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void pop_f(XMMRegister r);
   void pop_d(XMMRegister r);
   void push_d(XMMRegister r);
-#ifdef _LP64
   void pop_l(Register r = rax);
   void push_l(Register r = rax);
-#else
-  void pop_l(Register lo = rax, Register hi = rdx);
-  void pop_f();
-  void pop_d();
-
-  void push_l(Register lo = rax, Register hi = rdx);
-  void push_d();
-  void push_f();
-#endif // _LP64
 
   void pop(Register r) { ((MacroAssembler*)this)->pop(r); }
   void push(Register r) { ((MacroAssembler*)this)->push(r); }
@@ -168,7 +155,6 @@ class InterpreterMacroAssembler: public MacroAssembler {
     lea(rsp, Address(rbp, rcx, Address::times_ptr));
     // null last_sp until next java call
     movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), NULL_WORD);
-    NOT_LP64(empty_FPU_stack());
   }
 
   // Helpers for swap and dup
@@ -273,8 +259,6 @@ class InterpreterMacroAssembler: public MacroAssembler {
   // only if +VerifyOops && state == atos
 #define interp_verify_oop(reg, state) _interp_verify_oop(reg, state, __FILE__, __LINE__);
   void _interp_verify_oop(Register reg, TosState state, const char* file, int line);
-  // only if +VerifyFPU  && (state == ftos || state == dtos)
-  void verify_FPU(int stack_depth, TosState state = ftos);
 
   typedef enum { NotifyJVMTI, SkipNotifyJVMTI } NotifyMethodExitMode;
 

--- a/src/hotspot/cpu/x86/interpreterRT_x86.hpp
+++ b/src/hotspot/cpu/x86/interpreterRT_x86.hpp
@@ -33,7 +33,6 @@
 class SignatureHandlerGenerator: public NativeSignatureIterator {
  private:
   MacroAssembler* _masm;
-#ifdef AMD64
 #ifdef _WIN64
   unsigned int _num_args;
 #else
@@ -41,17 +40,11 @@ class SignatureHandlerGenerator: public NativeSignatureIterator {
   unsigned int _num_int_args;
 #endif // _WIN64
   int _stack_offset;
-#else
-  void move(int from_offset, int to_offset);
-  void box(int from_offset, int to_offset);
-#endif // AMD64
 
   void pass_int();
   void pass_long();
   void pass_float();
-#ifdef AMD64
   void pass_double();
-#endif // AMD64
   void pass_object();
 
  public:

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -120,7 +120,7 @@ address TemplateInterpreterGenerator::generate_ArrayIndexOutOfBounds_handler() {
              CAST_FROM_FN_PTR(address,
                               InterpreterRuntime::
                               throw_ArrayIndexOutOfBoundsException),
-             rax, rbx);
+             c_rarg1, rbx);
   return entry;
 }
 

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -63,15 +63,11 @@
 // if too small.
 // Run with +PrintInterpreter to get the VM to print out the size.
 // Max size with JVMTI
-#ifdef AMD64
 int TemplateInterpreter::InterpreterCodeSize = JVMCI_ONLY(268) NOT_JVMCI(256) * 1024;
-#else
-int TemplateInterpreter::InterpreterCodeSize = 224 * 1024;
-#endif // AMD64
 
 // Global Register Names
-static const Register rbcp     = LP64_ONLY(r13) NOT_LP64(rsi);
-static const Register rlocals  = LP64_ONLY(r14) NOT_LP64(rdi);
+static const Register rbcp     = r13;
+static const Register rlocals  = r14;
 
 const int method_offset = frame::interpreter_frame_method_offset * wordSize;
 const int bcp_offset    = frame::interpreter_frame_bcp_offset    * wordSize;
@@ -120,12 +116,11 @@ address TemplateInterpreterGenerator::generate_ArrayIndexOutOfBounds_handler() {
   // Setup parameters.
   // ??? convention: expect aberrant index in register ebx/rbx.
   // Pass array to create more detailed exceptions.
-  Register rarg = NOT_LP64(rax) LP64_ONLY(c_rarg1);
   __ call_VM(noreg,
              CAST_FROM_FN_PTR(address,
                               InterpreterRuntime::
                               throw_ArrayIndexOutOfBoundsException),
-             rarg, rbx);
+             rax, rbx);
   return entry;
 }
 
@@ -133,8 +128,7 @@ address TemplateInterpreterGenerator::generate_ClassCastException_handler() {
   address entry = __ pc();
 
   // object is at TOS
-  Register rarg = NOT_LP64(rax) LP64_ONLY(c_rarg1);
-  __ pop(rarg);
+  __ pop(c_rarg1);
 
   // expression stack must be empty before entering the VM if an
   // exception happened
@@ -144,7 +138,7 @@ address TemplateInterpreterGenerator::generate_ClassCastException_handler() {
              CAST_FROM_FN_PTR(address,
                               InterpreterRuntime::
                               throw_ClassCastException),
-             rarg);
+             c_rarg1);
   return entry;
 }
 
@@ -153,28 +147,25 @@ address TemplateInterpreterGenerator::generate_exception_handler_common(
   assert(!pass_oop || message == nullptr, "either oop or message but not both");
   address entry = __ pc();
 
-  Register rarg = NOT_LP64(rax) LP64_ONLY(c_rarg1);
-  Register rarg2 = NOT_LP64(rbx) LP64_ONLY(c_rarg2);
-
   if (pass_oop) {
     // object is at TOS
-    __ pop(rarg2);
+    __ pop(c_rarg2);
   }
   // expression stack must be empty before entering the VM if an
   // exception happened
   __ empty_expression_stack();
   // setup parameters
-  __ lea(rarg, ExternalAddress((address)name));
+  __ lea(c_rarg1, ExternalAddress((address)name));
   if (pass_oop) {
     __ call_VM(rax, CAST_FROM_FN_PTR(address,
                                      InterpreterRuntime::
                                      create_klass_exception),
-               rarg, rarg2);
+               c_rarg1, c_rarg2);
   } else {
-    __ lea(rarg2, ExternalAddress((address)message));
+    __ lea(c_rarg2, ExternalAddress((address)message));
     __ call_VM(rax,
                CAST_FROM_FN_PTR(address, InterpreterRuntime::create_exception),
-               rarg, rarg2);
+               c_rarg1, c_rarg2);
   }
   // throw exception
   __ jump(RuntimeAddress(Interpreter::throw_exception_entry()));
@@ -183,30 +174,6 @@ address TemplateInterpreterGenerator::generate_exception_handler_common(
 
 address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, int step, size_t index_size) {
   address entry = __ pc();
-
-#ifndef _LP64
-#ifdef COMPILER2
-  // The FPU stack is clean if UseSSE >= 2 but must be cleaned in other cases
-  if ((state == ftos && UseSSE < 1) || (state == dtos && UseSSE < 2)) {
-    for (int i = 1; i < 8; i++) {
-        __ ffree(i);
-    }
-  } else if (UseSSE < 2) {
-    __ empty_FPU_stack();
-  }
-#endif // COMPILER2
-  if ((state == ftos && UseSSE < 1) || (state == dtos && UseSSE < 2)) {
-    __ MacroAssembler::verify_FPU(1, "generate_return_entry_for compiled");
-  } else {
-    __ MacroAssembler::verify_FPU(0, "generate_return_entry_for compiled");
-  }
-
-  if (state == ftos) {
-    __ MacroAssembler::verify_FPU(UseSSE >= 1 ? 0 : 1, "generate_return_entry_for in interpreter");
-  } else if (state == dtos) {
-    __ MacroAssembler::verify_FPU(UseSSE >= 2 ? 0 : 1, "generate_return_entry_for in interpreter");
-  }
-#endif // _LP64
 
   // Restore stack bottom in case i2c adjusted stack
   __ movptr(rcx, Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize));
@@ -236,14 +203,11 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
     __ lea(rsp, Address(rsp, cache, Interpreter::stackElementScale()));
   }
 
-   const Register java_thread = NOT_LP64(rcx) LP64_ONLY(r15_thread);
    if (JvmtiExport::can_pop_frame()) {
-     NOT_LP64(__ get_thread(java_thread));
-     __ check_and_handle_popframe(java_thread);
+     __ check_and_handle_popframe(r15_thread);
    }
    if (JvmtiExport::can_force_early_return()) {
-     NOT_LP64(__ get_thread(java_thread));
-     __ check_and_handle_earlyret(java_thread);
+     __ check_and_handle_earlyret(r15_thread);
    }
 
   __ dispatch_next(state, step);
@@ -255,29 +219,19 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
 address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state, int step, address continuation) {
   address entry = __ pc();
 
-#ifndef _LP64
-  if (state == ftos) {
-    __ MacroAssembler::verify_FPU(UseSSE >= 1 ? 0 : 1, "generate_deopt_entry_for in interpreter");
-  } else if (state == dtos) {
-    __ MacroAssembler::verify_FPU(UseSSE >= 2 ? 0 : 1, "generate_deopt_entry_for in interpreter");
-  }
-#endif // _LP64
-
   // null last_sp until next java call
   __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), NULL_WORD);
   __ restore_bcp();
   __ restore_locals();
-  const Register thread = NOT_LP64(rcx) LP64_ONLY(r15_thread);
-  NOT_LP64(__ get_thread(thread));
 #if INCLUDE_JVMCI
   // Check if we need to take lock at entry of synchronized method.  This can
   // only occur on method entry so emit it only for vtos with step 0.
   if (EnableJVMCI && state == vtos && step == 0) {
     Label L;
-    __ cmpb(Address(thread, JavaThread::pending_monitorenter_offset()), 0);
+    __ cmpb(Address(r15_thread, JavaThread::pending_monitorenter_offset()), 0);
     __ jcc(Assembler::zero, L);
     // Clear flag.
-    __ movb(Address(thread, JavaThread::pending_monitorenter_offset()), 0);
+    __ movb(Address(r15_thread, JavaThread::pending_monitorenter_offset()), 0);
     // Satisfy calling convention for lock_method().
     __ get_method(rbx);
     // Take lock.
@@ -298,7 +252,7 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state, i
   // handle exceptions
   {
     Label L;
-    __ cmpptr(Address(thread, Thread::pending_exception_offset()), NULL_WORD);
+    __ cmpptr(Address(r15_thread, Thread::pending_exception_offset()), NULL_WORD);
     __ jcc(Assembler::zero, L);
     __ call_VM(noreg,
                CAST_FROM_FN_PTR(address,
@@ -319,46 +273,14 @@ address TemplateInterpreterGenerator::generate_result_handler_for(
   address entry = __ pc();
   switch (type) {
   case T_BOOLEAN: __ c2bool(rax);            break;
-#ifndef _LP64
-  case T_CHAR   : __ andptr(rax, 0xFFFF);    break;
-#else
   case T_CHAR   : __ movzwl(rax, rax);       break;
-#endif // _LP64
   case T_BYTE   : __ sign_extend_byte(rax);  break;
   case T_SHORT  : __ sign_extend_short(rax); break;
   case T_INT    : /* nothing to do */        break;
   case T_LONG   : /* nothing to do */        break;
   case T_VOID   : /* nothing to do */        break;
-#ifndef _LP64
-  case T_DOUBLE :
-  case T_FLOAT  :
-    { const Register t = InterpreterRuntime::SignatureHandlerGenerator::temp();
-      __ pop(t);                            // remove return address first
-      // Must return a result for interpreter or compiler. In SSE
-      // mode, results are returned in xmm0 and the FPU stack must
-      // be empty.
-      if (type == T_FLOAT && UseSSE >= 1) {
-        // Load ST0
-        __ fld_d(Address(rsp, 0));
-        // Store as float and empty fpu stack
-        __ fstp_s(Address(rsp, 0));
-        // and reload
-        __ movflt(xmm0, Address(rsp, 0));
-      } else if (type == T_DOUBLE && UseSSE >= 2 ) {
-        __ movdbl(xmm0, Address(rsp, 0));
-      } else {
-        // restore ST0
-        __ fld_d(Address(rsp, 0));
-      }
-      // and pop the temp
-      __ addptr(rsp, 2 * wordSize);
-      __ push(t);                           // restore return address
-    }
-    break;
-#else
   case T_FLOAT  : /* nothing to do */        break;
   case T_DOUBLE : /* nothing to do */        break;
-#endif // _LP64
 
   case T_OBJECT :
     // retrieve result from frame
@@ -467,12 +389,11 @@ void TemplateInterpreterGenerator::generate_counter_overflow(Label& do_continue)
   // of the verified entry point for the method or null if the
   // compilation did not complete (either went background or bailed
   // out).
-  Register rarg = NOT_LP64(rax) LP64_ONLY(c_rarg1);
-  __ movl(rarg, 0);
+  __ movl(c_rarg1, 0);
   __ call_VM(noreg,
              CAST_FROM_FN_PTR(address,
                               InterpreterRuntime::frequency_counter_overflow),
-             rarg);
+             c_rarg1);
 
   __ movptr(rbx, Address(rbp, method_offset));   // restore Method*
   // Preserve invariant that r13/r14 contain bcp/locals of sender frame
@@ -523,13 +444,8 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
   // the stack before the red zone
 
   Label after_frame_check_pop;
-  const Register thread = NOT_LP64(rsi) LP64_ONLY(r15_thread);
-#ifndef _LP64
-  __ push(thread);
-  __ get_thread(thread);
-#endif
 
-  const Address stack_limit(thread, JavaThread::stack_overflow_limit_offset());
+  const Address stack_limit(r15_thread, JavaThread::stack_overflow_limit_offset());
 
   // locals + overhead, in bytes
   __ mov(rax, rdx);
@@ -552,7 +468,6 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
   __ cmpptr(rsp, rax);
 
   __ jcc(Assembler::above, after_frame_check_pop);
-  NOT_LP64(__ pop(rsi));  // get saved bcp
 
   // Restore sender's sp as SP. This is necessary if the sender's
   // frame is an extended compiled frame (see gen_c2i_adapter())
@@ -568,7 +483,6 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
   __ jump(RuntimeAddress(SharedRuntime::throw_StackOverflowError_entry()));
   // all done with frame size check
   __ bind(after_frame_check_pop);
-  NOT_LP64(__ pop(rsi));
 
   // all done with frame size check
   __ bind(after_frame_check);
@@ -631,9 +545,8 @@ void TemplateInterpreterGenerator::lock_method() {
   __ subptr(monitor_block_top, entry_size / wordSize); // set new monitor block top
   // store object
   __ movptr(Address(rsp, BasicObjectLock::obj_offset()), rax);
-  const Register lockreg = NOT_LP64(rdx) LP64_ONLY(c_rarg1);
-  __ movptr(lockreg, rsp); // object address
-  __ lock_object(lockreg);
+  __ movptr(c_rarg1, rsp); // object address
+  __ lock_object(c_rarg1);
 }
 
 // Generate a fixed interpreter frame. This is identical setup for
@@ -728,19 +641,13 @@ address TemplateInterpreterGenerator::generate_Reference_get_entry(void) {
   // rdx: scratch
   // rdi: scratch
 
-  // Preserve the sender sp in case the load barrier
-  // calls the runtime
-  NOT_LP64(__ push(rsi));
-
   // Load the value of the referent field.
   const Address field_address(rax, referent_offset);
   __ load_heap_oop(rax, field_address, /*tmp1*/ rbx, /*tmp_thread*/ rdx, ON_WEAK_OOP_REF);
 
   // _areturn
-  const Register sender_sp = NOT_LP64(rsi) LP64_ONLY(r13);
-  NOT_LP64(__ pop(rsi));      // get sender sp
   __ pop(rdi);                // get return address
-  __ mov(rsp, sender_sp);     // set sp to sender sp
+  __ mov(rsp, r13);     // set sp to sender sp
   __ jmp(rdi);
   __ ret(0);
 
@@ -764,21 +671,15 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
   const int page_size = (int)os::vm_page_size();
   const int n_shadow_pages = shadow_zone_size / page_size;
 
-  const Register thread = NOT_LP64(rsi) LP64_ONLY(r15_thread);
-#ifndef _LP64
-  __ push(thread);
-  __ get_thread(thread);
-#endif
-
 #ifdef ASSERT
   Label L_good_limit;
-  __ cmpptr(Address(thread, JavaThread::shadow_zone_safe_limit()), NULL_WORD);
+  __ cmpptr(Address(r15_thread, JavaThread::shadow_zone_safe_limit()), NULL_WORD);
   __ jcc(Assembler::notEqual, L_good_limit);
   __ stop("shadow zone safe limit is not initialized");
   __ bind(L_good_limit);
 
   Label L_good_watermark;
-  __ cmpptr(Address(thread, JavaThread::shadow_zone_growth_watermark()), NULL_WORD);
+  __ cmpptr(Address(r15_thread, JavaThread::shadow_zone_growth_watermark()), NULL_WORD);
   __ jcc(Assembler::notEqual, L_good_watermark);
   __ stop("shadow zone growth watermark is not initialized");
   __ bind(L_good_watermark);
@@ -786,7 +687,7 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
 
   Label L_done;
 
-  __ cmpptr(rsp, Address(thread, JavaThread::shadow_zone_growth_watermark()));
+  __ cmpptr(rsp, Address(r15_thread, JavaThread::shadow_zone_growth_watermark()));
   __ jcc(Assembler::above, L_done);
 
   for (int p = 1; p <= n_shadow_pages; p++) {
@@ -795,15 +696,11 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
 
   // Record the new watermark, but only if update is above the safe limit.
   // Otherwise, the next time around the check above would pass the safe limit.
-  __ cmpptr(rsp, Address(thread, JavaThread::shadow_zone_safe_limit()));
+  __ cmpptr(rsp, Address(r15_thread, JavaThread::shadow_zone_safe_limit()));
   __ jccb(Assembler::belowEqual, L_done);
-  __ movptr(Address(thread, JavaThread::shadow_zone_growth_watermark()), rsp);
+  __ movptr(Address(r15_thread, JavaThread::shadow_zone_growth_watermark()), rsp);
 
   __ bind(L_done);
-
-#ifndef _LP64
-  __ pop(thread);
-#endif
 }
 
 // Interpreter stub for calling a native method. (asm interpreter)
@@ -877,9 +774,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // _do_not_unlock_if_synchronized to true. The remove_activation will
   // check this flag.
 
-  const Register thread1 = NOT_LP64(rax) LP64_ONLY(r15_thread);
-  NOT_LP64(__ get_thread(thread1));
-  const Address do_not_unlock_if_synchronized(thread1,
+  const Address do_not_unlock_if_synchronized(r15_thread,
         in_bytes(JavaThread::do_not_unlock_if_synchronized_offset()));
   __ movbool(do_not_unlock_if_synchronized, true);
 
@@ -895,7 +790,6 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   bang_stack_shadow_pages(true);
 
   // reset the _do_not_unlock_if_synchronized flag
-  NOT_LP64(__ get_thread(thread1));
   __ movbool(do_not_unlock_if_synchronized, false);
 
   // check for synchronized methods
@@ -937,26 +831,19 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
   // work registers
   const Register method = rbx;
-  const Register thread = NOT_LP64(rdi) LP64_ONLY(r15_thread);
-  const Register t      = NOT_LP64(rcx) LP64_ONLY(r11);
+  const Register thread = r15_thread;
+  const Register t      = r11;
 
   // allocate space for parameters
   __ get_method(method);
   __ movptr(t, Address(method, Method::const_offset()));
   __ load_unsigned_short(t, Address(t, ConstMethod::size_of_parameters_offset()));
 
-#ifndef _LP64
-  __ shlptr(t, Interpreter::logStackElementSize); // Convert parameter count to bytes.
-  __ addptr(t, 2*wordSize);     // allocate two more slots for JNIEnv and possible mirror
-  __ subptr(rsp, t);
-  __ andptr(rsp, -(StackAlignmentInBytes)); // gcc needs 16 byte aligned stacks to do XMM intrinsics
-#else
   __ shll(t, Interpreter::logStackElementSize);
 
   __ subptr(rsp, t);
   __ subptr(rsp, frame::arg_reg_save_area_bytes); // windows
   __ andptr(rsp, -16); // must be 16 byte boundary (see amd64 ABI)
-#endif // _LP64
 
   // get signature handler
   {
@@ -978,7 +865,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
          "adjust this code");
   assert(InterpreterRuntime::SignatureHandlerGenerator::to() == rsp,
          "adjust this code");
-  assert(InterpreterRuntime::SignatureHandlerGenerator::temp() == NOT_LP64(t) LP64_ONLY(rscratch1),
+  assert(InterpreterRuntime::SignatureHandlerGenerator::temp() == rscratch1,
          "adjust this code");
 
   // The generated handlers do not touch RBX (the method).
@@ -1007,13 +894,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     __ movptr(Address(rbp, frame::interpreter_frame_oop_temp_offset * wordSize),
             t);
     // pass handle to mirror
-#ifndef _LP64
-    __ lea(t, Address(rbp, frame::interpreter_frame_oop_temp_offset * wordSize));
-    __ movptr(Address(rsp, wordSize), t);
-#else
     __ lea(c_rarg1,
            Address(rbp, frame::interpreter_frame_oop_temp_offset * wordSize));
-#endif // _LP64
     __ bind(L);
   }
 
@@ -1034,16 +916,6 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   }
 
   // pass JNIEnv
-#ifndef _LP64
-   __ get_thread(thread);
-   __ lea(t, Address(thread, JavaThread::jni_environment_offset()));
-   __ movptr(Address(rsp, 0), t);
-
-   // set_last_Java_frame_before_call
-   // It is enough that the pc()
-   // points into the right code segment. It does not have to be the correct return pc.
-   __ set_last_Java_frame(thread, noreg, rbp, __ pc(), noreg);
-#else
    __ lea(c_rarg0, Address(r15_thread, JavaThread::jni_environment_offset()));
 
    // It is enough that the pc() points into the right code
@@ -1052,7 +924,6 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
    // case of preemption on Object.wait.
    Label native_return;
    __ set_last_Java_frame(rsp, rbp, native_return, rscratch1);
-#endif // _LP64
 
   // change thread state
 #ifdef ASSERT
@@ -1088,39 +959,10 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // pushes change or anything else is added to the stack then the code in
   // interpreter_frame_result must also change.
 
-#ifndef _LP64
-  // save potential result in ST(0) & rdx:rax
-  // (if result handler is the T_FLOAT or T_DOUBLE handler, result must be in ST0 -
-  // the check is necessary to avoid potential Intel FPU overflow problems by saving/restoring 'empty' FPU registers)
-  // It is safe to do this push because state is _thread_in_native and return address will be found
-  // via _last_native_pc and not via _last_jave_sp
-
-  // NOTE: the order of these push(es) is known to frame::interpreter_frame_result.
-  // If the order changes or anything else is added to the stack the code in
-  // interpreter_frame_result will have to be changed.
-
-  { Label L;
-    Label push_double;
-    ExternalAddress float_handler(AbstractInterpreter::result_handler(T_FLOAT));
-    ExternalAddress double_handler(AbstractInterpreter::result_handler(T_DOUBLE));
-    __ cmpptr(Address(rbp, (frame::interpreter_frame_result_handler_offset)*wordSize),
-              float_handler.addr(), noreg);
-    __ jcc(Assembler::equal, push_double);
-    __ cmpptr(Address(rbp, (frame::interpreter_frame_result_handler_offset)*wordSize),
-              double_handler.addr(), noreg);
-    __ jcc(Assembler::notEqual, L);
-    __ bind(push_double);
-    __ push_d(); // FP values are returned using the FPU, so push FPU contents (even if UseSSE > 0).
-    __ bind(L);
-  }
-#else
   __ push(dtos);
-#endif // _LP64
-
   __ push(ltos);
 
   // change thread state
-  NOT_LP64(__ get_thread(thread));
   __ movl(Address(thread, JavaThread::thread_state_offset()),
           _thread_in_native_trans);
 
@@ -1130,12 +972,6 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
                 Assembler::LoadLoad | Assembler::LoadStore |
                 Assembler::StoreLoad | Assembler::StoreStore));
   }
-#ifndef _LP64
-  if (AlwaysRestoreFPU) {
-    //  Make sure the control word is correct.
-    __ fldcw(ExternalAddress(StubRoutines::x86::addr_fpu_cntrl_wrd_std()));
-  }
-#endif // _LP64
 
   // check for safepoint operation in progress and/or pending suspend requests
   {
@@ -1155,13 +991,6 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     // preserved and correspond to the bcp/locals pointers. So we do a
     // runtime call by hand.
     //
-#ifndef _LP64
-    __ push(thread);
-    __ call(RuntimeAddress(CAST_FROM_FN_PTR(address,
-                                            JavaThread::check_special_condition_for_native_trans)));
-    __ increment(rsp, wordSize);
-    __ get_thread(thread);
-#else
     __ mov(c_rarg0, r15_thread);
     __ mov(r12, rsp); // remember sp (can only use r12 if not using call_VM)
     __ subptr(rsp, frame::arg_reg_save_area_bytes); // windows
@@ -1169,14 +998,12 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans)));
     __ mov(rsp, r12); // restore sp
     __ reinit_heapbase();
-#endif // _LP64
     __ bind(Continue);
   }
 
   // change thread state
   __ movl(Address(thread, JavaThread::thread_state_offset()), _thread_in_Java);
 
-#ifdef _LP64
   if (LockingMode != LM_LEGACY) {
     // Check preemption for Object.wait()
     Label not_preempted;
@@ -1192,7 +1019,6 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     // any pc will do so just use this one for LM_LEGACY to keep code together.
     __ bind(native_return);
   }
-#endif // _LP64
 
   // reset_last_Java_frame
   __ reset_last_Java_frame(thread, true);
@@ -1234,10 +1060,6 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     __ jcc(Assembler::notEqual, no_reguard);
 
     __ pusha(); // XXX only save smashed registers
-#ifndef _LP64
-    __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages)));
-    __ popa();
-#else
     __ mov(r12, rsp); // remember sp (can only use r12 if not using call_VM)
     __ subptr(rsp, frame::arg_reg_save_area_bytes); // windows
     __ andptr(rsp, -16); // align stack as required by ABI
@@ -1245,7 +1067,6 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     __ mov(rsp, r12); // restore sp
     __ popa(); // XXX only restore smashed registers
     __ reinit_heapbase();
-#endif // _LP64
 
     __ bind(no_reguard);
   }
@@ -1293,12 +1114,10 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
                             (intptr_t)(frame::interpreter_frame_initial_sp_offset *
                                        wordSize - (int)sizeof(BasicObjectLock)));
 
-      const Register regmon = NOT_LP64(rdx) LP64_ONLY(c_rarg1);
-
       // monitor expect in c_rarg1 for slow unlock path
-      __ lea(regmon, monitor); // address of first monitor
+      __ lea(c_rarg1, monitor); // address of first monitor
 
-      __ movptr(t, Address(regmon, BasicObjectLock::obj_offset()));
+      __ movptr(t, Address(c_rarg1, BasicObjectLock::obj_offset()));
       __ testptr(t, t);
       __ jcc(Assembler::notZero, unlock);
 
@@ -1309,7 +1128,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
       __ should_not_reach_here();
 
       __ bind(unlock);
-      __ unlock_object(regmon);
+      __ unlock_object(c_rarg1);
     }
     __ bind(L);
   }
@@ -1325,7 +1144,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // restore potential result in ST0 & handle result
 
   __ pop(ltos);
-  LP64_ONLY( __ pop(dtos));
+  __ pop(dtos);
 
   __ movptr(t, Address(rbp,
                        (frame::interpreter_frame_result_handler_offset) * wordSize));
@@ -1454,9 +1273,7 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
   // _do_not_unlock_if_synchronized to true. The remove_activation
   // will check this flag.
 
-  const Register thread = NOT_LP64(rax) LP64_ONLY(r15_thread);
-  NOT_LP64(__ get_thread(thread));
-  const Address do_not_unlock_if_synchronized(thread,
+  const Address do_not_unlock_if_synchronized(r15_thread,
         in_bytes(JavaThread::do_not_unlock_if_synchronized_offset()));
   __ movbool(do_not_unlock_if_synchronized, true);
 
@@ -1474,7 +1291,6 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
   bang_stack_shadow_pages(false);
 
   // reset the _do_not_unlock_if_synchronized flag
-  NOT_LP64(__ get_thread(thread));
   __ movbool(do_not_unlock_if_synchronized, false);
 
   // check for synchronized methods
@@ -1541,15 +1357,14 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   // rdx: return address/pc that threw exception
   __ restore_bcp();    // r13/rsi points to call/send
   __ restore_locals();
-  LP64_ONLY(__ reinit_heapbase());  // restore r12 as heapbase.
+  __ reinit_heapbase();  // restore r12 as heapbase.
   // Entry point for exceptions thrown within interpreter code
   Interpreter::_throw_exception_entry = __ pc();
   // expression stack is undefined here
   // rax: exception
   // r13/rsi: exception bcp
   __ verify_oop(rax);
-  Register rarg = NOT_LP64(rax) LP64_ONLY(c_rarg1);
-  LP64_ONLY(__ mov(c_rarg1, rax));
+  __ mov(c_rarg1, rax);
 
   // expression stack must be empty before entering the VM in case of
   // an exception
@@ -1558,7 +1373,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   __ call_VM(rdx,
              CAST_FROM_FN_PTR(address,
                           InterpreterRuntime::exception_handler_for_exception),
-             rarg);
+             c_rarg1);
   // rax: exception handler entry point
   // rdx: preserved exception oop
   // r13/rsi: bcp for exception handler
@@ -1588,8 +1403,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   // indicating that we are currently handling popframe, so that
   // call_VMs that may happen later do not trigger new popframe
   // handling cycles.
-  const Register thread = NOT_LP64(rcx) LP64_ONLY(r15_thread);
-  NOT_LP64(__ get_thread(thread));
+  const Register thread = r15_thread;
   __ movl(rdx, Address(thread, JavaThread::popframe_condition_offset()));
   __ orl(rdx, JavaThread::popframe_processing_bit);
   __ movl(Address(thread, JavaThread::popframe_condition_offset()), rdx);
@@ -1606,10 +1420,9 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
     // deoptimization blob's unpack entry because of the presence of
     // adapter frames in C2.
     Label caller_not_deoptimized;
-    Register rarg = NOT_LP64(rdx) LP64_ONLY(c_rarg1);
-    __ movptr(rarg, Address(rbp, frame::return_addr_offset * wordSize));
+    __ movptr(c_rarg1, Address(rbp, frame::return_addr_offset * wordSize));
     __ super_call_VM_leaf(CAST_FROM_FN_PTR(address,
-                               InterpreterRuntime::interpreter_contains), rarg);
+                               InterpreterRuntime::interpreter_contains), c_rarg1);
     __ testl(rax, rax);
     __ jcc(Assembler::notZero, caller_not_deoptimized);
 
@@ -1624,7 +1437,6 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
     __ subptr(rlocals, rax);
     __ addptr(rlocals, wordSize);
     // Save these arguments
-    NOT_LP64(__ get_thread(thread));
     __ super_call_VM_leaf(CAST_FROM_FN_PTR(address,
                                            Deoptimization::
                                            popframe_preserve_args),
@@ -1637,7 +1449,6 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
 
     // Inform deoptimization that it is responsible for restoring
     // these arguments
-    NOT_LP64(__ get_thread(thread));
     __ movl(Address(thread, JavaThread::popframe_condition_offset()),
             JavaThread::popframe_force_deopt_reexecution_bit);
 
@@ -1663,23 +1474,12 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   // maintain this kind of invariant all the time we call a small
   // fixup routine to move the mutated arguments onto the top of our
   // expression stack if necessary.
-#ifndef _LP64
-  __ mov(rax, rsp);
-  __ movptr(rbx, Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize));
-  __ lea(rbx, Address(rbp, rbx, Address::times_ptr));
-  __ get_thread(thread);
-  // PC must point into interpreter here
-  __ set_last_Java_frame(thread, noreg, rbp, __ pc(), noreg);
-  __ super_call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::popframe_move_outgoing_args), thread, rax, rbx);
-  __ get_thread(thread);
-#else
   __ mov(c_rarg1, rsp);
   __ movptr(c_rarg2, Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize));
   __ lea(c_rarg2, Address(rbp, c_rarg2, Address::times_ptr));
   // PC must point into interpreter here
   __ set_last_Java_frame(noreg, rbp, __ pc(), rscratch1);
   __ super_call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::popframe_move_outgoing_args), r15_thread, c_rarg1, c_rarg2);
-#endif
   __ reset_last_Java_frame(thread, true);
 
   // Restore the last_sp and null it out
@@ -1696,7 +1496,6 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   }
 
   // Clear the popframe condition flag
-  NOT_LP64(__ get_thread(thread));
   __ movl(Address(thread, JavaThread::popframe_condition_offset()),
           JavaThread::popframe_inactive);
 
@@ -1730,12 +1529,10 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
 
   // preserve exception over this code sequence
   __ pop_ptr(rax);
-  NOT_LP64(__ get_thread(thread));
   __ movptr(Address(thread, JavaThread::vm_result_offset()), rax);
   // remove the activation (without doing throws on illegalMonitorExceptions)
   __ remove_activation(vtos, rdx, false, true, false);
   // restore exception
-  NOT_LP64(__ get_thread(thread));
   __ get_vm_result(rax, thread);
 
   // In between activations - previous activation type unknown yet
@@ -1771,9 +1568,7 @@ address TemplateInterpreterGenerator::generate_earlyret_entry_for(TosState state
   __ empty_expression_stack();
   __ load_earlyret_value(state);  // 32 bits returns value in rdx, so don't reuse
 
-  const Register thread = NOT_LP64(rcx) LP64_ONLY(r15_thread);
-  NOT_LP64(__ get_thread(thread));
-  __ movptr(rcx, Address(thread, JavaThread::jvmti_thread_state_offset()));
+  __ movptr(rcx, Address(r15_thread, JavaThread::jvmti_thread_state_offset()));
   Address cond_addr(rcx, JvmtiThreadState::earlyret_state_offset());
 
   // Clear the earlyret state
@@ -1804,21 +1599,12 @@ void TemplateInterpreterGenerator::set_vtos_entry_points(Template* t,
                                                          address& vep) {
   assert(t->is_valid() && t->tos_in() == vtos, "illegal template");
   Label L;
-#ifndef _LP64
-  fep = __ pc();     // ftos entry point
-      __ push(ftos);
-      __ jmpb(L);
-  dep = __ pc();     // dtos entry point
-      __ push(dtos);
-      __ jmpb(L);
-#else
   fep = __ pc();     // ftos entry point
       __ push_f(xmm0);
       __ jmpb(L);
   dep = __ pc();     // dtos entry point
       __ push_d(xmm0);
       __ jmpb(L);
-#endif // _LP64
   lep = __ pc();     // ltos entry point
       __ push_l();
       __ jmpb(L);
@@ -1837,19 +1623,6 @@ void TemplateInterpreterGenerator::set_vtos_entry_points(Template* t,
 address TemplateInterpreterGenerator::generate_trace_code(TosState state) {
   address entry = __ pc();
 
-#ifndef _LP64
-  // prepare expression stack
-  __ pop(rcx);          // pop return address so expression stack is 'pure'
-  __ push(state);       // save tosca
-
-  // pass tosca registers as arguments & call tracer
-  __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::trace_bytecode), rcx, rax, rdx);
-  __ mov(rcx, rax);     // make sure return address is not destroyed by pop(state)
-  __ pop(state);        // restore tosca
-
-  // return
-  __ jmp(rcx);
-#else
   __ push(state);
   __ push(c_rarg0);
   __ push(c_rarg1);
@@ -1868,17 +1641,12 @@ address TemplateInterpreterGenerator::generate_trace_code(TosState state) {
   __ pop(c_rarg0);
   __ pop(state);
   __ ret(0);                                   // return from result handler
-#endif // _LP64
 
   return entry;
 }
 
 void TemplateInterpreterGenerator::count_bytecode() {
-  #ifndef _LP64
-  __ incrementl(ExternalAddress((address) &BytecodeCounter::_counter_value), rscratch1);
-  #else
   __ incrementq(ExternalAddress((address) &BytecodeCounter::_counter_value), rscratch1);
-  #endif
 }
 
 void TemplateInterpreterGenerator::histogram_bytecode(Template* t) {
@@ -1904,28 +1672,18 @@ void TemplateInterpreterGenerator::trace_bytecode(Template* t) {
 
   assert(Interpreter::trace_code(t->tos_in()) != nullptr,
          "entry must have been generated");
-#ifndef _LP64
-  __ call(RuntimeAddress(Interpreter::trace_code(t->tos_in())));
-#else
   __ mov(r12, rsp); // remember sp (can only use r12 if not using call_VM)
   __ andptr(rsp, -16); // align stack as required by ABI
   __ call(RuntimeAddress(Interpreter::trace_code(t->tos_in())));
   __ mov(rsp, r12); // restore sp
   __ reinit_heapbase();
-#endif // _LP64
 }
 
 
 void TemplateInterpreterGenerator::stop_interpreter_at() {
   Label L;
-  #ifndef _LP64
-  __ cmp32(ExternalAddress((address) &BytecodeCounter::_counter_value),
-           StopInterpreterAt,
-           rscratch1);
-  #else
   __ mov64(rscratch1, StopInterpreterAt);
   __ cmp64(rscratch1, ExternalAddress((address) &BytecodeCounter::_counter_value), rscratch2);
-  #endif
   __ jcc(Assembler::notEqual, L);
   __ int3();
   __ bind(L);

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3589,10 +3589,8 @@ void TemplateTable::_new() {
   //
   //  Go to slow path.
 
-  const Register thread = r15_thread;
-
   if (UseTLAB) {
-    __ tlab_allocate(thread, rax, rdx, 0, rcx, rbx, slow_case);
+    __ tlab_allocate(r15_thread, rax, rdx, 0, rcx, rbx, slow_case);
     if (ZeroTLAB) {
       // the fields have been already cleared
       __ jmp(initialize_header);

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -51,8 +51,8 @@
 #define __ Disassembler::hook<InterpreterMacroAssembler>(__FILE__, __LINE__, _masm)->
 
 // Global Register Names
-static const Register rbcp     = LP64_ONLY(r13) NOT_LP64(rsi);
-static const Register rlocals  = LP64_ONLY(r14) NOT_LP64(rdi);
+static const Register rbcp     = r13;
+static const Register rlocals  = r14;
 
 // Address Computation: local variables
 static inline Address iaddress(int n) {
@@ -62,12 +62,6 @@ static inline Address iaddress(int n) {
 static inline Address laddress(int n) {
   return iaddress(n + 1);
 }
-
-#ifndef _LP64
-static inline Address haddress(int n) {
-  return iaddress(n + 0);
-}
-#endif
 
 static inline Address faddress(int n) {
   return iaddress(n);
@@ -88,12 +82,6 @@ static inline Address iaddress(Register r) {
 static inline Address laddress(Register r) {
   return Address(rlocals, r, Address::times_ptr, Interpreter::local_offset_in_bytes(1));
 }
-
-#ifndef _LP64
-static inline Address haddress(Register r)       {
-  return Address(rlocals, r, Interpreter::stackElementScale(), Interpreter::local_offset_in_bytes(0));
-}
-#endif
 
 static inline Address faddress(Register r) {
   return iaddress(r);
@@ -156,10 +144,7 @@ static void do_oop_store(InterpreterMacroAssembler* _masm,
                          Register val,
                          DecoratorSet decorators = 0) {
   assert(val == noreg || val == rax, "parameter is just for looks");
-  __ store_heap_oop(dst, val,
-                    NOT_LP64(rdx) LP64_ONLY(rscratch2),
-                    NOT_LP64(rbx) LP64_ONLY(r9),
-                    NOT_LP64(rsi) LP64_ONLY(r8), decorators);
+  __ store_heap_oop(dst, val, rscratch2, r9, r8, decorators);
 }
 
 static void do_oop_load(InterpreterMacroAssembler* _masm,
@@ -285,10 +270,6 @@ void TemplateTable::lconst(int value) {
   } else {
     __ movl(rax, value);
   }
-#ifndef _LP64
-  assert(value >= 0, "check this code");
-  __ xorptr(rdx, rdx);
-#endif
 }
 
 
@@ -312,15 +293,7 @@ void TemplateTable::fconst(int value) {
       break;
     }
   } else {
-#ifdef _LP64
     ShouldNotReachHere();
-#else
-           if (value == 0) { __ fldz();
-    } else if (value == 1) { __ fld1();
-    } else if (value == 2) { __ fld1(); __ fld1(); __ faddp(); // should do a better solution here
-    } else                 { ShouldNotReachHere();
-    }
-#endif // _LP64
   }
 }
 
@@ -340,14 +313,7 @@ void TemplateTable::dconst(int value) {
       break;
     }
   } else {
-#ifdef _LP64
     ShouldNotReachHere();
-#else
-           if (value == 0) { __ fldz();
-    } else if (value == 1) { __ fld1();
-    } else                 { ShouldNotReachHere();
-    }
-#endif
   }
 }
 
@@ -365,7 +331,7 @@ void TemplateTable::sipush() {
 
 void TemplateTable::ldc(LdcType type) {
   transition(vtos, vtos);
-  Register rarg = NOT_LP64(rcx) LP64_ONLY(c_rarg1);
+  Register rarg = c_rarg1;
   Label call_ldc, notFloat, notClass, notInt, Done;
 
   if (is_ldc_wide(type)) {
@@ -433,7 +399,7 @@ void TemplateTable::fast_aldc(LdcType type) {
 
   Register result = rax;
   Register tmp = rdx;
-  Register rarg = NOT_LP64(rcx) LP64_ONLY(c_rarg1);
+  Register rarg = c_rarg1;
   int index_size = is_ldc_wide(type) ? sizeof(u2) : sizeof(u1);
 
   Label resolved;
@@ -496,7 +462,6 @@ void TemplateTable::ldc2_w() {
 
   // ltos
   __ movptr(rax, Address(rcx, rbx, Address::times_ptr, base_offset + 0 * wordSize));
-  NOT_LP64(__ movptr(rdx, Address(rcx, rbx, Address::times_ptr, base_offset + 1 * wordSize)));
   __ push(ltos);
   __ jmp(Done);
 
@@ -510,17 +475,10 @@ void TemplateTable::condy_helper(Label& Done) {
   const Register obj = rax;
   const Register off = rbx;
   const Register flags = rcx;
-  const Register rarg = NOT_LP64(rcx) LP64_ONLY(c_rarg1);
+  const Register rarg = c_rarg1;
   __ movl(rarg, (int)bytecode());
   call_VM(obj, CAST_FROM_FN_PTR(address, InterpreterRuntime::resolve_ldc), rarg);
-#ifndef _LP64
-  // borrow rdi from locals
-  __ get_thread(rdi);
-  __ get_vm_result_2(flags, rdi);
-  __ restore_locals();
-#else
   __ get_vm_result_2(flags, r15_thread);
-#endif
   // VMr = obj = base address to find primitive value to push
   // VMr2 = flags = (tos, off) using format of CPCE::_flags
   __ movl(off, flags);
@@ -595,7 +553,6 @@ void TemplateTable::condy_helper(Label& Done) {
       __ jccb(Assembler::notEqual, notLong);
       // ltos
       // Loading high word first because movptr clobbers rax
-      NOT_LP64(__ movptr(rdx, field.plus_disp(4)));
       __ movptr(rax, field);
       __ push(ltos);
       __ jmp(Done);
@@ -636,8 +593,8 @@ void TemplateTable::iload_internal(RewriteControl rc) {
   transition(vtos, itos);
   if (RewriteFrequentPairs && rc == may_rewrite) {
     Label rewrite, done;
-    const Register bc = LP64_ONLY(c_rarg3) NOT_LP64(rcx);
-    LP64_ONLY(assert(rbx != bc, "register damaged"));
+    const Register bc = c_rarg3;
+    assert(rbx != bc, "register damaged");
 
     // get next byte
     __ load_unsigned_byte(rbx,
@@ -693,7 +650,6 @@ void TemplateTable::lload() {
   transition(vtos, ltos);
   locals_index(rbx);
   __ movptr(rax, laddress(rbx));
-  NOT_LP64(__ movl(rdx, haddress(rbx)));
 }
 
 void TemplateTable::fload() {
@@ -731,7 +687,6 @@ void TemplateTable::wide_lload() {
   transition(vtos, ltos);
   locals_index_wide(rbx);
   __ movptr(rax, laddress(rbx));
-  NOT_LP64(__ movl(rdx, haddress(rbx)));
 }
 
 void TemplateTable::wide_fload() {
@@ -772,7 +727,7 @@ void TemplateTable::index_check_without_pop(Register array, Register index) {
   Label skip;
   __ jccb(Assembler::below, skip);
   // Pass array to create more detailed exceptions.
-  __ mov(NOT_LP64(rax) LP64_ONLY(c_rarg1), array);
+  __ mov(c_rarg1, array);
   __ jump(RuntimeAddress(Interpreter::_throw_ArrayIndexOutOfBoundsException_entry));
   __ bind(skip);
 }
@@ -793,7 +748,6 @@ void TemplateTable::laload() {
   // rax: index
   // rdx: array
   index_check(rdx, rax); // kills rbx
-  NOT_LP64(__ mov(rbx, rax));
   // rbx,: index
   __ access_load_at(T_LONG, IN_HEAP | IS_ARRAY, noreg /* ltos */,
                     Address(rdx, rbx, Address::times_8,
@@ -894,7 +848,6 @@ void TemplateTable::iload(int n) {
 void TemplateTable::lload(int n) {
   transition(vtos, ltos);
   __ movptr(rax, laddress(n));
-  NOT_LP64(__ movptr(rdx, haddress(n)));
 }
 
 void TemplateTable::fload(int n) {
@@ -946,8 +899,8 @@ void TemplateTable::aload_0_internal(RewriteControl rc) {
   if (RewriteFrequentPairs && rc == may_rewrite) {
     Label rewrite, done;
 
-    const Register bc = LP64_ONLY(c_rarg3) NOT_LP64(rcx);
-    LP64_ONLY(assert(rbx != bc, "register damaged"));
+    const Register bc = c_rarg3;
+    assert(rbx != bc, "register damaged");
 
     // get next byte
     __ load_unsigned_byte(rbx, at_bcp(Bytecodes::length_for(Bytecodes::_aload_0)));
@@ -1001,7 +954,6 @@ void TemplateTable::lstore() {
   transition(ltos, vtos);
   locals_index(rbx);
   __ movptr(laddress(rbx), rax);
-  NOT_LP64(__ movptr(haddress(rbx), rdx));
 }
 
 void TemplateTable::fstore() {
@@ -1032,33 +984,23 @@ void TemplateTable::wide_istore() {
 
 void TemplateTable::wide_lstore() {
   transition(vtos, vtos);
-  NOT_LP64(__ pop_l(rax, rdx));
-  LP64_ONLY(__ pop_l());
+  __ pop_l();
   locals_index_wide(rbx);
   __ movptr(laddress(rbx), rax);
-  NOT_LP64(__ movl(haddress(rbx), rdx));
 }
 
 void TemplateTable::wide_fstore() {
-#ifdef _LP64
   transition(vtos, vtos);
   __ pop_f(xmm0);
   locals_index_wide(rbx);
   __ movflt(faddress(rbx), xmm0);
-#else
-  wide_istore();
-#endif
 }
 
 void TemplateTable::wide_dstore() {
-#ifdef _LP64
   transition(vtos, vtos);
   __ pop_d(xmm0);
   locals_index_wide(rbx);
   __ movdbl(daddress(rbx), xmm0);
-#else
-  wide_lstore();
-#endif
 }
 
 void TemplateTable::wide_astore() {
@@ -1224,7 +1166,6 @@ void TemplateTable::istore(int n) {
 void TemplateTable::lstore(int n) {
   transition(ltos, vtos);
   __ movptr(laddress(n), rax);
-  NOT_LP64(__ movptr(haddress(n), rdx));
 }
 
 void TemplateTable::fstore(int n) {
@@ -1363,7 +1304,6 @@ void TemplateTable::iop2(Operation op) {
 
 void TemplateTable::lop2(Operation op) {
   transition(ltos, ltos);
-#ifdef _LP64
   switch (op) {
   case add  :                    __ pop_l(rdx); __ addptr(rax, rdx); break;
   case sub  : __ mov(rdx, rax);  __ pop_l(rax); __ subptr(rax, rdx); break;
@@ -1372,18 +1312,6 @@ void TemplateTable::lop2(Operation op) {
   case _xor :                    __ pop_l(rdx); __ xorptr(rax, rdx); break;
   default   : ShouldNotReachHere();
   }
-#else
-  __ pop_l(rbx, rcx);
-  switch (op) {
-    case add  : __ addl(rax, rbx); __ adcl(rdx, rcx); break;
-    case sub  : __ subl(rbx, rax); __ sbbl(rcx, rdx);
-                __ mov (rax, rbx); __ mov (rdx, rcx); break;
-    case _and : __ andl(rax, rbx); __ andl(rdx, rcx); break;
-    case _or  : __ orl (rax, rbx); __ orl (rdx, rcx); break;
-    case _xor : __ xorl(rax, rbx); __ xorl(rdx, rcx); break;
-    default   : ShouldNotReachHere();
-  }
-#endif
 }
 
 void TemplateTable::idiv() {
@@ -1411,21 +1339,12 @@ void TemplateTable::irem() {
 
 void TemplateTable::lmul() {
   transition(ltos, ltos);
-#ifdef _LP64
   __ pop_l(rdx);
   __ imulq(rax, rdx);
-#else
-  __ pop_l(rbx, rcx);
-  __ push(rcx); __ push(rbx);
-  __ push(rdx); __ push(rax);
-  __ lmul(2 * wordSize, 0);
-  __ addptr(rsp, 4 * wordSize);  // take off temporaries
-#endif
 }
 
 void TemplateTable::ldiv() {
   transition(ltos, ltos);
-#ifdef _LP64
   __ mov(rcx, rax);
   __ pop_l(rax);
   // generate explicit div0 check
@@ -1437,22 +1356,10 @@ void TemplateTable::ldiv() {
   //       needed), which may speed up this implementation for the common case.
   //       (see also JVM spec., p.243 & p.271)
   __ corrected_idivq(rcx); // kills rbx
-#else
-  __ pop_l(rbx, rcx);
-  __ push(rcx); __ push(rbx);
-  __ push(rdx); __ push(rax);
-  // check if y = 0
-  __ orl(rax, rdx);
-  __ jump_cc(Assembler::zero,
-             RuntimeAddress(Interpreter::_throw_ArithmeticException_entry));
-  __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::ldiv));
-  __ addptr(rsp, 4 * wordSize);  // take off temporaries
-#endif
 }
 
 void TemplateTable::lrem() {
   transition(ltos, ltos);
-#ifdef _LP64
   __ mov(rcx, rax);
   __ pop_l(rax);
   __ testq(rcx, rcx);
@@ -1464,56 +1371,27 @@ void TemplateTable::lrem() {
   //       (see also JVM spec., p.243 & p.271)
   __ corrected_idivq(rcx); // kills rbx
   __ mov(rax, rdx);
-#else
-  __ pop_l(rbx, rcx);
-  __ push(rcx); __ push(rbx);
-  __ push(rdx); __ push(rax);
-  // check if y = 0
-  __ orl(rax, rdx);
-  __ jump_cc(Assembler::zero,
-             RuntimeAddress(Interpreter::_throw_ArithmeticException_entry));
-  __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::lrem));
-  __ addptr(rsp, 4 * wordSize);
-#endif
 }
 
 void TemplateTable::lshl() {
   transition(itos, ltos);
   __ movl(rcx, rax);                             // get shift count
-  #ifdef _LP64
   __ pop_l(rax);                                 // get shift value
   __ shlq(rax);
-#else
-  __ pop_l(rax, rdx);                            // get shift value
-  __ lshl(rdx, rax);
-#endif
 }
 
 void TemplateTable::lshr() {
-#ifdef _LP64
   transition(itos, ltos);
   __ movl(rcx, rax);                             // get shift count
   __ pop_l(rax);                                 // get shift value
   __ sarq(rax);
-#else
-  transition(itos, ltos);
-  __ mov(rcx, rax);                              // get shift count
-  __ pop_l(rax, rdx);                            // get shift value
-  __ lshr(rdx, rax, true);
-#endif
 }
 
 void TemplateTable::lushr() {
   transition(itos, ltos);
-#ifdef _LP64
   __ movl(rcx, rax);                             // get shift count
   __ pop_l(rax);                                 // get shift value
   __ shrq(rax);
-#else
-  __ mov(rcx, rax);                              // get shift count
-  __ pop_l(rax, rdx);                            // get shift value
-  __ lshr(rdx, rax);
-#endif
 }
 
 void TemplateTable::fop2(Operation op) {
@@ -1545,46 +1423,16 @@ void TemplateTable::fop2(Operation op) {
       // double fmod(double x, double y) in math.h. The documentation of fmod states:
       // "If x or y is a NaN, a NaN is returned." without specifying what type of NaN
       // (signalling or quiet) is returned.
-      //
-      // On x86_32 platforms the FPU is used to perform the modulo operation. The
-      // reason is that on 32-bit Windows the sign of modulo operations diverges from
-      // what is considered the standard (e.g., -0.0f % -3.14f is 0.0f (and not -0.0f).
-      // The fprem instruction used on x86_32 is functionally equivalent to
-      // SharedRuntime::frem in that it returns a NaN.
-#ifdef _LP64
       __ movflt(xmm1, xmm0);
       __ pop_f(xmm0);
       __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::frem), 2);
-#else // !_LP64
-      __ push_f(xmm0);
-      __ pop_f();
-      __ fld_s(at_rsp());
-      __ fremr(rax);
-      __ f2ieee();
-      __ pop(rax);  // pop second operand off the stack
-      __ push_f();
-      __ pop_f(xmm0);
-#endif // _LP64
       break;
     default:
       ShouldNotReachHere();
       break;
     }
   } else {
-#ifdef _LP64
     ShouldNotReachHere();
-#else // !_LP64
-    switch (op) {
-    case add: __ fadd_s (at_rsp());                break;
-    case sub: __ fsubr_s(at_rsp());                break;
-    case mul: __ fmul_s (at_rsp());                break;
-    case div: __ fdivr_s(at_rsp());                break;
-    case rem: __ fld_s  (at_rsp()); __ fremr(rax); break;
-    default : ShouldNotReachHere();
-    }
-    __ f2ieee();
-    __ pop(rax);  // pop second operand off the stack
-#endif // _LP64
   }
 }
 
@@ -1612,61 +1460,18 @@ void TemplateTable::dop2(Operation op) {
       break;
     case rem:
       // Similar to fop2(), the modulo operation is performed using the
-      // SharedRuntime::drem method (on x86_64 platforms) or using the
-      // FPU (on x86_32 platforms) for the same reasons as mentioned in fop2().
-#ifdef _LP64
+      // SharedRuntime::drem method on x86_64 platforms for the same reasons
+      // as mentioned in fop2().
       __ movdbl(xmm1, xmm0);
       __ pop_d(xmm0);
       __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::drem), 2);
-#else // !_LP64
-      __ push_d(xmm0);
-      __ pop_d();
-      __ fld_d(at_rsp());
-      __ fremr(rax);
-      __ d2ieee();
-      __ pop(rax);
-      __ pop(rdx);
-      __ push_d();
-      __ pop_d(xmm0);
-#endif // _LP64
       break;
     default:
       ShouldNotReachHere();
       break;
     }
   } else {
-#ifdef _LP64
     ShouldNotReachHere();
-#else // !_LP64
-    switch (op) {
-    case add: __ fadd_d (at_rsp());                break;
-    case sub: __ fsubr_d(at_rsp());                break;
-    case mul: {
-      // strict semantics
-      __ fld_x(ExternalAddress(StubRoutines::x86::addr_fpu_subnormal_bias1()));
-      __ fmulp();
-      __ fmul_d (at_rsp());
-      __ fld_x(ExternalAddress(StubRoutines::x86::addr_fpu_subnormal_bias2()));
-      __ fmulp();
-      break;
-    }
-    case div: {
-      // strict semantics
-      __ fld_x(ExternalAddress(StubRoutines::x86::addr_fpu_subnormal_bias1()));
-      __ fmul_d (at_rsp());
-      __ fdivrp();
-      __ fld_x(ExternalAddress(StubRoutines::x86::addr_fpu_subnormal_bias2()));
-      __ fmulp();
-      break;
-    }
-    case rem: __ fld_d  (at_rsp()); __ fremr(rax); break;
-    default : ShouldNotReachHere();
-    }
-    __ d2ieee();
-    // Pop double precision number from rsp.
-    __ pop(rax);
-    __ pop(rdx);
-#endif // _LP64
   }
 }
 
@@ -1677,8 +1482,7 @@ void TemplateTable::ineg() {
 
 void TemplateTable::lneg() {
   transition(ltos, ltos);
-  LP64_ONLY(__ negq(rax));
-  NOT_LP64(__ lneg(rdx, rax));
+  __ negq(rax);
 }
 
 // Note: 'double' and 'long long' have 32-bits alignment on x86.
@@ -1702,8 +1506,7 @@ void TemplateTable::fneg() {
     static jlong *float_signflip  = double_quadword(&float_signflip_pool[1],  CONST64(0x8000000080000000),  CONST64(0x8000000080000000));
     __ xorps(xmm0, ExternalAddress((address) float_signflip), rscratch1);
   } else {
-    LP64_ONLY(ShouldNotReachHere());
-    NOT_LP64(__ fchs());
+    ShouldNotReachHere();
   }
 }
 
@@ -1714,11 +1517,7 @@ void TemplateTable::dneg() {
       double_quadword(&double_signflip_pool[1], CONST64(0x8000000000000000), CONST64(0x8000000000000000));
     __ xorpd(xmm0, ExternalAddress((address) double_signflip), rscratch1);
   } else {
-#ifdef _LP64
     ShouldNotReachHere();
-#else
-    __ fchs();
-#endif
   }
 }
 
@@ -1741,7 +1540,6 @@ void TemplateTable::wide_iinc() {
 }
 
 void TemplateTable::convert() {
-#ifdef _LP64
   // Checking
 #ifdef ASSERT
   {
@@ -1869,203 +1667,10 @@ void TemplateTable::convert() {
   default:
     ShouldNotReachHere();
   }
-#else // !_LP64
-  // Checking
-#ifdef ASSERT
-  { TosState tos_in  = ilgl;
-    TosState tos_out = ilgl;
-    switch (bytecode()) {
-      case Bytecodes::_i2l: // fall through
-      case Bytecodes::_i2f: // fall through
-      case Bytecodes::_i2d: // fall through
-      case Bytecodes::_i2b: // fall through
-      case Bytecodes::_i2c: // fall through
-      case Bytecodes::_i2s: tos_in = itos; break;
-      case Bytecodes::_l2i: // fall through
-      case Bytecodes::_l2f: // fall through
-      case Bytecodes::_l2d: tos_in = ltos; break;
-      case Bytecodes::_f2i: // fall through
-      case Bytecodes::_f2l: // fall through
-      case Bytecodes::_f2d: tos_in = ftos; break;
-      case Bytecodes::_d2i: // fall through
-      case Bytecodes::_d2l: // fall through
-      case Bytecodes::_d2f: tos_in = dtos; break;
-      default             : ShouldNotReachHere();
-    }
-    switch (bytecode()) {
-      case Bytecodes::_l2i: // fall through
-      case Bytecodes::_f2i: // fall through
-      case Bytecodes::_d2i: // fall through
-      case Bytecodes::_i2b: // fall through
-      case Bytecodes::_i2c: // fall through
-      case Bytecodes::_i2s: tos_out = itos; break;
-      case Bytecodes::_i2l: // fall through
-      case Bytecodes::_f2l: // fall through
-      case Bytecodes::_d2l: tos_out = ltos; break;
-      case Bytecodes::_i2f: // fall through
-      case Bytecodes::_l2f: // fall through
-      case Bytecodes::_d2f: tos_out = ftos; break;
-      case Bytecodes::_i2d: // fall through
-      case Bytecodes::_l2d: // fall through
-      case Bytecodes::_f2d: tos_out = dtos; break;
-      default             : ShouldNotReachHere();
-    }
-    transition(tos_in, tos_out);
-  }
-#endif // ASSERT
-
-  // Conversion
-  // (Note: use push(rcx)/pop(rcx) for 1/2-word stack-ptr manipulation)
-  switch (bytecode()) {
-    case Bytecodes::_i2l:
-      __ extend_sign(rdx, rax);
-      break;
-    case Bytecodes::_i2f:
-      if (UseSSE >= 1) {
-        __ cvtsi2ssl(xmm0, rax);
-      } else {
-        __ push(rax);          // store int on tos
-        __ fild_s(at_rsp());   // load int to ST0
-        __ f2ieee();           // truncate to float size
-        __ pop(rcx);           // adjust rsp
-      }
-      break;
-    case Bytecodes::_i2d:
-      if (UseSSE >= 2) {
-        __ cvtsi2sdl(xmm0, rax);
-      } else {
-      __ push(rax);          // add one slot for d2ieee()
-      __ push(rax);          // store int on tos
-      __ fild_s(at_rsp());   // load int to ST0
-      __ d2ieee();           // truncate to double size
-      __ pop(rcx);           // adjust rsp
-      __ pop(rcx);
-      }
-      break;
-    case Bytecodes::_i2b:
-      __ shll(rax, 24);      // truncate upper 24 bits
-      __ sarl(rax, 24);      // and sign-extend byte
-      LP64_ONLY(__ movsbl(rax, rax));
-      break;
-    case Bytecodes::_i2c:
-      __ andl(rax, 0xFFFF);  // truncate upper 16 bits
-      LP64_ONLY(__ movzwl(rax, rax));
-      break;
-    case Bytecodes::_i2s:
-      __ shll(rax, 16);      // truncate upper 16 bits
-      __ sarl(rax, 16);      // and sign-extend short
-      LP64_ONLY(__ movswl(rax, rax));
-      break;
-    case Bytecodes::_l2i:
-      /* nothing to do */
-      break;
-    case Bytecodes::_l2f:
-      // On 64-bit platforms, the cvtsi2ssq instruction is used to convert
-      // 64-bit long values to floats. On 32-bit platforms it is not possible
-      // to use that instruction with 64-bit operands, therefore the FPU is
-      // used to perform the conversion.
-      __ push(rdx);          // store long on tos
-      __ push(rax);
-      __ fild_d(at_rsp());   // load long to ST0
-      __ f2ieee();           // truncate to float size
-      __ pop(rcx);           // adjust rsp
-      __ pop(rcx);
-      if (UseSSE >= 1) {
-        __ push_f();
-        __ pop_f(xmm0);
-      }
-      break;
-    case Bytecodes::_l2d:
-      // On 32-bit platforms the FPU is used for conversion because on
-      // 32-bit platforms it is not not possible to use the cvtsi2sdq
-      // instruction with 64-bit operands.
-      __ push(rdx);          // store long on tos
-      __ push(rax);
-      __ fild_d(at_rsp());   // load long to ST0
-      __ d2ieee();           // truncate to double size
-      __ pop(rcx);           // adjust rsp
-      __ pop(rcx);
-      if (UseSSE >= 2) {
-        __ push_d();
-        __ pop_d(xmm0);
-      }
-      break;
-    case Bytecodes::_f2i:
-      // SharedRuntime::f2i does not differentiate between sNaNs and qNaNs
-      // as it returns 0 for any NaN.
-      if (UseSSE >= 1) {
-        __ push_f(xmm0);
-      } else {
-        __ push(rcx);          // reserve space for argument
-        __ fstp_s(at_rsp());   // pass float argument on stack
-      }
-      __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::f2i), 1);
-      break;
-    case Bytecodes::_f2l:
-      // SharedRuntime::f2l does not differentiate between sNaNs and qNaNs
-      // as it returns 0 for any NaN.
-      if (UseSSE >= 1) {
-       __ push_f(xmm0);
-      } else {
-        __ push(rcx);          // reserve space for argument
-        __ fstp_s(at_rsp());   // pass float argument on stack
-      }
-      __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::f2l), 1);
-      break;
-    case Bytecodes::_f2d:
-      if (UseSSE < 1) {
-        /* nothing to do */
-      } else if (UseSSE == 1) {
-        __ push_f(xmm0);
-        __ pop_f();
-      } else { // UseSSE >= 2
-        __ cvtss2sd(xmm0, xmm0);
-      }
-      break;
-    case Bytecodes::_d2i:
-      if (UseSSE >= 2) {
-        __ push_d(xmm0);
-      } else {
-        __ push(rcx);          // reserve space for argument
-        __ push(rcx);
-        __ fstp_d(at_rsp());   // pass double argument on stack
-      }
-      __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::d2i), 2);
-      break;
-    case Bytecodes::_d2l:
-      if (UseSSE >= 2) {
-        __ push_d(xmm0);
-      } else {
-        __ push(rcx);          // reserve space for argument
-        __ push(rcx);
-        __ fstp_d(at_rsp());   // pass double argument on stack
-      }
-      __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::d2l), 2);
-      break;
-    case Bytecodes::_d2f:
-      if (UseSSE <= 1) {
-        __ push(rcx);          // reserve space for f2ieee()
-        __ f2ieee();           // truncate to float size
-        __ pop(rcx);           // adjust rsp
-        if (UseSSE == 1) {
-          // The cvtsd2ss instruction is not available if UseSSE==1, therefore
-          // the conversion is performed using the FPU in this case.
-          __ push_f();
-          __ pop_f(xmm0);
-        }
-      } else { // UseSSE >= 2
-        __ cvtsd2ss(xmm0, xmm0);
-      }
-      break;
-    default             :
-      ShouldNotReachHere();
-  }
-#endif // _LP64
 }
 
 void TemplateTable::lcmp() {
   transition(ltos, itos);
-#ifdef _LP64
   Label done;
   __ pop_l(rdx);
   __ cmpq(rdx, rax);
@@ -2074,13 +1679,6 @@ void TemplateTable::lcmp() {
   __ setb(Assembler::notEqual, rax);
   __ movzbl(rax, rax);
   __ bind(done);
-#else
-
-  // y = rdx:rax
-  __ pop_l(rbx, rcx);             // get x = rcx:rbx
-  __ lcmp2int(rcx, rbx, rdx, rax);// rcx := cmp(x, y)
-  __ mov(rax, rcx);
-#endif
 }
 
 void TemplateTable::float_cmp(bool is_float, int unordered_result) {
@@ -2112,18 +1710,7 @@ void TemplateTable::float_cmp(bool is_float, int unordered_result) {
     }
     __ bind(done);
   } else {
-#ifdef _LP64
     ShouldNotReachHere();
-#else // !_LP64
-    if (is_float) {
-      __ fld_s(at_rsp());
-    } else {
-      __ fld_d(at_rsp());
-      __ pop(rdx);
-    }
-    __ pop(rcx);
-    __ fcmp2int(rax, unordered_result < 0);
-#endif // _LP64
   }
 }
 
@@ -2148,7 +1735,7 @@ void TemplateTable::branch(bool is_jsr, bool is_wide) {
   if (!is_wide) {
     __ sarl(rdx, 16);
   }
-  LP64_ONLY(__ movl2ptr(rdx, rdx));
+  __ movl2ptr(rdx, rdx);
 
   // Handle all the JSR stuff here, then exit.
   // It's much shorter and cleaner than intermingling with the non-JSR
@@ -2267,19 +1854,16 @@ void TemplateTable::branch(bool is_jsr, bool is_wide) {
       // it will be preserved in rbx.
       __ mov(rbx, rax);
 
-      NOT_LP64(__ get_thread(rcx));
-
       call_VM(noreg, CAST_FROM_FN_PTR(address, SharedRuntime::OSR_migration_begin));
 
       // rax is OSR buffer, move it to expected parameter location
-      LP64_ONLY(__ mov(j_rarg0, rax));
-      NOT_LP64(__ mov(rcx, rax));
+      __ mov(j_rarg0, rax);
       // We use j_rarg definitions here so that registers don't conflict as parameter
       // registers change across platforms as we are in the midst of a calling
       // sequence to the OSR nmethod and we don't want collision. These are NOT parameters.
 
-      const Register retaddr   = LP64_ONLY(j_rarg2) NOT_LP64(rdi);
-      const Register sender_sp = LP64_ONLY(j_rarg1) NOT_LP64(rdx);
+      const Register retaddr   = j_rarg2;
+      const Register sender_sp = j_rarg1;
 
       // pop the interpreter frame
       __ movptr(sender_sp, Address(rbp, frame::interpreter_frame_sender_sp_offset * wordSize)); // get sender sp
@@ -2350,8 +1934,7 @@ void TemplateTable::if_acmp(Condition cc) {
 void TemplateTable::ret() {
   transition(vtos, vtos);
   locals_index(rbx);
-  LP64_ONLY(__ movslq(rbx, iaddress(rbx))); // get return bci, compute return bcp
-  NOT_LP64(__ movptr(rbx, iaddress(rbx)));
+  __ movslq(rbx, iaddress(rbx)); // get return bci, compute return bcp
   __ profile_ret(rbx, rcx);
   __ get_method(rax);
   __ movptr(rbcp, Address(rax, Method::const_offset()));
@@ -2395,7 +1978,7 @@ void TemplateTable::tableswitch() {
   // continue execution
   __ bind(continue_execution);
   __ bswapl(rdx);
-  LP64_ONLY(__ movl2ptr(rdx, rdx));
+  __ movl2ptr(rdx, rdx);
   __ load_unsigned_byte(rbx, Address(rbcp, rdx, Address::times_1));
   __ addptr(rbcp, rdx);
   __ dispatch_only(vtos, true);
@@ -2485,8 +2068,6 @@ void TemplateTable::fast_binaryswitch() {
   const Register temp  = rsi;
 
   // Find array start
-  NOT_LP64(__ save_bcp());
-
   __ lea(array, at_bcp(3 * BytesPerInt)); // btw: should be able to
                                           // get rid of this
                                           // instruction (change
@@ -2543,10 +2124,7 @@ void TemplateTable::fast_binaryswitch() {
   __ movl(j , Address(array, i, Address::times_8, BytesPerInt));
   __ profile_switch_case(i, key, array);
   __ bswapl(j);
-  LP64_ONLY(__ movslq(j, j));
-
-  NOT_LP64(__ restore_bcp());
-  NOT_LP64(__ restore_locals());                           // restore rdi
+  __ movslq(j, j);
 
   __ load_unsigned_byte(rbx, Address(rbcp, j, Address::times_1));
   __ addptr(rbcp, j);
@@ -2557,10 +2135,7 @@ void TemplateTable::fast_binaryswitch() {
   __ profile_switch_default(i);
   __ movl(j, Address(array, -2 * BytesPerInt));
   __ bswapl(j);
-  LP64_ONLY(__ movslq(j, j));
-
-  NOT_LP64(__ restore_bcp());
-  NOT_LP64(__ restore_locals());
+  __ movslq(j, j);
 
   __ load_unsigned_byte(rbx, Address(rbcp, j, Address::times_1));
   __ addptr(rbcp, j);
@@ -2575,7 +2150,7 @@ void TemplateTable::_return(TosState state) {
 
   if (_desc->bytecode() == Bytecodes::_return_register_finalizer) {
     assert(state == vtos, "only valid state");
-    Register robj = LP64_ONLY(c_rarg1) NOT_LP64(rax);
+    Register robj = c_rarg1;
     __ movptr(robj, aaddress(0));
     __ load_klass(rdi, robj, rscratch1);
     __ testb(Address(rdi, Klass::misc_flags_offset()), KlassFlags::_misc_has_finalizer);
@@ -2590,13 +2165,7 @@ void TemplateTable::_return(TosState state) {
   if (_desc->bytecode() != Bytecodes::_return_register_finalizer) {
     Label no_safepoint;
     NOT_PRODUCT(__ block_comment("Thread-local Safepoint poll"));
-#ifdef _LP64
     __ testb(Address(r15_thread, JavaThread::polling_word_offset()), SafepointMechanism::poll_bit());
-#else
-    const Register thread = rdi;
-    __ get_thread(thread);
-    __ testb(Address(thread, JavaThread::polling_word_offset()), SafepointMechanism::poll_bit());
-#endif
     __ jcc(Assembler::zero, no_safepoint);
     __ push(state);
     __ push_cont_fastpath();
@@ -2694,7 +2263,7 @@ void TemplateTable::resolve_cache_and_index_for_method(int byte_no,
   if (VM_Version::supports_fast_class_init_checks() && bytecode() == Bytecodes::_invokestatic) {
     const Register method = temp;
     const Register klass  = temp;
-    const Register thread = LP64_ONLY(r15_thread) NOT_LP64(noreg);
+    const Register thread = r15_thread;
     assert(thread != noreg, "x86_32 not supported");
 
     __ movptr(method, Address(cache, in_bytes(ResolvedMethodEntry::method_offset())));
@@ -2821,12 +2390,8 @@ void TemplateTable::load_invokedynamic_entry(Register method) {
   {
     const address table_addr = (address) Interpreter::invoke_return_entry_table_for(code);
     ExternalAddress table(table_addr);
-#ifdef _LP64
     __ lea(rscratch1, table);
     __ movptr(index, Address(rscratch1, index, Address::times_ptr));
-#else
-    __ movptr(index, ArrayAddress(table, Address(noreg, index, Address::times_ptr)));
-#endif // _LP64
   }
 
   // push return address
@@ -2979,13 +2544,13 @@ void TemplateTable::pop_and_check_object(Register r) {
 void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteControl rc) {
   transition(vtos, vtos);
 
-  const Register obj   = LP64_ONLY(c_rarg3) NOT_LP64(rcx);
+  const Register obj   = c_rarg3;
   const Register cache = rcx;
   const Register index = rdx;
   const Register off   = rbx;
   const Register tos_state   = rax;
   const Register flags = rdx;
-  const Register bc    = LP64_ONLY(c_rarg3) NOT_LP64(rcx); // uses same reg as obj, so don't mix them
+  const Register bc    = c_rarg3; // uses same reg as obj, so don't mix them
 
   resolve_cache_and_index_for_field(byte_no, cache, index);
   jvmti_post_field_access(cache, index, is_static, false);
@@ -3081,7 +2646,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   __ access_load_at(T_LONG, IN_HEAP | MO_RELAXED, noreg /* ltos */, field, noreg, noreg);
   __ push(ltos);
   // Rewrite bytecode to be faster
-  LP64_ONLY(if (!is_static && rc == may_rewrite) patch_bytecode(Bytecodes::_fast_lgetfield, bc, rbx));
+  if (!is_static && rc == may_rewrite) patch_bytecode(Bytecodes::_fast_lgetfield, bc, rbx);
   __ jmp(Done);
 
   __ bind(notLong);
@@ -3141,9 +2706,9 @@ void TemplateTable::getstatic(int byte_no) {
 // The function may destroy various registers, just not the cache and index registers.
 void TemplateTable::jvmti_post_field_mod(Register cache, Register index, bool is_static) {
   // Cache is rcx and index is rdx
-  const Register entry = LP64_ONLY(c_rarg2) NOT_LP64(rax); // ResolvedFieldEntry
-  const Register obj = LP64_ONLY(c_rarg1) NOT_LP64(rbx);   // Object pointer
-  const Register value = LP64_ONLY(c_rarg3) NOT_LP64(rcx); // JValue object
+  const Register entry = c_rarg2; // ResolvedFieldEntry
+  const Register obj = c_rarg1;   // Object pointer
+  const Register value = c_rarg3; // JValue object
 
   if (JvmtiExport::can_post_field_modification()) {
     // Check to see if a field modification watch has been set before
@@ -3165,11 +2730,7 @@ void TemplateTable::jvmti_post_field_mod(Register cache, Register index, bool is
       // the object.  We don't know the size of the value, though; it
       // could be one or two words depending on its type. As a result,
       // we must find the type to determine where the object is.
-#ifndef _LP64
-      Label two_word, valsize_known;
-#endif
       __ load_unsigned_byte(value, Address(entry, in_bytes(ResolvedFieldEntry::type_offset())));
-#ifdef _LP64
       __ movptr(obj, at_tos_p1());  // initially assume a one word jvalue
       __ cmpl(value, ltos);
       __ cmovptr(Assembler::equal,
@@ -3177,22 +2738,6 @@ void TemplateTable::jvmti_post_field_mod(Register cache, Register index, bool is
       __ cmpl(value, dtos);
       __ cmovptr(Assembler::equal,
                  obj, at_tos_p2()); // dtos (two word jvalue)
-#else
-      __ mov(obj, rsp);
-      __ cmpl(value, ltos);
-      __ jccb(Assembler::equal, two_word);
-      __ cmpl(value, dtos);
-      __ jccb(Assembler::equal, two_word);
-      __ addptr(obj, Interpreter::expr_offset_in_bytes(1)); // one word jvalue (not ltos, dtos)
-      __ jmpb(valsize_known);
-
-      __ bind(two_word);
-      __ addptr(obj, Interpreter::expr_offset_in_bytes(2)); // two words jvalue
-
-      __ bind(valsize_known);
-      // setup object pointer
-      __ movptr(obj, Address(obj, 0));
-#endif
     }
 
     // object (tos)
@@ -3251,13 +2796,12 @@ void TemplateTable::putfield_or_static_helper(int byte_no, bool is_static, Rewri
 
   // field addresses
   const Address field(obj, off, Address::times_1, 0*wordSize);
-  NOT_LP64( const Address hi(obj, off, Address::times_1, 1*wordSize);)
 
   Label notByte, notBool, notInt, notShort, notChar,
         notLong, notFloat, notObj;
   Label Done;
 
-  const Register bc    = LP64_ONLY(c_rarg3) NOT_LP64(rcx);
+  const Register bc    = c_rarg3;
 
   // Test TOS state
   __ testl(tos_state, tos_state);
@@ -3360,11 +2904,9 @@ void TemplateTable::putfield_or_static_helper(int byte_no, bool is_static, Rewri
     if (!is_static) pop_and_check_object(obj);
     // MO_RELAXED: generate atomic store for the case of volatile field (important for x86_32)
     __ access_store_at(T_LONG, IN_HEAP | MO_RELAXED, field, noreg /* ltos*/, noreg, noreg, noreg);
-#ifdef _LP64
     if (!is_static && rc == may_rewrite) {
       patch_bytecode(Bytecodes::_fast_lputfield, bc, rbx, true, byte_no);
     }
-#endif // _LP64
     __ jmp(Done);
   }
 
@@ -3425,7 +2967,7 @@ void TemplateTable::putstatic(int byte_no) {
 
 void TemplateTable::jvmti_post_fast_field_mod() {
 
-  const Register scratch = LP64_ONLY(c_rarg3) NOT_LP64(rcx);
+  const Register scratch = c_rarg3;
 
   if (JvmtiExport::can_post_field_modification()) {
     // Check to see if a field modification watch has been set before
@@ -3456,14 +2998,12 @@ void TemplateTable::jvmti_post_fast_field_mod() {
     }
     __ mov(scratch, rsp);             // points to jvalue on the stack
     // access constant pool cache entry
-    LP64_ONLY(__ load_field_entry(c_rarg2, rax));
-    NOT_LP64(__ load_field_entry(rax, rdx));
+    __ load_field_entry(c_rarg2, rax);
     __ verify_oop(rbx);
     // rbx: object pointer copied above
     // c_rarg2: cache entry pointer
     // c_rarg3: jvalue object on the stack
-    LP64_ONLY(__ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::post_field_modification), rbx, c_rarg2, c_rarg3));
-    NOT_LP64(__ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::post_field_modification), rbx, rax, rcx));
+    __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::post_field_modification), rbx, c_rarg2, c_rarg3);
 
     switch (bytecode()) {             // restore tos values
     case Bytecodes::_fast_aputfield: __ pop_ptr(rax); break;
@@ -3526,11 +3066,7 @@ void TemplateTable::fast_storefield_helper(Address field, Register rax) {
     do_oop_store(_masm, field, rax);
     break;
   case Bytecodes::_fast_lputfield:
-#ifdef _LP64
     __ access_store_at(T_LONG, IN_HEAP, field, noreg /* ltos */, noreg, noreg, noreg);
-#else
-  __ stop("should not be rewritten");
-#endif
     break;
   case Bytecodes::_fast_iputfield:
     __ access_store_at(T_INT, IN_HEAP, field, rax, noreg, noreg, noreg);
@@ -3570,15 +3106,13 @@ void TemplateTable::fast_accessfield(TosState state) {
     __ testl(rcx, rcx);
     __ jcc(Assembler::zero, L1);
     // access constant pool cache entry
-    LP64_ONLY(__ load_field_entry(c_rarg2, rcx));
-    NOT_LP64(__ load_field_entry(rcx, rdx));
+    __ load_field_entry(c_rarg2, rcx);
     __ verify_oop(rax);
     __ push_ptr(rax);  // save object pointer before call_VM() clobbers it
-    LP64_ONLY(__ mov(c_rarg1, rax));
+    __ mov(c_rarg1, rax);
     // c_rarg1: object pointer copied above
     // c_rarg2: cache entry pointer
-    LP64_ONLY(__ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::post_field_access), c_rarg1, c_rarg2));
-    NOT_LP64(__ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::post_field_access), rax, rcx));
+    __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::post_field_access), c_rarg1, c_rarg2);
     __ pop_ptr(rax); // restore object pointer
     __ bind(L1);
   }
@@ -3599,11 +3133,7 @@ void TemplateTable::fast_accessfield(TosState state) {
     __ verify_oop(rax);
     break;
   case Bytecodes::_fast_lgetfield:
-#ifdef _LP64
     __ access_load_at(T_LONG, IN_HEAP, noreg /* ltos */, field, noreg, noreg);
-#else
-  __ stop("should not be rewritten");
-#endif
     break;
   case Bytecodes::_fast_igetfield:
     __ access_load_at(T_INT, IN_HEAP, rax, field, noreg, noreg);
@@ -3708,12 +3238,8 @@ void TemplateTable::prepare_invoke(Register cache, Register recv, Register flags
   {
     const address table_addr = (address) Interpreter::invoke_return_entry_table_for(code);
     ExternalAddress table(table_addr);
-#ifdef _LP64
     __ lea(rscratch1, table);
     __ movptr(flags, Address(rscratch1, flags, Address::times_ptr));
-#else
-    __ movptr(flags, ArrayAddress(table, Address(noreg, flags, Address::times_ptr)));
-#endif // _LP64
   }
 
   // push return address
@@ -3945,15 +3471,10 @@ void TemplateTable::invokeinterface(int byte_no) {
   __ restore_bcp();      // rbcp must be correct for exception handler   (was destroyed)
   __ restore_locals();   // make sure locals pointer is correct as well (was destroyed)
   // Pass arguments for generating a verbose error message.
-#ifdef _LP64
   recvKlass = c_rarg1;
   Register method    = c_rarg2;
   if (recvKlass != rdx) { __ movq(recvKlass, rdx); }
   if (method != rcx)    { __ movq(method, rcx);    }
-#else
-  recvKlass = rdx;
-  Register method    = rcx;
-#endif
   __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::throw_AbstractMethodErrorVerbose),
              recvKlass, method);
   // The call_VM checks for exception, so we should never return here.
@@ -3965,7 +3486,9 @@ void TemplateTable::invokeinterface(int byte_no) {
   __ restore_bcp();      // rbcp must be correct for exception handler   (was destroyed)
   __ restore_locals();   // make sure locals pointer is correct as well (was destroyed)
   // Pass arguments for generating a verbose error message.
-  LP64_ONLY( if (recvKlass != rdx) { __ movq(recvKlass, rdx); } )
+  if (recvKlass != rdx) {
+    __ movq(recvKlass, rdx);
+  }
   __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::throw_IncompatibleClassChangeErrorVerbose),
              recvKlass, rax);
   // the call_VM checks for exception, so we should never return here.
@@ -4048,13 +3571,8 @@ void TemplateTable::_new() {
 
   // make sure klass is initialized
   // init_state needs acquire, but x86 is TSO, and so we are already good.
-#ifdef _LP64
   assert(VM_Version::supports_fast_class_init_checks(), "must support fast class initialization checks");
   __ clinit_barrier(rcx, r15_thread, nullptr /*L_fast_path*/, &slow_case);
-#else
-  __ cmpb(Address(rcx, InstanceKlass::init_state_offset()), InstanceKlass::fully_initialized);
-  __ jcc(Assembler::notEqual, slow_case);
-#endif
 
   // get instance_size in InstanceKlass (scaled to a count of bytes)
   __ movl(rdx, Address(rcx, Klass::layout_helper_offset()));
@@ -4071,10 +3589,9 @@ void TemplateTable::_new() {
   //
   //  Go to slow path.
 
-  const Register thread = LP64_ONLY(r15_thread) NOT_LP64(rcx);
+  const Register thread = r15_thread;
 
   if (UseTLAB) {
-    NOT_LP64(__ get_thread(thread);)
     __ tlab_allocate(thread, rax, rdx, 0, rcx, rbx, slow_case);
     if (ZeroTLAB) {
       // the fields have been already cleared
@@ -4113,7 +3630,6 @@ void TemplateTable::_new() {
     int header_size_bytes = oopDesc::header_size() * HeapWordSize;
     assert(is_aligned(header_size_bytes, BytesPerLong), "oop header size must be 8-byte-aligned");
     __ movptr(Address(rax, rdx, Address::times_8, header_size_bytes - 1*oopSize), rcx);
-    NOT_LP64(__ movptr(Address(rax, rdx, Address::times_8, header_size_bytes - 2*oopSize), rcx));
     __ decrement(rdx);
     __ jcc(Assembler::notZero, loop);
     }
@@ -4128,10 +3644,8 @@ void TemplateTable::_new() {
       __ movptr(Address(rax, oopDesc::mark_offset_in_bytes()),
                 (intptr_t)markWord::prototype().value()); // header
       __ pop(rcx);   // get saved klass back in the register.
-#ifdef _LP64
       __ xorl(rsi, rsi); // use zero reg to clear memory (shorter code)
       __ store_klass_gap(rax, rsi);  // zero klass gap for compressed oops
-#endif
       __ store_klass(rax, rcx, rscratch1);  // klass
     }
 
@@ -4151,12 +3665,9 @@ void TemplateTable::_new() {
   __ pop(rcx);   // restore stack pointer to what it was when we came in.
   __ bind(slow_case_no_pop);
 
-  Register rarg1 = LP64_ONLY(c_rarg1) NOT_LP64(rax);
-  Register rarg2 = LP64_ONLY(c_rarg2) NOT_LP64(rdx);
-
-  __ get_constant_pool(rarg1);
-  __ get_unsigned_2_byte_index_at_bcp(rarg2, 1);
-  call_VM(rax, CAST_FROM_FN_PTR(address, InterpreterRuntime::_new), rarg1, rarg2);
+  __ get_constant_pool(c_rarg1);
+  __ get_unsigned_2_byte_index_at_bcp(c_rarg2, 1);
+  call_VM(rax, CAST_FROM_FN_PTR(address, InterpreterRuntime::_new), c_rarg1, c_rarg2);
    __ verify_oop(rax);
 
   // continue
@@ -4165,22 +3676,18 @@ void TemplateTable::_new() {
 
 void TemplateTable::newarray() {
   transition(itos, atos);
-  Register rarg1 = LP64_ONLY(c_rarg1) NOT_LP64(rdx);
-  __ load_unsigned_byte(rarg1, at_bcp(1));
+  __ load_unsigned_byte(c_rarg1, at_bcp(1));
   call_VM(rax, CAST_FROM_FN_PTR(address, InterpreterRuntime::newarray),
-          rarg1, rax);
+          c_rarg1, rax);
 }
 
 void TemplateTable::anewarray() {
   transition(itos, atos);
 
-  Register rarg1 = LP64_ONLY(c_rarg1) NOT_LP64(rcx);
-  Register rarg2 = LP64_ONLY(c_rarg2) NOT_LP64(rdx);
-
-  __ get_unsigned_2_byte_index_at_bcp(rarg2, 1);
-  __ get_constant_pool(rarg1);
+  __ get_unsigned_2_byte_index_at_bcp(c_rarg2, 1);
+  __ get_constant_pool(c_rarg1);
   call_VM(rax, CAST_FROM_FN_PTR(address, InterpreterRuntime::anewarray),
-          rarg1, rarg2, rax);
+          c_rarg1, c_rarg2, rax);
 }
 
 void TemplateTable::arraylength() {
@@ -4207,14 +3714,7 @@ void TemplateTable::checkcast() {
   call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::quicken_io_cc));
 
   // vm_result_2 has metadata result
-#ifndef _LP64
-  // borrow rdi from locals
-  __ get_thread(rdi);
-  __ get_vm_result_2(rax, rdi);
-  __ restore_locals();
-#else
   __ get_vm_result_2(rax, r15_thread);
-#endif
 
   __ pop_ptr(rdx); // restore receiver
   __ jmpb(resolved);
@@ -4271,14 +3771,7 @@ void TemplateTable::instanceof() {
   call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::quicken_io_cc));
   // vm_result_2 has metadata result
 
-#ifndef _LP64
-  // borrow rdi from locals
-  __ get_thread(rdi);
-  __ get_vm_result_2(rax, rdi);
-  __ restore_locals();
-#else
   __ get_vm_result_2(rax, r15_thread);
-#endif
 
   __ pop_ptr(rdx); // restore receiver
   __ verify_oop(rdx);
@@ -4326,21 +3819,19 @@ void TemplateTable::_breakpoint() {
 
   transition(vtos, vtos);
 
-  Register rarg = LP64_ONLY(c_rarg1) NOT_LP64(rcx);
-
   // get the unpatched byte code
-  __ get_method(rarg);
+  __ get_method(c_rarg1);
   __ call_VM(noreg,
              CAST_FROM_FN_PTR(address,
                               InterpreterRuntime::get_original_bytecode_at),
-             rarg, rbcp);
+             c_rarg1, rbcp);
   __ mov(rbx, rax);  // why?
 
   // post the breakpoint event
-  __ get_method(rarg);
+  __ get_method(c_rarg1);
   __ call_VM(noreg,
              CAST_FROM_FN_PTR(address, InterpreterRuntime::_breakpoint),
-             rarg, rbcp);
+             c_rarg1, rbcp);
 
   // complete the execution of original bytecode
   __ dispatch_only_normal(vtos);
@@ -4386,9 +3877,9 @@ void TemplateTable::monitorenter() {
 
   Label allocated;
 
-  Register rtop = LP64_ONLY(c_rarg3) NOT_LP64(rcx);
-  Register rbot = LP64_ONLY(c_rarg2) NOT_LP64(rbx);
-  Register rmon = LP64_ONLY(c_rarg1) NOT_LP64(rdx);
+  Register rtop = c_rarg3;
+  Register rbot = c_rarg2;
+  Register rmon = c_rarg1;
 
   // initialize entry pointer
   __ xorl(rmon, rmon); // points to free slot or null
@@ -4484,8 +3975,8 @@ void TemplateTable::monitorexit() {
         rbp, frame::interpreter_frame_initial_sp_offset * wordSize);
   const int entry_size = frame::interpreter_frame_monitor_size_in_bytes();
 
-  Register rtop = LP64_ONLY(c_rarg1) NOT_LP64(rdx);
-  Register rbot = LP64_ONLY(c_rarg2) NOT_LP64(rbx);
+  Register rtop = c_rarg1;
+  Register rbot = c_rarg2;
 
   Label found;
 
@@ -4539,13 +4030,12 @@ void TemplateTable::wide() {
 void TemplateTable::multianewarray() {
   transition(vtos, atos);
 
-  Register rarg = LP64_ONLY(c_rarg1) NOT_LP64(rax);
   __ load_unsigned_byte(rax, at_bcp(3)); // get number of dimensions
   // last dim is on top of stack; we want address of first one:
   // first_addr = last_addr + (ndims - 1) * stackElementSize - 1*wordsize
   // the latter wordSize to point to the beginning of the array.
-  __ lea(rarg, Address(rsp, rax, Interpreter::stackElementScale(), -wordSize));
-  call_VM(rax, CAST_FROM_FN_PTR(address, InterpreterRuntime::multianewarray), rarg);
+  __ lea(c_rarg1, Address(rsp, rax, Interpreter::stackElementScale(), -wordSize));
+  call_VM(rax, CAST_FROM_FN_PTR(address, InterpreterRuntime::multianewarray), c_rarg1);
   __ load_unsigned_byte(rbx, at_bcp(3));
   __ lea(rsp, Address(rsp, rbx, Interpreter::stackElementScale()));  // get rid of counts
 }

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
@@ -376,7 +376,6 @@ void TemplateInterpreterGenerator::generate_and_dispatch(Template* t, TosState t
   if (PrintBytecodePairHistogram)                                histogram_bytecode_pair(t);
   if (TraceBytecodes)                                            trace_bytecode(t);
   if (StopInterpreterAt > 0)                                     stop_interpreter_at();
-  __ verify_FPU(1, t->tos_in());
 #endif // !PRODUCT
   int step = 0;
   if (!t->does_dispatch()) {


### PR DESCRIPTION
x86 template interpreter carries `_LP64`-predicated code blocks that were supporting 32-bit x86. With that port gone, we can clean up the x86 template interpreter. I have checked no superfluous `LP64`, `AMD64`, `IA32` defines are left in affected files.

Where obvious, I inlined `r15_thread` and `c_arg*`. Left the uses that assign these args to symbolic locals that have meaningful names.

`verify_FPU` is also no-op now, removed that. There are related cleanups in compilers and runtime we need to do first, before we fully remove `VerifyFPU` flag. This change fans out a little to other platform template interpreters to remove `verify_FPU` as well.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `tier1`
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351151](https://bugs.openjdk.org/browse/JDK-8351151): Clean up x86 template interpreter after 32-bit x86 removal (**Sub-task** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24251/head:pull/24251` \
`$ git checkout pull/24251`

Update a local copy of the PR: \
`$ git checkout pull/24251` \
`$ git pull https://git.openjdk.org/jdk.git pull/24251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24251`

View PR using the GUI difftool: \
`$ git pr show -t 24251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24251.diff">https://git.openjdk.org/jdk/pull/24251.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24251#issuecomment-2754883673)
</details>
