### PR TITLE
8353669: IGV: dump OOP maps for MachSafePoint nodes

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -667,6 +667,15 @@ void IdealGraphPrinter::visit_node(Node* n, bool edges) {
       print_prop("lrg", lrg_id);
     }
 
+    if (node->is_MachSafePoint()) {
+      const OopMap* oopmap = node->as_MachSafePoint()->oop_map();
+      if (oopmap != nullptr) {
+        stringStream oopmap_stream;
+        oopmap->print_on(&oopmap_stream);
+        print_prop("oopmap", oopmap_stream.freeze());
+      }
+    }
+
     Compile::current()->_in_dump_cnt--;
 
     tail(PROPERTIES_ELEMENT);


### PR DESCRIPTION
This changeset dumps the OOP map of each MachSafePoint when available, i.e. at the `Final Code` phase. This should make it easier to learn about and diagnose OOP map building issues:

![final-code](https://github.com/user-attachments/assets/a477c9d1-0fe4-42ef-a367-336c54bec6a5)

#### Testing

- tier1 (windows-x64, linux-x64, linux-aarch64, macosx-x64, and macosx-aarch64; release and debug mode).
- Tested IGV manually on a few selected graphs. Tested automatically that dumping thousands of graphs does not trigger any assertion failure (by running `java -Xcomp -XX:PrintIdealGraphLevel=1`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353669](https://bugs.openjdk.org/browse/JDK-8353669): IGV: dump OOP maps for MachSafePoint nodes (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24422/head:pull/24422` \
`$ git checkout pull/24422`

Update a local copy of the PR: \
`$ git checkout pull/24422` \
`$ git pull https://git.openjdk.org/jdk.git pull/24422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24422`

View PR using the GUI difftool: \
`$ git pr show -t 24422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24422.diff">https://git.openjdk.org/jdk/pull/24422.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24422#issuecomment-2777964541)
</details>
