### PR TITLE
8353365: TOUCH_ASSERT_POISON clears GetLastError()

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2600,6 +2600,7 @@ static inline void report_error(Thread* t, DWORD exception_code,
 //-----------------------------------------------------------------------------
 JNIEXPORT
 LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
+  PreserveLastError ple;
   if (InterceptOSException) return EXCEPTION_CONTINUE_SEARCH;
   PEXCEPTION_RECORD exception_record = exceptionInfo->ExceptionRecord;
   DWORD exception_code = exception_record->ExceptionCode;

--- a/test/hotspot/gtest/utilities/test_vmerror.cpp
+++ b/test/hotspot/gtest/utilities/test_vmerror.cpp
@@ -35,7 +35,7 @@
 TEST_VM_ASSERT_MSG(vmErrorTest, fatalWithError,
                    "fatal error: GetLastError should be 6 - actually: 6") {
   SetLastError(6);
-  fatal("GetLastError should be 6 - actually: %d", (int)GetLastError());
+  fatal("GetLastError should be 6 - actually: %lu", GetLastError());
 }
 #endif // WINDOWS
 

--- a/test/hotspot/gtest/utilities/test_vmerror.cpp
+++ b/test/hotspot/gtest/utilities/test_vmerror.cpp
@@ -28,6 +28,17 @@
 
 #ifdef ASSERT
 
+#ifdef _WINDOWS
+
+#include <windows.h>
+
+TEST_VM_ASSERT_MSG(vmErrorTest, fatalWithError,
+                   "fatal error: GetLastError should be 6 - actually: 6") {
+  SetLastError(6);
+  fatal("GetLastError should be 6 - actually: %d", (int)GetLastError());
+}
+#endif // WINDOWS
+
 TEST_VM_ASSERT_MSG(vmErrorTest, resourceMark,
                   "fatal error: memory leak: allocating without ResourceMark") {
 


### PR DESCRIPTION
This is a very simple fix to save/restore the "last error" value on Windows, so that the TOUCH_ASSERT_POISON mechanism used in assert/guarantee/fatal, does not clear it.

Testing
 - new Windows-only gtest added to vmErrors test group
 - tiers 103 sanity

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353365](https://bugs.openjdk.org/browse/JDK-8353365): TOUCH_ASSERT_POISON clears GetLastError() (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [c080c068](https://git.openjdk.org/jdk/pull/24435/files/c080c068ccc698cd4e32cfa6cb2ed7d6cb1e504b)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer) Review applies to [c080c068](https://git.openjdk.org/jdk/pull/24435/files/c080c068ccc698cd4e32cfa6cb2ed7d6cb1e504b)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24435/head:pull/24435` \
`$ git checkout pull/24435`

Update a local copy of the PR: \
`$ git checkout pull/24435` \
`$ git pull https://git.openjdk.org/jdk.git pull/24435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24435`

View PR using the GUI difftool: \
`$ git pr show -t 24435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24435.diff">https://git.openjdk.org/jdk/pull/24435.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24435#issuecomment-2777622614)
</details>
