### PR TITLE
8352970: Remove unnecessary Windows version check in Win32ShellFolderManager2

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolderManager2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolderManager2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -291,7 +291,7 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
                 Win32ShellFolder2 drives = getDrives();
 
                 Win32ShellFolder2 recentFolder = getRecent();
-                if (recentFolder != null && OSInfo.getWindowsVersion().compareTo(OSInfo.WINDOWS_2000) >= 0) {
+                if (recentFolder != null) {
                     folders.add(recentFolder);
                 }
 

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolderManager2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolderManager2.java
@@ -43,7 +43,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import sun.awt.OSInfo;
 import sun.awt.util.ThreadGroupUtils;
 import sun.util.logging.PlatformLogger;
 

--- a/test/jdk/java/awt/FileDialog/FileSystemViewFiles.java
+++ b/test/jdk/java/awt/FileDialog/FileSystemViewFiles.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8352970
+   @requires (os.family == "windows")
+   @summary Basic sanity test for FileSystemView.getChooserComboBoxFiles().
+  */
+
+import java.io.File;
+import java.util.Arrays;
+import javax.swing.filechooser.FileSystemView;
+
+public class FileSystemViewFiles {
+
+    public static void main(String[] args) throws Exception {
+
+        FileSystemView fsv = FileSystemView.getFileSystemView();
+        File[] roots = fsv.getRoots();
+        File desktop = Arrays.asList(roots).stream()
+            .filter(f -> f.getName().equals("Desktop"))
+            .findFirst()
+            .orElse(null);
+        if (desktop == null) {
+            System.out.println("No desktop available in " + roots.length + " roots");
+            return;
+        }
+
+        File[] chooserFiles = fsv.getChooserComboBoxFiles();
+        boolean found = Arrays.asList(chooserFiles).stream()
+            .anyMatch(f -> f.equals(desktop));
+        if (!found) {
+            throw new RuntimeException("Desktop not included in chooser combo box files.");
+        }
+    }
+
+}

--- a/test/jdk/java/awt/FileDialog/FileSystemViewFilesTest.java
+++ b/test/jdk/java/awt/FileDialog/FileSystemViewFilesTest.java
@@ -31,7 +31,7 @@ import java.io.File;
 import java.util.Arrays;
 import javax.swing.filechooser.FileSystemView;
 
-public class FileSystemViewFiles {
+public class FileSystemViewFilesTest {
 
     public static void main(String[] args) throws Exception {
 


### PR DESCRIPTION
Win32ShellFolderManager2 contains a check as to whether the current Windows version is Windows 2000 or later. The current minimum supported version is Windows 10, so this is no longer needed.

No test seems to currently exercise this code, and it's not easy to reliably test, but I've added a basic test that should surface any fundamental issues. The change is very simple, though.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352970](https://bugs.openjdk.org/browse/JDK-8352970): Remove unnecessary Windows version check in Win32ShellFolderManager2 (**Bug** - P5)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24256/head:pull/24256` \
`$ git checkout pull/24256`

Update a local copy of the PR: \
`$ git checkout pull/24256` \
`$ git pull https://git.openjdk.org/jdk.git pull/24256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24256`

View PR using the GUI difftool: \
`$ git pr show -t 24256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24256.diff">https://git.openjdk.org/jdk/pull/24256.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24256#issuecomment-2754673287)
</details>
