### PR TITLE
8353321: [macos] ErrorTest.testAppContentWarning test case requires signing environment

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSign.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/MacSign.java
@@ -287,7 +287,7 @@ public final class MacSign {
             }
 
             public Builder addCert(CertificateRequest v) {
-                certs.add(v);
+                certs.add(Objects.requireNonNull(v));
                 return this;
             }
 

--- a/test/jdk/tools/jpackage/macosx/MacSignTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacSignTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.CannedFormattedString;
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.JPackageStringBundle;
+import jdk.jpackage.test.MacHelper;
+import jdk.jpackage.test.TKit;
+
+/*
+ * @test
+ * @summary jpackage with --mac-sign
+ * @library /test/jdk/tools/jpackage/helpers
+ * @library base
+ * @build SigningBase
+ * @build jdk.jpackage.test.*
+ * @build MacSignTest
+ * @requires (jpackage.test.MacSignTests == "run")
+ * @run main/othervm/timeout=720 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=MacSignTest
+ *  --jpt-before-run=SigningBase.verifySignTestEnvReady
+ */
+public class MacSignTest {
+
+    @Test
+    public static void testAppContentWarning() throws IOException {
+
+        // Create app content directory with the name known to fail signing.
+        // This will trigger jpackage exit with status code "1".
+        final var appContent = TKit.createTempDirectory("app-content").resolve("foo.1");
+        Files.createDirectory(appContent);
+        Files.createFile(appContent.resolve("file"));
+
+        final List<CannedFormattedString> expectedStrings = new ArrayList<>();
+        expectedStrings.add(JPackageStringBundle.MAIN.cannedFormattedString("message.codesign.failed.reason.app.content"));
+
+        final var xcodeWarning = JPackageStringBundle.MAIN.cannedFormattedString("message.codesign.failed.reason.xcode.tools");
+        if (!MacHelper.isXcodeDevToolsInstalled()) {
+            expectedStrings.add(xcodeWarning);
+        }
+
+        // --app-content and --type app-image
+        // Expect `message.codesign.failed.reason.app.content` message in the log.
+        // This is not a fatal error, just a warning.
+        // To make jpackage fail, specify bad additional content.
+        final var cmd = JPackageCommand.helloAppImage()
+                .ignoreDefaultVerbose(true)
+                .validateOutput(expectedStrings.toArray(CannedFormattedString[]::new))
+                .addArguments("--app-content", appContent)
+                .addArguments("--mac-sign")
+                .addArguments("--mac-signing-keychain", SigningBase.StandardKeychain.MAIN.spec().keychain().name())
+                .addArguments("--mac-app-image-sign-identity", SigningBase.StandardCertificateRequest.APP_IMAGE.spec().name());
+
+        if (MacHelper.isXcodeDevToolsInstalled()) {
+            // Check there is no warning about missing xcode command line developer tools.
+            cmd.validateOutput(TKit.assertTextStream(xcodeWarning.getValue()).negate());
+        }
+
+        cmd.execute(1);
+    }
+}

--- a/test/jdk/tools/jpackage/share/ErrorTest.java
+++ b/test/jdk/tools/jpackage/share/ErrorTest.java
@@ -47,7 +47,6 @@ import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.CannedFormattedString;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.JPackageStringBundle;
-import jdk.jpackage.test.MacHelper;
 import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.TKit;
 
@@ -556,34 +555,6 @@ public final class ErrorTest {
         ).map(TestSpec.Builder::nativeType).mapMulti(ErrorTest::duplicateForMacSign).toList());
 
         return toTestArgs(testCases.stream());
-    }
-
-    @Test(ifOS = MACOS)
-    public static void testAppContentWarning() {
-        // --app-content and --type app-image
-        // Expect `message.codesign.failed.reason.app.content` message in the log.
-        // This is not a fatal error, just a warning.
-        // To make jpackage fail, specify invalid signing identity.
-        final var cmd = JPackageCommand.helloAppImage()
-                .addArguments("--app-content", TKit.TEST_SRC_ROOT.resolve("apps/dukeplug.png"))
-                .addArguments("--mac-sign", "--mac-app-image-sign-identity", "foo");
-
-        final List<CannedFormattedString> expectedStrings = new ArrayList<>();
-        expectedStrings.add(JPackageStringBundle.MAIN.cannedFormattedString("message.codesign.failed.reason.app.content"));
-
-        final var xcodeWarning = JPackageStringBundle.MAIN.cannedFormattedString("message.codesign.failed.reason.xcode.tools");
-        if (!MacHelper.isXcodeDevToolsInstalled()) {
-            expectedStrings.add(xcodeWarning);
-        }
-
-        defaultInit(cmd, expectedStrings);
-
-        if (MacHelper.isXcodeDevToolsInstalled()) {
-            // Check there is no warning about missing xcode command line developer tools.
-            cmd.validateOutput(TKit.assertTextStream(xcodeWarning.getValue()).negate());
-        }
-
-        cmd.execute(1);
     }
 
     public static Collection<Object[]> testLinux() {


### PR DESCRIPTION
Move `ErrorTest.testAppContentWarning()` test case to `MacSignTest.testAppContentWarning()` and rework it to fail because of faulty app content and not invalid signing identity.

MacSignTest is supposed to be a placeholder for tests that require a signing environment but don't fit in any existing signing tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353321](https://bugs.openjdk.org/browse/JDK-8353321): [macos] ErrorTest.testAppContentWarning test case requires signing environment (**Enhancement** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24338/head:pull/24338` \
`$ git checkout pull/24338`

Update a local copy of the PR: \
`$ git checkout pull/24338` \
`$ git pull https://git.openjdk.org/jdk.git pull/24338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24338`

View PR using the GUI difftool: \
`$ git pr show -t 24338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24338.diff">https://git.openjdk.org/jdk/pull/24338.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24338#issuecomment-2767451547)
</details>
