### PR TITLE
8252473: [TESTBUG] compiler tests fail with minimal VM: Unrecognized VM option

### DIFF
--- a/test/hotspot/jtreg/compiler/arraycopy/TestCloneWithStressReflectiveCode.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestCloneWithStressReflectiveCode.java
@@ -26,10 +26,12 @@
  * @bug 8284951
  * @summary Test clone intrinsic with StressReflectiveCode.
  * @requires vm.debug
- * @run main/othervm -XX:-InlineUnsafeOps -XX:-ReduceInitialCardMarks -XX:+StressReflectiveCode -Xbatch -XX:-TieredCompilation
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-InlineUnsafeOps -XX:-ReduceInitialCardMarks -XX:+StressReflectiveCode -Xbatch -XX:-TieredCompilation
  *                   -XX:CompileCommand=dontinline,compiler.arraycopy.TestCloneWithStressReflectiveCode::test
  *                   compiler.arraycopy.TestCloneWithStressReflectiveCode
- * @run main/othervm -XX:-InlineUnsafeOps -XX:-ReduceInitialCardMarks -XX:+StressReflectiveCode -Xcomp -XX:-TieredCompilation
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-InlineUnsafeOps -XX:-ReduceInitialCardMarks -XX:+StressReflectiveCode -Xcomp -XX:-TieredCompilation
  *                   compiler.arraycopy.TestCloneWithStressReflectiveCode
  */
 

--- a/test/hotspot/jtreg/compiler/c2/ClearArray.java
+++ b/test/hotspot/jtreg/compiler/c2/ClearArray.java
@@ -27,11 +27,14 @@
  * @bug 8284883
  * @compile ClearArray.java
  * @summary ClearArray instruction overflows scratch buffer
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -Xbatch
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *   -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -Xbatch
  *   -XX:InitArrayShortSize=32768 -XX:-IdealizeClearArrayNode compiler.c2.ClearArray
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -Xbatch
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *   -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -Xbatch
  *   -XX:InitArrayShortSize=32768 -XX:-IdealizeClearArrayNode -XX:UseAVX=3 compiler.c2.ClearArray
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -Xbatch
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *   -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -Xbatch
  *   -XX:InitArrayShortSize=32768 -XX:MaxVectorSize=8 -XX:-IdealizeClearArrayNode -XX:UseAVX=3 compiler.c2.ClearArray
  */
 

--- a/test/hotspot/jtreg/compiler/c2/TestCMoveInfiniteGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCMoveInfiniteGVN.java
@@ -25,11 +25,13 @@
  * @test
  * @key stress randomness
  * @bug 8280123
- * @run main/othervm -Xcomp -XX:-TieredCompilation
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -Xcomp -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,compiler.c2.TestCMoveInfiniteGVN::test
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=43739875
  *                   compiler.c2.TestCMoveInfiniteGVN
- * @run main/othervm -Xcomp -XX:-TieredCompilation
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -Xcomp -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,compiler.c2.TestCMoveInfiniteGVN::test
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN
  *                   compiler.c2.TestCMoveInfiniteGVN

--- a/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
@@ -45,15 +45,19 @@ public class TestCastX2NotProcessedIGVN {
     public static void main(String[] args) {
         // Cross-product: +-AlignVector and +-UseCompactObjectHeaders
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:-UseCompactObjectHeaders",
                                    "-XX:-AlignVector");
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:-UseCompactObjectHeaders",
                                    "-XX:+AlignVector");
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:+UseCompactObjectHeaders",
                                    "-XX:-AlignVector");
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:+UseCompactObjectHeaders",
                                    "-XX:+AlignVector");
     }

--- a/test/hotspot/jtreg/compiler/c2/TestDeadDataLoopCmoveIdentity.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDeadDataLoopCmoveIdentity.java
@@ -26,9 +26,11 @@
  * @key stress randomness
  * @bug 8271056
  * @summary A dead data loop is created when applying an unsafe case of Cmov'ing identity.
- * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.c2.TestDeadDataLoopCmoveIdentity::*
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.c2.TestDeadDataLoopCmoveIdentity::*
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=359948366 compiler.c2.TestDeadDataLoopCmoveIdentity
- * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.c2.TestDeadDataLoopCmoveIdentity::*
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.c2.TestDeadDataLoopCmoveIdentity::*
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN compiler.c2.TestDeadDataLoopCmoveIdentity
  */
 

--- a/test/hotspot/jtreg/compiler/c2/TestDivModNodes.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDivModNodes.java
@@ -44,8 +44,8 @@ public class TestDivModNodes {
     private static long longRemainder;
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:-UseDivMod");
-        TestFramework.runWithFlags("-XX:+UseDivMod");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-UseDivMod");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+UseDivMod");
     }
 
     private static int nextNonZeroInt() {

--- a/test/hotspot/jtreg/compiler/c2/TestExHandlerTrap.java
+++ b/test/hotspot/jtreg/compiler/c2/TestExHandlerTrap.java
@@ -62,6 +62,7 @@ import java.util.ArrayList;
  * @requires vm.debug
  *
  * @run main/othervm
+ *   -XX:+IgnoreUnrecognizedVMOptions
  *   -Xbatch
  *   -Xlog:deoptimization=trace
  *   -XX:CompileCommand=PrintCompilation,compiler.c2.TestExHandlerTrap::payload

--- a/test/hotspot/jtreg/compiler/c2/TestGVNCrash.java
+++ b/test/hotspot/jtreg/compiler/c2/TestGVNCrash.java
@@ -28,7 +28,7 @@
  * @bug 8288204
  * @summary GVN Crash: assert() failed: correct memory chain
  *
- * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:CompileCommand=compileonly,compiler.c2.TestGVNCrash::test compiler.c2.TestGVNCrash
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:CompileCommand=compileonly,compiler.c2.TestGVNCrash::test compiler.c2.TestGVNCrash
  */
 
 package compiler.c2;

--- a/test/hotspot/jtreg/compiler/c2/TestInfiniteLoopCompilationFailure.java
+++ b/test/hotspot/jtreg/compiler/c2/TestInfiniteLoopCompilationFailure.java
@@ -25,9 +25,11 @@
  * @test
  * @bug 8306933
  * @summary C2: "assert(false) failed: infinite loop" failure
- * @run main/othervm -Xcomp -XX:CompileOnly=TestInfiniteLoopCompilationFailure::test -XX:-UseLoopPredicate -XX:-UseProfiledLoopPredicate
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -Xcomp -XX:CompileOnly=TestInfiniteLoopCompilationFailure::test -XX:-UseLoopPredicate -XX:-UseProfiledLoopPredicate
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=675320863 TestInfiniteLoopCompilationFailure
- * @run main/othervm -Xcomp -XX:CompileOnly=TestInfiniteLoopCompilationFailure::test -XX:-UseLoopPredicate -XX:-UseProfiledLoopPredicate
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -Xcomp -XX:CompileOnly=TestInfiniteLoopCompilationFailure::test -XX:-UseLoopPredicate -XX:-UseProfiledLoopPredicate
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN TestInfiniteLoopCompilationFailure
  */
 

--- a/test/hotspot/jtreg/compiler/c2/TestLoadSplitThruPhiNull.java
+++ b/test/hotspot/jtreg/compiler/c2/TestLoadSplitThruPhiNull.java
@@ -27,7 +27,7 @@
  * @summary C2: assert(has_node(i)) failed during split thru phi
  *
  * @run main/othervm -XX:-BackgroundCompilation TestLoadSplitThruPhiNull
- * @run main/othervm -XX:-BackgroundCompilation -XX:-ReduceFieldZeroing TestLoadSplitThruPhiNull
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-BackgroundCompilation -XX:-ReduceFieldZeroing TestLoadSplitThruPhiNull
  * @run main TestLoadSplitThruPhiNull
  *
  */

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
@@ -120,7 +120,7 @@ public class TestMergeStores {
             //   StoreI            [   StoreL  ]            StoreI
             // But now it would have been better to do this instead:
             //   [         StoreL       ] [       StoreL         ]
-            case "StressIGVN"  -> { framework.addFlags("-XX:+StressIGVN"); }
+            case "StressIGVN"  -> { framework.addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+StressIGVN"); }
             default -> { throw new RuntimeException("Test argument not recognized: " + args[0]); }
         }
         framework.start();

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStoresNullAdrType.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStoresNullAdrType.java
@@ -27,7 +27,8 @@ package compiler.c2;
  * @test
  * @bug 8318446 8331085
  * @summary Test merge stores, when "adr_type() == nullptr" because of TOP somewhere in the address.
- * @run main/othervm -XX:CompileCommand=compileonly,compiler.c2.TestMergeStoresNullAdrType::test
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:CompileCommand=compileonly,compiler.c2.TestMergeStoresNullAdrType::test
  *                   -XX:-TieredCompilation -Xcomp
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:+StressCCP
  *                   -XX:RepeatCompilation=1000

--- a/test/hotspot/jtreg/compiler/c2/TestModDivTopInput.java
+++ b/test/hotspot/jtreg/compiler/c2/TestModDivTopInput.java
@@ -26,9 +26,11 @@
  * @test
  * @bug 8283451
  * @summary C2: assert(_base == Long) failed: Not a Long
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressLCM -XX:+StressGCM -XX:+StressCCP -XX:+StressIGVN
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressLCM -XX:+StressGCM -XX:+StressCCP -XX:+StressIGVN
  *                   -Xcomp -XX:CompileOnly=TestModDivTopInput::* -XX:-TieredCompilation -XX:StressSeed=87628618 TestModDivTopInput
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressLCM -XX:+StressGCM -XX:+StressCCP -XX:+StressIGVN
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressLCM -XX:+StressGCM -XX:+StressCCP -XX:+StressIGVN
  *                   -Xcomp -XX:CompileOnly=TestModDivTopInput::* -XX:-TieredCompilation TestModDivTopInput
  */
 

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestByteVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestByteVect.java
@@ -27,9 +27,9 @@
  * @summary Implement vectorization optimizations in hotspot-server
  *
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m compiler.c2.cr6340864.TestByteVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestByteVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestByteVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestByteVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestByteVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestByteVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestByteVect
  */
 
 package compiler.c2.cr6340864;

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestDoubleVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestDoubleVect.java
@@ -27,9 +27,9 @@
  * @summary Implement vectorization optimizations in hotspot-server
  *
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic compiler.c2.cr6340864.TestDoubleVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestDoubleVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestDoubleVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestDoubleVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestDoubleVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestDoubleVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestDoubleVect
  */
 
 package compiler.c2.cr6340864;

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestFloatVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestFloatVect.java
@@ -27,9 +27,9 @@
  * @summary Implement vectorization optimizations in hotspot-server
  *
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic compiler.c2.cr6340864.TestFloatVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestFloatVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestFloatVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestFloatVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestFloatVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestFloatVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UseSignumIntrinsic -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestFloatVect
  */
 
 package compiler.c2.cr6340864;

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestIntVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestIntVect.java
@@ -27,9 +27,9 @@
  * @summary Implement vectorization optimizations in hotspot-server
  *
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m compiler.c2.cr6340864.TestIntVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestIntVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestIntVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestIntVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestIntVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestIntVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestIntVect
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=3 compiler.c2.cr6340864.TestIntVect
  */
 

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestIntVectRotate.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestIntVectRotate.java
@@ -27,9 +27,9 @@
  * @summary Implement Rotate vectorization optimizations in hotspot-server
  *
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m compiler.c2.cr6340864.TestIntVectRotate
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestIntVectRotate
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestIntVectRotate
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestIntVectRotate
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestIntVectRotate
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestIntVectRotate
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestIntVectRotate
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=3 compiler.c2.cr6340864.TestIntVectRotate
  */
 

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestLongVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestLongVect.java
@@ -27,9 +27,9 @@
  * @summary Implement vectorization optimizations in hotspot-server
  *
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m compiler.c2.cr6340864.TestLongVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestLongVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestLongVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestLongVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestLongVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestLongVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestLongVect
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=3 compiler.c2.cr6340864.TestLongVect
  */
 

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestLongVectRotate.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestLongVectRotate.java
@@ -27,9 +27,9 @@
  * @summary Implement Rotate vectorization optimizations in hotspot-server
  *
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m compiler.c2.cr6340864.TestLongVectRotate
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestLongVectRotate
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestLongVectRotate
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestLongVectRotate
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestLongVectRotate
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestLongVectRotate
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestLongVectRotate
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=3 compiler.c2.cr6340864.TestLongVectRotate
  */
 

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestShortVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestShortVect.java
@@ -27,9 +27,9 @@
  * @summary Implement vectorization optimizations in hotspot-server
  *
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m compiler.c2.cr6340864.TestShortVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestShortVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestShortVect
- * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestShortVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.c2.cr6340864.TestShortVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.c2.cr6340864.TestShortVect
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.c2.cr6340864.TestShortVect
  */
 
 package compiler.c2.cr6340864;

--- a/test/hotspot/jtreg/compiler/c2/irTests/ConvF2HFIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ConvF2HFIdealizationTests.java
@@ -48,7 +48,7 @@ public class ConvF2HFIdealizationTests {
         }
     }
     public static void main(String[] args) {
-        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector", "-XX:-UseSuperWord");
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-UseSuperWord");
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestConvI2LCastLongLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestConvI2LCastLongLoop.java
@@ -44,7 +44,7 @@ public class TestConvI2LCastLongLoop {
     private static final Random RANDOM = Utils.getRandomInstance();
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED", "-XX:LoopMaxUnroll=0", "-XX:-UseCountedLoopSafepoints");
+        TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:LoopMaxUnroll=0", "-XX:-UseCountedLoopSafepoints");
     }
 
     static int size = 1024;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestCountedLoopPhiValue.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestCountedLoopPhiValue.java
@@ -35,7 +35,7 @@ import compiler.lib.ir_framework.*;
 
 public class TestCountedLoopPhiValue {
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:LoopUnrollLimit=0");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:LoopUnrollLimit=0");
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
@@ -44,13 +44,17 @@ public class TestVectorConditionalMove {
 
     public static void main(String[] args) {
         // Cross-product: +-AlignVector and +-UseCompactObjectHeaders
-        TestFramework.runWithFlags("-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov",
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions",
+                                   "-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov",
                                    "-XX:-UseCompactObjectHeaders", "-XX:-AlignVector");
-        TestFramework.runWithFlags("-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov",
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions",
+                                   "-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov",
                                    "-XX:-UseCompactObjectHeaders", "-XX:+AlignVector");
-        TestFramework.runWithFlags("-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov",
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions",
+                                   "-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov",
                                    "-XX:+UseCompactObjectHeaders", "-XX:-AlignVector");
-        TestFramework.runWithFlags("-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov",
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions",
+                                   "-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov",
                                    "-XX:+UseCompactObjectHeaders", "-XX:+AlignVector");
     }
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
@@ -52,15 +52,19 @@ public class TestVectorizationMismatchedAccess {
     public static void main(String[] args) {
         // Cross-product: +-AlignVector and +-UseCompactObjectHeaders
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:-UseCompactObjectHeaders",
                                    "-XX:-AlignVector");
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:-UseCompactObjectHeaders",
                                    "-XX:+AlignVector");
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:+UseCompactObjectHeaders",
                                    "-XX:-AlignVector");
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:+UseCompactObjectHeaders",
                                    "-XX:+AlignVector");
     }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
@@ -43,15 +43,19 @@ public class TestVectorizationNotRun {
     public static void main(String[] args) {
         // Cross-product: +-AlignVector and +-UseCompactObjectHeaders
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:-UseCompactObjectHeaders",
                                    "-XX:-AlignVector");
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:-UseCompactObjectHeaders",
                                    "-XX:+AlignVector");
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:+UseCompactObjectHeaders",
                                    "-XX:-AlignVector");
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:+UseCompactObjectHeaders",
                                    "-XX:+AlignVector");
     }

--- a/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestIntegerMulRing.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestIntegerMulRing.java
@@ -37,7 +37,7 @@ public class TestIntegerMulRing {
     public static long lFld, lFld2, lFld3, lFld4;
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:-SplitIfBlocks");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-SplitIfBlocks");
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/ccp/TestShiftConvertAndNotification.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestShiftConvertAndNotification.java
@@ -26,7 +26,8 @@
  * @bug 8313672
  * @summary Test CCP notification for value update of AndL through LShiftI and
  *          ConvI2L.
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions
  *                   -XX:RepeatCompilation=20 -XX:-TieredCompilation
  *                   -XX:+StressIGVN -Xcomp
  *                   -XX:CompileCommand=compileonly,compiler.ccp.TestShiftConvertAndNotification::test

--- a/test/hotspot/jtreg/compiler/codegen/TestGCMLoadPlacement.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestGCMLoadPlacement.java
@@ -27,24 +27,28 @@ package compiler.codegen;
  * @test
  * @bug 8333393
  * @summary Test that loads are not scheduled too late.
- * @run main/othervm -XX:CompileCommand=compileonly,*Test*::test
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:CompileCommand=compileonly,*Test*::test
  *                   -XX:-TieredCompilation -Xbatch
  *                   -XX:PerMethodTrapLimit=0
  *                   -XX:CompileCommand=dontinline,*::dontInline
  *                   compiler.codegen.TestGCMLoadPlacement
- * @run main/othervm -XX:CompileCommand=compileonly,*Test*::test
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:CompileCommand=compileonly,*Test*::test
  *                   -XX:-TieredCompilation -Xbatch
  *                   -XX:PerMethodTrapLimit=0
  *                   -XX:CompileCommand=dontinline,*::dontInline
  *                   -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+StressGCM -XX:+StressLCM
  *                   compiler.codegen.TestGCMLoadPlacement
- * @run main/othervm -XX:LoopMaxUnroll=0
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:LoopMaxUnroll=0
  *                   -XX:CompileCommand=compileonly,*Test*::test
  *                   -XX:-TieredCompilation -Xbatch
  *                   -XX:PerMethodTrapLimit=0
  *                   compiler.codegen.TestGCMLoadPlacement
- * @run main/othervm -XX:LoopMaxUnroll=0
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:LoopMaxUnroll=0
  *                   -XX:CompileCommand=compileonly,*Test*::test
  *                   -XX:-TieredCompilation -Xbatch
  *                   -XX:PerMethodTrapLimit=0

--- a/test/hotspot/jtreg/compiler/controldependency/TestAddPChainMismatchedBase2.java
+++ b/test/hotspot/jtreg/compiler/controldependency/TestAddPChainMismatchedBase2.java
@@ -25,9 +25,11 @@
  * @test
  * @bug 8303737
  * @summary C2: cast nodes from PhiNode::Ideal() cause "Base pointers must match" assert failure
- * @run main/othervm -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:+StressCCP -Xcomp
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+                     -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:+StressCCP -Xcomp
  *                   -XX:CompileOnly=TestAddPChainMismatchedBase2::* -XX:StressSeed=1581936900 TestAddPChainMismatchedBase2
- * @run main/othervm -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:+StressCCP -Xcomp
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+                     -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:+StressCCP -Xcomp
  *                   -XX:CompileOnly=TestAddPChainMismatchedBase2::* TestAddPChainMismatchedBase2
  */
 

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8323190
  * @summary C2 Segfaults during code generation because of unhandled SafePointScalarMerge monitor debug info.
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xcomp -XX:+ReduceAllocationMerges TestInvalidLocation
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -Xcomp -XX:+ReduceAllocationMerges TestInvalidLocation
  */
 
 public class TestInvalidLocation {

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestG1BarrierGeneration.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestG1BarrierGeneration.java
@@ -102,6 +102,7 @@ public class TestG1BarrierGeneration {
             for (int j = 0; j < 2; j++) {
                 scenarios[scenarioIndex] =
                     new Scenario(scenarioIndex,
+                                 "-XX:+IgnoreUnrecognizedVMOptions",
                                  "-XX:CompileCommand=inline,java.lang.ref.*::*",
                                  "-XX:" + (i == 0 ? "-" : "+") + "UseCompressedOops",
                                  "-XX:" + (j == 0 ? "-" : "+") + "ReduceInitialCardMarks");

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCBarrierElision.java
@@ -99,7 +99,8 @@ public class TestZGCBarrierElision {
         }
         String commonName = Common.class.getName();
         TestFramework test = new TestFramework(testClass);
-        test.addFlags("-XX:+UseZGC", "-XX:+UnlockExperimentalVMOptions",
+        test.addFlags("-XX:+IgnoreUnrecognizedVMOptions",
+                      "-XX:+UseZGC", "-XX:+UnlockExperimentalVMOptions",
                       "-XX:CompileCommand=blackhole," + commonName + "::blackhole",
                       "-XX:CompileCommand=dontinline," + commonName + "::nonInlinedMethod",
                       "-XX:LoopMaxUnroll=0");

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCUnrolling.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCUnrolling.java
@@ -55,7 +55,8 @@ public class TestZGCUnrolling {
     }
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:+UseZGC", "-XX:LoopUnrollLimit=24");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions",
+                                   "-XX:+UseZGC", "-XX:LoopUnrollLimit=24");
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/inlining/LateInlinePrinting.java
+++ b/test/hotspot/jtreg/compiler/inlining/LateInlinePrinting.java
@@ -30,6 +30,7 @@
  * @library /test/lib
  * @requires vm.flagless
  * @requires vm.debug == true
+ * @requires vm.compiler2.enabled
  *
  * @run driver compiler.inlining.LateInlinePrinting
  */

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/HeapByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/HeapByteBufferTest.java
@@ -43,9 +43,11 @@
  * @library /test/lib
  *
  * @run main/othervm -Djdk.test.lib.random.seed=42
+ *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+OptoScheduling
  *      HeapByteBufferTest
  * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+OptoScheduling
  *      HeapByteBufferTest
  */

--- a/test/hotspot/jtreg/compiler/loopopts/FillArrayWithUnsafe.java
+++ b/test/hotspot/jtreg/compiler/loopopts/FillArrayWithUnsafe.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8283408
  * @summary Fill a byte array with Java Unsafe API
- * @run main/othervm -XX:+OptimizeFill compiler.loopopts.FillArrayWithUnsafe
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+OptimizeFill compiler.loopopts.FillArrayWithUnsafe
  */
 
 package compiler.loopopts;

--- a/test/hotspot/jtreg/compiler/loopopts/TestArrayFillIntrinsic.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestArrayFillIntrinsic.java
@@ -45,7 +45,7 @@ public class TestArrayFillIntrinsic {
         // replacing it with an intrinsic call even if OptimizeFill is enabled.
         TestFramework framework = new TestFramework();
         framework.addScenarios(new Scenario(0),
-                               new Scenario(1, "-XX:LoopUnrollLimit=0", "-XX:+OptimizeFill"));
+                               new Scenario(1, "-XX:+IgnoreUnrecognizedVMOptions", "-XX:LoopUnrollLimit=0", "-XX:+OptimizeFill"));
         framework.start();
     }
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestCMoveLimitType.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCMoveLimitType.java
@@ -26,7 +26,8 @@
  * @key stress randomness
  * @bug 8299975
  * @summary Limit underflow protection CMoveINode in PhaseIdealLoop::do_unroll must also protect type from underflow
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestCMoveLimitType::test*
  *                   -XX:CompileCommand=dontinline,compiler.loopopts.TestCMoveLimitType::dontInline
  *                   -XX:RepeatCompilation=50 -XX:+StressIGVN

--- a/test/hotspot/jtreg/compiler/loopopts/TestDeadIrreducibleLoopsMain.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestDeadIrreducibleLoopsMain.java
@@ -29,6 +29,7 @@
  * @summary Irreducible loops have many entries, only when the last entry loses
  *          control from the outside does the loop die, and have to disappear.
  * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:CompileCommand=compileonly,TestDeadIrreducibleLoopsMain::test*
  *      -XX:CompileCommand=compileonly,TestDeadIrreducibleLoops::test*
  *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN
@@ -42,6 +43,7 @@
  * @summary Irreducible loops have many entries, only when the last entry loses
  *          control from the outside does the loop die, and have to disappear.
  * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:CompileCommand=compileonly,TestDeadIrreducibleLoopsMain::test*
  *      -XX:CompileCommand=compileonly,TestDeadIrreducibleLoops::test*
  *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN
@@ -56,6 +58,7 @@
  * @summary Irreducible loops have many entries, only when the last entry loses
  *          control from the outside does the loop die, and have to disappear.
  * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:CompileCommand=compileonly,TestDeadIrreducibleLoopsMain::test*
  *      -XX:CompileCommand=compileonly,TestDeadIrreducibleLoops::test*
  *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN
@@ -70,6 +73,7 @@
  * @summary Irreducible loops have many entries, only when the last entry loses
  *          control from the outside does the loop die, and have to disappear.
  * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:CompileCommand=compileonly,TestDeadIrreducibleLoopsMain::test*
  *      -XX:CompileCommand=compileonly,TestDeadIrreducibleLoops::test*
  *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN

--- a/test/hotspot/jtreg/compiler/loopopts/TestOverUnrolling2.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestOverUnrolling2.java
@@ -26,8 +26,8 @@
  * @bug 8286625
  * @key stress
  * @summary C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-BackgroundCompilation -XX:+StressIGVN -XX:StressSeed=4232417824 TestOverUnrolling2
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-BackgroundCompilation -XX:+StressIGVN TestOverUnrolling2
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:-BackgroundCompilation -XX:+StressIGVN -XX:StressSeed=4232417824 TestOverUnrolling2
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:-BackgroundCompilation -XX:+StressIGVN TestOverUnrolling2
  */
 
 public class TestOverUnrolling2 {

--- a/test/hotspot/jtreg/compiler/loopopts/TestPeelingSkeletonPredicateInitialization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPeelingSkeletonPredicateInitialization.java
@@ -32,7 +32,8 @@
  *          5. The rangecheck is still before the peeling, and is not copied to the peeled loop. Hence
  *             we do not statically realize that the peeled loop can never be entered.
  *
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressLCM -XX:+StressGCM -XX:+StressCCP -XX:+StressIGVN
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressLCM -XX:+StressGCM -XX:+StressCCP -XX:+StressIGVN
  *                   -Xcomp -XX:-TieredCompilation
  *                   -XX:LoopMaxUnroll=0 -XX:LoopUnrollLimit=0 -XX:-LoopUnswitching
  *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestPeelingSkeletonPredicateInitialization::*

--- a/test/hotspot/jtreg/compiler/loopopts/TestPredicateInputBelowLoopPredicate.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPredicateInputBelowLoopPredicate.java
@@ -25,7 +25,7 @@
  * @test
  * bug 8280799
  * @summary C2: assert(false) failed: cyclic dependency prevents range check elimination
- * @run main/othervm -XX:-BackgroundCompilation -XX:-UseCountedLoopSafepoints TestPredicateInputBelowLoopPredicate
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-BackgroundCompilation -XX:-UseCountedLoopSafepoints TestPredicateInputBelowLoopPredicate
  */
 
 public class TestPredicateInputBelowLoopPredicate {

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyCountedLoop.java
@@ -27,10 +27,12 @@
  * @summary SIGFPE caused by C2 IdealLoopTree::do_remove_empty_loop
  * @key stress randomness
  *
- * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-TieredCompilation -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM
  *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestRemoveEmptyCountedLoop::test*
  *                   compiler.loopopts.TestRemoveEmptyCountedLoop
- * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=2160808391
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-TieredCompilation -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=2160808391
  *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestRemoveEmptyCountedLoop::test*
  *                   compiler.loopopts.TestRemoveEmptyCountedLoop
  */

--- a/test/hotspot/jtreg/compiler/loopopts/TestSplitThruPhiInfinitely.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSplitThruPhiInfinitely.java
@@ -52,6 +52,6 @@ public class TestSplitThruPhiInfinitely {
     }
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:-PartialPeelLoop");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-PartialPeelLoop");
     }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
@@ -483,8 +483,8 @@ public class TestDependencyOffsets {
         }
 
         String[] flags = switch (args[0]) {
-            case "vanilla-A" -> new String[] {"-XX:+AlignVector"};
-            case "vanilla-U" -> new String[] {"-XX:-AlignVector"};
+            case "vanilla-A" -> new String[] {"-XX:+IgnoreUnrecognizedVMOptions", "-XX:+AlignVector"};
+            case "vanilla-U" -> new String[] {"-XX:+IgnoreUnrecognizedVMOptions", "-XX:-AlignVector"};
             case "sse4-v016-A" -> new String[] {"-XX:UseSSE=4", "-XX:MaxVectorSize=16", "-XX:+AlignVector"};
             case "sse4-v016-U" -> new String[] {"-XX:UseSSE=4", "-XX:MaxVectorSize=16", "-XX:-AlignVector"};
             case "sse4-v008-A" -> new String[] {"-XX:UseSSE=4", "-XX:MaxVectorSize=8", "-XX:+AlignVector"};

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestEliminateAllocationWithCastP2XUse.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestEliminateAllocationWithCastP2XUse.java
@@ -28,7 +28,8 @@ package compiler.loopopts.superword;
  * @bug 8342498
  * @summary Test SuperWord, when it aligns to field-store, and the corresponding allocation is eliminated.
  * @run driver compiler.loopopts.superword.TestEliminateAllocationWithCastP2XUse
- * @run main/othervm -Xbatch
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -Xbatch
  *                   -XX:-SplitIfBlocks -XX:LoopMaxUnroll=8
  *                   -XX:+UnlockDiagnosticVMOptions -XX:DominatorSearchLimit=45
  *                   compiler.loopopts.superword.TestEliminateAllocationWithCastP2XUse

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestEquivalentInvariants.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestEquivalentInvariants.java
@@ -67,9 +67,9 @@ public class TestEquivalentInvariants {
 
     public static void main(String[] args) {
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
-                                   "-XX:-AlignVector");
+                                   "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-AlignVector");
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
-                                   "-XX:+AlignVector");
+                                   "-XX:+IgnoreUnrecognizedVMOptions", "-XX:+AlignVector");
     }
 
     public TestEquivalentInvariants() {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegment.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegment.java
@@ -173,7 +173,7 @@ public class TestMemorySegment {
         TestFramework framework = new TestFramework(TestMemorySegmentImpl.class);
         framework.addFlags("-DmemorySegmentProviderNameForTestVM=" + args[0]);
         if (args.length > 1 && args[1].equals("AlignVector")) {
-            framework.addFlags("-XX:+AlignVector");
+            framework.addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+AlignVector");
         }
         framework.setDefaultWarmup(100);
         framework.start();

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentUnalignedAddress.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentUnalignedAddress.java
@@ -86,7 +86,7 @@ public class TestMemorySegmentUnalignedAddress {
         framework.addFlags("-DmemorySegmentProviderNameForTestVM=" + args[0]);
         if (args.length > 1) {
             switch (args[1]) {
-                case "AlignVector" ->       { framework.addFlags("-XX:+AlignVector"); }
+                case "AlignVector" ->       { framework.addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+AlignVector"); }
                 case "VerifyAlignVector" -> { framework.addFlags("-XX:+AlignVector", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:+VerifyAlignVector"); }
                 default ->                  { throw new RuntimeException("unexpected: " + args[1]); }
             }

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestPickLastMemoryState.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestPickLastMemoryState.java
@@ -28,9 +28,11 @@
  * @bug 8290910 8293216
  * @summary Test which needs to select the memory state of the last load in a load pack in SuperWord::co_locate_pack.
  *
- * @run main/othervm -Xcomp -XX:CompileOnly=compiler.loopopts.superword.TestPickLastMemoryState::*
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -Xcomp -XX:CompileOnly=compiler.loopopts.superword.TestPickLastMemoryState::*
  *                   -Xbatch -XX:MaxVectorSize=16 compiler.loopopts.superword.TestPickLastMemoryState
- * @run main/othervm -Xcomp -XX:CompileOnly=compiler.loopopts.superword.TestPickLastMemoryState::*
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -Xcomp -XX:CompileOnly=compiler.loopopts.superword.TestPickLastMemoryState::*
  *                   -Xbatch -XX:MaxVectorSize=32 compiler.loopopts.superword.TestPickLastMemoryState
  * @run main/othervm -Xcomp -XX:CompileOnly=compiler.loopopts.superword.TestPickLastMemoryState::*
  *                   -Xbatch compiler.loopopts.superword.TestPickLastMemoryState

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -39,10 +39,10 @@ public class TestUnorderedReductionPartialVectorization {
     static final int ITER  = 10;
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:-UseCompactObjectHeaders", "-XX:-AlignVector");
-        TestFramework.runWithFlags("-XX:-UseCompactObjectHeaders", "-XX:+AlignVector");
-        TestFramework.runWithFlags("-XX:+UseCompactObjectHeaders", "-XX:-AlignVector");
-        TestFramework.runWithFlags("-XX:+UseCompactObjectHeaders", "-XX:+AlignVector");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-UseCompactObjectHeaders", "-XX:-AlignVector");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-UseCompactObjectHeaders", "-XX:+AlignVector");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+UseCompactObjectHeaders", "-XX:-AlignVector");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+UseCompactObjectHeaders", "-XX:+AlignVector");
     }
 
     @Run(test = {"test1"})

--- a/test/hotspot/jtreg/compiler/loopstripmining/AntiDependentLoadInOuterStripMinedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/AntiDependentLoadInOuterStripMinedLoop.java
@@ -26,7 +26,7 @@
  * @bug 8229483
  * @summary Sinking load out of loop may trigger: assert(found_sfpt) failed: no node in loop that's not input to safepoint
  *
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:LoopMaxUnroll=0 AntiDependentLoadInOuterStripMinedLoop
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:LoopMaxUnroll=0 AntiDependentLoadInOuterStripMinedLoop
  *
  */
 

--- a/test/hotspot/jtreg/compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java
@@ -26,7 +26,7 @@
  * @bug 8229450
  * @summary shared an identical bool node with a strip-mined loop
  *
- * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:LoopMaxUnroll=0 -XX:CompileCommand=dontinline,LoadDependsOnIfIdenticalToLoopExit::not_inlined -XX:CompileCommand=compileonly,LoadDependsOnIfIdenticalToLoopExit::test1 LoadDependsOnIfIdenticalToLoopExit
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:LoopMaxUnroll=0 -XX:CompileCommand=dontinline,LoadDependsOnIfIdenticalToLoopExit::not_inlined -XX:CompileCommand=compileonly,LoadDependsOnIfIdenticalToLoopExit::test1 LoadDependsOnIfIdenticalToLoopExit
  *
  */
 

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestConservativeAntiDep.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestConservativeAntiDep.java
@@ -26,7 +26,7 @@
  * @bug 8231550
  * @summary C2: ShouldNotReachHere() in verify_strip_mined_scheduling
  *
- * @run main/othervm -XX:-BackgroundCompilation -XX:LoopMaxUnroll=0 TestConservativeAntiDep
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-BackgroundCompilation -XX:LoopMaxUnroll=0 TestConservativeAntiDep
  *
  */
 

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestEliminatedLoadPinnedOnBackedge.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestEliminatedLoadPinnedOnBackedge.java
@@ -26,7 +26,7 @@
  * @bug 8257575
  * @summary C2: "failed: only phis" assert failure in loop strip mining verfication
  *
- * @run main/othervm -XX:LoopUnrollLimit=0 -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestEliminatedLoadPinnedOnBackedge::notInlined
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:LoopUnrollLimit=0 -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestEliminatedLoadPinnedOnBackedge::notInlined
  *                    -XX:CompileCommand=inline,TestEliminatedLoadPinnedOnBackedge::inlined TestEliminatedLoadPinnedOnBackedge
  *
  */

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java
@@ -26,7 +26,7 @@
  * @bug 8263303
  * @summary C2 compilation fails with assert(found_sfpt) failed: no node in loop that's not input to safepoint
  *
- * @run main/othervm -XX:-BackgroundCompilation -XX:LoopUnrollLimit=0 TestPinnedUseInOuterLSMUnusedBySfpt
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-BackgroundCompilation -XX:LoopUnrollLimit=0 TestPinnedUseInOuterLSMUnusedBySfpt
  *
  */
 

--- a/test/hotspot/jtreg/compiler/print/PrintInlining.java
+++ b/test/hotspot/jtreg/compiler/print/PrintInlining.java
@@ -29,7 +29,7 @@
  *                   compiler.print.PrintInlining
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining
  *                   compiler.print.PrintInlining
- * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+PrintIntrinsics
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+PrintIntrinsics
  *                   compiler.print.PrintInlining
  */
 

--- a/test/hotspot/jtreg/compiler/rangechecks/RangeCheckEliminationScaleNotOne.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/RangeCheckEliminationScaleNotOne.java
@@ -26,8 +26,8 @@
  * @bug 8215265
  * @summary C2: range check elimination may allow illegal out of bound access
  *
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:-UseLoopPredicate RangeCheckEliminationScaleNotOne
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:+UseLoopPredicate RangeCheckEliminationScaleNotOne
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:-UseLoopPredicate RangeCheckEliminationScaleNotOne
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:+UseLoopPredicate RangeCheckEliminationScaleNotOne
  *
  */
 

--- a/test/hotspot/jtreg/compiler/rangechecks/TestArrayAccessAboveRCAfterRCCastIIEliminated.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestArrayAccessAboveRCAfterRCCastIIEliminated.java
@@ -29,7 +29,7 @@
  * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
  *                   -XX:CompileCommand=dontinline,TestArrayAccessAboveRCAfterRCCastIIEliminated::notInlined
  *                   TestArrayAccessAboveRCAfterRCCastIIEliminated
- * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
  *                   -XX:CompileCommand=dontinline,TestArrayAccessAboveRCAfterRCCastIIEliminated::notInlined
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM TestArrayAccessAboveRCAfterRCCastIIEliminated
  * @run main TestArrayAccessAboveRCAfterRCCastIIEliminated

--- a/test/hotspot/jtreg/compiler/rangechecks/TestArrayAccessAboveRCAfterUnswitching.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestArrayAccessAboveRCAfterUnswitching.java
@@ -25,9 +25,9 @@
  * @test
  * @bug 8323274
  * @summary loop unswitching can cause an array load to become dependent on a test other than its range check
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileOnly=TestArrayAccessAboveRCAfterUnswitching::test
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileOnly=TestArrayAccessAboveRCAfterUnswitching::test
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=148059521 TestArrayAccessAboveRCAfterUnswitching
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileOnly=TestArrayAccessAboveRCAfterUnswitching::test
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileOnly=TestArrayAccessAboveRCAfterUnswitching::test
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM TestArrayAccessAboveRCAfterUnswitching
  */
 

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUUnderflow.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUUnderflow.java
@@ -27,7 +27,8 @@
  * @summary Dominator failure because ConvL2I node becomes TOP, kills data-flow, but range-check does not collapse
  *          due to insufficient overflow/underflow handling in CmpUNode::Value.
  *
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -Xcomp -XX:-TieredCompilation
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -Xcomp -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,compiler.rangechecks.TestRangeCheckCmpUUnderflow::*
  *                   -XX:RepeatCompilation=300
  *                   compiler.rangechecks.TestRangeCheckCmpUUnderflow

--- a/test/hotspot/jtreg/compiler/runtime/safepoints/TestMachTempsAcrossSafepoints.java
+++ b/test/hotspot/jtreg/compiler/runtime/safepoints/TestMachTempsAcrossSafepoints.java
@@ -56,8 +56,8 @@ public class TestMachTempsAcrossSafepoints {
 
     public static void main(String[] args) throws Exception {
         String inlineCmd = "-XX:CompileCommand=inline,java.lang.ref.SoftReference::get";
-        TestFramework.runWithFlags(inlineCmd, "-XX:+StressGCM", "-XX:+StressLCM", "-XX:StressSeed=1");
-        TestFramework.runWithFlags(inlineCmd, "-XX:+StressGCM", "-XX:+StressLCM");
+        TestFramework.runWithFlags(inlineCmd, "-XX:+IgnoreUnrecognizedVMOptions", "-XX:+StressGCM", "-XX:+StressLCM", "-XX:StressSeed=1");
+        TestFramework.runWithFlags(inlineCmd, "-XX:+IgnoreUnrecognizedVMOptions", "-XX:+StressGCM", "-XX:+StressLCM");
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/splitif/TestCrashAtIGVNSplitIfSubType.java
+++ b/test/hotspot/jtreg/compiler/splitif/TestCrashAtIGVNSplitIfSubType.java
@@ -25,8 +25,8 @@
  * @test
  * @bug 8303279
  * @summary C2: crash in SubTypeCheckNode::sub() at IGVN split if
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=598200189 TestCrashAtIGVNSplitIfSubType
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN TestCrashAtIGVNSplitIfSubType
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=598200189 TestCrashAtIGVNSplitIfSubType
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN TestCrashAtIGVNSplitIfSubType
  */
 
 public class TestCrashAtIGVNSplitIfSubType {

--- a/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I.java
+++ b/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I.java
@@ -25,11 +25,11 @@
  * @test
  * @bug 8331575
  * @summary C2: crash when ConvL2I is split thru phi at LongCountedLoop
- * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=92643864 TestLongCountedLoopConvL2I
- * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM TestLongCountedLoopConvL2I
- * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-BackgroundCompilation -XX:-TieredCompilation
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM TestLongCountedLoopConvL2I
  */
 

--- a/test/hotspot/jtreg/compiler/types/TestCheckCastPPBecomesTOP.java
+++ b/test/hotspot/jtreg/compiler/types/TestCheckCastPPBecomesTOP.java
@@ -27,7 +27,7 @@
  * @summary C2: SIGSEGV in PhaseIdealLoop::push_pinned_nodes_thru_region
  * @requires vm.gc.Parallel
  *
- * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
  *                   -XX:CompileOnly=TestCheckCastPPBecomesTOP::test1 -XX:LoopMaxUnroll=0
  *                   -XX:CompileCommand=dontinline,TestCheckCastPPBecomesTOP::notInlined -XX:+UseParallelGC TestCheckCastPPBecomesTOP
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation

--- a/test/hotspot/jtreg/compiler/vectorapi/TestLongVectorNeg.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestLongVectorNeg.java
@@ -31,7 +31,8 @@ import jdk.incubator.vector.LongVector;
  * @summary Test that LongVector.neg is properly handled by the _VectorUnaryOp C2 intrinsic
  * @modules jdk.incubator.vector
  * @requires vm.debug
- * @run main/othervm -XX:-TieredCompilation -XX:+AlwaysIncrementalInline -Xbatch
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-TieredCompilation -XX:+AlwaysIncrementalInline -Xbatch
  *                   -XX:CompileCommand=dontinline,compiler.vectorapi.TestLongVectorNeg::test
  *                   compiler.vectorapi.TestLongVectorNeg
  */

--- a/test/hotspot/jtreg/compiler/vectorapi/TestNoInline.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestNoInline.java
@@ -32,7 +32,7 @@ import jdk.incubator.vector.VectorSpecies;
  * @modules jdk.incubator.vector
  *
  * @run main/othervm -Xbatch -XX:-Inline            compiler.vectorapi.TestNoInline
- * @run main/othervm -Xbatch -XX:-IncrementalInline compiler.vectorapi.TestNoInline
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:-IncrementalInline compiler.vectorapi.TestNoInline
  */
 public class TestNoInline {
     static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_PREFERRED;

--- a/test/hotspot/jtreg/compiler/vectorization/TestReplicateAtConv.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReplicateAtConv.java
@@ -26,7 +26,7 @@
  * @bug 8341834 8343747
  * @summary Replicate node at a VectorCast (ConvL2I) causes superword to fail
  * @run main/othervm -XX:CompileCommand=compileonly,TestReplicateAtConv::test -Xcomp TestReplicateAtConv
- * @run main/othervm -XX:CompileCommand=compileonly,TestReplicateAtConv::test -Xcomp -XX:MaxVectorSize=8 TestReplicateAtConv
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:CompileCommand=compileonly,TestReplicateAtConv::test -Xcomp -XX:MaxVectorSize=8 TestReplicateAtConv
  */
 
 public class TestReplicateAtConv {

--- a/test/hotspot/jtreg/compiler/vectorization/TestReplicateLoopIV.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReplicateLoopIV.java
@@ -26,7 +26,7 @@
  * @bug 8286125
  * @summary C2: "bad AD file" with PopulateIndex on x86_64
  *
- * @run main/othervm -Xbatch -XX:MaxVectorSize=16 compiler.vectorization.TestReplicateLoopIV
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xbatch -XX:MaxVectorSize=16 compiler.vectorization.TestReplicateLoopIV
  */
 
 package compiler.vectorization;


### PR DESCRIPTION
This change adds ` -XX:-IgnoreUnrecognizedVMOptions` to problematic tests (or `@requires vm.compiler2.enabled` in one case), to prevent failures `Unrecognized VM option` on client VM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8252473](https://bugs.openjdk.org/browse/JDK-8252473): [TESTBUG] compiler tests fail with minimal VM: Unrecognized VM option (**Bug** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24262/head:pull/24262` \
`$ git checkout pull/24262`

Update a local copy of the PR: \
`$ git checkout pull/24262` \
`$ git pull https://git.openjdk.org/jdk.git pull/24262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24262`

View PR using the GUI difftool: \
`$ git pr show -t 24262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24262.diff">https://git.openjdk.org/jdk/pull/24262.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24262#issuecomment-2755284467)
</details>
