### PR TITLE
8353272: One instance of STATIC_LIB_CFLAGS was missed in JDK-8345683

### DIFF
--- a/make/common/native/Flags.gmk
+++ b/make/common/native/Flags.gmk
@@ -122,7 +122,7 @@ define SetupCompilerFlags
     $1_EXTRA_CXXFLAGS += $$($1_CXXFLAGS_$(OPENJDK_TARGET_OS)_release)
   endif
   ifeq ($(STATIC_LIBS), true)
-    $1_EXTRA_CXXFLAGS += $$(STATIC_LIB_CFLAGS)
+    $1_EXTRA_CXXFLAGS += -DSTATIC_BUILD=1
   endif
 
   # If no C++ flags are explicitly set, default to using the C flags.


### PR DESCRIPTION
It turns out one instance of STATIC_LIB_CFLAGS was missed in Flags.gmk when fixing [JDK-8345683](https://bugs.openjdk.org/browse/JDK-8345683). This was noticed by @cnqpzhang in https://github.com/openjdk/jdk/pull/24115/files#r2011164138.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353272](https://bugs.openjdk.org/browse/JDK-8353272): One instance of STATIC_LIB_CFLAGS was missed in JDK-8345683 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24327/head:pull/24327` \
`$ git checkout pull/24327`

Update a local copy of the PR: \
`$ git checkout pull/24327` \
`$ git pull https://git.openjdk.org/jdk.git pull/24327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24327`

View PR using the GUI difftool: \
`$ git pr show -t 24327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24327.diff">https://git.openjdk.org/jdk/pull/24327.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24327#issuecomment-2766249447)
</details>
