### PR TITLE
8352765: G1CollectedHeap::expand_and_allocate() may fail to allocate even after heap expansion succeeds

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -345,6 +345,8 @@ uint G1Policy::calculate_young_target_length(uint desired_young_length) const {
       uint receiving_young = MIN3(_free_regions_at_end_of_collection,
                                   desired_young_length,
                                   max_to_eat_into_reserve);
+      // Ensure that we provision for at least one Eden region.
+      receiving_young = MAX2(receiving_young, _g1h->survivor_regions_count() + 1);
       // We could already have allocated more regions than what we could get
       // above.
       receiving_additional_eden = allocated_young_length < receiving_young ?
@@ -364,6 +366,8 @@ uint G1Policy::calculate_young_target_length(uint desired_young_length) const {
       uint receiving_within_reserve = MIN2(desired_young_length - free_outside_reserve,
                                            max_to_eat_into_reserve);
       uint receiving_young = free_outside_reserve + receiving_within_reserve;
+
+      assert(receiving_young > _g1h->survivor_regions_count(), "We should provision for at least 1 Eden region");
       // Again, we could have already allocated more than we could get.
       receiving_additional_eden = allocated_young_length < receiving_young ?
                                   receiving_young - allocated_young_length : 0;

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -340,37 +340,39 @@ uint G1Policy::calculate_young_target_length(uint desired_young_length) const {
                               _reserve_regions,
                               max_to_eat_into_reserve);
 
+    uint desired_eden_length = desired_young_length - _g1h->survivor_regions_count();
+    uint allocated_eden_length = allocated_young_length - _g1h->survivor_regions_count();
+
     if (_free_regions_at_end_of_collection <= _reserve_regions) {
       // Fully eat (or already eating) into the reserve, hand back at most absolute_min_length regions.
-      uint receiving_young = MIN3(_free_regions_at_end_of_collection,
-                                  desired_young_length,
+      uint receiving_eden = MIN3(_free_regions_at_end_of_collection,
+                                  desired_eden_length,
                                   max_to_eat_into_reserve);
       // Ensure that we provision for at least one Eden region.
-      receiving_young = MAX2(receiving_young, _g1h->survivor_regions_count() + 1);
+      receiving_eden = MAX2(receiving_eden, 1u);
       // We could already have allocated more regions than what we could get
       // above.
-      receiving_additional_eden = allocated_young_length < receiving_young ?
-                                  receiving_young - allocated_young_length : 0;
+      receiving_additional_eden = allocated_eden_length < receiving_eden ?
+                                  receiving_eden - allocated_eden_length : 0;
 
       log_trace(gc, ergo, heap)("Young target length: Fully eat into reserve "
                                 "receiving young %u receiving additional eden %u",
-                                receiving_young,
+                                receiving_eden,
                                 receiving_additional_eden);
-    } else if (_free_regions_at_end_of_collection < (desired_young_length + _reserve_regions)) {
+    } else if (_free_regions_at_end_of_collection < (desired_eden_length + _reserve_regions)) {
       // Partially eat into the reserve, at most max_to_eat_into_reserve regions.
       uint free_outside_reserve = _free_regions_at_end_of_collection - _reserve_regions;
-      assert(free_outside_reserve < desired_young_length,
+      assert(free_outside_reserve < desired_eden_length,
              "must be %u %u",
-             free_outside_reserve, desired_young_length);
+             free_outside_reserve, desired_eden_length);
 
-      uint receiving_within_reserve = MIN2(desired_young_length - free_outside_reserve,
+      uint receiving_within_reserve = MIN2(desired_eden_length - free_outside_reserve,
                                            max_to_eat_into_reserve);
-      uint receiving_young = free_outside_reserve + receiving_within_reserve;
+      uint receiving_eden = free_outside_reserve + receiving_within_reserve;
 
-      assert(receiving_young > _g1h->survivor_regions_count(), "We should provision for at least 1 Eden region");
       // Again, we could have already allocated more than we could get.
-      receiving_additional_eden = allocated_young_length < receiving_young ?
-                                  receiving_young - allocated_young_length : 0;
+      receiving_additional_eden = allocated_eden_length < receiving_eden ?
+                                  receiving_eden - allocated_eden_length : 0;
 
       log_trace(gc, ergo, heap)("Young target length: Partially eat into reserve "
                                 "free outside reserve %u "
@@ -378,7 +380,7 @@ uint G1Policy::calculate_young_target_length(uint desired_young_length) const {
                                 "receiving young %u "
                                 "receiving additional eden %u",
                                 free_outside_reserve, receiving_within_reserve,
-                                receiving_young, receiving_additional_eden);
+                                receiving_eden, receiving_additional_eden);
     } else {
       // No need to use the reserve.
       receiving_additional_eden = desired_young_length - allocated_young_length;

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -340,8 +340,9 @@ uint G1Policy::calculate_young_target_length(uint desired_young_length) const {
                               _reserve_regions,
                               max_to_eat_into_reserve);
 
-    uint desired_eden_length = desired_young_length - _g1h->survivor_regions_count();
-    uint allocated_eden_length = allocated_young_length - _g1h->survivor_regions_count();
+    uint survivor_regions_count = _g1h->survivor_regions_count();
+    uint desired_eden_length = desired_young_length - survivor_regions_count;
+    uint allocated_eden_length = allocated_young_length - survivor_regions_count;
 
     if (_free_regions_at_end_of_collection <= _reserve_regions) {
       // Fully eat (or already eating) into the reserve, hand back at most absolute_min_length regions.
@@ -356,9 +357,8 @@ uint G1Policy::calculate_young_target_length(uint desired_young_length) const {
                                   receiving_eden - allocated_eden_length : 0;
 
       log_trace(gc, ergo, heap)("Young target length: Fully eat into reserve "
-                                "receiving young %u receiving additional eden %u",
-                                receiving_eden,
-                                receiving_additional_eden);
+                                "receiving eden %u receiving additional eden %u",
+                                receiving_eden, receiving_additional_eden);
     } else if (_free_regions_at_end_of_collection < (desired_eden_length + _reserve_regions)) {
       // Partially eat into the reserve, at most max_to_eat_into_reserve regions.
       uint free_outside_reserve = _free_regions_at_end_of_collection - _reserve_regions;
@@ -377,7 +377,7 @@ uint G1Policy::calculate_young_target_length(uint desired_young_length) const {
       log_trace(gc, ergo, heap)("Young target length: Partially eat into reserve "
                                 "free outside reserve %u "
                                 "receiving within reserve %u "
-                                "receiving young %u "
+                                "receiving eden %u "
                                 "receiving additional eden %u",
                                 free_outside_reserve, receiving_within_reserve,
                                 receiving_eden, receiving_additional_eden);


### PR DESCRIPTION
Hi,

Please review this change to ensure that G1 provisions for at least one Eden region after a GC when computing the young length target.

The issue reported in the CR occurs at the end of a GC, after successfully expanding the heap, an allocation fails because `policy()->should_allocate_mutator_region()` returns false. This happens because the computation did not properly account for young regions already allocated as survivor regions, leading to an Eden region target of zero.

With this change, we factor in the young regions that have already been allocated as survivor regions and ensure that at least one region is targeted for Eden.

Testing: Tier 1-3
              Reproducer in the CR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352765](https://bugs.openjdk.org/browse/JDK-8352765): G1CollectedHeap::expand_and_allocate() may fail to allocate even after heap expansion succeeds (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Man Cao](https://openjdk.org/census#manc) (@caoman - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24257/head:pull/24257` \
`$ git checkout pull/24257`

Update a local copy of the PR: \
`$ git checkout pull/24257` \
`$ git pull https://git.openjdk.org/jdk.git pull/24257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24257`

View PR using the GUI difftool: \
`$ git pr show -t 24257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24257.diff">https://git.openjdk.org/jdk/pull/24257.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24257#issuecomment-2754843385)
</details>
