### PR TITLE
8353341: C2: removal of a Mod[DF]Node crashes when the node is already dead

### DIFF
--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -1518,7 +1518,8 @@ Node* ModFNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   PhaseIterGVN* igvn = phase->is_IterGVN();
 
   bool result_is_unused = proj_out_or_null(TypeFunc::Parms) == nullptr;
-  if (result_is_unused) {
+  bool has_control_output = proj_out_or_null(TypeFunc::Control) != nullptr;
+  if (result_is_unused && has_control_output) {
     return replace_with_con(igvn, TypeF::make(0.));
   }
 
@@ -1569,7 +1570,8 @@ Node* ModDNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   PhaseIterGVN* igvn = phase->is_IterGVN();
 
   bool result_is_unused = proj_out_or_null(TypeFunc::Parms) == nullptr;
-  if (result_is_unused) {
+  bool has_control_output = proj_out_or_null(TypeFunc::Control) != nullptr;
+  if (result_is_unused && has_control_output) {
     return replace_with_con(igvn, TypeD::make(0.));
   }
 

--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -1518,8 +1518,8 @@ Node* ModFNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   PhaseIterGVN* igvn = phase->is_IterGVN();
 
   bool result_is_unused = proj_out_or_null(TypeFunc::Parms) == nullptr;
-  bool is_dead = proj_out_or_null(TypeFunc::Control) == nullptr;
-  if (result_is_unused && !is_dead) {
+  bool not_dead = proj_out_or_null(TypeFunc::Control) != nullptr;
+  if (result_is_unused && not_dead) {
     return replace_with_con(igvn, TypeF::make(0.));
   }
 
@@ -1570,8 +1570,8 @@ Node* ModDNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   PhaseIterGVN* igvn = phase->is_IterGVN();
 
   bool result_is_unused = proj_out_or_null(TypeFunc::Parms) == nullptr;
-  bool is_dead = proj_out_or_null(TypeFunc::Control) == nullptr;
-  if (result_is_unused && !is_dead) {
+  bool not_dead = proj_out_or_null(TypeFunc::Control) != nullptr;
+  if (result_is_unused && not_dead) {
     return replace_with_con(igvn, TypeD::make(0.));
   }
 

--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -1518,8 +1518,8 @@ Node* ModFNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   PhaseIterGVN* igvn = phase->is_IterGVN();
 
   bool result_is_unused = proj_out_or_null(TypeFunc::Parms) == nullptr;
-  bool has_control_output = proj_out_or_null(TypeFunc::Control) != nullptr;
-  if (result_is_unused && has_control_output) {
+  bool is_dead = proj_out_or_null(TypeFunc::Control) == nullptr;
+  if (result_is_unused && !is_dead) {
     return replace_with_con(igvn, TypeF::make(0.));
   }
 
@@ -1570,8 +1570,8 @@ Node* ModDNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   PhaseIterGVN* igvn = phase->is_IterGVN();
 
   bool result_is_unused = proj_out_or_null(TypeFunc::Parms) == nullptr;
-  bool has_control_output = proj_out_or_null(TypeFunc::Control) != nullptr;
-  if (result_is_unused && has_control_output) {
+  bool is_dead = proj_out_or_null(TypeFunc::Control) == nullptr;
+  if (result_is_unused && !is_dead) {
     return replace_with_con(igvn, TypeD::make(0.));
   }
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/FPModWithoutControlProj.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/FPModWithoutControlProj.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8353341
+ * @summary Test that Ideal transformations of Mod[DF]Node are not crashing
+ *          when control proj is absent, and the node is still removed.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.FPModWithoutControlProj
+ */
+public class FPModWithoutControlProj {
+    static int y;
+    static public boolean flag;
+    static int iArr[];
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:+StressIGVN");
+    }
+
+    @Run(test = {"testD", "testF"})
+    public void runMethod() {
+        testD();
+        testF();
+    }
+
+    @Test
+    @IR(failOn = {IRNode.MOD_D, IRNode.MOD_F})
+    public void testD() {
+        int x = 243;
+        double f1 = 119.303D, f2 = 2.637D;
+
+        for (int i11 = 0; i11 < 100; i11++) {
+            if (flag) {
+            } else if (flag) {
+                do {
+                    for (f2 = 3; ; f2--) {
+                        if (f2 % 3 == 1) {
+                            x -= y;
+                        }
+                        iArr[1] += 5;
+
+                    }
+                } while (f1 < 234);
+            }
+        }
+
+    }
+
+    @Test
+    @IR(failOn = {IRNode.MOD_D, IRNode.MOD_F})
+    public void testF() {
+        int x = 243;
+        float f1 = 119.303F, f2 = 2.637F;
+
+        for (int i11 = 0; i11 < 100; i11++) {
+            if (flag) {
+            } else if (flag) {
+                do {
+                    for (f2 = 3; ; f2--) {
+                        if (f2 % 3 == 1) {
+                            x -= y;
+                        }
+                        iArr[1] += 5;
+
+                    }
+                } while (f1 < 234);
+            }
+        }
+
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/FPModWithoutControlProj.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/FPModWithoutControlProj.java
@@ -62,7 +62,6 @@ public class FPModWithoutControlProj {
                             x -= y;
                         }
                         iArr[1] += 5;
-
                     }
                 } while (f1 < 234);
             }
@@ -84,7 +83,6 @@ public class FPModWithoutControlProj {
                             x -= y;
                         }
                         iArr[1] += 5;
-
                     }
                 } while (f1 < 234);
             }

--- a/test/hotspot/jtreg/compiler/c2/irTests/FPModWithoutControlProj.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/FPModWithoutControlProj.java
@@ -67,7 +67,6 @@ public class FPModWithoutControlProj {
                 } while (f1 < 234);
             }
         }
-
     }
 
     @Test
@@ -90,6 +89,5 @@ public class FPModWithoutControlProj {
                 } while (f1 < 234);
             }
         }
-
     }
 }


### PR DESCRIPTION
If the Mod[DF]Node has no control projection when it's being removed (because its result is unused), `extract_projections` will fail an assert. So, let's skip the removal.

But that should happen only when the nodes are already unreachable (control input being transitively top). At the end of the day, the node should be dropped. because of that, so there is no rush, and let dead node deletion do the job.

On the reduced reproducer, the crash is not common (even with `-XX:RepeatCompilation=300`, it might need more than a run to reproduce). So I've tried my fix on multiple thousands repeat compilations (by 300 packs) without a crash, and without having the modulo node alive at the end.

For instance, that's what happen on the reproducer. Quickly, some big sub-graph is dead, but nodes stay a while in the graph:
<img src="https://github.com/user-attachments/assets/7956771a-4bc4-4ab6-9207-3954cf067868" width="300">
Then:
<img src="https://github.com/user-attachments/assets/012868df-0d14-4292-aaeb-b342391ebbcd" width="300">
And eventually, everything is removed, so the control projection is removed, and `extract_projections` doesn't like it.
<img src="https://github.com/user-attachments/assets/cf20b745-cf86-48ba-94df-078aa50cdd45" width="300">

Thanks,
Marc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353341](https://bugs.openjdk.org/browse/JDK-8353341): C2: removal of a Mod[DF]Node crashes when the node is already dead (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24375/head:pull/24375` \
`$ git checkout pull/24375`

Update a local copy of the PR: \
`$ git checkout pull/24375` \
`$ git pull https://git.openjdk.org/jdk.git pull/24375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24375`

View PR using the GUI difftool: \
`$ git pr show -t 24375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24375.diff">https://git.openjdk.org/jdk/pull/24375.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24375#issuecomment-2771587506)
</details>
