### PR TITLE
8352994: ZGC: Fix regression introduced in JDK-8350572

### DIFF
--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -61,7 +61,7 @@
 // with callers to this function. Typically used to verify that object oops
 // and headers are safe to access.
 void z_verify_safepoints_are_blocked() {
-  if (VMError::is_error_reported_in_current_thread()) {
+  if (VMError::is_error_reported() && VMError::is_error_reported_in_current_thread()) {
     // The current thread has crashed and is creating an error report.
     // This may occur from any thread state, skip the safepoint_are_blocked
     // verification.


### PR DESCRIPTION
We have seen a bunch of timeouts that all points towards the introduction of a check against VMError::is_error_reported_in_current_thread() in the ZGC verification code. I propose this workaround to first check if there's really an error reporting event that is going on by checking VMError::is_error_reported().

The underlying performance issue (or hang(?)) when calling os::current_thread_id() is being investigated as a separate bug. This fix just tries to clean up issues we see when running ZGC testing.

Thanks to @plummercj for digging into this and proposing the same workaround.

Testing: GHA is clean, I'll run this through a few tiers of our CI pipeline