### PR TITLE
8353484: JFR: Simplify EventConfiguration

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -44,6 +44,7 @@ import jdk.jfr.Event;
 import jdk.jfr.EventType;
 import jdk.jfr.Name;
 import jdk.jfr.Period;
+import jdk.jfr.SettingControl;
 import jdk.jfr.ValueDescriptor;
 import jdk.jfr.internal.consumer.RepositoryFiles;
 import jdk.jfr.internal.event.EventConfiguration;
@@ -59,7 +60,6 @@ public final class MetadataRepository {
     private final Map<String, EventControl> nativeControls = LinkedHashMap.newHashMap(150);
     private final SettingsManager settingsManager = new SettingsManager();
     private final HiddenWait threadSleeper = new HiddenWait();
-    private Constructor<EventConfiguration> cachedEventConfigurationConstructor;
     private boolean staleMetadata = true;
     private boolean unregistered;
     private long lastUnloaded = -1;
@@ -103,7 +103,7 @@ public final class MetadataRepository {
         List<EventType> eventTypes = new ArrayList<>(configurations.size() + nativeEventTypes.size());
         for (EventConfiguration ec : configurations) {
             if (ec.isRegistered()) {
-                eventTypes.add(ec.getEventType());
+                eventTypes.add(ec.eventType());
             }
         }
         for (EventType t : nativeEventTypes.values()) {
@@ -117,7 +117,7 @@ public final class MetadataRepository {
     public synchronized EventType getEventType(Class<? extends jdk.internal.event.Event> eventClass) {
         EventConfiguration ec = getConfiguration(eventClass, false);
         if (ec != null && ec.isRegistered()) {
-            return ec.getEventType();
+            return ec.eventType();
         }
         throw new IllegalStateException("Event class " + eventClass.getName() + " is not registered");
     }
@@ -125,7 +125,7 @@ public final class MetadataRepository {
     public synchronized void unregister(Class<? extends Event> eventClass) {
         EventConfiguration configuration = getConfiguration(eventClass, false);
         if (configuration != null) {
-            configuration.getPlatformEventType().setRegistered(false);
+            configuration.platformEventType().setRegistered(false);
         }
         // never registered, ignore call
     }
@@ -147,14 +147,14 @@ public final class MetadataRepository {
             PlatformEventType pe = findMirrorType(eventClass);
             configuration = makeConfiguration(eventClass, pe, dynamicAnnotations, dynamicFields);
         }
-        configuration.getPlatformEventType().setRegistered(true);
-        TypeLibrary.addType(configuration.getPlatformEventType());
+        configuration.platformEventType().setRegistered(true);
+        TypeLibrary.addType(configuration.platformEventType());
         if (JVM.isRecording()) {
-            settingsManager.setEventControl(configuration.getEventControl(), true, JVM.counterTime());
+            settingsManager.setEventControl(configuration.eventControl(), true, JVM.counterTime());
             settingsManager.updateRetransform(Collections.singletonList((eventClass)));
        }
        setStaleMetadata();
-       return configuration.getEventType();
+       return configuration.eventType();
     }
 
     private PlatformEventType findMirrorType(Class<? extends jdk.internal.event.Event> eventClass) throws InternalError {
@@ -177,20 +177,6 @@ public final class MetadataRepository {
             Utils.ensureInitialized(eventClass);
         }
         return JVMSupport.getConfiguration(eventClass);
-    }
-
-    private EventConfiguration newEventConfiguration(EventType eventType, EventControl ec) {
-        try {
-            if (cachedEventConfigurationConstructor == null) {
-                var argClasses = new Class<?>[] { EventType.class, EventControl.class};
-                Constructor<EventConfiguration> c = EventConfiguration.class.getDeclaredConstructor(argClasses);
-                c.setAccessible(true);
-                cachedEventConfigurationConstructor = c;
-            }
-            return cachedEventConfigurationConstructor.newInstance(eventType, ec);
-        } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-            throw new InternalError(e);
-        }
     }
 
     private EventConfiguration makeConfiguration(Class<? extends jdk.internal.event.Event> eventClass, PlatformEventType pEventType, List<AnnotationElement> dynamicAnnotations, List<ValueDescriptor> dynamicFields) throws InternalError {
@@ -226,12 +212,12 @@ public final class MetadataRepository {
         }
         EventType eventType = PrivateAccess.getInstance().newEventType(pEventType);
         EventControl ec = new EventControl(pEventType, eventClass);
-        EventConfiguration configuration = newEventConfiguration(eventType, ec);
-        PlatformEventType pe = configuration.getPlatformEventType();
-        pe.setRegistered(true);
+        SettingControl[] settings = ec.getSettingControls().toArray(new SettingControl[0]);
+        EventConfiguration configuration = new EventConfiguration(pEventType, eventType, ec, settings, eventType.getId());
+        pEventType.setRegistered(true);
         // If class is instrumented or should not be instrumented, mark as instrumented.
-        if (JVM.isInstrumented(eventClass) || !JVMSupport.shouldInstrument(pe.isJDK(), pe.getName())) {
-            pe.setInstrumented();
+        if (JVM.isInstrumented(eventClass) || !JVMSupport.shouldInstrument(pEventType.isJDK(), pEventType.getName())) {
+            pEventType.setInstrumented();
         }
         JVMSupport.setConfiguration(eventClass, configuration);
         return configuration;
@@ -254,7 +240,7 @@ public final class MetadataRepository {
         for (Class<? extends jdk.internal.event.Event> clazz : eventClasses) {
             EventConfiguration eh = JVMSupport.getConfiguration(clazz);
             if (eh != null) {
-                controls.add(eh.getEventControl());
+                controls.add(eh.eventControl());
             }
         }
         return controls;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,7 +158,7 @@ final class SettingsManager {
         for(Class<? extends jdk.internal.event.Event> eventClass: eventClasses) {
             EventConfiguration ec = JVMSupport.getConfiguration(eventClass);
             if (ec != null ) {
-                PlatformEventType eventType = ec.getPlatformEventType();
+                PlatformEventType eventType = ec.platformEventType();
                 if (eventType.isMarkedForInstrumentation()) {
                     classes.add(eventClass);
                     eventType.markForInstrumentation(false);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/event/EventConfiguration.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/event/EventConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,38 +26,17 @@
 package jdk.jfr.internal.event;
 
 import jdk.jfr.EventType;
+import jdk.jfr.SettingControl;
 import jdk.jfr.internal.EventControl;
 import jdk.jfr.internal.JVM;
 import jdk.jfr.internal.PlatformEventType;
-import jdk.jfr.internal.PrivateAccess;
-import jdk.jfr.SettingControl;
 
-// Users should not be able to subclass or instantiate for security reasons.
-public final class EventConfiguration {
-    private final PlatformEventType platformEventType;
-    private final EventType eventType;
-    private final EventControl eventControl;
-    private final SettingControl[] settings;
-
-    // Private constructor so user code can't instantiate
-    private EventConfiguration(EventType eventType, EventControl eventControl) {
-        this.eventType = eventType;
-        this.platformEventType = PrivateAccess.getInstance().getPlatformEventType(eventType);
-        this.eventControl = eventControl;
-        this.settings = eventControl.getSettingControls().toArray(new SettingControl[0]);
-    }
-
-    // Class jdk.jfr.internal.PlatformEventType is not
-    // accessible from event class by design
-    public PlatformEventType getPlatformEventType() {
-        return platformEventType;
-    }
-
-    // Class jdk.jfr.internal.EventControl is not
-    // accessible from event class by design
-    public EventControl getEventControl() {
-        return eventControl;
-    }
+public record EventConfiguration(
+    PlatformEventType platformEventType,
+    EventType eventType,
+    EventControl eventControl,
+    SettingControl[] settings,
+    long id) {
 
     // Accessed by generated code in event class
     public boolean shouldCommit(long duration) {
@@ -72,11 +51,6 @@ public final class EventConfiguration {
     // Accessed by generated code in event class
     public boolean isEnabled() {
         return platformEventType.isCommittable();
-    }
-
-    // Accessed by generated code in event class
-    public EventType getEventType() {
-        return eventType;
     }
 
     // Not really part of the configuration, but the method
@@ -99,9 +73,5 @@ public final class EventConfiguration {
 
     public boolean isRegistered() {
         return platformEventType.isRegistered();
-    }
-
-    public long getId() {
-        return eventType.getId();
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/event/EventWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/event/EventWriter.java
@@ -234,14 +234,14 @@ public final class EventWriter {
 
     public boolean beginEvent(EventConfiguration configuration, long typeId) {
         // This check makes sure the event type matches what was added by instrumentation.
-        if (configuration.getId() != typeId) {
+        if (configuration.id() != typeId) {
             throw new InternalError("Unexpected type id " + typeId);
         }
         if (excluded) {
             // thread is excluded from writing events
             return false;
         }
-        this.eventType = configuration.getPlatformEventType();
+        this.eventType = configuration.platformEventType();
         reserveEventSizeField();
         putLong(eventType.getId());
         return true;


### PR DESCRIPTION
Could I have a review of a change that removes code that is unnecessary now that the Security Manager is no longer used.



Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353484](https://bugs.openjdk.org/browse/JDK-8353484): JFR: Simplify EventConfiguration (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24371/head:pull/24371` \
`$ git checkout pull/24371`

Update a local copy of the PR: \
`$ git checkout pull/24371` \
`$ git pull https://git.openjdk.org/jdk.git pull/24371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24371`

View PR using the GUI difftool: \
`$ git pr show -t 24371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24371.diff">https://git.openjdk.org/jdk/pull/24371.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24371#issuecomment-2772324020)
</details>
