### PR TITLE
8352114: New test runtime/interpreter/CountBytecodesTest.java is failing

### DIFF
--- a/test/hotspot/jtreg/runtime/interpreter/CountBytecodesTest.java
+++ b/test/hotspot/jtreg/runtime/interpreter/CountBytecodesTest.java
@@ -29,7 +29,7 @@
  * @summary Test the output for CountBytecodes and validate that the counter
  *          does not overflow for more than 2^32 bytecodes counted.
  * @library /test/lib
- * @run main/othervm/timeout=300 CountBytecodesTest
+ * @run driver/timeout=300 CountBytecodesTest
  */
 
 import java.util.regex.Matcher;
@@ -61,7 +61,7 @@ public class CountBytecodesTest {
                 // while maintaining execution of more than 2^32 bytecodes.
             }
         } else {
-            OutputAnalyzer output = ProcessTools.executeTestJava("-Xint", "-XX:+CountBytecodes", "CountBytecodesTest", "test");
+            OutputAnalyzer output = ProcessTools.executeLimitedTestJava("-Xint", "-XX:+CountBytecodes", "CountBytecodesTest", "test");
             output.shouldHaveExitValue(0);
 
             // Output format: [BytecodeCounter::counter_value = 38676232802]


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352114](https://bugs.openjdk.org/browse/JDK-8352114): New test runtime/interpreter/CountBytecodesTest.java is failing (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24281/head:pull/24281` \
`$ git checkout pull/24281`

Update a local copy of the PR: \
`$ git checkout pull/24281` \
`$ git pull https://git.openjdk.org/jdk.git pull/24281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24281`

View PR using the GUI difftool: \
`$ git pr show -t 24281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24281.diff">https://git.openjdk.org/jdk/pull/24281.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24281#issuecomment-2758467073)
</details>
