### PR TITLE
8353299: VerifyJarEntryName.java test fails

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/VerifyJarEntryName.java
+++ b/test/jdk/sun/security/tools/jarsigner/VerifyJarEntryName.java
@@ -96,22 +96,6 @@ public class VerifyJarEntryName {
     }
 
     /*
-     * Modify a single byte in signature filename in LOC, and
-     * validate that jarsigner -verify emits a warning message.
-     */
-    @Test
-    void verifySignatureEntryName() throws Exception {
-        modifyJarEntryName(ORIGINAL_JAR, MODIFIED_JAR, "MYKEY.SF");
-        SecurityTools.jarsigner("-verify -verbose " + MODIFIED_JAR)
-                .shouldContain("This JAR file contains internal " +
-                        "inconsistencies that may result in different " +
-                        "contents when reading via JarFile and JarInputStream:")
-                .shouldContain("- Entry XETA-INF/MYKEY.SF is present when reading " +
-                        "via JarInputStream but missing when reading via JarFile")
-                .shouldHaveExitValue(0);
-    }
-
-    /*
      * Validate that jarsigner -verify on a valid JAR works without
      * emitting warnings about internal inconsistencies.
      */


### PR DESCRIPTION
Please review the change for JDK-8353299.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353299](https://bugs.openjdk.org/browse/JDK-8353299): VerifyJarEntryName.java test fails (**Bug** - P3)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24337/head:pull/24337` \
`$ git checkout pull/24337`

Update a local copy of the PR: \
`$ git checkout pull/24337` \
`$ git pull https://git.openjdk.org/jdk.git pull/24337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24337`

View PR using the GUI difftool: \
`$ git pr show -t 24337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24337.diff">https://git.openjdk.org/jdk/pull/24337.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24337#issuecomment-2767429269)
</details>
