### PR TITLE
8353058: [PPC64] Some IR framework tests are failing after JDK-8352595

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
@@ -124,76 +124,87 @@ class Basics {
         i = 34;
     }
 
+    // Test failures on ideal phases only.
     @Test
-    @IR(failOn = {IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.COUNTED_LOOP},
+    @IR(failOn = {IRNode.STORE, IRNode.OOPMAP_WITH, "asdf", IRNode.COUNTED_LOOP},
+        counts = {IRNode.STORE, "2", IRNode.FIELD_ACCESS, "2", IRNode.STORE_I, "1"})
+    @ExpectedFailure(ruleId = 1, phase = CompilePhase.PRINT_IDEAL, failOn = 1)
+
+    @IR(failOn = {IRNode.STORE_F, IRNode.OOPMAP_WITH, "asdf", IRNode.COUNTED_LOOP},
+        counts = {IRNode.STORE, "2", IRNode.FIELD_ACCESS, "2", IRNode.STORE_I, "2"})
+    @ExpectedFailure(ruleId = 2, phase = CompilePhase.PRINT_IDEAL, counts = 3)
+
+    @IR(failOn = {IRNode.STORE, IRNode.OOPMAP_WITH, "asdf", IRNode.COUNTED_LOOP})
+    @ExpectedFailure(ruleId = 3, phase = CompilePhase.PRINT_IDEAL, failOn = 1)
+
+    @IR(counts = {IRNode.STORE, "3", IRNode.FIELD_ACCESS, "2", IRNode.COUNTED_LOOP, "2"})
+    @ExpectedFailure(ruleId = 4, phase = CompilePhase.PRINT_IDEAL, counts = {1, 3})
+
+    @IR(failOn = {IRNode.STORE, IRNode.OOPMAP_WITH, "asdf", IRNode.COUNTED_LOOP},
         counts = {IRNode.STORE, "3", IRNode.FIELD_ACCESS, "2", IRNode.COUNTED_LOOP, "2"})
-    @ExpectedFailure(ruleId = 1, phase = CompilePhase.PRINT_IDEAL, failOn = 1, counts = {1, 3})
-    @ExpectedFailure(ruleId = 1, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, failOn = 2)
-
-    @IR(failOn = {IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.COUNTED_LOOP})
-    @ExpectedFailure(ruleId = 2, phase = CompilePhase.PRINT_IDEAL, failOn = 1)
-    @ExpectedFailure(ruleId = 2, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, failOn = 2)
-
-    @IR(counts = {IRNode.STORE, "3", IRNode.FIELD_ACCESS, "1", IRNode.COUNTED_LOOP, "2"})
-    @ExpectedFailure(ruleId = 3, phase = CompilePhase.PRINT_IDEAL, counts = {1, 3})
-    @ExpectedFailure(ruleId = 3, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, counts = 2)
+    @ExpectedFailure(ruleId = 5, phase = CompilePhase.PRINT_IDEAL, failOn = 1, counts = {1, 3})
 
     @IR(counts = {IRNode.STORE_I, "2"})
-    @ExpectedFailure(ruleId = 4, phase = CompilePhase.PRINT_IDEAL, counts = 1)
+    @ExpectedFailure(ruleId = 6, phase = CompilePhase.PRINT_IDEAL, counts = 1)
     public void defaultOnIdeal() {
         i = 34;
         l = 34;
     }
 
+    // Test failures on mach phases only.
     @Test
     @IR(failOn = {IRNode.STORE_F, IRNode.FIELD_ACCESS, IRNode.COUNTED_LOOP},
-        counts = {IRNode.STORE_F, "3", IRNode.FIELD_ACCESS, "1", IRNode.COUNTED_LOOP, "2"})
+        counts = {IRNode.STORE_I, "1", IRNode.FIELD_ACCESS, "2", IRNode.OOPMAP_WITH, "asdf", "< 2"})
     @ExpectedFailure(ruleId = 1, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, failOn = 2)
-    @ExpectedFailure(ruleId = 1, phase = CompilePhase.PRINT_IDEAL, counts = {1, 3})
+
+    @IR(failOn = {IRNode.STORE_F, IRNode.OOPMAP_WITH, "asdf", IRNode.COUNTED_LOOP},
+        counts = {IRNode.STORE_I, "1", IRNode.FIELD_ACCESS, "1", IRNode.OOPMAP_WITH, "asdf", "< 2"})
+    @ExpectedFailure(ruleId = 2, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, counts = 2)
 
     @IR(failOn = {IRNode.STORE_F, IRNode.FIELD_ACCESS, IRNode.COUNTED_LOOP})
-    @ExpectedFailure(ruleId = 2, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, failOn = 2)
+    @ExpectedFailure(ruleId = 3, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, failOn = 2)
 
-    @IR(counts = {IRNode.STORE_F, "3", IRNode.FIELD_ACCESS, "1", IRNode.COUNTED_LOOP, "2"})
-    @ExpectedFailure(ruleId = 3, phase = CompilePhase.PRINT_IDEAL, counts = {1, 3})
+    @IR(counts = {IRNode.STORE_I, "1", IRNode.FIELD_ACCESS, "1", IRNode.OOPMAP_WITH, "asdf", "3"})
+    @ExpectedFailure(ruleId = 4, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, counts = {2, 3})
 
     @IR(failOn = {IRNode.STORE_F, IRNode.FIELD_ACCESS, IRNode.COUNTED_LOOP},
-        counts = {IRNode.STORE_F, "3", IRNode.FIELD_ACCESS, "2", IRNode.COUNTED_LOOP, "2"})
+        counts = {IRNode.STORE_I, "1", IRNode.FIELD_ACCESS, "1", IRNode.OOPMAP_WITH, "asdf", "3"})
+    @ExpectedFailure(ruleId = 5, phase = CompilePhase.PRINT_OPTO_ASSEMBLY,  failOn = 2, counts = {2, 3})
 
-    @ExpectedFailure(ruleId = 4, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, failOn = 2, counts = 2)
-    @ExpectedFailure(ruleId = 4, phase = CompilePhase.PRINT_IDEAL, counts = {1, 3})
-
-    @IR(counts = {IRNode.FIELD_ACCESS, "2"})
-    @ExpectedFailure(ruleId = 5, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, counts = 1)
-    public Object defaultOnOptoAssembly(Helper h) {
-        return h.getString();
+    @IR(counts = {IRNode.FIELD_ACCESS, "1"})
+    @ExpectedFailure(ruleId = 6, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, counts = 1)
+    public void defaultOnOptoAssembly() {
+        i = 34;
+        l = 34;
     }
 
+    // Test failures on ideal and mach phases.
     @Test
     @IR(failOn = {IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.COUNTED_LOOP},
-        counts = {IRNode.STORE, "20", IRNode.FIELD_ACCESS, "3", IRNode.COUNTED_LOOP, "2"})
+        counts = {IRNode.STORE, "2", IRNode.FIELD_ACCESS, "2", IRNode.STORE_I, "1"})
+    @ExpectedFailure(ruleId = 1, phase = CompilePhase.PRINT_IDEAL, failOn = 1)
     @ExpectedFailure(ruleId = 1, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, failOn = 2)
-    @ExpectedFailure(ruleId = 1, phase = CompilePhase.PRINT_IDEAL, failOn = 1, counts = {1, 3})
 
     @IR(failOn = {IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.COUNTED_LOOP})
     @ExpectedFailure(ruleId = 2, phase = CompilePhase.PRINT_IDEAL, failOn = 1)
     @ExpectedFailure(ruleId = 2, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, failOn = 2)
 
-    @IR(counts = {IRNode.STORE, "20", IRNode.FIELD_ACCESS, "2", IRNode.COUNTED_LOOP, "2"})
-    @ExpectedFailure(ruleId = 3, phase = CompilePhase.PRINT_IDEAL, counts = {1, 3})
+    @IR(counts = {IRNode.STORE, "20", IRNode.FIELD_ACCESS, "1", IRNode.STORE_I, "1"})
+    @ExpectedFailure(ruleId = 3, phase = CompilePhase.PRINT_IDEAL, counts = 1)
     @ExpectedFailure(ruleId = 3, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, counts = 2)
 
     @IR(failOn = {IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.COUNTED_LOOP},
-        counts = {IRNode.STORE, "20", IRNode.FIELD_ACCESS, "2", IRNode.COUNTED_LOOP, "2"})
-    @ExpectedFailure(ruleId = 4, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, failOn = 2, counts = 2)
+        counts = {IRNode.STORE, "20", IRNode.FIELD_ACCESS, "1", IRNode.COUNTED_LOOP, "2"})
     @ExpectedFailure(ruleId = 4, phase = CompilePhase.PRINT_IDEAL, failOn = 1, counts = {1, 3})
+    @ExpectedFailure(ruleId = 4, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, failOn = 2, counts = 2)
 
-    @IR(counts = {IRNode.FIELD_ACCESS, "2"})
-    @ExpectedFailure(ruleId = 5, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, counts = 1)
-    public Object defaultOnBoth(Helper h) {
+    @IR(failOn = {IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.COUNTED_LOOP, IRNode.STORE_I},
+        counts = {IRNode.STORE, "20", IRNode.FIELD_ACCESS, "1", IRNode.COUNTED_LOOP, "2", IRNode.OOPMAP_WITH, "asdf", "2"})
+    @ExpectedFailure(ruleId = 5, phase = CompilePhase.PRINT_IDEAL, failOn = {1, 4}, counts = {1, 3})
+    @ExpectedFailure(ruleId = 5, phase = CompilePhase.PRINT_OPTO_ASSEMBLY, failOn = 2, counts = {2, 4})
+    public void defaultOnBoth() {
         i = 34;
         l = 34;
-        return h.getString();
     }
 
     @Test
@@ -215,7 +226,7 @@ class Basics {
         return x;
     }
 
-    @Run(test = {"removeLoopsWithMultipleCompilations", "defaultOnOptoAssembly", "defaultOnBoth"})
+    @Run(test = "removeLoopsWithMultipleCompilations")
     @Warmup(1)
     public void run() {
         for (int i = 0; i < 10000; i++) {
@@ -224,8 +235,6 @@ class Basics {
         for (int i = 0; i < 10000; i++) {
             removeLoopsWithMultipleCompilations(3);
         }
-        defaultOnOptoAssembly(new Helper("a", 1));
-        defaultOnBoth(new Helper("a", 1));
     }
 
     @Test


### PR DESCRIPTION
`TestPhaseIRMatching` was recently updated with [JDK-8352595](https://bugs.openjdk.org/browse/JDK-8352595) which changed some matching on opto assembly from `IRNode.ALLOC` (now matching on ideal phases) to `IRNode.FIELD_ACCESS` (still matching on opto assembly). However, the updated code matches differently on PPC for some method invocation on a parameter which let the test fail on PPC:
```
public Object defaultOnOptoAssembly(Helper h) {
    return h.getString(); // emits one "Field: " string on most platforms but none on PPC
}
```

When I've revisited the test to analyze the failure, it was not evidently clear what I had in mind back there with `defaultOnX()`. My guess is that I've tried to have one method failing on ideal phases, one on mach phases and one on both while all the methods use `IRNode` entries that have default compile phases on ideal and mach phases. But that is not the case today. I've therefore rewritten the tests to adhere to my guess. I also removed the ambiguity among platforms to have the same number of field accesses on them.

How to read the `@ExpectedFailure` annotation:
```
  @IR(failOn = {IRNode.STORE, IRNode.FIELD_ACCESS, IRNode.COUNTED_LOOP, IRNode.STORE_I},
      counts = {IRNode.STORE, "20", IRNode.FIELD_ACCESS, "1", IRNode.COUNTED_LOOP, "2", IRNode.OOPMAP_WITH, "asdf", "2"})
  // Expect rule with id 5 (the one directly above) to fail:
  // - We fail when matching PRINT_IDEAL with the:
  //   - failOn attribute: The failing constraints are constraint 1 and 4 (while 2 and 3 pass)
  //   - counts attribute: The failing constraints are constraint 2 and 4 (while 1 and 3 pass).
  @ExpectedFailure(ruleId = 5, phase = CompilePhase.PRINT_IDEAL, failOn = {1, 4}, counts = {1, 3})
```

Thanks to @TheRealMDoerr for testing the patch on PPC!

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353058](https://bugs.openjdk.org/browse/JDK-8353058): [PPC64] Some IR framework tests are failing after JDK-8352595 (**Bug** - P4)


### Reviewers
 * [Marc Chevalier](https://openjdk.org/census#mchevalier) (@marc-chevalier - Author)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24373/head:pull/24373` \
`$ git checkout pull/24373`

Update a local copy of the PR: \
`$ git checkout pull/24373` \
`$ git pull https://git.openjdk.org/jdk.git pull/24373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24373`

View PR using the GUI difftool: \
`$ git pr show -t 24373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24373.diff">https://git.openjdk.org/jdk/pull/24373.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24373#issuecomment-2771500619)
</details>
