### PR TITLE
8353231: Test com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad still fails intermittently

### DIFF
--- a/test/jdk/com/sun/management/OperatingSystemMXBean/TEST.properties
+++ b/test/jdk/com/sun/management/OperatingSystemMXBean/TEST.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+exclusiveAccess.dirs=.


### PR DESCRIPTION
Test com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad still fails intermittently.
On failure, 10 attempts with sleep(200) each time, only read -1 from mbean.getProcessCpuLoad().
The method is documented to return -1 when info is not available, but want to avoid the test accepting a -1 and masking real problems.

Test failures are happening when multiple CPU load reding tests ran on the same host, at the same second.
Add a TEST.properties file containing: exclusiveAccess.dirs=.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353231](https://bugs.openjdk.org/browse/JDK-8353231): Test com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad still fails intermittently (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24352/head:pull/24352` \
`$ git checkout pull/24352`

Update a local copy of the PR: \
`$ git checkout pull/24352` \
`$ git pull https://git.openjdk.org/jdk.git pull/24352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24352`

View PR using the GUI difftool: \
`$ git pr show -t 24352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24352.diff">https://git.openjdk.org/jdk/pull/24352.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24352#issuecomment-2768936751)
</details>
