### PR TITLE
8353322: Specification of ChoiceFormat#parse(String, ParsePosition) is inadequate

### DIFF
--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -568,8 +568,8 @@ public class ChoiceFormat extends NumberFormat {
      * For example,
      * {@snippet lang=java :
      * var fmt = new ChoiceFormat("0#foo|1#bar|2#baz");
-     * fmt.parse("baz"); // returns 2
-     * fmt.parse("quux"); // returns NaN
+     * fmt.parse("baz", new ParsePosition(0)); // returns 2
+     * fmt.parse("quux", new ParsePosition(0)); // returns NaN
      * }
      *
      * @implNote The {@code Number} subtype returned by the JDK reference

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -558,22 +558,19 @@ public class ChoiceFormat extends NumberFormat {
     }
 
     /**
-     * Parses a {@code Number} from the input text. The value returned is the
-     * {@code limit} corresponding to the {@code format} that is the longest
-     * substring of the input text. Matching is done in ascending order, when
-     * multiple {@code formats} match the text equivalently in strength, the
-     * first matching {@code limit} is returned. If there is no match, {@code
-     * Double.NaN} is returned.
+     * Parses a {@code Number} from the input text, the subtype of which is always
+     * {@code Double}. The value returned is the {@code limit} corresponding
+     * to the {@code format} that is the longest substring of the input text.
+     * Matching is done in ascending order, when multiple {@code formats} match
+     * the text equivalently in strength, the first matching {@code limit} is
+     * returned. If there is no match, {@code Double.NaN} is returned.
      * <p>
      * For example,
      * {@snippet lang=java :
      * var fmt = new ChoiceFormat("0#foo|1#bar|2#baz");
-     * fmt.parse("baz", new ParsePosition(0)); // returns 2
+     * fmt.parse("baz", new ParsePosition(0)); // returns 2.0
      * fmt.parse("quux", new ParsePosition(0)); // returns NaN
      * }
-     *
-     * @implNote The {@code Number} subtype returned by the JDK reference
-     * implementation of this method is always {@code Double}.
      *
      * @param text the source text.
      * @param status an input-output parameter.  On input, the

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -558,8 +558,8 @@ public class ChoiceFormat extends NumberFormat {
     }
 
     /**
-     * Parses a {@code Number} from the input text, the subtype of which is always
-     * {@code Double}. The value returned is the {@code limit} corresponding
+     * Parses the input text starting at the index given by the {@code ParsePosition}
+     * as a {@code Double}. The value returned is the {@code limit} corresponding
      * to the {@code format} that is the longest substring of the input text.
      * Matching is done in ascending order, when multiple {@code format}s match
      * the text equivalently in strength, the first matching {@code limit} is

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -561,7 +561,7 @@ public class ChoiceFormat extends NumberFormat {
      * Parses a {@code Number} from the input text, the subtype of which is always
      * {@code Double}. The value returned is the {@code limit} corresponding
      * to the {@code format} that is the longest substring of the input text.
-     * Matching is done in ascending order, when multiple {@code formats} match
+     * Matching is done in ascending order, when multiple {@code format}s match
      * the text equivalently in strength, the first matching {@code limit} is
      * returned. If there is no match, {@code Double.NaN} is returned.
      * <p>
@@ -580,8 +580,8 @@ public class ChoiceFormat extends NumberFormat {
      * in the source text.  On exit, if an error did occur,
      * status.index is unchanged and status.errorIndex is set to the
      * first index of the character that caused the parse to fail.
-     * @return A Number which represents the {@code limit} corresponding to the {@code
-     * format} parsed.
+     * @return A Number which represents the {@code limit} corresponding to the
+     * {@code format} parsed, or {@code Double.NaN} if the parse fails.
      * @throws    NullPointerException if {@code status} is {@code null}
      *            or if {@code text} is {@code null} and the list of
      *            choice strings is not empty.

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -558,7 +558,23 @@ public class ChoiceFormat extends NumberFormat {
     }
 
     /**
-     * Parses a Number from the input text.
+     * Parses a {@code Number} from the input text. The value returned is the
+     * {@code limit} corresponding to the {@code format} that is the longest
+     * substring of the input text. Matching is done in ascending order, when
+     * multiple {@code formats} match the text equivalently in strength, the
+     * first matching {@code limit} is returned. If there is no match, {@code
+     * Double.NaN} is returned.
+     * <p>
+     * For example,
+     * {@snippet lang=java :
+     * var fmt = new ChoiceFormat("0#foo|1#bar|2#baz");
+     * fmt.parse("baz"); // returns 2
+     * fmt.parse("quux"); // returns NaN
+     * }
+     *
+     * @implNote The {@code Number} subtype returned by the JDK reference
+     * implementation of this method is always {@code Double}.
+     *
      * @param text the source text.
      * @param status an input-output parameter.  On input, the
      * status.index field indicates the first character of the
@@ -567,7 +583,8 @@ public class ChoiceFormat extends NumberFormat {
      * in the source text.  On exit, if an error did occur,
      * status.index is unchanged and status.errorIndex is set to the
      * first index of the character that caused the parse to fail.
-     * @return A Number representing the value of the number parsed.
+     * @return A Number which represents the {@code limit} corresponding to the {@code
+     * format} parsed.
      * @throws    NullPointerException if {@code status} is {@code null}
      *            or if {@code text} is {@code null} and the list of
      *            choice strings is not empty.


### PR DESCRIPTION
Please review this PR which specifies the `ChoiceFormat#parse(String, ParsePosition)` method. A corresponding CSR is filed. The current specification is simply "Parses a Number from the input text" which does not indicate how the value is returned. The criteria for a match, as well as no match should be made clear.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8353327](https://bugs.openjdk.org/browse/JDK-8353327) to be approved

### Issues
 * [JDK-8353322](https://bugs.openjdk.org/browse/JDK-8353322): Specification of ChoiceFormat#parse(String, ParsePosition) is inadequate (**Bug** - P4)
 * [JDK-8353327](https://bugs.openjdk.org/browse/JDK-8353327): Specification of ChoiceFormat#parse(String, ParsePosition) is inadequate (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24361/head:pull/24361` \
`$ git checkout pull/24361`

Update a local copy of the PR: \
`$ git checkout pull/24361` \
`$ git pull https://git.openjdk.org/jdk.git pull/24361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24361`

View PR using the GUI difftool: \
`$ git pr show -t 24361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24361.diff">https://git.openjdk.org/jdk/pull/24361.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24361#issuecomment-2769983136)
</details>
