### PR TITLE
8353665: RISC-V: IR verification fails in TestSubNodeFloatDoubleNegation.java

### DIFF
--- a/test/hotspot/jtreg/compiler/floatingpoint/TestSubNodeFloatDoubleNegation.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/TestSubNodeFloatDoubleNegation.java
@@ -55,7 +55,8 @@ public class TestSubNodeFloatDoubleNegation {
     @Test
     // Match a generic SubNode, because scalar Float16 operations are often
     // performed as float operations.
-    @IR(counts = { IRNode.SUB, "2" })
+    @IR(counts = { IRNode.SUB, "2" }, applyIfPlatform = {"riscv64", "false"})
+    @IR(counts = { IRNode.SUB, ">= 2" }, applyIfPlatform = {"riscv64", "true"})
     // Checks that the subtractions in 0 - (0 - hf) do not get eliminiated
     public static Float16 testHalfFloat(Float16 hf) {
         return Float16.subtract(


### PR DESCRIPTION
Hi,
Can you help to review this patch?
The newly added TestSubNodeFloatDoubleNegation.java (in https://github.com/openjdk/jdk/pull/24150) is to check `0 - (0 - x)` is not folded to `x` for float and double.
I have manually checked the IR and generated assembly code, it's not folded on riscv either, just there is an extra SubF in some code path.
So, the fix for this test on riscv should be simply make the check as `>= 2` rather than `2`.

Thanks