### PR TITLE
8353267: jmod create finds the wrong set of packages when class file are in non-package location

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolManager.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolManager.java
@@ -67,7 +67,7 @@ public class ResourcePoolManager {
     }
 
     /**
-     * Returns true if a resource name corresponding to a package name.
+     * Returns true if a resource is located in a named package.
      */
     public static boolean isNamedPackageResource(String name) {
         int index = name.lastIndexOf("/");

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolManager.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import jdk.internal.jimage.decompressor.CompressedResourceHeader;
-import jdk.internal.module.Resources;
+import jdk.internal.module.Checks;
 import jdk.internal.module.ModuleInfo;
 import jdk.internal.module.ModuleInfo.Attributes;
 import jdk.internal.module.ModuleTarget;
@@ -67,11 +67,16 @@ public class ResourcePoolManager {
     }
 
     /**
-     * Returns true if a resource has an effective package.
+     * Returns true if a resource name corresponding to a package name.
      */
-    public static boolean isNamedPackageResource(String path) {
-        return (path.endsWith(".class") && !path.endsWith("module-info.class")) ||
-                Resources.canEncapsulate(path);
+    public static boolean isNamedPackageResource(String name) {
+        int index = name.lastIndexOf("/");
+        if (index == -1) {
+            return false;
+        } else {
+            String pn = name.substring(0, index).replace('/', '.');
+            return Checks.isPackageName(pn);
+        }
     }
 
     static class ResourcePoolModuleImpl implements ResourcePoolModule {

--- a/test/jdk/tools/jlink/ClassFileInMetaInfo.java
+++ b/test/jdk/tools/jlink/ClassFileInMetaInfo.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8353267
+ * @summary Test jlink with a module containing a class file in its META-INF directory
+ * @library /test/lib
+ * @modules java.base/jdk.internal.module
+ *          jdk.jlink
+ *          jdk.jartool
+ * @run junit ClassFileInMetaInfo
+ */
+
+import java.lang.module.ModuleDescriptor;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.spi.ToolProvider;
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.util.ModuleInfoWriter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClassFileInMetaInfo {
+    private static PrintStream out;
+    private static String moduleName;
+    private static String classesDir;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        out = System.err; // inline with Junit
+        
+        // Create module foo containing
+        //     module-info.class
+        //     p/C.class
+        //     META-INF/extra/q/C.class
+        moduleName = "foo";
+        ModuleDescriptor descriptor = ModuleDescriptor.newModule(moduleName).build();
+        byte[] moduleInfo = ModuleInfoWriter.toBytes(descriptor);
+        Path dir = Files.createTempDirectory(Path.of("."), moduleName);
+        Files.write(dir.resolve("module-info.class"), moduleInfo);
+        Files.createFile(Files.createDirectory(dir.resolve("p")).resolve("C.class"));
+        Path extraClasses = dir.resolve("META-INF/extra/");
+        Files.createFile(Files.createDirectories(extraClasses.resolve("q")).resolve("C.class"));
+        classesDir = dir.toString();
+    }
+
+    @Test
+    void testExplodedModule() throws Exception {
+        test(classesDir);
+    }
+
+    @Test
+    void testModularJar() throws Exception {
+        String jarFile = "foo.jar";
+        ToolProvider jarTool = ToolProvider.findFirst("jar").orElseThrow();
+        int res = jarTool.run(out, out, "cf", jarFile, "-C", classesDir, ".");
+        assertEquals(0, res);
+        test(jarFile);
+    }
+
+    @Test
+    void testJmod() throws Exception {
+        String jmodFile = "foo.jmod";
+        ToolProvider jmodTool = ToolProvider.findFirst("jmod").orElseThrow();
+        int res = jmodTool.run(out, out, "create", "--class-path", classesDir, jmodFile);
+        assertEquals(0, res);
+        test(jmodFile);
+    }
+
+    /**
+     * jlink --module-path .. --add-modules foo --ouptut image
+     * image/bin/java --describe-module foo
+     */
+    private void test(String modulePath) throws Exception {
+        Path dir = Files.createTempDirectory(Path.of("."), "image");
+        Files.delete(dir);
+        String image = dir.toString();
+
+        ToolProvider jlinkTool = ToolProvider.findFirst("jlink").orElseThrow();
+        int res = jlinkTool.run(out, out,
+                "--module-path", modulePath,
+                "--add-modules", moduleName,
+                "--output", image);
+        assertEquals(0, res);
+
+        var pb = new ProcessBuilder(image + "/bin/java", "--describe-module", moduleName);
+        ProcessTools.executeProcess(pb)
+                .outputTo(out)
+                .errorTo(out)
+                .shouldHaveExitValue(0)
+                .shouldContain(moduleName)
+                .shouldContain("contains p")
+                .shouldNotContain("META-INF");
+    }
+}

--- a/test/jdk/tools/jlink/ClassFileInMetaInfo.java
+++ b/test/jdk/tools/jlink/ClassFileInMetaInfo.java
@@ -53,7 +53,7 @@ class ClassFileInMetaInfo {
     @BeforeAll
     static void setup() throws Exception {
         out = System.err; // inline with Junit
-        
+
         // Create module foo containing
         //     module-info.class
         //     p/C.class


### PR DESCRIPTION
`jmod create` maps the contents of the module to a set of packages. This mapping derives illegal package names when class resources are located in non-package locations, e.g. in the META-INF tree. `jlink` also has an issue in this area and doesn't correctly determine if a resource is in a named package when the resource is class file in a non-package location.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8353267: jmod create finds the wrong set of packages when class file are in non-package location`

### Issue
 * [JDK-8353267](https://bugs.openjdk.org/browse/JDK-8353267): jmod create finds the wrong set of packages when class file are in non-package location (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24362/head:pull/24362` \
`$ git checkout pull/24362`

Update a local copy of the PR: \
`$ git checkout pull/24362` \
`$ git pull https://git.openjdk.org/jdk.git pull/24362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24362`

View PR using the GUI difftool: \
`$ git pr show -t 24362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24362.diff">https://git.openjdk.org/jdk/pull/24362.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24362#issuecomment-2771823261)
</details>
