### PR TITLE
8334046: Set different values for CompLevel_any and CompLevel_all

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.hpp
@@ -53,7 +53,7 @@ enum MethodCompilation {
 
 // Enumeration to distinguish tiers of compilation
 enum CompLevel : s1 {
-  CompLevel_any               = -1,        // Used for querying the state
+  CompLevel_any               = -2,        // Used for querying the state
   CompLevel_all               = -1,        // Used for changing the state
   CompLevel_none              = 0,         // Interpreter
   CompLevel_simple            = 1,         // C1

--- a/test/hotspot/jtreg/compiler/whitebox/CompilerWhiteBoxTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/CompilerWhiteBoxTest.java
@@ -41,8 +41,10 @@ import java.util.function.Function;
 public abstract class CompilerWhiteBoxTest {
     /** {@code CompLevel::CompLevel_none} -- Interpreter */
     public static final int COMP_LEVEL_NONE = 0;
-    /** {@code CompLevel::CompLevel_any}, {@code CompLevel::CompLevel_all} */
-    public static final int COMP_LEVEL_ANY = -1;
+    /** {@code CompLevel::CompLevel_any} */
+    public static final int COMP_LEVEL_ANY = -2;
+    /** {@code CompLevel::CompLevel_all} */
+    public static final int COMP_LEVEL_ALL = -1;
     /** {@code CompLevel::CompLevel_simple} -- C1 */
     public static final int COMP_LEVEL_SIMPLE = 1;
     /** {@code CompLevel::CompLevel_limited_profile} -- C1, invocation &amp; backedge counters */
@@ -284,7 +286,7 @@ public abstract class CompilerWhiteBoxTest {
     }
 
     protected final void makeNotCompilable() {
-        WHITE_BOX.makeMethodNotCompilable(method, COMP_LEVEL_ANY,
+        WHITE_BOX.makeMethodNotCompilable(method, COMP_LEVEL_ALL,
                 testCase.isOsr());
     }
 

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -345,7 +345,7 @@ public class WhiteBox {
     return isMethodCompiled0(method, isOsr);
   }
   public        boolean isMethodCompilable(Executable method) {
-    return isMethodCompilable(method, -1 /*any*/);
+    return isMethodCompilable(method, -2 /*any*/);
   }
   public        boolean isMethodCompilable(Executable method, int compLevel) {
     return isMethodCompilable(method, compLevel, false /*not osr*/);
@@ -393,7 +393,7 @@ public class WhiteBox {
     return deoptimizeMethod0(method, isOsr);
   }
   public        void    makeMethodNotCompilable(Executable method) {
-    makeMethodNotCompilable(method, -1 /*any*/);
+    makeMethodNotCompilable(method, -1 /*all*/);
   }
   public        void    makeMethodNotCompilable(Executable method, int compLevel) {
     makeMethodNotCompilable(method, compLevel, false /*not osr*/);


### PR DESCRIPTION
Please review this trivial patch to set different values for CompLevel_any and CompLevel_all.
Setting different values for these fields make the implementation of [this other issue](https://bugs.openjdk.org/browse/JDK-8313713) much cleaner/easier.
Tested on OSX/Linux Aarch64/x86_64 with JTREG.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334046](https://bugs.openjdk.org/browse/JDK-8334046): Set different values for CompLevel_any and CompLevel_all (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24298/head:pull/24298` \
`$ git checkout pull/24298`

Update a local copy of the PR: \
`$ git checkout pull/24298` \
`$ git pull https://git.openjdk.org/jdk.git pull/24298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24298`

View PR using the GUI difftool: \
`$ git pr show -t 24298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24298.diff">https://git.openjdk.org/jdk/pull/24298.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24298#issuecomment-2761827619)
</details>
