### PR TITLE
8351660: C2: SIGFPE in unsigned_mod_value

### DIFF
--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -1319,6 +1319,11 @@ static const Type* unsigned_mod_value(PhaseGVN* phase, const Node* mod) {
     return TypeClass::ZERO;
   }
 
+  // Mod by zero?  Throw exception at runtime!
+  if (type_divisor->is_con() && type_divisor->get_con() == 0) {
+    return TypeClass::POS;
+  }
+
   const TypeClass* type_dividend = t1->cast<TypeClass>();
   if (type_dividend->is_con() && type_divisor->is_con()) {
     Unsigned dividend = static_cast<Unsigned>(type_dividend->get_con());

--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -1319,7 +1319,7 @@ static const Type* unsigned_mod_value(PhaseGVN* phase, const Node* mod) {
     return TypeClass::ZERO;
   }
 
-  // Mod by zero?  Throw exception at runtime!
+  // Mod by zero?  Throw an exception at runtime!
   if (type_divisor->is_con() && type_divisor->get_con() == 0) {
     return TypeClass::POS;
   }

--- a/test/hotspot/jtreg/compiler/integerArithmetic/TestUnsignedModByZero.java
+++ b/test/hotspot/jtreg/compiler/integerArithmetic/TestUnsignedModByZero.java
@@ -50,7 +50,7 @@
     }
 
      public static void main(String[] args) {
-        for (int i =0; i < 10_000; i++) {
+        for (int i = 0; i < 10_000; i++) {
              Asserts.assertThrows(ArithmeticException.class, TestUnsignedModByZero::testInt);
              Asserts.assertThrows(ArithmeticException.class, TestUnsignedModByZero::testLong);
         }

--- a/test/hotspot/jtreg/compiler/integerArithmetic/TestUnsignedModByZero.java
+++ b/test/hotspot/jtreg/compiler/integerArithmetic/TestUnsignedModByZero.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8351660
+ * @summary Test that modulo by zero throws exception at runtime in case of unsigned values.
+ * @library /test/lib
+ * @run main/othervm -Xbatch
+ *                   -XX:CompileCommand=compileonly,compiler.integerArithmetic.TestUnsignedModByZero::testInt
+ *                   -XX:CompileCommand=compileonly,compiler.integerArithmetic.TestUnsignedModByZero::testLong
+ *                   compiler.integerArithmetic.TestUnsignedModByZero
+ */
+
+ package compiler.integerArithmetic;
+
+ import jdk.test.lib.Asserts;
+
+
+ public class TestUnsignedModByZero {
+
+     public static Object testInt() {
+        double x = 1.0;
+        return Long.remainderUnsigned(1, (long)(x % x));
+    }
+
+     public static Object testLong() {
+        double x = 1.0;
+        return Long.remainderUnsigned(1, (long)(x % x));
+    }
+
+     public static void main(String[] args) {
+        for (int i =0; i < 10_000; i++) {
+             Asserts.assertThrows(ArithmeticException.class, TestUnsignedModByZero::testInt);
+             Asserts.assertThrows(ArithmeticException.class, TestUnsignedModByZero::testLong);
+        }
+     }
+ }

--- a/test/hotspot/jtreg/compiler/integerArithmetic/TestUnsignedModByZero.java
+++ b/test/hotspot/jtreg/compiler/integerArithmetic/TestUnsignedModByZero.java
@@ -41,7 +41,7 @@
 
      public static Object testInt() {
         double x = 1.0;
-        return Long.remainderUnsigned(1, (long)(x % x));
+        return Integer.remainderUnsigned(1, (int)(x % x));
     }
 
      public static Object testLong() {

--- a/test/hotspot/jtreg/compiler/integerArithmetic/TestUnsignedModByZero.java
+++ b/test/hotspot/jtreg/compiler/integerArithmetic/TestUnsignedModByZero.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8351660
- * @summary Test that modulo by zero throws exception at runtime in case of unsigned values.
+ * @summary Test that modulo by zero throws an exception at runtime in case of unsigned values.
  * @library /test/lib
  * @run main/othervm -Xbatch
  *                   -XX:CompileCommand=compileonly,compiler.integerArithmetic.TestUnsignedModByZero::testInt


### PR DESCRIPTION
Description :: The test program performs a`Long.remainderUnsigned` which triggers the call to the function `unsigned_mod_value`. At the end of `unsigned_mod_value` the expression,` return TypeClass::make(static_cast<Signed>(dividend % divisor))`, is computed which leads to a SIGFPE as the divisor in the test program is zero. The same behaviour was observed when the ` Long.remainderUnsigned` was replaced with `Integer.remainderUnsigned` in the test program. 

Solution :: The fix for [JDK-8345766](https://bugs.openjdk.org/browse/JDK-8345766) emitted specific ModF/ModD nodes, which is optimized and converted to runtime calls after optimizations. This was done during parsing prior to [JDK-8345766](https://bugs.openjdk.org/browse/JDK-8345766).  In the scenario where there was unsigned modulo operation as in this test, there was no check for modulo by zero that could trigger an exception during runtime. The below fix proposes a check for modulo by zero and throws exception at runtime.

A Jtreg test has been added as part of this fix. This test case is based on the original test that resulted in the bug. @eme64 is the contributor of the original test. Thank you @eme64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351660](https://bugs.openjdk.org/browse/JDK-8351660): C2: SIGFPE in unsigned_mod_value (**Bug** - P2)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**) Review applies to [667c7e7a](https://git.openjdk.org/jdk/pull/24410/files/667c7e7aa26ee42a5f019fd13ff024e9fd731b55)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)

### Contributors
 * Emanuel Peter `<epeter@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24410/head:pull/24410` \
`$ git checkout pull/24410`

Update a local copy of the PR: \
`$ git checkout pull/24410` \
`$ git pull https://git.openjdk.org/jdk.git pull/24410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24410`

View PR using the GUI difftool: \
`$ git pr show -t 24410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24410.diff">https://git.openjdk.org/jdk/pull/24410.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24410#issuecomment-2776814150)
</details>
