### PR TITLE
8353695: RISC-V: compiler/cpuflags/TestAESIntrinsicsOnUnsupportedConfig.java is failing with Zvkn

### DIFF
--- a/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java
@@ -26,7 +26,7 @@
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @requires vm.cpu.features ~= ".*aes.*" & !vm.graal.enabled
+ * @requires (vm.cpu.features ~= ".*aes.*" | vm.cpu.features ~= ".*zvkn.*") & !vm.graal.enabled
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=600 -Xbootclasspath/a:.

--- a/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnUnsupportedConfig.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnUnsupportedConfig.java
@@ -28,7 +28,7 @@
  *          java.management
  *
  * @build jdk.test.whitebox.WhiteBox
- * @requires !(vm.cpu.features ~= ".*aes.*")
+ * @requires !(vm.cpu.features ~= ".*aes.*" | vm.cpu.features ~= ".*zvkn.*")
  * @requires vm.compiler1.enabled | !vm.graal.enabled
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -109,12 +109,13 @@ public class IREncodingPrinter {
         "asimd",
         "sve",
         "sve2",
-        // Riscv64
+        // RISCV64
         "rvv",
         "zbkb",
         "zfh",
         "zvbb",
-        "zvfh"
+        "zvfh",
+        "zvkn"
     ));
 
     public IREncodingPrinter() {


### PR DESCRIPTION
Hi, please review this small change fixing two jtreg tests.
This issue menifests after https://github.com/openjdk/jdk/pull/24344 which auto detests and enables Zvkn extension.
The two tests only consider `aes` feature string, like `!(vm.cpu.features ~= ".*aes.*")`. But the feature string is `zvkn` for linux-riscv64 platform.
This adapts "@requires" of both tests considering the Zvkn feature of this platform. Both tests works as expected with qemu-system equipped with the Zvkn extension.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353695](https://bugs.openjdk.org/browse/JDK-8353695): RISC-V: compiler/cpuflags/TestAESIntrinsicsOnUnsupportedConfig.java is failing with Zvkn (**Bug** - P4)


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24433/head:pull/24433` \
`$ git checkout pull/24433`

Update a local copy of the PR: \
`$ git checkout pull/24433` \
`$ git pull https://git.openjdk.org/jdk.git pull/24433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24433`

View PR using the GUI difftool: \
`$ git pr show -t 24433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24433.diff">https://git.openjdk.org/jdk/pull/24433.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24433#issuecomment-2777432094)
</details>
