### PR TITLE
8353698: Output of Simple Web Server is garbled if the console's encoding is not UTF-8

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/JWebServer.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/JWebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/JWebServer.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/JWebServer.java
@@ -27,8 +27,6 @@ package sun.net.httpserver.simpleserver;
 
 import java.io.PrintWriter;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 /**
  * Programmatic entry point to start the jwebserver tool.
  */
@@ -65,7 +63,7 @@ public class JWebServer {
         setMaxReqTime();
         setMaxConnectionsIfNotSet();
 
-        int ec = SimpleFileServerImpl.start(new PrintWriter(System.out, true, UTF_8), "jwebserver", args);
+        int ec = SimpleFileServerImpl.start(new PrintWriter(System.out, true), "jwebserver", args);
         if (ec != 0) {
             System.exit(ec);
         }  // otherwise, the server has either been started successfully and

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/Main.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/Main.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/Main.java
@@ -26,7 +26,6 @@
 package sun.net.httpserver.simpleserver;
 
 import java.io.PrintWriter;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Programmatic entry point to start "java -m jdk.httpserver".
@@ -61,7 +60,7 @@ public class Main {
         setMaxReqTime();
         JWebServer.setMaxConnectionsIfNotSet();
 
-        int ec = SimpleFileServerImpl.start(new PrintWriter(System.out, true, UTF_8), "java", args);
+        int ec = SimpleFileServerImpl.start(new PrintWriter(System.out, true), "java", args);
         if (ec != 0) {
             System.exit(ec);
         }  // otherwise, the server has either been started successfully and

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLineNegativeTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLineNegativeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLineNegativeTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLineNegativeTest.java
@@ -48,6 +48,7 @@ import static org.testng.Assert.assertFalse;
 public class CommandLineNegativeTest {
 
     static final Path JAVA_HOME = Path.of(System.getProperty("java.home"));
+    static final String LOCALE_OPT = "-Duser.language=en -Duser.country=US";
     static final String JAVA = getJava(JAVA_HOME);
     static final Path CWD = Path.of(".").toAbsolutePath().normalize();
     static final Path TEST_DIR = CWD.resolve("CommandLineNegativeTest");
@@ -74,7 +75,7 @@ public class CommandLineNegativeTest {
     @Test(dataProvider = "unknownOption")
     public void testBadOption(String opt) throws Throwable {
         out.println("\n--- testUnknownOption, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", opt)
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt)
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: unknown option: " + opt);
     }
@@ -97,7 +98,7 @@ public class CommandLineNegativeTest {
     @Test(dataProvider = "tooManyOptionArgs")
     public void testTooManyOptionArgs(String opt, String arg) throws Throwable {
         out.println("\n--- testTooManyOptionArgs, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", opt, arg, arg)
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, arg, arg)
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: unknown option: " + arg);
     }
@@ -124,7 +125,7 @@ public class CommandLineNegativeTest {
     @Test(dataProvider = "noArg")
     public void testNoArg(String opt, String msg) throws Throwable {
         out.println("\n--- testNoArg, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", opt)
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt)
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: no value given for " + opt)
                 .shouldContain(msg);
@@ -148,7 +149,7 @@ public class CommandLineNegativeTest {
     @Test(dataProvider = "invalidValue")
     public void testInvalidValue(String opt, String val) throws Throwable {
         out.println("\n--- testInvalidValue, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", opt, val)
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, val)
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: invalid value given for " + opt + ": " + val);
     }
@@ -159,7 +160,7 @@ public class CommandLineNegativeTest {
     @Test(dataProvider = "portOptions")
     public void testPortOutOfRange(String opt) throws Throwable {
         out.println("\n--- testPortOutOfRange, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", opt, "65536")  // range 0 to 65535
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, "65536")  // range 0 to 65535
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: server config failed: " + "port out of range:65536");
     }
@@ -172,7 +173,7 @@ public class CommandLineNegativeTest {
         out.println("\n--- testRootNotAbsolute, opt=\"%s\" ".formatted(opt));
         var root = Path.of(".");
         assertFalse(root.isAbsolute());
-        simpleserver(JAVA, "-m", "jdk.httpserver", opt, root.toString())
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, root.toString())
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: server config failed: " + "Path is not absolute:");
     }
@@ -182,7 +183,7 @@ public class CommandLineNegativeTest {
         out.println("\n--- testRootNotADirectory, opt=\"%s\" ".formatted(opt));
         var file = TEST_FILE.toString();
         assertFalse(Files.isDirectory(TEST_FILE));
-        simpleserver(JAVA, "-m", "jdk.httpserver", opt, file)
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, file)
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: server config failed: " + "Path is not a directory: " + file);
     }
@@ -192,7 +193,7 @@ public class CommandLineNegativeTest {
         out.println("\n--- testRootDoesNotExist, opt=\"%s\" ".formatted(opt));
         Path root = TEST_DIR.resolve("not/existent/dir");
         assertFalse(Files.exists(root));
-        simpleserver(JAVA, "-m", "jdk.httpserver", opt, root.toString())
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, root.toString())
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: server config failed: " + "Path does not exist: " + root.toString());
     }
@@ -209,7 +210,7 @@ public class CommandLineNegativeTest {
         try {
             root.toFile().setReadable(false, false);
             assertFalse(Files.isReadable(root));
-            simpleserver(JAVA, "-m", "jdk.httpserver", opt, root.toString())
+            simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, root.toString())
                     .shouldNotHaveExitValue(0)
                     .shouldContain("Error: server config failed: " + "Path is not readable: " + root.toString());
         } finally {

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePortNotSpecifiedTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePortNotSpecifiedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePortNotSpecifiedTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePortNotSpecifiedTest.java
@@ -47,6 +47,7 @@ import static java.lang.System.out;
 public class CommandLinePortNotSpecifiedTest {
 
     static final Path JAVA_HOME = Path.of(System.getProperty("java.home"));
+    static final String LOCALE_OPT = "-Duser.language=en -Duser.country=US";
     static final String JAVA = getJava(JAVA_HOME);
     static final Path CWD = Path.of(".").toAbsolutePath().normalize();
     static final Path TEST_DIR = CWD.resolve("CommandLinePortNotSpecifiedTest");
@@ -84,7 +85,7 @@ public class CommandLinePortNotSpecifiedTest {
     @Test
     public void testPortNotSpecified() throws Throwable {
         out.println("\n--- testPortNotSpecified");
-        simpleserver(JAVA, "-m", "jdk.httpserver")
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
@@ -50,6 +50,7 @@ public class CommandLinePositiveTest {
 
     static final String JAVA_VERSION = System.getProperty("java.version");
     static final Path JAVA_HOME = Path.of(System.getProperty("java.home"));
+    static final String LOCALE_OPT = "-Duser.language=en -Duser.country=US";
     static final String JAVA = getJava(JAVA_HOME);
     static final Path CWD = Path.of(".").toAbsolutePath().normalize();
     static final Path TEST_DIR = CWD.resolve("CommandLinePositiveTest");
@@ -84,7 +85,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "directoryOptions")
     public void testDirectory(String opt) throws Throwable {
         out.println("\n--- testDirectory, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", "-p", "0", opt, TEST_DIR_STR)
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, TEST_DIR_STR)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
@@ -97,7 +98,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "portOptions")
     public void testPort(String opt) throws Throwable {
         out.println("\n--- testPort, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", opt, "0")
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, "0")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
@@ -128,7 +129,7 @@ public class CommandLinePositiveTest {
         out.println("\n--- testHelp, opt=\"%s\" ".formatted(opt));
         simpleserver(WaitForLine.HELP_STARTUP_LINE,
                      false,  // do not explicitly destroy the process
-                     JAVA, "-m", "jdk.httpserver", opt)
+                     JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt)
                 .shouldHaveExitValue(0)
                 .shouldContain(USAGE_TEXT)
                 .shouldContain(OPTIONS_TEXT);
@@ -142,7 +143,7 @@ public class CommandLinePositiveTest {
         out.println("\n--- testVersion, opt=\"%s\" ".formatted(opt));
         simpleserver(WaitForLine.VERSION_STARTUP_LINE,
                 false,  // do not explicitly destroy the process
-                JAVA, "-m", "jdk.httpserver", opt)
+                JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt)
                 .shouldHaveExitValue(0);
     }
 
@@ -152,12 +153,12 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "bindOptions")
     public void testBindAllInterfaces(String opt) throws Throwable {
         out.println("\n--- testBindAllInterfaces, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", "-p", "0", opt, "0.0.0.0")
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, "0.0.0.0")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
                 .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
         if (IPSupport.hasIPv6()) {
-            simpleserver(JAVA, "-m", "jdk.httpserver", opt, "::0")
+            simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, "::0")
                     .shouldHaveExitValue(NORMAL_EXIT_CODE)
                     .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
                     .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
@@ -167,7 +168,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "bindOptions")
     public void testLastOneWinsBindAddress(String opt) throws Throwable {
         out.println("\n--- testLastOneWinsBindAddress, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", "-p", "0", opt, "123.4.5.6", opt, LOOPBACK_ADDR)
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, "123.4.5.6", opt, LOOPBACK_ADDR)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
@@ -177,7 +178,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "directoryOptions")
     public void testLastOneWinsDirectory(String opt) throws Throwable {
         out.println("\n--- testLastOneWinsDirectory, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", "-p", "0", opt, TEST_DIR_STR, opt, TEST_DIR_STR)
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, TEST_DIR_STR, opt, TEST_DIR_STR)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
@@ -190,7 +191,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "outputOptions")
     public void testLastOneWinsOutput(String opt) throws Throwable {
         out.println("\n--- testLastOneWinsOutput, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", "-p", "0", opt, "none", opt, "verbose")
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", "-p", "0", opt, "none", opt, "verbose")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
@@ -200,7 +201,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "portOptions")
     public void testLastOneWinsPort(String opt) throws Throwable {
         out.println("\n--- testLastOneWinsPort, opt=\"%s\" ".formatted(opt));
-        simpleserver(JAVA, "-m", "jdk.httpserver", opt, "-999", opt, "0")
+        simpleserver(JAVA, LOCALE_OPT, "-m", "jdk.httpserver", opt, "-999", opt, "0")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLineNegativeTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLineNegativeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLineNegativeTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLineNegativeTest.java
@@ -49,6 +49,7 @@ public class CommandLineNegativeTest {
 
     static final Path JAVA_HOME = Path.of(System.getProperty("java.home"));
     static final String JWEBSERVER = getJwebserver(JAVA_HOME);
+    static final String LOCALE_OPT = "-J-Duser.language=en -J-Duser.country=US";
     static final Path CWD = Path.of(".").toAbsolutePath().normalize();
     static final Path TEST_DIR = CWD.resolve("CommandLineNegativeTest");
     static final Path TEST_FILE = TEST_DIR.resolve("file.txt");
@@ -74,7 +75,7 @@ public class CommandLineNegativeTest {
     @Test(dataProvider = "unknownOption")
     public void testBadOption(String opt) throws Throwable {
         out.println("\n--- testUnknownOption, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, opt)
+        simpleserver(JWEBSERVER, LOCALE_OPT, opt)
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: unknown option: " + opt);
     }
@@ -97,7 +98,7 @@ public class CommandLineNegativeTest {
     @Test(dataProvider = "tooManyOptionArgs")
     public void testTooManyOptionArgs(String opt, String arg) throws Throwable {
         out.println("\n--- testTooManyOptionArgs, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, opt, arg, arg)
+        simpleserver(JWEBSERVER, LOCALE_OPT, opt, arg, arg)
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: unknown option: " + arg);
     }
@@ -124,7 +125,7 @@ public class CommandLineNegativeTest {
     @Test(dataProvider = "noArg")
     public void testNoArg(String opt, String msg) throws Throwable {
         out.println("\n--- testNoArg, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, opt)
+        simpleserver(JWEBSERVER, LOCALE_OPT, opt)
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: no value given for " + opt)
                 .shouldContain(msg);
@@ -148,7 +149,7 @@ public class CommandLineNegativeTest {
     @Test(dataProvider = "invalidValue")
     public void testInvalidValue(String opt, String val) throws Throwable {
         out.println("\n--- testInvalidValue, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, opt, val)
+        simpleserver(JWEBSERVER, LOCALE_OPT, opt, val)
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: invalid value given for " + opt + ": " + val);
     }
@@ -159,7 +160,7 @@ public class CommandLineNegativeTest {
     @Test(dataProvider = "portOptions")
     public void testPortOutOfRange(String opt) throws Throwable {
         out.println("\n--- testPortOutOfRange, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, opt, "65536")  // range 0 to 65535
+        simpleserver(JWEBSERVER, LOCALE_OPT, opt, "65536")  // range 0 to 65535
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: server config failed: " + "port out of range:65536");
     }
@@ -172,7 +173,7 @@ public class CommandLineNegativeTest {
         out.println("\n--- testRootNotAbsolute, opt=\"%s\" ".formatted(opt));
         var root = Path.of(".");
         assertFalse(root.isAbsolute());
-        simpleserver(JWEBSERVER, opt, root.toString())
+        simpleserver(JWEBSERVER, LOCALE_OPT, opt, root.toString())
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: server config failed: " + "Path is not absolute:");
     }
@@ -182,7 +183,7 @@ public class CommandLineNegativeTest {
         out.println("\n--- testRootNotADirectory, opt=\"%s\" ".formatted(opt));
         var file = TEST_FILE.toString();
         assertFalse(Files.isDirectory(TEST_FILE));
-        simpleserver(JWEBSERVER, opt, file)
+        simpleserver(JWEBSERVER, LOCALE_OPT, opt, file)
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: server config failed: " + "Path is not a directory: " + file);
     }
@@ -192,7 +193,7 @@ public class CommandLineNegativeTest {
         out.println("\n--- testRootDoesNotExist, opt=\"%s\" ".formatted(opt));
         Path root = TEST_DIR.resolve("not/existent/dir");
         assertFalse(Files.exists(root));
-        simpleserver(JWEBSERVER, opt, root.toString())
+        simpleserver(JWEBSERVER, LOCALE_OPT, opt, root.toString())
                 .shouldNotHaveExitValue(0)
                 .shouldContain("Error: server config failed: " + "Path does not exist: " + root.toString());
     }
@@ -209,7 +210,7 @@ public class CommandLineNegativeTest {
         try {
             root.toFile().setReadable(false, false);
             assertFalse(Files.isReadable(root));
-            simpleserver(JWEBSERVER, opt, root.toString())
+            simpleserver(JWEBSERVER, LOCALE_OPT, opt, root.toString())
                     .shouldNotHaveExitValue(0)
                     .shouldContain("Error: server config failed: " + "Path is not readable: " + root.toString());
         } finally {

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePortNotSpecifiedTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePortNotSpecifiedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePortNotSpecifiedTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePortNotSpecifiedTest.java
@@ -47,6 +47,7 @@ import static java.lang.System.out;
 public class CommandLinePortNotSpecifiedTest {
 
     static final Path JAVA_HOME = Path.of(System.getProperty("java.home"));
+    static final String LOCALE_OPT = "-J-Duser.language=en -J-Duser.country=US";
     static final String JWEBSERVER = getJwebserver(JAVA_HOME);
     static final Path CWD = Path.of(".").toAbsolutePath().normalize();
     static final Path TEST_DIR = CWD.resolve("CommandLinePortNotSpecifiedTest");
@@ -84,7 +85,7 @@ public class CommandLinePortNotSpecifiedTest {
     @Test
     public void testPortNotSpecified() throws Throwable {
         out.println("\n--- testPortNotSpecified");
-        simpleserver(JWEBSERVER)
+        simpleserver(JWEBSERVER, LOCALE_OPT)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
@@ -50,6 +50,7 @@ public class CommandLinePositiveTest {
 
     static final String JAVA_VERSION = System.getProperty("java.version");
     static final Path JAVA_HOME = Path.of(System.getProperty("java.home"));
+    static final String LOCALE_OPT = "-J-Duser.language=en -J-Duser.country=US";
     static final String JWEBSERVER = getJwebserver(JAVA_HOME);
     static final Path CWD = Path.of(".").toAbsolutePath().normalize();
     static final Path TEST_DIR = CWD.resolve("CommandLinePositiveTest");
@@ -84,7 +85,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "directoryOptions")
     public void testDirectory(String opt) throws Throwable {
         out.println("\n--- testDirectory, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, "-p", "0", opt, TEST_DIR_STR)
+        simpleserver(JWEBSERVER, LOCALE_OPT, "-p", "0", opt, TEST_DIR_STR)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
@@ -97,7 +98,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "portOptions")
     public void testPort(String opt) throws Throwable {
         out.println("\n--- testPort, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, opt, "0")
+        simpleserver(JWEBSERVER, LOCALE_OPT, opt, "0")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
@@ -128,7 +129,7 @@ public class CommandLinePositiveTest {
         out.println("\n--- testHelp, opt=\"%s\" ".formatted(opt));
         simpleserver(WaitForLine.HELP_STARTUP_LINE,
                      false,  // do not explicitly destroy the process
-                JWEBSERVER, opt)
+                JWEBSERVER, LOCALE_OPT, opt)
                 .shouldHaveExitValue(0)
                 .shouldContain(USAGE_TEXT)
                 .shouldContain(OPTIONS_TEXT);
@@ -142,7 +143,7 @@ public class CommandLinePositiveTest {
         out.println("\n--- testVersion, opt=\"%s\" ".formatted(opt));
         simpleserver(WaitForLine.VERSION_STARTUP_LINE,
                      false,  // do not explicitly destroy the process
-                JWEBSERVER, opt)
+                JWEBSERVER, LOCALE_OPT, opt)
                 .shouldHaveExitValue(0);
     }
 
@@ -152,12 +153,12 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "bindOptions")
     public void testBindAllInterfaces(String opt) throws Throwable {
         out.println("\n--- testBindAllInterfaces, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, "-p", "0", opt, "0.0.0.0")
+        simpleserver(JWEBSERVER, LOCALE_OPT, "-p", "0", opt, "0.0.0.0")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
                 .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
         if (IPSupport.hasIPv6()) {
-            simpleserver(JWEBSERVER, opt, "::0")
+            simpleserver(JWEBSERVER, LOCALE_OPT, opt, "::0")
                     .shouldHaveExitValue(NORMAL_EXIT_CODE)
                     .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
                     .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
@@ -167,7 +168,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "bindOptions")
     public void testLastOneWinsBindAddress(String opt) throws Throwable {
         out.println("\n--- testLastOneWinsBindAddress, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, "-p", "0", opt, "123.4.5.6", opt, LOOPBACK_ADDR)
+        simpleserver(JWEBSERVER, LOCALE_OPT, "-p", "0", opt, "123.4.5.6", opt, LOOPBACK_ADDR)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
                 .shouldContain("URL http://" + LOOPBACK_ADDR);
@@ -177,7 +178,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "directoryOptions")
     public void testLastOneWinsDirectory(String opt) throws Throwable {
         out.println("\n--- testLastOneWinsDirectory, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, "-p", "0", opt, TEST_DIR_STR, opt, TEST_DIR_STR)
+        simpleserver(JWEBSERVER, LOCALE_OPT, "-p", "0", opt, TEST_DIR_STR, opt, TEST_DIR_STR)
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
@@ -190,7 +191,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "outputOptions")
     public void testLastOneWinsOutput(String opt) throws Throwable {
         out.println("\n--- testLastOneWinsOutput, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, "-p", "0", opt, "none", opt, "verbose")
+        simpleserver(JWEBSERVER, LOCALE_OPT, "-p", "0", opt, "none", opt, "verbose")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")
@@ -200,7 +201,7 @@ public class CommandLinePositiveTest {
     @Test(dataProvider = "portOptions")
     public void testLastOneWinsPort(String opt) throws Throwable {
         out.println("\n--- testLastOneWinsPort, opt=\"%s\" ".formatted(opt));
-        simpleserver(JWEBSERVER, opt, "-999", opt, "0")
+        simpleserver(JWEBSERVER, LOCALE_OPT, opt, "-999", opt, "0")
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Binding to loopback by default. For all interfaces use \"-b 0.0.0.0\" or \"-b ::\".")
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on " + LOOPBACK_ADDR + " port")

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/IPv6BoundHost.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/IPv6BoundHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/IPv6BoundHost.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/IPv6BoundHost.java
@@ -47,6 +47,7 @@ public class IPv6BoundHost {
     private static final Path JDK_BIN_DIR = Path.of(System.getProperty("java.home")).resolve("bin");
     private static final Path JWEBSERVER_BINARY = OperatingSystem.isWindows()
             ? JDK_BIN_DIR.resolve("jwebserver.exe") : JDK_BIN_DIR.resolve("jwebserver");
+    private static final String LOCALE_OPT = "-J-Duser.language=en -J-Duser.country=US";
 
     public static void main(final String[] args) throws Exception {
         IPSupport.printPlatformSupport(System.err); // for debug purposes
@@ -68,6 +69,7 @@ public class IPv6BoundHost {
         final StringBuilder sb = new StringBuilder();  // stdout & stderr
         final List<String> cmd = new ArrayList<>();
         cmd.add(JWEBSERVER_BINARY.toString());
+        cmd.add(LOCALE_OPT);
         cmd.addAll(args);
         // start the process and await the waitForLine before returning
         final Process p = ProcessTools.startProcess("8332020-test", new ProcessBuilder(cmd),

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java
@@ -71,6 +71,7 @@ import static org.testng.Assert.*;
  */
 public class MaxRequestTimeTest {
     static final Path JAVA_HOME = Path.of(System.getProperty("java.home"));
+    static final String LOCALE_OPT = "-J-Duser.language=en -J-Duser.country=US";
     static final String JWEBSERVER = getJwebserver(JAVA_HOME);
     static final Path CWD = Path.of(".").toAbsolutePath().normalize();
     static final Path TEST_DIR = CWD.resolve("MaxRequestTimeTest");
@@ -174,7 +175,7 @@ public class MaxRequestTimeTest {
     static Process startProcess(String name, StringBuffer sb) throws Throwable {
         // starts the process, parses the port and awaits startup line before sending requests
         return ProcessTools.startProcess(name,
-                new ProcessBuilder(JWEBSERVER, "-p", "0").directory(TEST_DIR.toFile()),
+                new ProcessBuilder(JWEBSERVER, LOCALE_OPT, "-p", "0").directory(TEST_DIR.toFile()),
                 line -> {
                     if (line.startsWith(REGULAR_STARTUP_LINE_STRING_2)) { parseAndSetPort(line); }
                     sb.append(line + "\n");


### PR DESCRIPTION
The output `jwebserver` and `java -m jdk.httpserver` uses UTF-8 encoding. Therefore, if the console encoding is not set to UTF-8 (for example, MS932 on Japanese Windows), garbled characters may appear. 
Since System.out knows the console's encoding, there's no need to specify it again with PrintWriter constructor.

The output `jwebserver` and `java -m jdk.httpserver` is localized in Japanese, German, and Chinese. This bug only occurs in these localized languages, so I haven't added any tests.
I have confirmed that the output of the two commands is not garbled in the default command prompts of both Japanese Windows and English Windows.

I tested jdk/com/sun/net/httpserver/simpleserver on English Windows, and all tests passed. However, when running on Japanese Windows, some tests failed because they expected output only in English.
I modified the tests so that `jwebserver` and `java -m jdk.httpserver` within the tests are executed with an English locale. After this modification, all tests passed on Japanese Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353698](https://bugs.openjdk.org/browse/JDK-8353698): Output of Simple Web Server is garbled if the console's encoding is not UTF-8 (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24437/head:pull/24437` \
`$ git checkout pull/24437`

Update a local copy of the PR: \
`$ git checkout pull/24437` \
`$ git pull https://git.openjdk.org/jdk.git pull/24437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24437`

View PR using the GUI difftool: \
`$ git pr show -t 24437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24437.diff">https://git.openjdk.org/jdk/pull/24437.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24437#issuecomment-2777668506)
</details>
