### PR TITLE
8352971: Increase maximum number of hold counts for ReentrantReadWriteLock

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
@@ -251,25 +251,25 @@ public class ReentrantReadWriteLock
      * Synchronization implementation for ReentrantReadWriteLock.
      * Subclassed into fair and nonfair versions.
      */
-    abstract static class Sync extends AbstractQueuedSynchronizer {
+    abstract static class Sync extends AbstractQueuedLongSynchronizer {
         private static final long serialVersionUID = 6317671515068378041L;
 
         /*
          * Read vs write count extraction constants and functions.
-         * Lock state is logically divided into two unsigned shorts:
+         * Lock state is logically divided into two ints:
          * The lower one representing the exclusive (writer) lock hold count,
          * and the upper the shared (reader) hold count.
          */
 
-        static final int SHARED_SHIFT   = 16;
-        static final int SHARED_UNIT    = (1 << SHARED_SHIFT);
-        static final int MAX_COUNT      = (1 << SHARED_SHIFT) - 1;
-        static final int EXCLUSIVE_MASK = (1 << SHARED_SHIFT) - 1;
+        static final int SHARED_SHIFT   = 32;
+        static final long SHARED_UNIT    = (1L << SHARED_SHIFT);
+        static final long MAX_COUNT      = Integer.MAX_VALUE;
+        static final long EXCLUSIVE_MASK = (1L << SHARED_SHIFT) - 1;
 
         /** Returns the number of shared holds represented in count. */
-        static int sharedCount(int c)    { return c >>> SHARED_SHIFT; }
+        static int sharedCount(long c)    { return (int)(c >>> SHARED_SHIFT); }
         /** Returns the number of exclusive holds represented in count. */
-        static int exclusiveCount(int c) { return c & EXCLUSIVE_MASK; }
+        static int exclusiveCount(long c) { return (int)(c & EXCLUSIVE_MASK); }
 
         /**
          * A counter for per-thread read hold counts.
@@ -367,11 +367,12 @@ public class ReentrantReadWriteLock
          * both read and write holds that are all released during a
          * condition wait and re-established in tryAcquire.
          */
+        @Override
         @ReservedStackAccess
-        protected final boolean tryRelease(int releases) {
+        protected final boolean tryRelease(long releases) {
             if (!isHeldExclusively())
                 throw new IllegalMonitorStateException();
-            int nextc = getState() - releases;
+            long nextc = getState() - releases;
             boolean free = exclusiveCount(nextc) == 0;
             if (free)
                 setExclusiveOwnerThread(null);
@@ -379,8 +380,9 @@ public class ReentrantReadWriteLock
             return free;
         }
 
+        @Override
         @ReservedStackAccess
-        protected final boolean tryAcquire(int acquires) {
+        protected final boolean tryAcquire(long acquires) {
             /*
              * Walkthrough:
              * 1. If read count nonzero or write count nonzero
@@ -393,8 +395,8 @@ public class ReentrantReadWriteLock
              *    and set owner.
              */
             Thread current = Thread.currentThread();
-            int c = getState();
-            int w = exclusiveCount(c);
+            long c = getState();
+            long w = exclusiveCount(c);
             if (c != 0) {
                 // (Note: if c != 0 and w == 0 then shared count != 0)
                 if (w == 0 || current != getExclusiveOwnerThread())
@@ -412,8 +414,9 @@ public class ReentrantReadWriteLock
             return true;
         }
 
+        @Override
         @ReservedStackAccess
-        protected final boolean tryReleaseShared(int unused) {
+        protected final boolean tryReleaseShared(long unused) {
             Thread current = Thread.currentThread();
             if (firstReader == current) {
                 // assert firstReaderHoldCount > 0;
@@ -435,8 +438,8 @@ public class ReentrantReadWriteLock
                 --rh.count;
             }
             for (;;) {
-                int c = getState();
-                int nextc = c - SHARED_UNIT;
+                long c = getState();
+                long nextc = c - SHARED_UNIT;
                 if (compareAndSetState(c, nextc))
                     // Releasing the read lock has no effect on readers,
                     // but it may allow waiting writers to proceed if
@@ -450,8 +453,9 @@ public class ReentrantReadWriteLock
                 "attempt to unlock read lock, not locked by current thread");
         }
 
+        @Override
         @ReservedStackAccess
-        protected final int tryAcquireShared(int unused) {
+        protected final long tryAcquireShared(long unused) {
             /*
              * Walkthrough:
              * 1. If write lock held by another thread, fail.
@@ -468,10 +472,10 @@ public class ReentrantReadWriteLock
              *    saturated, chain to version with full retry loop.
              */
             Thread current = Thread.currentThread();
-            int c = getState();
+            long c = getState();
             if (exclusiveCount(c) != 0 &&
                 getExclusiveOwnerThread() != current)
-                return -1;
+                return -1L;
             int r = sharedCount(c);
             if (!readerShouldBlock() &&
                 r < MAX_COUNT &&
@@ -490,7 +494,7 @@ public class ReentrantReadWriteLock
                         readHolds.set(rh);
                     rh.count++;
                 }
-                return 1;
+                return 1L;
             }
             return fullTryAcquireShared(current);
         }
@@ -499,7 +503,7 @@ public class ReentrantReadWriteLock
          * Full version of acquire for reads, that handles CAS misses
          * and reentrant reads not dealt with in tryAcquireShared.
          */
-        final int fullTryAcquireShared(Thread current) {
+        final long fullTryAcquireShared(Thread current) {
             /*
              * This code is in part redundant with that in
              * tryAcquireShared but is simpler overall by not
@@ -508,7 +512,7 @@ public class ReentrantReadWriteLock
              */
             HoldCounter rh = null;
             for (;;) {
-                int c = getState();
+                long c = getState();
                 if (exclusiveCount(c) != 0) {
                     if (getExclusiveOwnerThread() != current)
                         return -1;
@@ -529,7 +533,7 @@ public class ReentrantReadWriteLock
                             }
                         }
                         if (rh.count == 0)
-                            return -1;
+                            return -1L;
                     }
                 }
                 if (sharedCount(c) == MAX_COUNT)
@@ -551,7 +555,7 @@ public class ReentrantReadWriteLock
                         rh.count++;
                         cachedHoldCounter = rh; // cache for release
                     }
-                    return 1;
+                    return 1L;
                 }
             }
         }
@@ -564,7 +568,7 @@ public class ReentrantReadWriteLock
         @ReservedStackAccess
         final boolean tryWriteLock() {
             Thread current = Thread.currentThread();
-            int c = getState();
+            long c = getState();
             if (c != 0) {
                 int w = exclusiveCount(c);
                 if (w == 0 || current != getExclusiveOwnerThread())
@@ -587,7 +591,7 @@ public class ReentrantReadWriteLock
         final boolean tryReadLock() {
             Thread current = Thread.currentThread();
             for (;;) {
-                int c = getState();
+                long c = getState();
                 if (exclusiveCount(c) != 0 &&
                     getExclusiveOwnerThread() != current)
                     return false;
@@ -672,7 +676,7 @@ public class ReentrantReadWriteLock
             setState(0); // reset to unlocked state
         }
 
-        final int getCount() { return getState(); }
+        final long getCount() { return getState(); }
     }
 
     /**
@@ -1431,9 +1435,9 @@ public class ReentrantReadWriteLock
     public boolean hasWaiters(Condition condition) {
         if (condition == null)
             throw new NullPointerException();
-        if (!(condition instanceof AbstractQueuedSynchronizer.ConditionObject))
+        if (!(condition instanceof AbstractQueuedLongSynchronizer.ConditionObject))
             throw new IllegalArgumentException("not owner");
-        return sync.hasWaiters((AbstractQueuedSynchronizer.ConditionObject)condition);
+        return sync.hasWaiters((AbstractQueuedLongSynchronizer.ConditionObject)condition);
     }
 
     /**
@@ -1454,9 +1458,9 @@ public class ReentrantReadWriteLock
     public int getWaitQueueLength(Condition condition) {
         if (condition == null)
             throw new NullPointerException();
-        if (!(condition instanceof AbstractQueuedSynchronizer.ConditionObject))
+        if (!(condition instanceof AbstractQueuedLongSynchronizer.ConditionObject))
             throw new IllegalArgumentException("not owner");
-        return sync.getWaitQueueLength((AbstractQueuedSynchronizer.ConditionObject)condition);
+        return sync.getWaitQueueLength((AbstractQueuedLongSynchronizer.ConditionObject)condition);
     }
 
     /**
@@ -1479,9 +1483,9 @@ public class ReentrantReadWriteLock
     protected Collection<Thread> getWaitingThreads(Condition condition) {
         if (condition == null)
             throw new NullPointerException();
-        if (!(condition instanceof AbstractQueuedSynchronizer.ConditionObject))
+        if (!(condition instanceof AbstractQueuedLongSynchronizer.ConditionObject))
             throw new IllegalArgumentException("not owner");
-        return sync.getWaitingThreads((AbstractQueuedSynchronizer.ConditionObject)condition);
+        return sync.getWaitingThreads((AbstractQueuedLongSynchronizer.ConditionObject)condition);
     }
 
     /**
@@ -1494,7 +1498,7 @@ public class ReentrantReadWriteLock
      * @return a string identifying this lock, as well as its lock state
      */
     public String toString() {
-        int c = sync.getCount();
+        long c = sync.getCount();
         int w = Sync.exclusiveCount(c);
         int r = Sync.sharedCount(c);
 

--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -622,6 +622,7 @@ public class JSR166TestCase extends TestCase {
             String[] java20TestClassNames = {
                 "ForkJoinPool20Test",
                 "SynchronousQueue20Test",
+                "ReentrantReadWriteLock20Test"
             };
             addNamedTestClasses(suite, java20TestClassNames);
         }

--- a/test/jdk/java/util/concurrent/tck/ReentrantReadWriteLock20Test.java
+++ b/test/jdk/java/util/concurrent/tck/ReentrantReadWriteLock20Test.java
@@ -1,0 +1,101 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * This file is available under and governed by the GNU General Public
+ * License version 2 only, as published by the Free Software Foundation.
+ * However, the following notice accompanied the original version of this
+ * file:
+ *
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class ReentrantReadWriteLock20Test extends JSR166TestCase {
+    public static void main(String[] args) {
+        main(suite(), args);
+    }
+    public static Test suite() {
+        return new TestSuite(ReentrantReadWriteLock20Test.class);
+    }
+    public void test66kReadersFair()   { test66kReaders(true); }
+    public void test66kReadersUnfair() { test66kReaders(false); }
+
+    private void test66kReaders(boolean fairness) {
+        final var failure = new AtomicReference<Throwable>();
+        final var lock = new ReentrantReadWriteLock(fairness);
+        final var numThreads = 0x10000;
+        final var threads = new ArrayDeque<Thread>(numThreads);
+        final var latch = new CountDownLatch(1);
+        try {
+            for(int i = 0; i < numThreads && failure.get() == null;++i) {
+                var t = Thread.ofVirtual().unstarted(() -> {
+
+                    try {
+                        lock.readLock().lock();
+                    } catch (Throwable ex) {
+                        failure.compareAndSet(null, ex);
+                        return;
+                    }
+
+                    try {
+                        while (latch.getCount() > 0) {
+                            try {
+                                latch.await();
+                            } catch (InterruptedException ie) {}
+                        }
+                    }
+                    finally {
+                        lock.readLock().unlock();
+                    }
+                });
+
+                threads.addLast(t);
+                t.start();
+            }
+        } finally {
+            latch.countDown(); // Make sure waiters are
+            Thread next = null;
+            while ((next = threads.pollFirst()) != null) {
+                while (next.isAlive()) {
+                    try {
+                        next.join();
+                    } catch (InterruptedException ie) {
+                    }
+                }
+            }
+        }
+
+        assertEquals(null, failure.get());
+    }
+}

--- a/test/jdk/java/util/concurrent/tck/ReentrantReadWriteLockTest.java
+++ b/test/jdk/java/util/concurrent/tck/ReentrantReadWriteLockTest.java
@@ -1720,7 +1720,7 @@ public class ReentrantReadWriteLockTest extends JSR166TestCase {
             ? "ReentrantReadWriteLock$FairSync"
             : "ReentrantReadWriteLock$NonfairSync";
         final String conditionClassName
-            = "AbstractQueuedSynchronizer$ConditionObject";
+            = "AbstractQueuedLongSynchronizer$ConditionObject";
         final Thread.State expectedAcquireState = timedAcquire
             ? Thread.State.TIMED_WAITING
             : Thread.State.WAITING;


### PR DESCRIPTION
I'm breaking this change out as a separate improvement, since it will not be generally possible to adjust these limits on the j.u.c primitives since they might already use a backing `long` to pack in information which needs to be updated atomically (would require 128-bit atomics to widen them, and it still infeasible to change return types of pre-existing APIs).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352971](https://bugs.openjdk.org/browse/JDK-8352971): Increase maximum number of hold counts for ReentrantReadWriteLock (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24261/head:pull/24261` \
`$ git checkout pull/24261`

Update a local copy of the PR: \
`$ git checkout pull/24261` \
`$ git pull https://git.openjdk.org/jdk.git pull/24261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24261`

View PR using the GUI difftool: \
`$ git pr show -t 24261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24261.diff">https://git.openjdk.org/jdk/pull/24261.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24261#issuecomment-2757265587)
</details>
