### PR TITLE
8353458: Don't pass -Wno-format-nonliteral to CFLAGS

### DIFF
--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -61,7 +61,6 @@ $(eval $(call SetupJdkExecutable, BUILD_JPACKAGEAPPLAUNCHER, \
     DISABLED_WARNINGS_clang_Log.cpp := unused-const-variable, \
     CFLAGS_FILTER_OUT := -MD, \
     CXXFLAGS_FILTER_OUT := -MD, \
-    CFLAGS_macosx := -Wno-format-nonliteral, \
     CFLAGS_windows := -MT $(JPACKAGE_CFLAGS_windows), \
     CXXFLAGS_windows := -MT $(JPACKAGE_CXXFLAGS_windows), \
     LD_SET_ORIGIN := false, \

--- a/src/jdk.jpackage/share/native/common/tstrings.cpp
+++ b/src/jdk.jpackage/share/native/common/tstrings.cpp
@@ -52,13 +52,13 @@ tstring unsafe_format(tstring::const_pointer format, ...) {
 #ifdef _MSC_VER
         ret = _vsntprintf_s(&*fmtout.begin(), fmtout.size(), _TRUNCATE, format, args);
 #else
-#if defined(__GNUC__) && __GNUC__ >= 5
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #endif
         // With g++ this compiles only with '-std=gnu++0x' option
         ret = vsnprintf(&*fmtout.begin(), fmtout.size(), format, args);
-#if defined(__GNUC__) && __GNUC__ >= 5
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 #endif


### PR DESCRIPTION
The proper way to disable warnings is to use the DISABLED_WARNINGS arguments. In this particular case, there was already a pragma but due to incorrect restrictions it did not apply to clang.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353458](https://bugs.openjdk.org/browse/JDK-8353458): Don't pass -Wno-format-nonliteral to CFLAGS (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24357/head:pull/24357` \
`$ git checkout pull/24357`

Update a local copy of the PR: \
`$ git checkout pull/24357` \
`$ git pull https://git.openjdk.org/jdk.git pull/24357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24357`

View PR using the GUI difftool: \
`$ git pr show -t 24357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24357.diff">https://git.openjdk.org/jdk/pull/24357.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24357#issuecomment-2769368215)
</details>
