### PR TITLE
8352755: Misconceptions about j.text.DecimalFormat digits during parsing

### DIFF
--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2169,14 +2169,9 @@ public final class CompactNumberFormat extends NumberFormat {
     }
 
     /**
-     * Sets the maximum number of digits allowed in the integer portion of a
-     * number.
-     * The maximum allowed integer range is 309, if the {@code newValue} &gt; 309,
-     * then the maximum integer digits count is set to 309. Negative input
-     * values are replaced with 0.
-     *
-     * @param newValue the maximum number of integer digits to be shown
-     * @see #getMaximumIntegerDigits()
+     * {@inheritDoc}
+     * <p>The maximum allowed integer range is 309, if the {@code newValue} &gt;
+     * 309, then the maximum integer digits count is set to 309.
      */
     @Override
     public void setMaximumIntegerDigits(int newValue) {
@@ -2194,14 +2189,9 @@ public final class CompactNumberFormat extends NumberFormat {
     }
 
     /**
-     * Sets the minimum number of digits allowed in the integer portion of a
-     * number.
-     * The maximum allowed integer range is 309, if the {@code newValue} &gt; 309,
-     * then the minimum integer digits count is set to 309. Negative input
-     * values are replaced with 0.
-     *
-     * @param newValue the minimum number of integer digits to be shown
-     * @see #getMinimumIntegerDigits()
+     * {@inheritDoc}
+     * <p>The maximum allowed integer range is 309, if the {@code newValue} &gt;
+     * 309, then the minimum integer digits count is set to 309.
      */
     @Override
     public void setMinimumIntegerDigits(int newValue) {
@@ -2219,14 +2209,9 @@ public final class CompactNumberFormat extends NumberFormat {
     }
 
     /**
-     * Sets the minimum number of digits allowed in the fraction portion of a
-     * number.
-     * The maximum allowed fraction range is 340, if the {@code newValue} &gt; 340,
-     * then the minimum fraction digits count is set to 340. Negative input
-     * values are replaced with 0.
-     *
-     * @param newValue the minimum number of fraction digits to be shown
-     * @see #getMinimumFractionDigits()
+     * {@inheritDoc}
+     * <p>The maximum allowed fraction range is 340, if the {@code newValue} &gt;
+     * 340, then the minimum fraction digits count is set to 340.
      */
     @Override
     public void setMinimumFractionDigits(int newValue) {
@@ -2245,14 +2230,9 @@ public final class CompactNumberFormat extends NumberFormat {
     }
 
     /**
-     * Sets the maximum number of digits allowed in the fraction portion of a
-     * number.
-     * The maximum allowed fraction range is 340, if the {@code newValue} &gt; 340,
-     * then the maximum fraction digits count is set to 340. Negative input
-     * values are replaced with 0.
-     *
-     * @param newValue the maximum number of fraction digits to be shown
-     * @see #getMaximumFractionDigits()
+     * {@inheritDoc}
+     * <p>The maximum allowed fraction range is 340, if the {@code newValue} &gt;
+     * 340, then the maximum fraction digits count is set to 340.
      */
     @Override
     public void setMaximumFractionDigits(int newValue) {

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -110,6 +110,10 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * defined by {@link Character#digit Character.digit}, are recognized.
  *
  * <h3 id="digit_limits"> Integer and Fraction Digit Limits </h3>
+ * The integer and fraction digit limits are set by either applying a {@link ##patterns
+ * pattern} or using one of the appropriate {@code DecimalFormat} setter methods,
+ * for example, {@link #setMinimumFractionDigits(int)}. These limits have no impact
+ * on parsing behavior.
  * @implSpec
  * When formatting a {@code Number} other than {@code BigInteger} and
  * {@code BigDecimal}, {@code 309} is used as the upper limit for integer digits,
@@ -3972,9 +3976,8 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * Sets the maximum number of digits allowed in the integer portion of a
-     * number. Negative input values are replaced with 0.
-     * @see NumberFormat#setMaximumIntegerDigits
+     * {@inheritDoc}
+     * @see #getMaximumIntegerDigits()
      * @see ##digit_limits Integer and Fraction Digit Limits
      */
     @Override
@@ -3989,9 +3992,8 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * Sets the minimum number of digits allowed in the integer portion of a
-     * number. Negative input values are replaced with 0.
-     * @see NumberFormat#setMinimumIntegerDigits
+     * {@inheritDoc}
+     * @see #getMinimumIntegerDigits()
      * @see ##digit_limits Integer and Fraction Digit Limits
      */
     @Override
@@ -4006,9 +4008,8 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * Sets the maximum number of digits allowed in the fraction portion of a
-     * number. Negative input values are replaced with 0.
-     * @see NumberFormat#setMaximumFractionDigits
+     * {@inheritDoc}
+     * @see #getMaximumFractionDigits()
      * @see ##digit_limits Integer and Fraction Digit Limits
      */
     @Override
@@ -4023,9 +4024,8 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * Sets the minimum number of digits allowed in the fraction portion of a
-     * number. Negative input values are replaced with 0.
-     * @see NumberFormat#setMinimumFractionDigits
+     * {@inheritDoc}
+     * @see #getMinimumFractionDigits()
      * @see ##digit_limits Integer and Fraction Digit Limits
      */
     @Override
@@ -4040,10 +4040,11 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * Gets the maximum number of digits allowed in the integer portion of a
-     * number. The maximum number of integer digits can be set by either {@link #setMaximumIntegerDigits(int)}
-     * or {@link #applyPattern(String)}. See the {@link ##patterns Pattern Section} for
-     * comprehensive rules regarding maximum integer digits in patterns.
+     * {@inheritDoc}
+     * <p>The maximum number of integer digits can be set by either {@link
+     * #setMaximumIntegerDigits(int)} or {@link #applyPattern(String)}.
+     * See the {@link ##patterns Pattern Section} for comprehensive rules regarding
+     * maximum integer digits in patterns.
      * @see #setMaximumIntegerDigits
      * @see ##digit_limits Integer and Fraction Digit Limits
      */
@@ -4053,8 +4054,7 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * Gets the minimum number of digits allowed in the integer portion of a
-     * number.
+     * {@inheritDoc}
      * @see #setMinimumIntegerDigits
      * @see ##digit_limits Integer and Fraction Digit Limits
      */
@@ -4064,8 +4064,7 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * Gets the maximum number of digits allowed in the fraction portion of a
-     * number.
+     * {@inheritDoc}
      * @see #setMaximumFractionDigits
      * @see ##digit_limits Integer and Fraction Digit Limits
      */
@@ -4075,8 +4074,7 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * Gets the minimum number of digits allowed in the fraction portion of a
-     * number.
+     * {@inheritDoc}
      * @see #setMinimumFractionDigits
      * @see ##digit_limits Integer and Fraction Digit Limits
      */

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -129,9 +129,9 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * <ul>
  * <li> {@link #setParseIntegerOnly(boolean)}; when {@code true}, will only return the
  * integer portion of the number parsed from the String.
- * <li> {@link #setMinimumFractionDigits(int)}; Use to adjust the expected digits when
- * formatting. Use any of the other minimum/maximum or fraction/integer setter methods
- * in the same manner.
+ * <li> {@link #setMinimumFractionDigits(int)}; Use to adjust the expected digits
+ * when formatting. Use any of the other minimum/maximum or fraction/integer
+ * setter methods in the same manner. These methods have no impact on parsing behavior.
  * <li> {@link #setGroupingUsed(boolean)}; when {@code true}, formatted numbers will be displayed
  * with grouping separators. Additionally, when {@code false}, parsing will not expect
  * grouping separators in the parsed String.
@@ -918,7 +918,7 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Returns the maximum number of digits allowed in the integer portion of a
-     * number.
+     * number during formatting.
      *
      * @return the maximum number of digits
      * @see #setMaximumIntegerDigits
@@ -929,14 +929,18 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Sets the maximum number of digits allowed in the integer portion of a
-     * number. maximumIntegerDigits must be &ge; minimumIntegerDigits.  If the
-     * new value for maximumIntegerDigits is less than the current value
-     * of minimumIntegerDigits, then minimumIntegerDigits will also be set to
-     * the new value.
+     * number during formatting. {@code maximumIntegerDigits} must be &ge;
+     * {@code minimumIntegerDigits}. If the new value for {@code
+     * maximumIntegerDigits} is less than the current value of
+     * {@code minimumIntegerDigits}, then {@code minimumIntegerDigits} will
+     * also be set to the new value.
+     *
+     * @apiNote
+     * A concrete subclass may enforce an upper limit to this value appropriate
+     * to the numeric type being formatted.
      *
      * @param newValue the maximum number of integer digits to be shown; if
-     * less than zero, then zero is used. The concrete subclass may enforce an
-     * upper limit to this value appropriate to the numeric type being formatted.
+     * less than zero, then zero is used.
      * @see #getMaximumIntegerDigits
      */
     public void setMaximumIntegerDigits(int newValue) {
@@ -948,7 +952,7 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Returns the minimum number of digits allowed in the integer portion of a
-     * number.
+     * number during formatting.
      *
      * @return the minimum number of digits
      * @see #setMinimumIntegerDigits
@@ -959,14 +963,17 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Sets the minimum number of digits allowed in the integer portion of a
-     * number. minimumIntegerDigits must be &le; maximumIntegerDigits.  If the
-     * new value for minimumIntegerDigits exceeds the current value
-     * of maximumIntegerDigits, then maximumIntegerDigits will also be set to
-     * the new value
+     * number during formatting. {@code minimumIntegerDigits} must be &le;
+     * {@code maximumIntegerDigits}. If the new value for {@code minimumIntegerDigits}
+     * exceeds the current value of {@code maximumIntegerDigits}, then {@code
+     * maximumIntegerDigits} will also be set to the new value.
+     *
+     * @apiNote
+     * A subclass may enforce an upper limit to this value appropriate
+     * to the numeric type being formatted.
      *
      * @param newValue the minimum number of integer digits to be shown; if
-     * less than zero, then zero is used. The concrete subclass may enforce an
-     * upper limit to this value appropriate to the numeric type being formatted.
+     * less than zero, then zero is used.
      * @see #getMinimumIntegerDigits
      */
     public void setMinimumIntegerDigits(int newValue) {
@@ -978,7 +985,7 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Returns the maximum number of digits allowed in the fraction portion of a
-     * number.
+     * number during formatting.
      *
      * @return the maximum number of digits.
      * @see #setMaximumFractionDigits
@@ -989,14 +996,17 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Sets the maximum number of digits allowed in the fraction portion of a
-     * number. maximumFractionDigits must be &ge; minimumFractionDigits.  If the
-     * new value for maximumFractionDigits is less than the current value
-     * of minimumFractionDigits, then minimumFractionDigits will also be set to
-     * the new value.
+     * number during formatting. {@code maximumFractionDigits} must be &ge;
+     * {@code minimumFractionDigits}. If the new value for {@code maximumFractionDigits}
+     * is less than the current value of {@code minimumFractionDigits}, then
+     * {@code minimumFractionDigits} will also be set to the new value.
+     *
+     * @apiNote
+     * A subclass may enforce an upper limit to this value appropriate
+     * to the numeric type being formatted.
      *
      * @param newValue the maximum number of fraction digits to be shown; if
-     * less than zero, then zero is used. The concrete subclass may enforce an
-     * upper limit to this value appropriate to the numeric type being formatted.
+     * less than zero, then zero is used.
      * @see #getMaximumFractionDigits
      */
     public void setMaximumFractionDigits(int newValue) {
@@ -1008,7 +1018,7 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Returns the minimum number of digits allowed in the fraction portion of a
-     * number.
+     * number during formatting.
      *
      * @return the minimum number of digits
      * @see #setMinimumFractionDigits
@@ -1019,14 +1029,18 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Sets the minimum number of digits allowed in the fraction portion of a
-     * number. minimumFractionDigits must be &le; maximumFractionDigits.  If the
-     * new value for minimumFractionDigits exceeds the current value
-     * of maximumFractionDigits, then maximumFractionDigits will also be set to
-     * the new value
+     * number during formatting. {@code minimumFractionDigits} must be &le;
+     * {@code maximumFractionDigits}. If the new value for {@code
+     * minimumFractionDigits} exceeds the current value of {@code
+     * maximumFractionDigits}, then {@code maximumFractionDigits} will also be
+     * set to the new value.
+     *
+     * @apiNote
+     * A concrete subclass may enforce an upper limit to this value
+     * appropriate to the numeric type being formatted.
      *
      * @param newValue the minimum number of fraction digits to be shown; if
-     * less than zero, then zero is used. The concrete subclass may enforce an
-     * upper limit to this value appropriate to the numeric type being formatted.
+     * less than zero, then zero is used.
      * @see #getMinimumFractionDigits
      */
     public void setMinimumFractionDigits(int newValue) {


### PR DESCRIPTION
Please review this PR which clarifies the behavior for integer and fraction limits in NumberFormat and implementing classes. An associated CSR is filed.

There have been a few bugs submitted which indicate a misconception that these limits impact parsing. The actual behavior is that these limits only affect formatting. The specification is vague regarding this, and can be explicitly updated to eliminate confusion. As the implementing classes are updated to use `inheritDoc`, some shuffling around in the method specs are included in this change as well.

Alternatively I considered making this change as implementation specific to DecimalFormat and CompactNumberFormat only. (i.e. leave flexibility for other NumberFormat subclasses to define their own behavior on whether the limits affect parsing.) I am open to this option as well, but initially decided against it as 
1) Unlike formatting, it seems like a rare use case that you would want to suppress the range of digits of accepted during parsing. `setParseIntegerOnly()` already provides functionality to toggle between integer and fraction parsing.
2) The limits affecting formatting only has been the long-standing behavior for all the subclasses of NumberFormat provided by the OpenJDK reference implementation.