### PR TITLE
8353449: [BACKOUT] One instance of STATIC_LIB_CFLAGS was missed in JDK-8345683

### DIFF
--- a/make/common/native/Flags.gmk
+++ b/make/common/native/Flags.gmk
@@ -122,7 +122,7 @@ define SetupCompilerFlags
     $1_EXTRA_CXXFLAGS += $$($1_CXXFLAGS_$(OPENJDK_TARGET_OS)_release)
   endif
   ifeq ($(STATIC_LIBS), true)
-    $1_EXTRA_CXXFLAGS += -DSTATIC_BUILD=1
+    $1_EXTRA_CXXFLAGS += $$(STATIC_LIB_CFLAGS)
   endif
 
   # If no C++ flags are explicitly set, default to using the C flags.


### PR DESCRIPTION
Revert "8353272: One instance of STATIC_LIB_CFLAGS was missed in JDK-8345683"

This reverts commit cef5610b5d4f7c5c2ceda46995ef3a0d961294e5.

This causes failures building the static libs on Windows and macOS.

Thanks