### PR TITLE
8352920: Compilation failure: comparison of unsigned expression >= 0 is always true

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -178,6 +178,7 @@ class BytecodePrinter {
   }
 };
 
+#ifndef PRODUCT
 // We need a global instance to keep track of the states when the bytecodes
 // are executed. Access by multiple threads are controlled by ttyLocker.
 static BytecodePrinter _interpreter_printer;
@@ -193,6 +194,7 @@ void BytecodeTracer::trace_interpreter(const methodHandle& method, address bcp, 
     _interpreter_printer.trace(method, bcp, tos, tos2, st);
   }
 }
+#endif
 
 void BytecodeTracer::print_method_codes(const methodHandle& method, int from, int to, outputStream* st, int flags) {
   BytecodePrinter method_printer(flags);

--- a/src/hotspot/share/interpreter/bytecodeTracer.hpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.hpp
@@ -38,7 +38,7 @@ class outputStream;
 class BytecodeClosure;
 class BytecodeTracer: AllStatic {
  public:
-  static void trace_interpreter(const methodHandle& method, address bcp, uintptr_t tos, uintptr_t tos2, outputStream* st = tty);
+  NOT_PRODUCT(static void trace_interpreter(const methodHandle& method, address bcp, uintptr_t tos, uintptr_t tos2, outputStream* st = tty);)
   static void print_method_codes(const methodHandle& method, int from, int to, outputStream* st, int flags);
 };
 


### PR DESCRIPTION
Please review this patch to fix the compilation failure. The fix is simply to only define the `BytecodeTransfer::trace_interpreter` method  in NOT_PRODUCT builds.

Tested on OSX/Linux aarch64/x86_64 with JTREG.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352920](https://bugs.openjdk.org/browse/JDK-8352920): Compilation failure: comparison of unsigned expression &gt;= 0 is always true (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24284/head:pull/24284` \
`$ git checkout pull/24284`

Update a local copy of the PR: \
`$ git checkout pull/24284` \
`$ git pull https://git.openjdk.org/jdk.git pull/24284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24284`

View PR using the GUI difftool: \
`$ git pr show -t 24284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24284.diff">https://git.openjdk.org/jdk/pull/24284.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24284#issuecomment-2759925053)
</details>
