### PR TITLE
8351354: Enhance java -XshowSettings:security:tls to show enabled TLS groups and signature algorithms

### DIFF
--- a/src/java.base/share/classes/sun/launcher/SecuritySettings.java
+++ b/src/java.base/share/classes/sun/launcher/SecuritySettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.io.PrintStream;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.Security;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -136,7 +137,28 @@ public final class SecuritySettings {
             for (String s : ssls.getEnabledCipherSuites()) {
                 ostream.println(THREEINDENT + s);
             }
+
+            ostream.println("\n" + TWOINDENT + "Enabled Groups:");
+            String [] groups = ssls.getSSLParameters().getNamedGroups();
+            if (groups == null) {
+                ostream.println(THREEINDENT + "<none>");
+            } else {
+                for (String s : groups) {
+                    ostream.println(THREEINDENT + s);
+                }
+            }
+
+            ostream.println("\n" + TWOINDENT + "Enabled Signature Algorithms:");
+            String [] schemes = ssls.getSSLParameters().getSignatureSchemes();
+            if (schemes == null) {
+                ostream.println(THREEINDENT + "<none>");
+            } else {
+                for (String s : schemes) {
+                    ostream.println(THREEINDENT + s);
+                }
+            }
         }
+
         ostream.println();
     }
 


### PR DESCRIPTION
In this PR I added TLS groups and signature algorithms to the output of the show settings flag. The values are printed in a single column, like the cipher suites. There can be a lot of values so putting on a single line is ugly. I tried putting them in columns, but it is hard to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351354](https://bugs.openjdk.org/browse/JDK-8351354): Enhance java -XshowSettings:security:tls to show enabled TLS groups and signature algorithms (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24424/head:pull/24424` \
`$ git checkout pull/24424`

Update a local copy of the PR: \
`$ git checkout pull/24424` \
`$ git pull https://git.openjdk.org/jdk.git pull/24424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24424`

View PR using the GUI difftool: \
`$ git pr show -t 24424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24424.diff">https://git.openjdk.org/jdk/pull/24424.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24424#issuecomment-2776661341)
</details>
