### PR TITLE
8352768: CDS test MethodHandleTest.java failed in -Xcomp mode

### DIFF
--- a/src/hotspot/share/cds/aotClassInitializer.cpp
+++ b/src/hotspot/share/cds/aotClassInitializer.cpp
@@ -303,6 +303,7 @@ bool AOTClassInitializer::can_archive_initialized_mirror(InstanceKlass* ik) {
       {"java/lang/invoke/MethodHandles"},
       {"java/lang/invoke/SimpleMethodHandle"},
       {"java/lang/invoke/StringConcatFactory"},
+      {"java/lang/invoke/VarHandleGuards"},
       {"java/util/Collections"},
       {"java/util/stream/Collectors"},
       {"jdk/internal/constant/ConstantUtils"},


### PR DESCRIPTION
The failure happens because `java/lang/invoke/VarHandleGuards` is missing from the list of AOT-initialized classes. Please see the [JBS issue](https://bugs.openjdk.org/browse/JDK-8352768) for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352768](https://bugs.openjdk.org/browse/JDK-8352768): CDS test MethodHandleTest.java failed in -Xcomp mode (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24321/head:pull/24321` \
`$ git checkout pull/24321`

Update a local copy of the PR: \
`$ git checkout pull/24321` \
`$ git pull https://git.openjdk.org/jdk.git pull/24321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24321`

View PR using the GUI difftool: \
`$ git pr show -t 24321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24321.diff">https://git.openjdk.org/jdk/pull/24321.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24321#issuecomment-2765179097)
</details>
