### PR TITLE
8353329: Small memory leak when create GrowableArray with initial size 0

### DIFF
--- a/src/hotspot/share/utilities/growableArray.cpp
+++ b/src/hotspot/share/utilities/growableArray.cpp
@@ -43,9 +43,11 @@ void* GrowableArrayArenaAllocator::allocate(int max, int element_size, Arena* ar
 
 void* GrowableArrayCHeapAllocator::allocate(int max, int element_size, MemTag mem_tag) {
   assert(max >= 0, "integer overflow");
+
   if (max == 0) {
     return nullptr;
   }
+
   size_t byte_size = element_size * (size_t) max;
 
   // memory tag has to be specified for C heap allocation

--- a/src/hotspot/share/utilities/growableArray.cpp
+++ b/src/hotspot/share/utilities/growableArray.cpp
@@ -43,6 +43,7 @@ void* GrowableArrayArenaAllocator::allocate(int max, int element_size, Arena* ar
 
 void* GrowableArrayCHeapAllocator::allocate(int max, int element_size, MemTag mem_tag) {
   assert(max >= 0, "integer overflow");
+  if (max == 0) return nullptr;
   size_t byte_size = element_size * (size_t) max;
 
   // memory tag has to be specified for C heap allocation

--- a/src/hotspot/share/utilities/growableArray.cpp
+++ b/src/hotspot/share/utilities/growableArray.cpp
@@ -43,7 +43,9 @@ void* GrowableArrayArenaAllocator::allocate(int max, int element_size, Arena* ar
 
 void* GrowableArrayCHeapAllocator::allocate(int max, int element_size, MemTag mem_tag) {
   assert(max >= 0, "integer overflow");
-  if (max == 0) return nullptr;
+  if (max == 0) {
+    return nullptr;
+  }
   size_t byte_size = element_size * (size_t) max;
 
   // memory tag has to be specified for C heap allocation

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -811,10 +811,6 @@ class GrowableArrayCHeap : public GrowableArrayWithAllocator<E, GrowableArrayCHe
   STATIC_ASSERT(MT != mtNone);
 
   static E* allocate(int max, MemTag mem_tag) {
-    if (max == 0) {
-      return nullptr;
-    }
-
     return (E*)GrowableArrayCHeapAllocator::allocate(max, sizeof(E), mem_tag);
   }
 


### PR DESCRIPTION
Please review this small fix to avoid 1 byte leak when create a GrowableArray with initial size = 0.

GrowableArray's c-heap allocator does not check size = 0 and os:malloc(0) will malloc at least 1 byte.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353329](https://bugs.openjdk.org/browse/JDK-8353329): Small memory leak when create GrowableArray with initial size 0 (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24341/head:pull/24341` \
`$ git checkout pull/24341`

Update a local copy of the PR: \
`$ git checkout pull/24341` \
`$ git pull https://git.openjdk.org/jdk.git pull/24341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24341`

View PR using the GUI difftool: \
`$ git pr show -t 24341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24341.diff">https://git.openjdk.org/jdk/pull/24341.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24341#issuecomment-2767704914)
</details>
