### PR TITLE
8353041: NeverBranchNode causes incorrect block frequency calculation

### DIFF
--- a/src/hotspot/share/opto/domgraph.cpp
+++ b/src/hotspot/share/opto/domgraph.cpp
@@ -239,7 +239,8 @@ uint Block_Stack::most_frequent_successor( Block *b ) {
     Node* succ = n->as_NeverBranch()->proj_out(0)->unique_ctrl_out();
     int succ_idx = 0; // normal case
     if (succ == b->_succs[1]->head()) {
-      // edges swapped, rare case
+      // Edges swapped, rare case. May happen due to an unusual matcher
+      // traversal order for peeled infinite loops.
       succ_idx = 1;
     } else {
       assert(succ == b->_succs[0]->head(), "succ not found");

--- a/src/hotspot/share/opto/domgraph.cpp
+++ b/src/hotspot/share/opto/domgraph.cpp
@@ -233,9 +233,20 @@ uint Block_Stack::most_frequent_successor( Block *b ) {
   case Op_Jump:
   case Op_Root:
   case Op_Goto:
-  case Op_NeverBranch:
     freq_idx = 0;               // fall thru
     break;
+  case Op_NeverBranch: {
+    Node* succ = n->as_NeverBranch()->proj_out(0)->unique_ctrl_out();
+    int succ_idx = 0; // normal case
+    if (succ == b->_succs[1]->head()) {
+      // edges swapped, rare case
+      succ_idx = 1;
+    } else {
+      assert(succ == b->_succs[0]->head(), "succ not found");
+    }
+    freq_idx = succ_idx;
+    break;
+  }
   case Op_TailCall:
   case Op_TailJump:
   case Op_ForwardException:

--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -2160,8 +2160,13 @@ float Block::succ_prob(uint i) {
     // Pass frequency straight thru to target
     return 1.0f;
 
-  case Op_NeverBranch:
+  case Op_NeverBranch: {
+    Node* succ = n->as_NeverBranch()->proj_out(0)->unique_ctrl_out();
+    if (_succs[i]->head() == succ) {
+      return 1.0f;
+    }
     return 0.0f;
+  }
 
   case Op_TailCall:
   case Op_TailJump:


### PR DESCRIPTION
This fixes a quality of implementation issue for infinite loops using a NeverBranch node.  We need Block::succ_prob() to return 1.0f for the 100% successful back-edge so that block frequencies are computed correctly.  I also fixed Block_Stack::most_frequent_successor() to choose the correct successor.  I verified that this corrects the huge frequency ratio that was detected and clamped by JDK-8346888.

Currently this bug is labeled noreg-hard with no new regression test, as it's not obvious how to write such as test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353041](https://bugs.openjdk.org/browse/JDK-8353041): NeverBranchNode causes incorrect block frequency calculation (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24390/head:pull/24390` \
`$ git checkout pull/24390`

Update a local copy of the PR: \
`$ git checkout pull/24390` \
`$ git pull https://git.openjdk.org/jdk.git pull/24390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24390`

View PR using the GUI difftool: \
`$ git pr show -t 24390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24390.diff">https://git.openjdk.org/jdk/pull/24390.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24390#issuecomment-2773587258)
</details>
