### PR TITLE
8349890 : Option -Djava.security.debug=x509,ava breaks special chars

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/AVA.java
+++ b/src/java.base/share/classes/sun/security/x509/AVA.java
@@ -640,7 +640,7 @@ public class AVA implements DerEncoder {
      */
     public String toString() {
         return toKeywordValueString
-            (toKeyword(DEFAULT, Collections.emptyMap()));
+            (toKeyword(DEFAULT, Collections.emptyMap()), Boolean.TRUE);
     }
 
     /**
@@ -659,7 +659,7 @@ public class AVA implements DerEncoder {
      * OID/keyword map.
      */
     public String toRFC1779String(Map<String, String> oidMap) {
-        return toKeywordValueString(toKeyword(RFC1779, oidMap));
+        return toKeywordValueString(toKeyword(RFC1779, oidMap), Boolean.FALSE);
     }
 
     /**
@@ -758,12 +758,6 @@ public class AVA implements DerEncoder {
                     // escape null character
                     sbuffer.append("\\00");
 
-                } else if (debug != null && Debug.isOn("ava")) {
-
-                    // embed non-printable/non-escaped char
-                    // as escaped hex pairs for debugging
-                    byte[] valueBytes = Character.toString(c).getBytes(UTF_8);
-                    HexFormat.of().withPrefix("\\").withUpperCase().formatHex(sbuffer, valueBytes);
                 } else {
 
                     // append non-printable/non-escaped char
@@ -888,14 +882,6 @@ public class AVA implements DerEncoder {
                         }
                     }
 
-                } else if (debug != null && Debug.isOn("ava")) {
-
-                    // embed non-printable/non-escaped char
-                    // as escaped hex pairs for debugging
-
-                    previousWhite = false;
-                    byte[] valueBytes = Character.toString(c).getBytes(UTF_8);
-                    HexFormat.of().withPrefix("\\").withUpperCase().formatHex(sbuffer, valueBytes);
                 } else {
 
                     // append non-printable/non-escaped char
@@ -945,7 +931,7 @@ public class AVA implements DerEncoder {
         return AVAKeyword.hasKeyword(oid, RFC2253);
     }
 
-    private String toKeywordValueString(String keyword) {
+    private String toKeywordValueString(String keyword, Boolean isFromToString) {
         /*
          * Construct the value with as little copying and garbage
          * production as practical.  First the keyword (mandatory),
@@ -1019,7 +1005,7 @@ public class AVA implements DerEncoder {
 
                         sbuffer.append(c);
 
-                    } else if (debug != null && Debug.isOn("ava")) {
+                    } else if (debug != null && isFromToString && Debug.isOn("ava")) {
 
                         // embed non-printable/non-escaped char
                         // as escaped hex pairs for debugging

--- a/src/java.base/share/classes/sun/security/x509/AVA.java
+++ b/src/java.base/share/classes/sun/security/x509/AVA.java
@@ -640,7 +640,7 @@ public class AVA implements DerEncoder {
      */
     public String toString() {
         return toKeywordValueString
-            (toKeyword(DEFAULT, Collections.emptyMap()), Boolean.TRUE);
+            (toKeyword(DEFAULT, Collections.emptyMap()), true);
     }
 
     /**
@@ -659,7 +659,7 @@ public class AVA implements DerEncoder {
      * OID/keyword map.
      */
     public String toRFC1779String(Map<String, String> oidMap) {
-        return toKeywordValueString(toKeyword(RFC1779, oidMap), Boolean.FALSE);
+        return toKeywordValueString(toKeyword(RFC1779, oidMap), false);
     }
 
     /**

--- a/test/jdk/sun/security/x509/X500Name/PrintX500NameInDebugModeWithAvaOption.java
+++ b/test/jdk/sun/security/x509/X500Name/PrintX500NameInDebugModeWithAvaOption.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8349890
+ * @summary Make sure debug with AVA option does not interfere with parsing special characters.
+ * @modules java.base/sun.security.x509
+ * @library /test/lib
+ * @run main/othervm -Djava.security.debug=x509:ava PrintX500NameInDebugModeWithAvaOption
+ */
+
+import jdk.test.lib.Asserts;
+import sun.security.x509.X500Name;
+
+public class PrintX500NameInDebugModeWithAvaOption {
+
+    public static void main(String[] args) throws Exception {
+
+        X500Name name = new X500Name("cn=john doe + l=ca\\+lifornia + l =sf, O=Ñ");
+
+        //Test the name in default String format. This will perform the hex conversion to
+        //"\\C3\\91" for special character "Ñ"
+        Asserts.assertTrue(name.toString().contains("\\C3\\91"),"String does not contain expected value");
+
+        //Test the name in RFC2253 format. This should skip the hex conversion to return
+        //"\u00d1" for special character "Ñ"
+        Asserts.assertTrue(name.getRFC2253Name().contains("\u00d1"), "String does not contain expected value");
+
+        //Test the name in canonical name in RFC2253 format. This should skip the hex conversion to return
+        //"n\u0303" for special character "Ñ"
+        Asserts.assertTrue(name.getRFC2253CanonicalName().contains("n\u0303"),"String does not contain expected value");
+
+
+        //Test to print name in RFC1779 format. This should skip the hex conversion to print
+        //"\u00d1" for special character "Ñ"
+        Asserts.assertTrue(name.getRFC1779Name().contains("\u00d1"),"String does not contain expected value");
+    }
+}

--- a/test/jdk/sun/security/x509/X500Name/PrintX500PrincipalInDebugModeWithAvaOption.java
+++ b/test/jdk/sun/security/x509/X500Name/PrintX500PrincipalInDebugModeWithAvaOption.java
@@ -24,35 +24,38 @@
 /* @test
  * @bug 8349890
  * @summary Make sure debug with AVA option does not interfere with parsing special characters.
- * @modules java.base/sun.security.x509
  * @library /test/lib
- * @run main/othervm -Djava.security.debug=x509:ava PrintX500NameInDebugModeWithAvaOption
+ * @run main/othervm -Djava.security.debug=x509:ava PrintX500PrincipalInDebugModeWithAvaOption
  */
 
 import jdk.test.lib.Asserts;
-import sun.security.x509.X500Name;
+import javax.security.auth.x500.X500Principal;
 
-public class PrintX500NameInDebugModeWithAvaOption {
+public class PrintX500PrincipalInDebugModeWithAvaOption {
 
     public static void main(String[] args) throws Exception {
 
-        X500Name name = new X500Name("cn=john doe + l=ca\\+lifornia + l =sf, O=Ñ");
+        X500Principal name = new X500Principal("cn=john doe + l=ca\\+lifornia + l =sf, O=Ñ");
 
         //Test the name in default String format. This will perform the hex conversion to
         //"\\C3\\91" for special character "Ñ"
-        Asserts.assertTrue(name.toString().contains("\\C3\\91"),"String does not contain expected value");
+        Asserts.assertTrue(name.toString().contains("\\C3\\91"),
+                "String does not contain expected value");
 
         //Test the name in RFC2253 format. This should skip the hex conversion to return
         //"\u00d1" for special character "Ñ"
-        Asserts.assertTrue(name.getRFC2253Name().contains("\u00d1"), "String does not contain expected value");
+        Asserts.assertTrue(name.getName().contains("\u00d1"),
+                "String does not contain expected value");
 
         //Test the name in canonical name in RFC2253 format. This should skip the hex conversion to return
         //"n\u0303" for special character "Ñ"
-        Asserts.assertTrue(name.getRFC2253CanonicalName().contains("n\u0303"),"String does not contain expected value");
+        Asserts.assertTrue(name.getName(X500Principal.CANONICAL).contains("n\u0303"),
+                "String does not contain expected value");
 
 
         //Test to print name in RFC1779 format. This should skip the hex conversion to print
         //"\u00d1" for special character "Ñ"
-        Asserts.assertTrue(name.getRFC1779Name().contains("\u00d1"),"String does not contain expected value");
+        Asserts.assertTrue(name.getName(X500Principal.RFC1779).contains("\u00d1"),
+                "String does not contain expected value");
     }
 }


### PR DESCRIPTION
**A DESCRIPTION OF THE PROBLEM :**
Enabling -Djava.security.debug=x509,ava affects how special characters in certificates are processed. The expected behavior is that debugging should not interfere with the normal encoding of certificate fields.

**Fix:**
The Debugging will no longer interfere with these fields, unless you call toString().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349890](https://bugs.openjdk.org/browse/JDK-8349890): option -Djava.security.debug=x509,ava breaks special chars (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24360/head:pull/24360` \
`$ git checkout pull/24360`

Update a local copy of the PR: \
`$ git checkout pull/24360` \
`$ git pull https://git.openjdk.org/jdk.git pull/24360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24360`

View PR using the GUI difftool: \
`$ git pr show -t 24360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24360.diff">https://git.openjdk.org/jdk/pull/24360.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24360#issuecomment-2769972025)
</details>
