### PR TITLE
8353692: Relax memory constraint on updating ObjectMonitorTable's item count

### DIFF
--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -115,15 +115,16 @@ class ObjectMonitorTable : AllStatic {
   };
 
   static void inc_items_count() {
-    Atomic::inc(&_items_count);
+    Atomic::inc(&_items_count, memory_order_relaxed);
   }
 
   static void dec_items_count() {
-    Atomic::dec(&_items_count);
+    Atomic::dec(&_items_count, memory_order_relaxed);
   }
 
   static double get_load_factor() {
-    return (double)_items_count / (double)_table_size;
+    size_t count = Atomic::load(&_items_count);
+    return (double)count / (double)_table_size;
   }
 
   static size_t table_size(Thread* current = Thread::current()) {


### PR DESCRIPTION
It is a simple atomic counter for tracking hash table's load factor, only needs atomic guarantee.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353692](https://bugs.openjdk.org/browse/JDK-8353692): Relax memory constraint on updating ObjectMonitorTable's item count (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24432/head:pull/24432` \
`$ git checkout pull/24432`

Update a local copy of the PR: \
`$ git checkout pull/24432` \
`$ git pull https://git.openjdk.org/jdk.git pull/24432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24432`

View PR using the GUI difftool: \
`$ git pr show -t 24432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24432.diff">https://git.openjdk.org/jdk/pull/24432.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24432#issuecomment-2777344328)
</details>
