### PR TITLE
8353009: Improve documentation for Windows AArch64 builds

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -1723,9 +1723,10 @@ packages in the sysroot, configure the build with
 --with-sysroot=$SYSROOT</code></pre>
 <p>and run <code>make</code> normally.</p>
 <h4 id="building-for-windows-aarch64">Building for Windows AArch64</h4>
-<p>To generate Windows AArch64 builds using Cygwin, the target platform
-needs to be set to <code>aarch64-unknown-cygwin</code>. Configure the
-build with <code>--openjdk-target</code>:</p>
+<p>To generate Windows AArch64 builds using Cygwin on a Windows x64
+machine, the target platform needs to be set to
+<code>aarch64-unknown-cygwin</code> to enable cross compilation.
+Configure the build with <code>--openjdk-target</code>:</p>
 <pre><code>bash configure \
   --with-boot-jdk=$BOOT_JDK \
   --openjdk-target=aarch64-unknown-cygwin</code></pre>

--- a/doc/building.html
+++ b/doc/building.html
@@ -1732,16 +1732,10 @@ the installer as follows in a Windows command prompt:</p>
 --add Microsoft.VisualStudio.Component.VC.CoreBuildTools ^
 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 ^
 --add Microsoft.VisualStudio.Component.Windows11SDK.22621</code></pre>
-<p>When installation is complete, configure the build using the same
-command used with a full Visual Studio installation:</p>
-<pre><code>bash configure --with-boot-jdk=$BOOT_JDK</code></pre>
 <p>To generate Windows AArch64 builds using Cygwin on a Windows x64
-machine, the target platform needs to be set to
-<code>aarch64-unknown-cygwin</code> to enable cross compilation.
-Configure the build with <code>--openjdk-target</code>:</p>
-<pre><code>bash configure \
-  --with-boot-jdk=$BOOT_JDK \
-  --openjdk-target=aarch64-unknown-cygwin</code></pre>
+machine, you must set the proper target platform by adding
+<code>--openjdk-target=aarch64-unknown-cygwin</code> to your configure
+command line.</p>
 <h2 id="build-performance">Build Performance</h2>
 <p>Building the JDK requires a lot of horsepower. Some of the build
 tools can be adjusted to utilize more or less of resources such as

--- a/doc/building.html
+++ b/doc/building.html
@@ -1723,13 +1723,6 @@ packages in the sysroot, configure the build with
 --with-sysroot=$SYSROOT</code></pre>
 <p>and run <code>make</code> normally.</p>
 <h4 id="building-for-windows-aarch64">Building for Windows AArch64</h4>
-<p>Cygwin on a Windows AArch64 machine is an x86_64 environment. As a
-result, the build environment defaults to generating Windows x86_64
-builds. To work around this behavior, use the <code>--build</code>
-option to generate a native Windows AArch64 build:</p>
-<pre><code>bash configure \
-  --with-boot-jdk=$BOOT_JDK \
-  --build=aarch64-unknown-cygwin</code></pre>
 <p>To generate Windows AArch64 builds using Cygwin on a Windows x64
 machine, the target platform needs to be set to
 <code>aarch64-unknown-cygwin</code> to enable cross compilation.

--- a/doc/building.html
+++ b/doc/building.html
@@ -1722,6 +1722,13 @@ packages in the sysroot, configure the build with
 --with-devkit=$DEVKIT \
 --with-sysroot=$SYSROOT</code></pre>
 <p>and run <code>make</code> normally.</p>
+<h4 id="building-for-windows-aarch64">Building for Windows AArch64</h4>
+<p>To generate Windows AArch64 builds using Cygwin, the target platform
+needs to be set to <code>aarch64-unknown-cygwin</code>. Configure the
+build with <code>--openjdk-target</code>:</p>
+<pre><code>bash configure \
+  --with-boot-jdk=$BOOT_JDK \
+  --openjdk-target=aarch64-unknown-cygwin</code></pre>
 <h2 id="build-performance">Build Performance</h2>
 <p>Building the JDK requires a lot of horsepower. Some of the build
 tools can be adjusted to utilize more or less of resources such as

--- a/doc/building.html
+++ b/doc/building.html
@@ -1723,6 +1723,13 @@ packages in the sysroot, configure the build with
 --with-sysroot=$SYSROOT</code></pre>
 <p>and run <code>make</code> normally.</p>
 <h4 id="building-for-windows-aarch64">Building for Windows AArch64</h4>
+<p>Cygwin on a Windows AArch64 machine is an x86_64 environment. As a
+result, the build environment defaults to generating Windows x86_64
+builds. To work around this behavior, use the <code>--build</code>
+option to generate a native Windows AArch64 build:</p>
+<pre><code>bash configure \
+  --with-boot-jdk=$BOOT_JDK \
+  --build=aarch64-unknown-cygwin</code></pre>
 <p>To generate Windows AArch64 builds using Cygwin on a Windows x64
 machine, the target platform needs to be set to
 <code>aarch64-unknown-cygwin</code> to enable cross compilation.

--- a/doc/building.html
+++ b/doc/building.html
@@ -1723,6 +1723,18 @@ packages in the sysroot, configure the build with
 --with-sysroot=$SYSROOT</code></pre>
 <p>and run <code>make</code> normally.</p>
 <h4 id="building-for-windows-aarch64">Building for Windows AArch64</h4>
+<p>The Visual Studio Build Tools can be used for building the JDK
+without a full Visual Studio installation. To set up the Visual Studio
+2022 Build Tools on a Windows AArch64 machine for a native build, launch
+the installer as follows in a Windows command prompt:</p>
+<pre><code>vs_buildtools.exe --quiet --wait --norestart --nocache ^
+--installPath &quot;%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools&quot; ^
+--add Microsoft.VisualStudio.Component.VC.CoreBuildTools ^
+--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 ^
+--add Microsoft.VisualStudio.Component.Windows11SDK.22621</code></pre>
+<p>When installation is complete, configure the build using the same
+command used with a full Visual Studio installation:</p>
+<pre><code>bash configure --with-boot-jdk=$BOOT_JDK</code></pre>
 <p>To generate Windows AArch64 builds using Cygwin on a Windows x64
 machine, the target platform needs to be set to
 <code>aarch64-unknown-cygwin</code> to enable cross compilation.

--- a/doc/building.md
+++ b/doc/building.md
@@ -1457,6 +1457,17 @@ sh ./configure --with-jvm-variants=server \
 
 and run `make` normally.
 
+#### Building for Windows AArch64
+
+To generate Windows AArch64 builds using Cygwin, the target platform needs to be
+set to `aarch64-unknown-cygwin`. Configure the build with `--openjdk-target`:
+
+```
+bash configure \
+  --with-boot-jdk=$BOOT_JDK \
+  --openjdk-target=aarch64-unknown-cygwin
+```
+
 ## Build Performance
 
 Building the JDK requires a lot of horsepower. Some of the build tools can be

--- a/doc/building.md
+++ b/doc/building.md
@@ -1459,17 +1459,6 @@ and run `make` normally.
 
 #### Building for Windows AArch64
 
-Cygwin on a Windows AArch64 machine is an x86_64 environment. As a result, the
-build environment defaults to generating Windows x86_64 builds. To work around
-this behavior, use the `--build` option to generate a native Windows AArch64
-build:
-
-```
-bash configure \
-  --with-boot-jdk=$BOOT_JDK \
-  --build=aarch64-unknown-cygwin
-```
-
 To generate Windows AArch64 builds using Cygwin on a Windows x64 machine,
 the target platform needs to be set to `aarch64-unknown-cygwin` to enable
 cross compilation. Configure the build with `--openjdk-target`:

--- a/doc/building.md
+++ b/doc/building.md
@@ -1479,14 +1479,8 @@ bash configure --with-boot-jdk=$BOOT_JDK
 ```
 
 To generate Windows AArch64 builds using Cygwin on a Windows x64 machine,
-the target platform needs to be set to `aarch64-unknown-cygwin` to enable
-cross compilation. Configure the build with `--openjdk-target`:
-
-```
-bash configure \
-  --with-boot-jdk=$BOOT_JDK \
-  --openjdk-target=aarch64-unknown-cygwin
-```
+you must set the proper target platform by adding 
+`--openjdk-target=aarch64-unknown-cygwin` to your configure command line.
 
 ## Build Performance
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -1459,8 +1459,9 @@ and run `make` normally.
 
 #### Building for Windows AArch64
 
-To generate Windows AArch64 builds using Cygwin, the target platform needs to be
-set to `aarch64-unknown-cygwin`. Configure the build with `--openjdk-target`:
+To generate Windows AArch64 builds using Cygwin on a Windows x64 machine,
+the target platform needs to be set to `aarch64-unknown-cygwin` to enable
+cross compilation. Configure the build with `--openjdk-target`:
 
 ```
 bash configure \

--- a/doc/building.md
+++ b/doc/building.md
@@ -1458,6 +1458,25 @@ sh ./configure --with-jvm-variants=server \
 and run `make` normally.
 
 #### Building for Windows AArch64
+The Visual Studio Build Tools can be used for building the JDK without a full
+Visual Studio installation. To set up the Visual Studio 2022 Build Tools on a
+Windows AArch64 machine for a native build, launch the installer as follows
+in a Windows command prompt:
+
+```
+vs_buildtools.exe --quiet --wait --norestart --nocache ^
+--installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^
+--add Microsoft.VisualStudio.Component.VC.CoreBuildTools ^
+--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 ^
+--add Microsoft.VisualStudio.Component.Windows11SDK.22621
+```
+
+When installation is complete, configure the build using the same command used
+with a full Visual Studio installation:
+
+```
+bash configure --with-boot-jdk=$BOOT_JDK
+```
 
 To generate Windows AArch64 builds using Cygwin on a Windows x64 machine,
 the target platform needs to be set to `aarch64-unknown-cygwin` to enable

--- a/doc/building.md
+++ b/doc/building.md
@@ -1471,13 +1471,6 @@ vs_buildtools.exe --quiet --wait --norestart --nocache ^
 --add Microsoft.VisualStudio.Component.Windows11SDK.22621
 ```
 
-When installation is complete, configure the build using the same command used
-with a full Visual Studio installation:
-
-```
-bash configure --with-boot-jdk=$BOOT_JDK
-```
-
 To generate Windows AArch64 builds using Cygwin on a Windows x64 machine,
 you must set the proper target platform by adding 
 `--openjdk-target=aarch64-unknown-cygwin` to your configure command line.

--- a/doc/building.md
+++ b/doc/building.md
@@ -1459,6 +1459,17 @@ and run `make` normally.
 
 #### Building for Windows AArch64
 
+Cygwin on a Windows AArch64 machine is an x86_64 environment. As a result, the
+build environment defaults to generating Windows x86_64 builds. To work around
+this behavior, use the `--build` option to generate a native Windows AArch64
+build:
+
+```
+bash configure \
+  --with-boot-jdk=$BOOT_JDK \
+  --build=aarch64-unknown-cygwin
+```
+
 To generate Windows AArch64 builds using Cygwin on a Windows x64 machine,
 the target platform needs to be set to `aarch64-unknown-cygwin` to enable
 cross compilation. Configure the build with `--openjdk-target`:

--- a/doc/building.md
+++ b/doc/building.md
@@ -1472,7 +1472,7 @@ vs_buildtools.exe --quiet --wait --norestart --nocache ^
 ```
 
 To generate Windows AArch64 builds using Cygwin on a Windows x64 machine,
-you must set the proper target platform by adding 
+you must set the proper target platform by adding
 `--openjdk-target=aarch64-unknown-cygwin` to your configure command line.
 
 ## Build Performance


### PR DESCRIPTION
The target selection configuration flag for Windows AArch64 should be added to the build documentation for improved discoverability and completeness.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353009](https://bugs.openjdk.org/browse/JDK-8353009): Improve documentation for Windows AArch64 builds (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24267/head:pull/24267` \
`$ git checkout pull/24267`

Update a local copy of the PR: \
`$ git checkout pull/24267` \
`$ git pull https://git.openjdk.org/jdk.git pull/24267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24267`

View PR using the GUI difftool: \
`$ git pr show -t 24267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24267.diff">https://git.openjdk.org/jdk/pull/24267.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24267#issuecomment-2755900516)
</details>
