### PR TITLE
8353551: C2: Constant folding for ReverseBytes nodes

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -2021,6 +2021,36 @@ const Type* SqrtHFNode::Value(PhaseGVN* phase) const {
   return TypeH::make((float)sqrt((double)f));
 }
 
+template<typename T, BasicType B>
+const Type* reverse_bytes(const Node* node, PhaseGVN* phase) {
+  const Type* type = phase->type(node->in(1));
+  if (type == Type::TOP) {
+    return Type::TOP;
+  }
+  const TypeInteger* typeInteger = type->isa_integer(B);
+  if (typeInteger != nullptr && typeInteger->is_con()) {
+    const T res = byteswap<T>(static_cast<T>(typeInteger->get_con_as_long(B)));
+    return TypeInteger::make(res, B);
+  }
+  return node->bottom_type();
+}
+
+const Type* ReverseBytesINode::Value(PhaseGVN* phase) const {
+  return reverse_bytes<jint, T_INT>(this, phase);
+}
+
+const Type* ReverseBytesSNode::Value(PhaseGVN* phase) const {
+  return reverse_bytes<jshort, T_INT>(this, phase);
+}
+
+const Type* ReverseBytesUSNode::Value(PhaseGVN* phase) const {
+  return reverse_bytes<jchar, T_INT>(this, phase);
+}
+
+const Type* ReverseBytesLNode::Value(PhaseGVN* phase) const {
+  return reverse_bytes<jlong, T_LONG>(this, phase);
+}
+
 const Type* ReverseINode::Value(PhaseGVN* phase) const {
   const Type *t1 = phase->type( in(1) );
   if (t1 == Type::TOP) {

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -2021,7 +2021,7 @@ const Type* SqrtHFNode::Value(PhaseGVN* phase) const {
   return TypeH::make((float)sqrt((double)f));
 }
 
-const Type* reverse_bytes(int opcode, const Type* con) {
+static const Type* reverse_bytes(int opcode, const Type* con) {
   switch (opcode) {
     case Op_ReverseBytesS:  return TypeInt::make(byteswap(checked_cast<jshort>(con->is_int()->get_con())));
     case Op_ReverseBytesUS: return TypeInt::make(byteswap(checked_cast<jchar>(con->is_int()->get_con())));

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -561,48 +561,52 @@ public:
   virtual const Type* Value(PhaseGVN* phase) const;
 };
 
+
+class ReverseBytesNode : public InvolutionNode {
+public:
+  ReverseBytesNode(Node* in) : InvolutionNode(in) {}
+  virtual const Type* Value(PhaseGVN* phase) const;
+};
 //-------------------------------ReverseBytesINode--------------------------------
 // reverse bytes of an integer
-class ReverseBytesINode : public InvolutionNode {
+class ReverseBytesINode : public ReverseBytesNode {
 public:
-  ReverseBytesINode(Node* in) : InvolutionNode(in) {}
+  ReverseBytesINode(Node* in) : ReverseBytesNode(in) {
+  }
+
   virtual int Opcode() const;
   const Type* bottom_type() const { return TypeInt::INT; }
   virtual uint ideal_reg() const { return Op_RegI; }
-  virtual const Type* Value(PhaseGVN* phase) const;
 };
 
 //-------------------------------ReverseBytesLNode--------------------------------
 // reverse bytes of a long
-class ReverseBytesLNode : public InvolutionNode {
+class ReverseBytesLNode : public ReverseBytesNode {
 public:
-  ReverseBytesLNode(Node* in) : InvolutionNode(in) {}
+  ReverseBytesLNode(Node* in) : ReverseBytesNode(in) {}
   virtual int Opcode() const;
   const Type* bottom_type() const { return TypeLong::LONG; }
   virtual uint ideal_reg() const { return Op_RegL; }
-  virtual const Type* Value(PhaseGVN* phase) const;
 };
 
 //-------------------------------ReverseBytesUSNode--------------------------------
 // reverse bytes of an unsigned short / char
-class ReverseBytesUSNode : public InvolutionNode {
+class ReverseBytesUSNode : public ReverseBytesNode {
 public:
-  ReverseBytesUSNode(Node* in1) : InvolutionNode(in1) {}
+  ReverseBytesUSNode(Node* in1) : ReverseBytesNode(in1) {}
   virtual int Opcode() const;
   const Type* bottom_type() const { return TypeInt::CHAR; }
   virtual uint ideal_reg() const { return Op_RegI; }
-  virtual const Type* Value(PhaseGVN* phase) const;
 };
 
 //-------------------------------ReverseBytesSNode--------------------------------
 // reverse bytes of a short
-class ReverseBytesSNode : public InvolutionNode {
+class ReverseBytesSNode : public ReverseBytesNode {
 public:
-  ReverseBytesSNode(Node* in) : InvolutionNode(in) {}
+  ReverseBytesSNode(Node* in) : ReverseBytesNode(in) {}
   virtual int Opcode() const;
   const Type* bottom_type() const { return TypeInt::SHORT; }
   virtual uint ideal_reg() const { return Op_RegI; }
-  virtual const Type* Value(PhaseGVN* phase) const;
 };
 
 //-------------------------------ReverseINode--------------------------------

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -569,6 +569,7 @@ public:
   virtual int Opcode() const;
   const Type* bottom_type() const { return TypeInt::INT; }
   virtual uint ideal_reg() const { return Op_RegI; }
+  virtual const Type* Value(PhaseGVN* phase) const;
 };
 
 //-------------------------------ReverseBytesLNode--------------------------------
@@ -579,6 +580,7 @@ public:
   virtual int Opcode() const;
   const Type* bottom_type() const { return TypeLong::LONG; }
   virtual uint ideal_reg() const { return Op_RegL; }
+  virtual const Type* Value(PhaseGVN* phase) const;
 };
 
 //-------------------------------ReverseBytesUSNode--------------------------------
@@ -589,6 +591,7 @@ public:
   virtual int Opcode() const;
   const Type* bottom_type() const { return TypeInt::CHAR; }
   virtual uint ideal_reg() const { return Op_RegI; }
+  virtual const Type* Value(PhaseGVN* phase) const;
 };
 
 //-------------------------------ReverseBytesSNode--------------------------------
@@ -599,6 +602,7 @@ public:
   virtual int Opcode() const;
   const Type* bottom_type() const { return TypeInt::SHORT; }
   virtual uint ideal_reg() const { return Op_RegI; }
+  virtual const Type* Value(PhaseGVN* phase) const;
 };
 
 //-------------------------------ReverseINode--------------------------------

--- a/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
@@ -37,7 +37,7 @@ import jdk.test.lib.Asserts;
  * @bug 8353551
  * @summary Test that ReverseBytes operations constant-fold.
  * @library /test/lib /
- * @run driver compiler.c2.irTests.ReverseBytesConstantsTests
+ * @run driver compiler.c2.gvn.ReverseBytesConstantsTests
  */
 public class ReverseBytesConstantsTests {
 

--- a/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
+++ b/test/hotspot/jtreg/compiler/c2/gvn/ReverseBytesConstantsTests.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package compiler.c2.irTests;
+package compiler.c2.gvn;
 
 import compiler.lib.generators.Generators;
 import compiler.lib.generators.RestrictableGenerator;

--- a/test/hotspot/jtreg/compiler/c2/irTests/ReverseBytesConstantsTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ReverseBytesConstantsTests.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests;
+
+import compiler.lib.generators.Generators;
+import compiler.lib.generators.RestrictableGenerator;
+import compiler.lib.ir_framework.DontCompile;
+import compiler.lib.ir_framework.IR;
+import compiler.lib.ir_framework.IRNode;
+import compiler.lib.ir_framework.Run;
+import compiler.lib.ir_framework.Test;
+import compiler.lib.ir_framework.TestFramework;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @bug 8353551
+ * @summary Test that ReverseBytes operations constant-fold.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.ReverseBytesConstantsTests
+ */
+public class ReverseBytesConstantsTests {
+
+    private static final RestrictableGenerator<Integer> GEN_CHAR = Generators.G.safeRestrict(Generators.G.ints(), Character.MIN_VALUE, Character.MAX_VALUE);
+    private static final char C_CHAR = (char) GEN_CHAR.next().intValue();
+    private static final RestrictableGenerator<Integer> GEN_SHORT = Generators.G.safeRestrict(Generators.G.ints(), Short.MIN_VALUE, Short.MAX_VALUE);
+    private static final short C_SHORT = GEN_SHORT.next().shortValue();
+    private static final RestrictableGenerator<Long> GEN_LONG = Generators.G.longs();
+    private static final long C_LONG = GEN_LONG.next();
+    private static final RestrictableGenerator<Integer> GEN_INT = Generators.G.ints();
+    private static final int C_INT = GEN_INT.next();
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Run(test = {
+        "testI1", "testI2", "testI3",
+        "testL1", "testL2", "testL3",
+        "testS1", "testS2", "testS3",
+        "testUS1", "testUS2", "testUS3",
+    })
+    public void runMethod() {
+        assertResultI();
+        assertResultL();
+        assertResultS();
+        assertResultUS();
+    }
+
+    @DontCompile
+    public void assertResultI() {
+        Asserts.assertEQ(Integer.reverseBytes(0x04030201), testI1());
+        Asserts.assertEQ(Integer.reverseBytes(0x50607080), testI2());
+        Asserts.assertEQ(Integer.reverseBytes(C_INT), testI3());
+    }
+
+    @DontCompile
+    public void assertResultL() {
+        Asserts.assertEQ(Long.reverseBytes(0x0807060504030201L), testL1());
+        Asserts.assertEQ(Long.reverseBytes(0x1020304050607080L), testL2());
+        Asserts.assertEQ(Long.reverseBytes(C_LONG), testL3());
+    }
+
+    @DontCompile
+    public void assertResultS() {
+        Asserts.assertEQ(Short.reverseBytes((short) 0x0201), testS1());
+        Asserts.assertEQ(Short.reverseBytes((short) 0x7080), testS2());
+        Asserts.assertEQ(Short.reverseBytes(C_SHORT), testS3());
+    }
+
+    @DontCompile
+    public void assertResultUS() {
+        Asserts.assertEQ(Character.reverseBytes((char) 0x0201), testUS1());
+        Asserts.assertEQ(Character.reverseBytes((char) 0x7080), testUS2());
+        Asserts.assertEQ(Character.reverseBytes(C_CHAR), testUS3());
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_I})
+    public int testI1() {
+        return Integer.reverseBytes(0x04030201);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_I})
+    public int testI2() {
+        return Integer.reverseBytes(0x50607080);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_I})
+    public int testI3() {
+        return Integer.reverseBytes(C_INT);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_L})
+    public long testL1() {
+        return Long.reverseBytes(0x0807060504030201L);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_L})
+    public long testL2() {
+        return Long.reverseBytes(0x1020304050607080L);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_L})
+    public long testL3() {
+        return Long.reverseBytes(C_LONG);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_S})
+    public short testS1() {
+        return Short.reverseBytes((short) 0x0201);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_S})
+    public short testS2() {
+        return Short.reverseBytes((short) 0x7080);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_S})
+    public short testS3() {
+        return Short.reverseBytes(C_SHORT);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_US})
+    public char testUS1() {
+        return Character.reverseBytes((char) 0x0201);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_US})
+    public char testUS2() {
+        return Character.reverseBytes((char) 0x7080);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_US})
+    public char testUS3() {
+        return Character.reverseBytes(C_CHAR);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/ReverseBytesConstantsTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ReverseBytesConstantsTests.java
@@ -71,28 +71,32 @@ public class ReverseBytesConstantsTests {
     public void assertResultI() {
         Asserts.assertEQ(Integer.reverseBytes(0x04030201), testI1());
         Asserts.assertEQ(Integer.reverseBytes(0x50607080), testI2());
-        Asserts.assertEQ(Integer.reverseBytes(C_INT), testI3());
+        Asserts.assertEQ(Integer.reverseBytes(0x80706050), testI3());
+        Asserts.assertEQ(Integer.reverseBytes(C_INT), testI4());
     }
 
     @DontCompile
     public void assertResultL() {
         Asserts.assertEQ(Long.reverseBytes(0x0807060504030201L), testL1());
         Asserts.assertEQ(Long.reverseBytes(0x1020304050607080L), testL2());
-        Asserts.assertEQ(Long.reverseBytes(C_LONG), testL3());
+        Asserts.assertEQ(Long.reverseBytes(0x8070605040302010L), testL3());
+        Asserts.assertEQ(Long.reverseBytes(C_LONG), testL4());
     }
 
     @DontCompile
     public void assertResultS() {
         Asserts.assertEQ(Short.reverseBytes((short) 0x0201), testS1());
         Asserts.assertEQ(Short.reverseBytes((short) 0x7080), testS2());
-        Asserts.assertEQ(Short.reverseBytes(C_SHORT), testS3());
+        Asserts.assertEQ(Short.reverseBytes((short) 0x8070), testS3());
+        Asserts.assertEQ(Short.reverseBytes(C_SHORT), testS4());
     }
 
     @DontCompile
     public void assertResultUS() {
         Asserts.assertEQ(Character.reverseBytes((char) 0x0201), testUS1());
         Asserts.assertEQ(Character.reverseBytes((char) 0x7080), testUS2());
-        Asserts.assertEQ(Character.reverseBytes(C_CHAR), testUS3());
+        Asserts.assertEQ(Character.reverseBytes((char) 0x8070), testUS3());
+        Asserts.assertEQ(Character.reverseBytes(C_CHAR), testUS4());
     }
 
     @Test
@@ -110,6 +114,12 @@ public class ReverseBytesConstantsTests {
     @Test
     @IR(failOn = {IRNode.REVERSE_BYTES_I})
     public int testI3() {
+        return Integer.reverseBytes(0x80706050);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_I})
+    public int testI4() {
         return Integer.reverseBytes(C_INT);
     }
 
@@ -128,6 +138,12 @@ public class ReverseBytesConstantsTests {
     @Test
     @IR(failOn = {IRNode.REVERSE_BYTES_L})
     public long testL3() {
+        return Long.reverseBytes(0x8070605040302010L);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_L})
+    public long testL4() {
         return Long.reverseBytes(C_LONG);
     }
 
@@ -146,6 +162,12 @@ public class ReverseBytesConstantsTests {
     @Test
     @IR(failOn = {IRNode.REVERSE_BYTES_S})
     public short testS3() {
+        return Short.reverseBytes((short) 0x8070);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_S})
+    public short testS4() {
         return Short.reverseBytes(C_SHORT);
     }
 
@@ -164,6 +186,12 @@ public class ReverseBytesConstantsTests {
     @Test
     @IR(failOn = {IRNode.REVERSE_BYTES_US})
     public char testUS3() {
+        return Character.reverseBytes((char) 0x8070);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.REVERSE_BYTES_US})
+    public char testUS4() {
         return Character.reverseBytes(C_CHAR);
     }
 


### PR DESCRIPTION
This change implements constant folding for ReverseBytes nodes.

Currently, `byteswap` is included transitively by `reverse_bits.hpp`. I'm not sure if this is fine or if I need to add an explicit include there.

I appreciate any reviews and comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353551](https://bugs.openjdk.org/browse/JDK-8353551): C2: Constant folding for ReverseBytes nodes (**Enhancement** - P4)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**) Review applies to [278a2a7c](https://git.openjdk.org/jdk/pull/24382/files/278a2a7c9ea0ebadb309bce03c97e9e456dda89e)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24382/head:pull/24382` \
`$ git checkout pull/24382`

Update a local copy of the PR: \
`$ git checkout pull/24382` \
`$ git pull https://git.openjdk.org/jdk.git pull/24382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24382`

View PR using the GUI difftool: \
`$ git pr show -t 24382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24382.diff">https://git.openjdk.org/jdk/pull/24382.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24382#issuecomment-2773113035)
</details>
