### PR TITLE
8353614: JFR: jfr print --exact

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -537,7 +537,7 @@ public final class PrettyWriter extends EventPrintWriter {
         Percentage percentage = field.getAnnotation(Percentage.class);
         if (percentage != null) {
             if (value instanceof Number n) {
-                double p = n.doubleValue() *100;
+                double p = 100 * n.doubleValue();
                 if (showExact) {
                     println(String.format("%.9f%%", p));
                 } else {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -537,11 +537,11 @@ public final class PrettyWriter extends EventPrintWriter {
         Percentage percentage = field.getAnnotation(Percentage.class);
         if (percentage != null) {
             if (value instanceof Number n) {
-                double d = n.doubleValue();
+                double p = n.doubleValue() *100;
                 if (showExact) {
-                    println(String.format("%.9f%%", d));
+                    println(String.format("%.9f%%", p));
                 } else {
-                    println(String.format("%.2f", d * 100) + "%");
+                    println(String.format("%.2f%%", p));
                 }
                 return true;
             }
@@ -554,6 +554,7 @@ public final class PrettyWriter extends EventPrintWriter {
             boolean bytes = unit.equals(DataAmount.BYTES);
             if (bits || bytes) {
                 formatMemory(number.longValue(), bytes, frequency);
+                return true;
             }
         }
         MemoryAddress memoryAddress = field.getAnnotation(MemoryAddress.class);
@@ -579,7 +580,6 @@ public final class PrettyWriter extends EventPrintWriter {
         if (showExact) {
             StringBuilder sb = new StringBuilder();
             sb.append(value);
-            sb.append(" ");
             sb.append(bytesUnit ? " byte" : " bit");
             if (value > 1) {
                 sb.append("s");

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -59,13 +59,20 @@ import jdk.jfr.internal.util.ValueFormatter;
  */
 public final class PrettyWriter extends EventPrintWriter {
     private static final String TYPE_OLD_OBJECT = Type.TYPES_PREFIX + "OldObject";
+    private static final DateTimeFormatter TIME_FORMAT_EXACT = DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSSSS (yyyy-MM-dd)");
     private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS (yyyy-MM-dd)");
     private static final Long ZERO = 0L;
+    private final boolean showExact;
     private boolean showIds;
     private RecordedEvent currentEvent;
 
-    public PrettyWriter(PrintWriter destination) {
+    public PrettyWriter(PrintWriter destination, boolean showExact) {
         super(destination);
+        this.showExact = showExact;
+    }
+
+    public PrettyWriter(PrintWriter destination) {
+        this(destination, false);
     }
 
     @Override
@@ -508,7 +515,11 @@ public final class PrettyWriter extends EventPrintWriter {
                 println("Forever");
                 return true;
             }
-            println(ValueFormatter.formatDuration(d));
+            if (showExact) {
+                println(String.format("%.9f s", (double) d.toNanos() / 1_000_000_000));
+            } else {
+                println(ValueFormatter.formatDuration(d));
+            }
             return true;
         }
         if (value instanceof OffsetDateTime odt) {
@@ -516,40 +527,33 @@ public final class PrettyWriter extends EventPrintWriter {
                 println("N/A");
                 return true;
             }
-            println(TIME_FORMAT.format(odt));
+            if (showExact) {
+                println(TIME_FORMAT_EXACT.format(odt));
+            } else {
+                println(TIME_FORMAT.format(odt));
+            }
             return true;
         }
         Percentage percentage = field.getAnnotation(Percentage.class);
         if (percentage != null) {
             if (value instanceof Number n) {
                 double d = n.doubleValue();
-                println(String.format("%.2f", d * 100) + "%");
+                if (showExact) {
+                    println(String.format("%.9f%%", d));
+                } else {
+                    println(String.format("%.2f", d * 100) + "%");
+                }
                 return true;
             }
         }
         DataAmount dataAmount = field.getAnnotation(DataAmount.class);
-        if (dataAmount != null) {
-            if (value instanceof Number n) {
-                long amount = n.longValue();
-                if (field.getAnnotation(Frequency.class) != null) {
-                    if (dataAmount.value().equals(DataAmount.BYTES)) {
-                        println(ValueFormatter.formatBytesPerSecond(amount));
-                        return true;
-                    }
-                    if (dataAmount.value().equals(DataAmount.BITS)) {
-                        println(ValueFormatter.formatBitsPerSecond(amount));
-                        return true;
-                    }
-                } else {
-                    if (dataAmount.value().equals(DataAmount.BYTES)) {
-                        println(ValueFormatter.formatBytes(amount));
-                        return true;
-                    }
-                    if (dataAmount.value().equals(DataAmount.BITS)) {
-                        println(ValueFormatter.formatBits(amount));
-                        return true;
-                    }
-                }
+        if (dataAmount != null && value instanceof Number number) {
+            boolean frequency = field.getAnnotation(Frequency.class) != null;
+            String unit = dataAmount.value();
+            boolean bits = unit.equals(DataAmount.BITS);
+            boolean bytes = unit.equals(DataAmount.BYTES);
+            if (bits || bytes) {
+                formatMemory(number.longValue(), bytes, frequency);
             }
         }
         MemoryAddress memoryAddress = field.getAnnotation(MemoryAddress.class);
@@ -569,6 +573,36 @@ public final class PrettyWriter extends EventPrintWriter {
         }
 
         return false;
+    }
+
+    private void formatMemory(long value, boolean bytesUnit, boolean frequency) {
+        if (showExact) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(value);
+            sb.append(" ");
+            sb.append(bytesUnit ? " byte" : " bit");
+            if (value > 1) {
+                sb.append("s");
+            }
+            if (frequency) {
+                sb.append("/s");
+            }
+            println(sb.toString());
+            return;
+        }
+        if (frequency) {
+            if (bytesUnit) {
+                println(ValueFormatter.formatBytesPerSecond(value));
+            } else {
+                println(ValueFormatter.formatBitsPerSecond(value));
+            }
+            return;
+        }
+        if (bytesUnit) {
+            println(ValueFormatter.formatBytes(value));
+        } else {
+            println(ValueFormatter.formatBits(value));
+        }
     }
 
     public void setShowIds(boolean showIds) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Print.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Print.java
@@ -49,7 +49,7 @@ final class Print extends Command {
     @Override
     public List<String> getOptionSyntax() {
         List<String> list = new ArrayList<>();
-        list.add("[--xml|--json][--exact]");
+        list.add("[--xml|--json|--exact]");
         list.add("[--categories <filter>]");
         list.add("[--events <filter>]");
         list.add("[--stack-depth <depth>]");

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Print.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Print.java
@@ -73,7 +73,7 @@ final class Print extends Command {
         stream.println();
         stream.println("  --json                  Print recording in JSON format");
         stream.println();
-        stream.println("  --exact                 Pretty print numbers and timestamps in full precision.");
+        stream.println("  --exact                 Pretty-print numbers and timestamps with full precision.");
         stream.println();
         stream.println("  --categories <filter>   Select events matching a category name.");
         stream.println("                          The filter is a comma-separated list of names,");

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Print.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Print.java
@@ -83,6 +83,8 @@ final class Print extends Command {
         stream.println();
         stream.println("  --stack-depth <depth>   Number of frames in stack traces, by default 5");
         stream.println();
+        stream.println("  --exact                 Pretty print numbers and timestamps in full precision.");
+        stream.println();
         stream.println("  <file>                  Location of the recording file (.jfr)");
         stream.println();
         stream.println();
@@ -108,6 +110,7 @@ final class Print extends Command {
         int stackDepth = 5;
         EventPrintWriter eventWriter = null;
         int optionCount = options.size();
+        boolean exact = false;
         boolean foundEventFilter = false;
         boolean foundCategoryFilter = false;
         while (optionCount > 0) {
@@ -140,6 +143,9 @@ final class Print extends Command {
                     throw new UserSyntaxException("not a valid value for --stack-depth");
                 }
             }
+            if (acceptSwitch(options, "--exact")) {
+                exact = true;
+            }
             if (acceptFormatterOption(options, eventWriter, "--json")) {
                 eventWriter = new JSONWriter(pw);
             }
@@ -155,7 +161,7 @@ final class Print extends Command {
             optionCount = options.size();
         }
         if (eventWriter == null) {
-            eventWriter = new PrettyWriter(pw); // default to pretty printer
+            eventWriter = new PrettyWriter(pw, exact); // default to pretty printer
         }
         eventWriter.setStackDepth(stackDepth);
         if (!eventFilters.isEmpty()) {

--- a/src/jdk.jfr/share/man/jfr.md
+++ b/src/jdk.jfr/share/man/jfr.md
@@ -121,7 +121,7 @@ where:
 : Print the recording in JSON format.
 
 <a id="print-option-exact">`--exact`</a>
-: Pretty print numbers and timestamps in full precision.
+: Pretty-print numbers and timestamps with full precision.
 
 <a id="print-option-categories">`--categories` <*filters*></a>
 : Select events matching a category name.

--- a/src/jdk.jfr/share/man/jfr.md
+++ b/src/jdk.jfr/share/man/jfr.md
@@ -106,7 +106,7 @@ Use `jfr print` to print the contents of a flight recording file to standard out
 
 The syntax is:
 
-`jfr print` \[`--xml`|`--json`\]
+`jfr print` \[`--xml`|`--json`|`--exact`\]
            \[`--categories` <*filters*>\]
            \[`--events` <*filters*>\]
            \[`--stack-depth` <*depth*>\]
@@ -119,6 +119,9 @@ where:
 
 <a id="print-option-json">`--json`</a>
 : Print the recording in JSON format.
+
+<a id="print-option-exact">`--exact`</a>
+: Pretty print numbers and timestamps in full precision.
 
 <a id="print-option-categories">`--categories` <*filters*></a>
 : Select events matching a category name.

--- a/test/jdk/jdk/jfr/tool/TestPrint.java
+++ b/test/jdk/jdk/jfr/tool/TestPrint.java
@@ -24,9 +24,19 @@
 package jdk.jfr.tool;
 
 import java.io.FileWriter;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
+import jdk.jfr.Recording;
+import jdk.jfr.Event;
+import jdk.jfr.Percentage;
+import jdk.jfr.Timestamp;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.Timespan;
+import jdk.jfr.DataAmount;
+import jdk.jfr.Frequency;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -40,20 +50,105 @@ import jdk.test.lib.process.OutputAnalyzer;
  */
 public class TestPrint {
 
-    public static void main(String[] args) throws Throwable {
+    static class ExactEvent extends Event {
+        @DataAmount(DataAmount.BITS)
+        long oneBit;
 
+        @DataAmount(DataAmount.BITS)
+        long bits;
+
+        @Frequency
+        @DataAmount(DataAmount.BITS)
+        long oneBitPerSecond;
+
+        @Frequency
+        @DataAmount(DataAmount.BITS)
+        long bitsPerSecond;
+
+        @DataAmount(DataAmount.BYTES)
+        long oneByte;
+
+        @DataAmount(DataAmount.BYTES)
+        long bytes;
+
+        @Frequency
+        @DataAmount(DataAmount.BYTES)
+        long oneBytePerSecond;
+
+        @Frequency
+        @DataAmount(DataAmount.BYTES)
+        long bytesPerSecond;
+
+        @Percentage
+        double percentage;
+
+        @Timestamp(Timestamp.MILLISECONDS_SINCE_EPOCH)
+        long timestamp;
+
+        @Timespan(Timespan.NANOSECONDS)
+        long timespan;
+    }
+
+    public static void main(String[] args) throws Throwable {
+        testNoFile();
+        testMissingFile();
+        testIncorrectOption();
+        testExact();
+    }
+
+    private static void testNoFile() throws Throwable {
         OutputAnalyzer output = ExecuteHelper.jfr("print");
         output.shouldContain("missing file");
+    }
 
-        output = ExecuteHelper.jfr("print", "missing.jfr");
+    private static void testMissingFile() throws Throwable {
+        OutputAnalyzer output = ExecuteHelper.jfr("print", "missing.jfr");
         output.shouldContain("could not open file ");
+    }
 
-        Path file = Utils.createTempFile("faked-print-file",  ".jfr");
+    private static void testIncorrectOption() throws Throwable {
+        Path file = Utils.createTempFile("faked-print-file", ".jfr");
         FileWriter fw = new FileWriter(file.toFile());
         fw.write('d');
         fw.close();
-        output = ExecuteHelper.jfr("print", "--wrongOption", file.toAbsolutePath().toString());
+        OutputAnalyzer output = ExecuteHelper.jfr("print", "--wrongOption", file.toAbsolutePath().toString());
         output.shouldContain("unknown option");
         Files.delete(file);
+    }
+
+    private static void testExact() throws Throwable{
+        try (Recording r = new Recording()) {
+            r.start();
+            ExactEvent e = new ExactEvent();
+            e.begin();
+            e.oneBit            = 1L;
+            e.bits              = 222_222_222L;
+            e.oneBitPerSecond   = 1L;
+            e.bitsPerSecond     = 333_333_333L;
+            e.oneByte           = 1L;
+            e.bytes             = 444_444_444L;
+            e.oneBytePerSecond  = 1L;
+            e.bytesPerSecond    = 555_555_555L;
+            e.percentage        = 0.666_666_666_66;
+            e.timestamp         = 777;
+            e.timespan          = 888_888_888L;
+            e.commit();
+            r.stop();
+            Path file = Path.of("exact.jfr");
+            r.dump(file);
+            OutputAnalyzer output = ExecuteHelper.jfr("print", "--exact", file.toAbsolutePath().toString());
+            output.shouldContain("oneBit = 1 bit");
+            output.shouldContain("bits = 222222222 bits");
+            output.shouldContain("oneBitPerSecond = 1 bit/s");
+            output.shouldContain("bitsPerSecond = 333333333 bits/s");
+            output.shouldContain("oneByte = 1 byte");
+            output.shouldContain("bytes = 444444444 bytes");
+            output.shouldContain("oneBytePerSecond = 1 byte/s");
+            output.shouldContain("bytesPerSecond = 555555555 bytes/s");
+            output.shouldContain(String.valueOf(100 * e.percentage) + "%");
+            output.shouldContain("00.777000000 (19");
+            output.shouldContain(String.valueOf(e.timespan) + " s");
+            Files.delete(file);
+        }
     }
 }


### PR DESCRIPTION
Could I have a review of an enhancement that adds a command-line switch to `jfr print`, allowing timestamps, time spans, percentages, and byte values to be printed with full precision?

Testing: tier1 + jdk/jdk/jfr

Thank
Erik

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8354195](https://bugs.openjdk.org/browse/JDK-8354195) to be approved

### Issues
 * [JDK-8353614](https://bugs.openjdk.org/browse/JDK-8353614): JFR: jfr print --exact (**Enhancement** - P3)
 * [JDK-8354195](https://bugs.openjdk.org/browse/JDK-8354195): JFR: jfr print --exact (**CSR**)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24372/head:pull/24372` \
`$ git checkout pull/24372`

Update a local copy of the PR: \
`$ git checkout pull/24372` \
`$ git pull https://git.openjdk.org/jdk.git pull/24372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24372`

View PR using the GUI difftool: \
`$ git pr show -t 24372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24372.diff">https://git.openjdk.org/jdk/pull/24372.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24372#issuecomment-2792670257)
</details>
