### PR TITLE
8353359: C2: Or(I|L)Node::Ideal is missing AddNode::Ideal call

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -829,7 +829,7 @@ Node* OrINode::Ideal(PhaseGVN* phase, bool can_reshape) {
     Node* tn = phase->transform(and_a_b);
     return AddNode::make_not(phase, tn, T_INT);
   }
-  return nullptr;
+  return AddNode::Ideal(phase, can_reshape);
 }
 
 //------------------------------add_ring---------------------------------------
@@ -903,7 +903,7 @@ Node* OrLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     return AddNode::make_not(phase, tn, T_LONG);
   }
 
-  return nullptr;
+  return AddNode::Ideal(phase, can_reshape);
 }
 
 //------------------------------add_ring---------------------------------------

--- a/test/hotspot/jtreg/compiler/c2/irTests/OrINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/OrINodeIdealizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/irTests/OrINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/OrINodeIdealizationTests.java
@@ -38,7 +38,7 @@ public class OrINodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test = { "test1" })
+    @Run(test = { "test1", "test2", "test3" })
     public void runMethod() {
         int a = RunInfo.getRandom().nextInt();
         int b = RunInfo.getRandom().nextInt();
@@ -55,6 +55,8 @@ public class OrINodeIdealizationTests {
     @DontCompile
     public void assertResult(int a, int b) {
         Asserts.assertEQ((~a) | (~b), test1(a, b));
+        Asserts.assertEQ((a | 3) | 6, test2(a));
+        Asserts.assertEQ((a | 3) | a, test3(a));
     }
 
     // Checks (~a) | (~b) => ~(a & b)
@@ -64,5 +66,19 @@ public class OrINodeIdealizationTests {
                    IRNode.XOR, "1" })
     public int test1(int a, int b) {
         return (~a) | (~b);
+    }
+
+    // Checks (a | 3) | 6 => a | (3 | 6) => a | 7
+    @Test
+    @IR(counts = { IRNode.OR, "1"})
+    public int test2(int a) {
+        return (a | 3) | 6;
+    }
+
+    // Checks (a | 3) | a => (a | a) | 3 => a | 3
+    @Test
+    @IR(counts = { IRNode.OR, "1"})
+    public int test3(int a) {
+        return (a | 3) | a;
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/OrINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/OrINodeIdealizationTests.java
@@ -27,7 +27,7 @@ import compiler.lib.ir_framework.*;
 
 /*
  * @test
- * @bug 8322077
+ * @bug 8322077 8353359
  * @summary Test that Ideal transformations of OrINode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.OrINodeIdealizationTests

--- a/test/hotspot/jtreg/compiler/c2/irTests/OrLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/OrLNodeIdealizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/irTests/OrLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/OrLNodeIdealizationTests.java
@@ -27,7 +27,7 @@ import compiler.lib.ir_framework.*;
 
 /*
  * @test
- * @bug 8322077
+ * @bug 8322077 8353359
  * @summary Test that Ideal transformations of OrLNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.OrLNodeIdealizationTests

--- a/test/hotspot/jtreg/compiler/c2/irTests/OrLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/OrLNodeIdealizationTests.java
@@ -38,7 +38,7 @@ public class OrLNodeIdealizationTests {
         TestFramework.run();
     }
 
-    @Run(test = { "test1" })
+    @Run(test = { "test1", "test2", "test3" })
     public void runMethod() {
         long a = RunInfo.getRandom().nextLong();
         long b = RunInfo.getRandom().nextLong();
@@ -55,6 +55,8 @@ public class OrLNodeIdealizationTests {
     @DontCompile
     public void assertResult(long a, long b) {
         Asserts.assertEQ((~a) | (~b), test1(a, b));
+        Asserts.assertEQ((a | 3) | 6, test2(a));
+        Asserts.assertEQ((a | 3) | a, test3(a));
     }
 
     // Checks (~a) | (~b) => ~(a & b)
@@ -64,5 +66,20 @@ public class OrLNodeIdealizationTests {
                    IRNode.XOR, "1" })
     public long test1(long a, long b) {
         return (~a) | (~b);
+    }
+
+
+    // Checks (a | 3) | 6 => a | (3 | 6) => a | 7
+    @Test
+    @IR(counts = { IRNode.OR, "1"})
+    public long test2(long a) {
+        return (a | 3) | 6;
+    }
+
+    // Checks (a | 3) | a => (a | a) | 3 => a | 3
+    @Test
+    @IR(counts = { IRNode.OR, "1"})
+    public long test3(long a) {
+        return (a | 3) | a;
     }
 }


### PR DESCRIPTION
Hi,

this simple change adds a missing AddNode::Ideal call to Or(I|L)Node::Ideal. See the added tests for examples of optimizations that don't apply without this change.

Please let me know what you think.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353359](https://bugs.openjdk.org/browse/JDK-8353359): C2: Or(I|L)Node::Ideal is missing AddNode::Ideal call (**Bug** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24348/head:pull/24348` \
`$ git checkout pull/24348`

Update a local copy of the PR: \
`$ git checkout pull/24348` \
`$ git pull https://git.openjdk.org/jdk.git pull/24348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24348`

View PR using the GUI difftool: \
`$ git pr show -t 24348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24348.diff">https://git.openjdk.org/jdk/pull/24348.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24348#issuecomment-2768303400)
</details>
