### PR TITLE
8353066: Properly detect Windows/aarch64 as build platform

### DIFF
--- a/make/autoconf/build-aux/config.guess
+++ b/make/autoconf/build-aux/config.guess
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -53,15 +53,19 @@ if [ "x$OUT" = x ]; then
   fi
 fi
 
-# Test and fix cygwin on x86_64
-echo $OUT | grep 86-pc-cygwin > /dev/null 2> /dev/null
+# Test and fix cygwin/msys CPUs
+echo $OUT | grep -e "-pc-cygwin" > /dev/null 2> /dev/null
 if test $? != 0; then
-  echo $OUT | grep 86-pc-mingw > /dev/null 2> /dev/null
+  echo $OUT | grep -e "-pc-mingw" > /dev/null 2> /dev/null
 fi
 if test $? = 0; then
   case `echo $PROCESSOR_IDENTIFIER | cut -f1 -d' '` in
     intel64|Intel64|INTEL64|em64t|EM64T|amd64|AMD64|8664|x86_64)
       REAL_CPU=x86_64
+      OUT=$REAL_CPU`echo $OUT | sed -e 's/[^-]*//'`
+      ;;
+    ARMv8)
+      REAL_CPU=aarch64
       OUT=$REAL_CPU`echo $OUT | sed -e 's/[^-]*//'`
       ;;
   esac

--- a/make/autoconf/toolchain_microsoft.m4
+++ b/make/autoconf/toolchain_microsoft.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ AC_DEFUN([TOOLCHAIN_CHECK_POSSIBLE_VISUAL_STUDIO_ROOT],
       elif test "x$TARGET_CPU" = xaarch64; then
         # for host x86-64, target aarch64
         # aarch64 requires Visual Studio 16.8 or higher
-        VCVARSFILES="vcvarsamd64_arm64.bat vcvarsx86_arm64.bat"
+        VCVARSFILES="vcvarsarm64.bat vcvarsamd64_arm64.bat vcvarsx86_arm64.bat"
       fi
 
       for VCVARSFILE in $VCVARSFILES; do


### PR DESCRIPTION
Configure does not properly detect Windows/aarch64 on Cygwin. One complicating factor here is that no native aarch64 version of Cygwin exists, so it is running x64 binaries in emulated mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353066](https://bugs.openjdk.org/browse/JDK-8353066): Properly detect Windows/aarch64 as build platform (**Enhancement** - P4)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @skateball (no known openjdk.org user name / role)

### Contributors
 * Mikael Vidstedt `<mikael@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24397/head:pull/24397` \
`$ git checkout pull/24397`

Update a local copy of the PR: \
`$ git checkout pull/24397` \
`$ git pull https://git.openjdk.org/jdk.git pull/24397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24397`

View PR using the GUI difftool: \
`$ git pr show -t 24397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24397.diff">https://git.openjdk.org/jdk/pull/24397.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24397#issuecomment-2773963519)
</details>
