### PR TITLE
8340341: Warn in configure when using Xcode 16.0 or 16.1

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -291,6 +291,11 @@ AC_DEFUN_ONCE([TOOLCHAIN_PRE_DETECTION],
       # For Xcode, we set the Xcode version as TOOLCHAIN_VERSION
       TOOLCHAIN_VERSION=`$ECHO $XCODE_VERSION_OUTPUT | $CUT -f 2 -d ' '`
       TOOLCHAIN_DESCRIPTION="$TOOLCHAIN_DESCRIPTION from Xcode $TOOLCHAIN_VERSION"
+      if test "x$TOOLCHAIN_VERSION" = "x16" || test "x$TOOLCHAIN_VERSION" = "x16.1" ; then
+        AC_MSG_NOTICE([Xcode $TOOLCHAIN_VERSION has a compiler bug that causes the build to fail.])
+        AC_MSG_NOTICE([Please use Xcode 16.2 or later, or a version prior to 16.])
+        AC_MSG_ERROR([Compiler version is not supported.])
+      fi
     fi
   fi
   AC_SUBST(TOOLCHAIN_VERSION)


### PR DESCRIPTION
The JDK mainline build when using XCode 16 or 16.1 fails with:

```
* For target buildtools_create_symbols_javac__the.COMPILE_CREATE_SYMBOLS_batch:
Exception in thread "main" java.lang.ClassFormatError: StackMapTable format error: bad verification type
        at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:64)
        at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:52)
```

This is due to a compiler bug in Xcode, which was fixed in 16.2. We should catch this at configure time, since the build error is very confusing.