### PR TITLE
8353597 refactor aot cache input output

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -42,9 +42,10 @@ class CDSConfig : public AllStatic {
   static bool _is_using_full_module_graph;
   static bool _has_aot_linked_classes;
 
-  static char* _default_archive_path;
-  static char* _static_archive_path;
-  static char* _dynamic_archive_path;
+  const static char* _default_archive_path;
+  const static char* _input_static_archive_path;
+  const static char* _input_dynamic_archive_path;
+  const static char* _output_archive_path;
 
   static bool  _old_cds_flags_used;
   static bool  _new_aot_flags_used;
@@ -53,17 +54,26 @@ class CDSConfig : public AllStatic {
   static JavaThread* _dumper_thread;
 #endif
 
-  static void extract_shared_archive_paths(const char* archive_path,
-                                           char** base_archive_path,
-                                           char** top_archive_path);
-  static void init_shared_archive_paths();
+  static void extract_archive_paths(const char* archive_path,
+                                    const char** base_archive_path,
+                                    const char** top_archive_path);
+  static void init_classic_archive_paths();
+  static void init_complex_archive_paths(int num_archives);
+  static int num_archive_paths(const char* path_spec);
+  static void check_flag_single_path(const char* flag_name, const char* value);
+  static void init_aot_paths();
 
+  // Checks before Arguments::apply_ergo()
   static void check_flag_alias(bool alias_is_default, const char* alias_name);
   static void check_aot_flags();
   static void check_aotmode_off();
   static void check_aotmode_auto_or_on();
   static void check_aotmode_record();
   static void check_aotmode_create();
+  static void check_unsupported_dumping_module_options();
+
+  // Checks after Arguments::apply_ergo() has started
+  static void ergo_check_dynamic_dump_options();
 
 public:
   // Used by jdk.internal.misc.CDS.getCDSConfigStatus();
@@ -76,24 +86,25 @@ public:
   static int get_status() NOT_CDS_RETURN_(0);
 
   // Initialization and command-line checking
-  static void initialize() NOT_CDS_RETURN;
+  static void ergo_initialize() NOT_CDS_RETURN;
   static void set_old_cds_flags_used()                       { CDS_ONLY(_old_cds_flags_used = true); }
   static bool old_cds_flags_used()                           { return CDS_ONLY(_old_cds_flags_used) NOT_CDS(false); }
   static bool new_aot_flags_used()                           { return CDS_ONLY(_new_aot_flags_used) NOT_CDS(false); }
   static void check_internal_module_property(const char* key, const char* value) NOT_CDS_RETURN;
   static void check_incompatible_property(const char* key, const char* value) NOT_CDS_RETURN;
-  static void check_unsupported_dumping_module_options() NOT_CDS_RETURN;
   static bool has_unsupported_runtime_module_options() NOT_CDS_RETURN_(false);
   static bool check_vm_args_consistency(bool patch_mod_javabase, bool mode_flag_cmd_line) NOT_CDS_RETURN_(true);
   static const char* type_of_archive_being_loaded();
   static const char* type_of_archive_being_written();
+  static void prepare_for_dumping();
 
   // --- Basic CDS features
 
   // archive(s) in general
   static bool is_dumping_archive()                           { return is_dumping_static_archive() || is_dumping_dynamic_archive(); }
+
+  // input archive(s)
   static bool is_using_archive()                             NOT_CDS_RETURN_(false);
-  static int num_archives(const char* archive_path)          NOT_CDS_RETURN_(0);
 
   // static_archive
   static bool is_dumping_static_archive()                    { return CDS_ONLY(_is_dumping_static_archive) NOT_CDS(false); }
@@ -125,7 +136,7 @@ public:
 
   // dynamic_archive
   static bool is_dumping_dynamic_archive()                   { return CDS_ONLY(_is_dumping_dynamic_archive) NOT_CDS(false); }
-  static void enable_dumping_dynamic_archive()               { CDS_ONLY(_is_dumping_dynamic_archive = true); }
+  static void enable_dumping_dynamic_archive(const char* output_path) NOT_CDS_RETURN;
   static void disable_dumping_dynamic_archive()              { CDS_ONLY(_is_dumping_dynamic_archive = false); }
 
   // Misc CDS features
@@ -147,12 +158,11 @@ public:
 
   // archive_path
 
-  // Points to the classes.jsa in $JAVA_HOME
-  static char* default_archive_path()                        NOT_CDS_RETURN_(nullptr);
-  // The actual static archive  (if any) selected at runtime
-  static const char* static_archive_path()                   { return CDS_ONLY(_static_archive_path) NOT_CDS(nullptr); }
-  // The actual dynamic archive  (if any) selected at runtime
-  static const char* dynamic_archive_path()                  { return CDS_ONLY(_dynamic_archive_path) NOT_CDS(nullptr); }
+  // Points to the classes.jsa in $JAVA_HOME (could be input or output)
+  static const char* default_archive_path()                  NOT_CDS_RETURN_(nullptr);
+  static const char* input_static_archive_path()             { return CDS_ONLY(_input_static_archive_path) NOT_CDS(nullptr); }
+  static const char* input_dynamic_archive_path()            { return CDS_ONLY(_input_dynamic_archive_path) NOT_CDS(nullptr); }
+  static const char* output_archive_path()                   { return CDS_ONLY(_output_archive_path) NOT_CDS(nullptr); }
 
   // --- Archived java objects
 

--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -57,14 +57,11 @@ class CDSConfig : public AllStatic {
   static void extract_archive_paths(const char* archive_path,
                                     const char** base_archive_path,
                                     const char** top_archive_path);
-  static void init_classic_archive_paths();
-  static void init_complex_archive_paths(int num_archives);
   static int num_archive_paths(const char* path_spec);
   static void check_flag_single_path(const char* flag_name, const char* value);
-  static void init_aot_paths();
 
   // Checks before Arguments::apply_ergo()
-  static void check_flag_alias(bool alias_is_default, const char* alias_name);
+  static void check_new_flag(bool new_flag_is_default, const char* new_flag_name);
   static void check_aot_flags();
   static void check_aotmode_off();
   static void check_aotmode_auto_or_on();
@@ -72,8 +69,9 @@ class CDSConfig : public AllStatic {
   static void check_aotmode_create();
   static void check_unsupported_dumping_module_options();
 
-  // Checks after Arguments::apply_ergo() has started
-  static void ergo_check_dynamic_dump_options();
+  // Called after Arguments::apply_ergo() has started
+  static void ergo_init_classic_archive_paths();
+  static void ergo_init_aot_paths();
 
 public:
   // Used by jdk.internal.misc.CDS.getCDSConfigStatus();

--- a/src/hotspot/share/cds/dynamicArchive.hpp
+++ b/src/hotspot/share/cds/dynamicArchive.hpp
@@ -63,9 +63,8 @@ private:
   static GrowableArray<ObjArrayKlass*>* _array_klasses;
   static Array<ObjArrayKlass*>* _dynamic_archive_array_klasses;
 public:
-  static void check_for_dynamic_dump();
   static void dump_for_jcmd(const char* archive_name, TRAPS);
-  static void dump_at_exit(JavaThread* current, const char* archive_name);
+  static void dump_at_exit(JavaThread* current);
   static void dump_impl(bool jcmd_request, const char* archive_name, TRAPS);
   static bool is_mapped() { return FileMapInfo::dynamic_info() != nullptr; }
   static bool validate(FileMapInfo* dynamic_info);

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -268,7 +268,7 @@ private:
 public:
   FileMapHeader *header() const       { return _header; }
   static bool get_base_archive_name_from_header(const char* archive_name,
-                                                char** base_archive_name);
+                                                const char** base_archive_name);
   static bool is_preimage_static_archive(const char* file);
 
   bool init_from_file(int fd);
@@ -346,9 +346,8 @@ public:
   static void assert_mark(bool check);
 
   // File manipulation.
-  bool  initialize() NOT_CDS_RETURN_(false);
-  bool  open_for_read();
-  void  open_for_write();
+  bool  open_as_input() NOT_CDS_RETURN_(false);
+  void  open_as_output();
   void  write_header();
   void  write_region(int region, char* base, size_t size,
                      bool read_only, bool allow_exec);
@@ -425,6 +424,7 @@ public:
   }
 
  private:
+  bool  open_for_read();
   void  seek_to_position(size_t pos);
   bool  map_heap_region_impl() NOT_CDS_JAVA_HEAP_RETURN_(false);
   void  dealloc_heap_region() NOT_CDS_JAVA_HEAP_RETURN;

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -71,7 +71,6 @@ class MetaspaceShared : AllStatic {
     n_regions = 4              // total number of regions
   };
 
-  static void prepare_for_dumping() NOT_CDS_RETURN;
   static void preload_and_dump(TRAPS) NOT_CDS_RETURN;
 #ifdef _LP64
   static void adjust_heap_sizes_for_dumping() NOT_CDS_JAVA_HEAP_RETURN;

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -897,14 +897,13 @@ jint universe_init() {
   ClassLoaderData::init_null_class_loader_data();
 
 #if INCLUDE_CDS
-  DynamicArchive::check_for_dynamic_dump();
   if (CDSConfig::is_using_archive()) {
     // Read the data structures supporting the shared spaces (shared
     // system dictionary, symbol table, etc.)
     MetaspaceShared::initialize_shared_spaces();
   }
   if (CDSConfig::is_dumping_archive()) {
-    MetaspaceShared::prepare_for_dumping();
+    CDSConfig::prepare_for_dumping();
   }
 #endif
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3708,7 +3708,7 @@ jint Arguments::apply_ergo() {
     CompressedKlassPointers::pre_initialize();
   }
 
-  CDSConfig::initialize();
+  CDSConfig::ergo_initialize();
 
   // Initialize Metaspace flags and alignments
   Metaspace::ergo_initialize();

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -426,10 +426,9 @@ void before_exit(JavaThread* thread, bool halt) {
 #if INCLUDE_CDS
   // Dynamic CDS dumping must happen whilst we can still reliably
   // run Java code.
-  DynamicArchive::dump_at_exit(thread, ArchiveClassesAtExit);
+  DynamicArchive::dump_at_exit(thread);
   assert(!thread->has_pending_exception(), "must be");
 #endif
-
 
   // Actual shutdown logic begins here.
 

--- a/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,7 +265,7 @@ bool read_string(struct ps_prochandle* ph, uintptr_t addr, char* buf, size_t siz
 
 #ifdef LINUX
 // mangled name of CDSConfig::_static_archive_path
-#define SHARED_ARCHIVE_PATH_SYM "_ZN9CDSConfig20_static_archive_pathE"
+#define SHARED_ARCHIVE_PATH_SYM "_ZN9CDSConfig26_input_static_archive_pathE"
 #define USE_SHARED_SPACES_SYM "UseSharedSpaces"
 #define SHARED_BASE_ADDRESS_SYM "SharedBaseAddress"
 #define LIBJVM_NAME "/libjvm.so"
@@ -273,7 +273,7 @@ bool read_string(struct ps_prochandle* ph, uintptr_t addr, char* buf, size_t siz
 
 #ifdef __APPLE__
 // mangled name of CDSConfig::_static_archive_path
-#define SHARED_ARCHIVE_PATH_SYM "__ZN9CDSConfig20_static_archive_pathE"
+#define SHARED_ARCHIVE_PATH_SYM "__ZN9CDSConfig26_input_static_archive_pathE"
 #define USE_SHARED_SPACES_SYM "_UseSharedSpaces"
 #define SHARED_BASE_ADDRESS_SYM "_SharedBaseAddress"
 #define LIBJVM_NAME "/libjvm.dylib"

--- a/test/hotspot/jtreg/runtime/cds/appcds/AOTFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/AOTFlags.java
@@ -25,13 +25,14 @@
 /*
  * @test
  * @summary "AOT" aliases for traditional CDS command-line options
- * @requires vm.cds
+ * @requires vm.cds & vm.compMode != "Xcomp"
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build Hello
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello.jar Hello
  * @run driver AOTFlags
  */
 
+import java.io.File;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -297,6 +298,60 @@ public class AOTFlags {
         out.shouldContain("class path and/or module path are not compatible with the ones " +
                           "specified when the AOTConfiguration file was recorded");
         out.shouldContain("Unable to use create AOT cache");
+        out.shouldHaveExitValue(1);
+
+        //----------------------------------------------------------------------
+        printTestCase("Cannot use multiple paths in AOTConfiguration");
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-XX:AOTMode=record",
+            "-XX:AOTConfiguration=" + aotConfigFile + File.pathSeparator + "dummy",
+            "-cp", "noSuchJar.jar");
+
+        out = CDSTestUtils.executeAndLog(pb, "neg");
+        out.shouldContain("Option AOTConfiguration must specify a single file name");
+        out.shouldHaveExitValue(1);
+
+        //----------------------------------------------------------------------
+        printTestCase("Cannot use multiple paths in AOTCache");
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-XX:AOTMode=create",
+            "-XX:AOTConfiguration=" + aotConfigFile,
+            "-XX:AOTCache=" + aotCacheFile + File.pathSeparator + "dummy",
+            "-cp", "noSuchJar.jar");
+
+        out = CDSTestUtils.executeAndLog(pb, "neg");
+        out.shouldContain("Option AOTCache must specify a single file name");
+        out.shouldHaveExitValue(1);
+
+        //----------------------------------------------------------------------
+        printTestCase("Cannot use a dynamic CDS archive for -XX:AOTCache");
+        String staticArchive = "static.jsa";
+        String dynamicArchive = "dynamic.jsa";
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xshare:dump",
+            "-XX:SharedArchiveFile=" + staticArchive);
+        out = CDSTestUtils.executeAndLog(pb, "static");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-XX:SharedArchiveFile=" + staticArchive,
+            "-XX:ArchiveClassesAtExit=" + dynamicArchive,
+            "--version");
+        out = CDSTestUtils.executeAndLog(pb, "dynamic");
+        out.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xlog:cds",
+            "-XX:AOTMode=on",
+            "-XX:AOTCache=" + dynamicArchive,
+            "--version");
+
+        out = CDSTestUtils.executeAndLog(pb, "neg");
+        out.shouldContain("Unable to use AOT cache.");
+        out.shouldContain("Not a valid AOT cache (dynamic.jsa)");
         out.shouldHaveExitValue(1);
     }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -163,7 +163,7 @@ public class SharedArchiveFileOption extends DynamicArchiveTestBase {
 
         testcase("A dynamic archive is already loaded when -XX:SharedArchiveFile is specified");
         dump2(baseArchiveName /*this is overridden by -XX:SharedArchiveFile= below*/,
-              topArchiveName,
+              topArchiveName + "dummy",
               "-XX:SharedArchiveFile=" + topArchiveName,
               "-cp", appJar, mainClass)
             .assertAbnormalExit("-XX:ArchiveClassesAtExit is unsupported when a dynamic CDS archive is specified in -XX:SharedArchiveFile:");

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -163,7 +163,7 @@ public class SharedArchiveFileOption extends DynamicArchiveTestBase {
 
         testcase("A dynamic archive is already loaded when -XX:SharedArchiveFile is specified");
         dump2(baseArchiveName /*this is overridden by -XX:SharedArchiveFile= below*/,
-              topArchiveName + "dummy",
+              topArchiveName,
               "-XX:SharedArchiveFile=" + topArchiveName,
               "-cp", appJar, mainClass)
             .assertAbnormalExit("-XX:ArchiveClassesAtExit is unsupported when a dynamic CDS archive is specified in -XX:SharedArchiveFile:");

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
@@ -337,7 +337,7 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
                       .shouldContain(HELLO_WORLD)
                       .shouldContain("The shared archive file version " + hex(version2) + " does not match the required version " + hex(currentCDSVersion))
                       .shouldContain("The shared archive file has the wrong version")
-                      .shouldContain("Initialize dynamic archive failed")
+                      .shouldContain("Loading dynamic archive failed")
                       .shouldContain("Dumping shared data to file");
             });
         ft2 = Files.getLastModifiedTime(Paths.get(modVersion));

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ public class TestAutoCreateSharedArchiveNoDefaultArchive {
                                                          "-version");
             TestCommon.executeAndLog(pb, "show-version")
                       .shouldHaveExitValue(0)
-                      .shouldContain("Initialize static archive failed")
+                      .shouldContain("Loading static archive failed")
                       .shouldContain("Unable to map shared spaces")
                       .shouldNotContain("sharing");
         }
@@ -132,7 +132,7 @@ public class TestAutoCreateSharedArchiveNoDefaultArchive {
                                                          mainClass);
             TestCommon.executeAndLog(pb, "no-default-archive")
                       .shouldHaveExitValue(0)
-                      .shouldContain("Initialize static archive failed")
+                      .shouldContain("Loading static archive failed")
                       .shouldContain("Unable to map shared spaces")
                       .shouldNotContain("Dumping shared data to file");
             if (jsaFile.exists()) {


### PR DESCRIPTION
Since [JEP 483: Ahead-of-Time Class Loading & Linking](https://openjdk.org/jeps/483), VM options such as `-XX:AOTCache `are implemented as aliases of "classical" CDS options such as `-XX:SharedArchiveFile`.

In anticipation of the [JEP: Ahead-of-time Command Line Ergonomics](https://bugs.openjdk.org/browse/JDK-8350022), we should refactor the code that deals with the AOT options. Specifically, as we expect the JVM to be able to load from an "input AOT cache" and write to an "output AOT cache", we should clearly identify the input and output caches in separate APIs:

```
const char* CDSConfig::input_static_archive_path();
const char* CDSConfig::input_dynamic_archive_path();
const char* CDSConfig::output_archive_path();
```

This PR also cleans up the code by:
- renaming a few function to reflect what they actually do
- moving more "config" management code into cdsConfig.cpp

There's also a behavioral bug fix: before this PR, `-XX:AOTCache` was handled by the `ergo_init_classic_archive_paths()` function, which allows two files to be specified. E.g., `java -XX:AOTCache=static.jsa:dynamic.jsa`. That's because `-XX:AOTCache` was implemented as an alias of `-XX:SharedArchiveFile`, and the latter allows this usage.

However, this behavior is not specified in JEP 483. Allowing two files in -XX:AOTCache will cause unnecessary complexity when we implement [JDK-8353598: Allow AOT cache to be used in training run](https://bugs.openjdk.org/browse/JDK-8353598). Therefore, I added new test cases to disallow the use of two files.  This also means that we don't need to modify  the already over-complicated `ergo_init_classic_archive_paths()` for the AOT use cases