### PR TITLE
8315844: $LSB_RELEASE is not defined before use

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,7 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   UTIL_LOOKUP_PROGS(LOCALE, locale)
   UTIL_LOOKUP_PROGS(PATHTOOL, cygpath wslpath)
   UTIL_LOOKUP_PROGS(CMD, cmd.exe, $PATH:/cygdrive/c/windows/system32:/mnt/c/windows/system32:/c/windows/system32)
+  UTIL_LOOKUP_PROGS(LSB_RELEASE, lsb_release)
 ])
 
 ################################################################################
@@ -105,9 +106,6 @@ AC_DEFUN_ONCE([BASIC_SETUP_TOOLS],
   UTIL_LOOKUP_PROGS(NICE, nice)
   UTIL_LOOKUP_PROGS(READLINK, greadlink readlink)
   UTIL_LOOKUP_PROGS(WHOAMI, whoami)
-
-  # Tools only needed on some platforms
-  UTIL_LOOKUP_PROGS(LSB_RELEASE, lsb_release)
 
   # For compare.sh only
   UTIL_LOOKUP_PROGS(CMP, cmp)


### PR DESCRIPTION
When running configure on WSL, the following error message is printed, instead of proper Linux environment info:

```
    /build/.configure-support/generated-configure.sh: line 13102: -d: command not found 
```

This is due to us calling `$LSB_RELEASE -d`, but LSB_RELEASE is not yet defined at that point in time. Fix this by moving the LSB_RELEASE check forward.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315844](https://bugs.openjdk.org/browse/JDK-8315844): $LSB_RELEASE is not defined before use (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24409/head:pull/24409` \
`$ git checkout pull/24409`

Update a local copy of the PR: \
`$ git checkout pull/24409` \
`$ git pull https://git.openjdk.org/jdk.git pull/24409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24409`

View PR using the GUI difftool: \
`$ git pr show -t 24409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24409.diff">https://git.openjdk.org/jdk/pull/24409.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24409#issuecomment-2775188471)
</details>
