### PR TITLE
8353185: Introduce the concept of upgradeable files in context of JEP493

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JRTArchive.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JRTArchive.java
@@ -45,6 +45,7 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -63,6 +64,10 @@ import jdk.tools.jlink.plugin.ResourcePoolEntry.Type;
  */
 public class JRTArchive implements Archive {
 
+    // Set of files in java.base that are allowed to be upgradable.
+    private static final Set<String> UPGRADEABLE_FILES = Set.of("lib/tzdb.dat",
+                                                                "lib/security/cacerts");
+    private static final String JAVA_BASE = "java.base";
     private final String module;
     private final Path path;
     private final ModuleReference ref;
@@ -76,6 +81,7 @@ public class JRTArchive implements Archive {
     private final Map<String, ResourceDiff> resDiff;
     private final boolean errorOnModifiedFile;
     private final TaskHelper taskHelper;
+    private final Set<String> upgradeableFiles;
 
     /**
      * JRTArchive constructor
@@ -86,12 +92,15 @@ public class JRTArchive implements Archive {
      *        install aborts the link.
      * @param perModDiff The lib/modules (a.k.a jimage) diff for this module,
      *                   possibly an empty list if there are no differences.
+     * @param taskHelper The task helper instance.
+     * @param upgradeableFiles The set of files that are allowed for upgrades.
      */
     JRTArchive(String module,
                Path path,
                boolean errorOnModifiedFile,
                List<ResourceDiff> perModDiff,
-               TaskHelper taskHelper) {
+               TaskHelper taskHelper,
+               Set<String> upgradeableFiles) {
         this.module = module;
         this.path = path;
         this.ref = ModuleFinder.ofSystem()
@@ -105,6 +114,7 @@ public class JRTArchive implements Archive {
         this.resDiff = Objects.requireNonNull(perModDiff).stream()
                             .collect(Collectors.toMap(ResourceDiff::getName, Function.identity()));
         this.taskHelper = taskHelper;
+        this.upgradeableFiles = upgradeableFiles;
     }
 
     @Override
@@ -217,9 +227,18 @@ public class JRTArchive implements Archive {
 
                         // Read from the base JDK image.
                         Path path = BASE.resolve(m.resPath);
-                        if (shaSumMismatch(path, m.hashOrTarget, m.symlink)) {
+                        if (!isUpgradeableFile(m.resPath) &&
+                                shaSumMismatch(path, m.hashOrTarget, m.symlink)) {
                             if (errorOnModifiedFile) {
                                 String msg = taskHelper.getMessage("err.runtime.link.modified.file", path.toString());
+                                // Add hint for upgradeable files
+                                if (JAVA_BASE.equals(module) &&
+                                        UPGRADEABLE_FILES.contains(m.resPath)) {
+                                    msg += System.lineSeparator();
+                                    msg += taskHelper.getMessage("err.runtime.link.modified.file.upgrade.hint",
+                                                                 module,
+                                                                 m.resPath);
+                                }
                                 IOException cause = new IOException(msg);
                                 throw new UncheckedIOException(cause);
                             } else {
@@ -237,6 +256,19 @@ public class JRTArchive implements Archive {
                  })
                  .toList());
         }
+    }
+
+    /**
+     * Certain files in the java.base module are considered upgradeable. That is,
+     * their hash sums aren't checked if so permitted with a CLI switch.
+     *
+     * @param resPath The resource path of the file to check for upgradeability.
+     * @return {@code true} iff the file is upgradeable. {@code false} otherwise.
+     */
+    private boolean isUpgradeableFile(String resPath) {
+        return JAVA_BASE.equals(module) &&
+                upgradeableFiles.contains(resPath) &&
+                UPGRADEABLE_FILES.contains(resPath);
     }
 
     static boolean shaSumMismatch(Path res, String expectedSha, boolean isSymlink) {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Jlink.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Jlink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,7 +148,7 @@ public final class Jlink {
         private final Set<String> modules;
         private final ModuleFinder finder;
         private final boolean linkFromRuntimeImage;
-        private final boolean ignoreModifiedRuntime;
+        private final LinkableRuntimeImage.Config runtimeImageConfig;
         private final boolean generateRuntimeImage;
 
         /**
@@ -162,13 +162,13 @@ public final class Jlink {
                                   Set<String> modules,
                                   ModuleFinder finder,
                                   boolean linkFromRuntimeImage,
-                                  boolean ignoreModifiedRuntime,
+                                  LinkableRuntimeImage.Config runtimeImageConfig,
                                   boolean generateRuntimeImage) {
             this.output = output;
             this.modules = Objects.requireNonNull(modules);
             this.finder = finder;
             this.linkFromRuntimeImage = linkFromRuntimeImage;
-            this.ignoreModifiedRuntime = ignoreModifiedRuntime;
+            this.runtimeImageConfig = runtimeImageConfig;
             this.generateRuntimeImage = generateRuntimeImage;
         }
 
@@ -198,8 +198,8 @@ public final class Jlink {
             return linkFromRuntimeImage;
         }
 
-        public boolean ignoreModifiedRuntime() {
-            return ignoreModifiedRuntime;
+        public LinkableRuntimeImage.Config runtimeImageConfig() {
+            return runtimeImageConfig;
         }
 
         public boolean isGenerateRuntimeImage() {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/LinkableRuntimeImage.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/LinkableRuntimeImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Red Hat, Inc.
+ * Copyright (c) 2024, 2025, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import jdk.tools.jlink.internal.runtimelink.ResourceDiff;
 
@@ -67,7 +69,7 @@ public class LinkableRuntimeImage {
 
     public static Archive newArchive(String module,
                                      Path path,
-                                     boolean ignoreModifiedRuntime,
+                                     Config config,
                                      TaskHelper taskHelper) {
         assert isLinkableRuntime();
         // Here we retrieve the per module difference file, which is
@@ -81,8 +83,15 @@ public class LinkableRuntimeImage {
             throw new AssertionError("Failure to retrieve resource diff for " +
                                      "module " + module, e);
         }
-        return new JRTArchive(module, path, !ignoreModifiedRuntime, perModuleDiff, taskHelper);
+        return new JRTArchive(module,
+                              path,
+                              !config.ignoreModifiedRuntime,
+                              perModuleDiff,
+                              taskHelper,
+                              // Empty set if no upgradable files for the module
+                              config.upgradeableFiles.computeIfAbsent(module, k -> Set.of()));
     }
 
-
+    static record Config(boolean ignoreModifiedRuntime,
+                         Map<String, Set<String>> upgradeableFiles) {}
 }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
@@ -125,6 +125,8 @@ err.runtime.link.jdk.jlink.prohibited=This JDK does not contain packaged modules
 err.runtime.link.packaged.mods=This JDK has no packaged modules.\
 \ --keep-packaged-modules is not supported
 err.runtime.link.modified.file={0} has been modified
+err.runtime.link.modified.file.upgrade.hint=Hint: {1} is an upgradeable file.\
+\ Add --upgrade-files={0}/{1} to allow the upgrade.
 err.runtime.link.patched.module=jlink does not support linking from the run-time image\
 \ when running on a patched runtime with --patch-module
 err.no.module.path=--module-path option must be specified with --add-modules ALL-MODULE-PATH

--- a/test/jdk/tools/jlink/IntegrationTest.java
+++ b/test/jdk/tools/jlink/IntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,7 +159,7 @@ public class IntegrationTest {
                 mods,
                 JlinkTask.limitFinder(JlinkTask.newModuleFinder(modulePaths), limits, mods),
                 linkFromRuntime,
-                false /* ignore modified runtime */,
+                null /* run-time image link config */,
                 false /* generate run-time image */);
 
         List<Plugin> lst = new ArrayList<>();

--- a/test/jdk/tools/jlink/JLinkTest.java
+++ b/test/jdk/tools/jlink/JLinkTest.java
@@ -403,6 +403,17 @@ public class JLinkTest {
                 throw new RuntimeException("bug8240349 directory not deleted");
             }
         }
+
+        // Basic upgrade-files option parsing test
+        {
+            String imageDir = "bug8353185";
+            JImageGenerator.getJLinkTask()
+                    .output(helper.createNewImageDir(imageDir))
+                    .addMods("java.base")
+                    .option("--upgrade-files=java.base/foo/bar,java.base/lib/security/cacerts")
+                    .option("--upgrade-files=java.base/lib/tzdb.dat")
+                    .call().assertSuccess();
+        }
     }
 
     private static void testCompress(Helper helper, String moduleName, String... userOptions) throws IOException {


### PR DESCRIPTION
For JEP 493-enabled builds there are no JMODs. Certain files come from the installed JDK image when a user creates a custom run-time from it. This is problematic for example for files that often come from a different package (e.g. `cacerts` file for Linux distro builds of OpenJDK packaged as RPMs), or more generally when they get updated out-of-band of the JDK build itself like the tzupdater tool.

When that happens the hash sum recorded at JDK build time of those files no longer match, causing `jlink` to fail. I propose to allow for those files to get "upgraded" should this happen. The way this works is as follows:

1. The list of upgradeable files is hard-coded to `lib/tzdb.dat` and `lib/security/cacerts`. Only those two files from the `java.base` module will be allowed to be upgraded with a link from the current run-time image.
2. The upgrade needs to be opt-in. Similar to `--ignore-signing-information` for signed modular JARs. A user needs to add `--upgrade-files=<module>/<file-path>` for it to succeed.

`--upgrade-files` is a hidden `jlink` option since it only does anything for JEP 493 enabled builds. Users get a hint to apply the option if they so desire:

Example:

```
$ ./bin/jlink --add-modules java.base --output java.base-jdk
Error: [..]/lib/security/cacerts has been modified
Hint: lib/security/cacerts is an upgradeable file. Add --upgrade-files=java.base/lib/security/cacerts to allow the upgrade.
```

using the hint we get:

```
$ ./bin/jlink --add-modules java.base --output java.base-jdk --upgrade-files=java.base/lib/security/cacerts
$ ./java.base-jdk/bin/java --list-modules
java.base@25-internal
$ sha512sum ./java.base-jdk/lib/security/cacerts 
cf2b4c17161e79001c8e07def3de36c0d523f00a2a6b6e33893a2a3669d930957c11ac765dd29d5ff80e63ad100ef0258291891377f7133b997111ba97b15146  ./java.base-jdk/lib/security/cacerts
$ sha512sum ./lib/security/cacerts 
cf2b4c17161e79001c8e07def3de36c0d523f00a2a6b6e33893a2a3669d930957c11ac765dd29d5ff80e63ad100ef0258291891377f7133b997111ba97b15146  ./lib/security/cacerts
```

**Testing**

- [ ] GHA
- [x] `jdk/tools/jlink` jtreg tests
- [x] Some manual tests with updated `tzdb.dat` and `cacerts` files.

Thoughts?