### PR TITLE
8352685: Opensource JInternalFrame tests - series2

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -781,6 +781,7 @@ javax/swing/JColorChooser/8065098/bug8065098.java 8065647 macosx-all
 javax/swing/JTabbedPane/4666224/bug4666224.java 8144124  macosx-all
 javax/swing/JTabbedPane/TestJTabbedPaneOpaqueColor.java 8345090 windows-all,linux-all
 javax/swing/SwingUtilities/TestTextPosInPrint.java 8227025 windows-all
+javax/swing/JInternalFrame/bug4134077.java 8184985 windows-all
 
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_1.java 7131438,8022539 generic-all
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_2.java 7131438,8022539 generic-all

--- a/test/jdk/javax/swing/JInternalFrame/bug4130806.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4130806.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4130806
+ * @summary JInternalFrame's setIcon(true) works correctly
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4130806
+ */
+
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import java.beans.PropertyVetoException;
+
+public class bug4130806 {
+
+    private static final String INSTRUCTIONS = """
+        If an icon is visible for the iconified internalframe, the test passes.
+        Otherwise, the test fails.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4130806 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug4130806::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("bug4130806");
+        JDesktopPane mDesktop = new JDesktopPane();
+        frame.add(mDesktop);
+        frame.pack();
+        JInternalFrame jif = new JInternalFrame("My Frame");
+        jif.setIconifiable(true);
+        mDesktop.add(jif);
+        jif.setBounds(50,50,100,100);
+        try {
+            jif.setIcon(true);
+        } catch (PropertyVetoException e) {
+            throw new RuntimeException("PropertyVetoException received");
+        }
+        jif.setVisible(true);
+        frame.setSize(200, 200);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4134077.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4134077.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4134077
+ * @requires (os.family == "windows")
+ * @summary Metal,Window:If JInternalFrame's title text is long last must be ellipsis
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4134077
+ */
+
+import java.awt.BorderLayout;
+import java.awt.ComponentOrientation;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+public class bug4134077 {
+
+    private static JFrame frame;
+
+    private static final String INSTRUCTIONS = """
+        Try to resize internal frame with diferrent combinations of
+        LookAndFeels and title pane's buttons and orientation.
+
+        The internal frame's title should clip if its too long to
+        be entierly visible (ends by "...")
+        and window can never be
+        smaller than the width of the first two letters of the title
+        plus "...".""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4134077 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug4134077::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static void setLF(ActionEvent e) {
+        try {
+            UIManager.setLookAndFeel(((JButton)e.getSource()).getActionCommand());
+            SwingUtilities.updateComponentTreeUI(frame);
+        } catch (ClassNotFoundException | InstantiationException
+                 | UnsupportedLookAndFeelException
+                 | IllegalAccessException ex) {
+             throw new RuntimeException(ex);
+        }
+    }
+
+    private static JFrame createTestUI() {
+        frame = new JFrame("bug4134077");
+        JDesktopPane jdp = new JDesktopPane();
+        frame.add(jdp);
+
+        final JInternalFrame jif =
+                new JInternalFrame("Very Long Title For Internal Frame", true);
+        jdp.add(jif);
+        jif.setSize(150,150);
+        jif.setLocation(150, 50);
+        jif.setComponentOrientation(ComponentOrientation.LEFT_TO_RIGHT);
+        jif.setVisible(true);
+
+        JPanel p = new JPanel();
+
+        JButton metal = new JButton("Metal");
+        metal.setActionCommand("javax.swing.plaf.metal.MetalLookAndFeel");
+        metal.addActionListener((ActionEvent e) -> setLF(e));
+        p.add(metal);
+
+        JButton windows = new JButton("Windows");
+        windows.setActionCommand("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        windows.addActionListener((ActionEvent e) -> setLF(e));
+        p.add(windows);
+
+        JButton orientation = new JButton("Change orientation");
+        orientation.addActionListener(e -> {
+            jif.setComponentOrientation(
+                jif.getComponentOrientation() == ComponentOrientation.LEFT_TO_RIGHT
+                    ? ComponentOrientation.RIGHT_TO_LEFT
+                    : ComponentOrientation.LEFT_TO_RIGHT);
+        });
+        p.add(orientation);
+
+        JButton clo = new JButton("Closable");
+        clo.addActionListener(e -> jif.setClosable(!jif.isClosable()));
+        p.add(clo);
+
+        JButton ico = new JButton("Iconifiable");
+        ico.addActionListener(e -> jif.setIconifiable(!jif.isIconifiable()));
+        p.add(ico);
+
+        JButton max = new JButton("Maximizable");
+        max.addActionListener(e -> jif.setMaximizable(!jif.isMaximizable()));
+        p.add(max);
+
+        frame.add(p, BorderLayout.SOUTH);
+        frame.setSize(700, 300);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4193070.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4193070.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4193070
+ * @summary Tests correct mouse pointer shape
+ * @requires (os.family != "mac")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4193070
+ */
+
+import java.awt.Dimension;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+
+public class bug4193070 {
+
+    private static final String INSTRUCTIONS = """
+        Two internal frame will be shown. Select any internal frame;
+        Move mouse pointer inside the selected internal frame,
+            then to border of internal frame.
+        Mouse pointer should take the shape of resize cursor.
+        Now slowly move the mouse back inside the internal frame.
+        If mouse pointer shape does not change back to
+            normal shape of mouse pointer, then test failed.
+        Now try fast resizing an internal frame.
+        Check that mouse pointer always has resize shape,
+            even when it goes over other internal frame.
+        If during resizing mouse pointer shape changes,
+            then test failed. Otherwise test succeded.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4193070 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug4193070::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame f = new JFrame("bug4193070");
+        JDesktopPane dp = new JDesktopPane();
+
+        JInternalFrame intFrm1 = new JInternalFrame();
+        intFrm1.setResizable(true);
+        dp.add(intFrm1);
+
+        JInternalFrame intFrm2 = new JInternalFrame();
+        intFrm2.setResizable(true);
+        dp.add(intFrm2);
+
+        f.setContentPane(dp);
+        f.setSize(new Dimension(500, 275));
+
+        intFrm1.setBounds(25, 25, 200, 200);
+        intFrm1.show();
+
+        intFrm2.setBounds(275, 25, 200, 200);
+        intFrm2.show();
+        return f;
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4225701.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4225701.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4225701
+ * @summary Verifies MetalInternalFrameUI.installKeyboardActions
+ *          doesn't install listener
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4225701
+ */
+
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+
+public class bug4225701 {
+
+    private static final String INSTRUCTIONS = """
+        Give a focus to the internal frame "Frame 4" and press Ctrl-F4.
+        The "Frame 4" should be closed. Give a focus to the internal
+        frame "Frame 1" and press Ctrl-F4.
+        If "Frame 4" and "Frame 1" is not closed, then press Fail else press Pass.""";
+
+    public static void main(String[] args) throws Exception {
+         PassFailJFrame.builder()
+                .title("bug4225701 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug4225701::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+
+        JFrame frame = new JFrame("bug4225701");
+        JInternalFrame jif1 = new JInternalFrame("Frame 1", true, true, true, true);
+        JInternalFrame jif2 = new JInternalFrame("Frame 2", false);
+        JInternalFrame jif3 = new JInternalFrame("Frame 3", false);
+        JInternalFrame jif4 = new JInternalFrame("Frame 4", true, true, true, true);
+        JDesktopPane jdp = new JDesktopPane();
+
+        frame.setContentPane(jdp);
+
+        jdp.add(jif1);
+        jif1.setBounds(0, 150, 150, 150);
+        jif1.setVisible(true);
+
+        jdp.add(jif2);
+        jif2.setBounds(100, 100, 150, 150);
+        jif2.setVisible(true);
+
+        jdp.add(jif3);
+        jif3.setBounds(200, 50, 150, 150);
+        jif3.setVisible(true);
+
+        jdp.add(jif4);
+        jif4.setBounds(300, 0, 150, 150);
+        jif4.setVisible(true);
+
+        frame.setSize(500, 500);
+        return frame;
+    }
+
+}


### PR DESCRIPTION
Few JInternalFrame tests are opensourced

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352685](https://bugs.openjdk.org/browse/JDK-8352685): Opensource JInternalFrame tests - series2 (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24285/head:pull/24285` \
`$ git checkout pull/24285`

Update a local copy of the PR: \
`$ git checkout pull/24285` \
`$ git pull https://git.openjdk.org/jdk.git pull/24285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24285`

View PR using the GUI difftool: \
`$ git pr show -t 24285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24285.diff">https://git.openjdk.org/jdk/pull/24285.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24285#issuecomment-2760023048)
</details>
