### PR TITLE
8171508: os::jvm_path: error in handling -Dsun.java.launcher.is_altjvm option after 8066474

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1311,9 +1311,8 @@ void os::jvm_path(char *buf, jint buflen) {
     // value for buf is "<JAVA_HOME>/jre/lib/<vmtype>/libjvm.so".
     // If "/jre/lib/" appears at the right place in the string, then
     // assume we are installed in a JDK and we're done. Otherwise, check
-    // for a JAVA_HOME environment variable and fix up the path so it
-    // looks like libjvm.so is installed there (append a fake suffix
-    // hotspot/libjvm.so).
+    // for a JAVA_HOME environment variable and construct a path to the JVM
+    // being overridden.
     const char *p = buf + strlen(buf) - 1;
     for (int count = 0; p > buf && count < 4; ++count) {
       for (--p; p > buf && *p != '/'; --p)
@@ -1352,7 +1351,8 @@ void os::jvm_path(char *buf, jint buflen) {
         if (0 == access(buf, F_OK)) {
           // Use current module name "libjvm.so"
           len = strlen(buf);
-          snprintf(buf + len, buflen-len, "/hotspot/libjvm.so");
+          snprintf(buf + len, buflen-len, "/%s/libjvm%s",
+                   Abstract_VM_Version::vm_variant(), JNI_LIB_SUFFIX);
         } else {
           // Go back to path of .so
           rp = os::realpath((char *)dlinfo.dli_fname, buf, buflen);

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1504,15 +1504,14 @@ void os::jvm_path(char *buf, jint buflen) {
 
   if (Arguments::sun_java_launcher_is_altjvm()) {
     // Support for the java launcher's '-XXaltjvm=<path>' option. Typical
-    // value for buf is "<JAVA_HOME>/jre/lib/<arch>/<vmtype>/libjvm.so"
-    // or "<JAVA_HOME>/jre/lib/<vmtype>/libjvm.dylib". If "/jre/lib/"
-    // appears at the right place in the string, then assume we are
-    // installed in a JDK and we're done. Otherwise, check for a
+    // value for buf is or "<JAVA_HOME>/jre/lib/<vmtype>/libjvm.dylib".
+    // If "/jre/lib/" appears at the right place in the string, then
+    // assume we are installed in a JDK and we're done. Otherwise, check for a
     // JAVA_HOME environment variable and construct a path to the JVM
     // being overridden.
 
     const char *p = buf + strlen(buf) - 1;
-    for (int count = 0; p > buf && count < 5; ++count) {
+    for (int count = 0; p > buf && count < 4; ++count) {
       for (--p; p > buf && *p != '/'; --p)
         /* empty */ ;
     }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2777,11 +2777,10 @@ void os::jvm_path(char *buf, jint buflen) {
     // value for buf is "<JAVA_HOME>/jre/lib/<vmtype>/libjvm.so".
     // If "/jre/lib/" appears at the right place in the string, then
     // assume we are installed in a JDK and we're done. Otherwise, check
-    // for a JAVA_HOME environment variable and fix up the path so it
-    // looks like libjvm.so is installed there (append a fake suffix
-    // hotspot/libjvm.so).
+    // for a JAVA_HOME environment variable and construct a path to the JVM
+    // being overridden.
     const char *p = buf + strlen(buf) - 1;
-    for (int count = 0; p > buf && count < 5; ++count) {
+    for (int count = 0; p > buf && count < 4; ++count) {
       for (--p; p > buf && *p != '/'; --p)
         /* empty */ ;
     }
@@ -2818,7 +2817,8 @@ void os::jvm_path(char *buf, jint buflen) {
         if (0 == access(buf, F_OK)) {
           // Use current module name "libjvm.so"
           len = (int)strlen(buf);
-          snprintf(buf + len, buflen-len, "/hotspot/libjvm.so");
+          snprintf(buf + len, buflen-len, "/%s/libjvm%s",
+                   Abstract_VM_Version::vm_variant(), JNI_LIB_SUFFIX);
         } else {
           // Go back to path of .so
           rp = os::realpath(dli_fname, buf, buflen);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2208,9 +2208,8 @@ void os::jvm_path(char *buf, jint buflen) {
   buf[0] = '\0';
   if (Arguments::sun_java_launcher_is_altjvm()) {
     // Support for the java launcher's '-XXaltjvm=<path>' option. Check
-    // for a JAVA_HOME environment variable and fix up the path so it
-    // looks like jvm.dll is installed there (append a fake suffix
-    // hotspot/jvm.dll).
+    // for a JAVA_HOME environment variable and construct a path to the JVM
+    // being overridden.
     char* java_home_var = ::getenv("JAVA_HOME");
     if (java_home_var != nullptr && java_home_var[0] != 0 &&
         strlen(java_home_var) < (size_t)buflen) {
@@ -2225,7 +2224,8 @@ void os::jvm_path(char *buf, jint buflen) {
         jio_snprintf(jrebin_p, buflen-len, "\\bin\\");
       }
       len = strlen(buf);
-      jio_snprintf(buf + len, buflen-len, "hotspot\\jvm.dll");
+      jio_snprintf(buf + len, buflen-len, "%s\\jvm%s",
+                   Abstract_VM_Version::vm_variant(), JNI_LIB_SUFFIX);
     }
   }
 


### PR DESCRIPTION
This change fixes two issues in `os::jvm_path()`:

- go back 4 instead of 5 slashes and then checking for "/jre/lib";
- fix the hardcoded "hotspot" sub-directory before the jvm library name.

Passed tiers 1 - 3 testing.