### PR TITLE
8353344: RISC-V: Detect and enable several extensions for debug builds

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -187,18 +187,43 @@ void RiscvHwprobe::add_features_from_query_result() {
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZBS)) {
     VM_Version::ext_Zbs.enable_feature();
   }
+#ifndef PRODUCT
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZBKB)) {
+    VM_Version::ext_Zbkb.enable_feature();
+  }
+#endif
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZFH)) {
     VM_Version::ext_Zfh.enable_feature();
   }
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZFHMIN)) {
     VM_Version::ext_Zfhmin.enable_feature();
   }
+#ifndef PRODUCT
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVBB)) {
+    VM_Version::ext_Zvbb.enable_feature();
+  }
+#endif
+#ifndef PRODUCT
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVBC)) {
     VM_Version::ext_Zvbc.enable_feature();
   }
+#endif
+#ifndef PRODUCT
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKNED) &&
+      is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKNHB) &&
+      is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKB)   &&
+      is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKT)) {
+    VM_Version::ext_Zvkn.enable_feature();
+  }
+#endif
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVFH)) {
     VM_Version::ext_Zvfh.enable_feature();
   }
+#ifndef PRODUCT
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZFA)) {
+    VM_Version::ext_Zfa.enable_feature();
+  }
+#endif
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZICOND)) {
     VM_Version::ext_Zicond.enable_feature();
   }


### PR DESCRIPTION
Hi, please consider this small change.
Support for some riscv extesions is in experimental status due to lack of hardware implementations.
They won't be auto enabled at startup even through they could be detected through linux hwprobe syscall.
And it's not that convenient to enable them on the command line and easy to snip away when doing regression test.
To ensure they get some proper correctness test coverage, this turns on some of them for debug builds.
This follows the order of linux hwprobe syscall macro definitions [1]. I can consider adding more if this makes sense.
Manually tested on the command line with fastdebug build using qemu-system (running kernel-6.11).
```
ubuntu@ubuntu:~/jdk$ java -XX:+UnlockExperimentalVMOptions -XX:+PrintFlagsFinal -version | grep Zbkb
     bool UseZbkb                                  = true                            {ARCH experimental} {default}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (fastdebug build 25-internal-adhoc.ubuntu.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 25-internal-adhoc.ubuntu.jdk, mixed mode, sharing)

ubuntu@ubuntu:~/jdk$ java -XX:+UnlockExperimentalVMOptions -XX:+PrintFlagsFinal -version | grep Zvbb
     bool UseZvbb                                  = true                            {ARCH experimental} {default}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (fastdebug build 25-internal-adhoc.ubuntu.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 25-internal-adhoc.ubuntu.jdk, mixed mode, sharing)

ubuntu@ubuntu:~/jdk$ java -XX:+UnlockExperimentalVMOptions -XX:+PrintFlagsFinal -version | grep Zvkn
     bool UseZvkn                                  = true                            {ARCH experimental} {default}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (fastdebug build 25-internal-adhoc.ubuntu.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 25-internal-adhoc.ubuntu.jdk, mixed mode, sharing)

ubuntu@ubuntu:~/jdk$ java -XX:+UnlockExperimentalVMOptions -XX:+PrintFlagsFinal -version | grep Zfa
     bool UseZfa                                   = true                            {ARCH experimental} {default}
openjdk version "25-internal" 2025-09-16
OpenJDK Runtime Environment (fastdebug build 25-internal-adhoc.ubuntu.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 25-internal-adhoc.ubuntu.jdk, mixed mode, sharing)
```
[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp#L46-L82

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353344](https://bugs.openjdk.org/browse/JDK-8353344): RISC-V: Detect and enable several extensions for debug builds (**Enhancement** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24344/head:pull/24344` \
`$ git checkout pull/24344`

Update a local copy of the PR: \
`$ git checkout pull/24344` \
`$ git pull https://git.openjdk.org/jdk.git pull/24344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24344`

View PR using the GUI difftool: \
`$ git pr show -t 24344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24344.diff">https://git.openjdk.org/jdk/pull/24344.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24344#issuecomment-2768111225)
</details>
