### PR TITLE
8282053: IGV: refine schedule approximation

### DIFF
--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
@@ -796,8 +796,8 @@ public class ServerCompilerScheduler implements Scheduler {
             if (category.equals("control") || category.equals("mixed")) {
                 // Example: If, IfTrue, CallStaticJava.
                 n.isCFG = true;
-            } else if (n.inputNode.getProperties().get("type").equals("bottom")
-                       && n.preds.size() > 0 &&
+            } else if (n.inputNode.getProperties().get("type").equals("bottom") &&
+                       n.preds.size() > 0 &&
                        n.succs.size() > 0 &&
                        n.succs.stream().findFirst().get().inputNode.getProperties().get("name") == "Root" &&
                        n.preds.get(0) != null &&

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
@@ -67,6 +67,8 @@ public class ServerCompilerScheduler implements Scheduler {
         public boolean isBlockProjection;
         public boolean isBlockStart;
         public boolean isCFG;
+        public boolean isParm;
+        public boolean isProj;
         public int rank; // Rank for local scheduling priority.
 
         // Empty constructor for creating dummy CFG nodes without associated
@@ -79,6 +81,8 @@ public class ServerCompilerScheduler implements Scheduler {
             isBlockProjection = (p != null && p.equals("true"));
             p = n.getProperties().get("is_block_start");
             isBlockStart = (p != null && p.equals("true"));
+            isParm = isParm(this);
+            isProj = isProj(this);
             computeRank();
         }
 
@@ -464,7 +468,20 @@ public class ServerCompilerScheduler implements Scheduler {
         Set<Node> unscheduled = new HashSet<>();
         for (Node n : this.nodes) {
             if (n.block == null && reachable.contains(n) && !n.isCFG) {
-                unscheduled.add(n);
+                if (!n.isParm && !n.isProj) {
+                    unscheduled.add(n);
+                } else {
+                    // Schedule Parm and Proj nodes in same block as parent
+                    Node prev = n.preds.get(0);
+                    InputBlock blk = prev.block;
+                    if (blk != null) {
+                        n.block = blk;
+                        blk.addNode(n.inputNode.getId());
+                    } else {
+                        // Fallback in the case parent has no block
+                        unscheduled.add(n);
+                    }
+                }
             }
         }
 
@@ -781,10 +798,13 @@ public class ServerCompilerScheduler implements Scheduler {
                 n.isCFG = true;
             } else if (n.inputNode.getProperties().get("type").equals("bottom")
                        && n.preds.size() > 0 &&
+                       n.succs.size() > 0 &&
+                       n.succs.stream().findFirst().get().inputNode.getProperties().get("name") == "Root" &&
                        n.preds.get(0) != null &&
                        n.preds.get(0).inputNode.getProperties()
                        .get("category").equals("control")) {
                 // Example: Halt, Return, Rethrow.
+                // The root-as-successor check disallows machine nodes such as prefetchAlloc and rep_stos.
                 n.isCFG = true;
             } else if (n.isBlockStart || n.isBlockProjection) {
                 // Example: Root.


### PR DESCRIPTION
This patch refines the schedule approximation in IGV by 1)  placing parm. and projection nodes in the same block as their predecessors, and 2) disallows erroneously considering machine nodes such as prefetchAlloc and rep_stos as CFG nodes.

The reader may refer to the corresponding JBS issue where graphs sampled before and after the change are attached.

Testing: T1-T3 with no failures. Opened graphs before and after the change and saw no obvious problems. Opened a large number of graphs in CFG view and observed no unexpected IGV warnings, errors or assert failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282053](https://bugs.openjdk.org/browse/JDK-8282053): IGV: refine schedule approximation (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Daniel Lundén](https://openjdk.org/census#dlunden) (@dlunde - Committer)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24350/head:pull/24350` \
`$ git checkout pull/24350`

Update a local copy of the PR: \
`$ git checkout pull/24350` \
`$ git pull https://git.openjdk.org/jdk.git pull/24350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24350`

View PR using the GUI difftool: \
`$ git pr show -t 24350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24350.diff">https://git.openjdk.org/jdk/pull/24350.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24350#issuecomment-2768438411)
</details>
