### PR TITLE
8353005: AIX build broken after 8352481

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -622,7 +622,7 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_CORE],
     LDCXX="$CXX"
     # Force use of lld, since that is what we expect when setting flags later on
     if test "x$TOOLCHAIN_TYPE" = xclang; then
-      if test "x$OPENJDK_BUILD_OS" != "xmacosx"; then
+      if test "x$OPENJDK_TARGET_OS" = xlinux; then
         LD="$LD -fuse-ld=lld"
         LDCXX="$LDCXX -fuse-ld=lld"
       fi


### PR DESCRIPTION
Hi all,

Apologize for the inconvenience, fix of [JDK-8352481](https://bugs.openjdk.org/browse/JDK-8352481) make AIX build broekn.

According to the implementation of makefile function `FLAGS_SETUP_LDFLAGS_HELPER` which locate in make/autoconf/flags-ldflags.m4 file, only the combination of `$TOOLCHAIN_TYPE == clang` and `$OPENJDK_TARGET_OS == linux` support lld linker. So this PR limite the use of lld on linux instead of non-macos.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353005](https://bugs.openjdk.org/browse/JDK-8353005): AIX build broken after 8352481 (**Bug** - P2)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24270/head:pull/24270` \
`$ git checkout pull/24270`

Update a local copy of the PR: \
`$ git checkout pull/24270` \
`$ git pull https://git.openjdk.org/jdk.git pull/24270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24270`

View PR using the GUI difftool: \
`$ git pr show -t 24270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24270.diff">https://git.openjdk.org/jdk/pull/24270.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24270#issuecomment-2756367053)
</details>
