### PR TITLE
8349467: INIT_TARGETS tab completions on "make" lost with JDK-8348998

### DIFF
--- a/make/PreInit.gmk
+++ b/make/PreInit.gmk
@@ -48,6 +48,10 @@ include $(TOPDIR)/make/common/LogUtils.gmk
 # a configuration. This will define ALL_GLOBAL_TARGETS.
 include $(TOPDIR)/make/Global.gmk
 
+# Targets provided by Init.gmk.
+ALL_INIT_TARGETS := print-modules print-targets print-configuration \
+    print-tests reconfigure pre-compare-build post-compare-build
+
 # CALLED_TARGETS is the list of targets that the user provided,
 # or "default" if unspecified.
 CALLED_TARGETS := $(if $(MAKECMDGOALS), $(MAKECMDGOALS), default)
@@ -92,10 +96,6 @@ ifneq ($(SKIP_SPEC), true)
   # by all specs, but we approximate this by an arbitrary spec from the list.
   # This will setup ALL_MAIN_TARGETS.
   $(eval $(call DefineMainTargets, FORCE, $(firstword $(SPECS))))
-
-  # Targets provided by Init.gmk.
-  ALL_INIT_TARGETS := print-modules print-targets print-configuration \
-      print-tests reconfigure pre-compare-build post-compare-build
 
   # Separate called targets depending on type.
   INIT_TARGETS := $(filter $(ALL_INIT_TARGETS), $(CALLED_SPEC_TARGETS))


### PR DESCRIPTION
[JDK-8348998](https://bugs.openjdk.org/browse/JDK-8348998) broke tab completion for all init targets, i.e. `print-modules print-targets print-configuration print-tests reconfigure pre-compare-build post-compare-build`, of which `reconfigure` was probably the hardest hit.

The solution is to move the declaration of ALL_INIT_TARGETS so it is available even for the `SKIP_SPEC=true` part of PreInit.gmk.