### PR TITLE
8353471: ZGC: Redundant generation id in ZGeneration

### DIFF
--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -182,9 +182,9 @@ static double fragmentation_limit(ZGenerationId generation) {
   }
 }
 
-void ZGeneration::select_relocation_set(ZGenerationId generation, bool promote_all) {
+void ZGeneration::select_relocation_set(bool promote_all) {
   // Register relocatable pages with selector
-  ZRelocationSetSelector selector(fragmentation_limit(generation));
+  ZRelocationSetSelector selector(fragmentation_limit(_id));
   {
     ZGenerationPagesIterator pt_iter(_page_table, _id, _page_allocator);
     for (ZPage* page; pt_iter.next(&page);) {
@@ -238,7 +238,7 @@ void ZGeneration::select_relocation_set(ZGenerationId generation, bool promote_a
   // Selecting tenuring threshold must be done after select
   // which produces the liveness data, but before install,
   // which consumes the tenuring threshold.
-  if (generation == ZGenerationId::young) {
+  if (is_young()) {
     ZGeneration::young()->select_tenuring_threshold(selector.stats(), promote_all);
   }
 
@@ -811,7 +811,7 @@ uint ZGenerationYoung::compute_tenuring_threshold(ZRelocationSetSelectorStats st
 void ZGenerationYoung::concurrent_select_relocation_set() {
   ZStatTimerYoung timer(ZPhaseConcurrentSelectRelocationSetYoung);
   const bool promote_all = type() == ZYoungType::major_full_preclean;
-  select_relocation_set(_id, promote_all);
+  select_relocation_set(promote_all);
 }
 
 class VM_ZRelocateStartYoung : public VM_ZYoungOperation {
@@ -1153,7 +1153,7 @@ void ZGenerationOld::pause_verify() {
 
 void ZGenerationOld::concurrent_select_relocation_set() {
   ZStatTimerOld timer(ZPhaseConcurrentSelectRelocationSetOld);
-  select_relocation_set(_id, false /* promote_all */);
+  select_relocation_set(false /* promote_all */);
 }
 
 class VM_ZRelocateStartOld : public VM_ZOperation {

--- a/src/hotspot/share/gc/z/zGeneration.hpp
+++ b/src/hotspot/share/gc/z/zGeneration.hpp
@@ -91,7 +91,7 @@ protected:
 
   void mark_free();
 
-  void select_relocation_set(ZGenerationId generation, bool promote_all);
+  void select_relocation_set(bool promote_all);
   void reset_relocation_set();
 
   ZGeneration(ZGenerationId id, ZPageTable* page_table, ZPageAllocator* page_allocator);


### PR DESCRIPTION
The ZGeneration class (and in turn ZGenerationOld and ZGenerationYoung) keeps track of its own ZGenerationId, which means that the generation id does not need to be passed along as an argument when calling internal functions.

I've removed the id parameter from `ZGeneration::select_relocation_set` in favor of using the member variable `_id`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353471](https://bugs.openjdk.org/browse/JDK-8353471): ZGC: Redundant generation id in ZGeneration (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24374/head:pull/24374` \
`$ git checkout pull/24374`

Update a local copy of the PR: \
`$ git checkout pull/24374` \
`$ git pull https://git.openjdk.org/jdk.git pull/24374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24374`

View PR using the GUI difftool: \
`$ git pr show -t 24374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24374.diff">https://git.openjdk.org/jdk/pull/24374.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24374#issuecomment-2771512734)
</details>
