### PR TITLE
8353117: Crash: assert(id >= ThreadIdentifier::initial() && id < ThreadIdentifier::current()) failed: must be reasonable)

### DIFF
--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -236,8 +236,6 @@ void JavaThread::allocate_threadObj(Handle thread_group, const char* thread_name
   // constructor calls Thread.current(), which must be set here.
   java_lang_Thread::set_thread(thread_oop(), this);
   set_threadOopHandles(thread_oop());
-  // Set the _monitor_owner_id to the next thread_id temporarily while initialization runs.
-  set_monitor_owner_id(ThreadIdentifier::next());
 
   JavaValue result(T_VOID);
   if (thread_name != nullptr) {
@@ -263,8 +261,6 @@ void JavaThread::allocate_threadObj(Handle thread_group, const char* thread_name
                             Handle(),
                             CHECK);
   }
-  // Update the _monitor_owner_id with the tid value.
-  set_monitor_owner_id(java_lang_Thread::thread_id(thread_oop()));
 
   os::set_priority(this, NormPriority);
 

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -170,10 +170,14 @@ class JavaThread: public Thread {
 
  public:
   void set_monitor_owner_id(int64_t id) {
-    assert(id >= ThreadIdentifier::initial() && id < ThreadIdentifier::current(), "");
+    ThreadIdentifier::verify_id(id);
     _monitor_owner_id = id;
   }
-  int64_t monitor_owner_id() const { return _monitor_owner_id; }
+  int64_t monitor_owner_id() const {
+    int64_t id = _monitor_owner_id;
+    ThreadIdentifier::verify_id(id);
+    return id;
+  }
 
   // For tracking the heavyweight monitor the thread is pending on.
   ObjectMonitor* current_pending_monitor() {

--- a/src/hotspot/share/runtime/objectMonitor.inline.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.inline.hpp
@@ -41,14 +41,12 @@
 #include "utilities/globalDefinitions.hpp"
 
 inline int64_t ObjectMonitor::owner_id_from(JavaThread* thread) {
-  int64_t id = thread->monitor_owner_id();
-  assert(id >= ThreadIdentifier::initial() && id < ThreadIdentifier::current(), "must be reasonable");
-  return id;
+  return thread->monitor_owner_id();
 }
 
 inline int64_t ObjectMonitor::owner_id_from(oop vthread) {
   int64_t id = java_lang_Thread::thread_id(vthread);
-  assert(id >= ThreadIdentifier::initial() && id < ThreadIdentifier::current(), "must be reasonable");
+  ThreadIdentifier::verify_id(id);
   return id;
 }
 

--- a/src/hotspot/share/runtime/threadIdentifier.cpp
+++ b/src/hotspot/share/runtime/threadIdentifier.cpp
@@ -48,3 +48,10 @@ int64_t ThreadIdentifier::next() {
   } while (Atomic::cmpxchg(&next_thread_id, next_tid, next_tid + 1) != next_tid);
   return next_tid;
 }
+
+#ifdef ASSERT
+void ThreadIdentifier::verify_id(int64_t id) {
+  int64_t current_id = current();
+  assert(id >= initial() && id < current_id, "invalid id, " INT64_FORMAT " and current is " INT64_FORMAT, id, current_id);
+}
+#endif

--- a/src/hotspot/share/runtime/threadIdentifier.hpp
+++ b/src/hotspot/share/runtime/threadIdentifier.hpp
@@ -39,6 +39,7 @@ class ThreadIdentifier : AllStatic {
   static int64_t current();
   static int64_t unsafe_offset();
   static int64_t initial();
+  static void verify_id(int64_t id) NOT_DEBUG_RETURN;
 };
 
 #endif // SHARE_RUNTIME_THREADIDENTIFIER_HPP

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1031,6 +1031,7 @@ jboolean Threads::is_supported_jni_version(jint version) {
 void Threads::add(JavaThread* p, bool force_daemon) {
   // The threads lock must be owned at this point
   assert(Threads_lock->owned_by_self(), "must have threads lock");
+  assert(p->monitor_owner_id() != 0, "should be set");
 
   BarrierSet::barrier_set()->on_thread_attach(p);
 


### PR DESCRIPTION
Please review the following fix. For the attaching thread case we are incorrectly setting the `_monitor_owner_id` after `Threads::add()` is called, i.e after the attaching thread becomes visible through a ThreadsListHandle. So if another thread calls `Threads::owning_thread_from_monitor()` in between these events and iterates through all JavaThreads looking for the owner of a given monitor, we might find this attaching thread still with a `_monitor_owner_id` of 0.
I corrected the ordering and improved verification checks. Tested in mach5 tiers1-5.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353117](https://bugs.openjdk.org/browse/JDK-8353117): Crash: assert(id &gt;= ThreadIdentifier::initial() &amp;&amp; id &lt; ThreadIdentifier::current()) failed: must be reasonable) (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24336/head:pull/24336` \
`$ git checkout pull/24336`

Update a local copy of the PR: \
`$ git checkout pull/24336` \
`$ git pull https://git.openjdk.org/jdk.git pull/24336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24336`

View PR using the GUI difftool: \
`$ git pr show -t 24336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24336.diff">https://git.openjdk.org/jdk/pull/24336.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24336#issuecomment-2767110487)
</details>
