### PR TITLE
8353584: [BACKOUT] DaCapo xalan performance with -XX:+UseObjectMonitorTable

### DIFF
--- a/src/hotspot/share/runtime/basicLock.cpp
+++ b/src/hotspot/share/runtime/basicLock.cpp
@@ -27,7 +27,7 @@
 #include "runtime/objectMonitor.hpp"
 #include "runtime/synchronizer.hpp"
 
-void BasicLock::print_on(outputStream* st, oop owner) {
+void BasicLock::print_on(outputStream* st, oop owner) const {
   st->print("monitor");
   if (UseObjectMonitorTable) {
     ObjectMonitor* mon = object_monitor_cache();

--- a/src/hotspot/share/runtime/basicLock.hpp
+++ b/src/hotspot/share/runtime/basicLock.hpp
@@ -50,8 +50,6 @@ class BasicLock {
   static int metadata_offset_in_bytes() { return (int)offset_of(BasicLock, _metadata); }
 
  public:
-  BasicLock() : _metadata(0) {}
-
   // LM_MONITOR
   void set_bad_metadata_deopt() { set_metadata(badDispHeaderDeopt); }
 
@@ -61,12 +59,12 @@ class BasicLock {
   static int displaced_header_offset_in_bytes() { return metadata_offset_in_bytes(); }
 
   // LM_LIGHTWEIGHT
-  inline ObjectMonitor* object_monitor_cache();
+  inline ObjectMonitor* object_monitor_cache() const;
   inline void clear_object_monitor_cache();
   inline void set_object_monitor_cache(ObjectMonitor* mon);
   static int object_monitor_cache_offset_in_bytes() { return metadata_offset_in_bytes(); }
 
-  void print_on(outputStream* st, oop owner);
+  void print_on(outputStream* st, oop owner) const;
 
   // move a basic lock (used during deoptimization)
   void move_to(oop obj, BasicLock* dest);

--- a/src/hotspot/share/runtime/basicLock.inline.hpp
+++ b/src/hotspot/share/runtime/basicLock.inline.hpp
@@ -26,7 +26,6 @@
 #define SHARE_RUNTIME_BASICLOCK_INLINE_HPP
 
 #include "runtime/basicLock.hpp"
-#include "runtime/objectMonitor.inline.hpp"
 
 inline markWord BasicLock::displaced_header() const {
   assert(LockingMode == LM_LEGACY, "must be");
@@ -38,15 +37,10 @@ inline void BasicLock::set_displaced_header(markWord header) {
   Atomic::store(&_metadata, header.value());
 }
 
-inline ObjectMonitor* BasicLock::object_monitor_cache() {
+inline ObjectMonitor* BasicLock::object_monitor_cache() const {
   assert(UseObjectMonitorTable, "must be");
 #if !defined(ZERO) && (defined(X86) || defined(AARCH64) || defined(RISCV64) || defined(PPC64) || defined(S390))
-  ObjectMonitor* monitor = reinterpret_cast<ObjectMonitor*>(get_metadata());
-  if (monitor != nullptr && monitor->is_being_async_deflated()) {
-    clear_object_monitor_cache();
-    return nullptr;
-  }
-  return monitor;
+  return reinterpret_cast<ObjectMonitor*>(get_metadata());
 #else
   // Other platforms do not make use of the cache yet,
   // and are not as careful with maintaining the invariant

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -633,7 +633,7 @@ void LightweightSynchronizer::enter_for(Handle obj, BasicLock* lock, JavaThread*
   } else {
     do {
       // It is assumed that enter_for must enter on an object without contention.
-      monitor = inflate_and_enter(obj(), lock, ObjectSynchronizer::inflate_cause_monitor_enter, locking_thread, current);
+      monitor = inflate_and_enter(obj(), ObjectSynchronizer::inflate_cause_monitor_enter, locking_thread, current);
       // But there may still be a race with deflation.
     } while (monitor == nullptr);
   }
@@ -689,7 +689,7 @@ void LightweightSynchronizer::enter(Handle obj, BasicLock* lock, JavaThread* cur
       spin_yield.wait();
     }
 
-    ObjectMonitor* monitor = inflate_and_enter(obj(), lock, ObjectSynchronizer::inflate_cause_monitor_enter, current, current);
+    ObjectMonitor* monitor = inflate_and_enter(obj(), ObjectSynchronizer::inflate_cause_monitor_enter, current, current);
     if (monitor != nullptr) {
       cache_setter.set_monitor(monitor);
       return;
@@ -703,7 +703,7 @@ void LightweightSynchronizer::enter(Handle obj, BasicLock* lock, JavaThread* cur
   }
 }
 
-void LightweightSynchronizer::exit(oop object, BasicLock* lock, JavaThread* current) {
+void LightweightSynchronizer::exit(oop object, JavaThread* current) {
   assert(LockingMode == LM_LIGHTWEIGHT, "must be");
   assert(current == Thread::current(), "must be");
 
@@ -738,18 +738,7 @@ void LightweightSynchronizer::exit(oop object, BasicLock* lock, JavaThread* curr
 
   assert(mark.has_monitor(), "must be");
   // The monitor exists
-  ObjectMonitor* monitor;
-  if (UseObjectMonitorTable) {
-    monitor = lock->object_monitor_cache();
-    if (monitor == nullptr) {
-      monitor = current->om_get_from_monitor_cache(object);
-      if (monitor == nullptr) {
-        monitor = get_monitor_from_table(current, object);
-      }
-    }
-  } else {
-    monitor = ObjectSynchronizer::read_monitor(mark);
-  }
+  ObjectMonitor* monitor = ObjectSynchronizer::read_monitor(current, object, mark);
   if (monitor->has_anonymous_owner()) {
     assert(current->lock_stack().contains(object), "current must have object on its lock stack");
     monitor->set_owner_from_anonymous(current);
@@ -988,7 +977,7 @@ ObjectMonitor* LightweightSynchronizer::inflate_fast_locked_object(oop object, O
   return monitor;
 }
 
-ObjectMonitor* LightweightSynchronizer::inflate_and_enter(oop object, BasicLock* lock, ObjectSynchronizer::InflateCause cause, JavaThread* locking_thread, JavaThread* current) {
+ObjectMonitor* LightweightSynchronizer::inflate_and_enter(oop object, ObjectSynchronizer::InflateCause cause, JavaThread* locking_thread, JavaThread* current) {
   assert(LockingMode == LM_LIGHTWEIGHT, "only used for lightweight");
   VerifyThreadState vts(locking_thread, current);
 
@@ -1014,20 +1003,18 @@ ObjectMonitor* LightweightSynchronizer::inflate_and_enter(oop object, BasicLock*
 
   NoSafepointVerifier nsv;
 
+  // Lightweight monitors require that hash codes are installed first
+  ObjectSynchronizer::FastHashCode(locking_thread, object);
+
   // Try to get the monitor from the thread-local cache.
   // There's no need to use the cache if we are locking
   // on behalf of another thread.
   if (current == locking_thread) {
-    monitor = lock->object_monitor_cache();
-    if (monitor == nullptr) {
-      monitor = current->om_get_from_monitor_cache(object);
-    }
+    monitor = current->om_get_from_monitor_cache(object);
   }
 
   // Get or create the monitor
   if (monitor == nullptr) {
-    // Lightweight monitors require that hash codes are installed first
-    ObjectSynchronizer::FastHashCode(locking_thread, object);
     monitor = get_or_insert_monitor(object, current, cause);
   }
 
@@ -1175,6 +1162,9 @@ bool LightweightSynchronizer::quick_enter(oop obj, BasicLock* lock, JavaThread* 
   assert(obj != nullptr, "must be");
   NoSafepointVerifier nsv;
 
+  // If quick_enter succeeds with entering, the cache should be in a valid initialized state.
+  CacheSetter cache_setter(current, lock);
+
   LockStack& lock_stack = current->lock_stack();
   if (lock_stack.is_full()) {
     // Always go into runtime if the lock stack is full.
@@ -1201,28 +1191,17 @@ bool LightweightSynchronizer::quick_enter(oop obj, BasicLock* lock, JavaThread* 
 #endif
 
   if (mark.has_monitor()) {
-    ObjectMonitor* monitor;
-    if (UseObjectMonitorTable) {
-      // C2 fast-path may have put the monitor in the cache in the BasicLock.
-      monitor = lock->object_monitor_cache();
-      if (monitor == nullptr) {
-        // Otherwise look up the monitor in the thread's OMCache.
-        monitor = current->om_get_from_monitor_cache(obj);
-      }
-    } else {
-      monitor = ObjectSynchronizer::read_monitor(mark);
-    }
+    ObjectMonitor* const monitor = UseObjectMonitorTable ? current->om_get_from_monitor_cache(obj) :
+                                                           ObjectSynchronizer::read_monitor(mark);
 
     if (monitor == nullptr) {
       // Take the slow-path on a cache miss.
       return false;
     }
 
-    if (UseObjectMonitorTable) {
-      lock->set_object_monitor_cache(monitor);
-    }
-
-    if (monitor->spin_enter(current)) {
+    if (monitor->try_enter(current)) {
+      // ObjectMonitor enter successful.
+      cache_setter.set_monitor(monitor);
       return true;
     }
   }

--- a/src/hotspot/share/runtime/lightweightSynchronizer.hpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.hpp
@@ -61,12 +61,12 @@ class LightweightSynchronizer : AllStatic {
  public:
   static void enter_for(Handle obj, BasicLock* lock, JavaThread* locking_thread);
   static void enter(Handle obj, BasicLock* lock, JavaThread* current);
-  static void exit(oop object, BasicLock* lock, JavaThread* current);
+  static void exit(oop object, JavaThread* current);
 
   static ObjectMonitor* inflate_into_object_header(oop object, ObjectSynchronizer::InflateCause cause, JavaThread* locking_thread, Thread* current);
   static ObjectMonitor* inflate_locked_or_imse(oop object, ObjectSynchronizer::InflateCause cause, TRAPS);
   static ObjectMonitor* inflate_fast_locked_object(oop object, ObjectSynchronizer::InflateCause cause, JavaThread* locking_thread, JavaThread* current);
-  static ObjectMonitor* inflate_and_enter(oop object, BasicLock* lock, ObjectSynchronizer::InflateCause cause, JavaThread* locking_thread, JavaThread* current);
+  static ObjectMonitor* inflate_and_enter(oop object, ObjectSynchronizer::InflateCause cause, JavaThread* locking_thread, JavaThread* current);
 
   static void deflate_monitor(Thread* current, oop obj, ObjectMonitor* monitor);
 

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -148,7 +148,6 @@ class ObjectWaiter : public CHeapObj<mtThread> {
 #define OM_CACHE_LINE_SIZE DEFAULT_CACHE_LINE_SIZE
 
 class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
-  friend class LightweightSynchronizer;
   friend class ObjectSynchronizer;
   friend class ObjectWaiter;
   friend class VMStructs;

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -678,8 +678,7 @@ void ObjectSynchronizer::jni_enter(Handle obj, JavaThread* current) {
     ObjectMonitor* monitor;
     bool entered;
     if (LockingMode == LM_LIGHTWEIGHT) {
-      BasicLock lock;
-      entered = LightweightSynchronizer::inflate_and_enter(obj(), &lock, inflate_cause_jni_enter, current, current) != nullptr;
+      entered = LightweightSynchronizer::inflate_and_enter(obj(), inflate_cause_jni_enter, current, current) != nullptr;
     } else {
       monitor = inflate(current, obj(), inflate_cause_jni_enter);
       entered = monitor->enter(current);

--- a/src/hotspot/share/runtime/synchronizer.inline.hpp
+++ b/src/hotspot/share/runtime/synchronizer.inline.hpp
@@ -72,7 +72,7 @@ inline void ObjectSynchronizer::exit(oop object, BasicLock* lock, JavaThread* cu
   current->dec_held_monitor_count();
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    LightweightSynchronizer::exit(object, lock, current);
+    LightweightSynchronizer::exit(object, current);
   } else {
     exit_legacy(object, lock, current);
   }


### PR DESCRIPTION
This reverts commit 49cb7aaad903aa5209da9f4af4b484ff38c0fb8b.

Testing in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353584](https://bugs.openjdk.org/browse/JDK-8353584): [BACKOUT] DaCapo xalan performance with -XX:+UseObjectMonitorTable (**Sub-task** - P2)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24396/head:pull/24396` \
`$ git checkout pull/24396`

Update a local copy of the PR: \
`$ git checkout pull/24396` \
`$ git pull https://git.openjdk.org/jdk.git pull/24396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24396`

View PR using the GUI difftool: \
`$ git pr show -t 24396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24396.diff">https://git.openjdk.org/jdk/pull/24396.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24396#issuecomment-2773905636)
</details>
