### PR TITLE
8352896: LambdaExpr02.java runs wrong test class

### DIFF
--- a/test/langtools/tools/javac/lambda/LambdaExpr02.java
+++ b/test/langtools/tools/javac/lambda/LambdaExpr02.java
@@ -28,7 +28,7 @@
  *  basic test for simple lambda expressions in multiple scopes
  * @author  Brian Goetz
  * @author  Maurizio Cimadamore
- * @run main LambdaExpr01
+ * @run main LambdaExpr02
  */
 
 public class LambdaExpr02 {


### PR DESCRIPTION
Fix LambdaExpr02.java runs wrong test class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352896](https://bugs.openjdk.org/browse/JDK-8352896): LambdaExpr02.java runs wrong test class (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24277/head:pull/24277` \
`$ git checkout pull/24277`

Update a local copy of the PR: \
`$ git checkout pull/24277` \
`$ git pull https://git.openjdk.org/jdk.git pull/24277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24277`

View PR using the GUI difftool: \
`$ git pr show -t 24277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24277.diff">https://git.openjdk.org/jdk/pull/24277.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24277#issuecomment-2757930922)
</details>
