### PR TITLE
8353694: Resolved Class/Field/Method CP entries missing from AOT Configuration

### DIFF
--- a/src/hotspot/share/cds/archiveUtils.inline.hpp
+++ b/src/hotspot/share/cds/archiveUtils.inline.hpp
@@ -78,7 +78,7 @@ Array<T>* ArchiveUtils::archive_ptr_array(GrowableArray<T>* tmp_array) {
   Array<T>* archived_array = ArchiveBuilder::new_ro_array<T>(tmp_array->length());
   for (int i = 0; i < tmp_array->length(); i++) {
       T ptr = tmp_array->at(i);
-      if (!builder->is_in_buffer_space(ptr)) {
+      if (ptr != nullptr && !builder->is_in_buffer_space(ptr)) {
         if (is_dynamic_dump && MetaspaceShared::is_in_shared_metaspace(ptr)) {
           // We have a pointer that lives in the dynamic archive but points into
           // the static archive.

--- a/src/hotspot/share/cds/finalImageRecipes.cpp
+++ b/src/hotspot/share/cds/finalImageRecipes.cpp
@@ -36,6 +36,7 @@
 #include "memory/resourceArea.hpp"
 #include "oops/constantPool.inline.hpp"
 #include "runtime/handles.inline.hpp"
+#include "runtime/mutexLocker.hpp"
 
 static FinalImageRecipes* _final_image_recipes = nullptr;
 
@@ -43,56 +44,126 @@ void* FinalImageRecipes::operator new(size_t size) throw() {
   return ArchiveBuilder::current()->ro_region_alloc(size);
 }
 
-void FinalImageRecipes::record_recipes_impl() {
-  assert(CDSConfig::is_dumping_preimage_static_archive(), "must be");
+void FinalImageRecipes::record_all_classes() {
+  _all_klasses = ArchiveUtils::archive_array(ArchiveBuilder::current()->klasses());
+  ArchivePtrMarker::mark_pointer(&_all_klasses);
+}
+
+void FinalImageRecipes::record_recipes_for_constantpool() {
   ResourceMark rm;
+
+  // The recipes are recorded regardless of CDSConfig::is_dumping_{invokedynamic,dynamic_proxies,reflection_data}().
+  // If some of these options are not enabled, the corresponding recipes will be
+  // ignored during the final image assembly.
+
+  GrowableArray<Array<int>*> tmp_cp_recipes;
+  GrowableArray<int> tmp_cp_flags;
+
   GrowableArray<Klass*>* klasses = ArchiveBuilder::current()->klasses();
-
-  // Record the indys that have been resolved in the training run. These indys will be
-  // resolved during the final image assembly.
-
-  GrowableArray<InstanceKlass*> tmp_indy_klasses;
-  GrowableArray<Array<int>*> tmp_indy_cp_indices;
-  int total_indys_to_resolve = 0;
   for (int i = 0; i < klasses->length(); i++) {
+    GrowableArray<int> cp_indices;
+    int flags = 0;
+
     Klass* k = klasses->at(i);
     if (k->is_instance_klass()) {
       InstanceKlass* ik = InstanceKlass::cast(k);
-      GrowableArray<int> indices;
+      ConstantPool* cp = ik->constants();
+      ConstantPoolCache* cp_cache = cp->cache();
 
-      if (ik->constants()->cache() != nullptr) {
-        Array<ResolvedIndyEntry>* tmp_indy_entries = ik->constants()->cache()->resolved_indy_entries();
-        if (tmp_indy_entries != nullptr) {
-          for (int i = 0; i < tmp_indy_entries->length(); i++) {
-            ResolvedIndyEntry* rie = tmp_indy_entries->adr_at(i);
-            int cp_index = rie->constant_pool_index();
-            if (rie->is_resolved()) {
-              indices.append(cp_index);
-            }
+      for (int cp_index = 1; cp_index < cp->length(); cp_index++) { // Index 0 is unused
+        if (cp->tag_at(cp_index).value() == JVM_CONSTANT_Class) {
+          Klass* k = cp->resolved_klass_at(cp_index);
+          if (k->is_instance_klass()) {
+            cp_indices.append(cp_index);
+            flags |= HAS_CLASS;
           }
         }
       }
 
-      if (indices.length() > 0) {
-        tmp_indy_klasses.append(ArchiveBuilder::current()->get_buffered_addr(ik));
-        tmp_indy_cp_indices.append(ArchiveUtils::archive_array(&indices));
-        total_indys_to_resolve += indices.length();
+      if (cp_cache != nullptr) {
+        Array<ResolvedFieldEntry>* field_entries = cp_cache->resolved_field_entries();
+        if (field_entries != nullptr) {
+          for (int i = 0; i < field_entries->length(); i++) {
+            ResolvedFieldEntry* rfe = field_entries->adr_at(i);
+            if (rfe->is_resolved(Bytecodes::_getfield) ||
+                rfe->is_resolved(Bytecodes::_putfield)) {
+              cp_indices.append(rfe->constant_pool_index());
+              flags |= HAS_FIELD_AND_METHOD;
+            }
+          }
+        }
+
+        Array<ResolvedMethodEntry>* method_entries = cp_cache->resolved_method_entries();
+        if (method_entries != nullptr) {
+          for (int i = 0; i < method_entries->length(); i++) {
+            ResolvedMethodEntry* rme = method_entries->adr_at(i);
+            if (rme->is_resolved(Bytecodes::_invokevirtual) ||
+                rme->is_resolved(Bytecodes::_invokespecial) ||
+                rme->is_resolved(Bytecodes::_invokeinterface) ||
+                rme->is_resolved(Bytecodes::_invokestatic) ||
+                rme->is_resolved(Bytecodes::_invokehandle)) {
+              cp_indices.append(rme->constant_pool_index());
+              flags |= HAS_FIELD_AND_METHOD;
+            }
+          }
+        }
+
+        Array<ResolvedIndyEntry>* indy_entries = cp_cache->resolved_indy_entries();
+        if (indy_entries != nullptr) {
+          for (int i = 0; i < indy_entries->length(); i++) {
+            ResolvedIndyEntry* rie = indy_entries->adr_at(i);
+            int cp_index = rie->constant_pool_index();
+            if (rie->is_resolved()) {
+              cp_indices.append(cp_index);
+              flags |= HAS_INDY;
+            }
+          }
+        }
+      }
+    }
+
+    if (cp_indices.length() > 0) {
+      tmp_cp_recipes.append(ArchiveUtils::archive_array(&cp_indices));
+    } else {
+      tmp_cp_recipes.append(nullptr);
+    }
+    tmp_cp_flags.append(flags);
+  }
+
+  _cp_recipes = ArchiveUtils::archive_array(&tmp_cp_recipes);
+  ArchivePtrMarker::mark_pointer(&_cp_recipes);
+
+  _cp_flags = ArchiveUtils::archive_array(&tmp_cp_flags);
+  ArchivePtrMarker::mark_pointer(&_cp_flags);
+}
+
+void FinalImageRecipes::apply_recipes_for_constantpool(JavaThread* current) {
+  assert(CDSConfig::is_dumping_final_static_archive(), "must be");
+
+  for (int i = 0; i < _all_klasses->length(); i++) {
+    Array<int>* cp_indices = _cp_recipes->at(i);
+    int flags = _cp_flags->at(i);
+    if (cp_indices != nullptr) {
+      InstanceKlass* ik = InstanceKlass::cast(_all_klasses->at(i));
+      if (ik->is_loaded()) {
+        ResourceMark rm(current);
+        ConstantPool* cp = ik->constants();
+        GrowableArray<bool> preresolve_list(cp->length(), cp->length(), false);
+        for (int j = 0; j < cp_indices->length(); j++) {
+          preresolve_list.at_put(cp_indices->at(j), true);
+        }
+        if ((flags & HAS_CLASS) != 0) {
+          AOTConstantPoolResolver::preresolve_class_cp_entries(current, ik, &preresolve_list);
+        }
+        if ((flags & HAS_FIELD_AND_METHOD) != 0) {
+          AOTConstantPoolResolver::preresolve_field_and_method_cp_entries(current, ik, &preresolve_list);
+        }
+        if ((flags & HAS_INDY) != 0) {
+          AOTConstantPoolResolver::preresolve_indy_cp_entries(current, ik, &preresolve_list);
+        }
       }
     }
   }
-
-  _all_klasses = ArchiveUtils::archive_array(klasses);
-  ArchivePtrMarker::mark_pointer(&_all_klasses);
-
-  assert(tmp_indy_klasses.length() == tmp_indy_cp_indices.length(), "must be");
-  if (tmp_indy_klasses.length() > 0) {
-    _indy_klasses = ArchiveUtils::archive_array(&tmp_indy_klasses);
-    _indy_cp_indices = ArchiveUtils::archive_array(&tmp_indy_cp_indices);
-
-    ArchivePtrMarker::mark_pointer(&_indy_klasses);
-    ArchivePtrMarker::mark_pointer(&_indy_cp_indices);
-  }
-  log_info(cds)("%d indies in %d classes will be resolved in final CDS image", total_indys_to_resolve, tmp_indy_klasses.length());
 }
 
 void FinalImageRecipes::load_all_classes(TRAPS) {
@@ -118,27 +189,11 @@ void FinalImageRecipes::load_all_classes(TRAPS) {
   }
 }
 
-void FinalImageRecipes::apply_recipes_for_invokedynamic(TRAPS) {
-  assert(CDSConfig::is_dumping_final_static_archive(), "must be");
-
-  if (CDSConfig::is_dumping_invokedynamic() && _indy_klasses != nullptr) {
-    assert(_indy_cp_indices != nullptr, "must be");
-    for (int i = 0; i < _indy_klasses->length(); i++) {
-      InstanceKlass* ik = _indy_klasses->at(i);
-      ConstantPool* cp = ik->constants();
-      Array<int>* cp_indices = _indy_cp_indices->at(i);
-      GrowableArray<bool> preresolve_list(cp->length(), cp->length(), false);
-      for (int j = 0; j < cp_indices->length(); j++) {
-        preresolve_list.at_put(cp_indices->at(j), true);
-      }
-      AOTConstantPoolResolver::preresolve_indy_cp_entries(THREAD, ik, &preresolve_list);
-    }
-  }
-}
-
 void FinalImageRecipes::record_recipes() {
+  assert(CDSConfig::is_dumping_preimage_static_archive(), "must be");
   _final_image_recipes = new FinalImageRecipes();
-  _final_image_recipes->record_recipes_impl();
+  _final_image_recipes->record_all_classes();
+  _final_image_recipes->record_recipes_for_constantpool();
 }
 
 void FinalImageRecipes::apply_recipes(TRAPS) {
@@ -159,7 +214,7 @@ void FinalImageRecipes::apply_recipes(TRAPS) {
 
 void FinalImageRecipes::apply_recipes_impl(TRAPS) {
   load_all_classes(CHECK);
-  apply_recipes_for_invokedynamic(CHECK);
+  apply_recipes_for_constantpool(THREAD);
 }
 
 void FinalImageRecipes::serialize(SerializeClosure* soc) {

--- a/src/hotspot/share/cds/finalImageRecipes.hpp
+++ b/src/hotspot/share/cds/finalImageRecipes.hpp
@@ -42,26 +42,31 @@ template <typename T> class Array;
 //   - The list of all classes that are stored in the AOTConfiguration file.
 //   - The list of all classes that require AOT resolution of invokedynamic call sites.
 class FinalImageRecipes {
+  static constexpr int HAS_CLASS            = 0x1;
+  static constexpr int HAS_FIELD_AND_METHOD = 0x2;
+  static constexpr int HAS_INDY             = 0x4;
+
   // A list of all the archived classes from the preimage. We want to transfer all of these
   // into the final image.
   Array<Klass*>* _all_klasses;
 
-  // The classes who have resolved at least one indy CP entry during the training run.
-  // _indy_cp_indices[i] is a list of all resolved CP entries for _indy_klasses[i].
-  Array<InstanceKlass*>* _indy_klasses;
-  Array<Array<int>*>*    _indy_cp_indices;
+  // For each klass k _all_klasses->at(i), _cp_recipes->at(i) lists all the {klass,field,method,indy}
+  // cp indices that were resolved for k during the training run.
+  Array<Array<int>*>* _cp_recipes;
+  Array<int>* _cp_flags;
 
-  FinalImageRecipes() : _indy_klasses(nullptr), _indy_cp_indices(nullptr) {}
+  FinalImageRecipes() : _all_klasses(nullptr), _cp_recipes(nullptr), _cp_flags(nullptr) {}
 
   void* operator new(size_t size) throw();
 
   // Called when dumping preimage
-  void record_recipes_impl();
+  void record_all_classes();
+  void record_recipes_for_constantpool();
 
   // Called when dumping final image
   void apply_recipes_impl(TRAPS);
   void load_all_classes(TRAPS);
-  void apply_recipes_for_invokedynamic(TRAPS);
+  void apply_recipes_for_constantpool(JavaThread* current);
 
 public:
   static void serialize(SerializeClosure* soc);

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -146,6 +146,7 @@ Mutex*   ClassListFile_lock           = nullptr;
 Mutex*   UnregisteredClassesTable_lock= nullptr;
 Mutex*   LambdaFormInvokers_lock      = nullptr;
 Mutex*   ScratchObjects_lock          = nullptr;
+Mutex*   FinalImageRecipes_lock       = nullptr;
 #endif // INCLUDE_CDS
 Mutex*   Bootclasspath_lock           = nullptr;
 
@@ -298,6 +299,7 @@ void mutex_init() {
   MUTEX_DEFN(UnregisteredClassesTable_lock   , PaddedMutex  , nosafepoint-1);
   MUTEX_DEFN(LambdaFormInvokers_lock         , PaddedMutex  , safepoint);
   MUTEX_DEFN(ScratchObjects_lock             , PaddedMutex  , nosafepoint-1); // Holds DumpTimeTable_lock
+  MUTEX_DEFN(FinalImageRecipes_lock          , PaddedMutex  , nosafepoint);
 #endif // INCLUDE_CDS
   MUTEX_DEFN(Bootclasspath_lock              , PaddedMutex  , nosafepoint);
 

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -128,6 +128,7 @@ extern Mutex*   ClassListFile_lock;              // ClassListWriter()
 extern Mutex*   UnregisteredClassesTable_lock;   // UnregisteredClassesTableTable
 extern Mutex*   LambdaFormInvokers_lock;         // Protecting LambdaFormInvokers::_lambdaform_lines
 extern Mutex*   ScratchObjects_lock;             // Protecting _scratch_xxx_table in heapShared.cpp
+extern Mutex*   FinalImageRecipes_lock;          // Protecting the tables used by FinalImageRecipes.
 #endif // INCLUDE_CDS
 #if INCLUDE_JFR
 extern Mutex*   JfrStacktrace_lock;              // used to guard access to the JFR stacktrace table


### PR DESCRIPTION
This bug was discovered and [fixed in the Leyden repo](https://github.com/openjdk/leyden/commit/bd212673822a21164fbf57b255005339d28ef509). Now the constant pool class/field/method entries that were resolved in the training will be recorded in the AOT config file, so they will be AOT-resolved during cache assembly.

@iwanowww @shipilev could you review?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353694](https://bugs.openjdk.org/browse/JDK-8353694): Resolved Class/Field/Method CP entries missing from AOT Configuration (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24434/head:pull/24434` \
`$ git checkout pull/24434`

Update a local copy of the PR: \
`$ git checkout pull/24434` \
`$ git pull https://git.openjdk.org/jdk.git pull/24434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24434`

View PR using the GUI difftool: \
`$ git pr show -t 24434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24434.diff">https://git.openjdk.org/jdk/pull/24434.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24434#issuecomment-2777434502)
</details>
