### PR TITLE
8353176: C1: x86 patching stub always calls Thread::current()

### DIFF
--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -366,7 +366,7 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
     // Load without verification to keep code size small. We need it because
     // begin_initialized_entry_offset has to fit in a byte. Also, we know it's not null.
     __ movptr(tmp2, Address(_obj, java_lang_Class::klass_offset()));
-    __ get_thread(tmp);
+    __ movptr(tmp, r15_thread);
     __ cmpptr(tmp, Address(tmp2, InstanceKlass::init_thread_offset()));
     __ pop(tmp2);
     __ pop(tmp);

--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -360,17 +360,11 @@ void PatchingStub::emit_code(LIR_Assembler* ce) {
     }
     assert(_obj != noreg, "must be a valid register");
     Register tmp = rax;
-    Register tmp2 = rbx;
     __ push(tmp);
-    __ push(tmp2);
-    // Load without verification to keep code size small. We need it because
-    // begin_initialized_entry_offset has to fit in a byte. Also, we know it's not null.
-    __ movptr(tmp2, Address(_obj, java_lang_Class::klass_offset()));
-    __ movptr(tmp, r15_thread);
-    __ cmpptr(tmp, Address(tmp2, InstanceKlass::init_thread_offset()));
-    __ pop(tmp2);
-    __ pop(tmp);
-    __ jcc(Assembler::notEqual, call_patch);
+    __ movptr(tmp, Address(_obj, java_lang_Class::klass_offset()));
+    __ cmpptr(r15_thread, Address(tmp, InstanceKlass::init_thread_offset()));
+    __ pop(tmp); // pop it right away, no matter which path we take
+    __ jccb(Assembler::notEqual, call_patch);
 
     // access_field patches may execute the patched code before it's
     // copied back into place so we need to jump back into the main


### PR DESCRIPTION
Noticed this while looking at compiled code density. In C1 PatchingStub code, we _always_ perform a runtime call to `Thread::current()`, even though we can rely on `r15_thread` to be available. This currently emits a huge sequence of instructions for register save/restore and the call itself.

Current code calls to `MacroAssembler::get_thread()`, which is always doing that slowpath. This kind of accident would be less likely / impossible once we cleanup uses of `MacroAssembler::get_thread()` with [JDK-8353174](https://bugs.openjdk.org/browse/JDK-8353174).

Additional testing:
 - [x] Linux x86_64 server fastdebug, `tier1`
 - [x] Linux x86_64 server fastdebug, `tier1` + `-XX:TieredStopAtLevel=1`
 - [x] Linux x86_64 server fastdebug, `all`
 - [x] Linux x86_64 server fastdebug, `all` + `-XX:TieredStopAtLevel=1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353176](https://bugs.openjdk.org/browse/JDK-8353176): C1: x86 patching stub always calls Thread::current() (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24291/head:pull/24291` \
`$ git checkout pull/24291`

Update a local copy of the PR: \
`$ git checkout pull/24291` \
`$ git pull https://git.openjdk.org/jdk.git pull/24291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24291`

View PR using the GUI difftool: \
`$ git pr show -t 24291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24291.diff">https://git.openjdk.org/jdk/pull/24291.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24291#issuecomment-2761249332)
</details>
