### PR TITLE
8353274: [PPC64] Bug related to -XX:+UseCompactObjectHeaders -XX:-UseSIGTRAP in JDK-8305895

### DIFF
--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -802,6 +802,7 @@ class MacroAssembler: public Assembler {
   inline void decode_heap_oop(Register d);
 
   // Load/Store klass oop from klass field. Compress.
+  void load_klass_no_decode(Register dst, Register src);
   void load_klass(Register dst, Register src);
   void load_narrow_klass_compact(Register dst, Register src);
   void cmp_klass(ConditionRegister dst, Register obj, Register klass, Register tmp, Register tmp2);


### PR DESCRIPTION
`MacroAssembler::ic_check` compares the `Klass*` in the compact format (no decode). However, a right shift is needed in case of `UseCompactObjectHeaders` (see `load_narrow_klass_compact`). This was missing in the slower version which doesn't use SIGTRAP.