### PR TITLE
8352918: Shenandoah: Verifier does not deactivate barriers as intended

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -46,12 +46,18 @@
 
 ShenandoahGCStateResetter::ShenandoahGCStateResetter() :
   _heap(ShenandoahHeap::heap()),
-  _gc_state(_heap->gc_state()) {
+  _gc_state(_heap->gc_state()),
+  _gc_state_changed(_heap->_gc_state_changed) {
+  // Clear state to deactivate barriers. Indicate that state has changed
+  // so that verifier threads will use this value, rather than thread local
+  // values (which we are _not_ changing here).
   _heap->_gc_state.clear();
+  _heap->_gc_state_changed = true;
 }
 
 ShenandoahGCStateResetter::~ShenandoahGCStateResetter() {
   _heap->_gc_state.set(_gc_state);
+  _heap->_gc_state_changed = _gc_state_changed;
   assert(_heap->gc_state() == _gc_state, "Should be restored");
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -46,8 +46,8 @@
 
 ShenandoahGCStateResetter::ShenandoahGCStateResetter() :
   _heap(ShenandoahHeap::heap()),
-  _gc_state(_heap->gc_state()),
-  _gc_state_changed(_heap->_gc_state_changed) {
+  _saved_gc_state(_heap->gc_state()),
+  _saved_gc_state_changed(_heap->_gc_state_changed) {
   // Clear state to deactivate barriers. Indicate that state has changed
   // so that verifier threads will use this value, rather than thread local
   // values (which we are _not_ changing here).
@@ -56,9 +56,9 @@ ShenandoahGCStateResetter::ShenandoahGCStateResetter() :
 }
 
 ShenandoahGCStateResetter::~ShenandoahGCStateResetter() {
-  _heap->_gc_state.set(_gc_state);
-  _heap->_gc_state_changed = _gc_state_changed;
-  assert(_heap->gc_state() == _gc_state, "Should be restored");
+  _heap->_gc_state.set(_saved_gc_state);
+  _heap->_gc_state_changed = _saved_gc_state_changed;
+  assert(_heap->gc_state() == _saved_gc_state, "Should be restored");
 }
 
 void ShenandoahRootVerifier::roots_do(OopIterateClosure* oops) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
@@ -33,6 +33,7 @@ class ShenandoahGCStateResetter : public StackObj {
 private:
   ShenandoahHeap* const _heap;
   const char _gc_state;
+  const bool _gc_state_changed;
 
 public:
   ShenandoahGCStateResetter();

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
@@ -32,8 +32,8 @@
 class ShenandoahGCStateResetter : public StackObj {
 private:
   ShenandoahHeap* const _heap;
-  const char _gc_state;
-  const bool _gc_state_changed;
+  const char _saved_gc_state;
+  const bool _saved_gc_state_changed;
 
 public:
   ShenandoahGCStateResetter();


### PR DESCRIPTION
When verifying reachable objects, Shenandoah's verifier clears the `_gc_state` with the intention of deactivating barriers. However, the mechanism for this is a `friend` of the heap and does not toggle the flag to cause threads to use the value set on the verifier's safepoint. The net effect here is that the barriers are _not_ deactivated during verification. Leaving the barriers on while the verifier traverses the heap may have unintended consequences (cards marked, objects evacuated, etc.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352918](https://bugs.openjdk.org/browse/JDK-8352918): Shenandoah: Verifier does not deactivate barriers as intended (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24264/head:pull/24264` \
`$ git checkout pull/24264`

Update a local copy of the PR: \
`$ git checkout pull/24264` \
`$ git pull https://git.openjdk.org/jdk.git pull/24264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24264`

View PR using the GUI difftool: \
`$ git pr show -t 24264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24264.diff">https://git.openjdk.org/jdk/pull/24264.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24264#issuecomment-2755523445)
</details>
