### PR TITLE
8352565: Add native method implementation of Reference.get()

### DIFF
--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -350,6 +350,9 @@ JVM_HasReferencePendingList(JNIEnv *env);
 JNIEXPORT void JNICALL
 JVM_WaitForReferencePendingList(JNIEnv *env);
 
+JNIEXPORT jobject JNICALL
+JVM_ReferenceGet(JNIEnv *env, jobject ref);
+
 JNIEXPORT jboolean JNICALL
 JVM_ReferenceRefersTo(JNIEnv *env, jobject ref, jobject o);
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3031,9 +3031,17 @@ JVM_ENTRY(void, JVM_WaitForReferencePendingList(JNIEnv* env))
   }
 JVM_END
 
+JVM_ENTRY(jobject, JVM_ReferenceGet(JNIEnv* env, jobject ref))
+  oop ref_oop = JNIHandles::resolve_non_null(ref);
+  // PhantomReference has its own implementation of get().
+  assert(!java_lang_ref_Reference::is_phantom(ref_oop), "precondition");
+  oop referent = java_lang_ref_Reference::weak_referent(ref_oop);
+  return JNIHandles::make_local(THREAD, referent);
+JVM_END
+
 JVM_ENTRY(jboolean, JVM_ReferenceRefersTo(JNIEnv* env, jobject ref, jobject o))
   oop ref_oop = JNIHandles::resolve_non_null(ref);
-  // PhantomReference has it's own implementation of refersTo().
+  // PhantomReference has its own implementation of refersTo().
   // See: JVM_PhantomReferenceRefersTo
   assert(!java_lang_ref_Reference::is_phantom(ref_oop), "precondition");
   oop referent = java_lang_ref_Reference::weak_referent_no_keepalive(ref_oop);

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -354,8 +354,15 @@ public abstract sealed class Reference<T>
      */
     @IntrinsicCandidate
     public T get() {
-        return this.referent;
+        @SuppressWarnings("unchecked")
+        T result = (T) get0();
+        return result;
     }
+
+    /* Implementation of unintrinsified get().  Making get() native may lead
+     * C2 to sometimes prefer the native implementation over the intrinsic.
+     */
+    private native Object get0();
 
     /**
      * Tests if the referent of this reference object is {@code obj}.

--- a/src/java.base/share/native/libjava/Reference.c
+++ b/src/java.base/share/native/libjava/Reference.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,12 @@ JNIEXPORT void JNICALL
 Java_java_lang_ref_Reference_waitForReferencePendingList(JNIEnv *env, jclass ignore)
 {
     JVM_WaitForReferencePendingList(env);
+}
+
+JNIEXPORT jobject JNICALL
+Java_java_lang_ref_Reference_get0(JNIEnv *env, jobject ref)
+{
+    return JVM_ReferenceGet(env, ref);
 }
 
 JNIEXPORT jboolean JNICALL

--- a/test/hotspot/jtreg/gc/TestNativeReferenceGet.java
+++ b/test/hotspot/jtreg/gc/TestNativeReferenceGet.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8352565
+ * @summary Determine whether the native method implementation of
+ * Reference.get() works as expected.  Disable the intrinsic implementation to
+ * force use of the native method.
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm
+ *    -Xbootclasspath/a:.
+ *    -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *    -XX:DisableIntrinsic=_Reference_get
+ *    TestNativeReferenceGet
+ */
+
+import jdk.test.whitebox.WhiteBox;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.List;
+import java.util.ArrayList;
+
+public final class TestNativeReferenceGet {
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+
+    private static void gcUntilOld(Object o) {
+        while (!WB.isObjectInOldGen(o)) {
+            WB.fullGC();
+        }
+    }
+
+    private static final class TestObject {
+        public final int value;
+
+        public TestObject(int value) {
+            this.value = value;
+        }
+    }
+
+    private static final ReferenceQueue<TestObject> queue =
+        new ReferenceQueue<TestObject>();
+
+    private static final class Ref extends WeakReference<TestObject> {
+        public Ref(TestObject obj) {
+            super(obj, queue);
+        }
+    }
+
+    private static final int NUM_REFS = 100;
+
+    private static List<Ref> references = null;
+    private static List<TestObject> referents = null;
+
+    // Create all the objects used by the test, and ensure they are all in the
+    // old generation.
+    private static void setup() {
+        references = new ArrayList<Ref>(NUM_REFS);
+        referents = new ArrayList<TestObject>(NUM_REFS);
+
+        for (int i = 0; i < NUM_REFS; ++i) {
+            TestObject obj = new TestObject(i);
+            referents.add(obj);
+            references.add(new Ref(obj));
+        }
+
+        gcUntilOld(references);
+        gcUntilOld(referents);
+        for (int i = 0; i < NUM_REFS; ++i) {
+            gcUntilOld(references.get(i));
+            gcUntilOld(referents.get(i));
+        }
+    }
+
+    // Discard all the strong references.
+    private static void clearReferents() {
+        // Not using List.clear() because it doesn't document null'ing elements.
+        for (int i = 0; i < NUM_REFS; ++i) {
+            referents.set(i, null);
+        }
+    }
+
+    // Create new strong references from the weak references, by using the
+    // native method implementation of Reference.get() and recording the value
+    // in references.
+    private static void strengthenReferents() {
+        for (int i = 0; i < NUM_REFS; ++i) {
+            referents.set(i, references.get(i).get());
+        }
+    }
+
+    private static final long TIMEOUT = 10 * 1000; // 10 seconds, in millis.
+
+    private static void check() {
+        // None of the references should have been cleared and enqueued,
+        // because we have strong references to all the referents.
+        try {
+            if (queue.remove(TIMEOUT) != null) {
+                throw new RuntimeException("Reference enqueued");
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Test interrupted");
+        }
+        // Check details of expected state.
+        for (int i = 0; i < NUM_REFS; ++i) {
+            Ref reference = (Ref) references.get(i);
+            TestObject referent = reference.get();
+            if (referent == null) {
+                throw new RuntimeException("Referent not strengthened");
+            } else if (referent != referents.get(i)) {
+                throw new RuntimeException(
+                    "Reference referent differs from saved referent: " + i);
+            } else if (referent.value != i) {
+                throw new RuntimeException(
+                    "Referent " + i + " value: " + referent.value);
+            }
+        }
+    }
+
+    private static void testConcurrent() {
+        System.out.println("Testing concurrent GC");
+        try {
+            WB.concurrentGCAcquireControl();
+            clearReferents();
+            WB.concurrentGCRunTo(WB.BEFORE_MARKING_COMPLETED);
+            strengthenReferents();
+            WB.concurrentGCRunToIdle();
+            check();
+        } finally {
+            WB.concurrentGCReleaseControl();
+        }
+    }
+
+    private static void testNonconcurrent() {
+        System.out.println("Testing nonconcurrent GC");
+        clearReferents();
+        strengthenReferents();
+        WB.fullGC();
+        check();
+    }
+
+    public static final void main(String[] args) {
+        setup();
+        if (WB.supportsConcurrentGCBreakpoints()) {
+            testConcurrent();
+        } else {
+            testNonconcurrent();
+        }
+    }
+}


### PR DESCRIPTION
Please review this change which adds a native method providing the
implementation of Reference::get.  Referece::get is an intrinsic candidate, so
this native method implementation is only used when the intrinsic is not.

Currently there is intrinsic support by the interpreter, C1, C2, and graal,
which are always used.  With this change we can later remove all the
per-platform interpreter intrinsic implementations, and might also remove the
C1 intrinsic implementation.

Testing:
(1) mach5 tier1-6 normal (so using all the existing intrinsics).
(2) mach5 tier1-6 with interpreter and C1 Reference::get intrinsics disabled.

