### PR TITLE
8353129: CDS ArchiveRelocation tests fail after JDK-8325132

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2131,6 +2131,15 @@ WB_ENTRY(jint, WB_GetCDSCurrentVersion(JNIEnv* env, jobject wb))
 #endif
 WB_END
 
+WB_ENTRY(jint, WB_GetArchiveRelocationMode(JNIEnv* env, jobject wb))
+#if INCLUDE_CDS
+  return (jint)ArchiveRelocationMode;
+#else
+  ShouldNotReachHere();
+  return (jint)-1;
+#endif
+WB_END
+
 WB_ENTRY(jboolean, WB_CDSMemoryMappingFailed(JNIEnv* env, jobject wb))
   return FileMapInfo::memory_mapping_failed();
 WB_END
@@ -2923,6 +2932,7 @@ static JNINativeMethod methods[] = {
                                                       (void*)&WB_GetDefaultArchivePath},
   {CC"getCDSGenericHeaderMinVersion",     CC"()I",    (void*)&WB_GetCDSGenericHeaderMinVersion},
   {CC"getCurrentCDSVersion",              CC"()I",    (void*)&WB_GetCDSCurrentVersion},
+  {CC"getArchiveRelocationMode",          CC"()I",    (void*)&WB_GetArchiveRelocationMode},
   {CC"isSharingEnabled",   CC"()Z",                   (void*)&WB_IsSharingEnabled},
   {CC"isSharedInternedString", CC"(Ljava/lang/String;)Z", (void*)&WB_IsSharedInternedString },
   {CC"isSharedClass",      CC"(Ljava/lang/Class;)Z",  (void*)&WB_IsSharedClass },

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
@@ -39,10 +39,14 @@
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.whitebox.WhiteBox;
 import jtreg.SkippedException;
 
 public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
+    static int relocationMode = -1;
     public static void main(String... args) throws Exception {
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        relocationMode = wb.getArchiveRelocationMode();
         try {
             testOuter();
         } catch (SkippedException s) {
@@ -104,7 +108,7 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
               logArg,
               "-cp", appJar, mainClass)
             .assertNormalExit(output -> {
-                    if (dump_top_reloc) {
+                    if (dump_top_reloc && relocationMode != 0 /* ArchiveRelocationMode could be set via -javaoptions */) {
                         output.shouldContain(runtimeMsg);
                     } else {
                         output.shouldContain(relocationModeMsg);
@@ -117,7 +121,7 @@ public class DynamicArchiveRelocationTest extends DynamicArchiveTestBase {
              logArg,
             "-cp", appJar, mainClass)
             .assertNormalExit(output -> {
-                    if (run_reloc) {
+                    if (run_reloc && relocationMode != 0 /* ArchiveRelocationMode could be set via -javaoptions */) {
                         output.shouldContain(runtimeMsg);
                     } else {
                         output.shouldContain(relocationModeMsg);

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -728,6 +728,7 @@ public class WhiteBox {
   // Sharing & archiving
   public native int     getCDSGenericHeaderMinVersion();
   public native int     getCurrentCDSVersion();
+  public native int     getArchiveRelocationMode();
   public native String  getDefaultArchivePath();
   public native boolean cdsMemoryMappingFailed();
   public native boolean isSharingEnabled();


### PR DESCRIPTION
Two archive relocation tests failed when `-XX:ArchiveRelocationMode=0` is specified via the jtreg `-javaoption`.
A fix is to add a `WhiteBox.getArchiveRelocationMode()` method so that the tests can check if the `ArchiveRelocationMode` is set to 0 before checking the expected output.

Passed tiers 1 - 4 testing.