### PR TITLE
8352893: C2: OrL/INode::add_ring optimize (x | -1) to -1

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -854,6 +854,12 @@ const Type *OrINode::add_ring( const Type *t0, const Type *t1 ) const {
     }
   }
 
+  // If either input is all ones, the output is all ones.
+  // x | ~0 == ~0 <==> x | -1 == -1
+  if (r0 == TypeInt::MINUS_1 || r1 == TypeInt::MINUS_1) {
+    return TypeInt::MINUS_1;
+  }
+
   // If either input is not a constant, just return all integers.
   if( !r0->is_con() || !r1->is_con() )
     return TypeInt::INT;        // Any integer, but still no symbols.
@@ -910,6 +916,12 @@ Node* OrLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 const Type *OrLNode::add_ring( const Type *t0, const Type *t1 ) const {
   const TypeLong *r0 = t0->is_long(); // Handy access
   const TypeLong *r1 = t1->is_long();
+
+  // If either input is all ones, the output is all ones.
+  // x | ~0 == ~0 <==> x | -1 == -1
+  if (r0 == TypeLong::MINUS_1 || r1 == TypeLong::MINUS_1) {
+    return TypeLong::MINUS_1;
+  }
 
   // If either input is not a constant, just return all integers.
   if( !r0->is_con() || !r1->is_con() )

--- a/test/hotspot/jtreg/compiler/integerArithmetic/TestOrSaturate.java
+++ b/test/hotspot/jtreg/compiler/integerArithmetic/TestOrSaturate.java
@@ -29,7 +29,7 @@
 
  /*
   * @test
-  * @bug 8352839
+  * @bug 8352893
   * @summary Test that an or with all bits set is folded to all bits (x | -1 == -1).
   * @library / /test/lib
   * @run driver compiler.integerArithmetic.TestOrSaturate

--- a/test/hotspot/jtreg/compiler/integerArithmetic/TestOrSaturate.java
+++ b/test/hotspot/jtreg/compiler/integerArithmetic/TestOrSaturate.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+ package compiler.integerArithmetic;
+
+ import compiler.lib.ir_framework.*;
+ import jdk.test.lib.Asserts;
+
+ /*
+  * @test
+  * @bug 8352839
+  * @summary Test that an or with all bits set is folded to all bits (x | -1 == -1).
+  * @library / /test/lib
+  * @run driver compiler.integerArithmetic.TestOrSaturate
+  */
+
+public class TestOrSaturate {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    private final static int WARMUP = 10_000;
+
+    @Run(test = {"testL", "testI", "testDelayed"})
+    public static void check() {
+        for (int i = 0; i < WARMUP; i++) {
+            Asserts.assertEQ(-1L, testL(i));
+            Asserts.assertEQ(-1, testI(i));
+            Asserts.assertEQ(-1, testDelayed(i));
+        }
+    }
+
+    @Test
+    @IR(failOn = { IRNode.OR_L })
+    // Tests that the OrLNode is folded if one operand is -1.
+    private static long testL(long x) {
+        return x | -1L;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.OR_I })
+    // Tests that the OrINode is folded if one operand is -1.
+    private static int testI(int x) {
+        return x | -1;
+    }
+
+    @Test
+    @IR(counts = {IRNode.OR_I, "1"},
+        phase = CompilePhase.AFTER_PARSING)
+    @IR(failOn = { IRNode.OR_I })
+    // Tests that the OrI node is folded after parsing if one operand is -1.
+    private static int testDelayed(int x) {
+        int min1 = 42;
+        int limit = 2;
+
+        // Ensure that min1 == -1 is only known after some constant propagation.
+        for (; limit < 4; limit *= 2) {}
+        for (int i = 2; i < limit; i++) {
+            min1 = -1;
+        }
+
+        // Will only be folded after min1 == -1 is established.
+        return x | min1;
+    }
+}

--- a/test/hotspot/jtreg/compiler/integerArithmetic/TestOrSaturate.java
+++ b/test/hotspot/jtreg/compiler/integerArithmetic/TestOrSaturate.java
@@ -22,33 +22,34 @@
  *
  */
 
- package compiler.integerArithmetic;
+package compiler.integerArithmetic;
 
- import compiler.lib.ir_framework.*;
- import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
+import jdk.test.lib.Asserts;
 
- /*
-  * @test
-  * @bug 8352893
-  * @summary Test that an or with all bits set is folded to all bits (x | -1 == -1).
-  * @library / /test/lib
-  * @run driver compiler.integerArithmetic.TestOrSaturate
-  */
+/*
+ * @test
+ * @bug 8352893
+ * @summary Test that an or with all bits set is folded to all bits (x | -1 == -1).
+ * @key randomness
+ * @library / /test/lib
+ * @run driver compiler.integerArithmetic.TestOrSaturate
+ */
 
 public class TestOrSaturate {
     public static void main(String[] args) {
         TestFramework.run();
     }
 
-    private final static int WARMUP = 10_000;
+    private static final Random random = Utils.getRandomInstance();
 
     @Run(test = {"testL", "testI", "testDelayed"})
     public static void check() {
-        for (int i = 0; i < WARMUP; i++) {
-            Asserts.assertEQ(-1L, testL(i));
-            Asserts.assertEQ(-1, testI(i));
-            Asserts.assertEQ(-1, testDelayed(i));
-        }
+        Asserts.assertEQ(-1L, testL(random.nextLong()));
+        Asserts.assertEQ(-1, testI(random.nextInt()));
+        Asserts.assertEQ(-1, testDelayed(random.nextInt()));
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1440,6 +1440,16 @@ public class IRNode {
         optoOnly(OOPMAP_WITH, regex);
     }
 
+    public static final String OR_I = PREFIX + "OR_I" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(OR_I, "OrI");
+    }
+
+    public static final String OR_L = PREFIX + "OR_L" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(OR_L, "OrL");
+    }
+
     public static final String OR_VB = VECTOR_PREFIX + "OR_VB" + POSTFIX;
     static {
         vectorNode(OR_VB, "OrV", TYPE_BYTE);


### PR DESCRIPTION
# Issue Summary

The `add_ring()` implementations of `OrINode` and `OrLNode` are missing the optimization that an or with a value where all bits are ones (since we have signed integers in this case `~0 == -1`) will always yield all zeroes.

# Changes

This PR makes the following straight forward changes:
 - `Or(I|L)Node::add_ring()` returns `-1` if one of the two inputs is `-1`.
 - Add `Or(I|L)` nodes to the IR framework.
 - Add a regression IR test for the implemented optimization.

# Testing

- [Github Actions](https://github.com/mhaessig/jdk/actions/runs/14110978686)
- Ran tier1 through tier3 and Oracle internal testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352893](https://bugs.openjdk.org/browse/JDK-8352893): C2: OrL/INode::add_ring optimize (x | -1) to -1 (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [af9a3a67](https://git.openjdk.org/jdk/pull/24289/files/af9a3a670d29298ab4007677ef4c5516b86b3456)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24289/head:pull/24289` \
`$ git checkout pull/24289`

Update a local copy of the PR: \
`$ git checkout pull/24289` \
`$ git pull https://git.openjdk.org/jdk.git pull/24289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24289`

View PR using the GUI difftool: \
`$ git pr show -t 24289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24289.diff">https://git.openjdk.org/jdk/pull/24289.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24289#issuecomment-2760865407)
</details>
