### PR TITLE
8352946: SEGV_BND signal code of SIGSEGV missing from our signal-code table

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -49,6 +49,9 @@
 
 #include <signal.h>
 
+#if !defined(SEGV_BNDERR)
+#define SEGV_BNDERR 3
+#endif
 
 static const char* get_signal_name(int sig, char* out, size_t outlen);
 
@@ -969,6 +972,9 @@ static bool get_signal_code_description(const siginfo_t* si, enum_sigcode_desc_t
     { SIGFPE,  FPE_FLTSUB,   "FPE_FLTSUB",   "Subscript out of range." },
     { SIGSEGV, SEGV_MAPERR,  "SEGV_MAPERR",  "Address not mapped to object." },
     { SIGSEGV, SEGV_ACCERR,  "SEGV_ACCERR",  "Invalid permissions for mapped object." },
+#if defined(LINUX)
+    { SIGSEGV, SEGV_BNDERR,  "SEGV_BNDERR",  "Failed address bound checks." },
+#endif
 #if defined(AIX)
     // no explanation found what keyerr would be
     { SIGSEGV, SEGV_KEYERR,  "SEGV_KEYERR",  "key error" },


### PR DESCRIPTION
On Linux we had recently a crash looking like this
```

siginfo_t @ 0x00007fff2723dc98:
  Signal: 11 (SIGSEGV)
  Signal Code: 3 (unknown signal code)
  Address of faulting memory reference: 0x007fff8c31629838
```

Seems signal code 3 is
`#define SEGV_BNDERR 3 /* failed address bound checks */`

so we should add this to our signal code table; on AIX I cannot find this code so it might be Linux-only.
Even on Linux the define is not always available in the system headers so we better add a define .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352946](https://bugs.openjdk.org/browse/JDK-8352946): SEGV_BND signal code of SIGSEGV missing from our signal-code table (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24255/head:pull/24255` \
`$ git checkout pull/24255`

Update a local copy of the PR: \
`$ git checkout pull/24255` \
`$ git pull https://git.openjdk.org/jdk.git pull/24255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24255`

View PR using the GUI difftool: \
`$ git pr show -t 24255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24255.diff">https://git.openjdk.org/jdk/pull/24255.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24255#issuecomment-2754637114)
</details>
