### PR TITLE
8353568: SEGV_BNDERR signal code adjust definition

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -50,8 +50,9 @@
 #include <signal.h>
 
 #define SEGV_BNDERR_value 3
+
 #if defined(SEGV_BNDERR)
-STATIC_ASSERT(SEGV_BNDERR == SEGV_BNDERR_value)
+STATIC_ASSERT(SEGV_BNDERR == SEGV_BNDERR_value);
 #else
 #define SEGV_BNDERR SEGV_BNDERR_value
 #endif

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -49,8 +49,11 @@
 
 #include <signal.h>
 
-#if !defined(SEGV_BNDERR)
-#define SEGV_BNDERR 3
+#define SEGV_BNDERR_value 3
+#if defined(SEGV_BNDERR)
+STATIC_ASSERT(SEGV_BNDERR == SEGV_BNDERR_value)
+#else
+#define SEGV_BNDERR SEGV_BNDERR_value
 #endif
 
 static const char* get_signal_name(int sig, char* out, size_t outlen);


### PR DESCRIPTION
There was a remark from Thomas Stuefe in https://github.com/openjdk/jdk24u/pull/175 .

The idea was to add a   static assert for SEGV_BNDERR sig-code.
The static assert will alert us if we build on a newer Linux version and turns out we were wrong with our assumed number.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353568](https://bugs.openjdk.org/browse/JDK-8353568): SEGV_BNDERR signal code adjust definition (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/24441/head:pull/24441` \
`$ git checkout pull/24441`

Update a local copy of the PR: \
`$ git checkout pull/24441` \
`$ git pull https://git.openjdk.org/jdk.git pull/24441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24441`

View PR using the GUI difftool: \
`$ git pr show -t 24441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/24441.diff">https://git.openjdk.org/jdk/pull/24441.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/24441#issuecomment-2778019989)
</details>
