### PR TITLE
8353453: URLDecoder should use HexFormat

### DIFF
--- a/src/java.base/share/classes/java/net/URLDecoder.java
+++ b/src/java.base/share/classes/java/net/URLDecoder.java
@@ -29,6 +29,7 @@ import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.HexFormat;
 import java.util.Objects;
 
 /**
@@ -204,11 +205,7 @@ public final class URLDecoder {
 
                     while ( ((i+2) < numChars) &&
                             (c=='%')) {
-                        int v = Integer.parseInt(s, i + 1, i + 3, 16);
-                        if (v < 0)
-                            throw new IllegalArgumentException(
-                                    "URLDecoder: Illegal hex characters in escape "
-                                            + "(%) pattern - negative value");
+                        int v = HexFormat.fromHexDigits(s, i + 1, i + 3);
                         bytes[pos++] = (byte) v;
                         i+= 3;
                         if (i < numChars)


### PR DESCRIPTION
Use `HexFormat.fromHexDigits` in URLDecoder, instead of `Integer.parseInt`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353453](https://bugs.openjdk.org/browse/JDK-8353453): URLDecoder should use HexFormat (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24314/head:pull/24314` \
`$ git checkout pull/24314`

Update a local copy of the PR: \
`$ git checkout pull/24314` \
`$ git pull https://git.openjdk.org/jdk.git pull/24314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24314`

View PR using the GUI difftool: \
`$ git pr show -t 24314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24314.diff">https://git.openjdk.org/jdk/pull/24314.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24314#issuecomment-2769992022)
</details>
