### PR TITLE
8353235: Test jdk/jfr/api/metadata/annotations/TestPeriod.java fails with IllegalArgumentException

### DIFF
--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
@@ -26,6 +26,7 @@ package jdk.jfr.api.metadata.annotations;
 import jdk.jfr.Event;
 import jdk.jfr.EventType;
 import jdk.jfr.Period;
+import jdk.jfr.FlightRecorder;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.jfr.Events;
 
@@ -44,6 +45,7 @@ public class TestPeriod {
 
     public static void main(String[] args) throws Exception {
         EventType periodicEvent = EventType.getEventType(PeriodicEvent.class);
+        FlightRecorder.addPeriodicEvent(PeriodicEvent.class, () -> {});
         String defaultValue = Events.getSetting(periodicEvent, Period.NAME).getDefaultValue();
         Asserts.assertEQ(defaultValue, "47 s", "Incorrect default value for period");
     }


### PR DESCRIPTION
Hi all,

In test jdk/jfr/api/metadata/annotations/TestPeriod.java, the tested class `PeriodicEvent` extends `Event`, bug `Event` has three event types `enabled/stackTrace/threshold` by default. So we need to add `period` event type before test manually.

Change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353235](https://bugs.openjdk.org/browse/JDK-8353235): Test jdk/jfr/api/metadata/annotations/TestPeriod.java fails with IllegalArgumentException (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24320/head:pull/24320` \
`$ git checkout pull/24320`

Update a local copy of the PR: \
`$ git checkout pull/24320` \
`$ git pull https://git.openjdk.org/jdk.git pull/24320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24320`

View PR using the GUI difftool: \
`$ git pr show -t 24320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24320.diff">https://git.openjdk.org/jdk/pull/24320.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24320#issuecomment-2765020035)
</details>
