### PR TITLE
8353063: make/ide/vscode: Invalid Configuration Values

### DIFF
--- a/make/ide/vscode/hotspot/indexers/ccls-settings.txt
+++ b/make/ide/vscode/hotspot/indexers/ccls-settings.txt
@@ -22,7 +22,7 @@
 		],
 
 		// Disable conflicting features from cpptools
-		"C_Cpp.autocomplete": "Disabled",
-		"C_Cpp.errorSquiggles": "Disabled",
-		"C_Cpp.formatting": "Disabled",
-		"C_Cpp.intelliSenseEngine": "Disabled",
+		"C_Cpp.autocomplete": "disabled",
+		"C_Cpp.errorSquiggles": "disabled",
+		"C_Cpp.formatting": "disabled",
+		"C_Cpp.intelliSenseEngine": "disabled",

--- a/make/ide/vscode/hotspot/indexers/clangd-settings.txt
+++ b/make/ide/vscode/hotspot/indexers/clangd-settings.txt
@@ -11,7 +11,7 @@
 		],
 
 		// Disable conflicting features from cpptools
-		"C_Cpp.autocomplete": "Disabled",
-		"C_Cpp.errorSquiggles": "Disabled",
-		"C_Cpp.formatting": "Disabled",
-		"C_Cpp.intelliSenseEngine": "Disabled",
+		"C_Cpp.autocomplete": "disabled",
+		"C_Cpp.errorSquiggles": "disabled",
+		"C_Cpp.formatting": "disabled",
+		"C_Cpp.intelliSenseEngine": "disabled",

--- a/make/ide/vscode/hotspot/indexers/rtags-settings.txt
+++ b/make/ide/vscode/hotspot/indexers/rtags-settings.txt
@@ -8,7 +8,7 @@
 		"rtags.misc.compilationDatabaseDirectory": "{{OUTPUTDIR}}",
 
 		// Disable conflicting features from cpptools
-		"C_Cpp.autocomplete": "Disabled",
-		"C_Cpp.errorSquiggles": "Disabled",
-		"C_Cpp.formatting": "Disabled",
-		"C_Cpp.intelliSenseEngine": "Disabled",
+		"C_Cpp.autocomplete": "disabled",
+		"C_Cpp.errorSquiggles": "disabled",
+		"C_Cpp.formatting": "disabled",
+		"C_Cpp.intelliSenseEngine": "disabled",


### PR DESCRIPTION
The indexer setting templates used by the `vscode-project-*` `make` targets contain invalid configuration values. For example, `C_Cpp.formatting": "Disabled"`is invalid because VSCode (or rather the extension) expects the value to be non-capitalized. This PR fixes these invalid configuration options.

 I tested the changes by generating VSCode workspaces and checking whether VSCode complains about invalid values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353063](https://bugs.openjdk.org/browse/JDK-8353063): make/ide/vscode: Invalid Configuration Values (**Bug** - P5)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24280/head:pull/24280` \
`$ git checkout pull/24280`

Update a local copy of the PR: \
`$ git checkout pull/24280` \
`$ git pull https://git.openjdk.org/jdk.git pull/24280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24280`

View PR using the GUI difftool: \
`$ git pr show -t 24280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24280.diff">https://git.openjdk.org/jdk/pull/24280.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24280#issuecomment-2758315255)
</details>
