### PR TITLE
8288471: java/awt/ScrollPane/bug8077409Test.java is unstable and fails intermittently in CI

### DIFF
--- a/test/jdk/java/awt/ScrollPane/bug8077409Test.java
+++ b/test/jdk/java/awt/ScrollPane/bug8077409Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,10 @@
  * @key headful
  * @bug 8077409
  * @summary Drawing deviates when validate() is invoked on java.awt.ScrollPane
- * @author mikhail.cherkasov@oracle.com
  * @run main bug8077409Test
  */
 
 
-import java.awt.AWTEvent;
 import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Canvas;
@@ -40,9 +38,7 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Point;
-import java.awt.Robot;
 import java.awt.ScrollPane;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 
 public class bug8077409Test extends Frame {
@@ -66,42 +62,13 @@ public class bug8077409Test extends Frame {
         final bug8077409Test obj = new bug8077409Test();
         try {
             obj.setLocationRelativeTo(null);
-            Toolkit.getDefaultToolkit().addAWTEventListener(e -> {
-                KeyEvent keyEvent = (KeyEvent) e;
-                if (keyEvent.getID() == KeyEvent.KEY_RELEASED) {
-                    if (keyEvent.getKeyCode() == KeyEvent.VK_1) {
-                        System.out.println(obj.pane.toString());
-                        System.out.println("obj.myCanvas.pos: " + obj.myCanvas.getBounds());
-                        System.out.println(obj.myCanvas.toString());
-                    } else if (keyEvent.getKeyCode() == KeyEvent.VK_2) {
-                        obj.repaint();
-                    } else if (keyEvent.getKeyCode() == KeyEvent.VK_DOWN) {
-                        Point scrollPosition = obj.pane.getScrollPosition();
-                        scrollPosition.translate(0, 1);
-                        obj.pane.setScrollPosition(scrollPosition);
-                    } else if (keyEvent.getKeyCode() == KeyEvent.VK_UP) {
-                        Point scrollPosition = obj.pane.getScrollPosition();
-                        scrollPosition.translate(0, -1);
-                        obj.pane.setScrollPosition(scrollPosition);
-                    } else if (keyEvent.getKeyCode() == KeyEvent.VK_SPACE) {
-                        obj.pane.validate();
-                    }
-                }
-            }, AWTEvent.KEY_EVENT_MASK);
             obj.setVisible(true);
-            Robot robot = new Robot();
-            robot.waitForIdle();
-            robot.delay(300);
             Point scrollPosition = obj.pane.getScrollPosition();
             scrollPosition.translate(0, 1);
             obj.pane.setScrollPosition(scrollPosition);
 
             int y = obj.pane.getComponent(0).getLocation().y;
-            robot.waitForIdle();
-            robot.delay(300);
             obj.pane.validate();
-            robot.waitForIdle();
-            robot.delay(300);
             if (y != obj.pane.getComponent(0).getLocation().y) {
                 throw new RuntimeException("Wrong position of component in ScrollPane");
             } else {

--- a/test/jdk/java/awt/ScrollPane/bug8077409Test.java
+++ b/test/jdk/java/awt/ScrollPane/bug8077409Test.java
@@ -29,7 +29,6 @@
  * @run main bug8077409Test
  */
 
-
 import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Canvas;
@@ -49,13 +48,10 @@ public class bug8077409Test extends Frame {
         super();
         setLayout(new BorderLayout());
         pane = new ScrollPane();
-
         myCanvas = new MyCanvas();
         pane.add(myCanvas);
-
         add(pane, BorderLayout.CENTER);
         setSize(320, 480);
-
     }
 
     public static void main(String[] args) throws AWTException, InterruptedException {
@@ -66,13 +62,10 @@ public class bug8077409Test extends Frame {
             Point scrollPosition = obj.pane.getScrollPosition();
             scrollPosition.translate(0, 1);
             obj.pane.setScrollPosition(scrollPosition);
-
             int y = obj.pane.getComponent(0).getLocation().y;
             obj.pane.validate();
             if (y != obj.pane.getComponent(0).getLocation().y) {
                 throw new RuntimeException("Wrong position of component in ScrollPane");
-            } else {
-                System.out.println("Passed.....");
             }
         } finally {
             obj.dispose();
@@ -82,14 +75,15 @@ public class bug8077409Test extends Frame {
     @Override
     protected void processKeyEvent(KeyEvent e) {
         super.processKeyEvent(e);
-
     }
 
     class MyCanvas extends Canvas {
+        @Override
         public Dimension getPreferredSize() {
             return new Dimension(400, 800);
         }
 
+        @Override
         public void paint(Graphics g) {
             g.setColor(Color.BLACK);
             g.drawLine(0, 0, 399, 0);

--- a/test/jdk/java/awt/ScrollPane/bug8077409Test.java
+++ b/test/jdk/java/awt/ScrollPane/bug8077409Test.java
@@ -31,8 +31,19 @@
  */
 
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.AWTEvent;
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.ScrollPane;
+import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 
 public class bug8077409Test extends Frame {
   ScrollPane pane;
@@ -77,41 +88,52 @@ public class bug8077409Test extends Frame {
 
   public static void main(String[] args) throws AWTException, InterruptedException {
     final bug8077409Test obj = new bug8077409Test();
-    obj.setVisible(true);
-    Toolkit.getDefaultToolkit().addAWTEventListener(new AWTEventListener() {
-      @Override
-      public void eventDispatched(AWTEvent e) {
-        KeyEvent keyEvent = (KeyEvent) e;
-        if(keyEvent.getID() == KeyEvent.KEY_RELEASED) {
-            if (keyEvent.getKeyCode() == KeyEvent.VK_1) {
-              System.out.println(obj.pane.toString());
-              System.out.println("obj.myCanvas.pos: " + obj.myCanvas.getBounds());
-              System.out.println(obj.myCanvas.toString());
-            }  else if (keyEvent.getKeyCode() == KeyEvent.VK_2) {
-              obj.repaint();
-           } else if (keyEvent.getKeyCode() == KeyEvent.VK_DOWN) {
-              Point scrollPosition = obj.pane.getScrollPosition();
-              scrollPosition.translate(0, 1);
-              obj.pane.setScrollPosition(scrollPosition);
-            } else if (keyEvent.getKeyCode() == KeyEvent.VK_UP) {
-              Point scrollPosition = obj.pane.getScrollPosition();
-              scrollPosition.translate(0, -1);
-              obj.pane.setScrollPosition(scrollPosition);
-            } else if (keyEvent.getKeyCode() == KeyEvent.VK_SPACE) {
-              obj.pane.validate();
-            }
+    try {
+    obj.setLocationRelativeTo(null);
+    Toolkit.getDefaultToolkit().addAWTEventListener(e -> {
+      KeyEvent keyEvent = (KeyEvent) e;
+      if(keyEvent.getID() == KeyEvent.KEY_RELEASED) {
+          if (keyEvent.getKeyCode() == KeyEvent.VK_1) {
+            System.out.println(obj.pane.toString());
+            System.out.println("obj.myCanvas.pos: " + obj.myCanvas.getBounds());
+            System.out.println(obj.myCanvas.toString());
+          }  else if (keyEvent.getKeyCode() == KeyEvent.VK_2) {
+            obj.repaint();
+         } else if (keyEvent.getKeyCode() == KeyEvent.VK_DOWN) {
+            Point scrollPosition = obj.pane.getScrollPosition();
+            scrollPosition.translate(0, 1);
+            obj.pane.setScrollPosition(scrollPosition);
+          } else if (keyEvent.getKeyCode() == KeyEvent.VK_UP) {
+            Point scrollPosition = obj.pane.getScrollPosition();
+            scrollPosition.translate(0, -1);
+            obj.pane.setScrollPosition(scrollPosition);
+          } else if (keyEvent.getKeyCode() == KeyEvent.VK_SPACE) {
+            obj.pane.validate();
           }
         }
-    }, AWTEvent.KEY_EVENT_MASK);
+      }, AWTEvent.KEY_EVENT_MASK);
+      obj.setVisible(true);
+      Robot robot = new Robot();
+      robot.waitForIdle();
+      robot.delay(300);
       Point scrollPosition = obj.pane.getScrollPosition();
       scrollPosition.translate(0, 1);
       obj.pane.setScrollPosition(scrollPosition);
 
       int y = obj.pane.getComponent(0).getLocation().y;
+      robot.waitForIdle();
+      robot.delay(300);
       obj.pane.validate();
+      robot.waitForIdle();
+      robot.delay(300);
       if(y != obj.pane.getComponent(0).getLocation().y){
           throw new RuntimeException("Wrong position of component in ScrollPane");
+      } else {
+          System.out.println("Passed.....");
       }
+    } finally {
+        obj.dispose();
+    }
   }
 
 }

--- a/test/jdk/java/awt/ScrollPane/bug8077409Test.java
+++ b/test/jdk/java/awt/ScrollPane/bug8077409Test.java
@@ -89,17 +89,17 @@ public class bug8077409Test extends Frame {
   public static void main(String[] args) throws AWTException, InterruptedException {
     final bug8077409Test obj = new bug8077409Test();
     try {
-    obj.setLocationRelativeTo(null);
-    Toolkit.getDefaultToolkit().addAWTEventListener(e -> {
-      KeyEvent keyEvent = (KeyEvent) e;
-      if(keyEvent.getID() == KeyEvent.KEY_RELEASED) {
+      obj.setLocationRelativeTo(null);
+      Toolkit.getDefaultToolkit().addAWTEventListener(e -> {
+        KeyEvent keyEvent = (KeyEvent) e;
+        if (keyEvent.getID() == KeyEvent.KEY_RELEASED) {
           if (keyEvent.getKeyCode() == KeyEvent.VK_1) {
             System.out.println(obj.pane.toString());
             System.out.println("obj.myCanvas.pos: " + obj.myCanvas.getBounds());
             System.out.println(obj.myCanvas.toString());
-          }  else if (keyEvent.getKeyCode() == KeyEvent.VK_2) {
+          } else if (keyEvent.getKeyCode() == KeyEvent.VK_2) {
             obj.repaint();
-         } else if (keyEvent.getKeyCode() == KeyEvent.VK_DOWN) {
+          } else if (keyEvent.getKeyCode() == KeyEvent.VK_DOWN) {
             Point scrollPosition = obj.pane.getScrollPosition();
             scrollPosition.translate(0, 1);
             obj.pane.setScrollPosition(scrollPosition);
@@ -126,13 +126,13 @@ public class bug8077409Test extends Frame {
       obj.pane.validate();
       robot.waitForIdle();
       robot.delay(300);
-      if(y != obj.pane.getComponent(0).getLocation().y){
-          throw new RuntimeException("Wrong position of component in ScrollPane");
+      if (y != obj.pane.getComponent(0).getLocation().y) {
+        throw new RuntimeException("Wrong position of component in ScrollPane");
       } else {
-          System.out.println("Passed.....");
+        System.out.println("Passed.....");
       }
     } finally {
-        obj.dispose();
+      obj.dispose();
     }
   }
 

--- a/test/jdk/java/awt/ScrollPane/bug8077409Test.java
+++ b/test/jdk/java/awt/ScrollPane/bug8077409Test.java
@@ -46,94 +46,94 @@ import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 
 public class bug8077409Test extends Frame {
-  ScrollPane pane;
-  MyCanvas myCanvas;
+    ScrollPane pane;
+    MyCanvas myCanvas;
 
-  class MyCanvas extends Canvas {
-    public Dimension getPreferredSize() {
-      return new Dimension(400, 800);
+    public bug8077409Test() {
+        super();
+        setLayout(new BorderLayout());
+        pane = new ScrollPane();
+
+        myCanvas = new MyCanvas();
+        pane.add(myCanvas);
+
+        add(pane, BorderLayout.CENTER);
+        setSize(320, 480);
+
     }
 
-    public void paint(Graphics g) {
-      g.setColor(Color.BLACK);
-      g.drawLine(0, 0, 399, 0);
-      g.setColor(Color.RED);
-      g.drawLine(0, 1, 399, 1);
-      g.setColor(Color.BLUE);
-      g.drawLine(0, 2, 399, 2);
-      g.setColor(Color.GREEN);
-      g.drawLine(0, 3, 399, 3);
-    }
-
-  }
-
-  public bug8077409Test() {
-    super();
-    setLayout(new BorderLayout());
-    pane = new ScrollPane();
-
-    myCanvas = new MyCanvas();
-    pane.add(myCanvas);
-
-    add(pane, BorderLayout.CENTER);
-    setSize(320, 480);
-
-  }
-
-  @Override
-  protected void processKeyEvent(KeyEvent e) {
-    super.processKeyEvent(e);
-
-  }
-
-  public static void main(String[] args) throws AWTException, InterruptedException {
-    final bug8077409Test obj = new bug8077409Test();
-    try {
-      obj.setLocationRelativeTo(null);
-      Toolkit.getDefaultToolkit().addAWTEventListener(e -> {
-        KeyEvent keyEvent = (KeyEvent) e;
-        if (keyEvent.getID() == KeyEvent.KEY_RELEASED) {
-          if (keyEvent.getKeyCode() == KeyEvent.VK_1) {
-            System.out.println(obj.pane.toString());
-            System.out.println("obj.myCanvas.pos: " + obj.myCanvas.getBounds());
-            System.out.println(obj.myCanvas.toString());
-          } else if (keyEvent.getKeyCode() == KeyEvent.VK_2) {
-            obj.repaint();
-          } else if (keyEvent.getKeyCode() == KeyEvent.VK_DOWN) {
+    public static void main(String[] args) throws AWTException, InterruptedException {
+        final bug8077409Test obj = new bug8077409Test();
+        try {
+            obj.setLocationRelativeTo(null);
+            Toolkit.getDefaultToolkit().addAWTEventListener(e -> {
+                KeyEvent keyEvent = (KeyEvent) e;
+                if (keyEvent.getID() == KeyEvent.KEY_RELEASED) {
+                    if (keyEvent.getKeyCode() == KeyEvent.VK_1) {
+                        System.out.println(obj.pane.toString());
+                        System.out.println("obj.myCanvas.pos: " + obj.myCanvas.getBounds());
+                        System.out.println(obj.myCanvas.toString());
+                    } else if (keyEvent.getKeyCode() == KeyEvent.VK_2) {
+                        obj.repaint();
+                    } else if (keyEvent.getKeyCode() == KeyEvent.VK_DOWN) {
+                        Point scrollPosition = obj.pane.getScrollPosition();
+                        scrollPosition.translate(0, 1);
+                        obj.pane.setScrollPosition(scrollPosition);
+                    } else if (keyEvent.getKeyCode() == KeyEvent.VK_UP) {
+                        Point scrollPosition = obj.pane.getScrollPosition();
+                        scrollPosition.translate(0, -1);
+                        obj.pane.setScrollPosition(scrollPosition);
+                    } else if (keyEvent.getKeyCode() == KeyEvent.VK_SPACE) {
+                        obj.pane.validate();
+                    }
+                }
+            }, AWTEvent.KEY_EVENT_MASK);
+            obj.setVisible(true);
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(300);
             Point scrollPosition = obj.pane.getScrollPosition();
             scrollPosition.translate(0, 1);
             obj.pane.setScrollPosition(scrollPosition);
-          } else if (keyEvent.getKeyCode() == KeyEvent.VK_UP) {
-            Point scrollPosition = obj.pane.getScrollPosition();
-            scrollPosition.translate(0, -1);
-            obj.pane.setScrollPosition(scrollPosition);
-          } else if (keyEvent.getKeyCode() == KeyEvent.VK_SPACE) {
-            obj.pane.validate();
-          }
-        }
-      }, AWTEvent.KEY_EVENT_MASK);
-      obj.setVisible(true);
-      Robot robot = new Robot();
-      robot.waitForIdle();
-      robot.delay(300);
-      Point scrollPosition = obj.pane.getScrollPosition();
-      scrollPosition.translate(0, 1);
-      obj.pane.setScrollPosition(scrollPosition);
 
-      int y = obj.pane.getComponent(0).getLocation().y;
-      robot.waitForIdle();
-      robot.delay(300);
-      obj.pane.validate();
-      robot.waitForIdle();
-      robot.delay(300);
-      if (y != obj.pane.getComponent(0).getLocation().y) {
-        throw new RuntimeException("Wrong position of component in ScrollPane");
-      } else {
-        System.out.println("Passed.....");
-      }
-    } finally {
-      obj.dispose();
+            int y = obj.pane.getComponent(0).getLocation().y;
+            robot.waitForIdle();
+            robot.delay(300);
+            obj.pane.validate();
+            robot.waitForIdle();
+            robot.delay(300);
+            if (y != obj.pane.getComponent(0).getLocation().y) {
+                throw new RuntimeException("Wrong position of component in ScrollPane");
+            } else {
+                System.out.println("Passed.....");
+            }
+        } finally {
+            obj.dispose();
+        }
     }
-  }
+
+    @Override
+    protected void processKeyEvent(KeyEvent e) {
+        super.processKeyEvent(e);
+
+    }
+
+    class MyCanvas extends Canvas {
+        public Dimension getPreferredSize() {
+            return new Dimension(400, 800);
+        }
+
+        public void paint(Graphics g) {
+            g.setColor(Color.BLACK);
+            g.drawLine(0, 0, 399, 0);
+            g.setColor(Color.RED);
+            g.drawLine(0, 1, 399, 1);
+            g.setColor(Color.BLUE);
+            g.drawLine(0, 2, 399, 2);
+            g.setColor(Color.GREEN);
+            g.drawLine(0, 3, 399, 3);
+        }
+
+    }
 
 }


### PR DESCRIPTION
java/awt/ScrollPane/bug8077409Test.java is unstable and fails intermittently in CI, especially in MacOS machines.
Also the frame created in this test is not disposed which may interfere with other tests.

Fix:
Some stabilisations added and the frame is disposed properly.

Testing:
Tested 100 times per platform(macosx-x64,macosx-aarch64,windows-x64,linux-x64) and got all PASS.
I have also tested this on Windows-x64 with JDK 8u60b04 and JDK 8u60b20 as the original issue related to this test(JDK-8077409) was fixed in JDK 8u60b20.
With JDK 8u60b04:
Exception in thread "main" java.lang.RuntimeException: Wrong position of component in ScrollPane
        at bug8077409Test.main(bug8077409Test.java:142)

With JDK 8u60b20:
Passed.....

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288471](https://bugs.openjdk.org/browse/JDK-8288471): java/awt/ScrollPane/bug8077409Test.java is unstable and fails intermittently in CI (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) Review applies to [13d1deeb](https://git.openjdk.org/jdk/pull/24292/files/13d1deebe20adb7b2e477ffb806f8179cbb7e99c)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24292/head:pull/24292` \
`$ git checkout pull/24292`

Update a local copy of the PR: \
`$ git checkout pull/24292` \
`$ git pull https://git.openjdk.org/jdk.git pull/24292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24292`

View PR using the GUI difftool: \
`$ git pr show -t 24292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24292.diff">https://git.openjdk.org/jdk/pull/24292.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24292#issuecomment-2761054028)
</details>
