### PR TITLE
8353545: Improve debug info for StartOptionTest

### DIFF
--- a/test/langtools/jdk/jshell/StartOptionTest.java
+++ b/test/langtools/jdk/jshell/StartOptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,16 +89,32 @@ public class StartOptionTest {
     }
 
     protected void check(ByteArrayOutputStream str, Consumer<String> checkOut, String label) {
-        byte[] bytes = str.toByteArray();
-        str.reset();
-        String out = new String(bytes, StandardCharsets.UTF_8);
-        out = stripAnsi(out);
-        out = out.replaceAll("[\r\n]+", "\n");
-        if (checkOut != null) {
-            checkOut.accept(out);
-        } else {
-            assertEquals(out, "", label + ": Expected empty -- ");
+        try {
+            byte[] bytes = str.toByteArray();
+            str.reset();
+            String out = new String(bytes, StandardCharsets.UTF_8);
+            out = stripAnsi(out);
+            out = out.replaceAll("[\r\n]+", "\n");
+            if (checkOut != null) {
+                checkOut.accept(out);
+            } else {
+                assertEquals(out, "", label + ": Expected empty -- ");
+            }
+        } catch (Throwable t) {
+            logOutput("cmdout", cmdout);
+            logOutput("cmderr", cmderr);
+            logOutput("console", console);
+            logOutput("userout", userout);
+            logOutput("usererr", usererr);
+
+            throw t;
         }
+    }
+
+    private void logOutput(String outName, ByteArrayOutputStream out) {
+        System.err.println(outName + ": " +
+                           new String(out.toByteArray(),
+                                      StandardCharsets.UTF_8));
     }
 
     protected void checkExit(int ec, Consumer<Integer> checkCode) {


### PR DESCRIPTION
The `jdk/jshell/ToolProviderTest.java` is intermittently failing. It is not clear why, so this PR attempts to add some more debug info (printing all the remaining output when the output check fails), which hopefully will help to determine the cause of the failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353545](https://bugs.openjdk.org/browse/JDK-8353545): Improve debug info for StartOptionTest (**Task** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24376/head:pull/24376` \
`$ git checkout pull/24376`

Update a local copy of the PR: \
`$ git checkout pull/24376` \
`$ git pull https://git.openjdk.org/jdk.git pull/24376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24376`

View PR using the GUI difftool: \
`$ git pr show -t 24376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24376.diff">https://git.openjdk.org/jdk/pull/24376.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24376#issuecomment-2772230411)
</details>
