### PR TITLE
8353439: Shell grouping of -XX:OnError= commands is surprising

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -136,7 +136,9 @@ static const char* env_list[] = {
   nullptr                       // End marker.
 };
 
-// A simple parser for -XX:OnError, usage:
+// A simple parser for lists of commands such as -XX:OnError and -XX:OnOutOfMemoryError
+// Command list (ptr) is expected to be a sequence of commands delineated by semicolons and/or newlines.
+// Usage:
 //  ptr = OnError;
 //  while ((cmd = next_OnError_command(buffer, sizeof(buffer), &ptr) != nullptr)
 //     ... ...

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -145,13 +145,13 @@ static char* next_OnError_command(char* buf, int buflen, const char** ptr) {
 
   const char* cmd = *ptr;
 
-  // skip leading blanks or ';'
-  while (*cmd == ' ' || *cmd == ';') cmd++;
+  // skip leading blanks, ';' or newlines
+  while (*cmd == ' ' || *cmd == ';' || *cmd == '\n') cmd++;
 
   if (*cmd == '\0') return nullptr;
 
   const char * cmdend = cmd;
-  while (*cmdend != '\0' && *cmdend != ';') cmdend++;
+  while (*cmdend != '\0' && *cmdend != ';' && *cmdend != '\n') cmdend++;
 
   Arguments::copy_expand_pid(cmd, cmdend - cmd, buf, buflen);
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestOnError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestOnError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,10 @@ public class TestOnError {
 
     public static void main(String[] args) throws Exception {
         String msg = "Test Succeeded";
+        String msg1 = "OnError Test Message1";
+        String msg2 = "OnError Test Message2";
 
+        // Basic OnError test:
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
            "-XX:-CreateCoredumpOnCrash",
            "-XX:ErrorHandlerTest=14", // trigger potential SEGV
@@ -59,6 +62,30 @@ public class TestOnError {
            both get written to stdout.
         */
         output.stdoutShouldMatch("^" + msg); // match start of line only
+
+        // Test multiple OnError arguments:
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+           "-XX:-CreateCoredumpOnCrash",
+           "-XX:ErrorHandlerTest=14",
+           "-XX:OnError=echo " + msg1,
+           "-XX:OnError=echo " + msg2,
+           TestOnError.class.getName());
+
+        output = new OutputAnalyzer(pb.start());
+        output.stdoutShouldMatch("^" + msg1);
+        output.stdoutShouldMatch("^" + msg2);
+
+        // Test one argument with multiple commands using ; separator:
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+           "-XX:-CreateCoredumpOnCrash",
+           "-XX:ErrorHandlerTest=14",
+           "-XX:OnError=echo " + msg1 + ";echo " + msg2,
+           TestOnError.class.getName());
+
+        output = new OutputAnalyzer(pb.start());
+        output.stdoutShouldMatch("^" + msg1);
+        output.stdoutShouldMatch("^" + msg2);
+
         System.out.println("PASSED");
     }
 }


### PR DESCRIPTION
We should be consistent, and run all OnError items in a new shell.  Currently the ; separator causes a new shell, but multiple -XX:OnError= options are grouped into the same shell.

next_OnError_command() decides on where a new command starts.  It should recognise newlines, and all commands will get their own shell.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353439](https://bugs.openjdk.org/browse/JDK-8353439): Shell grouping of -XX:OnError= commands is surprising (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24354/head:pull/24354` \
`$ git checkout pull/24354`

Update a local copy of the PR: \
`$ git checkout pull/24354` \
`$ git pull https://git.openjdk.org/jdk.git pull/24354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24354`

View PR using the GUI difftool: \
`$ git pr show -t 24354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24354.diff">https://git.openjdk.org/jdk/pull/24354.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24354#issuecomment-2769444196)
</details>
