### PR TITLE
add a jcmd tool to print all threads and vthreads info (including unmounted vts and lock information)

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -746,6 +746,8 @@ class SerializeClosure;
   template(jdk_internal_vm_JcmdVThreadCommands,    "jdk/internal/vm/JcmdVThreadCommands")                         \
   template(printScheduler_name,                    "printScheduler")                                              \
   template(printPollers_name,                      "printPollers")                                                \
+  template(dumpThreadsAndVThreads_name,            "dumpThreadsAndVThreads")                                      \
+  template(void_thread_array_signature,            "()[Ljava/lang/Thread;")                                       \
 
   /*end*/
 

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1543,6 +1543,7 @@ void JavaThread::print_on(outputStream *st, bool print_extended_info) const {
   st->print_cr("[" INTPTR_FORMAT "]", (intptr_t)last_Java_sp() & ~right_n_bits(12));
   if (thread_oop != nullptr) {
     if (is_vthread_mounted()) {
+      st->print_cr("   java.lang.Thread.State: %s", java_lang_Thread::thread_status_name(thread_oop));
       st->print_cr("   Carrying virtual thread #" INT64_FORMAT, java_lang_Thread::thread_id(vthread()));
     } else {
       st->print_cr("   java.lang.Thread.State: %s", java_lang_Thread::thread_status_name(thread_oop));

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -482,7 +482,7 @@ void Thread::print_on(outputStream* st, bool print_extended_info) const {
     }
 
     st->print("tid=" INTPTR_FORMAT " ", p2i(this));
-    if (!is_Java_thread() || !JavaThread::cast(this)->is_vthread_mounted()) {
+    if (!is_Java_thread() || !JavaThread::cast(this)->is_vthread_mounted() || JavaThread::cast(this)->is_handshake_safe_for(Thread::current())) {
       osthread()->print_on(st);
     }
   }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1362,7 +1362,7 @@ void Threads::print_on(outputStream* st, bool print_stacks,
       } else {
         p->print_stack_on(st);
         if (p->is_vthread_mounted()) {
-          st->print_cr("   Mounted virtual thread #" INT64_FORMAT, java_lang_Thread::thread_id(p->vthread()));
+          st->print_cr("   Mounted virtual thread \"%s\" #" INT64_FORMAT, JavaThread::name_for(p->vthread()), java_lang_Thread::thread_id(p->vthread()));
           p->print_vthread_stack_on(st);
         }
       }

--- a/src/hotspot/share/runtime/vframe.hpp
+++ b/src/hotspot/share/runtime/vframe.hpp
@@ -140,6 +140,7 @@ class javaVFrame: public vframe {
   // printing used during stack dumps and diagnostics
   static void print_locked_object_class_name(outputStream* st, Handle obj, const char* lock_state);
   void print_lock_info_on(outputStream* st, int frame_count);
+  void print_unmounted_vthread_lock_info_on(outputStream* st, int frame_count, oop vthread);
   void print_lock_info(int frame_count) { print_lock_info_on(tty, frame_count); }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -803,6 +803,21 @@ public:
   virtual void execute(DCmdSource source, TRAPS);
 };
 
+class ThreadAndVThreadDumpDCmd : public DCmdWithParser {
+  public:
+    ThreadAndVThreadDumpDCmd(outputStream *output, bool heap) : DCmdWithParser(output, heap) {}
+    static const char *name() {
+      return "ThreadAndVThread.dump";
+    }
+    static const char *description() {
+      return "Dump all threads and virtual threads, with stack traces.";
+    }
+    static const char* impact() {
+      return "Medium: Depends on the number of threads and virtual threads.";
+    }
+    virtual void execute(DCmdSource source, TRAPS);
+  };
+
 class CompilationMemoryStatisticDCmd: public DCmdWithParser {
 protected:
   DCmdArgument<bool> _human_readable;

--- a/src/java.base/share/classes/jdk/internal/vm/ThreadDumper.java
+++ b/src/java.base/share/classes/jdk/internal/vm/ThreadDumper.java
@@ -367,4 +367,13 @@ public class ThreadDumper {
             return -1L;
         }
     }
+
+    public static Thread[] dumpThreadsAndVThreads() {
+        List<Thread> allThreadList = new ArrayList<>();
+        List<ThreadContainer> containers = allContainers();
+        containers.forEach(container -> {
+            allThreadList.addAll(container.threads().toList());
+        });
+        return allThreadList.toArray(new Thread[0]);
+    }
 }

--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -101,3 +101,6 @@ runtime/logging/LoaderConstraintsTest.java 8346442 generic-all
 runtime/Thread/AsyncExceptionOnMonitorEnter.java 0000000 generic-all
 runtime/Thread/StopAtExit.java 0000000 generic-all
 runtime/handshake/HandshakeWalkStackTest.java 0000000 generic-all
+
+# changed in loom repo to only print thread ID of mounted thread
+serviceability/dcmd/thread/PrintMountedVirtualThread.java 0000000 generic-all


### PR DESCRIPTION
I think it may be useful to add a tool which can print more information about the unmounted virtual threads after the JEP491.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24405/head:pull/24405` \
`$ git checkout pull/24405`

Update a local copy of the PR: \
`$ git checkout pull/24405` \
`$ git pull https://git.openjdk.org/jdk.git pull/24405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24405`

View PR using the GUI difftool: \
`$ git pr show -t 24405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24405.diff">https://git.openjdk.org/jdk/pull/24405.diff</a>

</details>
