### PR TITLE
8353278: Consolidate local file URL checks in jar: and file: URL schemes

### DIFF
--- a/src/java.base/share/classes/sun/net/www/ParseUtil.java
+++ b/src/java.base/share/classes/sun/net/www/ParseUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -507,6 +507,22 @@ public final class ParseUtil {
         }
     }
 
+    /**
+     * {@return true if the url is a file: URL for a 'local file' as defined by RFC 8089, Section 2}
+     *
+     * For unknown historical reasons, this method deviates from RFC 8089
+     * by allowing "~" as an alias for 'localhost'
+     *
+     * @param url the URL which may be a local file URL
+     */
+    public static boolean isLocalFileURL(URL url) {
+        if (url.getProtocol().equalsIgnoreCase("file")) {
+            String host = url.getHost();
+            return host == null || host.isEmpty() || host.equals("~") ||
+                    host.equalsIgnoreCase("localhost");
+        }
+        return false;
+    }
 
     // -- Character classes for parsing --
 

--- a/src/java.base/share/classes/sun/net/www/protocol/jar/JarFileFactory.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/JarFileFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.util.jar.JarFile;
 
 import jdk.internal.util.OperatingSystem;
 import sun.net.util.URLUtil;
+import sun.net.www.ParseUtil;
 
 /* A factory for cached JAR file. This class is used to both retrieve
  * and cache Jar files.
@@ -92,7 +93,7 @@ class JarFileFactory implements URLJarFile.URLJarFileCloseController {
             return get(url, false);
         }
         URL patched = urlFor(url);
-        if (!URLJarFile.isFileURL(patched)) {
+        if (!ParseUtil.isLocalFileURL(patched)) {
             // A temporary file will be created, we can prepopulate
             // the cache in this case.
             return get(url, useCaches);
@@ -158,9 +159,10 @@ class JarFileFactory implements URLJarFile.URLJarFileCloseController {
             // Deal with UNC pathnames specially. See 4180841
 
             String host = url.getHost();
-            if (host != null && !host.isEmpty() &&
-                    !host.equalsIgnoreCase("localhost")) {
-
+            // Subtly different from ParseUtil.isLocalFileURL, for historical reasons
+            boolean isLocalFile = ParseUtil.isLocalFileURL(url) && !"~".equals(host);
+            // For remote hosts, change 'file://host/folder/data.xml' to 'file:////host/folder/data.xml'
+            if (!isLocalFile) {
                 @SuppressWarnings("deprecation")
                 var _unused = url = new URL("file", "", "//" + host + url.getPath());
             }

--- a/src/java.base/share/classes/sun/net/www/protocol/jar/URLJarFile.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/URLJarFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/net/www/protocol/jar/URLJarFile.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/URLJarFile.java
@@ -49,7 +49,7 @@ public class URLJarFile extends JarFile {
     private Map<String, Attributes> superEntries;
 
     static JarFile getJarFile(URL url, URLJarFileCloseController closeController) throws IOException {
-        if (isFileURL(url)) {
+        if (ParseUtil.isLocalFileURL(url)) {
             Runtime.Version version = "runtime".equals(url.getRef())
                     ? JarFile.runtimeVersion()
                     : JarFile.baseVersion();
@@ -69,20 +69,6 @@ public class URLJarFile extends JarFile {
             throws IOException {
         super(new File(ParseUtil.decode(url.getFile())), true, ZipFile.OPEN_READ, version);
         this.closeController = closeController;
-    }
-
-    static boolean isFileURL(URL url) {
-        if (url.getProtocol().equalsIgnoreCase("file")) {
-            /*
-             * Consider this a 'file' only if it's a LOCAL file, because
-             * 'file:' URLs can be accessible through ftp.
-             */
-            String host = url.getHost();
-            if (host == null || host.isEmpty() || host.equals("~") ||
-                host.equalsIgnoreCase("localhost"))
-                return true;
-        }
-        return false;
     }
 
     /**

--- a/src/java.base/unix/classes/sun/net/www/protocol/file/Handler.java
+++ b/src/java.base/unix/classes/sun/net/www/protocol/file/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,8 +64,7 @@ public class Handler extends URLStreamHandler {
     public URLConnection openConnection(URL u, Proxy p)
            throws IOException {
         String host = u.getHost();
-        if (host == null || host.isEmpty() || host.equals("~") ||
-            host.equalsIgnoreCase("localhost")) {
+        if (ParseUtil.isLocalFileURL(u)) {
             File file = new File(ParseUtil.decode(u.getPath()));
             return createFileURLConnection(u, file);
         }

--- a/src/java.base/windows/classes/sun/net/www/protocol/file/Handler.java
+++ b/src/java.base/windows/classes/sun/net/www/protocol/file/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,9 +72,7 @@ public class Handler extends URLStreamHandler {
         path = path.replace('/', '\\');
         path = path.replace('|', ':');
 
-        if ((host == null) || host.isEmpty() ||
-                host.equalsIgnoreCase("localhost") ||
-                host.equals("~")) {
+        if (ParseUtil.isLocalFileURL(url)) {
            return createFileURLConnection(url, new File(path));
         }
 


### PR DESCRIPTION
Please help review this cleanup PR which consolidates 'local file' URL checks across the 'file:' and 'jar:' URL scheme implementations and defines this check in terms of RFC 8089, Section 2.

This PR:

* Moves `URLJarFile.isFileURL` to `sun.net.www.ParseUtil` where it is documented according to RFC 8089 and given the more suitable name `isLocalFileURL`
* Updates `isLocalFileURL` to simplify an `if (x) return true;` statement to `return x;`
* Updates `URLJarFile.getJarFile` and `JarFileFactory.getOrCreate` to use `isLocalFileURL`
* Updates `JarFileFactory.urlFor` to use `isLocalFileURL` (while maintaining and documenting the historical and subtly different non-treatment of '~' as an alias for 'localhost')
* Updates `sun.net.www.protocol.file.Handler.openConnection` to use `isLocalFileURL` in windows/unix implementations

This is a pure cleanup / refactoring PR, no tests are updated here. Existing testing in this area seems sparse, so I have tried to limit the number of code tweaks to a minimium to make reviews easier.

Testing: GHA runs green, as well as tier2 on MacOS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353278](https://bugs.openjdk.org/browse/JDK-8353278): Consolidate local file URL checks in jar: and file: URL schemes (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24332/head:pull/24332` \
`$ git checkout pull/24332`

Update a local copy of the PR: \
`$ git checkout pull/24332` \
`$ git pull https://git.openjdk.org/jdk.git pull/24332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24332`

View PR using the GUI difftool: \
`$ git pr show -t 24332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24332.diff">https://git.openjdk.org/jdk/pull/24332.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24332#issuecomment-2768380355)
</details>
