### PR TITLE
8330598: java/net/httpclient/Http1ChunkedTest.java fails with java.util.MissingFormatArgumentException: Format specifier '%s'

### DIFF
--- a/test/jdk/java/net/httpclient/Http1ChunkedTest.java
+++ b/test/jdk/java/net/httpclient/Http1ChunkedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,7 +97,7 @@ public class Http1ChunkedTest {
                         }
                     }
                     if (!received) {
-                        System.out.printf("%s: Unexpected headers received: dropping request.%n");
+                        System.out.printf("%s: Unexpected headers received: dropping request.%n", name);
                         continue;
                     }
                     OutputStream os = serverConn.getOutputStream();


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330598](https://bugs.openjdk.org/browse/JDK-8330598): java/net/httpclient/Http1ChunkedTest.java fails with java.util.MissingFormatArgumentException: Format specifier '%s' (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24324/head:pull/24324` \
`$ git checkout pull/24324`

Update a local copy of the PR: \
`$ git checkout pull/24324` \
`$ git pull https://git.openjdk.org/jdk.git pull/24324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24324`

View PR using the GUI difftool: \
`$ git pr show -t 24324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24324.diff">https://git.openjdk.org/jdk/pull/24324.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24324#issuecomment-2765844002)
</details>
