### PR TITLE
8304674: File java.c compile error with -fsanitize=address -O0

### DIFF
--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -186,7 +186,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJLI, \
     OPTIMIZATION := HIGH, \
     CFLAGS := $(LIBJLI_CFLAGS) $(LIBZ_CFLAGS), \
     DISABLED_WARNINGS_gcc := unused-function unused-variable, \
-    DISABLED_WARNINGS_gcc_java.c := return-type, \
     DISABLED_WARNINGS_clang := deprecated-non-prototype format-nonliteral \
         unused-function, \
     DISABLED_WARNINGS_clang_java_md_macosx.m := unused-variable, \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -186,6 +186,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJLI, \
     OPTIMIZATION := HIGH, \
     CFLAGS := $(LIBJLI_CFLAGS) $(LIBZ_CFLAGS), \
     DISABLED_WARNINGS_gcc := unused-function unused-variable, \
+    DISABLED_WARNINGS_gcc_java.c := return-type, \
     DISABLED_WARNINGS_clang := deprecated-non-prototype format-nonliteral \
         unused-function, \
     DISABLED_WARNINGS_clang_java_md_macosx.m := unused-variable, \

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -666,7 +666,10 @@ JavaMain(void* _args)
         ret = 1;
     }
     LEAVE();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreturn-type"
 }
+#pragma GCC diagnostic pop
 
 /*
  * Test if the given name is one of the class path options.

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -666,10 +666,14 @@ JavaMain(void* _args)
         ret = 1;
     }
     LEAVE();
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wreturn-type"
+#endif
 }
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif
 
 /*
  * Test if the given name is one of the class path options.


### PR DESCRIPTION
Hi all,
File src/java.base/share/native/libjli/java.c compile error: control reaches end of non-void function [-Werror=return-type] with gcc options -fsanitize=address -O0. The function int JavaMain(void* _args) in this file will execute return ret in LEAVE() macro, but gcc with -O0 is not smart enough to recognized that the function already has return statement before at the end of function. It's a gcc bug which has been recorded by [80959](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80959), and below code snippet can demonstrate the gcc bug. I think we should disable return-type gcc warning for java.c file before the gcc bug has been fixed. Risk is low.

```
> cat java.c
char a() {
  return 0;
  int b;
  if (a(&b))
    return 0;
}

> gcc -O0 -Wall -Wextra -Werror -O0 -c java.c -fsanitize=address
java.c: In function ‘a’:
java.c:6:1: error: control reaches end of non-void function [-Werror=return-type]
    6 | }
      | ^
cc1: all warnings being treated as errors
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8304674](https://bugs.openjdk.org/browse/JDK-8304674): File java.c compile error with -fsanitize=address -O0 (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24318/head:pull/24318` \
`$ git checkout pull/24318`

Update a local copy of the PR: \
`$ git checkout pull/24318` \
`$ git pull https://git.openjdk.org/jdk.git pull/24318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24318`

View PR using the GUI difftool: \
`$ git pr show -t 24318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24318.diff">https://git.openjdk.org/jdk/pull/24318.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24318#issuecomment-2764608029)
</details>
