### PR TITLE
8353227: JFR: Prepare tests for strong parser validation

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMCrash.java
+++ b/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMCrash.java
@@ -40,7 +40,26 @@ import jdk.jfr.consumer.EventStream;
  */
 public class TestJVMCrash {
 
+    /*
+     * We don't run if -esa is specified, because parser invariants are not
+     * guaranteed for emergency dumps, which are provided on a best-effort basis only.
+     */
+    private static boolean hasIncompatibleTestOptions() {
+        String testVmOpts[] = System.getProperty("test.vm.opts","").split("\\s+");
+        for (String s : testVmOpts) {
+            if (s.equals("-esa")) {
+                System.out.println("Incompatible option: " + s + " specified. Skipping test.");
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static void main(String... args) {
+        if (hasIncompatibleTestOptions()) {
+            return;
+        }
+
         int id = 1;
         while (true) {
             try (TestProcess process = new TestProcess("crash-application-" + id++, false /* createCore */))  {

--- a/test/jdk/jdk/jfr/event/runtime/TestShutdownEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestShutdownEvent.java
@@ -64,7 +64,26 @@ public class TestShutdownEvent {
              new TestSig("INT")
     };
 
+    /*
+     * We don't run if -esa is specified, because parser invariants are not
+     * guaranteed for emergency dumps, which are provided on a best-effort basis only.
+     */
+    private static boolean hasIncompatibleTestOptions() {
+        String testVmOpts[] = System.getProperty("test.vm.opts","").split("\\s+");
+        for (String s : testVmOpts) {
+            if (s.equals("-esa")) {
+                System.out.println("Incompatible option: " + s + " specified. Skipping test.");
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static void main(String[] args) throws Throwable {
+        if (hasIncompatibleTestOptions()) {
+            return;
+        }
+
         for (int i = 0; i < subTests.length; ++i) {
             int attempts = subTests[i].attempts();
             if (attempts == 0) {

--- a/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
+++ b/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
@@ -74,7 +74,26 @@ public class TestDumpOnCrash {
         }
     }
 
+    /*
+     * We don't run if -esa is specified, because parser invariants are not
+     * guaranteed for emergency dumps, which are provided on a best-effort basis only.
+     */
+    private static boolean hasIncompatibleTestOptions() {
+        String testVmOpts[] = System.getProperty("test.vm.opts","").split("\\s+");
+        for (String s : testVmOpts) {
+            if (s.equals("-esa")) {
+                System.out.println("Incompatible option: " + s + " specified. Skipping test.");
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static void main(String[] args) throws Exception {
+        if (hasIncompatibleTestOptions()) {
+            return;
+        }
+
         // Test without dumppath
         test(CrasherIllegalAccess.class, "", true, null, true);
         test(CrasherIllegalAccess.class, "", false, null, true);


### PR DESCRIPTION
Greetings,

Tests:

- jdk/jfr/jvm/TestDumpOnCrash.java
- jdk/jfr/event/runtime/TestShutdownEvent.java

Cannot run with -esa in combination with [JDK-8351698](https://bugs.openjdk.org/browse/JDK-8351698), because parser invariants are not guaranteed for emergency dumps, which are provided on a best-effort basis only.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353227](https://bugs.openjdk.org/browse/JDK-8353227): JFR: Prepare tests for strong parser validation (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24317/head:pull/24317` \
`$ git checkout pull/24317`

Update a local copy of the PR: \
`$ git checkout pull/24317` \
`$ git pull https://git.openjdk.org/jdk.git pull/24317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24317`

View PR using the GUI difftool: \
`$ git pr show -t 24317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24317.diff">https://git.openjdk.org/jdk/pull/24317.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24317#issuecomment-2764586846)
</details>
