### PR TITLE
8352972: PPC64: Intrinsify Unsafe::setMemory

### DIFF
--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -2454,37 +2454,28 @@ class StubGenerator: public StubCodeGenerator {
       __ andi_(R0, rScratch1, 1);
       __ bne(CR0, L_fillBytes);
 
-      {
-        UnsafeMemoryAccessMark umam(this, true, true);
-        // At this point, we know the lower bit of size is zero and a
-        // multiple of 2
-        do_setmemory_atomic_loop(2, dest, size, byteVal, _masm);
-      }
+      // Mark remaining code as such which performs Unsafe accesses.
+      UnsafeMemoryAccessMark umam(this, true, false);
+
+      // At this point, we know the lower bit of size is zero and a
+      // multiple of 2
+      do_setmemory_atomic_loop(2, dest, size, byteVal, _masm);
 
       __ align(32);
       __ bind(L_fill8Bytes);
-      {
-        UnsafeMemoryAccessMark umam(this, true, true);
-        // At this point, we know the lower 3 bits of size are zero and a
-        // multiple of 8
-        do_setmemory_atomic_loop(8, dest, size, byteVal, _masm);
-      }
+      // At this point, we know the lower 3 bits of size are zero and a
+      // multiple of 8
+      do_setmemory_atomic_loop(8, dest, size, byteVal, _masm);
 
       __ align(32);
       __ bind(L_fill4Bytes);
-      {
-        UnsafeMemoryAccessMark umam(this, true, true);
-        // At this point, we know the lower 2 bits of size are zero and a
-        // multiple of 4
-        do_setmemory_atomic_loop(4, dest, size, byteVal, _masm);
-      }
+      // At this point, we know the lower 2 bits of size are zero and a
+      // multiple of 4
+      do_setmemory_atomic_loop(4, dest, size, byteVal, _masm);
 
       __ align(32);
       __ bind(L_fillBytes);
-      {
-        UnsafeMemoryAccessMark umam(this, true, true);
-        do_setmemory_atomic_loop(1, dest, size, byteVal, _masm);
-      }
+      do_setmemory_atomic_loop(1, dest, size, byteVal, _masm);
     }
 
     return start;

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -2383,6 +2383,114 @@ class StubGenerator: public StubCodeGenerator {
   }
 
 
+  // Helper for generate_unsafe_setmemory
+  //
+  // Atomically fill an array of memory using 1-, 2-, 4-, or 8-byte chunks and return.
+  static void do_setmemory_atomic_loop(int elem_size, Register dest, Register size, Register byteVal,
+                                       MacroAssembler *_masm) {
+
+    Label L_Loop, L_Tail; // 2x unrolled loop
+
+    // Propagate byte to required width
+    if (elem_size > 1) __ rldimi(byteVal, byteVal,  8, 64 - 2 *  8);
+    if (elem_size > 2) __ rldimi(byteVal, byteVal, 16, 64 - 2 * 16);
+    if (elem_size > 4) __ rldimi(byteVal, byteVal, 32, 64 - 2 * 32);
+
+    __ srwi_(R0, size, exact_log2(2 * elem_size)); // size is a 32 bit value
+    __ beq(CR0, L_Tail);
+    __ mtctr(R0);
+
+    __ align(32); // loop alignment
+    __ bind(L_Loop);
+    __ store_sized_value(byteVal, 0, dest, elem_size);
+    __ store_sized_value(byteVal, elem_size, dest, elem_size);
+    __ addi(dest, dest, 2 * elem_size);
+    __ bdnz(L_Loop);
+
+    __ bind(L_Tail);
+    __ andi_(R0, size, elem_size);
+    __ bclr(Assembler::bcondCRbiIs1, Assembler::bi0(CR0, Assembler::equal), Assembler::bhintbhBCLRisReturn);
+    __ store_sized_value(byteVal, 0, dest, elem_size);
+    __ blr();
+  }
+
+  //
+  //  Generate 'unsafe' set memory stub
+  //  Though just as safe as the other stubs, it takes an unscaled
+  //  size_t (# bytes) argument instead of an element count.
+  //
+  //  Input:
+  //    R3_ARG1   - destination array address
+  //    R4_ARG2   - byte count (size_t)
+  //    R5_ARG3   - byte value
+  //
+  address generate_unsafe_setmemory(address unsafe_byte_fill) {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, StubGenStubId::unsafe_setmemory_id);
+    address start = __ function_entry();
+
+    // bump this on entry, not on exit:
+    // inc_counter_np(SharedRuntime::_unsafe_set_memory_ctr);
+
+    {
+      Label L_exit, L_fill8Bytes, L_fill4Bytes, L_fillBytes;
+
+      const Register dest = R3_ARG1;
+      const Register size = R4_ARG2;
+      const Register byteVal = R5_ARG3;
+      const Register rScratch1 = R6;
+
+      // fill_to_memory_atomic(unsigned char*, unsigned long, unsigned char)
+
+      // Check for pointer & size alignment
+      __ orr(rScratch1, dest, size);
+
+      __ andi_(R0, rScratch1, 7);
+      __ beq(CR0, L_fill8Bytes);
+
+      __ andi_(R0, rScratch1, 3);
+      __ beq(CR0, L_fill4Bytes);
+
+      __ andi_(R0, rScratch1, 1);
+      __ bne(CR0, L_fillBytes);
+
+      {
+        UnsafeMemoryAccessMark umam(this, true, true);
+        // At this point, we know the lower bit of size is zero and a
+        // multiple of 2
+        do_setmemory_atomic_loop(2, dest, size, byteVal, _masm);
+      }
+
+      __ align(32);
+      __ bind(L_fill8Bytes);
+      {
+        UnsafeMemoryAccessMark umam(this, true, true);
+        // At this point, we know the lower 3 bits of size are zero and a
+        // multiple of 8
+        do_setmemory_atomic_loop(8, dest, size, byteVal, _masm);
+      }
+
+      __ align(32);
+      __ bind(L_fill4Bytes);
+      {
+        UnsafeMemoryAccessMark umam(this, true, true);
+        // At this point, we know the lower 2 bits of size are zero and a
+        // multiple of 4
+        do_setmemory_atomic_loop(4, dest, size, byteVal, _masm);
+      }
+
+      __ align(32);
+      __ bind(L_fillBytes);
+      {
+        UnsafeMemoryAccessMark umam(this, true, true);
+        do_setmemory_atomic_loop(1, dest, size, byteVal, _masm);
+      }
+    }
+
+    return start;
+  }
+
+
   //
   //  Generate generic array copy stubs
   //
@@ -3207,6 +3315,7 @@ class StubGenerator: public StubCodeGenerator {
       StubRoutines::_arrayof_jshort_fill = generate_fill(StubGenStubId::arrayof_jshort_fill_id);
       StubRoutines::_arrayof_jint_fill   = generate_fill(StubGenStubId::arrayof_jint_fill_id);
     }
+    StubRoutines::_unsafe_setmemory = generate_unsafe_setmemory(StubRoutines::_jbyte_fill);
 #endif
   }
 

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -2433,7 +2433,7 @@ class StubGenerator: public StubCodeGenerator {
     // inc_counter_np(SharedRuntime::_unsafe_set_memory_ctr);
 
     {
-      Label L_exit, L_fill8Bytes, L_fill4Bytes, L_fillBytes;
+      Label L_fill8Bytes, L_fill4Bytes, L_fillBytes;
 
       const Register dest = R3_ARG1;
       const Register size = R4_ARG2;


### PR DESCRIPTION
Similar to the x86 implementation. The non-product feature for counting things like `SharedRuntime::_unsafe_set_memory_ctr` is currently not supported on PPC64. I've left it commented out.

Before this patch (measured on Power10):
```
Benchmark                       (aligned)  (size)  Mode  Cnt   Score   Error  Units
MemorySegmentZeroUnsafe.panama       true       1  avgt   30  15.048 ± 0.095  ns/op
MemorySegmentZeroUnsafe.panama       true       2  avgt   30  15.054 ± 0.089  ns/op
MemorySegmentZeroUnsafe.panama       true       3  avgt   30  15.161 ± 0.089  ns/op
MemorySegmentZeroUnsafe.panama       true       4  avgt   30  15.147 ± 0.082  ns/op
MemorySegmentZeroUnsafe.panama       true       5  avgt   30  15.198 ± 0.089  ns/op
MemorySegmentZeroUnsafe.panama       true       6  avgt   30  15.128 ± 0.099  ns/op
MemorySegmentZeroUnsafe.panama       true       7  avgt   30  19.234 ± 0.148  ns/op
MemorySegmentZeroUnsafe.panama       true       8  avgt   30  15.060 ± 0.090  ns/op
MemorySegmentZeroUnsafe.panama       true      15  avgt   30  19.229 ± 0.171  ns/op
MemorySegmentZeroUnsafe.panama       true      16  avgt   30  15.030 ± 0.082  ns/op
MemorySegmentZeroUnsafe.panama       true      63  avgt   30  85.290 ± 0.431  ns/op
MemorySegmentZeroUnsafe.panama       true      64  avgt   30  84.273 ± 0.843  ns/op
MemorySegmentZeroUnsafe.panama       true     255  avgt   30  89.551 ± 0.706  ns/op
MemorySegmentZeroUnsafe.panama       true     256  avgt   30  87.736 ± 0.679  ns/op
MemorySegmentZeroUnsafe.panama      false       1  avgt   30  15.044 ± 0.073  ns/op
MemorySegmentZeroUnsafe.panama      false       2  avgt   30  14.980 ± 0.058  ns/op
MemorySegmentZeroUnsafe.panama      false       3  avgt   30  15.138 ± 0.126  ns/op
MemorySegmentZeroUnsafe.panama      false       4  avgt   30  15.025 ± 0.049  ns/op
MemorySegmentZeroUnsafe.panama      false       5  avgt   30  15.192 ± 0.118  ns/op
MemorySegmentZeroUnsafe.panama      false       6  avgt   30  15.464 ± 0.667  ns/op
MemorySegmentZeroUnsafe.panama      false       7  avgt   30  19.179 ± 0.143  ns/op
MemorySegmentZeroUnsafe.panama      false       8  avgt   30  15.278 ± 0.130  ns/op
MemorySegmentZeroUnsafe.panama      false      15  avgt   30  19.428 ± 0.146  ns/op
MemorySegmentZeroUnsafe.panama      false      16  avgt   30  18.011 ± 1.233  ns/op
MemorySegmentZeroUnsafe.panama      false      63  avgt   30  87.090 ± 0.989  ns/op
MemorySegmentZeroUnsafe.panama      false      64  avgt   30  86.513 ± 0.623  ns/op
MemorySegmentZeroUnsafe.panama      false     255  avgt   30  89.415 ± 0.831  ns/op
MemorySegmentZeroUnsafe.panama      false     256  avgt   30  90.665 ± 0.798  ns/op
MemorySegmentZeroUnsafe.unsafe       true       1  avgt   30  86.530 ± 0.504  ns/op
MemorySegmentZeroUnsafe.unsafe       true       2  avgt   30  84.540 ± 0.399  ns/op
MemorySegmentZeroUnsafe.unsafe       true       3  avgt   30  86.954 ± 0.768  ns/op
MemorySegmentZeroUnsafe.unsafe       true       4  avgt   30  86.409 ± 0.801  ns/op
MemorySegmentZeroUnsafe.unsafe       true       5  avgt   30  86.774 ± 0.808  ns/op
MemorySegmentZeroUnsafe.unsafe       true       6  avgt   30  86.128 ± 0.804  ns/op
MemorySegmentZeroUnsafe.unsafe       true       7  avgt   30  86.512 ± 0.434  ns/op
MemorySegmentZeroUnsafe.unsafe       true       8  avgt   30  85.680 ± 0.335  ns/op
MemorySegmentZeroUnsafe.unsafe       true      15  avgt   30  88.098 ± 0.660  ns/op
MemorySegmentZeroUnsafe.unsafe       true      16  avgt   30  86.162 ± 0.634  ns/op
MemorySegmentZeroUnsafe.unsafe       true      63  avgt   30  87.605 ± 0.606  ns/op
MemorySegmentZeroUnsafe.unsafe       true      64  avgt   30  86.423 ± 0.667  ns/op
MemorySegmentZeroUnsafe.unsafe       true     255  avgt   30  89.882 ± 0.416  ns/op
MemorySegmentZeroUnsafe.unsafe       true     256  avgt   30  89.026 ± 0.555  ns/op
MemorySegmentZeroUnsafe.unsafe      false       1  avgt   30  86.808 ± 0.250  ns/op
MemorySegmentZeroUnsafe.unsafe      false       2  avgt   30  86.504 ± 0.427  ns/op
MemorySegmentZeroUnsafe.unsafe      false       3  avgt   30  87.304 ± 0.570  ns/op
MemorySegmentZeroUnsafe.unsafe      false       4  avgt   30  85.787 ± 0.395  ns/op
MemorySegmentZeroUnsafe.unsafe      false       5  avgt   30  86.032 ± 0.517  ns/op
MemorySegmentZeroUnsafe.unsafe      false       6  avgt   30  85.668 ± 0.414  ns/op
MemorySegmentZeroUnsafe.unsafe      false       7  avgt   30  85.621 ± 0.457  ns/op
MemorySegmentZeroUnsafe.unsafe      false       8  avgt   30  85.744 ± 0.384  ns/op
MemorySegmentZeroUnsafe.unsafe      false      15  avgt   30  85.898 ± 0.380  ns/op
MemorySegmentZeroUnsafe.unsafe      false      16  avgt   30  86.993 ± 0.532  ns/op
MemorySegmentZeroUnsafe.unsafe      false      63  avgt   30  86.700 ± 0.558  ns/op
MemorySegmentZeroUnsafe.unsafe      false      64  avgt   30  87.678 ± 0.721  ns/op
MemorySegmentZeroUnsafe.unsafe      false     255  avgt   30  91.774 ± 0.860  ns/op
MemorySegmentZeroUnsafe.unsafe      false     256  avgt   30  89.748 ± 0.749  ns/op
```

With this patch:
```
Benchmark                       (aligned)  (size)  Mode  Cnt   Score   Error  Units
MemorySegmentZeroUnsafe.panama       true       1  avgt   30  14.912 ± 0.025  ns/op
MemorySegmentZeroUnsafe.panama       true       2  avgt   30  14.867 ± 0.036  ns/op
MemorySegmentZeroUnsafe.panama       true       3  avgt   30  14.920 ± 0.053  ns/op
MemorySegmentZeroUnsafe.panama       true       4  avgt   30  14.857 ± 0.063  ns/op
MemorySegmentZeroUnsafe.panama       true       5  avgt   30  14.858 ± 0.064  ns/op
MemorySegmentZeroUnsafe.panama       true       6  avgt   30  14.860 ± 0.051  ns/op
MemorySegmentZeroUnsafe.panama       true       7  avgt   30  18.953 ± 0.064  ns/op
MemorySegmentZeroUnsafe.panama       true       8  avgt   30  15.143 ± 0.247  ns/op
MemorySegmentZeroUnsafe.panama       true      15  avgt   30  18.983 ± 0.056  ns/op
MemorySegmentZeroUnsafe.panama       true      16  avgt   30  14.940 ± 0.094  ns/op
MemorySegmentZeroUnsafe.panama       true      63  avgt   30  26.827 ± 0.555  ns/op
MemorySegmentZeroUnsafe.panama       true      64  avgt   30  19.061 ± 0.058  ns/op
MemorySegmentZeroUnsafe.panama       true     255  avgt   30  90.837 ± 0.399  ns/op
MemorySegmentZeroUnsafe.panama       true     256  avgt   30  19.362 ± 0.090  ns/op
MemorySegmentZeroUnsafe.panama      false       1  avgt   30  14.956 ± 0.138  ns/op
MemorySegmentZeroUnsafe.panama      false       2  avgt   30  14.985 ± 0.155  ns/op
MemorySegmentZeroUnsafe.panama      false       3  avgt   30  14.941 ± 0.085  ns/op
MemorySegmentZeroUnsafe.panama      false       4  avgt   30  14.972 ± 0.085  ns/op
MemorySegmentZeroUnsafe.panama      false       5  avgt   30  14.910 ± 0.043  ns/op
MemorySegmentZeroUnsafe.panama      false       6  avgt   30  14.969 ± 0.054  ns/op
MemorySegmentZeroUnsafe.panama      false       7  avgt   30  18.995 ± 0.053  ns/op
MemorySegmentZeroUnsafe.panama      false       8  avgt   30  14.953 ± 0.047  ns/op
MemorySegmentZeroUnsafe.panama      false      15  avgt   30  19.115 ± 0.073  ns/op
MemorySegmentZeroUnsafe.panama      false      16  avgt   30  16.341 ± 1.398  ns/op
MemorySegmentZeroUnsafe.panama      false      63  avgt   30  26.872 ± 0.571  ns/op
MemorySegmentZeroUnsafe.panama      false      64  avgt   30  28.553 ± 1.134  ns/op
MemorySegmentZeroUnsafe.panama      false     255  avgt   30  90.925 ± 0.248  ns/op
MemorySegmentZeroUnsafe.panama      false     256  avgt   30  92.178 ± 0.271  ns/op
MemorySegmentZeroUnsafe.unsafe       true       1  avgt   30  19.302 ± 0.083  ns/op
MemorySegmentZeroUnsafe.unsafe       true       2  avgt   30  19.266 ± 0.056  ns/op
MemorySegmentZeroUnsafe.unsafe       true       3  avgt   30  19.053 ± 0.091  ns/op
MemorySegmentZeroUnsafe.unsafe       true       4  avgt   30  19.173 ± 0.069  ns/op
MemorySegmentZeroUnsafe.unsafe       true       5  avgt   30  18.818 ± 0.020  ns/op
MemorySegmentZeroUnsafe.unsafe       true       6  avgt   30  18.861 ± 0.038  ns/op
MemorySegmentZeroUnsafe.unsafe       true       7  avgt   30  19.667 ± 0.399  ns/op
MemorySegmentZeroUnsafe.unsafe       true       8  avgt   30  19.091 ± 0.043  ns/op
MemorySegmentZeroUnsafe.unsafe       true      15  avgt   30  18.886 ± 0.048  ns/op
MemorySegmentZeroUnsafe.unsafe       true      16  avgt   30  19.177 ± 0.053  ns/op
MemorySegmentZeroUnsafe.unsafe       true      63  avgt   30  28.420 ± 0.373  ns/op
MemorySegmentZeroUnsafe.unsafe       true      64  avgt   30  18.841 ± 0.069  ns/op
MemorySegmentZeroUnsafe.unsafe       true     255  avgt   30  90.813 ± 0.247  ns/op
MemorySegmentZeroUnsafe.unsafe       true     256  avgt   30  19.134 ± 0.118  ns/op
MemorySegmentZeroUnsafe.unsafe      false       1  avgt   30  19.129 ± 0.030  ns/op
MemorySegmentZeroUnsafe.unsafe      false       2  avgt   30  19.098 ± 0.044  ns/op
MemorySegmentZeroUnsafe.unsafe      false       3  avgt   30  18.843 ± 0.044  ns/op
MemorySegmentZeroUnsafe.unsafe      false       4  avgt   30  18.818 ± 0.027  ns/op
MemorySegmentZeroUnsafe.unsafe      false       5  avgt   30  19.014 ± 0.104  ns/op
MemorySegmentZeroUnsafe.unsafe      false       6  avgt   30  19.219 ± 0.155  ns/op
MemorySegmentZeroUnsafe.unsafe      false       7  avgt   30  19.898 ± 0.371  ns/op
MemorySegmentZeroUnsafe.unsafe      false       8  avgt   30  19.624 ± 0.385  ns/op
MemorySegmentZeroUnsafe.unsafe      false      15  avgt   30  18.876 ± 0.055  ns/op
MemorySegmentZeroUnsafe.unsafe      false      16  avgt   30  18.934 ± 0.086  ns/op
MemorySegmentZeroUnsafe.unsafe      false      63  avgt   30  27.063 ± 0.652  ns/op
MemorySegmentZeroUnsafe.unsafe      false      64  avgt   30  27.689 ± 1.003  ns/op
MemorySegmentZeroUnsafe.unsafe      false     255  avgt   30  90.606 ± 0.455  ns/op
MemorySegmentZeroUnsafe.unsafe      false     256  avgt   30  91.078 ± 0.155  ns/op
```

`Unsafe` cases with small `Cnt` are significantly faster. Aligned large cases, too.

Generated code:
```
StubRoutines::unsafe_setmemory [0x0000781304468980, 0x0000781304468aa0] (288 bytes)
--------------------------------------------------------------------------------
  0x0000781304468980:   or      r6,r3,r4
  0x0000781304468984:   andi.   r0,r6,7
  0x0000781304468988:   beq-    0x00007813044689e0,bo=0b01100[no_hint]
  0x000078130446898c:   andi.   r0,r6,3
  0x0000781304468990:   beq-    0x0000781304468a20,bo=0b01100[no_hint]
  0x0000781304468994:   andi.   r0,r6,1
  0x0000781304468998:   bne-    0x0000781304468a60,bo=0b00100[no_hint]
  0x000078130446899c:   rldimi  r5,r5,8,48
  0x00007813044689a0:   rlwinm. r0,r4,30,2,31
  0x00007813044689a4:   beq-    0x00007813044689d0,bo=0b01100[no_hint]
  0x00007813044689a8:   mtctr   r0
  0x00007813044689ac:   nop
  0x00007813044689b0:   nop
  0x00007813044689b4:   nop
  0x00007813044689b8:   nop
  0x00007813044689bc:   nop
  0x00007813044689c0:   sth     r5,0(r3)
  0x00007813044689c4:   sth     r5,2(r3)
  0x00007813044689c8:   addi    r3,r3,4
  0x00007813044689cc:   bdnz+   0x00007813044689c0,bo=0b10000[no_hint]
  0x00007813044689d0:   andi.   r0,r4,2
  0x00007813044689d4:   beqlr-  bo=0b01100[no_hint],bh=0b00[subroutine_return]
  0x00007813044689d8:   sth     r5,0(r3)
  0x00007813044689dc:   blr     bo=0b10100,bh=0b00[subroutine_return]
  0x00007813044689e0:   rldimi  r5,r5,8,48
  0x00007813044689e4:   rldimi  r5,r5,16,32
  0x00007813044689e8:   rldimi  r5,r5,32,0
  0x00007813044689ec:   rlwinm. r0,r4,28,4,31
  0x00007813044689f0:   beq-    0x0000781304468a10,bo=0b01100[no_hint]
  0x00007813044689f4:   mtctr   r0
  0x00007813044689f8:   nop
  0x00007813044689fc:   nop
  0x0000781304468a00:   std     r5,0(r3)
  0x0000781304468a04:   std     r5,8(r3)
  0x0000781304468a08:   addi    r3,r3,16
  0x0000781304468a0c:   bdnz+   0x0000781304468a00,bo=0b10000[no_hint]
  0x0000781304468a10:   andi.   r0,r4,8
  0x0000781304468a14:   beqlr-  bo=0b01100[no_hint],bh=0b00[subroutine_return]
  0x0000781304468a18:   std     r5,0(r3)
  0x0000781304468a1c:   blr     bo=0b10100,bh=0b00[subroutine_return]
  0x0000781304468a20:   rldimi  r5,r5,8,48
  0x0000781304468a24:   rldimi  r5,r5,16,32
  0x0000781304468a28:   rlwinm. r0,r4,29,3,31
  0x0000781304468a2c:   beq-    0x0000781304468a50,bo=0b01100[no_hint]
  0x0000781304468a30:   mtctr   r0
  0x0000781304468a34:   nop
  0x0000781304468a38:   nop
  0x0000781304468a3c:   nop
  0x0000781304468a40:   stw     r5,0(r3)
  0x0000781304468a44:   stw     r5,4(r3)
  0x0000781304468a48:   addi    r3,r3,8
  0x0000781304468a4c:   bdnz+   0x0000781304468a40,bo=0b10000[no_hint]
  0x0000781304468a50:   andi.   r0,r4,4
  0x0000781304468a54:   beqlr-  bo=0b01100[no_hint],bh=0b00[subroutine_return]
  0x0000781304468a58:   stw     r5,0(r3)
  0x0000781304468a5c:   blr     bo=0b10100,bh=0b00[subroutine_return]
  0x0000781304468a60:   rlwinm. r0,r4,31,1,31
  0x0000781304468a64:   beq-    0x0000781304468a90,bo=0b01100[no_hint]
  0x0000781304468a68:   mtctr   r0
  0x0000781304468a6c:   nop
  0x0000781304468a70:   nop
  0x0000781304468a74:   nop
  0x0000781304468a78:   nop
  0x0000781304468a7c:   nop
  0x0000781304468a80:   stb     r5,0(r3)
  0x0000781304468a84:   stb     r5,1(r3)
  0x0000781304468a88:   addi    r3,r3,2
  0x0000781304468a8c:   bdnz+   0x0000781304468a80,bo=0b10000[no_hint]
  0x0000781304468a90:   andi.   r0,r4,1
  0x0000781304468a94:   beqlr-  bo=0b01100[no_hint],bh=0b00[subroutine_return]
  0x0000781304468a98:   stb     r5,0(r3)
  0x0000781304468a9c:   blr     bo=0b10100,bh=0b00[subroutine_return]
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352972](https://bugs.openjdk.org/browse/JDK-8352972): PPC64: Intrinsify Unsafe::setMemory (**Enhancement** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @dbriemann (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24254/head:pull/24254` \
`$ git checkout pull/24254`

Update a local copy of the PR: \
`$ git checkout pull/24254` \
`$ git pull https://git.openjdk.org/jdk.git pull/24254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24254`

View PR using the GUI difftool: \
`$ git pr show -t 24254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24254.diff">https://git.openjdk.org/jdk/pull/24254.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24254#issuecomment-2754606821)
</details>
