### PR TITLE
8349075: Once again allow -compilejdk in JAVA_OPTIONS

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -75,9 +75,6 @@ endif
 
 # This is the JDK that we will test
 JDK_UNDER_TEST := $(JDK_IMAGE_DIR)
-# The JDK used to compile jtreg test code. By default it is the same as
-# JDK_UNDER_TEST.
-JDK_FOR_COMPILE := $(JDK_IMAGE_DIR)
 
 TEST_RESULTS_DIR := $(OUTPUTDIR)/test-results
 TEST_SUPPORT_DIR := $(OUTPUTDIR)/test-support
@@ -945,6 +942,11 @@ define SetupRunJtregTestBody
     $1_JTREG_BASIC_OPTIONS += -e:JIB_HOME=$$(JIB_HOME)
   endif
 
+  ifneq ($$(JDK_FOR_COMPILE), )
+    # Allow overriding the JDK used for compilation from the command line
+    $1_JTREG_BASIC_OPTIONS += -compilejdk:$$(JDK_FOR_COMPILE)
+  endif
+
   $1_JTREG_BASIC_OPTIONS += -e:TEST_IMAGE_DIR=$(TEST_IMAGE_DIR)
 
   $1_JTREG_BASIC_OPTIONS += -e:DOCS_JDK_IMAGE_DIR=$$(DOCS_JDK_IMAGE_DIR)
@@ -997,7 +999,6 @@ define SetupRunJtregTestBody
       $$(JTREG_JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
           -Dprogram=jtreg -jar $$(JT_HOME)/lib/jtreg.jar \
           $$($1_JTREG_BASIC_OPTIONS) \
-          -compilejdk:$$(JDK_FOR_COMPILE) \
           -testjdk:$$(JDK_UNDER_TEST) \
           -dir:$$(JTREG_TOPDIR) \
           -reportDir:$$($1_TEST_RESULTS_DIR) \


### PR DESCRIPTION
[JDK-8348905](https://bugs.openjdk.org/browse/JDK-8348905) added the possibility to set `JDK_FOR_COMPILE` on the command line to pass the `-compilejdk:` argument to jtreg. Unfortunately the way it did this meant that -compilejdk: were always passed, so trying to set it separately in JAVAOPTIONS failed due to a duplicate argument error.

This PR will instead only set  `-compilejdk:` if `JDK_FOR_COMPILE` is given on the command line.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349075](https://bugs.openjdk.org/browse/JDK-8349075): Once again allow -compilejdk in JAVA_OPTIONS (**Bug** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24386/head:pull/24386` \
`$ git checkout pull/24386`

Update a local copy of the PR: \
`$ git checkout pull/24386` \
`$ git pull https://git.openjdk.org/jdk.git pull/24386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24386`

View PR using the GUI difftool: \
`$ git pr show -t 24386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24386.diff">https://git.openjdk.org/jdk/pull/24386.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24386#issuecomment-2773327297)
</details>
