### PR TITLE
8353681: jpackage suppresses errors when executed with --verbose option

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Arguments.java
@@ -551,16 +551,13 @@ public class Arguments {
             generateBundle(bp.getBundleParamsAsMap());
             return true;
         } catch (Exception e) {
-            if (Log.isVerbose()) {
-                Log.verbose(e);
-            } else {
-                String msg1 = e.getMessage();
-                Log.fatalError(msg1);
-                if (e.getCause() != null && e.getCause() != e) {
-                    String msg2 = e.getCause().getMessage();
-                    if (msg2 != null && !msg1.contains(msg2)) {
-                        Log.fatalError(msg2);
-                    }
+            Log.verbose(e);
+            String msg1 = e.getMessage();
+            Log.fatalError(msg1);
+            if (e.getCause() != null && e.getCause() != e) {
+                String msg2 = e.getCause().getMessage();
+                if (msg2 != null && !msg1.contains(msg2)) {
+                    Log.fatalError(msg2);
                 }
             }
             return false;

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -42,7 +42,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1174,16 +1173,20 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
     }
 
     public static Stream<String> stripTimestamps(Stream<String> stream) {
-        // [HH:mm:ss.SSS]
-        final Pattern timestampRegexp = Pattern.compile(
-                "^\\[\\d\\d:\\d\\d:\\d\\d.\\d\\d\\d\\] ");
-        return stream.map(str -> {
-            Matcher m = timestampRegexp.matcher(str);
-            if (m.find()) {
-                str = str.substring(m.end());
-            }
+        return stream.map(JPackageCommand::stripTimestamp);
+    }
+
+    public static String stripTimestamp(String str) {
+        final var m = TIMESTAMP_REGEXP.matcher(str);
+        if (m.find()) {
+            return str.substring(m.end());
+        } else {
             return str;
-        });
+        }
+    }
+
+    public static boolean withTimestamp(String str) {
+        return TIMESTAMP_REGEXP.matcher(str).find();
     }
 
     @Override
@@ -1279,4 +1282,8 @@ public class JPackageCommand extends CommandArguments<JPackageCommand> {
     }).get();
 
     private static final String UNPACKED_PATH_ARGNAME = "jpt-unpacked-folder";
+
+    // [HH:mm:ss.SSS]
+    private static final Pattern TIMESTAMP_REGEXP = Pattern.compile(
+            "^\\[\\d\\d:\\d\\d:\\d\\d.\\d\\d\\d\\] ");
 }


### PR DESCRIPTION
Always print error messages from the last trapped exception to stderr. Optionally, print its stasktrace to stdout when in verbose mode.

Add relevant test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8353681: jpackage suppresses errors when executed with --verbose option`

### Issue
 * [JDK-8353681](https://bugs.openjdk.org/browse/JDK-8353681): jpackage suppresses errors when executed with --verbose option (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24428/head:pull/24428` \
`$ git checkout pull/24428`

Update a local copy of the PR: \
`$ git checkout pull/24428` \
`$ git pull https://git.openjdk.org/jdk.git pull/24428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24428`

View PR using the GUI difftool: \
`$ git pr show -t 24428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24428.diff">https://git.openjdk.org/jdk/pull/24428.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24428#issuecomment-2777322667)
</details>
