### PR TITLE
8353138: Screen capture for test TaskbarPositionTest.java, failure case

### DIFF
--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -315,19 +315,6 @@ public class TaskbarPositionTest implements ActionListener {
         robot.keyRelease(KeyEvent.VK_ESCAPE);
     }
 
-    private static void saveScreenCapture(Robot robot, GraphicsDevice[] screens) {
-        for (int i = 0; i < screens.length; i++) {
-            Rectangle bounds = screens[i].getDefaultConfiguration()
-                                         .getBounds();
-            BufferedImage image = robot.createScreenCapture(bounds);
-            try {
-                ImageIO.write(image, "png", new File("Screenshot.png"));
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
     public static void main(String[] args) throws Throwable {
         GraphicsDevice mainScreen = GraphicsEnvironment.getLocalGraphicsEnvironment()
                                                        .getDefaultScreenDevice();
@@ -468,6 +455,19 @@ public class TaskbarPositionTest implements ActionListener {
                     frame.dispose();
                 }
             });
+        }
+    }
+
+    private static void saveScreenCapture(Robot robot, GraphicsDevice[] screens) {
+        for (int i = 0; i < screens.length; i++) {
+            Rectangle bounds = screens[i].getDefaultConfiguration()
+                    .getBounds();
+            BufferedImage image = robot.createScreenCapture(bounds);
+            try {
+                ImageIO.write(image, "png", new File("Screenshot.png"));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 }

--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -214,12 +214,16 @@ public class TaskbarPositionTest implements ActionListener {
     }
 
     // for debugging purpose, saves screen capture when test fails.
-    private static void saveScreenCapture(Robot robot) {
-        BufferedImage image = robot.createScreenCapture(screenBounds);
-        try {
-            ImageIO.write(image, "png", new File("Screenshot.png"));
-        } catch (IOException e) {
-            e.printStackTrace();
+    private static void saveScreenCapture(Robot robot, GraphicsDevice[] screens) {
+        for (int i = 0; i < screens.length; i++) {
+            Rectangle bounds = screens[i].getDefaultConfiguration()
+                                         .getBounds();
+            BufferedImage image = robot.createScreenCapture(bounds);
+            try {
+                ImageIO.write(image, "png", new File("Screenshot.png"));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 
@@ -457,7 +461,7 @@ public class TaskbarPositionTest implements ActionListener {
 
             robot.waitForIdle();
         } catch (Throwable t) {
-            saveScreenCapture(robot);
+            saveScreenCapture(robot, screens);
             throw t;
         } finally {
             SwingUtilities.invokeAndWait(() -> {

--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -37,7 +37,11 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
 
+import javax.imageio.ImageIO;
 import javax.swing.AbstractAction;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
@@ -74,6 +78,7 @@ public class TaskbarPositionTest implements ActionListener {
     private static JFrame frame;
     private static JPopupMenu popupMenu;
     private static JPanel panel;
+    private static Robot robot;
 
     private static JComboBox<String> combo1;
     private static JComboBox<String> combo2;
@@ -209,11 +214,22 @@ public class TaskbarPositionTest implements ActionListener {
         }
     }
 
+    // for debugging purpose, saves screen capture when test fails.
+    private static void saveScreenCapture(Rectangle bounds) {
+        BufferedImage image = robot.createScreenCapture(bounds);
+        try {
+            ImageIO.write(image,"png", new File("Screenshot.png"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
     /**
      * Tests if the popup is on the screen.
      */
     private static void isPopupOnScreen(JPopupMenu popup, Rectangle checkBounds) {
         if (!popup.isVisible()) {
+            saveScreenCapture(checkBounds);
             throw new RuntimeException("Popup not visible");
         }
         Dimension dim = popup.getSize();
@@ -221,6 +237,7 @@ public class TaskbarPositionTest implements ActionListener {
         Rectangle bounds = new Rectangle(pt, dim);
 
         if (!SwingUtilities.isRectangleContainingRectangle(checkBounds, bounds)) {
+            saveScreenCapture(checkBounds);
             throw new RuntimeException("Popup is outside of screen bounds "
                     + checkBounds + " / " + bounds);
         }
@@ -228,6 +245,7 @@ public class TaskbarPositionTest implements ActionListener {
 
     private static void isComboPopupOnScreen(JComboBox<?> comboBox) {
         if (!comboBox.isPopupVisible()) {
+            saveScreenCapture(screenBounds);
             throw new RuntimeException("ComboBox popup not visible");
         }
         JPopupMenu popupMenu = (JPopupMenu) comboBox.getUI().getAccessibleChild(comboBox, 0);
@@ -339,7 +357,7 @@ public class TaskbarPositionTest implements ActionListener {
 
         try {
             // Use Robot to automate the test
-            Robot robot = new Robot();
+            robot = new Robot();
             robot.setAutoDelay(50);
 
             SwingUtilities.invokeAndWait(TaskbarPositionTest::new);

--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -78,7 +78,6 @@ public class TaskbarPositionTest implements ActionListener {
     private static JFrame frame;
     private static JPopupMenu popupMenu;
     private static JPanel panel;
-    private static Robot robot;
 
     private static JComboBox<String> combo1;
     private static JComboBox<String> combo2;
@@ -215,10 +214,10 @@ public class TaskbarPositionTest implements ActionListener {
     }
 
     // for debugging purpose, saves screen capture when test fails.
-    private static void saveScreenCapture(Rectangle bounds) {
-        BufferedImage image = robot.createScreenCapture(bounds);
+    private static void saveScreenCapture(Robot robot) {
+        BufferedImage image = robot.createScreenCapture(screenBounds);
         try {
-            ImageIO.write(image,"png", new File("Screenshot.png"));
+            ImageIO.write(image, "png", new File("Screenshot.png"));
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -229,7 +228,6 @@ public class TaskbarPositionTest implements ActionListener {
      */
     private static void isPopupOnScreen(JPopupMenu popup, Rectangle checkBounds) {
         if (!popup.isVisible()) {
-            saveScreenCapture(checkBounds);
             throw new RuntimeException("Popup not visible");
         }
         Dimension dim = popup.getSize();
@@ -237,7 +235,6 @@ public class TaskbarPositionTest implements ActionListener {
         Rectangle bounds = new Rectangle(pt, dim);
 
         if (!SwingUtilities.isRectangleContainingRectangle(checkBounds, bounds)) {
-            saveScreenCapture(checkBounds);
             throw new RuntimeException("Popup is outside of screen bounds "
                     + checkBounds + " / " + bounds);
         }
@@ -245,7 +242,6 @@ public class TaskbarPositionTest implements ActionListener {
 
     private static void isComboPopupOnScreen(JComboBox<?> comboBox) {
         if (!comboBox.isPopupVisible()) {
-            saveScreenCapture(screenBounds);
             throw new RuntimeException("ComboBox popup not visible");
         }
         JPopupMenu popupMenu = (JPopupMenu) comboBox.getUI().getAccessibleChild(comboBox, 0);
@@ -355,11 +351,11 @@ public class TaskbarPositionTest implements ActionListener {
             }
         }
 
-        try {
-            // Use Robot to automate the test
-            robot = new Robot();
-            robot.setAutoDelay(50);
+        // Use Robot to automate the test
+        Robot robot = new Robot();
+        robot.setAutoDelay(50);
 
+        try {
             SwingUtilities.invokeAndWait(TaskbarPositionTest::new);
 
             robot.waitForIdle();
@@ -460,6 +456,9 @@ public class TaskbarPositionTest implements ActionListener {
             hidePopup(robot);
 
             robot.waitForIdle();
+        } catch (Throwable t) {
+            saveScreenCapture(robot);
+            throw t;
         } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {

--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -213,20 +213,6 @@ public class TaskbarPositionTest implements ActionListener {
         }
     }
 
-    // for debugging purpose, saves screen capture when test fails.
-    private static void saveScreenCapture(Robot robot, GraphicsDevice[] screens) {
-        for (int i = 0; i < screens.length; i++) {
-            Rectangle bounds = screens[i].getDefaultConfiguration()
-                                         .getBounds();
-            BufferedImage image = robot.createScreenCapture(bounds);
-            try {
-                ImageIO.write(image, "png", new File("Screenshot.png"));
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
     /**
      * Tests if the popup is on the screen.
      */
@@ -327,6 +313,19 @@ public class TaskbarPositionTest implements ActionListener {
     private static void hidePopup(Robot robot) {
         robot.keyPress(KeyEvent.VK_ESCAPE);
         robot.keyRelease(KeyEvent.VK_ESCAPE);
+    }
+
+    private static void saveScreenCapture(Robot robot, GraphicsDevice[] screens) {
+        for (int i = 0; i < screens.length; i++) {
+            Rectangle bounds = screens[i].getDefaultConfiguration()
+                    .getBounds();
+            BufferedImage image = robot.createScreenCapture(bounds);
+            try {
+                ImageIO.write(image, "png", new File("Screenshot.png"));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     public static void main(String[] args) throws Throwable {

--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -318,7 +318,7 @@ public class TaskbarPositionTest implements ActionListener {
     private static void saveScreenCapture(Robot robot, GraphicsDevice[] screens) {
         for (int i = 0; i < screens.length; i++) {
             Rectangle bounds = screens[i].getDefaultConfiguration()
-                    .getBounds();
+                                         .getBounds();
             BufferedImage image = robot.createScreenCapture(bounds);
             try {
                 ImageIO.write(image, "png", new File("Screenshot.png"));


### PR DESCRIPTION
Hi Reviewers,

Added screen capture in case of test failure using Robot. 

Please review and let me know your suggestion if any.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353138](https://bugs.openjdk.org/browse/JDK-8353138): Screen capture for test TaskbarPositionTest.java, failure case (**Sub-task** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) Review applies to [cec51c11](https://git.openjdk.org/jdk/pull/24286/files/cec51c11e00deb60a2b0db1a6f925352227b44d3)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24286/head:pull/24286` \
`$ git checkout pull/24286`

Update a local copy of the PR: \
`$ git checkout pull/24286` \
`$ git pull https://git.openjdk.org/jdk.git pull/24286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24286`

View PR using the GUI difftool: \
`$ git pr show -t 24286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24286.diff">https://git.openjdk.org/jdk/pull/24286.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24286#issuecomment-2760315808)
</details>
