### PR TITLE
8352906: stdout/err.encoding on Windows set by incorrect Win32 call

### DIFF
--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -45,7 +45,7 @@
 #endif
 
 typedef void (WINAPI *PGNSI)(LPSYSTEM_INFO);
-static boolean SetupI18nProps(LCID lcid, char** language, char** script, char** country,
+static BOOL SetupI18nProps(LCID lcid, char** language, char** script, char** country,
                char** variant, char** encoding);
 
 #define PROPSIZE 9      // eight-letter + null terminator
@@ -128,7 +128,7 @@ getEncodingInternal(LCID lcid)
     return ret;
 }
 
-static char* getConsoleEncoding(boolean output)
+static char* getConsoleEncoding(BOOL output)
 {
     size_t buflen = 16;
     char* buf = malloc(buflen);
@@ -225,7 +225,7 @@ getHomeFromShell32()
     return u_path;
 }
 
-static boolean
+static BOOL
 haveMMX(void)
 {
     return IsProcessorFeaturePresent(PF_MMX_INSTRUCTIONS_AVAILABLE);
@@ -255,7 +255,7 @@ cpu_isalist(void)
     return NULL;
 }
 
-static boolean
+static BOOL
 SetupI18nProps(LCID lcid, char** language, char** script, char** country,
                char** variant, char** encoding) {
     /* script */
@@ -347,8 +347,8 @@ GetJavaProperties(JNIEnv* env)
     /* OS properties */
     {
         char buf[100];
-        boolean is_workstation;
-        boolean is_64bit;
+        BOOL is_workstation;
+        BOOL is_64bit;
         DWORD platformId;
         {
             OSVERSIONINFOEX ver;

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -141,12 +141,17 @@ static char* getConsoleEncoding(BOOL output)
     } else {
         cp = GetConsoleCP();
     }
-    if (cp >= 874 && cp <= 950)
+    if (cp >= 874 && cp <= 950) {
         snprintf(buf, buflen, "ms%d", cp);
-    else if (cp == 65001)
+    } else if (cp == 65001) {
         snprintf(buf, buflen, "UTF-8");
-    else
+    } else if (cp == 0) {
+        // Failed to get the console code page
+        free(buf);
+        buf = NULL;
+    } else {
         snprintf(buf, buflen, "cp%d", cp);
+    }
     return buf;
 }
 

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ getEncodingInternal(LCID lcid)
     return ret;
 }
 
-static char* getConsoleEncoding()
+static char* getConsoleEncoding(boolean output)
 {
     size_t buflen = 16;
     char* buf = malloc(buflen);
@@ -136,7 +136,11 @@ static char* getConsoleEncoding()
     if (buf == NULL) {
         return NULL;
     }
-    cp = GetConsoleCP();
+    if (output) {
+        cp = GetConsoleOutputCP();
+    } else {
+        cp = GetConsoleCP();
+    }
     if (cp >= 874 && cp <= 950)
         snprintf(buf, buflen, "ms%d", cp);
     else if (cp == 65001)
@@ -677,7 +681,7 @@ GetJavaProperties(JNIEnv* env)
             hStdOutErr = GetStdHandle(STD_OUTPUT_HANDLE);
             if (hStdOutErr != INVALID_HANDLE_VALUE &&
                 GetFileType(hStdOutErr) == FILE_TYPE_CHAR) {
-                sprops.stdout_encoding = getConsoleEncoding();
+                sprops.stdout_encoding = getConsoleEncoding(TRUE);
             }
             hStdOutErr = GetStdHandle(STD_ERROR_HANDLE);
             if (hStdOutErr != INVALID_HANDLE_VALUE &&
@@ -685,7 +689,7 @@ GetJavaProperties(JNIEnv* env)
                 if (sprops.stdout_encoding != NULL)
                     sprops.stderr_encoding = sprops.stdout_encoding;
                 else
-                    sprops.stderr_encoding = getConsoleEncoding();
+                    sprops.stderr_encoding = getConsoleEncoding(TRUE);
             }
         }
     }


### PR DESCRIPTION
Those system property values on Windows were derived from Windows' `GetConsoleCP()` call, but they should have been taken from `GetConsoleOutputCP()`. Replacing the incorrect call with the correct one won't change any behavior, as both calls return the same value by default (`GetOEMCP()`). However, it is still the right thing to do.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352906](https://bugs.openjdk.org/browse/JDK-8352906): stdout/err.encoding on Windows set by incorrect Win32 call (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24263/head:pull/24263` \
`$ git checkout pull/24263`

Update a local copy of the PR: \
`$ git checkout pull/24263` \
`$ git pull https://git.openjdk.org/jdk.git pull/24263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24263`

View PR using the GUI difftool: \
`$ git pr show -t 24263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24263.diff">https://git.openjdk.org/jdk/pull/24263.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24263#issuecomment-2755480455)
</details>
