### PR TITLE
8353002: Remove unnecessary Windows version check in WTaskbarPeer

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WTaskbarPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WTaskbarPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import java.awt.Window;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
 import sun.awt.AWTAccessor;
-import sun.awt.OSInfo;
 import sun.awt.shell.ShellFolder;
 
 final class WTaskbarPeer implements TaskbarPeer {
@@ -44,9 +43,7 @@ final class WTaskbarPeer implements TaskbarPeer {
 
     private static synchronized void init() {
         if (!initExecuted) {
-            supported = OSInfo.getWindowsVersion()
-                    .compareTo(OSInfo.WINDOWS_7) >= 0
-                    && ShellFolder.invoke(() -> nativeInit());
+            supported = ShellFolder.invoke(() -> nativeInit());
         }
         initExecuted = true;
     }

--- a/test/jdk/java/awt/Dialog/TaskbarFeatureTest.java
+++ b/test/jdk/java/awt/Dialog/TaskbarFeatureTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Taskbar;
+import java.awt.Taskbar.Feature;
+
+/*
+ * @test
+ * @bug 8353002
+ * @key headful
+ * @requires (os.family == "windows")
+ * @summary Verifies that expected taskbar features are supported on Windows.
+ */
+
+public class TaskbarFeatureTest {
+
+    public static void main(String[] args) throws Exception {
+        Taskbar taskbar = Taskbar.getTaskbar();
+        testFeature(taskbar, Feature.ICON_BADGE_IMAGE_WINDOW);
+        testFeature(taskbar, Feature.PROGRESS_STATE_WINDOW);
+        testFeature(taskbar, Feature.PROGRESS_VALUE_WINDOW);
+        testFeature(taskbar, Feature.USER_ATTENTION_WINDOW);
+    }
+
+    private static void testFeature(Taskbar taskbar, Feature feature) {
+        if (!taskbar.isSupported(feature)) {
+            throw new RuntimeException("Feature not supported: " + feature);
+        }
+    }
+}


### PR DESCRIPTION
WTaskbarPeer contains a check as to whether the current Windows version is Windows 7 or later. The current minimum supported version is Windows 10, so this is no longer needed.

There didn't seem to be a public test exercising this code, so I also added a basic Taskbar sanity test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353002](https://bugs.openjdk.org/browse/JDK-8353002): Remove unnecessary Windows version check in WTaskbarPeer (**Bug** - P5)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24287/head:pull/24287` \
`$ git checkout pull/24287`

Update a local copy of the PR: \
`$ git checkout pull/24287` \
`$ git pull https://git.openjdk.org/jdk.git pull/24287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24287`

View PR using the GUI difftool: \
`$ git pr show -t 24287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24287.diff">https://git.openjdk.org/jdk/pull/24287.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24287#issuecomment-2760744666)
</details>
