### PR TITLE
8321591: (fs) Improve String -> Path conversion performance (win)

### DIFF
--- a/test/micro/org/openjdk/bench/java/nio/file/PathOfString.java
+++ b/test/micro/org/openjdk/bench/java/nio/file/PathOfString.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.nio.file;
+
+import java.nio.file.Path;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class PathOfString {
+    @Param({"C:\\Users\\foo\\bar\\gus.txt",              // absolute
+            "C:\\Users\\\\foo\\\\bar\\gus.txt",          // ... with extra '\\'s
+            "\\\\.\\UNC\\localhost\\C$\\Users\\foo",     // UNC
+            "\\\\.\\UNC\\localhost\\C$\\\\Users\\\\foo", // ... with extra '\\'s
+            "\\\\?\\C:\\Users\\foo\\bar\\gus.txt",       // long path prefix
+            "\\\\?\\C:\\Users\\\\foo\\bar\\\\gus.txt",   // ... with extra '\\'s
+            ".\\foo\\bar\\gus.txt",                      // relative
+            ".\\foo\\\\bar\\\\gus.txt",                  // ... with extra '\\'s
+            "\\foo\\bar\\gus.txt",                     // current drive-relative
+            "\\foo\\\\bar\\\\gus.txt",                 // ... with extra '\\'s
+            "C:foo\\bar\\gus.txt",         // drive's current directory-relative
+            "C:foo\\\\bar\\\\gus.txt"})    // ... with extra '\\'s
+
+    public String path;
+
+    @Benchmark
+    public Path parse() {
+        return Path.of(path);
+    }
+}


### PR DESCRIPTION
Improve the performance of `WindowsPathParser.normalize` by using a `char` array to perform the normalization in place instead of appending to a `StringBuilder`. The `Result` inner class is also converted to a `record`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321591](https://bugs.openjdk.org/browse/JDK-8321591): (fs) Improve String -&gt; Path conversion performance (win) (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24400/head:pull/24400` \
`$ git checkout pull/24400`

Update a local copy of the PR: \
`$ git checkout pull/24400` \
`$ git pull https://git.openjdk.org/jdk.git pull/24400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24400`

View PR using the GUI difftool: \
`$ git pr show -t 24400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24400.diff">https://git.openjdk.org/jdk/pull/24400.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24400#issuecomment-2774086072)
</details>
