### PR TITLE
8353226: JFR: emit old object samples must be transitive closure complete for segment

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
@@ -256,7 +256,7 @@ void StackTraceBlobInstaller::install(ObjectSample* sample) {
   writer.write_type(TYPE_STACKTRACE);
   writer.write_count(1);
   ObjectSampleCheckpoint::write_stacktrace(stack_trace, writer);
-  blob = writer.copy();
+  blob = stack_trace->should_write() ? writer.copy() : writer.move();
   _cache.put(sample, blob);
   sample->set_stacktrace(blob);
 }
@@ -362,9 +362,17 @@ static void write_thread_blob(const ObjectSample* sample, JfrCheckpointWriter& w
   }
 }
 
+static GrowableArray<traceid>* _stacktrace_ids = nullptr;
+
 static void write_stacktrace_blob(const ObjectSample* sample, JfrCheckpointWriter& writer) {
+  assert(_stacktrace_ids != nullptr, "invariant");
   if (sample->has_stacktrace()) {
     write_blob(sample->stacktrace(), writer);
+    return;
+  }
+  const traceid stacktrace_id = sample->stack_trace_id();
+  if (stacktrace_id != 0) {
+    _stacktrace_ids->append(stacktrace_id);
   }
 }
 
@@ -402,7 +410,15 @@ void ObjectSampleCheckpoint::write(const ObjectSampler* sampler, EdgeStore* edge
   assert(sampler != nullptr, "invariant");
   assert(edge_store != nullptr, "invariant");
   assert(thread != nullptr, "invariant");
-  write_sample_blobs(sampler, emit_all, thread);
+  {
+    ResourceMark rm(thread);
+    _stacktrace_ids = new GrowableArray<traceid>(JfrOptionSet::old_object_queue_size());
+    write_sample_blobs(sampler, emit_all, thread);
+    if (_stacktrace_ids->is_nonempty()) {
+      _stacktrace_ids->sort(sort_traceid);
+      JfrStackTraceRepository::write_leak_profiler(_stacktrace_ids, thread);
+    }
+  }
   // write reference chains
   if (!edge_store->is_empty()) {
     JfrCheckpointWriter writer(thread);

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
@@ -102,7 +102,9 @@ void JfrStackTrace::write(JfrChunkWriter& sw) const {
 }
 
 void JfrStackTrace::write(JfrCheckpointWriter& cpw) const {
+  assert(!_written, "invariant");
   write_stacktrace(cpw, _id, _reached_root, _nr_of_frames, _frames);
+  _written = true;
 }
 
 bool JfrStackFrame::equals(const JfrStackFrame& rhs) const {

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.hpp
@@ -82,7 +82,6 @@ class JfrStackTrace : public JfrCHeapObj {
 
   const JfrStackTrace* next() const { return _next; }
 
-  bool should_write() const { return !_written; }
   void write(JfrChunkWriter& cw) const;
   void write(JfrCheckpointWriter& cpw) const;
   bool equals(const JfrStackTrace& rhs) const;
@@ -107,6 +106,7 @@ class JfrStackTrace : public JfrCHeapObj {
  public:
   traceid hash() const { return _hash; }
   traceid id() const { return _id; }
+  bool should_write() const { return !_written; }
 };
 
 #endif // SHARE_JFR_RECORDER_STACKTRACE_JFRSTACKTRACE_HPP

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -27,7 +27,10 @@
 #include "jfr/recorder/repository/jfrChunkWriter.hpp"
 #include "jfr/recorder/stacktrace/jfrStackTraceRepository.hpp"
 #include "jfr/support/jfrThreadLocal.hpp"
+#include "jfr/utilities/jfrPredicate.hpp"
+#include "jfr/utilities/jfrRelation.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "utilities/growableArray.hpp"
 
 /*
  * There are two separate repository instances.
@@ -241,4 +244,37 @@ size_t JfrStackTraceRepository::clear() {
 traceid JfrStackTraceRepository::next_id() {
   MutexLocker lock(JfrStacktrace_lock, Mutex::_no_safepoint_check_flag);
   return ++_next_id;
+}
+
+static inline bool should_write(const JfrStackTrace* stacktrace, GrowableArray<traceid>* leakp_set) {
+  assert(stacktrace != nullptr, "invariant");
+  return stacktrace->should_write() && JfrPredicate<traceid, compare_traceid>::test(leakp_set, stacktrace->id());
+}
+
+void JfrStackTraceRepository::write_leak_profiler(GrowableArray<traceid>* leakp_set, Thread* t) {
+  assert(leakp_set != nullptr, "invariant");
+  assert(leakp_set->is_nonempty(), "invariant");
+  assert(t != nullptr, "invariant");
+
+  JfrCheckpointWriter writer(t);
+  writer.write_type(TYPE_STACKTRACE);
+  const int64_t count_offset = writer.reserve(sizeof(u4)); // Don't know how many yet
+
+  int count = 0;
+  const JfrStackTraceRepository& repo = leak_profiler_instance();
+
+  for (u4 i = 0; i < TABLE_SIZE; ++i) {
+    const JfrStackTrace* stacktrace = repo._table[i];
+    while (stacktrace != nullptr) {
+      if (should_write(stacktrace, leakp_set)) {
+        stacktrace->write(writer);
+        ++count;
+      }
+      stacktrace = stacktrace->next();
+    }
+  }
+
+  assert(count > 0, "invariant");
+  assert(count <= leakp_set->length(), "invariant");
+  writer.write_count(count, count_offset);
 }

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
@@ -30,8 +30,10 @@
 #include "jfr/utilities/jfrTypes.hpp"
 
 class JavaThread;
-class JfrCheckpointWriter;
 class JfrChunkWriter;
+
+template <typename>
+class GrowableArray;
 
 class JfrStackTraceRepository : public JfrCHeapObj {
   friend class JfrDeprecatedEdge;
@@ -62,6 +64,7 @@ class JfrStackTraceRepository : public JfrCHeapObj {
 
   static const JfrStackTrace* lookup_for_leak_profiler(traceid hash, traceid id);
   static void record_for_leak_profiler(JavaThread* thread, int skip = 0);
+    static void write_leak_profiler(GrowableArray<traceid>* leakp_set, Thread* t);
   static void clear_leak_profiler();
 
   static traceid next_id();


### PR DESCRIPTION
Greetings,

EventEmitter::write_events() only serializes blobified stack traces as part of old object checkpoint serialization. Still, it categorically writes a stack trace id as part of the event, even for non-blobified stack traces. As a result, the segment is incomplete. Stack traces must be serialized directly from the leak profiler repository to ensure closure. 

Testing: jdk_jfr

Thanks
Markus