### PR TITLE
8352935: Launcher should not add $JDK/../lib to LD_LIBRARY_PATH

### DIFF
--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -348,7 +348,6 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
          *
          *     o          $JVMPATH (directory portion only)
          *     o          $JDK/lib
-         *     o          $JDK/../lib
          *
          * followed by the user's previous effective LD_LIBRARY_PATH, if
          * any.
@@ -377,10 +376,8 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
 
                 snprintf(new_runpath, new_runpath_size, LD_LIBRARY_PATH "="
                         "%s:"
-                        "%s/lib:"
-                        "%s/../lib",
+                        "%s/lib",
                         new_jvmpath,
-                        jdkroot,
                         jdkroot
                         );
 

--- a/test/jdk/tools/launcher/ExecutionEnvironment.java
+++ b/test/jdk/tools/launcher/ExecutionEnvironment.java
@@ -141,7 +141,6 @@ public class ExecutionEnvironment extends TestHelper {
                     String libPath = LD_LIBRARY_PATH + "=" +
                         jvmroot + "/lib/server" + System.getProperty("path.separator") +
                         jvmroot + "/lib" + System.getProperty("path.separator") +
-                        jvmroot + "/../lib" + System.getProperty("path.separator") +
                         LD_LIBRARY_PATH_VALUE;
                     if (!tr.matches(libPath)) {
                         flagError(tr, "FAIL: did not get <" + libPath + ">");

--- a/test/jdk/tools/launcher/Test7029048.java
+++ b/test/jdk/tools/launcher/Test7029048.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/launcher/Test7029048.java
+++ b/test/jdk/tools/launcher/Test7029048.java
@@ -134,7 +134,7 @@ public class Test7029048 extends TestHelper {
     private static enum TestCase {
         NO_DIR(0),                      // Directory does not exist
         NO_LIBJVM(0),                   // Directory exists, but no libjvm.so
-        LIBJVM(3);                      // Directory exists, with a libjvm.so
+        LIBJVM(2);                      // Directory exists, with a libjvm.so
         private final int value;
         TestCase(int i) {
             this.value = i;

--- a/test/jdk/tools/launcher/Test7029048.java
+++ b/test/jdk/tools/launcher/Test7029048.java
@@ -26,21 +26,10 @@
  * @bug 7029048 8217340 8217216
  * @summary Ensure that the launcher defends against user settings of the
  *          LD_LIBRARY_PATH environment variable on Unixes
- * @requires os.family != "windows" & os.family != "mac" & !vm.musl & os.family != "aix"
+ * @requires os.family != "windows" & os.family != "mac"
  * @library /test/lib
- * @compile -XDignore.symbol.file ExecutionEnvironment.java Test7029048.java
- * @run main/othervm -DexpandedLdLibraryPath=false Test7029048
- */
-
-/**
- * @test
- * @bug 7029048 8217340 8217216
- * @summary Ensure that the launcher defends against user settings of the
- *          LD_LIBRARY_PATH environment variable on Unixes
- * @requires os.family == "aix" | vm.musl
- * @library /test/lib
- * @compile -XDignore.symbol.file ExecutionEnvironment.java Test7029048.java
- * @run main/othervm -DexpandedLdLibraryPath=true Test7029048
+ * @compile ExecutionEnvironment.java Test7029048.java
+ * @run main/othervm Test7029048
  */
 
 import java.io.File;
@@ -51,13 +40,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import jdk.test.lib.Platform;
+
 public class Test7029048 extends TestHelper {
 
     private static final String LIBJVM = ExecutionEnvironment.LIBJVM;
     private static final String LD_LIBRARY_PATH =
             ExecutionEnvironment.LD_LIBRARY_PATH;
-    private static final String LD_LIBRARY_PATH_64 =
-            ExecutionEnvironment.LD_LIBRARY_PATH_64;
 
     private static final File libDir =
             new File(System.getProperty("sun.boot.library.path"));
@@ -70,9 +59,6 @@ public class Test7029048 extends TestHelper {
 
     private static final File dstClientDir = new File(dstLibDir, "client");
     private static final File dstClientLibjvm = new File(dstClientDir, LIBJVM);
-
-    static final boolean IS_EXPANDED_LD_LIBRARY_PATH =
-            Boolean.getBoolean("expandedLdLibraryPath");
 
     static String getValue(String name, List<String> in) {
         for (String x : in) {
@@ -170,7 +156,7 @@ public class Test7029048 extends TestHelper {
                     }
 
                     desc = "LD_LIBRARY_PATH should not be set (no libjvm.so)";
-                    if (IS_EXPANDED_LD_LIBRARY_PATH) {
+                    if (Platform.isAix() || Platform.isMusl()) {
                         printSkipMessage(desc);
                         continue;
                     }
@@ -180,7 +166,7 @@ public class Test7029048 extends TestHelper {
                         recursiveDelete(dstLibDir);
                     }
                     desc = "LD_LIBRARY_PATH should not be set (no directory)";
-                    if (IS_EXPANDED_LD_LIBRARY_PATH) {
+                    if (Platform.isAix() || Platform.isMusl()) {
                         printSkipMessage(desc);
                         continue;
                     }


### PR DESCRIPTION
In the JDK launcher, there is a codepath which would set/modify the LD_LIBRARY_PATH. This happens unconditionally on AIX and Linux/musl and can also happen on other Linux platforms if an LD_LIBRARY_PATH is pre-set which contains a libjvm.so.

The LD_LIBRARY_PATH is set to $JVMPATH:$JDK/lib:$JDK/../lib. The last part of this, $JDK/../lib, seems to be a remnant of times when there was a jre subfolder in a JDK deployment. So it should likely be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352935](https://bugs.openjdk.org/browse/JDK-8352935): Launcher should not add $JDK/../lib to LD_LIBRARY_PATH (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) Review applies to [9d41d444](https://git.openjdk.org/jdk/pull/24351/files/9d41d444237032aaaea526875abf77ceda25a6d1)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) Review applies to [6f32ead9](https://git.openjdk.org/jdk/pull/24351/files/6f32ead9ba1803fe766f1ef4a6ed861ab0a32da3)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24351/head:pull/24351` \
`$ git checkout pull/24351`

Update a local copy of the PR: \
`$ git checkout pull/24351` \
`$ git pull https://git.openjdk.org/jdk.git pull/24351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24351`

View PR using the GUI difftool: \
`$ git pr show -t 24351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24351.diff">https://git.openjdk.org/jdk/pull/24351.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24351#issuecomment-2768736612)
</details>
