### PR TITLE
8351654: Agent transformer bytecodes should be verified

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5333,7 +5333,8 @@ ClassFileParser::ClassFileParser(ClassFileStream* stream,
   assert(0 == _access_flags.as_unsigned_short(), "invariant");
 
   // Figure out whether we can skip format checking (matching classic VM behavior)
-  _need_verify = Verifier::should_verify_for(_loader_data->class_loader());
+  // Always verify CFLH bytes from the user agents.
+  _need_verify = stream->from_class_file_load_hook() ? true : Verifier::should_verify_for(_loader_data->class_loader());
 
   // synch back verification state to stream to check for truncation.
   stream->set_need_verify(_need_verify);

--- a/src/hotspot/share/classfile/classFileStream.cpp
+++ b/src/hotspot/share/classfile/classFileStream.cpp
@@ -34,13 +34,15 @@ void ClassFileStream::truncated_file_error(TRAPS) const {
 ClassFileStream::ClassFileStream(const u1* buffer,
                                  int length,
                                  const char* source,
-                                 bool from_boot_loader_modules_image) :
+                                 bool from_boot_loader_modules_image,
+                                 bool from_class_file_load_hook) :
   _buffer_start(buffer),
   _buffer_end(buffer + length),
   _current(buffer),
   _source(source),
   _need_verify(true),  // may be reset by ClassFileParser when this stream is parsed.
-  _from_boot_loader_modules_image(from_boot_loader_modules_image) {
+  _from_boot_loader_modules_image(from_boot_loader_modules_image),
+  _from_class_file_load_hook(from_class_file_load_hook) {
     assert(buffer != nullptr, "caller should throw NPE");
 }
 
@@ -68,5 +70,6 @@ const ClassFileStream* ClassFileStream::clone() const {
   return new ClassFileStream(new_buffer_start,
                              length(),
                              clone_source(),
-                             from_boot_loader_modules_image());
+                             from_boot_loader_modules_image(),
+                             from_class_file_load_hook());
 }

--- a/src/hotspot/share/classfile/classFileStream.hpp
+++ b/src/hotspot/share/classfile/classFileStream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,9 @@ class ClassFileStream: public ResourceObj {
   const char* const _source;     // Source of stream (directory name, ZIP/JAR archive name)
   bool _need_verify;             // True if we need to verify and check truncation of stream bytes.
   bool _from_boot_loader_modules_image;  // True if this was created by ClassPathImageEntry.
-  void truncated_file_error(TRAPS) const ;
+  bool _from_class_file_load_hook;       // True if this is from CFLH (needs verification)
+
+  void truncated_file_error(TRAPS) const;
 
  protected:
   const u1* clone_buffer() const;
@@ -55,7 +57,8 @@ class ClassFileStream: public ResourceObj {
   ClassFileStream(const u1* buffer,
                   int length,
                   const char* source,
-                  bool from_boot_loader_modules_image = false);
+                  bool from_boot_loader_modules_image = false,
+                  bool from_class_file_load_hook = false);
 
   virtual const ClassFileStream* clone() const;
 
@@ -154,6 +157,8 @@ class ClassFileStream: public ResourceObj {
   bool at_eos() const { return _current == _buffer_end; }
 
   uint64_t compute_fingerprint() const;
+
+  bool from_class_file_load_hook() const { return _from_class_file_load_hook; }
 };
 
 #endif // SHARE_CLASSFILE_CLASSFILESTREAM_HPP

--- a/src/hotspot/share/classfile/klassFactory.cpp
+++ b/src/hotspot/share/classfile/klassFactory.cpp
@@ -76,7 +76,9 @@ InstanceKlass* KlassFactory::check_shared_class_file_load_hook(
       s2 path_index = ik->shared_classpath_index();
       ClassFileStream* stream = new ClassFileStream(ptr,
                                                     pointer_delta_as_int(end_ptr, ptr),
-                                                    cfs->source(), false, /* from_class_file_load_hook */ true);
+                                                    cfs->source(),
+                                                    /* from_boot_loader_modules_image */ false,
+                                                    /* from_class_file_load_hook */ true);
       ClassLoadInfo cl_info(protection_domain);
       ClassFileParser parser(stream,
                              class_name,
@@ -155,7 +157,9 @@ static ClassFileStream* check_class_file_load_hook(ClassFileStream* stream,
       // Set new class file stream using JVMTI agent modified class file data.
       stream = new ClassFileStream(ptr,
                                    pointer_delta_as_int(end_ptr, ptr),
-                                   stream->source(), false, /* from_class_file_load_hook */ true);
+                                   stream->source(),
+                                   /* from_boot_loader_modules_image */ false,
+                                   /* from_class_file_load_hook */ true);
     }
   }
 

--- a/src/hotspot/share/classfile/klassFactory.cpp
+++ b/src/hotspot/share/classfile/klassFactory.cpp
@@ -76,7 +76,7 @@ InstanceKlass* KlassFactory::check_shared_class_file_load_hook(
       s2 path_index = ik->shared_classpath_index();
       ClassFileStream* stream = new ClassFileStream(ptr,
                                                     pointer_delta_as_int(end_ptr, ptr),
-                                                    cfs->source());
+                                                    cfs->source(), false, /* from_class_file_load_hook */ true);
       ClassLoadInfo cl_info(protection_domain);
       ClassFileParser parser(stream,
                              class_name,
@@ -155,7 +155,7 @@ static ClassFileStream* check_class_file_load_hook(ClassFileStream* stream,
       // Set new class file stream using JVMTI agent modified class file data.
       stream = new ClassFileStream(ptr,
                                    pointer_delta_as_int(end_ptr, ptr),
-                                   stream->source());
+                                   stream->source(), false, /* from_class_file_load_hook */ true);
     }
   }
 

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleJavaBaseVerify.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleJavaBaseVerify.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8351654
- * @summary Make sure --patch-module for java.base verifies the classfile.
+ * @summary Show that --patch-module for java.base does not verify the classfile.
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleJavaBaseVerify.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleJavaBaseVerify.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8351654
+ * @summary Make sure --patch-module for java.base verifies the classfile.
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @compile PatchModuleMain.java
+ * @run driver PatchModuleJavaBaseVerify
+ */
+
+import jdk.test.lib.compiler.InMemoryJavaCompiler;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+public class PatchModuleJavaBaseVerify {
+
+    public static void main(String[] args) throws Exception {
+        String source = "package java.lang; "                       +
+                        "public class NewClass { "                  +
+                        "    static { "                             +
+                        "        System.out.println(\"I pass!\"); " +
+                        "    } "                                    +
+                        "}";
+
+        ClassFileInstaller.writeClassToDisk("java/lang/NewClass",
+             InMemoryJavaCompiler.compile("java.lang.NewClass", source, "--patch-module=java.base"),
+             "mods/java.base");
+
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("--patch-module=java.base=mods/java.base",
+             "-Xlog:verification", "PatchModuleMain", "java.lang.NewClass");
+
+        new OutputAnalyzer(pb.start())
+            .shouldContain("I pass!")
+            .shouldContain("End class verification for: PatchModuleMain")
+            .shouldNotContain("End class verification for: java.lang.NewClass")
+            .shouldHaveExitValue(0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/verifier/CFLH/TestChecker.java
+++ b/test/hotspot/jtreg/runtime/verifier/CFLH/TestChecker.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package checker;
+
+public interface TestChecker {
+    void check(Integer i);
+
+    static TestChecker instance() {
+        return TestCheckerImpl.instance;
+    }
+
+    class TestCheckerImpl implements TestChecker {
+        private static final TestCheckerImpl instance = new TestCheckerImpl();
+
+        @Override
+        public void check(Integer i) {
+            System.out.println("Checking: " + i);
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
+++ b/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
@@ -69,7 +69,7 @@ public class TestVerify {
 
         @Override
         public byte[] transform(Module module, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
-            //System.out.println("Maybe transforming module class " + className);
+          
             if (className.equals(INTERNAL_CLASS_TO_BREAK)) {
                 System.out.println("Instrumenting modular class " + INTERNAL_CLASS_TO_BREAK);
 

--- a/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
+++ b/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test Verifier should verify ClassFileLoadHook bytes even if on bootclasspath
+ * @bug 8351654
+ * @requires vm.jvmti
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @modules java.compiler
+ *          java.instrument
+ *          jdk.jartool/sun.tools.jar
+ * @compile TestChecker.java
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller checker/TestChecker
+ * @run main TestVerify buildAgent
+ * @run main/othervm --patch-module=java.base=. -Dagent.retransform=false -javaagent:redefineagent.jar TestVerify
+ * @run main/othervm --patch-module=java.base=. -Dagent.retransform=true -javaagent:redefineagent.jar TestVerify
+ */
+
+import java.lang.invoke.MethodHandles;
+import java.time.Duration;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassTransform;
+import java.lang.classfile.MethodTransform;
+import java.lang.classfile.constantpool.InterfaceMethodRefEntry;
+import java.lang.classfile.instruction.ReturnInstruction;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.lang.instrument.Instrumentation;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.ProtectionDomain;
+
+import java.io.PrintWriter;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import java.io.FileNotFoundException;
+
+public class TestVerify {
+
+    private static final String CLASS_TO_BREAK = "java.time.Duration";
+    private static final String INTERNAL_CLASS_TO_BREAK = CLASS_TO_BREAK.replace('.', '/');
+    private static final boolean DEBUG = false;
+
+    private static class BadTransformer implements ClassFileTransformer {
+
+        @Override
+        public byte[] transform(Module module, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+            //System.out.println("Maybe transforming module class " + className);
+            if (className.equals(INTERNAL_CLASS_TO_BREAK)) {
+                System.out.println("Instrumenting modular class " + INTERNAL_CLASS_TO_BREAK);
+
+                var methodTransform = MethodTransform.transformingCode((builder, element) -> {
+                    if (element instanceof ReturnInstruction) {
+                        System.out.println("Injecting bug");
+                        // THE BUG! insert broken function call
+
+                        var checkerDesc = ClassDesc.of("checker", "TestChecker");
+                        builder.invokestatic(checkerDesc, "instance", MethodTypeDesc.of(checkerDesc), true);
+
+                        // dup the instance ref, this is just to get a bad argument to the next method call
+                        builder.dup();
+
+                        // then call a check method that doesn't take that type, but we have the wrong desc
+                        builder.invokeinterface(checkerDesc, "check", MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_Integer));
+
+                        System.out.println("Done injecting bug");
+                    }
+                    builder.with(element);
+                });
+                var classTransform = ClassTransform.transformingMethods(mm -> mm.methodName().stringValue().equals("getSeconds"), methodTransform);
+
+                byte[] bytes;
+                try {
+                    var cf = ClassFile.of();
+                    var existingClass = cf.parse(classfileBuffer);
+                    bytes = cf.transformClass(existingClass, classTransform);
+
+                    if (DEBUG) Files.write(Path.of("bad.class"), bytes);
+                } catch (Throwable e) {
+                    System.out.println(e);
+                    throw new AssertionError(e);
+                }
+                return bytes;
+            }
+            return null;
+        }
+    }
+
+    static Instrumentation inst = null;
+    static boolean verifyErrorThrown = false;
+
+    public static void premain(String args, Instrumentation instrumentation) throws Exception {
+        System.out.println("Premain");
+        inst = instrumentation;
+
+        // double check our class hasn't been loaded yet
+        for (Class clazz : inst.getAllLoadedClasses()) {
+            if (clazz.getName().equals(CLASS_TO_BREAK)) {
+                throw new AssertionError("Oops! Class " + CLASS_TO_BREAK + " is already loaded, the test can't work");
+            }
+        }
+
+        boolean retransform = Boolean.getBoolean("agent.retransform");
+        if (retransform) {
+            // for the bug the class we call must be already loaded, so that we retransform it
+            var clazz = Class.forName(CLASS_TO_BREAK);
+            try {
+                 inst.addTransformer(new BadTransformer(), true);
+                 inst.retransformClasses(clazz);
+             } catch (VerifyError ve) {
+                 System.out.println("Passed: threw VerifyError during retransform");
+                 verifyErrorThrown = true;
+             }
+        } else {
+            // no verify error, the class is used in TestMain
+            inst.addTransformer(new BadTransformer());
+        }
+    }
+
+    private static void buildAgent() {
+        try {
+            ClassFileInstaller.main("TestVerify");
+        } catch (Exception e) {
+            throw new RuntimeException("Could not write agent classfile", e);
+        }
+
+        try {
+            PrintWriter pw = new PrintWriter("MANIFEST.MF");
+            pw.println("Premain-Class: TestVerify");
+            pw.println("Agent-Class: TestVerify");
+            pw.println("Can-Retransform-Classes: true");
+            pw.println("Can-Redefine-Classes: true");
+            pw.close();
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException("Could not write manifest file for the agent", e);
+        }
+
+        sun.tools.jar.Main jarTool = new sun.tools.jar.Main(System.out, System.err, "jar");
+        if (!jarTool.run(new String[] { "-cmf", "MANIFEST.MF", "redefineagent.jar", "TestVerify.class" })) {
+            throw new RuntimeException("Could not write the agent jar file");
+        }
+    }
+
+    public static void main(String argv[]) {
+        if (argv.length == 1 && argv[0].equals("buildAgent")) {
+            buildAgent();
+            return;
+        }
+
+        try {
+            // Now load the class for the VerifyError.
+            System.out.println("1 hour is " + Duration.ofHours(1).getSeconds() + " seconds");
+            if (!verifyErrorThrown) {
+                throw new RuntimeException("Failed: Did not throw VerifyError");
+            }
+        } catch (VerifyError e) {
+            System.out.println("Passed: VerifyError " + e.getMessage());
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
+++ b/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
@@ -22,7 +22,8 @@
  */
 
 /*
- * @test Verifier should verify ClassFileLoadHook bytes even if on bootclasspath
+ * @test 
+ * @summary Verifier should verify ClassFileLoadHook bytes even if on bootclasspath
  * @bug 8351654
  * @requires vm.jvmti
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
+++ b/test/hotspot/jtreg/runtime/verifier/CFLH/TestVerify.java
@@ -101,7 +101,6 @@ public class TestVerify {
 
                     if (DEBUG) Files.write(Path.of("bad.class"), bytes);
                 } catch (Throwable e) {
-                    System.out.println(e);
                     throw new AssertionError(e);
                 }
                 return bytes;


### PR DESCRIPTION
This change enables verification for classes provided with the JVMTI ClassFileLoadHook.  The test was adapted from the one sent by the submitter @rjernst.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351654](https://bugs.openjdk.org/browse/JDK-8351654): Agent transformer bytecodes should be verified (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) Review applies to [6e59012c](https://git.openjdk.org/jdk/pull/24333/files/6e59012cb3331d76e53c3e04e4b95ea42fef060d)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24333/head:pull/24333` \
`$ git checkout pull/24333`

Update a local copy of the PR: \
`$ git checkout pull/24333` \
`$ git pull https://git.openjdk.org/jdk.git pull/24333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24333`

View PR using the GUI difftool: \
`$ git pr show -t 24333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24333.diff">https://git.openjdk.org/jdk/pull/24333.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24333#issuecomment-2766789262)
</details>
