### PR TITLE
8352731: Compiler workaround to forcibly set "-Xlint:-options" can be removed

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -238,10 +238,6 @@ public class JavaCompiler {
      */
     public Log log;
 
-    /** Whether or not the options lint category was initially disabled
-     */
-    boolean optionsCheckingInitiallyDisabled;
-
     /** Factory for creating diagnostic objects
      */
     JCDiagnostic.Factory diagFactory;
@@ -439,12 +435,6 @@ public class JavaCompiler {
         moduleFinder.moduleNameFromSourceReader = this::readModuleName;
 
         options = Options.instance(context);
-        // See if lint options checking was explicitly disabled by the
-        // user; this is distinct from the options check being
-        // enabled/disabled.
-        optionsCheckingInitiallyDisabled =
-            options.isSet(Option.XLINT_CUSTOM, "-options") ||
-            options.isSet(Option.XLINT_CUSTOM, "none");
 
         verbose       = options.isSet(VERBOSE);
         sourceOutput  = options.isSet(PRINTSOURCE); // used to be -s
@@ -927,11 +917,6 @@ public class JavaCompiler {
         if (hasBeenUsed)
             checkReusable();
         hasBeenUsed = true;
-
-        // forcibly set the equivalent of -Xlint:-options, so that no further
-        // warnings about command line options are generated from this point on
-        options.put(XLINT_CUSTOM.primaryName + "-" + LintCategory.OPTIONS.option, "true");
-        options.remove(XLINT_CUSTOM.primaryName + LintCategory.OPTIONS.option);
 
         start_msec = now();
 


### PR DESCRIPTION
Back in 2011, in order to prevent repeated warnings about bootclasspath not being set ([JDK-7022337](https://bugs.openjdk.org/browse/JDK-7022337)), code was added to `JavaCompiler.java` to forcibly set the `-Xlint:-options` flag after compiler startup:
```java
        // forcibly set the equivalent of -Xlint:-options, so that no further
        // warnings about command line options are generated from this point on
        options.put(XLINT_CUSTOM.primaryName + "-" + LintCategory.OPTIONS.option, "true");
        options.remove(XLINT_CUSTOM.primaryName + LintCategory.OPTIONS.option);
```
This workaround complicates logic relating to warnings in the `"options"` category and, due to improvements to the compiler design since then, it's no longer needed to actually fix the problem. So it can be removed.

As a separate cleanup, the field `optionsCheckingInitiallyDisabled` in `JavaCompiler.java` is no longer used and so it can also be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352731](https://bugs.openjdk.org/browse/JDK-8352731): Compiler workaround to forcibly set "-Xlint:-options" can be removed (**Bug** - P5)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24309/head:pull/24309` \
`$ git checkout pull/24309`

Update a local copy of the PR: \
`$ git checkout pull/24309` \
`$ git pull https://git.openjdk.org/jdk.git pull/24309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24309`

View PR using the GUI difftool: \
`$ git pr show -t 24309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24309.diff">https://git.openjdk.org/jdk/pull/24309.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24309#issuecomment-2763565624)
</details>
