### PR TITLE
8353330: Test runtime/cds/appcds/SignedJar.java fails in CDSHeapVerifier

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -103,8 +103,6 @@ gc/shenandoah/TestEvilSyncBug.java#generational 8345501 generic-all
 
 # :hotspot_runtime
 
-runtime/cds/appcds/SignedJar.java 8353330 generic-all
-
 runtime/jni/terminatedThread/TestTerminatedThread.java 8317789 aix-ppc64
 runtime/handshake/HandshakeSuspendExitTest.java 8294313 generic-all
 runtime/Monitor/SyncOnValueBasedClassTest.java 8340995 linux-s390x


### PR DESCRIPTION
Java core-lib changes in [JDK-8339280](https://bugs.openjdk.org/browse/JDK-8339280) for code-signing causes more java.lang.invoke classes to be initialized in the assembly phase.

Static fields like `java/lang/invoke/MethodHandleImpl$ArrayAccessor::OBJECT_ARRAY_SETTER` are just cached MethodHandles whose object identity doesn't matter. So it's OK for them to be stored into the AOT cache. Therefore, I added them to the CDSHeapVerifier exclusion lists.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353330](https://bugs.openjdk.org/browse/JDK-8353330): Test runtime/cds/appcds/SignedJar.java fails in CDSHeapVerifier (**Bug** - P3)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24363/head:pull/24363` \
`$ git checkout pull/24363`

Update a local copy of the PR: \
`$ git checkout pull/24363` \
`$ git pull https://git.openjdk.org/jdk.git pull/24363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24363`

View PR using the GUI difftool: \
`$ git pr show -t 24363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24363.diff">https://git.openjdk.org/jdk/pull/24363.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24363#issuecomment-2770278099)
</details>
