### PR TITLE
8353709: Debug symbols bundle should contain full debug files when building --with-external-symbols-in-bundles=public

### DIFF
--- a/make/Bundles.gmk
+++ b/make/Bundles.gmk
@@ -242,7 +242,10 @@ ifneq ($(filter product-bundles% legacy-bundles, $(MAKECMDGOALS)), )
       )
 
   JDK_SYMBOLS_BUNDLE_FILES := \
-      $(call FindFiles, $(SYMBOLS_IMAGE_DIR))
+      $(filter-out \
+          %.stripped.pdb, \
+          $(call FindFiles, $(SYMBOLS_IMAGE_DIR)) \
+      )
 
   TEST_DEMOS_BUNDLE_FILES := $(filter $(JDK_DEMOS_IMAGE_HOMEDIR)/demo/%, \
       $(ALL_JDK_DEMOS_FILES))


### PR DESCRIPTION
Currently, when building with `--with-external-symbols-in-bundles=public`, the debug symbols bundle contains the stripped pdb files. It should better have the full pdb files since stripped pdbs are in the runtime image already.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353709](https://bugs.openjdk.org/browse/JDK-8353709): Debug symbols bundle should contain full debug files when building --with-external-symbols-in-bundles=public (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24440/head:pull/24440` \
`$ git checkout pull/24440`

Update a local copy of the PR: \
`$ git checkout pull/24440` \
`$ git pull https://git.openjdk.org/jdk.git pull/24440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24440`

View PR using the GUI difftool: \
`$ git pr show -t 24440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24440.diff">https://git.openjdk.org/jdk/pull/24440.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24440#issuecomment-2777854954)
</details>
