### PR TITLE
8353662: Add test for non-local file URL fallback to FTP

### DIFF
--- a/test/jdk/sun/net/www/protocol/file/NonLocalFtpFallback.java
+++ b/test/jdk/sun/net/www/protocol/file/NonLocalFtpFallback.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @test
+ * @bug 8353662
+ * @summary Verify long-standing behavior of resolving non-local file URLs using FTP.
+ * @run junit NonLocalFtpFallback
+ */
+
+public class NonLocalFtpFallback {
+
+    // Port 21 may not be available, use an HTTP proxy with an ephemeral port
+    private HttpServer proxyServer;
+
+    // The file requested in this test
+    private Path file;
+
+    // FTP URIs requested by the proxy client
+    private Set<URI> uris = new HashSet<>();
+
+    /**
+     * Set up the HTTP proxy used for serving FTP in this test
+     *
+     * @throws IOException if an unexpected IO error occurs
+     */
+    @BeforeEach
+    public void setup() throws IOException {
+        // Create a file with some random data
+        byte[] data = new byte[512];
+        new Random().nextBytes(data);
+        file = Files.write(Path.of("ftp-file.txt"), data);
+
+        // Set up an HTTP proxy server
+        proxyServer = HttpServer.create();
+        // Bind to the loopback address with an ephemeral port
+        InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
+        proxyServer.bind(new InetSocketAddress(loopbackAddress, 0), 0);
+        // Handler for the FTP proxy request
+        proxyServer.createContext("/", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                // Record the URI requested
+                uris.add(exchange.getRequestURI());
+                // Send the data
+                exchange.sendResponseHeaders(200, Files.size(file));
+                try (OutputStream out = exchange.getResponseBody()) {
+                    Files.copy(file, out);
+                }
+                // Complete the exchange
+                exchange.close();
+            }
+        });
+        // Start the proxy server
+        proxyServer.start();
+    }
+
+    /**
+     * Shut down proxy server and clean up files created
+     *
+     * @throws IOException if an unexpected IO error occurs
+     */
+    @AfterEach
+    public void destroy() throws IOException {
+        proxyServer.stop(2);
+        Files.delete(file);
+    }
+
+    /**
+     * Verifies the long-standing and unspecified FTP fallback feature where the file
+     * URL scheme handler attempts an FTP connection for non-local files.
+     *
+     * The non-local file URL used here is of the form file://127.0.0.1/path. Since the
+     * host component here is not equal to "localhost", this is considered a non-local
+     * URL.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void verifyNonLocalFtpFallback() throws Exception {
+        URL localURL = file.toUri().toURL();
+        URL nonLocalURL = new URL("file", "127.0.0.1", localURL.getFile());
+
+        // Open the non-local file: URL connection using a proxy
+        Proxy proxy = new Proxy(Proxy.Type.HTTP,
+                new InetSocketAddress(proxyServer.getAddress().getAddress(),
+                        proxyServer.getAddress().getPort()));
+        URLConnection con = nonLocalURL.openConnection(proxy);
+
+        // Assert that the expected file content is retrieved
+        try (InputStream in = con.getInputStream()) {
+            byte[] retrived = in.readAllBytes();
+            assertArrayEquals(Files.readAllBytes(file), retrived);
+        }
+
+        // Assert that the expected FTP URI was requested in the HTTP proxy
+        assertEquals(1, uris.size());
+        URL ftpURL = new URL("ftp", "127.0.0.1", localURL.getFile());
+        assertEquals(ftpURL.toURI(), uris.iterator().next());
+    }
+}

--- a/test/jdk/sun/net/www/protocol/file/NonLocalFtpFallback.java
+++ b/test/jdk/sun/net/www/protocol/file/NonLocalFtpFallback.java
@@ -37,6 +37,8 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -119,7 +121,9 @@ public class NonLocalFtpFallback {
     @Test
     public void verifyNonLocalFtpFallback() throws Exception {
         URL localURL = file.toUri().toURL();
-        URL nonLocalURL = new URL("file", "127.0.0.1", localURL.getFile());
+        URL nonLocalURL = new URL("file",
+                InetAddress.getLoopbackAddress().getHostAddress(),
+                localURL.getFile());
 
         // Open the non-local file: URL connection using a proxy
         Proxy proxy = new Proxy(Proxy.Type.HTTP,

--- a/test/jdk/sun/net/www/protocol/file/NonLocalFtpFallback.java
+++ b/test/jdk/sun/net/www/protocol/file/NonLocalFtpFallback.java
@@ -121,9 +121,9 @@ public class NonLocalFtpFallback {
     @Test
     public void verifyNonLocalFtpFallback() throws Exception {
         URL localURL = file.toUri().toURL();
-        URL nonLocalURL = new URL("file",
-                InetAddress.getLoopbackAddress().getHostAddress(),
-                localURL.getFile());
+        // We can use a fake host name here, no actual FTP request will be made
+        String hostname = "remotehost";
+        URL nonLocalURL = new URL("file", hostname, localURL.getFile());
 
         // Open the non-local file: URL connection using a proxy
         Proxy proxy = new Proxy(Proxy.Type.HTTP,
@@ -139,7 +139,7 @@ public class NonLocalFtpFallback {
 
         // Assert that the expected FTP URI was requested in the HTTP proxy
         assertEquals(1, uris.size());
-        URL ftpURL = new URL("ftp", "127.0.0.1", localURL.getFile());
+        URL ftpURL = new URL("ftp", hostname, localURL.getFile());
         assertEquals(ftpURL.toURI(), uris.iterator().next());
     }
 }


### PR DESCRIPTION
Please review this test-only PR which introduces testing of the unspecified but long-standing fallback to FTP for non-local files in the 'file' URL scheme. 

This in preparation for the upcoming proposal to disable the feature by default in JDK-8353440.

Since we cannot reliably bind an FTP server to port 21, the test instead uses an HTTP proxy, binding to an ephemeral port. This menas we don't test non-proxy code paths. We still test that the FTP fallback is used, which is the key point here. (We aim to test file URL connections, not FTP URL connection internals) 

An alternative here could be to just verify that the returned URLConnection is an instance of FtpURLConnection. However, I opted for an end-to-end test here, since the amount of extra code seems reasonable.

By temporarly moving this test to tier1, I was able to confirm this test runs green also on Windows GHA.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353662](https://bugs.openjdk.org/browse/JDK-8353662): Add test for non-local file URL fallback to FTP (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24418/head:pull/24418` \
`$ git checkout pull/24418`

Update a local copy of the PR: \
`$ git checkout pull/24418` \
`$ git pull https://git.openjdk.org/jdk.git pull/24418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24418`

View PR using the GUI difftool: \
`$ git pr show -t 24418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24418.diff">https://git.openjdk.org/jdk/pull/24418.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24418#issuecomment-2777550555)
</details>
