### PR TITLE
8353219: RISC-V: Fix client builds after JDK-8345298

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -6151,6 +6151,8 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+#endif // COMPILER2_OR_JVMCI
+
   // x10 = input (float16)
   // f10 = result (float)
   // t1  = temporary register
@@ -6248,8 +6250,6 @@ class StubGenerator: public StubCodeGenerator {
     __ ret();
     return entry;
   }
-
-#endif // COMPILER2_OR_JVMCI
 
 #ifdef COMPILER2
 


### PR DESCRIPTION
Hi, please review this trivial change fixing a client build issue.
The definitions of both `generate_float16ToFloat()` and `generate_floatToFloat16()` should be moved out of `COMPILER2_OR_JVMCI` macro scope. Testing: client builds fine on linux-riscv64 with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353219](https://bugs.openjdk.org/browse/JDK-8353219): RISC-V: Fix client builds after JDK-8345298 (**Bug** - P4)


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24307/head:pull/24307` \
`$ git checkout pull/24307`

Update a local copy of the PR: \
`$ git checkout pull/24307` \
`$ git pull https://git.openjdk.org/jdk.git pull/24307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24307`

View PR using the GUI difftool: \
`$ git pr show -t 24307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24307.diff">https://git.openjdk.org/jdk/pull/24307.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24307#issuecomment-2763017203)
</details>
