### PR TITLE
8353263: Parallel: Remove locking in PSOldGen::resize

### DIFF
--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -262,8 +262,9 @@ bool PSOldGen::expand_to_reserved() {
 }
 
 void PSOldGen::shrink(size_t bytes) {
-  assert_lock_strong(PSOldGenExpand_lock);
-  assert_locked_or_safepoint(Heap_lock);
+  assert(Thread::current()->is_VM_thread(), "precondition");
+  assert(SafepointSynchronize::is_at_safepoint(), "precondition");
+  assert(bytes > 0, "precondition");
 
   size_t size = align_down(bytes, virtual_space()->alignment());
   if (size > 0) {
@@ -314,11 +315,9 @@ void PSOldGen::resize(size_t desired_free_space) {
   }
   if (new_size > current_size) {
     size_t change_bytes = new_size - current_size;
-    MutexLocker x(PSOldGenExpand_lock);
     expand(change_bytes);
   } else {
     size_t change_bytes = current_size - new_size;
-    MutexLocker x(PSOldGenExpand_lock);
     shrink(change_bytes);
   }
 


### PR DESCRIPTION
Simple removing the use of `PSOldGenExpand_lock` in resizing logic after full-gc, because the calling context is inside a safepoint.

Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353263](https://bugs.openjdk.org/browse/JDK-8353263): Parallel: Remove locking in PSOldGen::resize (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24322/head:pull/24322` \
`$ git checkout pull/24322`

Update a local copy of the PR: \
`$ git checkout pull/24322` \
`$ git pull https://git.openjdk.org/jdk.git pull/24322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24322`

View PR using the GUI difftool: \
`$ git pr show -t 24322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24322.diff">https://git.openjdk.org/jdk/pull/24322.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24322#issuecomment-2765724201)
</details>
