### PR TITLE
8353479: jcmd with streaming output breaks intendation

### DIFF
--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -138,6 +138,7 @@ public:
     if (is_streaming()) {
       if (!_error) {
         _error = !_reply_writer->write_fully(str, (int)len);
+        update_position(str, len);
       }
     } else {
       bufferedStream::write(str, len);


### PR DESCRIPTION
`outputStream` implementations should call `update_position` from `write` to correctly handle indentation.
The fix adds the call to `attachStream::write`

testing: sanity tier1;
   in progress: tier2..4,hs-tier5-svc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8353479: jcmd with streaming output breaks intendation`

### Issue
 * [JDK-8353479](https://bugs.openjdk.org/browse/JDK-8353479): jcmd with streaming output breaks intendation (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24368/head:pull/24368` \
`$ git checkout pull/24368`

Update a local copy of the PR: \
`$ git checkout pull/24368` \
`$ git pull https://git.openjdk.org/jdk.git pull/24368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24368`

View PR using the GUI difftool: \
`$ git pr show -t 24368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24368.diff">https://git.openjdk.org/jdk/pull/24368.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24368#issuecomment-2770734996)
</details>
