### PR TITLE
8332947: [macos] OpenURIHandler events not received when AWT is embedded in another toolkit

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -125,10 +125,6 @@ AWT_ASSERT_APPKIT_THREAD;
             isApplicationOwner = YES;
         }
     }
-
-    NSLog(@"ApplicationDelegate::sharedDelegate: shouldInstall=%d, isApplicationOwner=%d, overrideDelegate=%d",
-            shouldInstall, isApplicationOwner, overrideDelegate);
-
     checked = YES;
     if (!shouldInstall) {
         [ThreadUtilities setApplicationOwner:NO];
@@ -198,8 +194,6 @@ AWT_ASSERT_APPKIT_THREAD;
 - (id) init {
 AWT_ASSERT_APPKIT_THREAD;
 
-    NSLog(@"AWT: ApplicationDelegate::init");
-
     self = [super init];
     if (!self) return self;
 
@@ -208,9 +202,6 @@ AWT_ASSERT_APPKIT_THREAD;
     if ([NSApp isKindOfClass:[NSApplicationAWT class]]) {
         usingDefaultNib = [NSApp usingDefaultNib];
     }
-
-    NSLog(@"AWT: usingDefaultNib=%d", usingDefaultNib);
-
     if (!usingDefaultNib) return self;
 
     NSMenu *menuBar = [[NSApplication sharedApplication] mainMenu];
@@ -266,8 +257,6 @@ AWT_ASSERT_APPKIT_THREAD;
                                  aboutAvailable, aboutEnabled, prefsAvailable, prefsEnabled);
     CHECK_EXCEPTION();
 
-    NSLog(@"AWT: register notifications");
-
     // register for the finish launching and system power off notifications by default
     NSNotificationCenter *ctr = [NSNotificationCenter defaultCenter];
     Class clz = [ApplicationDelegate class];
@@ -278,8 +267,6 @@ AWT_ASSERT_APPKIT_THREAD;
     [ctr addObserver:clz selector:@selector(_appDidHide) name:NSApplicationDidHideNotification object:nil];
     [ctr addObserver:clz selector:@selector(_appDidUnhide) name:NSApplicationDidUnhideNotification object:nil];
     [ctr addObserver:clz selector:@selector(_embeddedEvent:) name:@"EmbeddedEvent" object:nil];
-
-    NSLog(@"AWT: normal exit");
 
     return self;
 }
@@ -314,8 +301,6 @@ static jclass sjc_AppEventHandler = NULL;
 
 + (void)_openURL:(NSString *)url {
 AWT_ASSERT_APPKIT_THREAD;
-    NSLog(@"AWT: ApplicationDelegate::_openURL: %@", url);
-
     //fprintf(stderr,"jm_handleOpenURL\n");
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     jstring jURL = NSStringToJavaString(env, url);
@@ -495,7 +480,6 @@ AWT_ASSERT_APPKIT_THREAD;
 }
 
 + (void)_embeddedEvent:(NSNotification *)notification {
-    NSLog(@"AWT: ApplicationDelegate::_embeddedEvent");
     NSString *name = notification.userInfo[@"name"];
 
     if ([name isEqualToString:@"openURL"]) {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -197,17 +197,6 @@ AWT_ASSERT_APPKIT_THREAD;
     self = [super init];
     if (!self) return self;
 
-    // register for the finish launching and system power off notifications by default
-    NSNotificationCenter *ctr = [NSNotificationCenter defaultCenter];
-    Class clz = [ApplicationDelegate class];
-    [ctr addObserver:clz selector:@selector(_willFinishLaunching) name:NSApplicationWillFinishLaunchingNotification object:nil];
-    [ctr addObserver:clz selector:@selector(_systemWillPowerOff) name:NSWorkspaceWillPowerOffNotification object:nil];
-    [ctr addObserver:clz selector:@selector(_appDidActivate) name:NSApplicationDidBecomeActiveNotification object:nil];
-    [ctr addObserver:clz selector:@selector(_appDidDeactivate) name:NSApplicationDidResignActiveNotification object:nil];
-    [ctr addObserver:clz selector:@selector(_appDidHide) name:NSApplicationDidHideNotification object:nil];
-    [ctr addObserver:clz selector:@selector(_appDidUnhide) name:NSApplicationDidUnhideNotification object:nil];
-    [ctr addObserver:clz selector:@selector(_embeddedEvent:) name:@"EmbeddedEvent" object:nil];
-
     // Prep for about and preferences menu
     BOOL usingDefaultNib = YES;
     if ([NSApp isKindOfClass:[NSApplicationAWT class]]) {
@@ -267,6 +256,17 @@ AWT_ASSERT_APPKIT_THREAD;
     (*env)->CallStaticVoidMethod(env, sjc_AppMenuBarHandler, sjm_initMenuStates,
                                  aboutAvailable, aboutEnabled, prefsAvailable, prefsEnabled);
     CHECK_EXCEPTION();
+
+    // register for the finish launching and system power off notifications by default
+    NSNotificationCenter *ctr = [NSNotificationCenter defaultCenter];
+    Class clz = [ApplicationDelegate class];
+    [ctr addObserver:clz selector:@selector(_willFinishLaunching) name:NSApplicationWillFinishLaunchingNotification object:nil];
+    [ctr addObserver:clz selector:@selector(_systemWillPowerOff) name:NSWorkspaceWillPowerOffNotification object:nil];
+    [ctr addObserver:clz selector:@selector(_appDidActivate) name:NSApplicationDidBecomeActiveNotification object:nil];
+    [ctr addObserver:clz selector:@selector(_appDidDeactivate) name:NSApplicationDidResignActiveNotification object:nil];
+    [ctr addObserver:clz selector:@selector(_appDidHide) name:NSApplicationDidHideNotification object:nil];
+    [ctr addObserver:clz selector:@selector(_appDidUnhide) name:NSApplicationDidUnhideNotification object:nil];
+    [ctr addObserver:clz selector:@selector(_embeddedEvent:) name:@"EmbeddedEvent" object:nil];
 
     return self;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -44,7 +44,7 @@
 #define PREFERENCES_TAG  42
 
 // Custom event that is provided by AWT to allow libraries like
-// JavaFX to forward native events to AWT even if AWT runs in 
+// JavaFX to forward native events to AWT even if AWT runs in
 // embedded mode.
 static NSString* awtEmbeddedEvent = @"AWTEmbeddedEvent";
 
@@ -137,7 +137,7 @@ AWT_ASSERT_APPKIT_THREAD;
         Class clz = [ApplicationDelegate class];
         [ctr addObserver:clz selector:@selector(_embeddedEvent:) name:awtEmbeddedEvent object:nil];
     }
-    
+
     checked = YES;
     if (!shouldInstall) {
         [ThreadUtilities setApplicationOwner:NO];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -125,6 +125,12 @@ AWT_ASSERT_APPKIT_THREAD;
             isApplicationOwner = YES;
         }
     }
+
+    // Register embedded event listener
+    NSNotificationCenter *ctr = [NSNotificationCenter defaultCenter];
+    Class clz = [ApplicationDelegate class];
+    [ctr addObserver:clz selector:@selector(_embeddedEvent:) name:@"EmbeddedEvent" object:nil];
+
     checked = YES;
     if (!shouldInstall) {
         [ThreadUtilities setApplicationOwner:NO];
@@ -266,7 +272,6 @@ AWT_ASSERT_APPKIT_THREAD;
     [ctr addObserver:clz selector:@selector(_appDidDeactivate) name:NSApplicationDidResignActiveNotification object:nil];
     [ctr addObserver:clz selector:@selector(_appDidHide) name:NSApplicationDidHideNotification object:nil];
     [ctr addObserver:clz selector:@selector(_appDidUnhide) name:NSApplicationDidUnhideNotification object:nil];
-    [ctr addObserver:clz selector:@selector(_embeddedEvent:) name:@"EmbeddedEvent" object:nil];
 
     return self;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -125,6 +125,10 @@ AWT_ASSERT_APPKIT_THREAD;
             isApplicationOwner = YES;
         }
     }
+
+    NSLog(@"ApplicationDelegate::sharedDelegate: shouldInstall=%d, isApplicationOwner=%d, overrideDelegate=%d",
+            shouldInstall, isApplicationOwner, overrideDelegate);
+
     checked = YES;
     if (!shouldInstall) {
         [ThreadUtilities setApplicationOwner:NO];
@@ -194,6 +198,8 @@ AWT_ASSERT_APPKIT_THREAD;
 - (id) init {
 AWT_ASSERT_APPKIT_THREAD;
 
+    NSLog(@"AWT: ApplicationDelegate::init");
+
     self = [super init];
     if (!self) return self;
 
@@ -202,6 +208,9 @@ AWT_ASSERT_APPKIT_THREAD;
     if ([NSApp isKindOfClass:[NSApplicationAWT class]]) {
         usingDefaultNib = [NSApp usingDefaultNib];
     }
+
+    NSLog(@"AWT: usingDefaultNib=%d", usingDefaultNib);
+
     if (!usingDefaultNib) return self;
 
     NSMenu *menuBar = [[NSApplication sharedApplication] mainMenu];
@@ -257,6 +266,8 @@ AWT_ASSERT_APPKIT_THREAD;
                                  aboutAvailable, aboutEnabled, prefsAvailable, prefsEnabled);
     CHECK_EXCEPTION();
 
+    NSLog(@"AWT: register notifications");
+
     // register for the finish launching and system power off notifications by default
     NSNotificationCenter *ctr = [NSNotificationCenter defaultCenter];
     Class clz = [ApplicationDelegate class];
@@ -267,6 +278,8 @@ AWT_ASSERT_APPKIT_THREAD;
     [ctr addObserver:clz selector:@selector(_appDidHide) name:NSApplicationDidHideNotification object:nil];
     [ctr addObserver:clz selector:@selector(_appDidUnhide) name:NSApplicationDidUnhideNotification object:nil];
     [ctr addObserver:clz selector:@selector(_embeddedEvent:) name:@"EmbeddedEvent" object:nil];
+
+    NSLog(@"AWT: normal exit");
 
     return self;
 }
@@ -301,6 +314,8 @@ static jclass sjc_AppEventHandler = NULL;
 
 + (void)_openURL:(NSString *)url {
 AWT_ASSERT_APPKIT_THREAD;
+    NSLog(@"AWT: ApplicationDelegate::_openURL: %@", url);
+
     //fprintf(stderr,"jm_handleOpenURL\n");
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     jstring jURL = NSStringToJavaString(env, url);
@@ -480,6 +495,7 @@ AWT_ASSERT_APPKIT_THREAD;
 }
 
 + (void)_embeddedEvent:(NSNotification *)notification {
+    NSLog(@"AWT: ApplicationDelegate::_embeddedEvent");
     NSString *name = notification.userInfo[@"name"];
 
     if ([name isEqualToString:@"openURL"]) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestContinuationPinningAndEA.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestContinuationPinningAndEA.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires vm.continuations
+ * @bug 8347997
+ * @library /test/lib /
+ * @summary Test that Continuation.pin() and unpin() intrinsics work with EA.
+ * @modules java.base/jdk.internal.vm
+ * @run driver compiler.c2.irTests.TestContinuationPinningAndEA
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+import jdk.internal.vm.Continuation;
+
+public class TestContinuationPinningAndEA {
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.vm=ALL-UNNAMED");
+    }
+
+    @Run(test = {
+            "test_AllocPinUnpin", "test_PinUnpinAlloc",
+            "test_AllocPinUnpinNoInline", "test_PinUnpinAllocNoInline",
+    })
+    public void runMethod() {
+        test_AllocPinUnpin();
+        test_PinUnpinAlloc();
+        test_AllocPinUnpinNoInline();
+        test_PinUnpinAllocNoInline();
+    }
+
+    // ===Cases where allocations are removed===
+    static class AllocPinUnpin {
+        final Object o;
+
+        @ForceInline
+        public AllocPinUnpin() {
+            o = new Object();
+            Continuation.pin();
+            Continuation.unpin();
+        }
+    }
+
+    static class PinUnpinAlloc {
+        final Object o;
+
+        @ForceInline
+        public PinUnpinAlloc() {
+            Continuation.pin();
+            Continuation.unpin();
+            o = new Object();
+        }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.ALLOC})
+    void test_AllocPinUnpin() {
+        new AllocPinUnpin();
+    }
+
+    @Test
+    @IR(failOn = {IRNode.ALLOC})
+    void test_PinUnpinAlloc() {
+        new PinUnpinAlloc();
+    }
+
+    // ===Sanity check that allocations would happen===
+    static class AllocPinUnpinNoInline {
+        final Object o;
+
+        @DontInline
+        public AllocPinUnpinNoInline() {
+            o = new Object();
+            Continuation.pin();
+            Continuation.unpin();
+        }
+    }
+
+    static class PinUnpinAllocNoInline {
+        final Object o;
+
+        @DontInline
+        public PinUnpinAllocNoInline() {
+            Continuation.pin();
+            Continuation.unpin();
+            o = new Object();
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ALLOC, ">0"})
+    void test_AllocPinUnpinNoInline() {
+        new AllocPinUnpinNoInline();
+    }
+
+    @Test
+    @IR(counts = {IRNode.ALLOC, ">0"})
+    void test_PinUnpinAllocNoInline() {
+        new PinUnpinAllocNoInline();
+    }
+}


### PR DESCRIPTION
When trying to register an open URI handler when using JavaFX with a native menu, this task fails on Mac.
Either the native menu is not shown or the URIs are not received.

This pull request fixes this issue if AWT is registered after JavaFX, so that AWT runs embedded inside JavaFX.
It fixes this by introducing a native event to AWT, which can be used by JavaFX to forward events such as an openURL event.

JavaFX Pull Request: https://github.com/openjdk/jfx/pull/1755
Co-Author: @FlorianKirmaier

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8332947](https://bugs.openjdk.org/browse/JDK-8332947): [macos] OpenURIHandler events not received when AWT is embedded in another toolkit (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24379/head:pull/24379` \
`$ git checkout pull/24379`

Update a local copy of the PR: \
`$ git checkout pull/24379` \
`$ git pull https://git.openjdk.org/jdk.git pull/24379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24379`

View PR using the GUI difftool: \
`$ git pr show -t 24379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24379.diff">https://git.openjdk.org/jdk/pull/24379.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24379#issuecomment-2802988629)
</details>
