### PR TITLE
8353345: C2 asserts because maskShiftAmount modifies node without deleting the hash

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/gvn/DoubleLShiftCrashDuringIGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/DoubleLShiftCrashDuringIGVN.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8353345
+ * @summary During the transformation (X << con1) << con2 ==> X << (con1 + con2) in IGVN,
+ *          we modified the inner shift, during the transformation of the outer shift without
+ *          removing it from the hashtable
+ *
+ * @run main/othervm -XX:CompileCommand=compileonly,*DoubleLShiftCrashDuringIGVN*::* -Xcomp DoubleLShiftCrashDuringIGVN
+ */
+
+public class DoubleLShiftCrashDuringIGVN {
+    public static long shift=0;
+
+    public static int test() {
+        int s = 1;
+
+        shift = 12;
+        for (int i = 0; i < 4; i++) {
+            for (int j = 0; j < 4; j++) {
+                s <<= shift;
+            }
+            shift = 33;
+        }
+        return s;
+    }
+
+    public static void main(String[] strArr) {
+        test();
+    }
+}


### PR DESCRIPTION
Delete the hash, then set_req. Also, not do any of that outside IGVN, but requires to register nested shifts for IGVN in parsing not to miss them later.

Thanks,
Marc