### PR TITLE
8353189: [ASAN] memory leak after 8352184

### DIFF
--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -137,6 +137,9 @@ const char* Abstract_VM_Version::vm_vendor() {
 }
 
 
+// The VM info string should be a constant, but its value cannot be finalized until after VM arguments
+// have been fully processed. And we want to avoid dynamic memory allocation which will cause ASAN
+// report error, so we enumerate all the cases by static const string value.
 const char* Abstract_VM_Version::vm_info_string() {
   switch (Arguments::mode()) {
     case Arguments::_int:


### PR DESCRIPTION
Hi all,

This PR will try to fix memory leak after JDK-8352184. which re-do [JDK-8352184](https://bugs.openjdk.org/browse/JDK-8352184) using the original, purely static uses of the various description strings, as @jianglizhou had proposed.

Additional testing:

- [x] jtreg tests(include tier1/2/3 etc.) on linux-x64
- [x] jtreg tests(include tier1/2/3 etc.) on linux-aarch64
- [x] full `java -version` tests, the test shell script show as below.

[JDK-8353189.sh.txt](https://github.com/user-attachments/files/19643535/JDK-8353189.sh.txt)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353189](https://bugs.openjdk.org/browse/JDK-8353189): [ASAN] memory leak after 8352184 (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jiangli Zhou](https://openjdk.org/census#jiangli) (@jianglizhou - **Reviewer**)

### Contributors
 * Jiangli Zhou `<jiangli@openjdk.org>`
 * David Holmes `<dholmes@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24299/head:pull/24299` \
`$ git checkout pull/24299`

Update a local copy of the PR: \
`$ git checkout pull/24299` \
`$ git pull https://git.openjdk.org/jdk.git pull/24299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24299`

View PR using the GUI difftool: \
`$ git pr show -t 24299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24299.diff">https://git.openjdk.org/jdk/pull/24299.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24299#issuecomment-2761905757)
</details>
