### PR TITLE
8349007: The jtreg test ResolvedMethodTableHash takes excessive time

### DIFF
--- a/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
+++ b/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,11 @@
  * @test
  * @bug 8249719
  * @summary ResolvedMethodTable hash function should take method class into account
- * @run main/othervm/manual -Xmx256m -XX:MaxMetaspaceSize=256m ResolvedMethodTableHash 200000
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver ResolvedMethodTableHash
  */
 
 import java.lang.invoke.MethodHandle;
@@ -35,72 +39,89 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-// The test generates thousands MethodHandles to the methods of the same name
-// and the same signature. This should not take too long, unless Method hash
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+// The test generates a thousand MethodHandles to the methods of the same name
+// and the same signature. The rehash warning shouldn't be returned, unless Method hash
 // function takes only the name and the signature as an input.
-public class ResolvedMethodTableHash extends ClassLoader {
+public class ResolvedMethodTableHash {
 
-    // Generate a MethodHandle for ClassName.m()
-    private MethodHandle generate(String className) throws ReflectiveOperationException {
-        byte[] buf = new byte[100];
-        int size = writeClass(buf, className);
-        Class<?> cls = defineClass(null, buf, 0, size);
-        return MethodHandles.publicLookup().findStatic(cls, "m", MethodType.methodType(void.class));
-    }
+    public static class ResolvedMethodTableHashTest extends ClassLoader {
+        // Generate a MethodHandle for ClassName.m()
+        private MethodHandle generate(String className) throws ReflectiveOperationException {
+                byte[] buf = new byte[100];
+                int size = writeClass(buf, className);
+                Class<?> cls = defineClass(null, buf, 0, size);
+                return MethodHandles.publicLookup().findStatic(cls, "m", MethodType.methodType(void.class));
+        }
 
-    private MethodHandle generateWithSameName() throws ReflectiveOperationException {
-        byte[] buf = new byte[100];
-        int size = writeClass(buf, "MH$$");
-        // use different classloader instances to load the classes with the same name
-        Class<?> cls = new ResolvedMethodTableHash().defineClass(null, buf, 0, size);
-        return MethodHandles.publicLookup().findStatic(cls, "m", MethodType.methodType(void.class));
-    }
+        private MethodHandle generateWithSameName() throws ReflectiveOperationException {
+                byte[] buf = new byte[100];
+                int size = writeClass(buf, "MH$$");
+                // use different classloader instances to load the classes with the same name
+                Class<?> cls = new ResolvedMethodTableHashTest().defineClass(null, buf, 0, size);
+                return MethodHandles.publicLookup().findStatic(cls, "m", MethodType.methodType(void.class));
+        }
 
-    // Produce a class file with the given name and a single method:
-    //     public static native void m();
-    private int writeClass(byte[] buf, String className) {
-        return ByteBuffer.wrap(buf)
-                .putInt(0xCAFEBABE)       // magic
-                .putInt(50)               // version: 50
-                .putShort((short) 7)      // constant_pool_count: 7
-                .put((byte) 7).putShort((short) 2)
-                .put((byte) 1).putShort((short) className.length()).put(className.getBytes())
-                .put((byte) 7).putShort((short) 4)
-                .put((byte) 1).putShort((short) 16).put("java/lang/Object".getBytes())
-                .put((byte) 1).putShort((short) 1).put("m".getBytes())
-                .put((byte) 1).putShort((short) 3).put("()V".getBytes())
-                .putShort((short) 0x21)   // access_flags: public super
-                .putShort((short) 1)      // this_class: #1
-                .putShort((short) 3)      // super_class: #3
-                .putShort((short) 0)      // interfaces_count: 0
-                .putShort((short) 0)      // fields_count: 0
-                .putShort((short) 1)      // methods_count: 1
-                .putShort((short) 0x109)  //   access_flags: public static native
-                .putShort((short) 5)      //   name_index: #5
-                .putShort((short) 6)      //   descriptor_index: #6
-                .putShort((short) 0)      //   attributes_count: 0
-                .putShort((short) 0)      // attributes_count: 0
-                .position();
+        // Produce a class file with the given name and a single method:
+        //         public static native void m();
+        private int writeClass(byte[] buf, String className) {
+                return ByteBuffer.wrap(buf)
+                                .putInt(0xCAFEBABE)           // magic
+                                .putInt(50)                           // version: 50
+                                .putShort((short) 7)          // constant_pool_count: 7
+                                .put((byte) 7).putShort((short) 2)
+                                .put((byte) 1).putShort((short) className.length()).put(className.getBytes())
+                                .put((byte) 7).putShort((short) 4)
+                                .put((byte) 1).putShort((short) 16).put("java/lang/Object".getBytes())
+                                .put((byte) 1).putShort((short) 1).put("m".getBytes())
+                                .put((byte) 1).putShort((short) 3).put("()V".getBytes())
+                                .putShort((short) 0x21)   // access_flags: public super
+                                .putShort((short) 1)          // this_class: #1
+                                .putShort((short) 3)          // super_class: #3
+                                .putShort((short) 0)          // interfaces_count: 0
+                                .putShort((short) 0)          // fields_count: 0
+                                .putShort((short) 1)          // methods_count: 1
+                                .putShort((short) 0x109)  //   access_flags: public static native
+                                .putShort((short) 5)          //   name_index: #5
+                                .putShort((short) 6)          //   descriptor_index: #6
+                                .putShort((short) 0)          //   attributes_count: 0
+                                .putShort((short) 0)          // attributes_count: 0
+                                .position();
+        }
+
+        public static void main(String[] args) throws Exception {
+
+                ResolvedMethodTableHashTest generator = new ResolvedMethodTableHashTest();
+                List<MethodHandle> handles = new ArrayList<>();
+
+                int count = args.length > 0 ? Integer.parseInt(args[0]) : 200000;
+
+                for (int i = 0; i < count; i++) {
+                        // prevents metaspace oom
+                        if (i % 20 != 0) {
+                                handles.add(generator.generate("MH$" + i));
+                        } else {
+                                handles.add(generator.generateWithSameName());
+                        }
+                        if (i % 1000 == 0) {
+                                System.out.println("Generated " + i + " handles");
+                        }
+                }
+
+                System.out.println("Test passed");
+        }
     }
 
     public static void main(String[] args) throws Exception {
-        ResolvedMethodTableHash generator = new ResolvedMethodTableHash();
-        List<MethodHandle> handles = new ArrayList<>();
 
-        int count = args.length > 0 ? Integer.parseInt(args[0]) : 200000;
-
-        for (int i = 0; i < count; i++) {
-            // prevents metaspace oom
-            if (i % 20 != 0) {
-                handles.add(generator.generate("MH$" + i));
-            } else {
-                handles.add(generator.generateWithSameName());
-            }
-            if (i % 1000 == 0) {
-                System.out.println("Generated " + i + " handles");
-            }
-        }
-
-        System.out.println("Test passed");
+        // Running the table with only 1000 entries should not provoke a needs rehash warning, unless the hash code is bad.
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:membername+table",
+                                                                             ResolvedMethodTableHashTest.class.getName(), "1001");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldNotContain("[membername,table] Rehash warning, load factor");
+        output.shouldContain("Generated 1000 handles");
+        output.shouldHaveExitValue(0);
     }
 }

--- a/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
+++ b/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
@@ -50,67 +50,67 @@ public class ResolvedMethodTableHash {
     public static class ResolvedMethodTableHashTest extends ClassLoader {
         // Generate a MethodHandle for ClassName.m()
         private MethodHandle generate(String className) throws ReflectiveOperationException {
-                byte[] buf = new byte[100];
-                int size = writeClass(buf, className);
-                Class<?> cls = defineClass(null, buf, 0, size);
-                return MethodHandles.publicLookup().findStatic(cls, "m", MethodType.methodType(void.class));
+            byte[] buf = new byte[100];
+            int size = writeClass(buf, className);
+            Class<?> cls = defineClass(null, buf, 0, size);
+            return MethodHandles.publicLookup().findStatic(cls, "m", MethodType.methodType(void.class));
         }
 
         private MethodHandle generateWithSameName() throws ReflectiveOperationException {
-                byte[] buf = new byte[100];
-                int size = writeClass(buf, "MH$$");
-                // use different classloader instances to load the classes with the same name
-                Class<?> cls = new ResolvedMethodTableHashTest().defineClass(null, buf, 0, size);
-                return MethodHandles.publicLookup().findStatic(cls, "m", MethodType.methodType(void.class));
+            byte[] buf = new byte[100];
+            int size = writeClass(buf, "MH$$");
+            // use different classloader instances to load the classes with the same name
+            Class<?> cls = new ResolvedMethodTableHashTest().defineClass(null, buf, 0, size);
+            return MethodHandles.publicLookup().findStatic(cls, "m", MethodType.methodType(void.class));
         }
 
         // Produce a class file with the given name and a single method:
         //         public static native void m();
         private int writeClass(byte[] buf, String className) {
-                return ByteBuffer.wrap(buf)
-                                .putInt(0xCAFEBABE)           // magic
-                                .putInt(50)                           // version: 50
-                                .putShort((short) 7)          // constant_pool_count: 7
-                                .put((byte) 7).putShort((short) 2)
-                                .put((byte) 1).putShort((short) className.length()).put(className.getBytes())
-                                .put((byte) 7).putShort((short) 4)
-                                .put((byte) 1).putShort((short) 16).put("java/lang/Object".getBytes())
-                                .put((byte) 1).putShort((short) 1).put("m".getBytes())
-                                .put((byte) 1).putShort((short) 3).put("()V".getBytes())
-                                .putShort((short) 0x21)   // access_flags: public super
-                                .putShort((short) 1)          // this_class: #1
-                                .putShort((short) 3)          // super_class: #3
-                                .putShort((short) 0)          // interfaces_count: 0
-                                .putShort((short) 0)          // fields_count: 0
-                                .putShort((short) 1)          // methods_count: 1
-                                .putShort((short) 0x109)  //   access_flags: public static native
-                                .putShort((short) 5)          //   name_index: #5
-                                .putShort((short) 6)          //   descriptor_index: #6
-                                .putShort((short) 0)          //   attributes_count: 0
-                                .putShort((short) 0)          // attributes_count: 0
-                                .position();
+            return ByteBuffer.wrap(buf)
+                .putInt(0xCAFEBABE)           // magic
+                .putInt(50)                           // version: 50
+                .putShort((short) 7)          // constant_pool_count: 7
+                .put((byte) 7).putShort((short) 2)
+                .put((byte) 1).putShort((short) className.length()).put(className.getBytes())
+                .put((byte) 7).putShort((short) 4)
+                .put((byte) 1).putShort((short) 16).put("java/lang/Object".getBytes())
+                .put((byte) 1).putShort((short) 1).put("m".getBytes())
+                .put((byte) 1).putShort((short) 3).put("()V".getBytes())
+                .putShort((short) 0x21)   // access_flags: public super
+                .putShort((short) 1)          // this_class: #1
+                .putShort((short) 3)          // super_class: #3
+                .putShort((short) 0)          // interfaces_count: 0
+                .putShort((short) 0)          // fields_count: 0
+                .putShort((short) 1)          // methods_count: 1
+                .putShort((short) 0x109)  //   access_flags: public static native
+                .putShort((short) 5)          //   name_index: #5
+                .putShort((short) 6)          //   descriptor_index: #6
+                .putShort((short) 0)          //   attributes_count: 0
+                .putShort((short) 0)          // attributes_count: 0
+                .position();
         }
 
         public static void main(String[] args) throws Exception {
 
-                ResolvedMethodTableHashTest generator = new ResolvedMethodTableHashTest();
-                List<MethodHandle> handles = new ArrayList<>();
+            ResolvedMethodTableHashTest generator = new ResolvedMethodTableHashTest();
+            List<MethodHandle> handles = new ArrayList<>();
 
-                int count = args.length > 0 ? Integer.parseInt(args[0]) : 200000;
+            int count = 1001;
 
-                for (int i = 0; i < count; i++) {
-                        // prevents metaspace oom
-                        if (i % 20 != 0) {
-                                handles.add(generator.generate("MH$" + i));
-                        } else {
-                                handles.add(generator.generateWithSameName());
-                        }
-                        if (i % 1000 == 0) {
-                                System.out.println("Generated " + i + " handles");
-                        }
+            for (int i = 0; i < count; i++) {
+                // prevents metaspace oom
+                if (i % 20 != 0) {
+                    handles.add(generator.generate("MH$" + i));
+                } else {
+                    handles.add(generator.generateWithSameName());
                 }
+                if (i % 1000 == 0) {
+                    System.out.println("Generated " + i + " handles");
+                }
+            }
 
-                System.out.println("Test passed");
+            System.out.println("Test passed");
         }
     }
 
@@ -118,7 +118,7 @@ public class ResolvedMethodTableHash {
 
         // Running the table with only 1000 entries should not provoke a needs rehash warning, unless the hash code is bad.
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xlog:membername+table",
-                                                                             ResolvedMethodTableHashTest.class.getName(), "1001");
+                                                                             ResolvedMethodTableHashTest.class.getName());
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("[membername,table] Rehash warning, load factor");
         output.shouldContain("Generated 1000 handles");


### PR DESCRIPTION
This is mostly test change.  ResolvedMethodTableHash.java is run /manual but still takes a long time and doesn't really verify that the hash code is any good.  This add logging, triggers concurrent work like other ConcurrentHashtables, and checks that a small table is not rehashed.
Tested with tier1 (including test).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349007](https://bugs.openjdk.org/browse/JDK-8349007): The jtreg test ResolvedMethodTableHash takes excessive time (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24383/head:pull/24383` \
`$ git checkout pull/24383`

Update a local copy of the PR: \
`$ git checkout pull/24383` \
`$ git pull https://git.openjdk.org/jdk.git pull/24383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24383`

View PR using the GUI difftool: \
`$ git pr show -t 24383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24383.diff">https://git.openjdk.org/jdk/pull/24383.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24383#issuecomment-2773262336)
</details>
